### PR TITLE
Gelida changes 2023 edition

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -218,7 +218,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "afm" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -477,7 +477,7 @@
 "apd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "apw" = (
 /obj/machinery/light{
 	dir = 8
@@ -489,7 +489,7 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "apC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -605,7 +605,7 @@
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "atY" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
@@ -663,12 +663,13 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/landing_zone_1)
-"avv" = (
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 4
+"avl" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/landing_zone_1)
+/turf/open/floor/mainship/black/full,
+/area/gelida/powergen)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison,
@@ -719,7 +720,7 @@
 "awQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "awU" = (
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
@@ -731,7 +732,7 @@
 /obj/structure/bed/chair/sofa/corsat/verticaltop,
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "axl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -838,7 +839,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aDi" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/platform_decoration{
@@ -957,7 +958,7 @@
 "aHZ" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aIf" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -979,7 +980,7 @@
 /turf/open/floor/prison/cellstripe{
 	dir = 1
 	},
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aJe" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = -5;
@@ -1101,13 +1102,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"aNl" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "aNw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -1116,7 +1110,7 @@
 "aNR" = (
 /obj/structure/bed/chair/sofa/corsat/verticaltop,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aOd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1150,10 +1144,14 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
 /area/gelida/landing_zone_1)
+"aPQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "aPS" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aPZ" = (
 /obj/structure/reagent_dispensers/beerkeg{
 	pixel_x = 5
@@ -1198,7 +1196,7 @@
 	use_power = 0
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/outdoors/rock)
+/area/gelida/indoors/a_block/corpo)
 "aQq" = (
 /obj/structure/prop/mainship/gelida/powerccable,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -1209,10 +1207,6 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/outdoors/colony_streets/central_streets)
-"aQr" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/mining)
 "aQt" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/darkbrown/full,
@@ -1313,6 +1307,10 @@
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_east_street)
+"aTD" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/prison/plate,
+/area/gelida/landing_zone_2)
 "aTH" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -1349,7 +1347,7 @@
 "aUs" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aVe" = (
 /turf/open/shuttle/dropship/four,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
@@ -1381,7 +1379,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aWU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -1494,7 +1492,7 @@
 "aZE" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "aZV" = (
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/rock)
@@ -1506,6 +1504,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_east_street)
+"baf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "bay" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -1657,7 +1659,7 @@
 /obj/structure/rack/nometal,
 /obj/item/storage/holster/flarepouch/full,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "bdC" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_y = 7
@@ -1679,12 +1681,6 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/executive)
-"bdE" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "bdV" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/blue,
@@ -1702,7 +1698,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1754,7 +1750,7 @@
 "bgd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bgH" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -1798,7 +1794,7 @@
 "bic" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bid" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -1842,7 +1838,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bjt" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform,
@@ -1979,7 +1975,7 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison/cellstripe,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "boo" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/ai_node,
@@ -2054,7 +2050,7 @@
 "bqw" = (
 /obj/structure/bed/chair/sofa/corsat/verticalmiddle,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bqS" = (
 /obj/item/tool/kitchen/knife/ritual,
 /turf/open/floor/wood,
@@ -2125,7 +2121,7 @@
 "bua" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "buA" = (
 /obj/structure/prop/mainship/gelida/rails,
 /obj/structure/prop/mainship/gelida/rails{
@@ -2272,13 +2268,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
-"bzz" = (
-/obj/structure/prop/mainship/gelida/lightstick{
-	pixel_x = 11;
-	pixel_y = 25
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "bzM" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -2304,7 +2293,7 @@
 "bAh" = (
 /obj/machinery/newscaster,
 /turf/closed/wall,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bBz" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_street)
@@ -2440,7 +2429,7 @@
 "bFN" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bFY" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -2508,7 +2497,7 @@
 "bHY" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bIi" = (
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/lone_buildings/chunk)
@@ -2583,7 +2572,7 @@
 /obj/structure/bed/chair/sofa/corsat/verticalmiddle,
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bLf" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -2612,7 +2601,7 @@
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "bMA" = (
 /turf/open/shuttle/dropship/five,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
@@ -2688,7 +2677,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bNT" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
@@ -2892,11 +2881,11 @@
 	pixel_y = -3
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "bVQ" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "bWI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
@@ -2920,11 +2909,11 @@
 	dir = 2
 	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bXz" = (
 /obj/structure/bed/chair/sofa/corsat/verticalsouth,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "bXX" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/prison/whitegreenfull2,
@@ -3114,6 +3103,12 @@
 "ced" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/south_street)
+"cei" = (
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "cek" = (
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
@@ -3161,7 +3156,7 @@
 "cfG" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cgn" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -3376,12 +3371,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
-"cof" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "cot" = (
 /obj/structure/table/mainship,
 /obj/item/tool/pen{
@@ -3430,7 +3419,7 @@
 /area/gelida/indoors/c_block/mining)
 "cqM" = (
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "cqV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3489,7 +3478,7 @@
 /obj/effect/spawner/random/engineering/pickaxe,
 /obj/effect/spawner/random/engineering/pickaxe,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "csP" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/platform{
@@ -3597,7 +3586,7 @@
 /obj/effect/spawner/random/engineering/tool,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "cxg" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -3650,7 +3639,7 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "cyd" = (
 /obj/structure/filingcabinet{
 	pixel_x = -8;
@@ -3783,13 +3772,22 @@
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/casino)
+"cCQ" = (
+/obj/machinery/door_control{
+	dir = 1;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/snow/layer0{
+	dir = 1
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "cCZ" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "cDx" = (
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cDL" = (
 /obj/machinery/light{
 	dir = 8
@@ -3999,7 +3997,7 @@
 "cIy" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cIQ" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/caves/east_caves)
@@ -4101,7 +4099,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cMf" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/prison/whitegreenfull2,
@@ -4199,7 +4197,7 @@
 /turf/open/floor/prison/cellstripe{
 	dir = 1
 	},
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cQd" = (
 /obj/effect/spawner/random/engineering/pickaxe,
 /turf/open/floor/plating/ground/ice,
@@ -4213,11 +4211,11 @@
 	},
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cQx" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "cQW" = (
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
@@ -4518,7 +4516,7 @@
 "cZX" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dag" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -4536,7 +4534,7 @@
 /obj/item/weapon/cane,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "daV" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -4690,7 +4688,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dgs" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -4744,7 +4742,7 @@
 /obj/structure/cable,
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dhx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4822,7 +4820,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dkY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -4876,7 +4874,7 @@
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "dmP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4968,7 +4966,7 @@
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "dqA" = (
 /obj/structure/cargo_container{
 	dir = 4
@@ -5087,12 +5085,6 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"dug" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/w_rockies)
 "duO" = (
 /obj/structure/table/mainship,
 /obj/item/book{
@@ -5153,7 +5145,11 @@
 "dwS" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
+"dxi" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/landing_zone_2)
 "dxk" = (
 /obj/structure/largecrate/supply{
 	pixel_x = -4
@@ -5383,7 +5379,7 @@
 "dEZ" = (
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "dFb" = (
 /obj/item/bananapeel{
 	desc = "A bunch of tiny bits of shattered metal.";
@@ -5474,7 +5470,7 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "dHv" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/prison/whitegreenfull2,
@@ -5482,7 +5478,7 @@
 "dII" = (
 /obj/structure/cargo_container,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dIK" = (
 /obj/item/weapon/gun/pistol/m1911,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -5542,7 +5538,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dKD" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -5668,11 +5664,11 @@
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dOO" = (
 /obj/structure/prop/mainship/gelida/propladder,
 /turf/open/floor/plating,
-/area/gelida/outdoors/rock)
+/area/gelida/indoors/a_block/corpo)
 "dOS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -5718,7 +5714,7 @@
 "dQm" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dQX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Eastlock"
@@ -5811,7 +5807,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "dUC" = (
 /obj/item/storage/backpack/marine/satchel{
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
@@ -6214,7 +6210,7 @@
 	pixel_y = -16
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eeF" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/structure/cable,
@@ -6284,7 +6280,7 @@
 "egm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "egn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -6369,7 +6365,7 @@
 "elo" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "emD" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -6424,7 +6420,7 @@
 "eoI" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "eoN" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -6487,7 +6483,7 @@
 "eqE" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "eqI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -6503,7 +6499,7 @@
 /area/gelida/indoors/b_block/bridge)
 "eqT" = (
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "era" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -6622,7 +6618,7 @@
 "etT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "etY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet,
@@ -6637,7 +6633,7 @@
 "eum" = (
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "euu" = (
 /obj/item/defibrillator,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6758,7 +6754,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "ewO" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -6785,12 +6781,6 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
-"eyQ" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "eyU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/random/misc/structure/curtain/medical,
@@ -6832,7 +6822,7 @@
 "ezB" = (
 /obj/machinery/floodlight,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "ezN" = (
 /obj/item/ammo_magazine/rifle/tx11{
 	current_rounds = 0
@@ -6965,7 +6955,7 @@
 "eEw" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eEH" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -7081,6 +7071,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
+"eHa" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/indoors/c_block/mining)
 "eHf" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/prison,
@@ -7311,7 +7306,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eOo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /turf/open/floor/prison,
@@ -7386,7 +7381,7 @@
 /obj/machinery/door/airlock/mainship/generic,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eRE" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -7438,7 +7433,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eTa" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison,
@@ -7592,7 +7587,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eWP" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7628,6 +7623,10 @@
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
+"eXG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "eXT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
@@ -7712,7 +7711,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "eZJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7951,6 +7950,11 @@
 /obj/structure/prop/mainship/gelida/rails,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/rock)
+"fjX" = (
+/obj/effect/turf_decal/warning_stripes/box,
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/prison,
+/area/gelida/outdoors/colony_streets/central_streets)
 "fkl" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8018,6 +8022,13 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
+"fng" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/gelida/indoors/c_block/garage)
 "fnx" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/flashlight/lamp{
@@ -8047,6 +8058,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
+"fpe" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/indoors/c_block/mining)
 "fpo" = (
 /obj/structure/table/mainship,
 /obj/item/tool/stamp/denied{
@@ -8216,7 +8231,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "fwk" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison,
@@ -8351,7 +8366,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "fCJ" = (
 /turf/open/floor/prison{
 	dir = 1
@@ -8465,9 +8480,6 @@
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"fHK" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
 "fHM" = (
 /obj/effect/ai_node,
 /turf/open/shuttle/dropship/seven,
@@ -8629,6 +8641,10 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
+"fPV" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "fQl" = (
 /turf/closed/shuttle/dropship2/enginefive{
 	dir = 1
@@ -8721,7 +8737,7 @@
 "fTM" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "fTS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8756,7 +8772,7 @@
 /obj/effect/spawner/random/engineering/tool,
 /obj/item/armor_module/module/antenna,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "fVp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -8842,7 +8858,7 @@
 "fXJ" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "fYA" = (
 /obj/structure/table/mainship,
 /obj/structure/flora/pottedplant{
@@ -8956,7 +8972,7 @@
 "gaR" = (
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "gbt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -9052,7 +9068,7 @@
 "geP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gfh" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -9061,10 +9077,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/central_caves)
-"gfH" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_2)
 "ggk" = (
 /obj/effect/acid_hole,
 /turf/closed/wall,
@@ -9135,7 +9147,7 @@
 /turf/open/floor/prison{
 	dir = 8
 	},
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gio" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -9235,7 +9247,7 @@
 /obj/effect/ai_node,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gma" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/prison/darkbrown/full,
@@ -9388,7 +9400,7 @@
 "gqh" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gqE" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -9412,7 +9424,10 @@
 "grj" = (
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
+"grl" = (
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/gelida/powergen)
 "grK" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /obj/effect/landmark/weed_node,
@@ -9421,7 +9436,7 @@
 "gsb" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gse" = (
 /obj/structure/prop/mainship/gelida/rails,
 /turf/open/floor/tile/dark2,
@@ -9464,20 +9479,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/central_streets)
-"gtS" = (
-/obj/structure/largecrate,
-/obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
-"gub" = (
-/obj/machinery/door_control{
-	dir = 1;
-	id = "checkpoint1"
-	},
-/turf/open/floor/plating/ground/snow/layer0{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "guf" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -9491,7 +9492,7 @@
 "gum" = (
 /obj/item/trash/kepler,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gun" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -9716,7 +9717,7 @@
 "gAr" = (
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "gAw" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -9756,7 +9757,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gBs" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -10052,7 +10053,7 @@
 /obj/effect/ai_node,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gLF" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -10084,12 +10085,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
-"gMw" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
+/area/gelida/cavestructuretwo)
 "gMH" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -10384,7 +10380,7 @@
 /area/gelida/indoors/b_block/bar)
 "gVM" = (
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "gXb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -10420,7 +10416,7 @@
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "gZo" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -10433,7 +10429,7 @@
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/weaponry/melee,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "gZE" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/plating,
@@ -10441,7 +10437,7 @@
 "gZL" = (
 /obj/structure/largecrate,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "gZW" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_14";
@@ -10534,6 +10530,10 @@
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
+"hdI" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
 "hdJ" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -10606,7 +10606,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "hgC" = (
 /obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /obj/item/reagent_containers/food/drinks/flask/marine{
@@ -10957,7 +10957,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "hsx" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -10965,7 +10965,7 @@
 "hsH" = (
 /obj/item/storage/briefcase,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "hsP" = (
 /obj/structure/platform{
 	dir = 1
@@ -11499,11 +11499,11 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hNx" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hNA" = (
 /obj/structure/table/mainship{
 	dir = 4;
@@ -11542,7 +11542,7 @@
 "hOM" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hOW" = (
 /obj/machinery/computer/security/wooden_tv{
 	desc = "An old TV hooked up to a video cassette recorder, you can even use it to time shift WOW.";
@@ -11614,7 +11614,7 @@
 "hRV" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "hSz" = (
 /obj/machinery/light{
 	dir = 4
@@ -11768,7 +11768,7 @@
 /obj/effect/spawner/random/misc/structure/barrel,
 /obj/machinery/light,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "hWs" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -11826,15 +11826,15 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hXS" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hYa" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "hYu" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 1
@@ -11973,7 +11973,7 @@
 "icv" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "icL" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -12075,7 +12075,7 @@
 "igB" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "igD" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 4
@@ -12137,7 +12137,11 @@
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/engineering/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
+"iig" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "iiu" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = -6;
@@ -12210,7 +12214,7 @@
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/engineering/powercell,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ijV" = (
 /obj/structure/stairs/seamless,
 /obj/effect/ai_node,
@@ -12383,7 +12387,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ipC" = (
 /obj/structure/closet/basketball,
 /turf/open/floor/prison/whitegreenfull2,
@@ -12524,7 +12528,7 @@
 "ivx" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iwh" = (
 /obj/structure/platform,
 /turf/closed/wall,
@@ -12737,7 +12741,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iDC" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/prison/sterilewhite/full,
@@ -12746,6 +12750,11 @@
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
+"iDI" = (
+/obj/structure/rack/nometal,
+/obj/item/storage/holster/flarepouch/full,
+/turf/open/floor/plating,
+/area/gelida/indoors/c_block/garage)
 "iDL" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -12887,7 +12896,7 @@
 "iJR" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iJT" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison/darkpurple{
@@ -12938,7 +12947,7 @@
 "iLi" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iLp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13077,7 +13086,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iPh" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 1
@@ -13096,7 +13105,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "iQf" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -13194,7 +13203,7 @@
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "iUh" = (
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "iUl" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -13369,7 +13378,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jaB" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -13403,7 +13412,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jbg" = (
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/prison/whitegreenfull2,
@@ -13437,7 +13446,7 @@
 /obj/effect/spawner/random/food_or_drink/kitchen,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jcI" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -13605,7 +13614,7 @@
 /obj/effect/landmark/start/job/xenomorph,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jkC" = (
 /obj/machinery/optable,
 /turf/open/floor/prison/sterilewhite,
@@ -13714,6 +13723,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/op_centre)
+"jpS" = (
+/obj/structure/stairs/cornerdark/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
+"jpU" = (
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "jpV" = (
 /turf/closed/shuttle/dropship2/walltwo/alt,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
@@ -13773,7 +13794,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jqL" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -13795,7 +13816,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jrs" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/blue/plate{
@@ -13879,7 +13900,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "jue" = (
 /obj/structure/platform{
 	dir = 6
@@ -14039,7 +14060,7 @@
 "jAG" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jAU" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -14092,7 +14113,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jDy" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -14115,7 +14136,7 @@
 "jDC" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jEw" = (
 /obj/machinery/light,
 /turf/open/floor/prison/darkred/full,
@@ -14265,15 +14286,15 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jKW" = (
 /obj/effect/turf_decal/tile/full/black,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jLe" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plating,
-/area/gelida/outdoors/rock)
+/area/gelida/indoors/a_block/corpo)
 "jLi" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -14309,7 +14330,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jMm" = (
 /obj/structure/platform{
 	dir = 8
@@ -14379,7 +14400,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jNG" = (
 /obj/effect/spawner/random/misc/structure/curtain,
 /turf/open/floor/prison/whitepurple/full{
@@ -14461,7 +14482,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "jQe" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 4;
@@ -14683,13 +14704,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
-"jUy" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/landing_zone_1)
+/area/gelida/powergen)
 "jUR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -14981,9 +14996,6 @@
 "kgP" = (
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
-"kgS" = (
-/turf/closed/wall,
-/area/gelida/outdoors/rock)
 "kgY" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -14996,7 +15008,7 @@
 "khi" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "khq" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -15032,7 +15044,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kiD" = (
 /obj/item/tool/screwdriver{
 	pixel_x = -8;
@@ -15084,7 +15096,7 @@
 "kjv" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kjB" = (
 /obj/machinery/light{
 	dir = 8
@@ -15122,6 +15134,9 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
+"kmW" = (
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "knc" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -15262,7 +15277,7 @@
 "krB" = (
 /obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "krK" = (
 /obj/structure/fence,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -15298,13 +15313,6 @@
 	},
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
-"ksO" = (
-/obj/structure/window/framed/colony,
-/obj/machinery/door/poddoor/mainship{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "ksQ" = (
 /turf/open/floor/prison/blue{
 	dir = 5
@@ -15336,7 +15344,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "kuI" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -15355,10 +15363,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
-"kvM" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/west_caves)
 "kwo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -15378,7 +15382,7 @@
 	},
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kwR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -15428,6 +15432,12 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_street)
+"kym" = (
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "kyO" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/door_control{
@@ -15571,7 +15581,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kEc" = (
 /obj/structure/table/mainship,
 /obj/machinery/door_control{
@@ -15594,7 +15604,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kEn" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -15926,13 +15936,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/landing_zone_1)
-"kPF" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
 "kPS" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -16043,7 +16046,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "kUF" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -16201,7 +16204,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "laK" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -16212,6 +16215,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
+"laV" = (
+/obj/structure/largecrate,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/prison/plate,
+/area/gelida/landing_zone_2)
 "laW" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
@@ -16226,7 +16234,7 @@
 "lby" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lbJ" = (
 /obj/structure/bed/chair/sofa/corsat/right,
 /turf/open/floor/prison,
@@ -16234,7 +16242,7 @@
 "lcg" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lcj" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -16547,7 +16555,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "lnc" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/effect/ai_node,
@@ -16591,14 +16599,14 @@
 	},
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lnC" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lnR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -16615,7 +16623,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "loB" = (
 /obj/item/stack/sheet/wood/large_stack,
 /obj/machinery/power/apc/drained,
@@ -16927,7 +16935,7 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/spawner/random/engineering/powercell,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lAW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17055,7 +17063,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lEy" = (
 /obj/structure/inflatable/wall,
 /turf/open/floor/prison,
@@ -17069,7 +17077,7 @@
 "lEZ" = (
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lFj" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -17098,7 +17106,7 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lGx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -17109,7 +17117,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lHx" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -17161,7 +17169,7 @@
 "lID" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lIG" = (
 /obj/machinery/light{
 	dir = 4
@@ -17330,7 +17338,7 @@
 /obj/machinery/power/geothermal,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lMU" = (
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
@@ -17376,10 +17384,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
-"lPb" = (
-/obj/structure/cable,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "lPd" = (
 /obj/structure/cargo_container{
 	dir = 4
@@ -17439,7 +17443,7 @@
 /obj/machinery/constructable_frame/state_2,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lRN" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -17531,7 +17535,7 @@
 "lUi" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "lVd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17576,7 +17580,7 @@
 "lVD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lWb" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 6
@@ -17632,7 +17636,7 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "lXT" = (
 /obj/structure/dispenser/oxygen,
 /turf/open/floor/prison/darkbrown/full,
@@ -17648,12 +17652,6 @@
 "lYx" = (
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"lYA" = (
-/obj/effect/turf_decal/warning_stripes/box,
-/obj/structure/rack,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/central_streets)
 "lYK" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
@@ -17798,7 +17796,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mec" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -17861,6 +17859,12 @@
 /obj/structure/table/mainship,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
+"mgH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "mgP" = (
 /obj/structure/closet/crate,
 /turf/open/floor/prison/plate,
@@ -18023,7 +18027,7 @@
 /obj/structure/prop/mainship/brokengen,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mls" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
@@ -18081,7 +18085,7 @@
 /obj/effect/spawner/random/engineering/metal,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mmF" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -18216,7 +18220,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mqu" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/south_east_street)
@@ -18370,7 +18374,7 @@
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mvy" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -18520,7 +18524,7 @@
 /obj/effect/landmark/start/job/xenomorph,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mAo" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
@@ -18561,7 +18565,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mCI" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/darkbrown/full,
@@ -18730,7 +18734,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mJP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -18753,7 +18757,7 @@
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mKq" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -18826,7 +18830,7 @@
 "mMd" = (
 /obj/machinery/constructable_frame/state_2,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mMy" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -18901,6 +18905,12 @@
 /obj/item/shard,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
+"mPq" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "mPv" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -18940,7 +18950,7 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "mQy" = (
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
@@ -19017,7 +19027,7 @@
 "mSM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "mTc" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -19134,6 +19144,12 @@
 	dir = 8
 	},
 /area/gelida/outdoors/colony_streets/north_street)
+"mXM" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/lone_buildings/storage_blocks)
 "mXU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -19230,7 +19246,7 @@
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ncQ" = (
 /turf/closed/shuttle/dropship2/enginefive{
 	dir = 1
@@ -19286,7 +19302,7 @@
 /obj/effect/landmark/start/job/xenomorph,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ndU" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -19382,7 +19398,7 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ngu" = (
 /obj/structure/stairs/seamless,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -19483,6 +19499,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
+"njN" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/indoors/c_block/mining)
 "njW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19524,7 +19544,7 @@
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nkO" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform,
@@ -19543,10 +19563,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
-"nlQ" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "nma" = (
 /obj/structure/flora/ausbushes/sunnybush{
 	pixel_y = 13
@@ -19598,7 +19614,7 @@
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/engineering/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nnR" = (
 /turf/closed/wall/r_wall{
 	dir = 9
@@ -19648,16 +19664,15 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
+"nqS" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "nqZ" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
-"nrb" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "nri" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -19778,7 +19793,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ntZ" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_22";
@@ -19905,7 +19920,7 @@
 "nyC" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nyZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19965,7 +19980,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nBP" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/plating,
@@ -20034,12 +20049,12 @@
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nEw" = (
 /obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nEL" = (
 /obj/effect/spawner/random/misc/structure/curtain/medical,
 /turf/open/floor/prison/sterilewhite/full,
@@ -20079,7 +20094,7 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/machinery/light,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nGk" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -20183,7 +20198,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nJL" = (
 /obj/item/ammo_magazine/rifle/tx11{
 	current_rounds = 0;
@@ -20289,7 +20304,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nMr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison/whitepurple/full{
@@ -20462,7 +20477,7 @@
 /obj/structure/table/mainship,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "nRP" = (
 /obj/structure/flora/ausbushes/sunnybush{
 	pixel_y = 10
@@ -20554,6 +20569,12 @@
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/east_central_street)
+"nUy" = (
+/obj/effect/turf_decal/warning_stripes/box,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/prison,
+/area/gelida/outdoors/colony_streets/central_streets)
 "nUK" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -20897,12 +20918,12 @@
 "ogl" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ogw" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ogJ" = (
 /obj/structure/dropship_piece/two/engine/leftbottom,
 /turf/closed/shuttle/dropship2/engineone{
@@ -20960,7 +20981,7 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ojm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -21050,7 +21071,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "omq" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -21158,6 +21179,10 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/landing_zone_forecon/landing_zone_4)
+"osr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "osB" = (
 /obj/machinery/light,
 /turf/open/floor/prison/sterilewhite/full,
@@ -21179,16 +21204,11 @@
 /obj/machinery/door/airlock/dropship_hatch/left/two,
 /turf/open/shuttle/dropship/three,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
-"otd" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/west_caves)
 "otr" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/turf_decal/tile/full/black,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "ott" = (
 /obj/structure/bed/alien,
 /obj/item/pipe{
@@ -21312,7 +21332,7 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oyd" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -21403,7 +21423,7 @@
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oBw" = (
 /obj/machinery/light{
 	dir = 4
@@ -21422,13 +21442,6 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/admin)
-"oBM" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
 "oBR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -21691,7 +21704,7 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oIG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21928,7 +21941,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oRP" = (
 /obj/machinery/light{
 	dir = 1
@@ -22021,7 +22034,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oTW" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison,
@@ -22104,6 +22117,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
+"oXa" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/powergen)
 "oXh" = (
 /obj/structure/table/mainship,
 /obj/structure/flora/pottedplant{
@@ -22123,7 +22143,7 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oXo" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -22206,15 +22226,6 @@
 /obj/structure/largecrate/supply,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/op_centre)
-"oZd" = (
-/obj/machinery/door_control{
-	dir = 1;
-	id = "checkpoint3"
-	},
-/turf/open/floor/prison/whitepurple/full{
-	dir = 4
-	},
-/area/gelida/indoors/a_block/dorms)
 "oZe" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -22244,7 +22255,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "oZU" = (
 /turf/open/floor/prison/whitepurple/full{
 	dir = 4
@@ -22283,7 +22294,7 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pcy" = (
 /obj/machinery/light{
 	dir = 8
@@ -22327,7 +22338,7 @@
 /obj/effect/turf_decal/warning_stripes/thick/corner,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pdJ" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -22379,7 +22390,7 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pfk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -22392,7 +22403,11 @@
 "pfm" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
+"pfn" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/indoors/a_block/fitness)
 "pfs" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -22466,6 +22481,10 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
+"phd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "phj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -22939,7 +22958,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pyY" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = -7;
@@ -22972,7 +22991,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pzF" = (
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/prison/whitepurple/full{
@@ -23058,7 +23077,7 @@
 	name = "SOM exit point 24"
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pBL" = (
 /obj/structure/closet,
 /turf/open/floor/prison/whitepurple/full{
@@ -23196,7 +23215,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pHY" = (
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/landing_zone_2)
@@ -23320,7 +23339,7 @@
 	name = "SOM exit point 23"
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pKE" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -23417,7 +23436,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pOe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23474,12 +23493,9 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
-"pPB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+"pPO" = (
+/turf/closed/wall/r_wall,
+/area/gelida/powergen)
 "pPQ" = (
 /obj/machinery/floodlight/colony{
 	pixel_y = 6
@@ -23649,7 +23665,7 @@
 "pVA" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pVU" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = 4;
@@ -23697,7 +23713,7 @@
 "pXd" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "pXp" = (
 /obj/item/tool/wirecutters,
 /turf/open/floor/prison/blue{
@@ -23800,7 +23816,7 @@
 "qaM" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qaN" = (
 /obj/structure/inflatable/wall,
 /obj/effect/ai_node,
@@ -23838,7 +23854,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qba" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -23917,7 +23933,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qex" = (
 /turf/closed/shuttle/dropship2/corners{
 	dir = 1
@@ -24002,7 +24018,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qhT" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -24020,7 +24036,7 @@
 "qih" = (
 /obj/structure/prop/mainship/gelida/propserver,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qin" = (
 /turf/closed/shuttle/dropship2/finleft,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
@@ -24099,7 +24115,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qlC" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -24121,7 +24137,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qmh" = (
 /obj/machinery/light{
 	dir = 4
@@ -24156,7 +24172,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qmF" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -24215,7 +24231,7 @@
 /obj/structure/stairs/seamless,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qpm" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -24272,7 +24288,6 @@
 	},
 /area/gelida/indoors/a_block/executive)
 "qrZ" = (
-/obj/structure/nuke_disk_candidate,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "qsS" = (
@@ -24348,7 +24363,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qwd" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -24381,6 +24396,12 @@
 	dir = 8
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
+"qxa" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "qxc" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -24401,7 +24422,7 @@
 /obj/structure/stairs/seamless,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "qxs" = (
 /obj/structure/bookcase{
 	pixel_x = 2;
@@ -25287,13 +25308,6 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"rbw" = (
-/obj/structure/cable,
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/landing_zone_1)
 "rbD" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/storage/fancy/cigarettes/kpack{
@@ -25342,10 +25356,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
-"rcM" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
-/turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
 "rcO" = (
 /obj/structure/bed,
 /obj/structure/bed{
@@ -25424,7 +25434,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "rez" = (
 /obj/effect/spawner/gibspawner/robot,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -25596,7 +25606,7 @@
 	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "riu" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2
@@ -25847,12 +25857,6 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/fitness)
-"rpe" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/indoors/lone_buildings/storage_blocks)
 "rpG" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/tile/yellow/patch,
@@ -26347,6 +26351,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/central_streets)
+"rJo" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "rKr" = (
 /obj/structure/table/mainship,
 /obj/item/clothing/gloves/black,
@@ -26470,7 +26478,7 @@
 "rNs" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
-/area/gelida/outdoors/rock)
+/area/gelida/indoors/a_block/corpo)
 "rNw" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -26722,6 +26730,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
+"rXv" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/powergen)
 "rXK" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -26852,10 +26867,6 @@
 	dir = 10
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
-"sdt" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "sdy" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -26999,7 +27010,7 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "sjb" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
@@ -27462,7 +27473,14 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plating,
-/area/gelida/outdoors/rock)
+/area/gelida/indoors/a_block/corpo)
+"sxL" = (
+/obj/structure/cable,
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
 "sxS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/light{
@@ -28139,7 +28157,7 @@
 	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "sUO" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -28195,7 +28213,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "sWh" = (
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "sWl" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -28545,6 +28563,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
+"tiQ" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "tjd" = (
 /obj/item/shard,
 /obj/effect/ai_node,
@@ -28756,8 +28778,10 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "tqh" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/outdoors/rock)
+/area/gelida/powergen)
 "tqi" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_west_street)
@@ -28925,6 +28949,9 @@
 /obj/structure/table/fancywoodentable,
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
+"txG" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/landing_zone_1)
 "txH" = (
 /turf/closed/wall,
 /area/gelida/indoors/a_block/corpo)
@@ -28963,13 +28990,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
-"tyV" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
 "tyY" = (
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/decal/cleanable/blood/oil,
@@ -29726,6 +29746,10 @@
 "uew" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
+"uez" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "ueD" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/whitepurple/full{
@@ -30053,7 +30077,7 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "upW" = (
 /turf/open/floor/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "urz" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/prison,
@@ -30315,11 +30339,6 @@
 "uDM" = (
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"uEc" = (
-/obj/effect/turf_decal/warning_stripes/box,
-/obj/effect/spawner/random/misc/structure/supplycrate,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/central_streets)
 "uEh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -30330,6 +30349,13 @@
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
+"uEr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/indoors/c_block/mining)
 "uEs" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/structure/cable,
@@ -30500,10 +30526,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "uIz" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "uIC" = (
 /obj/structure/platform_decoration{
 	dir = 10
@@ -30530,6 +30557,9 @@
 	dir = 4
 	},
 /area/gelida/landing_zone_forecon/landing_zone_4)
+"uJH" = (
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "uJO" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -30627,11 +30657,6 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/hallway)
-"uNr" = (
-/obj/structure/rack/nometal,
-/obj/item/storage/holster/flarepouch/full,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "uNy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
@@ -30718,6 +30743,12 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
+"uRt" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/w_rockies)
 "uRG" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -30905,7 +30936,7 @@
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "uXf" = (
 /turf/open/floor/prison/cellstripe,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "uXi" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -31233,11 +31264,13 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
 "vih" = (
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/turf/open/floor/mainship/black/full,
+/area/gelida/powergen)
 "vin" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -31304,7 +31337,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "vlh" = (
 /obj/machinery/shower{
 	dir = 1
@@ -31867,13 +31900,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "vFl" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/powergen)
 "vFn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -32052,6 +32083,13 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
+"vMo" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/powergen)
 "vMO" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 5
@@ -32140,10 +32178,10 @@
 /area/gelida/indoors/a_block/fitness)
 "vQe" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/area/gelida/powergen)
 "vQm" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -32475,11 +32513,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "wcn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "wcB" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -32587,10 +32624,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/b_block/bridge)
 "whv" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/powergen)
 "whD" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
@@ -32607,10 +32645,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"wii" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/a_block/fitness)
 "wiC" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -33278,12 +33312,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"wHN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "wHY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -33801,13 +33829,6 @@
 /obj/structure/platform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
-"xdv" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "xef" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -34032,7 +34053,11 @@
 /obj/structure/table/mainship,
 /obj/item/clothing/head/collectable/tophat,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
+"xot" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "xow" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -34348,6 +34373,15 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/landing_zone_2)
+"xBa" = (
+/obj/machinery/door_control{
+	dir = 1;
+	id = "checkpoint3"
+	},
+/turf/open/floor/prison/whitepurple/full{
+	dir = 4
+	},
+/area/gelida/indoors/a_block/dorms)
 "xBf" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/platform{
@@ -34772,6 +34806,13 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
+"xNK" = (
+/obj/structure/prop/mainship/gelida/lightstick{
+	pixel_x = 11;
+	pixel_y = 25
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "xNL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -35145,12 +35186,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/fitness)
-"xYH" = (
-/obj/structure/prop/vehicle/truck/destructible{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "xYQ" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
@@ -35181,6 +35216,12 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
+"yae" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
 "yan" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/shower{
@@ -35385,7 +35426,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "yiB" = (
 /turf/closed/wall,
-/area/gelida/caves/west_caves)
+/area/gelida/cavestructuretwo)
 "yiI" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/effect/spawner/gibspawner/xeno,
@@ -36816,7 +36857,7 @@ ndb
 ndb
 ndb
 ndb
-dug
+uRt
 nsK
 "}
 (7,1,1) = {"
@@ -37496,9 +37537,9 @@ iUh
 cPM
 upW
 upW
-eqE
+aPQ
 upW
-ckC
+kmW
 uXf
 iUh
 sUt
@@ -37721,7 +37762,7 @@ mSM
 upW
 glN
 aUs
-ckC
+kmW
 iUh
 jua
 ckC
@@ -38385,8 +38426,8 @@ cPM
 upW
 eEw
 aPS
-ckC
-gbt
+kmW
+xot
 uXf
 iUh
 sUt
@@ -38603,13 +38644,13 @@ cmF
 cmF
 bem
 iUh
-ckC
+kmW
 upW
 eOl
 gqh
 mSM
 res
-ckC
+kmW
 iUh
 sUt
 cmF
@@ -38824,7 +38865,7 @@ cmF
 cmF
 cmF
 bjn
-ckC
+kmW
 aIJ
 cZX
 upW
@@ -39050,7 +39091,7 @@ iUh
 iUh
 res
 cZX
-ckC
+kmW
 upW
 mSM
 geP
@@ -39949,12 +39990,12 @@ cmF
 cmF
 cmF
 xXi
-otd
+nqS
 xXi
 xXi
 xXi
 xXi
-otd
+nqS
 xXi
 xXi
 cmF
@@ -40383,7 +40424,7 @@ res
 mSM
 fwg
 upW
-ckC
+kmW
 upW
 upW
 sWh
@@ -40619,7 +40660,7 @@ cmF
 cmF
 cmF
 cmF
-kvM
+tiQ
 cmF
 cmF
 xXi
@@ -40737,7 +40778,7 @@ cZq
 hoS
 vaN
 vaN
-gub
+cCQ
 kcN
 kcN
 kcN
@@ -41044,12 +41085,12 @@ xIt
 apd
 apA
 bAh
-ckC
-ckC
+kmW
+kmW
 eez
 eZB
-jBU
-ckC
+osr
+kmW
 bAh
 awQ
 apd
@@ -41184,7 +41225,7 @@ uhx
 uhx
 gMH
 uhx
-sdt
+hdI
 uhx
 uhx
 uhx
@@ -41263,7 +41304,7 @@ nsK
 cgS
 xIt
 xIt
-ckC
+kmW
 upW
 upW
 upW
@@ -41271,7 +41312,7 @@ dgr
 upW
 fwg
 bFN
-ckC
+kmW
 upW
 bFN
 upW
@@ -41409,7 +41450,7 @@ rzM
 rzM
 rzM
 ker
-cof
+qxa
 rqw
 jOV
 kdQ
@@ -41489,7 +41530,7 @@ atX
 axk
 bLc
 bXz
-ckC
+kmW
 upW
 fCu
 gum
@@ -41503,8 +41544,8 @@ gbt
 ckC
 wpv
 xXi
-otd
-otd
+nqS
+nqS
 xXi
 oMk
 xXi
@@ -41621,17 +41662,17 @@ bZn
 bZn
 bZn
 bZn
-sdt
+hdI
 hoS
 vaN
 vaN
 vaN
 kcN
-uEc
-uEc
-lYA
-uEc
-lYA
+fjX
+fjX
+nUy
+fjX
+nUy
 kcN
 ndb
 ndb
@@ -41710,11 +41751,11 @@ yiB
 yiB
 sWh
 bNN
-ckC
+kmW
 aUs
 upW
 eWM
-ckC
+kmW
 upW
 upW
 upW
@@ -41889,9 +41930,9 @@ wDw
 npE
 lBm
 mnD
-gtS
+laV
 aiO
-gfH
+dxi
 xPU
 wOd
 wOd
@@ -41940,7 +41981,7 @@ awQ
 awQ
 dkT
 kuB
-kgS
+yiB
 yiB
 xIt
 cmF
@@ -42155,14 +42196,14 @@ xIt
 yiB
 dhv
 yiB
-kgS
-kgS
-kgS
-kgS
-kgS
-kgS
-kgS
-kgS
+yiB
+yiB
+yiB
+yiB
+yiB
+yiB
+yiB
+yiB
 xIt
 xIt
 cmF
@@ -42332,9 +42373,9 @@ wDw
 npE
 npE
 lBm
-gtS
+laV
 ybl
-rcM
+aTD
 pHY
 qcd
 wOd
@@ -45573,7 +45614,7 @@ yfp
 gJD
 odg
 tkC
-oZd
+xBa
 yfp
 lIA
 oDb
@@ -49046,14 +49087,14 @@ xIt
 vqi
 xIt
 cqM
-ckC
+uJH
 cqM
-ckC
+uJH
 etT
 cqM
 cqM
-ckC
-ckC
+uJH
+uJH
 xIt
 xIt
 vqi
@@ -49268,16 +49309,16 @@ xIt
 vqi
 cqM
 cqM
-ckC
-ckC
+uJH
+uJH
 cqM
-gbt
+eXG
 elo
 mJj
 cqM
-ckC
+uJH
 cqM
-ckC
+uJH
 hXS
 xIt
 xIt
@@ -49499,10 +49540,10 @@ elo
 cqM
 elo
 etT
-ckC
+uJH
 ivx
-jBU
-hCQ
+baf
+pPO
 uGF
 uGF
 uGF
@@ -49715,7 +49756,7 @@ cqM
 khi
 etT
 egm
-gbt
+eXG
 cqM
 elo
 cqM
@@ -49945,8 +49986,8 @@ elo
 cqM
 cqM
 oya
-ckC
-ckC
+uJH
+uJH
 pxr
 gfl
 uGF
@@ -50152,7 +50193,7 @@ xIt
 xIt
 xIt
 xIt
-ckC
+uJH
 hXS
 cqM
 cqM
@@ -50165,7 +50206,7 @@ cqM
 cqM
 cqM
 mJj
-ckC
+uJH
 ivx
 cqM
 xIt
@@ -50201,7 +50242,7 @@ tzc
 sWa
 tXO
 vPO
-wii
+pfn
 sKa
 sKa
 ams
@@ -50379,15 +50420,15 @@ hXS
 gVM
 cqM
 kio
-ckC
-gbt
-ckC
+uJH
+eXG
+uJH
 cqM
-ckC
+uJH
 cqM
-ckC
+uJH
 cqM
-ckC
+uJH
 ivx
 cqM
 cqM
@@ -50596,7 +50637,7 @@ xIt
 xIt
 xIt
 xIt
-hCQ
+pPO
 igB
 ivx
 jAG
@@ -50611,9 +50652,9 @@ igB
 igB
 ojk
 oBs
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
 xIt
 etT
 cqM
@@ -50818,27 +50859,27 @@ xIt
 xIt
 xIt
 xIt
-hCQ
+pPO
 laA
 cqM
-jBU
+baf
 cqM
-ckC
-ckC
-jBU
+uJH
+uJH
+baf
 cqM
-ckC
+uJH
 cqM
-ckC
-ckC
-ckC
-jBU
+uJH
+uJH
+uJH
+baf
 cqM
 icv
-hCQ
+pPO
 laA
 cqM
-ckC
+uJH
 cqM
 xIt
 xIt
@@ -51039,9 +51080,9 @@ xIt
 xIt
 fVm
 xIt
-ckC
-hCQ
-ckC
+uJH
+pPO
+uJH
 iDj
 jDu
 jDu
@@ -51056,9 +51097,9 @@ jUt
 omp
 jDu
 oRO
-ckC
-hCQ
-ckC
+uJH
+pPO
+uJH
 fXJ
 elo
 cqM
@@ -51261,21 +51302,21 @@ uGF
 xIt
 cqM
 elo
-ckC
-hCQ
-ckC
+uJH
+pPO
+uJH
 iJR
 jDC
-vQe
+vFl
 eqT
-vQe
+vFl
 lID
 lID
 lID
 lID
-kPF
+vMo
 ogl
-kPF
+vMo
 oIs
 oTT
 etT
@@ -51483,34 +51524,34 @@ uGF
 cqM
 elo
 bVQ
-ckC
-ckC
-ckC
+uJH
+uJH
+uJH
 iLi
 eqT
-hCQ
+pPO
 kEl
-hCQ
+pPO
 lMM
 mli
 mMd
 lMM
-hCQ
+pPO
 kEl
-hCQ
+pPO
 eqT
 oXj
-ckC
+uJH
 nyC
-ckC
+uJH
 cqM
-ckC
+uJH
 fXJ
 cqM
 cqM
 xIt
-hCQ
-hCQ
+pPO
+pPO
 xIt
 uGF
 uGF
@@ -51707,32 +51748,32 @@ fXJ
 eqE
 gVM
 cqM
-ckC
+uJH
 iOZ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
 oZF
 cqM
-hCQ
+pPO
 pzm
 kDZ
 fXJ
-ckC
+uJH
 elo
-ckC
+uJH
 cqM
 dwS
-ckC
+uJH
 nyC
 uGF
 uGF
@@ -51927,35 +51968,35 @@ cqM
 elo
 cqM
 gAr
-ckC
-hCQ
+uJH
+pPO
 cqM
 iPn
 eqT
-hCQ
+pPO
 kUo
-hCQ
+pPO
 lRq
 lMM
 lMM
 mli
-hCQ
+pPO
 kUo
-hCQ
+pPO
 eqT
 oTT
-ckC
+uJH
 nyC
 dwS
-ckC
+uJH
 cqM
 elo
-ckC
+uJH
 cqM
-ckC
+uJH
 cqM
-jBU
-uzr
+baf
+fPV
 pxr
 gfl
 uGF
@@ -52145,38 +52186,38 @@ gfl
 qzH
 uGF
 uGF
-ckC
+uJH
 dqw
 gaR
 elo
-ckC
-hCQ
+uJH
+pPO
 cqM
 iLi
 eqT
-wcn
+vQe
 lby
-wcn
+vQe
 lVD
 gVM
 lID
 gVM
-wcn
+vQe
 eqT
-wcn
+vQe
 eqT
 oTT
-ckC
-hCQ
+uJH
+pPO
 cqM
 elo
-ckC
-ckC
+uJH
+uJH
 cqM
-hCQ
-hCQ
+pPO
+pPO
 cqM
-ckC
+uJH
 xIt
 xIt
 pxr
@@ -52366,13 +52407,13 @@ uGF
 uGF
 qzH
 bMh
-ckC
+uJH
 dqw
 cqM
 egm
 bVQ
 hYa
-hCQ
+pPO
 loy
 iLi
 jKV
@@ -52389,17 +52430,17 @@ otr
 jKW
 oTT
 icv
-hCQ
-xdv
+pPO
+rXv
 cqM
 elo
 cqM
-hCQ
-hCQ
+pPO
+pPO
 qih
 cqM
 icv
-hCQ
+pPO
 xIt
 xIt
 xIt
@@ -52610,18 +52651,18 @@ jKV
 jKW
 jKW
 oXj
-jBU
-hCQ
+baf
+pPO
 cqM
 cqM
-xIt
+grl
 cqM
 pXd
 qes
 qkR
-ckC
+uJH
 cqM
-ckC
+uJH
 xIt
 xIt
 xIt
@@ -52811,39 +52852,39 @@ gfl
 aEE
 bVQ
 cqM
-ckC
+uJH
 xIt
 xIt
 bdt
 dwS
 nyC
-ckC
+uJH
 jaz
 eqT
-vQe
+vFl
 lby
-vQe
+vFl
 mdA
 lID
 mdA
 lID
-kPF
+vMo
 ogw
-kPF
+vMo
 ogl
 oTT
 dwS
-hCQ
+pPO
 cqM
 cqM
-xIt
-xIt
+grl
+grl
 pXd
 qhP
 qkR
 cqM
-jBU
-jBU
+baf
+baf
 xIt
 xIt
 xIt
@@ -53036,22 +53077,22 @@ cqM
 xIt
 xIt
 xIt
-ckC
-ckC
+uJH
+uJH
 nyC
-ckC
+uJH
 iLi
 eqT
-hCQ
+pPO
 kEl
-hCQ
+pPO
 mli
 lMM
 mli
 lMM
-hCQ
+pPO
 kEl
-hCQ
+pPO
 eqT
 pbF
 cqM
@@ -53064,8 +53105,8 @@ pXd
 qih
 eqT
 cqM
-ckC
-ckC
+uJH
+uJH
 xIt
 xIt
 xIt
@@ -53257,24 +53298,24 @@ gfl
 cqM
 cqM
 xIt
-gbt
+eXG
 cqM
 cqM
-hCQ
-ckC
+pPO
+uJH
 iJR
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
+pPO
 oTT
 dwS
 hNx
@@ -53286,8 +53327,8 @@ bVQ
 etT
 eqT
 dwS
-ckC
-hCQ
+uJH
+pPO
 xIt
 xIt
 xIt
@@ -53482,24 +53523,24 @@ xIt
 xIt
 xIt
 dwS
-hCQ
-ckC
+pPO
+uJH
 jaU
 eqT
-hCQ
+pPO
 kUo
-hCQ
+pPO
 mli
 lMM
 lMM
 mMd
-hCQ
+pPO
 kUo
-hCQ
+pPO
 eqT
 oTT
 cqM
-hCQ
+pPO
 cqM
 cqM
 cqM
@@ -53509,7 +53550,7 @@ cqM
 cqM
 etT
 icv
-hCQ
+pPO
 xIt
 xIt
 xIt
@@ -53704,24 +53745,24 @@ xIt
 xIt
 xIt
 xIt
-hCQ
+pPO
 cqM
 iJR
 eqT
-wcn
+vQe
 eqT
-wcn
+vQe
 gVM
 gVM
 lID
 gVM
-oBM
+oXa
 eqT
-wcn
+vQe
 eqT
 oTT
-ckC
-hCQ
+uJH
+pPO
 pHo
 pBo
 cqM
@@ -53729,9 +53770,9 @@ cqM
 pXd
 qhP
 cqM
-ckC
-ckC
-hCQ
+uJH
+uJH
+pPO
 xIt
 xIt
 xIt
@@ -53926,7 +53967,7 @@ xIt
 xIt
 xIt
 icv
-hCQ
+pPO
 laA
 jcs
 jMk
@@ -53943,17 +53984,17 @@ jMk
 jMk
 pdD
 hYa
-hCQ
+pPO
 laA
 cqM
 cqM
 cqM
-hCQ
-hCQ
-ckC
+pPO
+pPO
+uJH
 cqM
-hCQ
-hCQ
+pPO
+pPO
 xIt
 xIt
 uGF
@@ -54147,15 +54188,15 @@ uGF
 xIt
 xIt
 xIt
-ckC
-hCQ
+uJH
+pPO
 ncH
-njJ
-njJ
+uez
+uez
 kjv
 jNs
-whv
-njJ
+wcn
+uez
 kjv
 kjv
 peR
@@ -54171,10 +54212,10 @@ igB
 igB
 igB
 igB
-hCQ
-ckC
+pPO
+uJH
 cqM
-hCQ
+pPO
 uGF
 xEg
 gfl
@@ -54368,24 +54409,24 @@ uGF
 gfl
 loD
 xIt
-ckC
+uJH
 gZd
-hCQ
+pPO
 cqM
 dwS
-vih
-ckC
+uIz
+uJH
 cqM
 eqE
-gbt
-wHN
-ckC
+eXG
+whv
+uJH
 nBG
-njJ
-njJ
+uez
+uez
 kjv
 kjv
-njJ
+uez
 lEp
 pyS
 kjv
@@ -54395,9 +54436,9 @@ pNV
 nEw
 cqM
 dwS
-ckC
+uJH
 qoT
-ckC
+uJH
 uGF
 uGF
 qzH
@@ -54590,30 +54631,30 @@ uGF
 uGF
 eqE
 cqM
-ckC
-ckC
-hCQ
-hCQ
-hCQ
-hCQ
-hCQ
+uJH
+uJH
+pPO
+pPO
+pPO
+pPO
+pPO
 hNx
 hNx
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
 nEg
-hCQ
+pPO
 hNx
 hNx
-hCQ
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
+pPO
 etT
 cqM
-ckC
-ckC
+uJH
+uJH
 nEw
 kjv
 qlT
@@ -54809,35 +54850,35 @@ uGF
 uGF
 qzH
 gfl
-ckC
+uJH
 cqM
-ckC
+uJH
 cqM
-ckC
-hCQ
+uJH
+pPO
 ihZ
-ckC
-vFl
+uJH
+vih
 cqM
 lcg
 etT
 cqM
-pPB
-jBU
+mgH
+baf
 nEw
-hCQ
+pPO
 cqM
 cqM
 cqM
-ckC
-ckC
+uJH
+uJH
 cqM
 cqM
 cqM
 cqM
 etT
 ivx
-ckC
+uJH
 etT
 gVM
 qxq
@@ -55030,40 +55071,40 @@ xIt
 asP
 gfl
 qzH
-ckC
-ckC
+uJH
+uJH
 eqT
 eqT
 cqM
 gZy
-hCQ
+pPO
 ijG
 elo
-jBU
-ckC
+baf
+uJH
 cqM
 elo
-gbt
+eXG
 cqM
 elo
 nEw
-hCQ
+pPO
 elo
 etT
 cqM
 cqM
 elo
 cqM
-jBU
+baf
 cqM
 cqM
 cqM
 hXS
 cqM
-ckC
-wpv
+uJH
+phd
 qxq
-ckC
+uJH
 gfl
 uGF
 uGF
@@ -55256,7 +55297,7 @@ cqM
 cqM
 dwS
 eqT
-ckC
+uJH
 cqM
 cqM
 dwS
@@ -55269,7 +55310,7 @@ kjv
 mAk
 kjv
 nFV
-hCQ
+pPO
 laA
 elo
 cqM
@@ -55278,11 +55319,11 @@ dwS
 bVQ
 cqM
 dwS
-ckC
+uJH
 cqM
 hXS
-jBU
-ckC
+baf
+uJH
 gVM
 qoT
 uGF
@@ -55481,7 +55522,7 @@ eqT
 cqM
 cqM
 hOM
-ckC
+uJH
 siX
 jQd
 jQd
@@ -55491,21 +55532,21 @@ jQd
 jQd
 nkH
 ivx
-hCQ
+pPO
 cqM
 cqM
 elo
 pfm
 cqM
-ckC
+uJH
 cqM
-ckC
-ckC
-ckC
+uJH
+uJH
+uJH
 hXS
 cqM
-ckC
-ckC
+uJH
+uJH
 xIt
 xIt
 xIt
@@ -55704,13 +55745,13 @@ ogl
 ogl
 ogl
 kjv
-uIz
-gbt
+tqh
+eXG
 krB
-gbt
-ckC
+eXG
+uJH
 mmD
-gbt
+eXG
 nnL
 nJe
 hNx
@@ -55719,13 +55760,13 @@ elo
 cqM
 etT
 cqM
-hCQ
-hCQ
-hCQ
-hCQ
+pPO
+pPO
+pPO
+pPO
 pVA
 igB
-hCQ
+pPO
 xIt
 xIt
 xIt
@@ -55924,15 +55965,15 @@ cqM
 eqT
 cqM
 cqM
-ckC
+uJH
 dHk
 iJR
-ckC
-ckC
-gbt
+uJH
+uJH
+eXG
 lEZ
-gbt
-gbt
+eXG
+eXG
 ntU
 nLC
 nyC
@@ -55942,12 +55983,12 @@ cqM
 cqM
 dwS
 cqM
-ckC
-hCQ
+uJH
+pPO
 cqM
-ckC
+uJH
 igB
-hCQ
+pPO
 xIt
 xIt
 xIt
@@ -56161,11 +56202,11 @@ hNx
 cqM
 bVQ
 elo
-ckC
+uJH
 cqM
 etT
 cqM
-hCQ
+pPO
 cqM
 etT
 igB
@@ -56367,28 +56408,28 @@ xIt
 eum
 cqM
 cqM
-ckC
-hCQ
+uJH
+pPO
 cqM
 etT
 cqM
-ckC
+uJH
 cqM
 elo
-ckC
+uJH
 etT
 egm
 ivx
-hCQ
+pPO
 cqM
 etT
 cqM
-ckC
+uJH
 cqM
 elo
 cqM
-hCQ
-hCQ
+pPO
+pPO
 pVA
 igB
 xIt
@@ -56589,28 +56630,28 @@ xIt
 xIt
 eqT
 cqM
-ckC
-hCQ
+uJH
+pPO
 eqE
 elo
 egm
 kDZ
-ckC
+uJH
 eqE
 cqM
 elo
 cqM
 ivx
-hCQ
-aNl
+pPO
+avl
 cqM
-ckC
+uJH
 gVM
 cqM
-ckC
-ckC
-hCQ
-hCQ
+uJH
+uJH
+pPO
+pPO
 cqM
 igB
 xIt
@@ -56653,8 +56694,8 @@ dzL
 tNN
 dzL
 aQm
-tqh
-tqh
+kJL
+kJL
 ugJ
 sYg
 bBz
@@ -56810,11 +56851,11 @@ uGF
 xIt
 xIt
 xIt
-ckC
+uJH
 cqM
-hCQ
+pPO
 cqM
-ckC
+uJH
 gVM
 gVM
 cqM
@@ -56823,16 +56864,16 @@ cqM
 mCj
 mMd
 nRL
-hCQ
-ckC
+pPO
+uJH
 cqM
-ckC
-ckC
+uJH
+uJH
 gVM
-ckC
-ckC
-hCQ
-hCQ
+uJH
+uJH
+pPO
+pPO
 pVA
 igB
 xIt
@@ -57038,8 +57079,8 @@ xIt
 xIt
 xIt
 xIt
-ckC
-hCQ
+uJH
+pPO
 xIt
 xIt
 xIt
@@ -57051,7 +57092,7 @@ igB
 hXS
 igB
 hXS
-xXi
+iig
 igB
 igB
 vqi
@@ -57268,14 +57309,14 @@ xIt
 xIt
 xIt
 uGF
-ckC
-ckC
+uJH
+uJH
 gfl
-ckC
-ckC
+uJH
+uJH
 uGF
-ckC
-hCQ
+uJH
+pPO
 xIt
 xIt
 xIt
@@ -61439,7 +61480,7 @@ pPX
 pPX
 pPX
 pPX
-lPb
+fpe
 fgn
 svr
 vUI
@@ -61883,7 +61924,7 @@ gCO
 dbK
 dbK
 rgs
-tyV
+uEr
 oFt
 szN
 bJY
@@ -62104,7 +62145,7 @@ fgn
 jSP
 rlA
 fgn
-aQr
+njN
 fgn
 xEZ
 wPx
@@ -62543,7 +62584,7 @@ xEZ
 xEZ
 xEZ
 xEZ
-gMw
+eHa
 xEZ
 xEZ
 kci
@@ -63874,10 +63915,10 @@ ndb
 ndb
 ndb
 dYh
-jUy
-rbw
-jUy
-avv
+yae
+sxL
+yae
+jpS
 ndb
 ndb
 ndb
@@ -64095,11 +64136,11 @@ ndb
 ndb
 ndb
 ndb
-fHK
-fHK
+txG
+txG
 hcL
-fHK
-fHK
+txG
+txG
 ndb
 ndb
 ndb
@@ -64315,13 +64356,13 @@ eWY
 mDs
 ndb
 ndb
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
 hcL
-fHK
-fHK
+txG
+txG
 ndb
 ndb
 ndb
@@ -64537,10 +64578,10 @@ eWY
 mDs
 ndb
 ndb
-fHK
-fHK
+txG
+txG
 xmm
-fHK
+txG
 nKB
 xmm
 xmm
@@ -64761,7 +64802,7 @@ eWY
 eWY
 eWY
 eWY
-fHK
+txG
 xmm
 nKB
 nRW
@@ -64779,8 +64820,8 @@ ndb
 ndb
 ndb
 ndb
-fHK
-fHK
+txG
+txG
 jDt
 ndb
 ndb
@@ -64991,19 +65032,19 @@ xmm
 xmm
 nvl
 ndb
-fHK
+txG
 ndb
 ndb
 ndb
-fHK
+txG
 ndb
-fHK
+txG
 ndb
-fHK
-fHK
+txG
+txG
 xmm
 xmm
-fHK
+txG
 ndb
 ndb
 ndb
@@ -65203,31 +65244,31 @@ eWY
 mDs
 eWY
 eWY
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 hcL
-fHK
-fHK
-fHK
+txG
+txG
+txG
 xmm
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
 xmm
-fHK
-fHK
-fHK
-xmm
-xmm
+txG
+txG
+txG
 xmm
 xmm
 xmm
-fHK
-fHK
-fHK
+xmm
+xmm
+txG
+txG
+txG
 ndb
 ndb
 ndb
@@ -65424,18 +65465,18 @@ eWY
 eWY
 mDs
 eWY
-fHK
-fHK
+txG
+txG
 xmm
 xmm
-fHK
+txG
 hcL
-fHK
+txG
 jDt
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
 xmm
 xmm
 xmm
@@ -65449,7 +65490,7 @@ xmm
 xmm
 xmm
 xmm
-fHK
+txG
 ndb
 ndb
 ndb
@@ -65646,17 +65687,17 @@ eWY
 eWY
 mDs
 eWY
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
 wGi
 jDt
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 xmm
@@ -65671,7 +65712,7 @@ xmm
 xmm
 xmm
 xmm
-fHK
+txG
 ndb
 ndb
 ndb
@@ -65868,9 +65909,9 @@ eWY
 eWY
 mDs
 eWY
-fHK
-fHK
-fHK
+txG
+txG
+txG
 jDt
 jDt
 wGi
@@ -65878,7 +65919,7 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 xmm
 xmm
 xmm
@@ -66098,9 +66139,9 @@ jDt
 bGu
 jDt
 jDt
-bzz
+xNK
 jDt
-fHK
+txG
 xmm
 xmm
 xmm
@@ -66115,7 +66156,7 @@ xmm
 xmm
 xmm
 xmm
-fHK
+txG
 ndb
 ndb
 ndb
@@ -66318,12 +66359,12 @@ jDt
 jDt
 jDt
 tVR
-bdE
-bdE
+jpU
+jpU
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 xmm
@@ -66333,7 +66374,7 @@ xmm
 xmm
 xmm
 xmm
-fHK
+txG
 xmm
 xmm
 xmm
@@ -66544,8 +66585,8 @@ jDt
 jDt
 jDt
 pcI
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 xmm
@@ -66553,13 +66594,13 @@ xmm
 xmm
 xmm
 xmm
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
+txG
+txG
 ndb
 ndb
 ndb
@@ -66758,30 +66799,30 @@ rIi
 ndb
 ndb
 jDt
-fHK
-fHK
-fHK
+txG
+txG
+txG
 wGi
 jDt
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 xmm
 xmm
 xmm
 xmm
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
+txG
+txG
+txG
+txG
 ndb
 ndb
 ndb
@@ -66979,24 +67020,24 @@ eWY
 rIi
 ndb
 ndb
-fHK
-fHK
+txG
+txG
 xmm
-fHK
+txG
 hcL
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 bGr
 bGr
 bGr
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
 jDt
 jDt
 jDt
@@ -67201,20 +67242,20 @@ eWY
 rIi
 ndb
 ndb
-fHK
-fHK
+txG
+txG
 xmm
-fHK
+txG
 wGi
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 cKR
 xmm
-fHK
+txG
 jDt
 jDt
 jDt
@@ -67425,7 +67466,7 @@ ndb
 xmm
 xmm
 nDB
-fHK
+txG
 jDt
 wGi
 wGi
@@ -67435,8 +67476,8 @@ nKB
 nKB
 nKB
 nKB
-fHK
-fHK
+txG
+txG
 jDt
 jDt
 jDt
@@ -67644,20 +67685,20 @@ eWY
 eWY
 rIi
 ndb
-fHK
-fHK
-fHK
+txG
+txG
+txG
 jDt
 jDt
 jDt
 jDt
 jDt
 jDt
-fHK
+txG
 xmm
-fHK
+txG
 hcL
-fHK
+txG
 jDt
 jDt
 jDt
@@ -67866,27 +67907,27 @@ eWY
 ndb
 rIi
 ndb
-fHK
+txG
 jDt
 jDt
 jDt
 jDt
 jDt
 jDt
-fHK
-fHK
-fHK
+txG
+txG
+txG
 xmm
-fHK
+txG
 wGi
 pcI
 jDt
 jDt
 jDt
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
 pcI
 jDt
 jDt
@@ -68092,11 +68133,11 @@ jDt
 jDt
 jDt
 pcI
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
 nvl
 iHW
 rmn
@@ -68105,20 +68146,20 @@ rmn
 vsX
 jDt
 nLz
-fHK
-fHK
+txG
+txG
 cuW
 cuW
-fHK
+txG
 jDt
 jDt
 jDt
 jDt
 jDt
-bzz
+xNK
 jDt
 ndb
-rpe
+mXM
 nsK
 "}
 (148,1,1) = {"
@@ -68312,8 +68353,8 @@ rIi
 ndb
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 xmm
 xmm
 nDB
@@ -68328,9 +68369,9 @@ oVE
 jDt
 jDt
 jDt
-fHK
-fHK
-fHK
+txG
+txG
+txG
 jDt
 jDt
 jwF
@@ -68533,11 +68574,11 @@ eWY
 ngv
 jDt
 jDt
-fHK
-fHK
-fHK
+txG
+txG
+txG
 xmm
-fHK
+txG
 jDt
 jDt
 fwH
@@ -68549,7 +68590,7 @@ jhS
 jhS
 hey
 xBY
-nlQ
+rJo
 jDt
 jDt
 jDt
@@ -68755,7 +68796,7 @@ eWY
 ngv
 jDt
 jDt
-fHK
+txG
 xmm
 xmm
 jDt
@@ -68976,7 +69017,7 @@ eWY
 eWY
 ngv
 jDt
-fHK
+txG
 xmm
 xmm
 pcI
@@ -68995,7 +69036,7 @@ nkm
 eXl
 xAe
 xTr
-nrb
+kym
 jDt
 pcI
 jDt
@@ -69219,7 +69260,7 @@ mWd
 gCK
 mAF
 dci
-nrb
+kym
 jDt
 jDt
 jDt
@@ -69443,7 +69484,7 @@ mWd
 gCK
 fpy
 dci
-nrb
+kym
 jDt
 jDt
 jDt
@@ -69666,7 +69707,7 @@ oLu
 oLu
 qxM
 dci
-nrb
+kym
 jDt
 jDt
 jDt
@@ -69892,7 +69933,7 @@ hey
 jDt
 jDt
 jDt
-fHK
+txG
 ndb
 rIi
 nsK
@@ -70113,8 +70154,8 @@ pUt
 gCK
 uUq
 jDt
-fHK
-fHK
+txG
+txG
 ndb
 rIi
 nsK
@@ -70336,7 +70377,7 @@ gCK
 kDw
 jDt
 jDt
-fHK
+txG
 ndb
 rIi
 nsK
@@ -70919,7 +70960,7 @@ jZM
 jIb
 gKW
 hjw
-uNr
+iDI
 mrh
 mrh
 hWR
@@ -71162,7 +71203,7 @@ bdf
 ekG
 cJz
 ekG
-ksO
+fng
 mqu
 uHE
 nzi
@@ -71384,7 +71425,7 @@ mqX
 wVG
 moh
 cJz
-ksO
+fng
 mqu
 cnw
 jum
@@ -71606,7 +71647,7 @@ mhK
 nDG
 bMU
 ybe
-ksO
+fng
 mqu
 bvQ
 epv
@@ -72232,8 +72273,8 @@ tyz
 tyz
 tyz
 pPZ
-xYH
-eyQ
+cei
+mPq
 eux
 bBV
 jIb
@@ -72334,7 +72375,7 @@ kVt
 jDt
 jDt
 jDt
-fHK
+txG
 ndb
 rIi
 nsK
@@ -72556,7 +72597,7 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 ndb
 rIi
 nsK
@@ -72749,7 +72790,7 @@ ndb
 ndb
 ndb
 rkR
-fHK
+txG
 jDt
 jDt
 jDt
@@ -72777,7 +72818,7 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 ndb
 ndb
 rIi
@@ -72999,7 +73040,7 @@ jDt
 jDt
 jDt
 pcI
-fHK
+txG
 ndb
 ndb
 rIi
@@ -73195,9 +73236,9 @@ fBC
 fBC
 fBC
 jDt
-fHK
-fHK
-fHK
+txG
+txG
+txG
 jDt
 jDt
 bhm
@@ -73221,7 +73262,7 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 ndb
 ndb
 rIi
@@ -73415,13 +73456,13 @@ ndb
 ndb
 ndb
 rkR
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
+txG
+txG
 jDt
 jDt
 bhm
@@ -73441,7 +73482,7 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 jDt
 xmm
 ndb
@@ -73637,15 +73678,15 @@ ndb
 ndb
 ndb
 rkR
-fHK
+txG
 xmm
 xmm
 xmm
 xmm
 xmm
 xmm
-fHK
-fHK
+txG
+txG
 jDt
 jDt
 bhm
@@ -73658,12 +73699,12 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 jDt
 jDt
 jDt
-fHK
-fHK
+txG
+txG
 ndb
 ndb
 ndb
@@ -73860,16 +73901,16 @@ ndb
 ndb
 ndb
 ndb
-fHK
-fHK
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
+txG
+txG
 xmm
 xmm
-fHK
-fHK
+txG
+txG
 jDt
 jDt
 jDt
@@ -73879,12 +73920,12 @@ jDt
 jDt
 jDt
 jDt
-fHK
+txG
 xmm
-fHK
-fHK
-fHK
-fHK
+txG
+txG
+txG
+txG
 xmm
 ndb
 ndb

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -1144,10 +1144,6 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
 /area/gelida/landing_zone_1)
-"aPQ" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/cavestructuretwo)
 "aPS" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/cleanmarked,
@@ -1455,12 +1451,22 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
+"aYP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "aYW" = (
 /obj/effect/landmark/patrol_point{
 	id = "SOM_13";
 	name = "SOM exit point 13"
 	},
 /turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
+"aZg" = (
+/obj/structure/prop/vehicle/crane/destructible,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "aZi" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -1504,10 +1510,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"baf" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/gelida/powergen)
 "bay" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -3157,6 +3159,10 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/prison,
 /area/gelida/cavestructuretwo)
+"cfP" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "cgn" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -5941,6 +5947,10 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
+"dXQ" = (
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
 "dXY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -7623,10 +7633,6 @@
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
-"eXG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/gelida/powergen)
 "eXT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
@@ -8641,9 +8647,8 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"fPV" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/ice,
+"fPM" = (
+/turf/open/floor/plating,
 /area/gelida/powergen)
 "fQl" = (
 /turf/closed/shuttle/dropship2/enginefive{
@@ -9425,9 +9430,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/cavestructuretwo)
-"grl" = (
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/gelida/powergen)
 "grK" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /obj/effect/landmark/weed_node,
@@ -12138,10 +12140,6 @@
 /obj/effect/spawner/random/engineering/cable,
 /turf/open/floor/plating,
 /area/gelida/powergen)
-"iig" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/powergen)
 "iiu" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = -6;
@@ -12325,6 +12323,10 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
+"ind" = (
+/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
+/area/gelida/outdoors/colony_streets/central_streets)
 "inq" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/tile/dark2,
@@ -12396,6 +12398,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
+"iqm" = (
+/turf/closed/wall/r_wall,
+/area/gelida/powergen)
 "iqP" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -12805,6 +12810,10 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
+"iFR" = (
+/obj/effect/spawner/random/engineering/cable,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
 "iGe" = (
 /obj/machinery/light{
 	dir = 8
@@ -15134,9 +15143,6 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
-"kmW" = (
-/turf/open/floor/plating,
-/area/gelida/cavestructuretwo)
 "knc" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -16970,6 +16976,10 @@
 	dir = 1
 	},
 /area/gelida/landing_zone_2)
+"lBr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "lBy" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/tool{
@@ -17068,6 +17078,10 @@
 /obj/structure/inflatable/wall,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
+"lEI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "lEJ" = (
 /obj/structure/cable,
 /turf/open/floor/prison/green/full{
@@ -20330,6 +20344,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
+"nMT" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/powergen)
 "nNn" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/mainship/stripesquare,
@@ -20703,6 +20721,12 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/admin)
+"nZn" = (
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "nZo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/prop/mainship/gelida/rails{
@@ -21179,10 +21203,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"osr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/gelida/cavestructuretwo)
 "osB" = (
 /obj/machinery/light,
 /turf/open/floor/prison/sterilewhite/full,
@@ -21451,6 +21471,10 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/fitness)
+"oBU" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "oCf" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/prison/whitepurple/full{
@@ -22334,6 +22358,10 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
+"pdh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "pdD" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner,
 /obj/structure/cable,
@@ -22481,10 +22509,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
-"phd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/powergen)
 "phj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -23067,6 +23091,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_east_street)
+"pAK" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "pBj" = (
 /obj/structure/bed/stool,
 /turf/open/floor/prison,
@@ -23406,6 +23434,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
+"pLW" = (
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/gelida/powergen)
 "pMg" = (
 /obj/structure/flora/ausbushes/pointybush{
 	pixel_y = 12
@@ -23493,9 +23524,6 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
-"pPO" = (
-/turf/closed/wall/r_wall,
-/area/gelida/powergen)
 "pPQ" = (
 /obj/machinery/floodlight/colony{
 	pixel_y = 6
@@ -26204,6 +26232,10 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/gelida/indoors/b_block/hydro)
+"rCQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/gelida/powergen)
 "rDm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -28306,6 +28338,9 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
+"sZZ" = (
+/turf/open/floor/plating,
+/area/gelida/cavestructuretwo)
 "tad" = (
 /obj/structure/table/mainship,
 /obj/item/flashlight/lamp{
@@ -29318,6 +29353,12 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
+"tMh" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "tMH" = (
 /turf/closed/shuttle/dropship2/glassfive,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
@@ -29438,6 +29479,10 @@
 /obj/item/weapon/gun/rifle/tx11,
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
+"tRT" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
+/area/gelida/outdoors/colony_streets/central_streets)
 "tRY" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -29502,6 +29547,11 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
+"tUx" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/engineering/mineral,
+/turf/open/floor/prison/plate,
+/area/gelida/indoors/lone_buildings/storage_blocks)
 "tUK" = (
 /obj/machinery/door/airlock/dropship_hatch/right/two,
 /turf/open/shuttle/dropship/three,
@@ -29746,10 +29796,6 @@
 "uew" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"uez" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/powergen)
 "ueD" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/whitepurple/full{
@@ -30557,9 +30603,6 @@
 	dir = 4
 	},
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"uJH" = (
-/turf/open/floor/plating,
-/area/gelida/powergen)
 "uJO" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -34054,10 +34097,6 @@
 /obj/item/clothing/head/collectable/tophat,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/cavestructuretwo)
-"xot" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/gelida/cavestructuretwo)
 "xow" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -37537,9 +37576,9 @@ iUh
 cPM
 upW
 upW
-aPQ
+pAK
 upW
-kmW
+sZZ
 uXf
 iUh
 sUt
@@ -37762,7 +37801,7 @@ mSM
 upW
 glN
 aUs
-kmW
+sZZ
 iUh
 jua
 ckC
@@ -38426,8 +38465,8 @@ cPM
 upW
 eEw
 aPS
-kmW
-xot
+sZZ
+pdh
 uXf
 iUh
 sUt
@@ -38644,13 +38683,13 @@ cmF
 cmF
 bem
 iUh
-kmW
+sZZ
 upW
 eOl
 gqh
 mSM
 res
-kmW
+sZZ
 iUh
 sUt
 cmF
@@ -38865,7 +38904,7 @@ cmF
 cmF
 cmF
 bjn
-kmW
+sZZ
 aIJ
 cZX
 upW
@@ -39091,7 +39130,7 @@ iUh
 iUh
 res
 cZX
-kmW
+sZZ
 upW
 mSM
 geP
@@ -39653,7 +39692,7 @@ rpT
 sgS
 oqj
 sgS
-mgP
+tUx
 xtZ
 bYC
 hoS
@@ -39874,15 +39913,15 @@ bbF
 sgS
 rpT
 jWo
-mgP
-mgP
+tUx
+tUx
 iUc
 bYC
 uhx
 bZn
 bZn
-bZn
-bZn
+tMh
+nZn
 bZn
 bZn
 bZn
@@ -40109,7 +40148,7 @@ rzM
 rzM
 rzM
 uhx
-hoS
+tRT
 vaN
 gzT
 ndb
@@ -40331,7 +40370,7 @@ mSD
 mSD
 omN
 cZq
-hoS
+ind
 vaN
 gGG
 ndb
@@ -40424,7 +40463,7 @@ res
 mSM
 fwg
 upW
-kmW
+sZZ
 upW
 upW
 sWh
@@ -41005,7 +41044,7 @@ gLF
 bZn
 bZn
 bZn
-bZn
+aZg
 bZn
 rqw
 iqP
@@ -41085,12 +41124,12 @@ xIt
 apd
 apA
 bAh
-kmW
-kmW
+sZZ
+sZZ
 eez
 eZB
-osr
-kmW
+aYP
+sZZ
 bAh
 awQ
 apd
@@ -41304,7 +41343,7 @@ nsK
 cgS
 xIt
 xIt
-kmW
+sZZ
 upW
 upW
 upW
@@ -41312,7 +41351,7 @@ dgr
 upW
 fwg
 bFN
-kmW
+sZZ
 upW
 bFN
 upW
@@ -41530,7 +41569,7 @@ atX
 axk
 bLc
 bXz
-kmW
+sZZ
 upW
 fCu
 gum
@@ -41660,7 +41699,7 @@ bZn
 bZn
 bZn
 bZn
-bZn
+nZn
 bZn
 hdI
 hoS
@@ -41751,11 +41790,11 @@ yiB
 yiB
 sWh
 bNN
-kmW
+sZZ
 aUs
 upW
 eWM
-kmW
+sZZ
 upW
 upW
 upW
@@ -42101,13 +42140,13 @@ gVv
 gVv
 rMv
 vaN
+dXQ
 vaN
 vaN
 vaN
 vaN
 vaN
-vaN
-vaN
+iFR
 vaN
 ndb
 ndb
@@ -49087,14 +49126,14 @@ xIt
 vqi
 xIt
 cqM
-uJH
+fPM
 cqM
-uJH
+fPM
 etT
 cqM
 cqM
-uJH
-uJH
+fPM
+fPM
 xIt
 xIt
 vqi
@@ -49309,16 +49348,16 @@ xIt
 vqi
 cqM
 cqM
-uJH
-uJH
+fPM
+fPM
 cqM
-eXG
+rCQ
 elo
 mJj
 cqM
-uJH
+fPM
 cqM
-uJH
+fPM
 hXS
 xIt
 xIt
@@ -49540,10 +49579,10 @@ elo
 cqM
 elo
 etT
-uJH
+fPM
 ivx
-baf
-pPO
+lBr
+iqm
 uGF
 uGF
 uGF
@@ -49756,7 +49795,7 @@ cqM
 khi
 etT
 egm
-eXG
+rCQ
 cqM
 elo
 cqM
@@ -49986,8 +50025,8 @@ elo
 cqM
 cqM
 oya
-uJH
-uJH
+fPM
+fPM
 pxr
 gfl
 uGF
@@ -50193,7 +50232,7 @@ xIt
 xIt
 xIt
 xIt
-uJH
+fPM
 hXS
 cqM
 cqM
@@ -50206,7 +50245,7 @@ cqM
 cqM
 cqM
 mJj
-uJH
+fPM
 ivx
 cqM
 xIt
@@ -50420,15 +50459,15 @@ hXS
 gVM
 cqM
 kio
-uJH
-eXG
-uJH
+fPM
+rCQ
+fPM
 cqM
-uJH
+fPM
 cqM
-uJH
+fPM
 cqM
-uJH
+fPM
 ivx
 cqM
 cqM
@@ -50637,7 +50676,7 @@ xIt
 xIt
 xIt
 xIt
-pPO
+iqm
 igB
 ivx
 jAG
@@ -50652,9 +50691,9 @@ igB
 igB
 ojk
 oBs
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
 xIt
 etT
 cqM
@@ -50859,27 +50898,27 @@ xIt
 xIt
 xIt
 xIt
-pPO
+iqm
 laA
 cqM
-baf
+lBr
 cqM
-uJH
-uJH
-baf
+fPM
+fPM
+lBr
 cqM
-uJH
+fPM
 cqM
-uJH
-uJH
-uJH
-baf
+fPM
+fPM
+fPM
+lBr
 cqM
 icv
-pPO
+iqm
 laA
 cqM
-uJH
+fPM
 cqM
 xIt
 xIt
@@ -51080,9 +51119,9 @@ xIt
 xIt
 fVm
 xIt
-uJH
-pPO
-uJH
+fPM
+iqm
+fPM
 iDj
 jDu
 jDu
@@ -51097,9 +51136,9 @@ jUt
 omp
 jDu
 oRO
-uJH
-pPO
-uJH
+fPM
+iqm
+fPM
 fXJ
 elo
 cqM
@@ -51302,9 +51341,9 @@ uGF
 xIt
 cqM
 elo
-uJH
-pPO
-uJH
+fPM
+iqm
+fPM
 iJR
 jDC
 vFl
@@ -51524,34 +51563,34 @@ uGF
 cqM
 elo
 bVQ
-uJH
-uJH
-uJH
+fPM
+fPM
+fPM
 iLi
 eqT
-pPO
+iqm
 kEl
-pPO
+iqm
 lMM
 mli
 mMd
 lMM
-pPO
+iqm
 kEl
-pPO
+iqm
 eqT
 oXj
-uJH
+fPM
 nyC
-uJH
+fPM
 cqM
-uJH
+fPM
 fXJ
 cqM
 cqM
 xIt
-pPO
-pPO
+iqm
+iqm
 xIt
 uGF
 uGF
@@ -51748,32 +51787,32 @@ fXJ
 eqE
 gVM
 cqM
-uJH
+fPM
 iOZ
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
 oZF
 cqM
-pPO
+iqm
 pzm
 kDZ
 fXJ
-uJH
+fPM
 elo
-uJH
+fPM
 cqM
 dwS
-uJH
+fPM
 nyC
 uGF
 uGF
@@ -51968,35 +52007,35 @@ cqM
 elo
 cqM
 gAr
-uJH
-pPO
+fPM
+iqm
 cqM
 iPn
 eqT
-pPO
+iqm
 kUo
-pPO
+iqm
 lRq
 lMM
 lMM
 mli
-pPO
+iqm
 kUo
-pPO
+iqm
 eqT
 oTT
-uJH
+fPM
 nyC
 dwS
-uJH
+fPM
 cqM
 elo
-uJH
+fPM
 cqM
-uJH
+fPM
 cqM
-baf
-fPV
+lBr
+cfP
 pxr
 gfl
 uGF
@@ -52186,12 +52225,12 @@ gfl
 qzH
 uGF
 uGF
-uJH
+fPM
 dqw
 gaR
 elo
-uJH
-pPO
+fPM
+iqm
 cqM
 iLi
 eqT
@@ -52207,17 +52246,17 @@ eqT
 vQe
 eqT
 oTT
-uJH
-pPO
+fPM
+iqm
 cqM
 elo
-uJH
-uJH
+fPM
+fPM
 cqM
-pPO
-pPO
+iqm
+iqm
 cqM
-uJH
+fPM
 xIt
 xIt
 pxr
@@ -52407,13 +52446,13 @@ uGF
 uGF
 qzH
 bMh
-uJH
+fPM
 dqw
 cqM
 egm
 bVQ
 hYa
-pPO
+iqm
 loy
 iLi
 jKV
@@ -52430,17 +52469,17 @@ otr
 jKW
 oTT
 icv
-pPO
+iqm
 rXv
 cqM
 elo
 cqM
-pPO
-pPO
+iqm
+iqm
 qih
 cqM
 icv
-pPO
+iqm
 xIt
 xIt
 xIt
@@ -52651,18 +52690,18 @@ jKV
 jKW
 jKW
 oXj
-baf
-pPO
+lBr
+iqm
 cqM
 cqM
-grl
+pLW
 cqM
 pXd
 qes
 qkR
-uJH
+fPM
 cqM
-uJH
+fPM
 xIt
 xIt
 xIt
@@ -52852,13 +52891,13 @@ gfl
 aEE
 bVQ
 cqM
-uJH
+fPM
 xIt
 xIt
 bdt
 dwS
 nyC
-uJH
+fPM
 jaz
 eqT
 vFl
@@ -52874,17 +52913,17 @@ vMo
 ogl
 oTT
 dwS
-pPO
+iqm
 cqM
 cqM
-grl
-grl
+pLW
+pLW
 pXd
 qhP
 qkR
 cqM
-baf
-baf
+lBr
+lBr
 xIt
 xIt
 xIt
@@ -53077,22 +53116,22 @@ cqM
 xIt
 xIt
 xIt
-uJH
-uJH
+fPM
+fPM
 nyC
-uJH
+fPM
 iLi
 eqT
-pPO
+iqm
 kEl
-pPO
+iqm
 mli
 lMM
 mli
 lMM
-pPO
+iqm
 kEl
-pPO
+iqm
 eqT
 pbF
 cqM
@@ -53105,8 +53144,8 @@ pXd
 qih
 eqT
 cqM
-uJH
-uJH
+fPM
+fPM
 xIt
 xIt
 xIt
@@ -53298,24 +53337,24 @@ gfl
 cqM
 cqM
 xIt
-eXG
+rCQ
 cqM
 cqM
-pPO
-uJH
+iqm
+fPM
 iJR
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
+iqm
 oTT
 dwS
 hNx
@@ -53327,8 +53366,8 @@ bVQ
 etT
 eqT
 dwS
-uJH
-pPO
+fPM
+iqm
 xIt
 xIt
 xIt
@@ -53523,24 +53562,24 @@ xIt
 xIt
 xIt
 dwS
-pPO
-uJH
+iqm
+fPM
 jaU
 eqT
-pPO
+iqm
 kUo
-pPO
+iqm
 mli
 lMM
 lMM
 mMd
-pPO
+iqm
 kUo
-pPO
+iqm
 eqT
 oTT
 cqM
-pPO
+iqm
 cqM
 cqM
 cqM
@@ -53550,7 +53589,7 @@ cqM
 cqM
 etT
 icv
-pPO
+iqm
 xIt
 xIt
 xIt
@@ -53745,7 +53784,7 @@ xIt
 xIt
 xIt
 xIt
-pPO
+iqm
 cqM
 iJR
 eqT
@@ -53761,8 +53800,8 @@ eqT
 vQe
 eqT
 oTT
-uJH
-pPO
+fPM
+iqm
 pHo
 pBo
 cqM
@@ -53770,9 +53809,9 @@ cqM
 pXd
 qhP
 cqM
-uJH
-uJH
-pPO
+fPM
+fPM
+iqm
 xIt
 xIt
 xIt
@@ -53967,7 +54006,7 @@ xIt
 xIt
 xIt
 icv
-pPO
+iqm
 laA
 jcs
 jMk
@@ -53984,17 +54023,17 @@ jMk
 jMk
 pdD
 hYa
-pPO
+iqm
 laA
 cqM
 cqM
 cqM
-pPO
-pPO
-uJH
+iqm
+iqm
+fPM
 cqM
-pPO
-pPO
+iqm
+iqm
 xIt
 xIt
 uGF
@@ -54188,15 +54227,15 @@ uGF
 xIt
 xIt
 xIt
-uJH
-pPO
+fPM
+iqm
 ncH
-uez
-uez
+oBU
+oBU
 kjv
 jNs
 wcn
-uez
+oBU
 kjv
 kjv
 peR
@@ -54212,10 +54251,10 @@ igB
 igB
 igB
 igB
-pPO
-uJH
+iqm
+fPM
 cqM
-pPO
+iqm
 uGF
 xEg
 gfl
@@ -54409,24 +54448,24 @@ uGF
 gfl
 loD
 xIt
-uJH
+fPM
 gZd
-pPO
+iqm
 cqM
 dwS
 uIz
-uJH
+fPM
 cqM
 eqE
-eXG
+rCQ
 whv
-uJH
+fPM
 nBG
-uez
-uez
+oBU
+oBU
 kjv
 kjv
-uez
+oBU
 lEp
 pyS
 kjv
@@ -54436,9 +54475,9 @@ pNV
 nEw
 cqM
 dwS
-uJH
+fPM
 qoT
-uJH
+fPM
 uGF
 uGF
 qzH
@@ -54631,30 +54670,30 @@ uGF
 uGF
 eqE
 cqM
-uJH
-uJH
-pPO
-pPO
-pPO
-pPO
-pPO
+fPM
+fPM
+iqm
+iqm
+iqm
+iqm
+iqm
 hNx
 hNx
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
 nEg
-pPO
+iqm
 hNx
 hNx
-pPO
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
+iqm
 etT
 cqM
-uJH
-uJH
+fPM
+fPM
 nEw
 kjv
 qlT
@@ -54850,35 +54889,35 @@ uGF
 uGF
 qzH
 gfl
-uJH
+fPM
 cqM
-uJH
+fPM
 cqM
-uJH
-pPO
+fPM
+iqm
 ihZ
-uJH
+fPM
 vih
 cqM
 lcg
 etT
 cqM
 mgH
-baf
+lBr
 nEw
-pPO
+iqm
 cqM
 cqM
 cqM
-uJH
-uJH
+fPM
+fPM
 cqM
 cqM
 cqM
 cqM
 etT
 ivx
-uJH
+fPM
 etT
 gVM
 qxq
@@ -55071,40 +55110,40 @@ xIt
 asP
 gfl
 qzH
-uJH
-uJH
+fPM
+fPM
 eqT
 eqT
 cqM
 gZy
-pPO
+iqm
 ijG
 elo
-baf
-uJH
+lBr
+fPM
 cqM
 elo
-eXG
+rCQ
 cqM
 elo
 nEw
-pPO
+iqm
 elo
 etT
 cqM
 cqM
 elo
 cqM
-baf
+lBr
 cqM
 cqM
 cqM
 hXS
 cqM
-uJH
-phd
+fPM
+lEI
 qxq
-uJH
+fPM
 gfl
 uGF
 uGF
@@ -55297,7 +55336,7 @@ cqM
 cqM
 dwS
 eqT
-uJH
+fPM
 cqM
 cqM
 dwS
@@ -55310,7 +55349,7 @@ kjv
 mAk
 kjv
 nFV
-pPO
+iqm
 laA
 elo
 cqM
@@ -55319,11 +55358,11 @@ dwS
 bVQ
 cqM
 dwS
-uJH
+fPM
 cqM
 hXS
-baf
-uJH
+lBr
+fPM
 gVM
 qoT
 uGF
@@ -55522,7 +55561,7 @@ eqT
 cqM
 cqM
 hOM
-uJH
+fPM
 siX
 jQd
 jQd
@@ -55532,21 +55571,21 @@ jQd
 jQd
 nkH
 ivx
-pPO
+iqm
 cqM
 cqM
 elo
 pfm
 cqM
-uJH
+fPM
 cqM
-uJH
-uJH
-uJH
+fPM
+fPM
+fPM
 hXS
 cqM
-uJH
-uJH
+fPM
+fPM
 xIt
 xIt
 xIt
@@ -55746,12 +55785,12 @@ ogl
 ogl
 kjv
 tqh
-eXG
+rCQ
 krB
-eXG
-uJH
+rCQ
+fPM
 mmD
-eXG
+rCQ
 nnL
 nJe
 hNx
@@ -55760,13 +55799,13 @@ elo
 cqM
 etT
 cqM
-pPO
-pPO
-pPO
-pPO
+iqm
+iqm
+iqm
+iqm
 pVA
 igB
-pPO
+iqm
 xIt
 xIt
 xIt
@@ -55965,15 +56004,15 @@ cqM
 eqT
 cqM
 cqM
-uJH
+fPM
 dHk
 iJR
-uJH
-uJH
-eXG
+fPM
+fPM
+rCQ
 lEZ
-eXG
-eXG
+rCQ
+rCQ
 ntU
 nLC
 nyC
@@ -55983,12 +56022,12 @@ cqM
 cqM
 dwS
 cqM
-uJH
-pPO
+fPM
+iqm
 cqM
-uJH
+fPM
 igB
-pPO
+iqm
 xIt
 xIt
 xIt
@@ -56202,11 +56241,11 @@ hNx
 cqM
 bVQ
 elo
-uJH
+fPM
 cqM
 etT
 cqM
-pPO
+iqm
 cqM
 etT
 igB
@@ -56408,28 +56447,28 @@ xIt
 eum
 cqM
 cqM
-uJH
-pPO
+fPM
+iqm
 cqM
 etT
 cqM
-uJH
+fPM
 cqM
 elo
-uJH
+fPM
 etT
 egm
 ivx
-pPO
+iqm
 cqM
 etT
 cqM
-uJH
+fPM
 cqM
 elo
 cqM
-pPO
-pPO
+iqm
+iqm
 pVA
 igB
 xIt
@@ -56630,28 +56669,28 @@ xIt
 xIt
 eqT
 cqM
-uJH
-pPO
+fPM
+iqm
 eqE
 elo
 egm
 kDZ
-uJH
+fPM
 eqE
 cqM
 elo
 cqM
 ivx
-pPO
+iqm
 avl
 cqM
-uJH
+fPM
 gVM
 cqM
-uJH
-uJH
-pPO
-pPO
+fPM
+fPM
+iqm
+iqm
 cqM
 igB
 xIt
@@ -56851,11 +56890,11 @@ uGF
 xIt
 xIt
 xIt
-uJH
+fPM
 cqM
-pPO
+iqm
 cqM
-uJH
+fPM
 gVM
 gVM
 cqM
@@ -56864,16 +56903,16 @@ cqM
 mCj
 mMd
 nRL
-pPO
-uJH
+iqm
+fPM
 cqM
-uJH
-uJH
+fPM
+fPM
 gVM
-uJH
-uJH
-pPO
-pPO
+fPM
+fPM
+iqm
+iqm
 pVA
 igB
 xIt
@@ -57079,8 +57118,8 @@ xIt
 xIt
 xIt
 xIt
-uJH
-pPO
+fPM
+iqm
 xIt
 xIt
 xIt
@@ -57092,7 +57131,7 @@ igB
 hXS
 igB
 hXS
-iig
+nMT
 igB
 igB
 vqi
@@ -57309,14 +57348,14 @@ xIt
 xIt
 xIt
 uGF
-uJH
-uJH
+fPM
+fPM
 gfl
-uJH
-uJH
+fPM
+fPM
 uGF
-uJH
-pPO
+fPM
+iqm
 xIt
 xIt
 xIt

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -39,13 +39,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
-"aaN" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	pixel_x = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "aaS" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -63,7 +56,7 @@
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "abc" = (
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "abi" = (
 /obj/machinery/light{
 	dir = 8
@@ -133,7 +126,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ada" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -141,10 +134,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_west_street)
-"adq" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "adr" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -221,10 +210,15 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "aeZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/central_caves)
+/obj/item/storage/briefcase{
+	pixel_y = 1
+	},
+/obj/item/storage/briefcase{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "afm" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -273,7 +267,7 @@
 /area/gelida/indoors/a_block/security)
 "aiO" = (
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aiY" = (
 /obj/effect/spawner/random/engineering/wood,
 /obj/machinery/light{
@@ -339,7 +333,7 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "alr" = (
 /turf/open/floor/plating,
 /area/shuttle/drop2/gelida)
@@ -378,7 +372,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall/unmeltable,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "amY" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -404,10 +398,9 @@
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
 "anV" = (
-/obj/structure/table/mainship,
-/obj/item/flashlight/lamp,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "aob" = (
 /obj/structure/platform{
 	dir = 4
@@ -482,9 +475,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "apd" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "apw" = (
 /obj/machinery/light{
@@ -492,16 +484,16 @@
 	},
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "apA" = (
-/obj/structure/largecrate/random/case/small,
-/obj/structure/rack/nometal,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "apC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "apR" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -520,9 +512,10 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "arf" = (
-/obj/structure/fence,
-/turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "arA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
@@ -584,11 +577,11 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "atx" = (
-/obj/item/fuel_cell{
+/obj/effect/spawner/random/engineering/fuelcell{
 	pixel_x = 3;
 	pixel_y = 15
 	},
-/obj/item/fuel_cell{
+/obj/effect/spawner/random/engineering/fuelcell{
 	pixel_x = -10;
 	pixel_y = 18
 	},
@@ -609,8 +602,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "atX" = (
-/turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "atY" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
@@ -667,7 +662,13 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
+"avv" = (
+/obj/structure/stairs/cornerdark/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison,
@@ -716,20 +717,21 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "awQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "awU" = (
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
 "axf" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "axk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/obj/structure/bed/chair/sofa/corsat/verticaltop,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "axl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -743,14 +745,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/fitness)
-"ayb" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "ayp" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -778,7 +772,7 @@
 	},
 /obj/structure/prop/mainship/gelida/propserver,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "azt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -841,11 +835,10 @@
 	},
 /area/gelida/landing_zone_forecon/landing_zone_4)
 "aBZ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "aDi" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/platform_decoration{
@@ -856,7 +849,7 @@
 "aDk" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aDu" = (
 /obj/machinery/photocopier,
 /turf/open/floor/prison/sterilewhite/full,
@@ -873,9 +866,9 @@
 /area/gelida/indoors/a_block/kitchen)
 "aEE" = (
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/w_rockies)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "aEI" = (
 /obj/machinery/light{
 	dir = 4
@@ -962,13 +955,13 @@
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "aHZ" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/spawner/random/machinery/disposal,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "aIf" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aIj" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -982,18 +975,11 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "aIJ" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/c_block/mining)
-"aIW" = (
-/obj/structure/fence,
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cellstripe{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/central_streets)
+/area/gelida/caves/west_caves)
 "aJe" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = -5;
@@ -1102,7 +1088,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aMT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreenfull2,
@@ -1115,16 +1101,21 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
+"aNl" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "aNw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/hallway)
 "aNR" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/structure/bed/chair/sofa/corsat/verticaltop,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "aOd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -1134,7 +1125,7 @@
 "aOj" = (
 /obj/machinery/microwave,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aOl" = (
 /obj/structure/bed/chair/sofa/corsat/verticalmiddle,
 /turf/open/floor/tile/yellow/patch,
@@ -1154,12 +1145,14 @@
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "aPA" = (
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/engineering/metal,
+/obj/effect/spawner/random/engineering/metal,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "aPS" = (
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/prison/cleanmarked,
 /area/gelida/caves/west_caves)
 "aPZ" = (
 /obj/structure/reagent_dispensers/beerkeg{
@@ -1216,6 +1209,10 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/outdoors/colony_streets/central_streets)
+"aQr" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/indoors/c_block/mining)
 "aQt" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/darkbrown/full,
@@ -1232,7 +1229,7 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/area/gelida/caves/central_caves)
 "aQU" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -1342,18 +1339,17 @@
 	dir = 1
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "aUn" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/pizzapasta/mushroompizzaslice,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "aUs" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
+/area/gelida/caves/west_caves)
 "aVe" = (
 /turf/open/shuttle/dropship/four,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
@@ -1381,9 +1377,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "aWS" = (
-/obj/structure/platform,
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 4
+	},
+/area/gelida/caves/west_caves)
 "aWU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -1471,7 +1469,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "aZn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
@@ -1494,9 +1492,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
 "aZE" = (
-/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/caves/west_caves)
 "aZV" = (
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/rock)
@@ -1558,7 +1556,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bbT" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -1632,7 +1630,7 @@
 "bdo" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/black/full,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bdq" = (
 /obj/structure/table/mainship,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1656,9 +1654,10 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "bdt" = (
-/obj/effect/spawner/random/machinery/disposal,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/rack/nometal,
+/obj/item/storage/holster/flarepouch/full,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "bdC" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_y = 7
@@ -1680,6 +1679,12 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/executive)
+"bdE" = (
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "bdV" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/blue,
@@ -1692,11 +1697,12 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "bem" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison/greenblue{
-	dir = 5
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1
 	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1746,13 +1752,9 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "bgd" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/mining)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "bgH" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -1781,7 +1783,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bhE" = (
 /turf/closed/shuttle/dropship2/fins,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
@@ -1794,12 +1796,9 @@
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "bic" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "bid" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -1838,10 +1837,11 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "bjn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/engineering/metal,
-/obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "bjt" = (
 /obj/structure/window/framed/colony,
@@ -1941,7 +1941,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bmp" = (
 /obj/structure/holohoop{
 	pixel_y = 27
@@ -1976,9 +1976,10 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "bnc" = (
-/obj/effect/spawner/random/misc/structure/supplycrate,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison/cellstripe,
+/area/gelida/caves/west_caves)
 "boo" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/ai_node,
@@ -2037,6 +2038,8 @@
 /area/gelida/indoors/a_block/bridges/corpo)
 "bpY" = (
 /obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "bqb" = (
@@ -2049,11 +2052,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
 "bqw" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
+/obj/structure/bed/chair/sofa/corsat/verticalmiddle,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "bqS" = (
 /obj/item/tool/kitchen/knife/ritual,
 /turf/open/floor/wood,
@@ -2122,15 +2123,9 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "bua" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/spawner/random/misc/structure/supplycrate,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "buA" = (
 /obj/structure/prop/mainship/gelida/rails,
 /obj/structure/prop/mainship/gelida/rails{
@@ -2165,10 +2160,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/admin)
-"bvh" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "bvn" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2240,7 +2231,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bwU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/platebot,
@@ -2281,6 +2272,13 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
+"bzz" = (
+/obj/structure/prop/mainship/gelida/lightstick{
+	pixel_x = 11;
+	pixel_y = 25
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "bzM" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -2304,8 +2302,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "bAh" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/floor/mainship/black/full,
+/obj/machinery/newscaster,
+/turf/closed/wall,
 /area/gelida/caves/west_caves)
 "bBz" = (
 /turf/open/floor/plating/ground/snow/layer2,
@@ -2362,6 +2360,10 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint2"
+	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "bDp" = (
@@ -2372,7 +2374,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/unmeltable,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bDR" = (
 /obj/structure/platform_decoration{
 	dir = 5
@@ -2436,28 +2438,28 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "bFN" = (
-/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
-/turf/open/floor/prison/greenblue{
-	dir = 9
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "bFY" = (
-/obj/structure/rack/nometal,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "bGr" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bGu" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = 11;
 	pixel_y = 25
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bGB" = (
 /obj/machinery/washing_machine{
 	pixel_y = 15
@@ -2498,15 +2500,15 @@
 /area/gelida/indoors/a_block/dorms)
 "bHK" = (
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bHO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/cargo)
 "bHY" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "bIi" = (
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/lone_buildings/chunk)
@@ -2529,14 +2531,14 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/area/gelida/caves/central_caves)
 "bJk" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bJl" = (
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor/plating,
@@ -2578,9 +2580,10 @@
 /turf/closed/wall,
 /area/gelida/indoors/c_block/cargo)
 "bLc" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/obj/structure/bed/chair/sofa/corsat/verticalmiddle,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "bLf" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -2605,9 +2608,11 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "bMh" = (
-/obj/item/trash/sosjerky,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "bMA" = (
 /turf/open/shuttle/dropship/five,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
@@ -2675,9 +2680,15 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/security)
 "bNN" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/outdoors/rock)
+/obj/item/clothing/mask/facehugger/dead{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	name = "????";
+	stat = 2
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "bNT" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
@@ -2739,7 +2750,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "bPQ" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -2776,7 +2787,7 @@
 "bQY" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bRr" = (
 /obj/structure/table/mainship,
 /obj/item/grown/nettle/death{
@@ -2812,7 +2823,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "bSO" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/flask/marine,
@@ -2875,19 +2886,16 @@
 	},
 /area/gelida/outdoors/rock)
 "bVM" = (
-/obj/item/storage/briefcase{
-	pixel_y = 1
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_y = -3
 	},
-/obj/item/storage/briefcase{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "bVQ" = (
-/obj/effect/turf_decal/tile/full/black,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "bWI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -2906,17 +2914,17 @@
 	},
 /area/gelida/indoors/b_block/bridge)
 "bXk" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1
+/obj/structure/window_frame/colony,
+/obj/effect/spawner/random/misc/shard,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "bXz" = (
-/turf/open/floor/prison/greenblue{
-	dir = 5
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/bed/chair/sofa/corsat/verticalsouth,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "bXX" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/prison/whitegreenfull2,
@@ -3054,7 +3062,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ccm" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -3151,10 +3159,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "cfG" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/engineering/powercell,
+/obj/item/trash/sosjerky,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/caves/west_caves)
 "cgn" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -3198,7 +3205,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "chk" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -3280,12 +3287,8 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "ckC" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2
-	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "ckG" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/tool,
@@ -3373,6 +3376,12 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
+"cof" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "cot" = (
 /obj/structure/table/mainship,
 /obj/item/tool/pen{
@@ -3383,8 +3392,9 @@
 	pixel_y = 8
 	},
 /obj/structure/cable,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "cpa" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -3419,11 +3429,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "cqM" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "cqV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3476,13 +3483,13 @@
 "csz" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "csL" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/central_streets)
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/pickaxe,
+/obj/effect/spawner/random/engineering/pickaxe,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "csP" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/platform{
@@ -3499,13 +3506,10 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "ctu" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/spawner/random/misc/structure/barrel,
+/obj/effect/landmark/weed_node,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/caves/west_caves)
 "ctT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3541,7 +3545,7 @@
 "cuW" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "cuY" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
 /turf/open/floor/prison/whitegreenfull2,
@@ -3559,7 +3563,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cvm" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/wood,
@@ -3588,9 +3592,12 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
 "cwT" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/metal,
+/obj/effect/spawner/random/engineering/tool,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "cxg" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -3621,7 +3628,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cxK" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -3635,19 +3642,15 @@
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "cxU" = (
-/obj/effect/spawner/random/engineering/wood,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/turf_decal/tile/full/black,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "cyd" = (
 /obj/structure/filingcabinet{
 	pixel_x = -8;
@@ -3664,7 +3667,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/unmeltable,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cyw" = (
 /obj/structure/rack/nometal,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -3696,7 +3699,7 @@
 "czo" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "czt" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 8
@@ -3706,13 +3709,6 @@
 "czE" = (
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/kitchen)
-"czM" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "czN" = (
 /turf/open/floor/prison{
 	dir = 4
@@ -3745,10 +3741,6 @@
 /obj/item/ammo_magazine/flamer_tank,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"cAP" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "cAR" = (
 /obj/structure/bed{
 	dir = 4;
@@ -3771,7 +3763,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cBP" = (
 /obj/effect/spawner/random/misc/structure/supplycrate{
 	pixel_x = 1;
@@ -3791,22 +3783,12 @@
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/casino)
-"cCC" = (
-/obj/structure/fence,
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/central_streets)
 "cCZ" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "cDx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison/cleanmarked,
 /area/gelida/caves/west_caves)
 "cDL" = (
 /obj/machinery/light{
@@ -3842,7 +3824,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 5
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cDV" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -3981,11 +3963,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
-"cIf" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "cIp" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/reagent_containers/jerrycan{
@@ -4020,10 +3997,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "cIy" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/prison/darkbrown/full,
 /area/gelida/caves/west_caves)
 "cIQ" = (
 /turf/open/floor/plating/ground/snow/layer2,
@@ -4060,7 +4035,7 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "cKJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4083,7 +4058,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "cLe" = (
 /obj/machinery/door_control{
 	id = "A-Block-Dorm Shutters";
@@ -4123,12 +4098,10 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "cLZ" = (
-/obj/structure/stairs/seamless{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "cMf" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/prison/whitegreenfull2,
@@ -4161,7 +4134,7 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "cNE" = (
 /obj/machinery/vending/coffee,
@@ -4197,7 +4170,7 @@
 "cNV" = (
 /obj/structure/closet,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "cOj" = (
 /obj/structure/table/reinforced/prison,
 /obj/effect/spawner/random/engineering/toolbox{
@@ -4222,42 +4195,29 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_street)
-"cPh" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "cPM" = (
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/turf/open/floor/prison/cellstripe{
+	dir = 1
+	},
+/area/gelida/caves/west_caves)
 "cQd" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/spawner/random/engineering/pickaxe,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "cQe" = (
-/obj/structure/largecrate,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
-"cQx" = (
-/obj/structure/rack/nometal,
-/obj/item/tool/shovel/spade{
-	pixel_x = -4
-	},
-/obj/item/tool/shovel/spade{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/area/gelida/caves/west_caves)
+"cQx" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "cQW" = (
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
@@ -4548,7 +4508,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "cZN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4556,32 +4516,27 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "cZX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
+/obj/effect/ai_node,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "dag" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "dao" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/engineering/pickaxe,
+/turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "daK" = (
 /obj/machinery/floodlight,
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "daN" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/effect/ai_node,
+/obj/item/weapon/cane,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "daV" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -4641,7 +4596,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "dcl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -4654,7 +4609,7 @@
 "dcx" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "dcJ" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -4679,12 +4634,6 @@
 	dir = 8
 	},
 /area/gelida/outdoors/colony_streets/north_street)
-"ddH" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 10
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
 "ddP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/w_rockies)
@@ -4695,9 +4644,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "deu" = (
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/mainship/black/full,
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "deV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4729,7 +4678,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "dga" = (
 /obj/machinery/light{
 	dir = 4
@@ -4738,12 +4687,9 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "dgr" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "dgs" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4795,11 +4741,10 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "dhv" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/structure/girder/reinforced,
 /turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
+/area/gelida/caves/west_caves)
 "dhx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4872,9 +4817,11 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "dkT" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/black/full,
+/obj/structure/table/mainship,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "dkY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4915,9 +4862,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/freezer,
 /area/gelida/indoors/a_block/dorms)
-"dmh" = (
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
 "dmn" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -4929,8 +4873,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/admin)
 "dmt" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "dmP" = (
@@ -5021,11 +4965,10 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "dqw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "dqA" = (
 /obj/structure/cargo_container{
 	dir = 4
@@ -5047,16 +4990,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
-"drm" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "drE" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 5
@@ -5144,7 +5077,7 @@
 "dtV" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "dtZ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -5154,6 +5087,12 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
+"dug" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/w_rockies)
 "duO" = (
 /obj/structure/table/mainship,
 /obj/item/book{
@@ -5212,7 +5151,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "dwS" = (
-/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "dxk" = (
@@ -5254,7 +5193,7 @@
 "dyf" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "dyh" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/plating,
@@ -5442,11 +5381,9 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "dEZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "dFb" = (
 /obj/item/bananapeel{
 	desc = "A bunch of tiny bits of shattered metal.";
@@ -5534,20 +5471,18 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
 "dHk" = (
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "dHv" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
 "dII" = (
-/obj/structure/cargo_container{
-	dir = 4
-	},
+/obj/structure/cargo_container,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "dIK" = (
 /obj/item/weapon/gun/pistol/m1911,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -5603,9 +5538,11 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "dKf" = (
-/obj/structure/bed/chair/sofa/corsat/verticalsouth,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "dKD" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -5663,7 +5600,7 @@
 	serial_number = 16
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "dMR" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/heatinggrate,
@@ -5727,8 +5664,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "dOA" = (
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor/prison/cleanmarked,
 /area/gelida/caves/west_caves)
 "dOO" = (
 /obj/structure/prop/mainship/gelida/propladder,
@@ -5777,14 +5716,8 @@
 	},
 /area/gelida/indoors/a_block/bridges/corpo)
 "dQm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
-"dQM" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/prison/darkbrown/full,
 /area/gelida/caves/west_caves)
 "dQX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -5852,7 +5785,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "dTL" = (
 /obj/structure/table/mainship{
 	dir = 1;
@@ -5873,9 +5806,12 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "dUu" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/plating/platebotc,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "dUC" = (
 /obj/item/storage/backpack/marine/satchel{
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
@@ -5973,7 +5909,7 @@
 "dWk" = (
 /obj/structure/rack/nometal,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "dWr" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6016,8 +5952,9 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/fitness)
 "dYh" = (
+/obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "dYl" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -6272,14 +6209,17 @@
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "eez" = (
-/obj/item/shard,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/table/mainship,
+/obj/item/flashlight/lamp/green{
+	pixel_y = -16
+	},
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "eeF" = (
-/obj/effect/spawner/random/misc/structure/supplycrate,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/obj/effect/landmark/xeno_resin_door,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "eeK" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -6288,9 +6228,8 @@
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "eeT" = (
 /obj/structure/cable,
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "eeZ" = (
 /obj/item/clothing/under/colonist{
 	pixel_x = 5;
@@ -6343,13 +6282,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "egm" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2
-	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "egn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -6363,6 +6298,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint2"
+	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "egQ" = (
@@ -6428,10 +6367,9 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/garage)
 "elo" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "emD" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -6484,9 +6422,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/fitness)
 "eoI" = (
-/obj/effect/spawner/random/machinery/disposal,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "eoN" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -6509,7 +6447,7 @@
 "epc" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "epj" = (
 /obj/machinery/door/airlock/dropship_hatch/left/two,
 /turf/open/shuttle/dropship/three,
@@ -6547,14 +6485,9 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "eqE" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
-	},
 /obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "eqI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -6569,8 +6502,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/bridge)
 "eqT" = (
-/turf/open/floor/prison/cellstripe,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "era" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -6589,7 +6522,7 @@
 	dir = 5
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "esc" = (
 /obj/item/tool/wrench,
 /obj/effect/ai_node,
@@ -6682,17 +6615,14 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "etI" = (
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
 "etT" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "etY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet,
@@ -6703,14 +6633,11 @@
 "euf" = (
 /obj/structure/cargo_container/nt,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eum" = (
-/obj/item/clothing/head/welding,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "euu" = (
 /obj/item/defibrillator,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6826,15 +6753,17 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "ewI" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "ewO" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "ewR" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -6845,7 +6774,7 @@
 /obj/machinery/landinglight/ds1,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eyF" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -6856,6 +6785,12 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
+"eyQ" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "eyU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/random/misc/structure/curtain/medical,
@@ -6895,9 +6830,8 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "ezB" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/black/full,
+/obj/machinery/floodlight,
+/turf/open/floor/prison/cleanmarked,
 /area/gelida/caves/west_caves)
 "ezN" = (
 /obj/item/ammo_magazine/rifle/tx11{
@@ -6989,7 +6923,7 @@
 "eDu" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eDG" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/spacecash/c100,
@@ -7029,11 +6963,9 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "eEw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/structure/cargo_container/gorg,
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "eEH" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -7056,10 +6988,6 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"eEX" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/gelida/caves/west_caves)
 "eEZ" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -7067,7 +6995,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eFc" = (
 /obj/item/clothing/head/flatcap{
 	pixel_y = 16
@@ -7114,7 +7042,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eGa" = (
 /obj/structure/table/reinforced/prison,
 /obj/effect/spawner/random/misc/paperbin{
@@ -7141,7 +7069,7 @@
 /obj/machinery/door/airlock/mainship/generic,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eGO" = (
 /obj/effect/spawner/random/decal/blood,
 /turf/open/floor/prison/sterilewhite,
@@ -7168,7 +7096,7 @@
 	pixel_y = -13
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eHy" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -7185,7 +7113,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eHT" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -7295,11 +7223,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"eLt" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "eLB" = (
 /obj/structure/cable,
 /obj/vehicle/ridden/powerloader{
@@ -7358,9 +7281,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "eNo" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall,
-/area/gelida/indoors/c_block/mining)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "eNH" = (
 /obj/structure/filingcabinet{
 	pixel_x = -8;
@@ -7383,11 +7307,10 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "eOl" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	pixel_x = -4
+/obj/structure/cargo_container/gorg{
+	dir = 4
 	},
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "eOo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
@@ -7432,6 +7355,10 @@
 "eQj" = (
 /obj/structure/table/mainship,
 /obj/item/circuitboard/apc,
+/obj/machinery/door_control{
+	dir = 1;
+	id = "checkpoint2"
+	},
 /turf/open/floor/prison/whitepurple/full{
 	dir = 4
 	},
@@ -7456,10 +7383,10 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
 "eRD" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/obj/machinery/light,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/machinery/door/airlock/mainship/generic,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "eRE" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -7474,10 +7401,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "eRN" = (
-/obj/machinery/vending/hydronutrients,
-/obj/machinery/light,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/caves/central_caves)
 "eRR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -7507,10 +7433,11 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "eSL" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
+/obj/item/trash/chips,
+/obj/structure/bed/chair/sofa/corsat{
+	pixel_y = 16
+	},
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "eTa" = (
 /obj/effect/spawner/random/engineering/wood,
@@ -7535,13 +7462,13 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eTU" = (
 /obj/structure/cargo_container/hd_blue{
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eUn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7580,7 +7507,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "eVl" = (
 /obj/item/flashlight/lamp/green{
 	pixel_x = 5;
@@ -7594,17 +7521,15 @@
 /turf/open/floor/tile/dark2,
 /area/gelida/indoors/c_block/mining)
 "eVp" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/south_east_street)
+/obj/structure/cable,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/outdoors/colony_streets/north_street)
 "eVq" = (
 /obj/structure/platform{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eVy" = (
 /obj/structure/table/mainship,
 /obj/item/tool/crowbar/red,
@@ -7662,11 +7587,12 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "eWM" = (
-/obj/structure/bed/chair/sofa/corsat{
+/obj/structure/bed/chair/sofa/corsat/right{
 	pixel_y = 16
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "eWP" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7686,7 +7612,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "eXm" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/prison,
@@ -7708,7 +7634,6 @@
 	dir = 1;
 	name = "\improper Mining Control"
 	},
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
@@ -7778,16 +7703,16 @@
 "eZd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/mining)
 "eZB" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "eZJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7844,7 +7769,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "fcp" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/structure/window_frame/colony,
@@ -8021,7 +7946,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fjn" = (
 /obj/structure/prop/mainship/gelida/rails,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -8052,12 +7977,6 @@
 /obj/structure/platform,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
-"flC" = (
-/obj/structure/platform{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
 "flF" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/nuke_disk_candidate,
@@ -8139,7 +8058,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fpt" = (
 /obj/machinery/conveyor/inverted{
 	dir = 8
@@ -8151,7 +8070,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "fpK" = (
 /obj/structure/rack/nometal,
 /obj/item/clothing/shoes/blue{
@@ -8171,14 +8090,12 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
 "fpP" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/structure/cable,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/outdoors/colony_streets/north_street)
 "fqs" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor/prison/whitepurple/full{
@@ -8226,7 +8143,7 @@
 "fsz" = (
 /obj/structure/largecrate,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fsX" = (
 /turf/closed/shuttle/dropship2/corners{
 	dir = 4
@@ -8255,7 +8172,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fuL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -8288,17 +8205,17 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fwd" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "fwg" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
+/obj/structure/bed/chair/sofa/corsat/left{
+	pixel_y = 16
+	},
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "fwk" = (
 /obj/effect/spawner/random/engineering/wood,
@@ -8318,7 +8235,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "fwL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -8364,7 +8281,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fyL" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
@@ -8405,7 +8322,7 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "fBC" = (
 /turf/closed/wall/r_wall,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "fBJ" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
@@ -8430,11 +8347,11 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "fCu" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
+/obj/structure/bed/chair/sofa/corsat{
+	pixel_y = 16
 	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "fCJ" = (
 /turf/open/floor/prison{
 	dir = 1
@@ -8475,11 +8392,10 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "fEZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "fFz" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -8505,9 +8421,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "fFR" = (
-/obj/effect/spawner/random/engineering/structure/powergenerator/superweighted,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/structure/cable,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/north_street)
 "fGk" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -8549,6 +8465,9 @@
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
+"fHK" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/landing_zone_1)
 "fHM" = (
 /obj/effect/ai_node,
 /turf/open/shuttle/dropship/seven,
@@ -8557,12 +8476,10 @@
 /turf/closed/shuttle/dropship2/enginethree,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "fIl" = (
-/obj/structure/closet/crate/internals,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/north_street)
 "fIn" = (
 /turf/open/floor/prison/whitepurple/full{
 	dir = 4
@@ -8579,7 +8496,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fJX" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -8662,15 +8579,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
-"fNq" = (
-/obj/structure/stairs/seamless{
-	dir = 8
-	},
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "fNF" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -8716,7 +8624,7 @@
 "fPw" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "fPB" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -8811,8 +8719,8 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "fTM" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating,
+/obj/structure/table/mainship,
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "fTS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -8844,16 +8752,23 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/dorms)
 "fVm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mainship/stripesquare,
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/tool,
+/obj/item/armor_module/module/antenna,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "fVp" = (
-/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint3"
+	},
+/turf/open/floor/prison/plate,
+/area/gelida/outdoors/colony_streets/north_west_street)
 "fVE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -8912,19 +8827,22 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
 "fXy" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
+/obj/structure/table/mainship{
+	dir = 1;
+	flipped = 1
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/colony_streets/south_east_street)
+/obj/item/armor_module/module/antenna,
+/turf/open/floor/prison/whitepurple/full{
+	dir = 4
+	},
+/area/gelida/indoors/a_block/dorms)
 "fXD" = (
 /turf/closed/shuttle/dropship2/finback,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "fXJ" = (
-/turf/open/floor/prison/greenblue{
-	dir = 6
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "fYA" = (
 /obj/structure/table/mainship,
 /obj/structure/flora/pottedplant{
@@ -8984,12 +8902,11 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "fZP" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
+/obj/effect/landmark/weed_node,
 /obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_west_street)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "fZR" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /obj/machinery/atmospherics/components/unary/vent_pump,
@@ -9002,7 +8919,6 @@
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
@@ -9038,15 +8954,12 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "gaR" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "gbt" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "gbQ" = (
 /obj/structure/platform{
@@ -9092,14 +9005,12 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "gcX" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 8
+/obj/structure/table/mainship,
+/obj/item/armor_module/module/antenna,
+/turf/open/floor/prison/whitepurple/full{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
+/area/gelida/indoors/a_block/dorms)
 "gdc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -9137,11 +9048,11 @@
 "geE" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "geP" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "gfh" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -9150,6 +9061,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/central_caves)
+"gfH" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/landing_zone_2)
 "ggk" = (
 /obj/effect/acid_hole,
 /turf/closed/wall,
@@ -9203,7 +9118,7 @@
 "gic" = (
 /obj/structure/closet,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "gid" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -9216,13 +9131,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
 "gim" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8
 	},
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "gio" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -9310,14 +9223,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/fitness)
-"glq" = (
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 8
-	},
-/turf/open/floor/tile/dark2{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "glI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
@@ -9327,10 +9232,9 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "glN" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
+/obj/effect/ai_node,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "gma" = (
 /obj/structure/closet/emcloset,
@@ -9360,9 +9264,11 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
 "gmI" = (
-/obj/effect/spawner/random/engineering/toolbox,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 10
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "gmJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -9480,11 +9386,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
 "gqh" = (
-/obj/effect/landmark/patrol_point{
-	id = "SOM_24";
-	name = "SOM exit point 24"
-	},
-/turf/open/floor/mainship/black/full,
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "gqE" = (
 /obj/structure/platform_decoration,
@@ -9507,8 +9410,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
 "grj" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "grK" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
@@ -9516,11 +9419,9 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
 "gsb" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "gse" = (
 /obj/structure/prop/mainship/gelida/rails,
 /turf/open/floor/tile/dark2,
@@ -9548,10 +9449,10 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "gtj" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "gtp" = (
@@ -9562,6 +9463,20 @@
 	pixel_y = 21
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
+"gtS" = (
+/obj/structure/largecrate,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/prison/plate,
+/area/gelida/landing_zone_2)
+"gub" = (
+/obj/machinery/door_control{
+	dir = 1;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/snow/layer0{
+	dir = 1
+	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "guf" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -9574,8 +9489,8 @@
 /turf/open/shuttle/dropship/six,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "gum" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating,
+/obj/item/trash/kepler,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "gun" = (
 /obj/machinery/conveyor{
@@ -9622,10 +9537,10 @@
 "guX" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "gve" = (
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "gvg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -9740,7 +9655,7 @@
 /obj/machinery/landinglight/ds1,
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "gyz" = (
 /turf/closed/shuttle/dropship2/finback{
 	dir = 1
@@ -9780,9 +9695,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
 "gzF" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
 "gzM" = (
 /obj/structure/cargo_container/ch_green{
 	dir = 4;
@@ -9795,14 +9710,12 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "gzT" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/central_caves)
+/obj/structure/cargo_container/ch_red,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
 "gAr" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "gAw" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -9838,9 +9751,11 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/c_block/cargo)
 "gBm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/mainship/black/full,
+/obj/structure/largecrate,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison/darkbrown/full,
 /area/gelida/caves/west_caves)
 "gBs" = (
 /obj/structure/window/framed/colony,
@@ -9878,7 +9793,7 @@
 /area/gelida/indoors/a_block/fitness)
 "gCK" = (
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "gCM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -9922,10 +9837,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"gEt" = (
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "gEI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth/snowrock,
@@ -9969,12 +9880,11 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "gGG" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cargo_container/ch_red{
+	dir = 1
 	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
 "gHe" = (
 /obj/machinery/button/door/open_only/landing_zone/lz2,
 /obj/structure/window/reinforced/tinted{
@@ -9985,7 +9895,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "gHg" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/prison/darkred/full,
@@ -10007,9 +9917,11 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/central_streets)
 "gHV" = (
-/obj/structure/table/mainship,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/cargo_container/ch_red{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/central_streets)
 "gIp" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 4
@@ -10021,11 +9933,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
-"gIN" = (
-/obj/structure/prop/mainship/brokengen,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "gIP" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/prison/whitegreenfull2,
@@ -10116,11 +10023,10 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "gKU" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "gKW" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -10142,17 +10048,24 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "gLz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/mainship/generic,
+/obj/effect/ai_node,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "gLF" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/bed/chair/sofa/corsat/left{
-	pixel_y = 16
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
 	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "gLM" = (
 /obj/structure/cargo_container,
 /turf/open/floor/prison,
@@ -10163,20 +10076,31 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_street)
 "gMi" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -7;
-	pixel_y = 7
+/obj/item/clothing/mask/facehugger/dead{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	name = "????";
+	pixel_x = -1;
+	pixel_y = -9;
+	stat = 2
 	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
-"gMH" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
+"gMw" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/indoors/c_block/mining)
+"gMH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
 "gMN" = (
 /obj/machinery/light{
 	dir = 1
@@ -10189,7 +10113,7 @@
 /obj/structure/platform_decoration,
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "gNq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -10270,7 +10194,7 @@
 	},
 /obj/item/tool/screwdriver,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "gPO" = (
 /obj/item/reagent_containers/food/drinks/flask/marine,
 /obj/machinery/atmospherics/components/unary/vent_pump,
@@ -10283,7 +10207,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "gPU" = (
 /obj/structure/platform_decoration{
 	dir = 10
@@ -10459,9 +10383,8 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "gVM" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "gXb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -10486,7 +10409,7 @@
 "gXV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "gYz" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/blood,
@@ -10494,8 +10417,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
 "gZd" = (
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "gZo" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -10505,26 +10430,25 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "gZy" = (
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "gZE" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/plating,
 /area/storage/testroom)
 "gZL" = (
-/obj/machinery/power/smes/buildable{
-	capacity = 1e+006;
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/largecrate,
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "gZW" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_14";
 	name = "TGMC exit point 14"
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
+/area/gelida/outdoors/colony_streets/east_central_street)
 "had" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -10570,7 +10494,7 @@
 "hbX" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "hca" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -10596,7 +10520,7 @@
 "hcL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "hcR" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/prison,
@@ -10604,7 +10528,7 @@
 "hdk" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "hdo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/spawner/random/misc/structure/supplycrate,
@@ -10619,11 +10543,18 @@
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "hdY" = (
-/obj/structure/stairs/seamless{
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/gelida/outdoors/colony_streets/central_streets)
 "hdZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -10644,7 +10575,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "heL" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -10670,10 +10601,12 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/hydro)
 "hgq" = (
-/turf/open/floor/prison/greenblue{
-	dir = 1
+/obj/effect/spawner/random/misc/structure/barrel,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/caves/west_caves)
 "hgC" = (
 /obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /obj/item/reagent_containers/food/drinks/flask/marine{
@@ -10795,7 +10728,7 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "hkx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -10897,7 +10830,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "hnn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -11019,27 +10952,20 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "hsw" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
+/obj/structure/table/mainship,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/caves/west_caves)
 "hsx" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "hsH" = (
-/obj/structure/table/mainship,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/item/storage/briefcase,
+/turf/open/floor/prison,
+/area/gelida/caves/west_caves)
 "hsP" = (
 /obj/structure/platform{
 	dir = 1
@@ -11170,14 +11096,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/hallway)
-"hxm" = (
-/obj/item/stack/rods,
-/obj/structure/window_frame/colony,
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "hxv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -11239,11 +11157,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "hzP" = (
-/obj/item/fuel_cell{
+/obj/effect/spawner/random/engineering/fuelcell{
 	pixel_x = -8;
 	pixel_y = 16
 	},
-/obj/item/fuel_cell{
+/obj/effect/spawner/random/engineering/fuelcell{
 	pixel_x = 8;
 	pixel_y = 16
 	},
@@ -11357,10 +11275,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "hCQ" = (
-/obj/structure/stairs/seamless,
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/gelida/caves/west_caves)
 "hCY" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -11414,7 +11329,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "hEP" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -11474,7 +11389,7 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "hJp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -11522,14 +11437,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorm_north)
-"hLc" = (
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/toolbox,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_y = -3
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "hLj" = (
 /obj/structure/fence,
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -11589,19 +11496,14 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "hNw" = (
-/obj/structure/stairs/seamless{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "hNx" = (
-/obj/structure/table/mainship,
-/obj/item/flashlight/lamp/green{
-	pixel_y = -16
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "hNA" = (
 /obj/structure/table/mainship{
 	dir = 4;
@@ -11638,8 +11540,9 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
 "hOM" = (
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "hOW" = (
 /obj/machinery/computer/security/wooden_tv{
 	desc = "An old TV hooked up to a video cassette recorder, you can even use it to time shift WOW.";
@@ -11659,10 +11562,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/hallway)
-"hPL" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "hQc" = (
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
@@ -11713,9 +11612,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/central_streets)
 "hRV" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/prison/cleanmarked,
+/area/gelida/caves/west_caves)
 "hSz" = (
 /obj/machinery/light{
 	dir = 4
@@ -11759,7 +11658,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "hTl" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -11866,9 +11765,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "hVN" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/effect/spawner/random/misc/structure/barrel,
+/obj/machinery/light,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "hWs" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -11924,21 +11823,18 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "hXI" = (
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "hXS" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/structure/cable,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "hYa" = (
-/obj/structure/prop/mainship/sensor_computer1,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_y = 7
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/obj/machinery/light,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "hYu" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 1
@@ -12003,7 +11899,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "hZX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
@@ -12075,9 +11971,9 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "icv" = (
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/nw_rockies)
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "icL" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -12177,11 +12073,9 @@
 /turf/open/liquid/water/river,
 /area/gelida/indoors/a_block/fitness)
 "igB" = (
-/obj/item/stack/rods,
-/obj/structure/window_frame/colony,
-/obj/structure/platform,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/gelida/caves/west_caves)
 "igD" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 4
@@ -12215,7 +12109,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ihl" = (
 /turf/closed/wall,
 /area/gelida/indoors/a_block/dorm_north)
@@ -12229,11 +12123,6 @@
 	dir = 4
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
-"ihx" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "ihz" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/darkred/full,
@@ -12245,12 +12134,10 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "ihZ" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/engineering/cable,
 /turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/caves/west_caves)
 "iiu" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_x = -6;
@@ -12320,8 +12207,9 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "ijG" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/mainship/black/full,
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/engineering/powercell,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "ijV" = (
 /obj/structure/stairs/seamless,
@@ -12423,7 +12311,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "imm" = (
 /obj/structure/flora/bush{
 	pixel_y = 9
@@ -12472,7 +12360,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ioS" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -12492,17 +12380,10 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "ipx" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 11
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/prop/mainship/gelida/planterboxsoil{
-	dir = 9
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "ipC" = (
 /obj/structure/closet/basketball,
 /turf/open/floor/prison/whitegreenfull2,
@@ -12512,10 +12393,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
 "iqP" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/turf_decal/tile/full/black,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
+/area/gelida/outdoors/colony_streets/south_west_street)
 "iqY" = (
 /obj/structure/table/mainship,
 /obj/item/paper,
@@ -12582,7 +12464,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "itG" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/prison/darkbrown/full,
@@ -12640,12 +12522,9 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "ivx" = (
-/obj/structure/largecrate,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "iwh" = (
 /obj/structure/platform,
 /turf/closed/wall,
@@ -12736,11 +12615,6 @@
 	dir = 4
 	},
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"iyK" = (
-/obj/machinery/constructable_frame/state_2,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "iyN" = (
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -12858,11 +12732,12 @@
 /turf/open/floor/prison,
 /area/lv624/lazarus/console)
 "iDj" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "iDC" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/prison/sterilewhite/full,
@@ -12916,7 +12791,7 @@
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "iFn" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/plating,
@@ -12949,7 +12824,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "iIp" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = -9;
@@ -13010,14 +12885,9 @@
 /turf/open/floor/tile/dark2,
 /area/gelida/indoors/c_block/mining)
 "iJR" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "iJT" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison/darkpurple{
@@ -13066,12 +12936,9 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "iLi" = (
-/obj/structure/closet,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "iLp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13207,10 +13074,10 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "iOZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "iPh" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 1
@@ -13226,8 +13093,9 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "iPn" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "iQf" = (
 /obj/structure/cable,
@@ -13325,15 +13193,14 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "iUh" = (
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison/darkbrown/full,
 /area/gelida/caves/west_caves)
 "iUl" = (
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "iUm" = (
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/corpo)
@@ -13499,7 +13366,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
 "jaz" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "jaB" = (
@@ -13532,10 +13400,9 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "jaU" = (
-/obj/structure/sign/securearea{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "jbg" = (
 /obj/structure/stairs/cornerdark/seamless,
@@ -13562,13 +13429,15 @@
 "jcm" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jcs" = (
-/obj/structure/platform_decoration{
-	dir = 10
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "jcI" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -13602,7 +13471,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jdX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13693,14 +13562,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "jhS" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jio" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -13734,9 +13602,10 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "jkr" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "jkC" = (
 /obj/machinery/optable,
 /turf/open/floor/prison/sterilewhite,
@@ -13790,13 +13659,13 @@
 "jmj" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jmn" = (
 /obj/structure/cargo_container/nt{
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "jmO" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -13901,8 +13770,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "jqF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "jqL" = (
@@ -13923,8 +13792,8 @@
 /turf/closed/shuttle/dropship2/glassfive,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "jrq" = (
+/obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "jrs" = (
@@ -14006,17 +13875,17 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "jua" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/glasses/meson,
-/obj/item/shard,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "jue" = (
 /obj/structure/platform{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "jum" = (
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
@@ -14071,7 +13940,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jwG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -14144,15 +14013,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
 "jyY" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "jzO" = (
 /obj/structure/stairs/seamless,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -14174,10 +14037,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/b_block/hydro)
 "jAG" = (
-/obj/structure/table/mainship,
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "jAU" = (
 /obj/machinery/power/apc/drained,
@@ -14213,10 +14074,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "jBU" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "jCt" = (
@@ -14228,11 +14086,13 @@
 /area/lv624/lazarus/console)
 "jDt" = (
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jDu" = (
-/obj/item/trash/kepler,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "jDy" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -14253,16 +14113,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "jDC" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 9
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
-"jDU" = (
-/obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/caves/west_caves)
 "jEw" = (
 /obj/machinery/light,
@@ -14410,13 +14262,13 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "jKV" = (
-/obj/structure/window/framed/colony,
+/obj/effect/turf_decal/tile/full/black,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/caves/west_caves)
 "jKW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
+/obj/effect/turf_decal/tile/full/black,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "jLe" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -14453,17 +14305,11 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "jMk" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
 	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "jMm" = (
 /obj/structure/platform{
 	dir = 8
@@ -14499,7 +14345,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jMX" = (
 /obj/structure/cargo_container,
 /turf/open/floor/prison/cleanmarked,
@@ -14530,11 +14376,10 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
 "jNs" = (
-/obj/item/tool/weldingtool,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/ai_node,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/caves/west_caves)
 "jNG" = (
 /obj/effect/spawner/random/misc/structure/curtain,
 /turf/open/floor/prison/whitepurple/full{
@@ -14553,7 +14398,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "jOx" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "Showeroom"
@@ -14589,10 +14434,11 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "jOV" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/gelida/outdoors/colony_streets/south_west_street)
 "jPr" = (
 /obj/machinery/prop/mainship/computer/PC{
 	dir = 4;
@@ -14611,10 +14457,11 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "jQd" = (
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 6
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
 	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "jQe" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 4;
@@ -14643,7 +14490,7 @@
 "jQE" = (
 /obj/structure/closet/crate,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "jQO" = (
 /obj/machinery/light{
 	dir = 1
@@ -14738,12 +14585,10 @@
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "jRU" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
+/obj/structure/window_frame/colony,
+/obj/effect/spawner/random/misc/shard,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/indoors/c_block/garage)
 "jSb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -14816,7 +14661,7 @@
 "jTN" = (
 /obj/machinery/photocopier,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "jTP" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -14834,10 +14679,17 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
 "jUt" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/engineering/powercell,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
+"jUy" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
 "jUR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -14936,14 +14788,8 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
-"jYq" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "jYs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -15002,7 +14848,7 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/weaponry/gun/sidearms,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "kci" = (
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
@@ -15027,7 +14873,6 @@
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -15073,9 +14918,10 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "kdQ" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_2)
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/gelida/outdoors/colony_streets/south_west_street)
 "kdS" = (
 /obj/machinery/vending/snack{
 	pixel_y = 16
@@ -15117,7 +14963,7 @@
 "kfN" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "kgx" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -15136,27 +14982,21 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
 "kgS" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/engineering/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/turf/closed/wall,
+/area/gelida/outdoors/rock)
 "kgY" = (
-/obj/structure/closet/crate,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "khd" = (
 /obj/item/weapon/telebaton,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "khi" = (
-/turf/open/floor/prison/greenblue{
-	dir = 9
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "khq" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -15187,11 +15027,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "kio" = (
-/obj/structure/cargo_container,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "kiD" = (
 /obj/item/tool/screwdriver{
 	pixel_x = -8;
@@ -15241,11 +15082,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "kjv" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "kjB" = (
 /obj/machinery/light{
 	dir = 8
@@ -15312,7 +15151,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "knX" = (
@@ -15380,7 +15218,7 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "kqs" = (
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "kqw" = (
 /obj/machinery/light{
 	dir = 8
@@ -15422,12 +15260,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "krB" = (
-/obj/structure/table/mainship,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/prop/vehicle/truck/destructible,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "krK" = (
 /obj/structure/fence,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -15463,6 +15298,13 @@
 	},
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
+"ksO" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/gelida/indoors/c_block/garage)
 "ksQ" = (
 /turf/open/floor/prison/blue{
 	dir = 5
@@ -15473,7 +15315,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ktT" = (
 /turf/open/floor/prison/blue{
 	dir = 9
@@ -15487,8 +15329,13 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "kuB" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/mainship/stripesquare,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 11
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoil{
+	dir = 9
+	},
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "kuI" = (
 /obj/structure/cable,
@@ -15508,6 +15355,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
+"kvM" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "kwo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -15522,9 +15373,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "kwJ" = (
-/obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/stripesquare,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "kwR" = (
 /obj/effect/landmark/weed_node,
@@ -15686,7 +15539,7 @@
 "kDw" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "kDS" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/landmark/weed_node,
@@ -15715,11 +15568,10 @@
 	},
 /area/gelida/outdoors/colony_streets/south_east_street)
 "kDZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "kEc" = (
 /obj/structure/table/mainship,
 /obj/machinery/door_control{
@@ -15737,15 +15589,12 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "kEl" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	pixel_x = -1;
-	pixel_y = -9;
-	stat = 2
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	pixel_x = -4
 	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "kEn" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -16015,9 +15864,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "kNj" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_west_street)
@@ -16079,7 +15925,14 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
+"kPF" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "kPS" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -16116,9 +15969,6 @@
 "kRn" = (
 /turf/closed/wall,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"kRt" = (
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/landing_zone_2)
 "kRu" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood,
@@ -16178,22 +16028,22 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "kUd" = (
-/obj/structure/largecrate/supply/medicine,
-/obj/effect/turf_decal/warning_stripes/thin{
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside/regular{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/outdoors/colony_streets/south_west_street)
 "kUg" = (
 /turf/closed/shuttle/dropship2/enginethree{
 	dir = 1
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "kUo" = (
-/obj/machinery/door/airlock/mainship/generic,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "kUF" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -16210,7 +16060,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "kVA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -16347,13 +16197,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
 "laA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_west_street)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "laK" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -16376,22 +16224,17 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "lby" = (
-/obj/effect/landmark/patrol_point{
-	id = "SOM_23";
-	name = "SOM exit point 23"
-	},
-/turf/open/floor/mainship/black/full,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/caves/west_caves)
 "lbJ" = (
 /obj/structure/bed/chair/sofa/corsat/right,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "lcg" = (
-/obj/structure/cable,
-/turf/open/floor/prison/green/full{
-	dir = 4
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "lcj" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -16593,12 +16436,12 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/executive)
 "lie" = (
-/obj/structure/rack/nometal,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/prop/mainship/gelida/smallwire,
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/south_east_street)
 "lii" = (
 /obj/machinery/light{
 	dir = 4
@@ -16694,7 +16537,16 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "lmN" = (
-/turf/open/floor/mainship/black/full,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 11
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoil{
+	dir = 9
+	},
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "lnc" = (
 /obj/effect/spawner/random/engineering/metal,
@@ -16734,12 +16586,18 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/bridge)
 "lnz" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "lnC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "lnR" = (
 /obj/effect/landmark/weed_node,
@@ -16751,13 +16609,13 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "loy" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/cargo)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "loB" = (
 /obj/item/stack/sheet/wood/large_stack,
 /obj/machinery/power/apc/drained,
@@ -16783,7 +16641,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lqf" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 9
@@ -16798,7 +16656,7 @@
 "lqI" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lqR" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -16897,10 +16755,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"lsX" = (
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "ltF" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/prison,
@@ -17070,14 +16924,10 @@
 /turf/closed/wall,
 /area/gelida/indoors/lone_buildings/chunk)
 "lAB" = (
-/obj/item/shard,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/turf_decal/tile/full/black,
+/obj/effect/spawner/random/engineering/powercell,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "lAW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17111,7 +16961,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lBy" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/tool{
@@ -17156,7 +17006,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -17203,9 +17052,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
 "lEp" = (
-/obj/machinery/floodlight,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "lEy" = (
 /obj/structure/inflatable/wall,
 /turf/open/floor/prison,
@@ -17217,8 +17067,9 @@
 	},
 /area/gelida/indoors/b_block/bridge)
 "lEZ" = (
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "lFj" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -17244,27 +17095,21 @@
 /turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/rock)
 "lGp" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "lGx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
-"lGM" = (
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+"lHs" = (
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
-/area/gelida/outdoors/colony_streets/south_west_street)
-"lHs" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "lHx" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -17312,11 +17157,10 @@
 "lIC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lID" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
+/obj/structure/cable,
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "lIG" = (
 /obj/machinery/light{
@@ -17330,7 +17174,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "lIK" = (
@@ -17478,15 +17321,15 @@
 "lMx" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "lMI" = (
 /obj/structure/mecha_wreckage/ripley,
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "lMM" = (
-/obj/effect/turf_decal/tile/full/black,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
+/obj/machinery/power/geothermal,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "lMU" = (
 /turf/open/floor/prison/whitegreenfull2,
@@ -17494,7 +17337,7 @@
 "lMX" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lMZ" = (
 /obj/structure/table/reinforced/prison,
 /obj/machinery/prop/mainship/computer/PC{
@@ -17519,7 +17362,7 @@
 "lOq" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "lOA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -17532,7 +17375,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
+"lPb" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkbrown/full,
+/area/gelida/indoors/c_block/mining)
 "lPd" = (
 /obj/structure/cargo_container{
 	dir = 4
@@ -17589,12 +17436,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
 "lRq" = (
-/obj/item/trash/chips,
-/obj/structure/bed/chair/sofa/corsat{
-	pixel_y = 16
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/machinery/constructable_frame/state_2,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "lRN" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -17629,7 +17474,6 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "lSR" = (
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
@@ -17685,8 +17529,8 @@
 /turf/closed/wall,
 /area/gelida/indoors/c_block/garage)
 "lUi" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
+/obj/machinery/vending/snack,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "lVd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -17730,8 +17574,9 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "lVD" = (
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "lWb" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 6
@@ -17784,13 +17629,10 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
 "lXy" = (
-/obj/machinery/door/airlock/mainship/generic,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/full/black,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "lXT" = (
 /obj/structure/dispenser/oxygen,
 /turf/open/floor/prison/darkbrown/full,
@@ -17806,6 +17648,12 @@
 "lYx" = (
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
+"lYA" = (
+/obj/effect/turf_decal/warning_stripes/box,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/prison,
+/area/gelida/outdoors/colony_streets/central_streets)
 "lYK" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
@@ -17845,7 +17693,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "lZK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17947,10 +17795,10 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/central_streets)
 "mdA" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/head/beret/eng,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "mec" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -18030,7 +17878,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mhj" = (
 /turf/closed/wall,
 /area/gelida/indoors/a_block/medical)
@@ -18149,7 +17997,7 @@
 "mkD" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mkF" = (
 /obj/item/ammo_magazine/pistol/m1911{
 	current_rounds = 0;
@@ -18172,11 +18020,10 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/central_streets)
 "mli" = (
-/obj/structure/bed/chair/sofa/corsat/right{
-	pixel_y = 16
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/prop/mainship/brokengen,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "mls" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
@@ -18199,7 +18046,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mlX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -18230,11 +18077,11 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "mmD" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/metal,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "mmF" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -18244,13 +18091,16 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
 "mmH" = (
-/obj/structure/fence,
 /obj/structure/platform_decoration{
 	dir = 8
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
+	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint2"
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
@@ -18291,11 +18141,9 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/corpo)
 "mnD" = (
-/obj/machinery/door/poddoor/shutters/mainship/containment{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/rock)
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/prison/plate,
+/area/gelida/landing_zone_2)
 "mnI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -18365,9 +18213,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/fitness)
 "mqp" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "mqu" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/south_east_street)
@@ -18383,13 +18232,13 @@
 	dir = 2
 	},
 /turf/open/floor/mainship/black/full,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mqR" = (
 /obj/machinery/landinglight/ds1,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mqX" = (
 /obj/item/shard,
 /turf/open/floor/carpet,
@@ -18424,9 +18273,6 @@
 /obj/item/weapon/gun/revolver/cmb,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
-"msI" = (
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
 "msQ" = (
 /obj/structure/table/mainship,
 /obj/item/toy/bikehorn,
@@ -18436,9 +18282,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "mth" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall,
 /area/gelida/indoors/c_block/mining)
 "mtu" = (
@@ -18522,10 +18366,11 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "muV" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/cable,
-/turf/open/floor/plating/platebotc,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "mvy" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -18671,11 +18516,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/kitchen)
 "mAk" = (
-/obj/effect/decal/cleanable/blood{
-	desc = "Watch your step."
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/job/xenomorph,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "mAo" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
@@ -18685,7 +18530,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mAF" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -18696,7 +18541,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mBa" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -18713,11 +18558,10 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "mCj" = (
-/obj/machinery/floodlight/colony,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 5
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "mCI" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/darkbrown/full,
@@ -18725,7 +18569,7 @@
 "mDb" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mDh" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -18734,9 +18578,11 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "mDs" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/landing_zone_2)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/south_east_street)
 "mDU" = (
 /obj/structure/inflatable/wall{
 	dir = 1
@@ -18758,7 +18604,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mET" = (
 /obj/structure/table/mainship,
 /obj/item/tool/weldpack{
@@ -18786,22 +18632,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"mFD" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "mFF" = (
-/obj/structure/prop/mainship/sensor_computer3,
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_y = 7
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/obj/structure/cargo_container/nt,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_2)
 "mGn" = (
 /obj/machinery/light{
 	dir = 4
@@ -18893,9 +18727,9 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "mJj" = (
-/obj/structure/stairs/seamless,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "mJP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -18904,15 +18738,11 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/medical)
 "mJV" = (
-/obj/structure/table/mainship,
-/obj/machinery/light{
+/obj/structure/cargo_container/nt{
 	dir = 1
 	},
-/obj/effect/spawner/random/clothing/sunglasses{
-	pixel_y = 5
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_2)
 "mKd" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 4
@@ -18920,8 +18750,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "mKk" = (
+/obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "mKq" = (
 /obj/effect/landmark/weed_node,
@@ -18930,7 +18761,7 @@
 "mKv" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mKJ" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/weaponry/ammo,
@@ -18993,8 +18824,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/admin)
 "mMd" = (
-/turf/open/floor/plating/heatinggrate,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/machinery/constructable_frame/state_2,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "mMy" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -19031,7 +18863,7 @@
 /area/gelida/indoors/a_block/dorm_north)
 "mOj" = (
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mOp" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
@@ -19060,14 +18892,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "mPk" = (
-/obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cargo_container/nt{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/landing_zone_1)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_2)
 "mPm" = (
 /obj/item/shard,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -19108,12 +18937,10 @@
 /turf/closed/wall,
 /area/gelida/indoors/c_block/garage)
 "mQj" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/full/black,
 /obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/engineering)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "mQy" = (
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
@@ -19188,8 +19015,8 @@
 	},
 /area/gelida/indoors/a_block/kitchen)
 "mSM" = (
-/obj/structure/rack/nometal,
-/turf/open/floor/mainship/black/full,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "mTc" = (
 /obj/structure/barricade/wooden{
@@ -19221,7 +19048,7 @@
 "mUd" = (
 /obj/structure/largecrate,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "mUy" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -19273,7 +19100,7 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "mWd" = (
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "mWv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -19391,7 +19218,7 @@
 "nct" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ncu" = (
 /turf/open/floor/tile/dark2,
 /area/gelida/outdoors/rock)
@@ -19400,8 +19227,10 @@
 /turf/closed/wall,
 /area/gelida/indoors/c_block/bridge)
 "ncH" = (
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/colony_streets/south_east_street)
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "ncQ" = (
 /turf/closed/shuttle/dropship2/enginefive{
 	dir = 1
@@ -19453,11 +19282,11 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "ndP" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/turf_decal/tile/full/black,
+/obj/effect/landmark/start/job/xenomorph,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "ndU" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -19545,34 +19374,26 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ngh" = (
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
 	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "ngu" = (
 /obj/structure/stairs/seamless,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "ngv" = (
-/obj/structure/bed,
-/obj/structure/bed{
-	buckling_y = 13;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
 	},
-/turf/open/floor/prison/plate,
-/area/gelida/indoors/c_block/mining)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "ngw" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -19581,7 +19402,7 @@
 /area/gelida/indoors/c_block/bridge)
 "ngP" = (
 /turf/closed/wall/r_wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nhb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison{
@@ -19659,15 +19480,9 @@
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "njJ" = (
-/obj/structure/flora/pottedplant{
-	desc = "It is made of Fiberbush(tm). It contains asbestos.";
-	name = "synthetic potted plant";
-	pixel_y = 8
-	},
-/turf/open/floor/prison/greenblue{
-	dir = 5
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "njW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19691,7 +19506,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nkv" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
@@ -19702,7 +19517,12 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "nkH" = (
-/obj/structure/window/framed/colony,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "nkO" = (
@@ -19723,6 +19543,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
+"nlQ" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "nma" = (
 /obj/structure/flora/ausbushes/sunnybush{
 	pixel_y = 13
@@ -19767,12 +19591,14 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "nnL" = (
-/obj/machinery/floodlight,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 4
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/rack/nometal,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "nnR" = (
 /turf/closed/wall/r_wall{
 	dir = 9
@@ -19814,9 +19640,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"npU" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
 "nqO" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/cheesyfries,
@@ -19829,6 +19652,12 @@
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
+"nrb" = (
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "nri" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -19863,13 +19692,6 @@
 /obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"nrZ" = (
-/obj/structure/window/framed/colony,
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "nsn" = (
 /obj/structure/cargo_container/ch_green,
 /turf/open/floor/prison/plate,
@@ -19952,9 +19774,9 @@
 	},
 /area/gelida/indoors/a_block/executive)
 "ntU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/xenomorph,
-/obj/structure/cable,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "ntZ" = (
@@ -19988,7 +19810,7 @@
 "nvl" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nvz" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -20028,7 +19850,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nwf" = (
 /turf/open/floor/prison/blue{
 	dir = 8
@@ -20081,10 +19903,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "nyC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/central_caves)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "nyZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20098,12 +19919,11 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "nzX" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
 	},
-/obj/structure/rack/nometal,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/turf/closed/wall/r_wall,
+/area/gelida/landing_zone_1)
 "nAe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -20141,10 +19961,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/bridges)
 "nBG" = (
-/turf/open/floor/prison/green/full{
-	dir = 4
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "nBP" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/plating,
@@ -20154,7 +19975,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nCJ" = (
 /obj/structure/platform_decoration{
 	dir = 9
@@ -20177,18 +19998,15 @@
 /obj/machinery/landinglight/ds1,
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nDy" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "nDB" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/mining)
+/obj/item/lightstick/red/anchored,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/landing_zone_1)
 "nDF" = (
 /obj/structure/cargo_container,
 /turf/open/floor/prison,
@@ -20212,15 +20030,15 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "nEg" = (
+/obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "nEw" = (
+/obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "nEL" = (
 /obj/effect/spawner/random/misc/structure/curtain/medical,
@@ -20255,15 +20073,13 @@
 /turf/closed/wall/r_wall,
 /area/gelida/indoors/a_block/dorm_north)
 "nFV" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/light,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "nGk" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -20287,10 +20103,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
-"nGJ" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "nGK" = (
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -20354,7 +20166,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nIM" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -20368,11 +20180,10 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "nJe" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "nJL" = (
 /obj/item/ammo_magazine/rifle/tx11{
 	current_rounds = 0;
@@ -20381,11 +20192,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
-"nJY" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "nJZ" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/reagent_containers/food/snacks/packaged_burrito,
@@ -20421,7 +20227,7 @@
 "nKB" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nKH" = (
 /obj/structure/table/mainship,
 /obj/item/paper{
@@ -20454,7 +20260,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "nLz" = (
@@ -20470,7 +20275,7 @@
 	stat = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nLA" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -20501,23 +20306,19 @@
 	dir = 6
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nMS" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/effect/spawner/gibspawner/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "nNn" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/cargo_container/nt,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/landing_zone_1)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/indoors/c_block/mining)
 "nNt" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -20533,7 +20334,7 @@
 	dir = 5
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nNF" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -20658,8 +20459,8 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "nRL" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "nRP" = (
@@ -20680,10 +20481,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "nRW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/landing_zone_1)
 "nSf" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -20696,7 +20496,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nSG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20708,7 +20508,7 @@
 	dir = 5
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nST" = (
 /obj/structure/table/mainship{
 	dir = 8;
@@ -20743,7 +20543,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nTQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -20771,7 +20571,7 @@
 	dir = 5
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "nVU" = (
 /obj/effect/ai_node,
 /obj/effect/spawner/random/decal/blood,
@@ -20810,7 +20610,7 @@
 "nXw" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "nXE" = (
 /obj/structure/table/fancywoodentable,
 /obj/effect/spawner/random/misc/folder/nooffset{
@@ -20925,7 +20725,7 @@
 /area/gelida/indoors/c_block/cargo)
 "oas" = (
 /turf/closed/wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "oav" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -21004,10 +20804,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/corpo)
-"oco" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "ocv" = (
 /turf/open/floor/prison/darkpurple,
 /area/gelida/indoors/a_block/dorms)
@@ -21022,10 +20818,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"odh" = (
-/obj/item/shard,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "odq" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/cleanmarked,
@@ -21091,7 +20883,7 @@
 "ogh" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ogi" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/station_alert{
@@ -21103,17 +20895,14 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "ogl" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/head/collectable/tophat,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "ogw" = (
-/obj/structure/closet,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "ogJ" = (
 /obj/structure/dropship_piece/two/engine/leftbottom,
 /turf/closed/shuttle/dropship2/engineone{
@@ -21168,10 +20957,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/central_caves)
 "ojk" = (
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "ojm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -21256,13 +21045,12 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "omp" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
 	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "omq" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -21357,7 +21145,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "orM" = (
 /obj/structure/platform,
 /turf/open/floor/podhatch/floor,
@@ -21374,10 +21162,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/bridges/corpo)
-"osK" = (
-/obj/effect/spawner/random/engineering/structure/powergenerator,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "osS" = (
 /turf/closed/shuttle/dropship2/enginefive{
 	dir = 1
@@ -21395,9 +21179,15 @@
 /obj/machinery/door/airlock/dropship_hatch/left/two,
 /turf/open/shuttle/dropship/three,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
+"otd" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "otr" = (
-/obj/machinery/constructable_frame/state_2,
-/turf/open/floor/mainship/black/full,
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/turf_decal/tile/full/black,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "ott" = (
 /obj/structure/bed/alien,
@@ -21447,7 +21237,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ovj" = (
 /obj/machinery/power/apc/drained{
 	name = "Mining APC";
@@ -21487,14 +21277,11 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "owj" = (
-/obj/structure/prop/mainship/sensor_computer1,
-/obj/structure/window/reinforced/windowstake{
-	dir = 8
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/gelida/caves/central_caves)
 "owm" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 1;
@@ -21521,10 +21308,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "oya" = (
-/obj/structure/sign/securearea{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "oyd" = (
 /obj/structure/stairs/cornerdark/seamless{
@@ -21574,12 +21361,12 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "oAK" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/platform_decoration{
+	dir = 9
 	},
-/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "oAR" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -21613,9 +21400,10 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "oBs" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "oBw" = (
 /obj/machinery/light{
 	dir = 4
@@ -21634,6 +21422,13 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/admin)
+"oBM" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "oBR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -21743,7 +21538,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "oEA" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -21751,7 +21546,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "oEE" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -21877,7 +21672,6 @@
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = -13
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/nw_rockies)
 "oHR" = (
@@ -21893,17 +21687,11 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
-"oIn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "oIs" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/obj/machinery/floodlight/colony,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "oIG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21981,7 +21769,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "oLA" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -21999,12 +21787,10 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/b_block/bridge)
 "oMk" = (
-/obj/structure/window/framed/colony,
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "oMo" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -22138,9 +21924,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "oRO" = (
-/obj/machinery/light,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "oRP" = (
 /obj/machinery/light{
 	dir = 1
@@ -22173,7 +21961,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "oSg" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
@@ -22193,6 +21981,9 @@
 /area/gelida/indoors/a_block/admin)
 "oSV" = (
 /obj/effect/spawner/gibspawner/xeno,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
@@ -22200,7 +21991,7 @@
 "oTb" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "oTs" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -22208,7 +21999,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "oTy" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -22225,10 +22016,12 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "oTT" = (
-/obj/structure/bed/chair/sofa/corsat/verticaltop,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "oTW" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison,
@@ -22286,7 +22079,7 @@
 /obj/structure/stairs/seamless,
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "oVG" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
@@ -22324,7 +22117,11 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "oXj" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "oXo" = (
@@ -22333,7 +22130,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "oXD" = (
 /obj/structure/table/mainship,
 /obj/machinery/faxmachine,
@@ -22404,16 +22201,20 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"oYN" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "oYR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/structure/largecrate/supply,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/op_centre)
+"oZd" = (
+/obj/machinery/door_control{
+	dir = 1;
+	id = "checkpoint3"
+	},
+/turf/open/floor/prison/whitepurple/full{
+	dir = 4
+	},
+/area/gelida/indoors/a_block/dorms)
 "oZe" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -22438,13 +22239,12 @@
 /turf/closed/shuttle/dropship2/walltwo/alt,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "oZF" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 5
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "oZU" = (
 /turf/open/floor/prison/whitepurple/full{
 	dir = 4
@@ -22457,11 +22257,6 @@
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
-"par" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "paM" = (
 /obj/structure/bed{
 	dir = 9;
@@ -22482,9 +22277,13 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "pbF" = (
-/obj/item/storage/briefcase,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pcy" = (
 /obj/machinery/light{
 	dir = 8
@@ -22497,7 +22296,7 @@
 "pcI" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "pcM" = (
 /obj/machinery/light{
 	dir = 8
@@ -22525,8 +22324,9 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "pdD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "pdJ" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -22567,11 +22367,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
-"peq" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "peB" = (
 /obj/structure/inflatable/wall{
 	dir = 1
@@ -22580,19 +22375,11 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/admin)
-"peC" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "peR" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pfk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -22603,13 +22390,9 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "pfm" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pfs" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -22640,7 +22423,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "pgt" = (
 /obj/item/storage/surgical_tray,
 /obj/structure/table/reinforced/prison,
@@ -22788,7 +22571,6 @@
 	dir = 4
 	},
 /obj/machinery/floodlight/colony,
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -22847,15 +22629,9 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/admin)
 "pkT" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/plating,
+/area/gelida/caves/central_caves)
 "pla" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
 /turf/open/floor/prison,
@@ -22873,7 +22649,7 @@
 "plT" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "pma" = (
 /obj/effect/acid_hole{
 	dir = 4
@@ -23030,7 +22806,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ptl" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/mainship/stripesquare,
@@ -23081,9 +22857,10 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/indoors/a_block/corpo)
 "pvp" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/gelida/caves/central_caves)
 "pvC" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -23095,13 +22872,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
-"pwt" = (
-/obj/structure/largecrate/random/case/double,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "pwy" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -23137,15 +22907,8 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "pxr" = (
-/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating,
-/area/gelida/caves/west_caves)
-"pxX" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/caves/central_caves)
 "pxY" = (
 /turf/open/floor/prison/blue/plate{
 	dir = 1
@@ -23173,11 +22936,10 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "pyS" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison/green/full{
-	dir = 4
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pyY" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = -7;
@@ -23206,12 +22968,11 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "pzm" = (
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/structure/sign/securearea{
+	dir = 1
 	},
-/obj/structure/table/mainship,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "pzF" = (
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/prison/whitepurple/full{
@@ -23292,9 +23053,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "pBo" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/ground/ice,
+/obj/effect/landmark/patrol_point{
+	id = "SOM_24";
+	name = "SOM exit point 24"
+	},
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "pBL" = (
 /obj/structure/closet,
@@ -23325,7 +23088,6 @@
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -23430,12 +23192,14 @@
 	},
 /area/gelida/indoors/a_block/executive)
 "pHo" = (
-/obj/structure/cable,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/sign/securearea{
+	dir = 1
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pHY" = (
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "pIp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -23505,7 +23269,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "pJR" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/beakers,
@@ -23543,7 +23307,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "pKg" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -23551,9 +23315,12 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "pKl" = (
-/obj/machinery/door/airlock/mainship/generic,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/landmark/patrol_point{
+	id = "SOM_23";
+	name = "SOM exit point 23"
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pKE" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -23600,7 +23367,7 @@
 	},
 /obj/item/tool/crowbar,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "pLJ" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/misc/paperbin{
@@ -23647,13 +23414,10 @@
 	},
 /area/gelida/outdoors/colony_streets/south_street)
 "pNV" = (
-/obj/machinery/power/apc/drained{
-	name = "Geothermal APC";
-	start_charge = 0
-	},
 /obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pOe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23710,6 +23474,12 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
+"pPB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "pPQ" = (
 /obj/machinery/floodlight/colony{
 	pixel_y = 6
@@ -23867,7 +23637,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "pVu" = (
 /obj/structure/table/mainship,
 /obj/item/storage/donut_box/empty{
@@ -23877,8 +23647,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "pVA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "pVU" = (
@@ -23911,14 +23680,7 @@
 "pWw" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
-"pWH" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/landing_zone_1)
 "pWU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
@@ -23933,10 +23695,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "pXd" = (
-/obj/structure/prop/mainship/brokengen,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/window/framed/colony,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "pXp" = (
 /obj/item/tool/wirecutters,
 /turf/open/floor/prison/blue{
@@ -24009,7 +23770,9 @@
 "pZH" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 8
+	},
 /area/gelida/outdoors/colony_streets/south_west_street)
 "qac" = (
 /turf/open/floor/prison/sterilewhite,
@@ -24035,8 +23798,7 @@
 	},
 /area/gelida/indoors/a_block/bridges/garden_bridge)
 "qaM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
+/obj/structure/cargo_container/gorg,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "qaN" = (
@@ -24070,10 +23832,11 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qaW" = (
-/obj/structure/table/mainship,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "qba" = (
@@ -24106,7 +23869,7 @@
 "qcd" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qcg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/darkred/full,
@@ -24130,7 +23893,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "qeb" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -24149,14 +23912,12 @@
 	},
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "qes" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/prop/mainship/sensor_computer1,
+/obj/structure/window/reinforced/windowstake{
+	dir = 8
 	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "qex" = (
 /turf/closed/shuttle/dropship2/corners{
 	dir = 1
@@ -24197,12 +23958,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
-"qfQ" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "qfU" = (
 /obj/item/inflatable,
 /turf/open/floor/prison,
@@ -24241,16 +23996,12 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"qhw" = (
-/obj/structure/closet/crate/internals,
-/obj/effect/turf_decal/warning_stripes/thin{
+"qhP" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/window/reinforced/windowstake{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
-"qhP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "qhT" = (
 /obj/structure/stairs/seamless{
@@ -24267,10 +24018,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "qih" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/prop/mainship/gelida/propserver,
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "qin" = (
@@ -24335,6 +24083,10 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint2"
+	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
 "qkJ" = (
@@ -24343,22 +24095,16 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "qkR" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/bed/chair/comfy{
+	dir = 1
 	},
-/obj/structure/stairs/cornerdark/seamless,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
-"qlb" = (
-/obj/effect/turf_decal/tile/full/black,
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "qlC" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qlD" = (
 /obj/effect/spawner/random/misc/structure/supplycrate{
 	pixel_x = 10;
@@ -24372,11 +24118,10 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "qlT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/prison/greenblue{
-	dir = 10
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "qmh" = (
 /obj/machinery/light{
 	dir = 4
@@ -24408,11 +24153,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
 "qmz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/caves/west_caves)
 "qmF" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -24468,11 +24212,10 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "qoT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/structure/stairs/seamless,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "qpm" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -24514,7 +24257,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qrj" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison,
@@ -24529,19 +24272,9 @@
 	},
 /area/gelida/indoors/a_block/executive)
 "qrZ" = (
-/obj/structure/table/mainship,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"qsl" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "qsS" = (
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/bridge)
@@ -24611,11 +24344,11 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "qvJ" = (
-/obj/structure/platform{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/stairs/seamless,
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "qwd" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -24623,7 +24356,7 @@
 "qwh" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qwH" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -24665,9 +24398,10 @@
 	},
 /area/gelida/outdoors/colony_streets/north_street)
 "qxq" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/structure/stairs/seamless,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/west_caves)
 "qxs" = (
 /obj/structure/bookcase{
 	pixel_x = 2;
@@ -24688,7 +24422,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "qxW" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -24750,11 +24484,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "qzH" = (
-/obj/item/tool/shovel/spade,
-/turf/open/floor/prison/greenblue{
-	dir = 6
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "qzL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -24776,17 +24508,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "qAk" = (
-/obj/effect/turf_decal/tile/full/black,
-/obj/effect/spawner/random/engineering/powercell,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
-"qAz" = (
-/obj/structure/largecrate/random/case/small,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "qBt" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/kitchen,
@@ -24871,10 +24596,6 @@
 /obj/item/clothing/head/hardhat/orange,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"qFt" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "qFK" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/prison{
@@ -24933,11 +24654,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "qHK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/gelida/caves/west_caves)
 "qHZ" = (
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/prison/whitegreenfull2,
@@ -25084,7 +24803,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qLU" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -25152,7 +24871,7 @@
 "qNH" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "qNT" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -25162,7 +24881,7 @@
 "qOf" = (
 /obj/structure/cargo_container/nt,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "qOg" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -25193,7 +24912,7 @@
 /area/gelida/indoors/c_block/cargo)
 "qOE" = (
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "qOH" = (
 /obj/structure/cargo_container{
 	dir = 1
@@ -25264,17 +24983,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "qRh" = (
-/obj/machinery/colony_floodlight_switch{
-	pixel_y = 30
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
-"qRm" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
+/obj/effect/ai_node,
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/rock)
 "qRn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -25446,17 +25157,6 @@
 "qWU" = (
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
-"qXc" = (
-/obj/structure/stairs/seamless{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
-"qXe" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "qXf" = (
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
@@ -25469,10 +25169,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"qXC" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
 "qXQ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -25591,6 +25287,13 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_west_street)
+"rbw" = (
+/obj/structure/cable,
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/landing_zone_1)
 "rbD" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/storage/fancy/cigarettes/kpack{
@@ -25639,6 +25342,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
+"rcM" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/prison/plate,
+/area/gelida/landing_zone_2)
 "rcO" = (
 /obj/structure/bed,
 /obj/structure/bed{
@@ -25709,11 +25416,14 @@
 "rem" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "res" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
+/obj/item/clothing/mask/facehugger/dead{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	name = "????";
+	stat = 2
+	},
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "rez" = (
 /obj/effect/spawner/gibspawner/robot,
@@ -25827,18 +25537,14 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/bridges/corpo)
 "rhC" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Generator Room"
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/engineering)
+/turf/closed/wall/r_wall,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "rhH" = (
-/obj/item/weapon/cane,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/b_block/bridge)
 "rhQ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -25883,10 +25589,13 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_street)
 "riq" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
 	},
-/turf/open/floor/mainship/black/full,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "riu" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -25902,7 +25611,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "riW" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
@@ -25924,16 +25633,17 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "rjV" = (
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
-"rkg" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/ai_node,
-/turf/open/floor/prison/greenblue{
-	dir = 9
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_street)
+"rkg" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/c_block/mining)
 "rkr" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/bottle/sake{
@@ -25943,9 +25653,11 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "rkG" = (
-/obj/item/clothing/gloves/insulated,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_east_street)
 "rkP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -25958,7 +25670,7 @@
 /area/gelida/indoors/a_block/bridges/corpo)
 "rkR" = (
 /turf/closed/wall,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "rkS" = (
 /obj/item/clothing/suit/storage/RO{
 	name = "\improper UA jacket"
@@ -25999,7 +25711,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "rln" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -26015,6 +25727,7 @@
 /area/gelida/indoors/a_block/admin)
 "rlA" = (
 /obj/effect/landmark/excavation_site_spawner,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "rlU" = (
@@ -26039,7 +25752,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "rmB" = (
 /obj/structure/platform_decoration,
 /obj/structure/stairs/cornerdark/seamless,
@@ -26080,10 +25793,6 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/admin)
-"rnV" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "roh" = (
 /obj/structure/table/mainship,
 /obj/item/paper,
@@ -26138,6 +25847,12 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/fitness)
+"rpe" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/lone_buildings/storage_blocks)
 "rpG" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/tile/yellow/patch,
@@ -26146,8 +25861,18 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "rqw" = (
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 2
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint1"
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
 "rra" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -26201,11 +25926,11 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "rsR" = (
-/obj/effect/turf_decal/tile/full/black,
-/obj/effect/landmark/start/job/xenomorph,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/c_block/garage)
 "rsY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -26220,7 +25945,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "rtR" = (
 /obj/item/stack/rods,
 /turf/open/floor/prison/blue/plate{
@@ -26347,7 +26072,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ryG" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -26492,19 +26217,16 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "rDu" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/cargo)
 "rDx" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/cargo_container/nt{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
 	},
-/area/gelida/landing_zone_1)
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/c_block/bridge)
 "rDK" = (
 /obj/machinery/light{
 	dir = 4
@@ -26528,8 +26250,11 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
 "rDW" = (
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/c_block/casino)
 "rDZ" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 8
@@ -26699,9 +26424,11 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "rMD" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/indoors/c_block/cargo)
 "rME" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /turf/open/floor/plating,
@@ -26766,10 +26493,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "rNG" = (
-/obj/structure/stairs/seamless,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/ice,
-/area/gelida/caves/west_caves)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_street)
 "rOf" = (
 /obj/machinery/light{
 	dir = 4
@@ -26777,12 +26505,6 @@
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
-"rOn" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/south_east_street)
 "rOI" = (
 /turf/open/floor/tile/dark2{
 	dir = 4
@@ -26793,11 +26515,6 @@
 	dir = 8
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
-"rPc" = (
-/obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "rPq" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/spawner/gibspawner/xeno,
@@ -26807,10 +26524,6 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"rPO" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison/greenblue,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "rPS" = (
 /obj/item/trash/mre,
 /turf/open/floor/prison/blue/plate{
@@ -26861,11 +26574,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"rQA" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "rQS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
@@ -26926,10 +26634,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/b_block/bridge)
-"rSK" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "rTb" = (
 /obj/item/shard,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -26940,12 +26644,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"rVm" = (
-/obj/structure/platform{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
 "rVn" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/cans/souto{
@@ -27041,10 +26739,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
-"rYN" = (
-/obj/effect/spawner/random/misc/structure/chair_or_metal/east,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "rYO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -27061,15 +26755,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/central_streets)
-"rZj" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "rZo" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/whitegreenfull2,
@@ -27078,15 +26763,6 @@
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/central_streets)
-"rZA" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "rZN" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -27176,6 +26852,10 @@
 	dir = 10
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
+"sdt" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/gelida/outdoors/colony_streets/central_streets)
 "sdy" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -27216,15 +26896,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/op_centre)
-"sfC" = (
-/obj/effect/spawner/random/engineering/structure/powergenerator{
-	pixel_x = -6
-	},
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "sfR" = (
 /obj/structure/table/mainship,
 /obj/item/book/manual/chef_recipes,
@@ -27235,13 +26906,13 @@
 	dir = 1
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "sgl" = (
 /obj/machinery/landinglight/ds1{
 	dir = 8
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "sgp" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -27257,7 +26928,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "sgw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -27272,14 +26943,6 @@
 	dir = 10
 	},
 /area/gelida/indoors/a_block/admin)
-"sgK" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "sgL" = (
 /obj/item/inflatable,
 /turf/open/floor/prison/darkred/full,
@@ -27324,9 +26987,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"sil" = (
-/turf/open/floor/prison/greenblue,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "sir" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -27336,8 +26996,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "siX" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/structure/cable,
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "sjb" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
@@ -27459,6 +27121,7 @@
 /obj/item/flashlight/lamp{
 	pixel_x = 7
 	},
+/obj/item/storage/holster/flarepouch/full,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "sno" = (
@@ -27467,10 +27130,6 @@
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
-"sns" = (
-/obj/effect/spawner/random/misc/structure/chair_or_metal/north,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
 "snA" = (
 /turf/closed/wall,
 /area/gelida/indoors/a_block/bridges/op_centre)
@@ -27574,12 +27233,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen/corner,
 /area/gelida/indoors/a_block/medical)
-"srp" = (
-/obj/structure/bed/chair/sofa/corsat/left{
-	pixel_y = 16
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
 "srs" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -27599,15 +27252,6 @@
 	dir = 4
 	},
 /area/gelida/outdoors/colony_streets/north_street)
-"srP" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "srQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 6
@@ -27620,10 +27264,6 @@
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
-"ssj" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "ssD" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/misc/folder/nooffset{
@@ -27759,6 +27399,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "svV" = (
@@ -27838,7 +27479,7 @@
 "syd" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "sym" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -27855,20 +27496,13 @@
 	pixel_x = 5
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "syO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/kitchen)
-"syU" = (
-/obj/structure/prop/mainship/sensor_computer2,
-/obj/structure/window/reinforced/windowstake{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "szf" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/pickaxe,
@@ -27911,6 +27545,10 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint2"
+	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
 "sAH" = (
@@ -27928,12 +27566,6 @@
 	dir = 4
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
-"sAT" = (
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
 "sBt" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/pistachios,
@@ -27964,19 +27596,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"sCl" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "sCG" = (
 /obj/structure/platform{
 	dir = 1
 	},
 /turf/closed/wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "sCH" = (
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -28051,13 +27676,6 @@
 /obj/item/shard,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
-"sEO" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
 "sEZ" = (
 /obj/structure/table/mainship,
 /obj/item/tool/soap,
@@ -28065,12 +27683,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorm_north)
-"sFe" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "sFv" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
@@ -28236,13 +27848,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
-"sKD" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "sKE" = (
 /obj/machinery/light{
 	dir = 8
@@ -28267,7 +27872,7 @@
 "sMe" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "sMi" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -28287,13 +27892,13 @@
 	dir = 10
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "sMC" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "sMK" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/trash/plate,
@@ -28355,7 +27960,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "sOb" = (
 /turf/closed/wall,
 /area/gelida/indoors/c_block/cargo)
@@ -28428,11 +28033,11 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
 	},
-/obj/structure/fence,
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/central_streets)
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/rock)
 "sQp" = (
 /obj/structure/table/mainship,
+/obj/item/armor_module/module/antenna,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "sQv" = (
@@ -28530,8 +28135,10 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "sUt" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "sUO" = (
 /obj/structure/platform_decoration{
@@ -28587,12 +28194,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "sWh" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 4
-	},
-/obj/effect/spawner/random/food_or_drink/kitchen,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "sWl" = (
 /obj/structure/bed/chair/comfy{
@@ -28654,13 +28256,6 @@
 	},
 /turf/closed/wall,
 /area/gelida/indoors/a_block/admin)
-"sYS" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "sZy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -28676,10 +28271,6 @@
 	dir = 10
 	},
 /area/gelida/indoors/a_block/dorms)
-"sZG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
 "sZR" = (
 /obj/machinery/light{
 	dir = 4
@@ -28732,7 +28323,6 @@
 "taY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/spawner/random/engineering/wood,
-/obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "taZ" = (
@@ -28776,11 +28366,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
-"tbM" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tbN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -28878,12 +28463,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"tfP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tfZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -28912,7 +28491,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "thu" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -28927,7 +28506,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "tib" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -28956,13 +28535,7 @@
 "tiC" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
-"tiD" = (
-/obj/structure/stairs/seamless{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "tiJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/prop/mainship/gelida/lightstick{
@@ -29042,22 +28615,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"tkX" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
-"tlr" = (
-/turf/open/floor/prison/cellstripe{
-	dir = 1
-	},
-/area/gelida/indoors/lone_buildings/spaceport)
-"tlu" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "tlE" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/light{
@@ -29095,16 +28652,12 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/dorms)
-"tmt" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tmu" = (
 /obj/structure/platform{
 	dir = 10
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tmz" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/prison/darkbrown/full,
@@ -29267,12 +28820,6 @@
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"ttk" = (
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/metal,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "tto" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -29287,11 +28834,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"ttF" = (
-/turf/open/floor/prison/greenblue{
-	dir = 10
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "ttT" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -29300,28 +28842,12 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
-"tuc" = (
-/obj/structure/prop/mainship/gelida/smallwire,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
 "tud" = (
 /obj/structure/bed/roller,
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
-"tuA" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
-"tuI" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
 "tuK" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 8;
@@ -29351,10 +28877,6 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"twb" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
 "twk" = (
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
@@ -29379,14 +28901,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/hallway)
-"twP" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
-"twR" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "twW" = (
 /obj/structure/inflatable/wall,
 /turf/open/shuttle/dropship/floor,
@@ -29449,6 +28963,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
+"tyV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/gelida/indoors/c_block/mining)
 "tyY" = (
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/decal/cleanable/blood/oil,
@@ -29494,7 +29015,7 @@
 "tAx" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tAB" = (
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
@@ -29515,14 +29036,6 @@
 /obj/item/reagent_containers/food/snacks/sandwiches/bread,
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
-"tAZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Greenhouse Storage"
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "tBa" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -29607,10 +29120,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/cargo)
-"tDa" = (
-/obj/structure/bed/chair/sofa/corsat/verticaltop,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tDZ" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /turf/open/floor/prison,
@@ -29641,17 +29150,12 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
-"tFQ" = (
-/obj/structure/window/framed/colony,
-/obj/structure/platform,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "tFU" = (
 /obj/structure/platform_decoration{
 	dir = 6
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tGa" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/storage/backpack/marine/satchel{
@@ -29679,12 +29183,6 @@
 /obj/effect/spawner/random/weaponry/ammo/sidearm,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
-"tHo" = (
-/obj/structure/cargo_container{
-	dir = 1
-	},
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tHt" = (
 /obj/machinery/shower{
 	dir = 1
@@ -29736,10 +29234,6 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/colony_streets/central_streets)
-"tJH" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
 "tJZ" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/blue{
@@ -29767,10 +29261,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"tKH" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tKP" = (
 /obj/structure/platform{
 	dir = 9
@@ -29808,13 +29298,6 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
-"tMD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "tMH" = (
 /turf/closed/shuttle/dropship2/glassfive,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
@@ -29824,12 +29307,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_street)
-"tNn" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "tNv" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/wood,
@@ -29896,10 +29373,6 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
-"tQB" = (
-/obj/structure/prop/vehicle/crane/destructible,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
 "tQN" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -29925,14 +29398,6 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
-"tQV" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "tRg" = (
 /obj/item/tool/weldingtool{
 	pixel_x = 6;
@@ -29962,7 +29427,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tSO" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/prison/plate,
@@ -30026,7 +29491,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tUU" = (
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/whitegreenfull2,
@@ -30046,8 +29511,9 @@
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "tWd" = (
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
@@ -30058,7 +29524,7 @@
 "tWk" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tWB" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/item/shard,
@@ -30067,10 +29533,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
-"tWG" = (
-/obj/structure/bed/chair/sofa/corsat/verticalmiddle,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
 "tWN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -30089,7 +29551,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "tXa" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -30108,7 +29570,7 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "tXO" = (
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -30172,7 +29634,7 @@
 /obj/machinery/light,
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "uak" = (
 /turf/closed/wall/r_wall,
 /area/gelida/indoors/b_block/bridge)
@@ -30191,9 +29653,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/bridge)
-"ubr" = (
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/engineering)
 "ubE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -30210,6 +29669,9 @@
 "ubR" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/bridge)
 "uce" = (
@@ -30248,26 +29710,12 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
-"udH" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
-"udI" = (
-/obj/machinery/vending/snack{
-	pixel_x = -7;
-	pixel_y = 16
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "udK" = (
 /obj/structure/platform{
 	dir = 9
 	},
 /turf/closed/wall,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "udO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -30449,7 +29897,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "ukV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/platform_decoration{
@@ -30604,14 +30052,12 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "upW" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/prison,
 /area/gelida/caves/west_caves)
 "urz" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "urM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/sterilewhite,
@@ -30649,7 +30095,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/coffee/cafe_latte,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "uuq" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/prison/whitegreenfull2,
@@ -30669,11 +30115,6 @@
 /obj/machinery/suit_storage_unit{
 	pixel_x = 16
 	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
-"uvy" = (
-/obj/structure/table/mainship,
-/obj/item/circuitboard/airlock,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "uvE" = (
@@ -30786,14 +30227,6 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"uAk" = (
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 1
-	},
-/turf/open/floor/tile/dark2{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "uAt" = (
 /obj/effect/spawner/random/decal/blood,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -30851,20 +30284,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/b_block/bridge)
-"uCq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
-"uCC" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/prop/mainship/brokengen,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "uDa" = (
 /obj/structure/table/mainship,
 /obj/structure/bed/chair{
@@ -30892,10 +30311,15 @@
 "uDG" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "uDM" = (
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
+"uEc" = (
+/obj/effect/turf_decal/warning_stripes/box,
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/prison,
+/area/gelida/outdoors/colony_streets/central_streets)
 "uEh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -30931,7 +30355,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "uFt" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -31076,20 +30500,16 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "uIz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/turf_decal/warning_stripes/thick,
 /obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "uIC" = (
 /obj/structure/platform_decoration{
 	dir = 10
 	},
 /turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/rock)
-"uIK" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/caves/west_caves)
 "uJf" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -31151,16 +30571,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/rock)
-"uLp" = (
-/obj/structure/flora/pottedplant{
-	desc = "It is made of Fiberbush(tm). It contains asbestos.";
-	name = "synthetic potted plant";
-	pixel_y = 8
-	},
-/turf/open/floor/prison/greenblue{
-	dir = 6
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "uLr" = (
 /obj/structure/stairs/seamless,
 /obj/machinery/door/poddoor/shutters/mainship/open{
@@ -31217,6 +30627,11 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/hallway)
+"uNr" = (
+/obj/structure/rack/nometal,
+/obj/item/storage/holster/flarepouch/full,
+/turf/open/floor/plating,
+/area/gelida/indoors/c_block/garage)
 "uNy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
@@ -31236,13 +30651,6 @@
 	dir = 10
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
-"uOC" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_2)
 "uPa" = (
 /obj/item/tool/pickaxe/silver,
 /obj/structure/cable,
@@ -31268,15 +30676,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
-"uPq" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/prison/cellstripe{
-	dir = 1
-	},
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/landing_zone_1)
 "uPv" = (
 /obj/item/trash/barcardine,
 /turf/open/floor/prison/blue,
@@ -31387,10 +30787,6 @@
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/garage)
-"uUj" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "uUl" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer/PC{
@@ -31413,7 +30809,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "uUx" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/flashlight/lamp/green{
@@ -31499,7 +30895,7 @@
 "uWz" = (
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "uWL" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -31508,7 +30904,7 @@
 /turf/closed/shuttle/dropship2/engine_sidealt,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "uXf" = (
-/turf/closed/wall/r_wall,
+/turf/open/floor/prison/cellstripe,
 /area/gelida/caves/west_caves)
 "uXi" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -31522,18 +30918,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "uXX" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
-"uYc" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/c_block/mining)
 "uYy" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/n_rockies)
@@ -31612,15 +31003,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"vap" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
-"vaq" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "var" = (
 /obj/structure/table/mainship,
 /turf/open/floor/plating,
@@ -31672,7 +31054,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "vbN" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -31717,25 +31099,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
-"veq" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/gelida/indoors/c_block/mining)
 "veR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/darkpurple{
 	dir = 8
 	},
 /area/gelida/indoors/a_block/dorms)
-"veZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Engineering Hut"
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/engineering)
 "vfe" = (
 /obj/structure/coatrack{
 	pixel_x = 11;
@@ -31746,7 +31115,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "vfg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -31771,12 +31140,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"vft" = (
-/obj/structure/barricade/wooden{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/engineering)
 "vfw" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -31804,13 +31167,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
-"vgf" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/south_west_street)
+/area/gelida/landing_zone_1)
 "vgA" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -31850,21 +31207,12 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"vhR" = (
-/obj/structure/ore_box,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "vhT" = (
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/metal,
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
-"vhV" = (
-/obj/structure/prop/mainship/gelida/propserver,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "vib" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -31885,8 +31233,10 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
 "vih" = (
-/obj/structure/cable,
-/turf/open/floor/plating/ground/ice,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "vin" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -31921,29 +31271,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"vjn" = (
-/obj/structure/rack/nometal,
-/obj/item/tool/minihoe{
-	pixel_x = -4
-	},
-/obj/item/tool/minihoe{
-	pixel_x = 4
-	},
-/obj/item/tool/minihoe{
-	pixel_y = -4
-	},
-/obj/item/tool/wirecutters/clippers{
-	pixel_y = -4
-	},
-/obj/item/tool/wirecutters/clippers{
-	pixel_y = -2
-	},
-/obj/item/tool/wirecutters/clippers,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "vjI" = (
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/prison/darkbrown/full,
@@ -31973,8 +31300,10 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_street)
 "vkT" = (
-/obj/effect/spawner/random/engineering/technology_scanner,
-/turf/open/floor/mainship/black/full,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4
+	},
 /area/gelida/caves/west_caves)
 "vlh" = (
 /obj/machinery/shower{
@@ -31990,10 +31319,6 @@
 /obj/item/trash/popcorn,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"vly" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "vlA" = (
 /turf/closed/shuttle/dropship2/finright,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
@@ -32031,7 +31356,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "vnQ" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
 /obj/effect/ai_node,
@@ -32125,20 +31450,12 @@
 	dir = 6
 	},
 /area/gelida/outdoors/colony_streets/north_street)
-"vsf" = (
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
-"vsn" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
 "vsp" = (
 /obj/machinery/vending/snack{
 	pixel_y = 16
@@ -32179,7 +31496,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "vsY" = (
 /obj/machinery/light{
 	dir = 1
@@ -32219,7 +31536,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 9
 	},
@@ -32252,10 +31568,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"vvA" = (
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "vvU" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = 12;
@@ -32360,7 +31672,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "vyd" = (
 /obj/structure/bed/chair/sofa/corsat/left,
 /turf/open/floor/wood,
@@ -32402,13 +31714,6 @@
 "vAn" = (
 /turf/closed/shuttle/dropship2/aisle,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"vAA" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "vAB" = (
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/garage)
@@ -32501,12 +31806,6 @@
 "vCE" = (
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
-"vCG" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison/greenblue{
-	dir = 10
-	},
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "vCO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -32557,7 +31856,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "vEM" = (
 /turf/open/floor/prison,
 /area/gelida/landing_zone_forecon/landing_zone_4)
@@ -32568,8 +31867,13 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "vFl" = (
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/w_rockies)
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "vFn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -32631,15 +31935,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"vHd" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 11
-	},
-/obj/structure/prop/mainship/gelida/planterboxsoil{
-	dir = 9
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "vHC" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
@@ -32797,7 +32092,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "vNW" = (
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 6
@@ -32814,12 +32109,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"vOx" = (
-/obj/item/shard,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/south_east_street)
 "vOM" = (
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
@@ -32831,11 +32120,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
-"vOY" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/south_west_street)
 "vPi" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -32855,9 +32139,11 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/fitness)
 "vQe" = (
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/w_rockies)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "vQm" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -32891,10 +32177,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
-"vQK" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "vQP" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
@@ -32903,10 +32185,6 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/corpo)
-"vQV" = (
-/obj/structure/table/mainship,
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
 "vSd" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -32932,11 +32210,11 @@
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "vTV" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "vUe" = (
 /obj/structure/flora/ausbushes/sunnybush{
 	pixel_y = 13
@@ -32980,16 +32258,6 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
-"vUL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/prison,
-/area/gelida/indoors/lone_buildings/spaceport)
 "vUQ" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -33044,7 +32312,7 @@
 "vXc" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "vXh" = (
 /obj/structure/inflatable/wall,
 /turf/open/floor/prison/blue/plate{
@@ -33076,17 +32344,6 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"vYq" = (
-/obj/structure/stairs/seamless{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "vYQ" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -33110,6 +32367,9 @@
 /obj/structure/window/framed/colony,
 /obj/structure/platform,
 /obj/structure/platform{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/mainship{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -33215,9 +32475,11 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "wcn" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/mining)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/gelida/caves/west_caves)
 "wcB" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -33290,7 +32552,7 @@
 "weV" = (
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wfe" = (
 /obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/prison/darkbrown/full,
@@ -33303,9 +32565,6 @@
 "wfV" = (
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
-"wfW" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/windbreaker)
 "wgZ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -33328,19 +32587,14 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/b_block/bridge)
 "whv" = (
+/obj/effect/landmark/weed_node,
 /obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/nw_rockies)
+/turf/open/floor/plating,
+/area/gelida/caves/west_caves)
 "whD" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_1)
-"whE" = (
-/obj/structure/platform{
-	dir = 5
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
+/area/gelida/landing_zone_2)
 "whI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -33353,6 +32607,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/landing_zone_forecon/landing_zone_4)
+"wii" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/prison/whitegreenfull2,
+/area/gelida/indoors/a_block/fitness)
 "wiC" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -33403,19 +32661,12 @@
 /obj/effect/spawner/random/decal/blood,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
-"wkg" = (
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/lone_buildings/spaceport)
 "wko" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
-"wkA" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/prison/darkyellow/full,
-/area/gelida/indoors/lone_buildings/engineering)
 "wkB" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /turf/open/floor/prison/whitegreen/full,
@@ -33431,9 +32682,6 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/fitness)
-"wkT" = (
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
 "wkX" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/yellow/patch,
@@ -33470,7 +32718,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "woj" = (
 /obj/structure/table/mainship,
 /obj/structure/flora/pottedplant{
@@ -33489,22 +32737,12 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wol" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"woq" = (
-/obj/machinery/power/smes/buildable{
-	capacity = 1e+006;
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/engineering)
 "wot" = (
 /obj/structure/bookcase{
 	pixel_y = 16
@@ -33620,9 +32858,6 @@
 "wsk" = (
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/hallway)
-"wsp" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "wsw" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -33640,7 +32875,7 @@
 /obj/structure/rack/nometal,
 /obj/effect/spawner/random/engineering/powercell,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wsJ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -33693,7 +32928,7 @@
 "wud" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wue" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -33731,11 +32966,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "wuQ" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/obj/effect/spawner/random/engineering/structure/powergenerator,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "wvm" = (
 /obj/structure/table/mainship,
@@ -33745,7 +32976,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wvE" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/mainship/black/full,
@@ -33859,10 +33090,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/c_block/mining)
-"wAp" = (
-/obj/structure/stairs/seamless/platform,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
 "wAs" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -33899,13 +33126,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"wBt" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "wBH" = (
 /obj/item/tool/wet_sign{
 	pixel_x = -11;
@@ -33951,7 +33171,7 @@
 /area/gelida/indoors/c_block/mining)
 "wDw" = (
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wDE" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -33960,7 +33180,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wEk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -33977,18 +33197,6 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
-"wFG" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
-"wFK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/gelida/indoors/lone_buildings/spaceport)
 "wFM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -34015,7 +33223,7 @@
 "wGi" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wGo" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Colony Marshals"
@@ -34056,12 +33264,12 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "wHB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 9
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wHJ" = (
 /obj/structure/platform_decoration,
 /obj/structure/bed/roller,
@@ -34070,6 +33278,12 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
+"wHN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "wHY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -34091,7 +33305,7 @@
 "wIz" = (
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wIS" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /turf/open/floor/prison/whitegreenfull2,
@@ -34109,18 +33323,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/nw_rockies)
-"wKl" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/gelida/indoors/lone_buildings/engineering)
 "wKm" = (
-/obj/structure/fence,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "checkpoint3"
+	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "wKr" = (
@@ -34133,12 +33344,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_west_street)
-"wKD" = (
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "wKI" = (
 /obj/machinery/light{
 	dir = 8
@@ -34155,7 +33360,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wLx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -34243,23 +33448,16 @@
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/cargo)
-"wNI" = (
-/obj/structure/prop/mainship/gelida/lightstick{
-	pixel_x = 11;
-	pixel_y = 25
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
 "wOd" = (
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wON" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "wOW" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -34394,7 +33592,7 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "wTN" = (
 /turf/closed/wall/r_wall/unmeltable,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wTO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -34442,12 +33640,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 10
 	},
-/area/gelida/landing_zone_1)
-"wVy" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/caves/west_caves)
+/area/gelida/landing_zone_2)
 "wVC" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -34477,11 +33670,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"wWN" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "wXv" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -34526,7 +33714,7 @@
 "wZs" = (
 /obj/structure/largecrate,
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "wZC" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -34613,6 +33801,13 @@
 /obj/structure/platform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
+"xdv" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/black/full,
+/area/gelida/caves/west_caves)
 "xef" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -34644,9 +33839,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
-"xfn" = (
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/lone_buildings/outdoor_bot)
 "xfT" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_y = 16
@@ -34753,14 +33945,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"xma" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 10
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
 "xmb" = (
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/darkbrown/full,
@@ -34787,7 +33971,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "xmm" = (
 /turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xmr" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -34800,7 +33984,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xmx" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/prison,
@@ -34825,10 +34009,6 @@
 	dir = 8
 	},
 /area/gelida/outdoors/colony_streets/north_street)
-"xmY" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/mining)
 "xnc" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison/darkred/full,
@@ -34849,8 +34029,9 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/b_block/bridge)
 "xod" = (
-/obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/mainship/black/full,
+/obj/structure/table/mainship,
+/obj/item/clothing/head/collectable/tophat,
+/turf/open/floor/prison/whitegreenfull2,
 /area/gelida/caves/west_caves)
 "xow" = (
 /obj/structure/platform_decoration{
@@ -34860,14 +34041,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/b_block/bridge)
-"xoy" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 6
-	},
-/area/gelida/outdoors/colony_streets/south_west_street)
 "xoV" = (
 /obj/structure/table/reinforced/prison,
 /obj/machinery/prop/mainship/computer/PC{
@@ -34895,7 +34068,7 @@
 /area/gelida/indoors/a_block/admin)
 "xpG" = (
 /turf/open/floor/plating,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xpN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
@@ -34956,7 +34129,7 @@
 "xrD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xsf" = (
 /obj/item/stack/rods,
 /obj/item/shard,
@@ -35071,7 +34244,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xwq" = (
 /obj/structure/cargo_container{
 	dir = 1
@@ -35116,7 +34289,7 @@
 "xyj" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xyo" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison/kitchen,
@@ -35140,7 +34313,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xyZ" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -35158,7 +34331,7 @@
 "xAe" = (
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xAf" = (
 /turf/open/floor/prison/darkpurple{
 	dir = 6
@@ -35174,7 +34347,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xBf" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/platform{
@@ -35209,8 +34382,9 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xCv" = (
 /obj/structure/window/framed/colony,
 /obj/structure/platform{
@@ -35437,11 +34611,6 @@
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
-"xIX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/central_streets)
 "xJa" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -35472,19 +34641,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"xJD" = (
-/obj/structure/bed,
-/obj/structure/bed{
-	buckling_y = 13;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/plate,
-/area/gelida/indoors/c_block/mining)
 "xJK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -35500,15 +34656,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"xKd" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "xKz" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -35589,12 +34736,6 @@
 /obj/item/tool/wirecutters,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
-"xMe" = (
-/obj/structure/rack/nometal,
-/obj/effect/spawner/random/engineering/toolbox,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "xMf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -35627,10 +34768,6 @@
 /obj/structure/cargo_container,
 /turf/open/floor/plating/platebot,
 /area/gelida/indoors/c_block/cargo)
-"xNw" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/south_east_street)
 "xNI" = (
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/prison/darkbrown/full,
@@ -35647,7 +34784,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xNQ" = (
 /obj/item/clothing/shoes/veteran/pmc{
 	name = "steel toe boots"
@@ -35672,7 +34809,7 @@
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xOE" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -35682,23 +34819,19 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xOJ" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/platform{
 	dir = 6
 	},
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xOM" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/op_centre)
-"xOO" = (
-/obj/structure/sign/securearea,
-/turf/closed/wall,
-/area/gelida/indoors/c_block/mining)
 "xOP" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
@@ -35749,7 +34882,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "xPZ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -35800,27 +34933,19 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/dorms)
-"xRj" = (
-/obj/effect/turf_decal/tile/full/black,
-/turf/open/floor/plating,
-/area/gelida/caves/west_caves)
 "xRk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"xRt" = (
-/obj/structure/closet/crate,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/mining)
 "xRE" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/platform{
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xRX" = (
 /obj/structure/ore_box{
 	pixel_x = -4
@@ -35830,13 +34955,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/prison/cleanmarked,
-/area/gelida/landing_zone_2)
-"xSn" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/whitegreenfull2,
-/area/gelida/indoors/lone_buildings/spaceport)
+/area/gelida/landing_zone_1)
 "xSR" = (
 /turf/open/floor/prison/whitegreen{
 	dir = 4
@@ -35875,7 +34994,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
-/area/gelida/landing_zone_2)
+/area/gelida/landing_zone_1)
 "xTw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
@@ -36005,9 +35124,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "xXi" = (
-/obj/machinery/power/geothermal,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "xXU" = (
 /obj/structure/filingcabinet/filingcabinet{
@@ -36020,10 +35138,6 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
-"xYi" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/turf/open/floor/prison/cleanmarked,
-/area/gelida/indoors/lone_buildings/spaceport)
 "xYl" = (
 /turf/open/floor/plating,
 /area/gelida/outdoors/colony_streets/south_east_street)
@@ -36031,6 +35145,12 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/fitness)
+"xYH" = (
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "xYQ" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
@@ -36106,7 +35226,7 @@
 "ybl" = (
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/prison/plate,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ybx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -36116,11 +35236,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"ybG" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "ybM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -36177,11 +35292,6 @@
 "ydo" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
-"ydp" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/weaponry/melee,
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "ydx" = (
 /obj/structure/prop/mainship/gelida/miner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -36190,7 +35300,7 @@
 /turf/open/floor/prison{
 	dir = 4
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ydU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -36243,23 +35353,17 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "yhg" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "yhr" = (
 /obj/effect/spawner/random/machinery/microwave,
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
-"yhO" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/gelida/caves/west_caves)
 "yhX" = (
 /obj/structure/table/mainship,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -36280,7 +35384,7 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "yiB" = (
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/gelida/caves/west_caves)
 "yiI" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
@@ -36346,7 +35450,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 6
 	},
-/area/gelida/landing_zone_1)
+/area/gelida/landing_zone_2)
 "ykZ" = (
 /obj/item/clothing/shoes/jackboots{
 	pixel_y = -5
@@ -37046,7 +36150,7 @@ gEI
 gEI
 gEI
 gEI
-nvd
+rhH
 nsK
 "}
 (4,1,1) = {"
@@ -37064,20 +36168,20 @@ xIt
 xIt
 xIt
 xIt
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -37268,7 +36372,7 @@ ndb
 ndb
 ndb
 ndb
-nvd
+rjV
 nsK
 "}
 (5,1,1) = {"
@@ -37279,36 +36383,36 @@ xIt
 xIt
 xIt
 xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-vqi
-xIt
-lmN
-yiB
-lmN
-yiB
-dQm
-lmN
-lmN
 yiB
 yiB
 xIt
 xIt
-vqi
+yiB
+yiB
+yiB
 xIt
 xIt
 xIt
 xIt
-cmF
-cmF
-cmF
-cmF
-cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -37490,7 +36594,7 @@ ndb
 ndb
 ndb
 ndb
-nvd
+rkg
 nsK
 "}
 (6,1,1) = {"
@@ -37501,37 +36605,37 @@ xIt
 xIt
 xIt
 xIt
-xIt
-cmF
-cmF
-cmF
-cmF
-xIt
-xIt
-vqi
-lmN
-lmN
 yiB
+dII
+ewI
+geP
+gBm
+gZL
 yiB
-lmN
-oco
-gEt
-qaM
-lmN
-yiB
-lmN
-yiB
-twP
 xIt
 xIt
 xIt
-cmF
-cmF
-wpv
-cmF
-wpv
-cmF
-cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -37712,7 +36816,7 @@ ndb
 ndb
 ndb
 ndb
-nvd
+dug
 nsK
 "}
 (7,1,1) = {"
@@ -37722,40 +36826,40 @@ xIt
 xIt
 xIt
 xIt
-xIt
-cmF
-cmF
-wpv
-cmF
-cmF
-wpv
-lmN
-qRm
-lmN
-lmN
-oIn
-gEt
-lmN
-lmN
-jrq
-gEt
-lmN
-gEt
-dQm
 yiB
-bvh
-qhP
-uXf
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
+cDx
+dKf
+cIy
+gim
+geP
+aPS
+gZL
+yiB
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -37905,7 +37009,7 @@ wOd
 ove
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 wOd
@@ -37923,7 +37027,7 @@ bbO
 wOd
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 wOd
@@ -37943,42 +37047,42 @@ xIt
 xIt
 xIt
 xIt
-dOs
-cmF
-cmF
-wpv
-cmF
-cmF
-dOs
-cmF
-lmN
-twP
-oIn
-lmN
-oXj
+yiB
+yiB
+cDx
+dOA
 dQm
-oIn
-oco
-lmN
-gEt
-lmN
-lmN
-oIn
-lmN
-twP
-lUi
-cmF
-qhP
-cmF
-cmF
-cmF
-cmF
-dOs
-wpv
-cmF
-cmF
-wpv
-dOs
+mSM
+iUh
+bgd
+hRV
+yiB
+yiB
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -38126,10 +37230,10 @@ fsz
 wOd
 tWR
 wDw
-siX
-siX
-siX
-siX
+npE
+npE
+npE
+npE
 wOd
 tFU
 cZL
@@ -38146,8 +37250,8 @@ tmu
 bbO
 wOd
 wOd
-siX
-siX
+npE
+npE
 wOd
 wOd
 wOd
@@ -38164,44 +37268,44 @@ cgS
 xIt
 xIt
 xIt
-xIt
 cmF
-cmF
-cmF
-cmF
-xIt
-xIt
-xIt
-lUi
-lmN
-qRm
-lUi
+bem
+iUh
+aBZ
 dQm
-oIn
-lmN
-oIn
-lUi
-gEt
-lmN
-qaM
-gEt
-lmN
-lmN
-eSL
-yiB
-yiB
-yiB
-wpv
-cmF
+upW
+upW
+mSM
+bic
+geP
+bua
+sUt
+ckC
 xIt
 xIt
 xIt
-cmF
-wpv
-cmF
-cmF
-cmF
-cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -38345,10 +37449,10 @@ wOd
 wOd
 fsz
 hbX
-siX
+npE
 wDw
-siX
-siX
+npE
+npE
 wOd
 wOd
 wOd
@@ -38370,7 +37474,7 @@ bbO
 wOd
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 wOd
@@ -38385,32 +37489,21 @@ nsK
 cgS
 xIt
 xIt
-xIt
 cmF
 cmF
-wpv
-cmF
-xIt
-xIt
-lmN
-lmN
-lmN
-yiB
-twP
-lmN
-lmN
-lmN
-gBm
-dQm
-lmN
-lmN
-lmN
-lmN
-lmN
-qaM
-yiB
-bvh
-lmN
+bjn
+iUh
+cPM
+upW
+upW
+eqE
+upW
+ckC
+uXf
+iUh
+sUt
+jBU
+ckC
 xIt
 xIt
 xIt
@@ -38419,12 +37512,23 @@ xIt
 xIt
 xIt
 xIt
-cmF
-wpv
-cmF
-cmF
-wpv
-cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -38567,8 +37671,8 @@ ngP
 ngP
 wOd
 vNT
-siX
-siX
+npE
+npE
 wOd
 wOd
 wOd
@@ -38594,7 +37698,7 @@ bbO
 wOd
 wOd
 lIC
-siX
+npE
 wOd
 wOd
 lIC
@@ -38607,46 +37711,46 @@ nsK
 cgS
 xIt
 xIt
-xIt
 cmF
 cmF
+bjn
+geP
+aIJ
+cZX
+mSM
+upW
+glN
+aUs
+ckC
+iUh
+jua
+ckC
+ckC
 cmF
-cmF
-xIt
-xIt
-lmN
-lmN
-lmN
-yiB
-twP
-dmh
-lmN
-gBm
-yiB
-oco
-yiB
-lmN
-yiB
-lmN
-yiB
-lmN
-yiB
-bvh
-lmN
-lmN
-xIt
-xIt
-lmN
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-cmF
-cmF
-cmF
-cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -38817,7 +37921,7 @@ tmu
 bbO
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 wOd
@@ -38829,47 +37933,47 @@ nsK
 cgS
 xIt
 xIt
-wpv
 cmF
 cmF
-cmF
-xIt
-xIt
-xIt
-xIt
-xIt
-lmN
+bjn
+iUh
+cPM
+bFN
+aPS
+ezB
+cDx
+upW
 uXf
-eEX
-bvh
-mKk
-eEX
-eEX
-eEX
-jqF
-nEw
-nEg
-eEX
-eEX
-eEX
-nRW
-kwJ
-uXf
-uXf
-uXf
-xIt
-dQm
-lmN
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
+iUh
+sUt
+dOs
+ckC
 dOs
 cmF
-wpv
-dOs
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 cJC
@@ -39009,9 +38113,9 @@ nvd
 ndb
 ngP
 eHG
-siX
+npE
 wDw
-siX
+npE
 wOd
 tFU
 cZL
@@ -39040,7 +38144,7 @@ tmu
 bbO
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 ndb
@@ -39050,46 +38154,46 @@ nsK
 (13,1,1) = {"
 cgS
 xIt
-xIt
+cmF
+cmF
+cmF
+yiB
+yiB
+cQe
+upW
+ezB
+ezB
+cDx
+upW
+hVN
+yiB
+yiB
 cmF
 cmF
 cmF
 cmF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uXf
-lmN
-lmN
-qhP
-lmN
-yiB
-yiB
-qhP
-lmN
-yiB
-lmN
-yiB
-yiB
-yiB
-qhP
-lmN
-yiB
-uXf
-lmN
-lmN
-yiB
-lmN
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
 cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+anV
+anV
 cmF
 cmF
 cmF
@@ -39232,8 +38336,8 @@ ngP
 ngP
 ngP
 wDw
-siX
-siX
+npE
+npE
 wOd
 qrg
 oTb
@@ -39262,7 +38366,7 @@ nBT
 fyu
 wOd
 wOd
-siX
+npE
 wOd
 wOd
 ndb
@@ -39272,48 +38376,48 @@ nsK
 (14,1,1) = {"
 cgS
 xIt
-cmF
-cmF
-cmF
-cmF
-cmF
-cmF
 xIt
-xIt
+cmF
+cmF
+bjn
+iUh
+cPM
+upW
+eEw
 aPS
-xIt
-yiB
+ckC
+gbt
 uXf
-yiB
-czM
-glN
-glN
-glN
-glN
-jBU
-glN
-glN
-glN
-glN
-cIy
-gMH
-glN
-sFe
-yiB
-uXf
-yiB
-lsX
-gEt
-lmN
+iUh
+sUt
+ckC
+wpv
+cmF
+anV
+anV
+cmF
+cmF
+cmF
 xIt
-bAh
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
 xIt
 xIt
 cmF
-dOs
+cmF
+cmF
+uzr
+wpv
+cmF
 cmF
 uzr
 cmF
@@ -39455,7 +38559,7 @@ ngP
 aIf
 wDw
 wDw
-siX
+npE
 xmu
 pHY
 urz
@@ -39484,7 +38588,7 @@ wLl
 pHY
 bPK
 wOd
-siX
+npE
 wOd
 wOd
 ndb
@@ -39494,54 +38598,54 @@ nsK
 (15,1,1) = {"
 cgS
 xIt
+xIt
 cmF
+cmF
+bem
+iUh
+ckC
+upW
+eOl
+gqh
+mSM
+res
+ckC
+iUh
+sUt
+cmF
+cmF
+cmF
+anV
+anV
 cmF
 wpv
 cmF
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 wpv
 cmF
 cmF
-xIt
-lmN
-gEt
-yiB
-uXf
-yiB
-qFt
-uIK
-npU
-npU
-npU
-iPn
-iPn
-iPn
-iPn
-grj
-grj
-grj
-apd
-udH
-dQm
-kuB
-lmN
-rSK
-lmN
-dQm
-dQm
-yhO
-xIt
-xIt
-xIt
-xIt
-xIt
-cmF
-cmF
+dOs
 cmF
 uzr
 cmF
 cmF
+dOs
+uzr
+cmF
+cmF
 rfq
-rfq
+qHK
 cJC
 sPY
 sPY
@@ -39675,8 +38779,8 @@ nvd
 ndb
 ngP
 tAx
-siX
-siX
+npE
+npE
 wOd
 iUl
 pHY
@@ -39719,45 +38823,45 @@ xIt
 cmF
 cmF
 cmF
-cmF
-cmF
-cmF
-cmF
-lmN
-gEt
-xod
-yiB
-yiB
-yiB
+bjn
+ckC
+aIJ
+cZX
+upW
+upW
+glN
+upW
+bnc
+geP
 sUt
-npU
-uXf
-eOl
-uXf
-xXi
-gIN
-otr
-xXi
-uXf
-eOl
-uXf
-npU
-mFD
-yiB
-fTM
-yiB
-lmN
-yiB
-lsX
-lmN
-lmN
-xIt
-uXf
-uXf
-xIt
+ckC
 cmF
 cmF
 wpv
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+anV
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+anV
+dag
+cmF
+cmF
+cmF
+cmF
+uzr
+cmF
+cmF
 cmF
 uzr
 cmF
@@ -39897,7 +39001,7 @@ nvd
 ngP
 ngP
 ngP
-siX
+npE
 wOd
 wOd
 iUl
@@ -39929,7 +39033,7 @@ pHY
 geE
 wOd
 wDw
-siX
+npE
 wOd
 ndb
 nvd
@@ -39939,47 +39043,47 @@ nsK
 cgS
 xIt
 xIt
-mPF
-cmF
-dOs
 cmF
 cmF
+bjn
+iUh
+iUh
 res
-oIn
-lsX
-rSK
-dmh
-lmN
-yiB
-par
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-vAA
-lmN
-uXf
-oya
-dkT
-lsX
-yiB
-gEt
-yiB
-lmN
-lUi
-yiB
-fTM
+cZX
+ckC
+upW
+mSM
+geP
+iUh
+sUt
+gbt
 cmF
 cmF
-dOs
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+anV
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+anV
+anV
+cmF
+cmF
+wpv
+cmF
+uzr
+cmF
+cmF
 cmF
 xIt
 xIt
@@ -40118,7 +39222,7 @@ tqi
 nvd
 ndb
 ngP
-siX
+npE
 wOd
 wOd
 lIC
@@ -40151,7 +39255,7 @@ pHY
 geE
 wOd
 wDw
-siX
+npE
 wOd
 ndb
 nvd
@@ -40162,46 +39266,46 @@ cgS
 xIt
 xIt
 cmF
-cmF
-cmF
 xIt
-xIt
-lmN
-gEt
-lmN
+yiB
+yiB
+aPS
+iUh
 vkT
+aWS
+vkT
+iUh
+aPS
 yiB
-uXf
-lmN
-cIf
-npU
-uXf
-aaN
-uXf
-iyK
-xXi
-xXi
-gIN
-uXf
-aaN
-uXf
-npU
-udH
 yiB
-fTM
-lUi
-yiB
-lmN
-gEt
-yiB
-lmN
-yiB
-lmN
-qhP
-uzr
-yiB
+xIt
+ckC
+dOs
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
 wpv
 cmF
+cmF
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+uzr
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -40383,47 +39487,47 @@ nsK
 cgS
 xIt
 xIt
-cmF
-cmF
 xIt
 xIt
 xIt
 yiB
-eLt
+cQx
+dUu
 iUh
-gEt
-yiB
-uXf
-lmN
-sUt
-npU
-npU
-lnC
-npU
-fVm
-dmh
-iPn
-dmh
-npU
-npU
-npU
-npU
-udH
-yiB
-uXf
-lmN
-gEt
-yiB
-yiB
-lmN
-uXf
-uXf
-lmN
+iUh
+iUh
+hgq
+hRV
 yiB
 xIt
 xIt
-yiB
+ckC
+cmF
+dOs
+cmF
+cmF
+cmF
+cmF
+dOs
+cmF
+cmF
 wpv
+cmF
+cmF
+uzr
+cmF
+cmF
+dOs
+cmF
+cmF
+cmF
+cmF
+cmF
+dOs
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -40522,19 +39626,19 @@ vaN
 rsp
 vaN
 vaN
-vaN
-vaN
-vaN
-vaN
-vaN
-rsp
-vaN
-vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+qRh
+ndb
+ndb
 sQn
-vaN
-tqi
-dag
-eEX
+ndb
+ndb
+ndb
+xUF
 xPZ
 sOU
 xUF
@@ -40594,8 +39698,8 @@ wLl
 pHY
 geE
 wOd
-siX
-siX
+npE
+npE
 wOd
 ndb
 nvd
@@ -40604,45 +39708,45 @@ nsK
 (20,1,1) = {"
 cgS
 xIt
+xIt
+xIt
+xIt
+xIt
+yiB
+yiB
+yiB
+eRD
+grj
+gLz
+yiB
+yiB
+yiB
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
 wpv
 cmF
 cmF
+cmF
+cmF
+cmF
+cmF
+uzr
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
 xIt
-xMe
-yiB
-eLt
-lmN
-oIn
-xod
-lmN
-uXf
-yiB
-sUt
-qlb
-qlb
-xRj
-qAk
-xRj
-qlb
-bVQ
-qlb
-xRj
-xRj
-iqP
-xRj
-udH
-yiB
-uXf
-dQm
-lmN
-gEt
-lmN
-uXf
-uXf
-vhV
-lmN
-yiB
-uXf
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -40742,23 +39846,23 @@ bZn
 bZn
 bZn
 bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-lLK
-sqm
-sKr
-bZn
-qHr
-ddH
-wfW
+gmI
+vaN
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 nNF
-tqi
+tqF
 ndb
 ndb
 ndb
@@ -40782,9 +39886,9 @@ tqi
 tqi
 tqF
 cNp
-tqi
+rhC
 ngP
-wOd
+ngP
 wOd
 wOd
 wOd
@@ -40816,8 +39920,8 @@ wLl
 pHY
 geE
 wOd
-siX
-siX
+npE
+npE
 wOd
 ndb
 nvd
@@ -40826,45 +39930,45 @@ nsK
 (21,1,1) = {"
 cgS
 xIt
-cmF
-cmF
-wpv
 xIt
-hLc
+xIt
+xIt
+xIt
+yiB
 lmN
 lUi
-jDU
-xIt
-rSK
-lmN
+sWh
+gsb
+sWh
+hsw
 kuB
-lmN
-par
-xRj
-xRj
-xRj
-qlb
-lMM
-xRj
-rsR
-xRj
-xRj
-qlb
-xRj
-xRj
-mFD
-qhP
-uXf
-lmN
-lmN
+yiB
 xIt
-lmN
-nkH
-owj
-tNn
-yiB
-lmN
-yiB
+xIt
+cmF
+cmF
+cmF
+xXi
+otd
+xXi
+xXi
+xXi
+xXi
+otd
+xXi
+xXi
+cmF
+uzr
+cmF
+cmF
+cmF
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -40963,25 +40067,25 @@ rzM
 rzM
 rzM
 rzM
-jBv
 uhx
-uhx
-adq
-uiF
-uiF
-glq
-vYq
-fNq
-uAk
-adq
-fqQ
-osK
-nGJ
-crF
+hoS
+vaN
+gzT
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 tqF
 tqF
-tqi
-tqi
+tqF
 ndb
 ndb
 ndb
@@ -41003,10 +40107,10 @@ tqi
 tqi
 tqF
 qOV
-ilJ
-tqi
-wOd
-wOd
+cNp
+rhC
+ngP
+ngP
 wOd
 wOd
 wOd
@@ -41038,8 +40142,8 @@ wLl
 pHY
 geE
 wOd
-siX
-siX
+npE
+npE
 wOd
 wOd
 nvd
@@ -41048,45 +40152,45 @@ nsK
 (22,1,1) = {"
 cgS
 xIt
-cmF
-cmF
-cmF
 xIt
-xod
-lmN
 yiB
-xIt
-xIt
+yiB
+yiB
+xod
+cZX
+upW
+cZX
 mSM
-lUi
+aUs
+upW
 fTM
 yiB
-ihx
-npU
-npU
-lnC
-npU
-cZX
-iPn
-cZX
-iPn
-grj
-hVN
-grj
-grj
-udH
-lUi
-uXf
-lmN
-lmN
+yiB
+xIt
+cmF
+cmF
+wpv
+xXi
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+xXi
+wpv
+pvC
+cmF
+cmF
+cmF
 xIt
 xIt
-nkH
-syU
-tNn
-lmN
-qhP
-qhP
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -41186,21 +40290,21 @@ mSD
 mSD
 omN
 cZq
-sfC
-qvJ
-wKl
-wKl
-wKl
-wKl
-ubr
-veZ
-wKl
-wKl
-wKl
-wKl
-flC
-wuQ
-ixM
+hoS
+vaN
+gGG
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+tqi
 tqF
 tqF
 tqi
@@ -41226,8 +40330,8 @@ tqi
 tqF
 nNF
 ilJ
-tqi
-wOd
+wuQ
+ngP
 wOd
 wOd
 lIC
@@ -41260,7 +40364,7 @@ wLl
 pHY
 fix
 wOd
-siX
+npE
 wDw
 wOd
 wOd
@@ -41270,45 +40374,45 @@ nsK
 (23,1,1) = {"
 cgS
 xIt
+yiB
+yiB
+aHZ
+sWh
+upW
+res
+mSM
+fwg
+upW
+ckC
+upW
+upW
+sWh
+yiB
+xIt
+cmF
+cmF
+cmF
+xXi
+cmF
 wpv
 cmF
 cmF
-xIt
-xIt
-lmN
-xIt
-xIt
-xIt
-yiB
-yiB
-fTM
-yiB
-sUt
-npU
-uXf
-eOl
-uXf
-gIN
+cmF
+cmF
+cmF
 xXi
-gIN
-xXi
-uXf
-eOl
-uXf
-npU
-ayb
-lmN
-kuB
-gqh
-lmN
-lby
-lmN
-nkH
-vhV
-npU
-lmN
-yiB
-yiB
+cmF
+uzr
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -41408,21 +40512,21 @@ ewj
 gJP
 sXy
 cZq
-qvJ
-msI
-pXd
-pXd
-uCC
-msI
-gZy
-gZy
-msI
-msI
-wkA
-wkA
-msI
-flC
-crF
+hoS
+vaN
+gHV
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+tqi
 tqF
 qOV
 tqi
@@ -41447,9 +40551,9 @@ tqi
 tqi
 tqF
 tqF
-ilJ
-tqi
-wOd
+cNp
+wuQ
+ngP
 wOd
 wOd
 wOd
@@ -41492,45 +40596,45 @@ nsK
 (24,1,1) = {"
 cgS
 xIt
-cmF
-wpv
-cmF
-xIt
-xIt
-lmN
-lmN
-xIt
-oco
-lmN
-lmN
-uXf
 yiB
-qFt
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-uXf
-udH
-lUi
-kuB
-lUi
-lmN
-lmN
-lmN
-xod
-dQm
-npU
-lUi
+aeZ
+aNR
+bqw
+bXz
+daN
+upW
+eSL
+aZE
+aNR
+bqw
+bXz
+sWh
 yiB
-uXf
+yiB
+ckC
+cmF
+cmF
+xXi
+cmF
+cmF
+cmF
+cmF
+kvM
+cmF
+cmF
+xXi
+cmF
+uzr
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -41630,21 +40734,21 @@ ewj
 nGB
 sXy
 cZq
-nJe
-pXd
-vly
-hXI
-twR
-msI
-pNV
-hPL
-lHs
-lHs
-hPL
-rqw
-tuI
-aWS
-crF
+hoS
+vaN
+vaN
+gub
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+ndb
+ndb
+kgY
+tqi
 tqF
 qOV
 tqF
@@ -41669,13 +40773,13 @@ tqi
 ndb
 qOV
 tqi
-ilJ
-tqi
+cNp
+rhC
+ngP
 ngP
 wOd
 wOd
-wOd
-wOd
+mFF
 wOd
 sMv
 nSH
@@ -41703,7 +40807,7 @@ xAT
 nMP
 xwk
 wOd
-siX
+npE
 wDw
 wOd
 wOd
@@ -41714,45 +40818,45 @@ nsK
 (25,1,1) = {"
 cgS
 xIt
+xIt
+sWh
+cZX
+upW
+cfG
+upW
+aUs
+eWM
+mSM
+gMi
+hsH
+upW
+upW
+bHY
+riq
+ctu
 cmF
-cmF
-cmF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-lUi
-uXf
-yiB
-peq
-npU
-uXf
-aaN
-uXf
-gIN
+dOs
 xXi
+cmF
+cmF
+cmF
+cmF
+cmF
+dOs
+cmF
 xXi
-otr
-uXf
-aaN
-uXf
-npU
-udH
-lmN
-uXf
-lmN
-lmN
-lmN
-lmN
-lmN
-lmN
-lmN
-dQm
-yiB
-uXf
+cmF
+uzr
+cmF
+cmF
+dOs
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -41852,21 +40956,21 @@ wrn
 wrn
 sXy
 cZq
-nJe
-pXd
-jNs
-hXI
-twR
-msI
-qRh
-cPh
-cPh
-cPh
-cPh
+uhx
+bZn
+bZn
+bZn
+gLF
+bZn
+bZn
+bZn
+bZn
+bZn
 rqw
-tuI
-aWS
-fFR
+iqP
+qHr
+qHr
+ixM
 tqF
 tqF
 tqF
@@ -41891,13 +40995,13 @@ ndb
 ndb
 tqi
 tqi
-nvd
+ilJ
+npE
 ngP
-ngP
-ngP
+npE
 wOd
 wOd
-wOd
+mJV
 wOd
 wOd
 sMv
@@ -41925,9 +41029,9 @@ nMP
 xwk
 wOd
 wOd
-siX
+npE
 wDw
-siX
+npE
 wOd
 ndb
 nvd
@@ -41936,45 +41040,45 @@ nsK
 (26,1,1) = {"
 cgS
 xIt
+xIt
+apd
+apA
+bAh
+ckC
+ckC
+eez
+eZB
+jBU
+ckC
+bAh
+awQ
+apd
+bHY
+bXk
+ckC
 cmF
 cmF
-wpv
+xXi
 cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+oMk
+cmF
+uzr
+cmF
+cmF
+cmF
+cmF
+anV
 xIt
 xIt
 xIt
 xIt
 xIt
-xIt
-xIt
-uXf
-lmN
-qFt
-npU
-npU
-npU
-npU
-dmh
-dmh
-iPn
-dmh
-uIK
-npU
-npU
-npU
-udH
-yiB
-uXf
-jaU
-gqh
-lmN
-lmN
-nkH
-syU
-lmN
-yiB
-yiB
-uXf
 xIt
 xIt
 xIt
@@ -42074,21 +41178,21 @@ wrn
 wrn
 sXy
 cZq
-nJe
-pXd
-ihZ
-eum
-cQd
-msI
-sKD
-aZE
-gHV
-gHV
+gzF
+uhx
+uhx
+uhx
+gMH
+uhx
+sdt
+uhx
+uhx
+uhx
 rqw
-rqw
-geP
-aWS
-fFR
+jyY
+jyY
+jph
+crF
 tqi
 tqF
 tqF
@@ -42114,12 +41218,12 @@ tqF
 tqi
 tqi
 ilJ
-ndb
-ngP
+nAJ
+wDw
+npE
+npE
 wOd
-wOd
-wOd
-wOd
+mPk
 wOd
 wOd
 wOd
@@ -42147,7 +41251,7 @@ wOd
 wOd
 wOd
 wOd
-siX
+npE
 wDw
 wDw
 ndb
@@ -42159,64 +41263,64 @@ nsK
 cgS
 xIt
 xIt
-cmF
-cmF
-cmF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-yiB
-uXf
-lmN
-sWh
-riq
-riq
-riq
-riq
-riq
-riq
+ckC
+upW
+upW
+upW
 dgr
+upW
+fwg
+bFN
+ckC
+upW
+bFN
+upW
+bHY
 riq
-riq
-riq
-riq
-riq
-vaq
-lmN
-uXf
-lmN
-lmN
-lmN
-lmN
-uXf
-uXf
-yiB
-lmN
-uXf
-uXf
+cmF
+cmF
+cmF
+xXi
+cmF
+anV
+cmF
+cmF
+cmF
+cmF
+cmF
+xXi
+cmF
+uzr
+cmF
+wpv
+cmF
+cmF
+cmF
+cmF
+cmF
 xIt
 xIt
-vih
-vih
-vih
-vih
-eFS
-vih
-vih
-vih
-vih
-whv
-icv
-whv
+xIt
+xIt
+xIt
+xIt
+anV
+cmF
+cmF
+dOs
+cmF
+cmF
+cmF
+cmF
+rih
+otX
+rih
 oHr
 fZS
-aEE
-vQe
-vQe
-vQe
+yaB
+fBJ
+fBJ
+fBJ
 lII
 vcq
 vcq
@@ -42295,21 +41399,21 @@ qQf
 aLW
 qQf
 wcO
-uRG
-oMk
-gZL
-tQV
+cZq
+uhx
+rzM
+ker
+rzM
+hdY
+rzM
+rzM
+rzM
+ker
+cof
 rqw
-rqw
-rhC
-rjV
-cPh
-mdA
-gHV
-cPh
-eoI
-msI
-aWS
+jOV
+kdQ
+kdQ
 crF
 tqi
 mMH
@@ -42335,10 +41439,10 @@ tqF
 tqi
 tqi
 mMH
-nvd
-ndb
-ngP
-wOd
+ilJ
+tqF
+npE
+npE
 wHB
 wDE
 itw
@@ -42369,7 +41473,7 @@ wOd
 wOd
 wOd
 wOd
-siX
+npE
 wDw
 wDw
 ndb
@@ -42380,48 +41484,48 @@ nsK
 (28,1,1) = {"
 cgS
 xIt
-xIt
-dOs
-cmF
-cmF
-dOs
-xIt
-xIt
-xIt
-xIt
-xIt
 yiB
-uXf
-lmN
+atX
+axk
+bLc
+bXz
+ckC
+upW
+fCu
+gum
+aNR
+bqw
+bXz
+apd
 yiB
 yiB
-lmN
-oco
-qhP
-yiB
-lmN
-dwS
-bvh
-twP
-twP
-twP
-twP
-jYq
-twP
-eEX
-eEX
-eEX
-eEX
-eEX
-eEX
-uXf
-yiB
-lmN
-uXf
-cmF
-cmF
+gbt
+ckC
 wpv
-vih
+xXi
+otd
+otd
+xXi
+oMk
+xXi
+xXi
+xXi
+xXi
+cmF
+uzr
+cmF
+cmF
+cmF
+anV
+anV
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+anV
+cmF
 cmF
 wpv
 cmF
@@ -42517,22 +41621,22 @@ bZn
 bZn
 bZn
 bZn
-uhx
-oMk
-woq
-jMk
-rjV
-rjV
-qxq
-rjV
-eqE
-rqw
-rqw
-hPL
-rqw
-jua
-igB
-mAk
+sdt
+hoS
+vaN
+vaN
+vaN
+kcN
+uEc
+uEc
+lYA
+uEc
+lYA
+kcN
+ndb
+ndb
+kgY
+kUd
 mMH
 tqi
 dqv
@@ -42557,11 +41661,11 @@ tqi
 tqi
 tqi
 tqi
-nvd
-ngP
-ngP
-ngP
-nNn
+hkj
+wDw
+npE
+npE
+lBm
 pHY
 pHY
 pHY
@@ -42590,8 +41694,8 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wDw
 wOd
 ndb
@@ -42602,48 +41706,48 @@ nsK
 (29,1,1) = {"
 cgS
 xIt
-xIt
-xIt
+yiB
+yiB
+sWh
+bNN
+ckC
+aUs
+upW
+eWM
+ckC
+upW
+upW
+upW
+sWh
+yiB
+ckC
+ckC
 cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+uzr
+cmF
+cmF
+cmF
+anV
+anV
 wpv
 cmF
 cmF
-xIt
-xIt
-xIt
-yiB
-upW
-uXf
-lmN
-lUi
-yiB
-yiB
-lmN
-rSK
-oco
-lmN
-cAP
-fwg
-cAP
-cAP
-dwS
-dwS
-cAP
-ybG
-rQA
-dwS
-ybG
-dwS
-ezB
-rPc
-lmN
-lUi
-yiB
-mJj
-yiB
+cmF
+wpv
+uzr
 cmF
 cmF
-vih
 cmF
 cmF
 cmF
@@ -42727,7 +41831,7 @@ rzM
 rzM
 fyp
 tZi
-cCC
+qkB
 rzM
 rzM
 rzM
@@ -42739,22 +41843,22 @@ rzM
 rzM
 rzM
 rzM
-uhx
-oMk
-bHY
-rqw
-rqw
-rkG
-msI
-tMD
-cPh
-cPh
-cPh
-odh
-cfG
-jUt
-tFQ
-crF
+rzM
+fda
+vaN
+vaN
+ndb
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 wcb
@@ -42765,29 +41869,29 @@ tqF
 tqF
 tqF
 tqi
-lEZ
-lEZ
-lEZ
-pKl
-lEZ
-lEZ
-lEZ
-tqF
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 qOV
 tqi
 tqi
 tqi
 tqi
-ilJ
-ndb
-ngP
-wOd
-mPk
+hkj
+npE
+wDw
+npE
+lBm
+mnD
+gtS
 aiO
-mUd
-aiO
-pHY
+gfH
 xPU
 wOd
 wOd
@@ -42812,8 +41916,8 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wDw
 lIC
 ndb
@@ -42825,47 +41929,47 @@ nsK
 cgS
 xIt
 xIt
+yiB
+sWh
+cLZ
+kuB
+dkT
+awQ
+apd
+awQ
+awQ
+dkT
+kuB
+kgS
+yiB
 xIt
 cmF
-wpv
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+pvC
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+uzr
 dOs
 cmF
-cmF
-rSK
-lmN
-yiB
-yiB
-uXf
-uXf
-uXf
-uXf
-uXf
-kuB
-kuB
-uXf
-uXf
-uXf
-dQM
-uXf
-kuB
-kuB
-uXf
-uXf
-uXf
-uXf
-dQm
-lmN
-yiB
-yiB
-rPc
-dwS
-gAr
-wVy
-hCQ
-vih
-vih
-vih
-pBo
 wpv
 cmF
 cmF
@@ -42920,7 +42024,7 @@ iAv
 iAv
 quG
 iAv
-xJK
+fVp
 iAv
 iAv
 woF
@@ -42949,7 +42053,7 @@ gVv
 gVv
 gVv
 gVv
-cCC
+qkB
 gVv
 gVv
 gVv
@@ -42961,22 +42065,22 @@ vaN
 vaN
 vaN
 vaN
-cZq
-whE
-msI
-qXC
-aHZ
-cwT
-msI
-cxU
-vft
-kDZ
-eez
-nJY
-gHV
-msI
-rVm
-crF
+vaN
+vaN
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 qRn
@@ -42986,26 +42090,26 @@ tqF
 qOV
 tqF
 tqF
-lEZ
-lEZ
-kio
-iLi
-qoT
-ivx
-cQe
-lEZ
-lEZ
 tqi
 tqi
 tqi
 tqi
 tqi
 tqi
-nvd
-ndb
-ngP
-wOd
-rDx
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+hkj
+wDw
+wDw
+npE
+lBm
 mUd
 mUd
 aiO
@@ -43032,11 +42136,11 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
-siX
-siX
-siX
+npE
+npE
+npE
+npE
+npE
 wOd
 ndb
 ndb
@@ -43048,44 +42152,44 @@ cgS
 xIt
 xIt
 xIt
-cmF
-cmF
-cmF
-wpv
 yiB
-lmN
+dhv
 yiB
-lmN
-yiB
-uXf
 kgS
-yiB
-upW
-lmN
-vsf
-dQm
-lmN
-yiB
-qhP
-rPc
-uXf
-lmN
-lmN
-lmN
-yiB
-yiB
-lmN
-lmN
-lmN
-lmN
-dQm
-bvh
-yiB
-dQm
-dmh
-rNG
+kgS
+kgS
+kgS
+kgS
+kgS
+kgS
+kgS
+xIt
+xIt
 cmF
 cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+anV
+anV
+anV
+xIt
+xIt
+anV
+anV
+cmF
+dOs
+cmF
+cmF
+cmF
+dOs
+cmF
+cmF
+cmF
+deu
 cmF
 cmF
 cmF
@@ -43121,8 +42225,8 @@ ndb
 ndb
 yiI
 fBJ
-vFl
-vFl
+ndb
+ndb
 fBJ
 fBJ
 fBJ
@@ -43142,7 +42246,7 @@ kZp
 kZp
 vaE
 tzc
-btm
+wKm
 tzc
 uew
 kIz
@@ -43183,22 +42287,22 @@ bCj
 flJ
 vaN
 rMv
-mCj
-jcs
-whE
-nrZ
-nrZ
-nrZ
-msI
-mQj
-veZ
-msI
-hxm
-pWH
-nrZ
-rVm
-oIs
-jQd
+vaN
+vaN
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 tqi
@@ -43208,37 +42312,37 @@ tqF
 qOV
 qOV
 tqi
-lEZ
-wkT
-tHo
-tKH
-gim
-wkg
-xYi
-cQe
-lEZ
 tqi
 tqi
 tqi
 tqi
 tqi
 tqi
-nvd
-ngP
-ngP
-ngP
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqF
+tqF
+hkj
+wDw
+npE
+npE
 lBm
-mUd
+gtS
 ybl
-aiO
+rcM
 pHY
 qcd
 wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wOd
 wOd
 uWz
@@ -43250,15 +42354,15 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wOd
 wDw
 wDw
-siX
+npE
 wOd
-siX
-siX
+npE
+npE
 wOd
 ndb
 ndb
@@ -43269,45 +42373,45 @@ nsK
 cgS
 xIt
 xIt
-wpv
+jBU
+cmF
+njJ
+ckC
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+dOs
+cmF
+cmF
+cmF
+cmF
+anV
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
 cmF
 wpv
 cmF
-yiB
-yiB
-npU
-npU
-lmN
-ydp
-uXf
-jAG
-nRL
-qhP
-yiB
-lmN
-gEt
-oco
-lmN
-gEt
-rPc
-uXf
-gEt
-dQm
-lmN
-lmN
-gEt
-lmN
-qhP
-lmN
-lmN
-lmN
-twP
-lmN
-yiB
-wpv
-rNG
-yiB
-wpv
+cmF
+cmF
+uzr
 cmF
 cmF
 wpv
@@ -43406,21 +42510,21 @@ rnb
 shp
 vaN
 vaN
-ndh
-rzM
-rzM
-rzM
-rzM
-qkR
-nFV
-etT
-drm
-wKD
-aIW
-sAT
-lGM
-jQd
-tqi
+vaN
+vaN
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 tqi
@@ -43429,26 +42533,26 @@ tqF
 qOV
 tqF
 qOV
-lEZ
-lEZ
-wkT
-dII
-twb
-kjv
-wkg
-wkT
-lnz
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
 tqi
 tqF
-ilJ
-tqF
-ngP
-siX
+hkj
+wDw
+wDw
+npE
 lBm
 pHY
 pHY
@@ -43458,12 +42562,12 @@ sMC
 wOd
 wOd
 wOd
-siX
+npE
 wDw
 wDw
-siX
-siX
-siX
+npE
+npE
+npE
 wOd
 wOd
 wOd
@@ -43471,16 +42575,16 @@ wOd
 wOd
 wOd
 wOd
-siX
+npE
 wDw
 wDw
 wDw
 wDw
-siX
+npE
 wOd
 wOd
 wDw
-siX
+npE
 wOd
 ndb
 ndb
@@ -43491,48 +42595,48 @@ nsK
 cgS
 xIt
 xIt
-cmF
-cmF
-cmF
+ckC
+ckC
+njJ
+anV
 xIt
-lmN
-lmN
-lUi
-npU
-yiB
-lmN
-lmN
-lUi
-jKW
-gLz
-dwS
-nRL
-ybG
-dwS
-ntU
-dwS
-qih
-uXf
-lmN
-gEt
-lmN
-gEt
-lUi
-lmN
-lmN
-lUi
-yiB
-lmN
-twP
-qhP
-yiB
-dmh
-mJj
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+wpv
 cmF
 cmF
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+uzr
+cmF
+cmF
+xIt
 xIt
 xIt
 xIt
@@ -43615,7 +42719,7 @@ vaN
 vaN
 vaN
 gVv
-cCC
+qkB
 gVv
 gVv
 vaN
@@ -43633,16 +42737,16 @@ edD
 edD
 kab
 gVv
-gVv
-xJu
-gHP
-gVv
-gVv
-qkB
-vYQ
-tqi
-tqi
-tqi
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 tqi
@@ -43651,26 +42755,26 @@ tqF
 tqF
 nAJ
 tqi
-lGp
-wkg
-tKH
-twb
-lVD
-kjv
-lVD
-wkg
-wkg
-wkg
-iDj
 tqi
 tqi
 tqi
 tqi
 tqi
-ilJ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
-siX
-wDw
+hkj
+npE
+npE
+npE
 cDU
 nfY
 nfY
@@ -43680,24 +42784,24 @@ ykX
 wOd
 lIC
 wOd
-siX
+npE
 wDw
-siX
+npE
 gXV
 wDw
 wDw
-siX
+npE
 qwh
-siX
-siX
+npE
+npE
 wOd
 wOd
-siX
+npE
 wDw
 gXV
 wDw
 wDw
-siX
+npE
 lIC
 wOd
 wOd
@@ -43714,44 +42818,44 @@ cgS
 xIt
 xIt
 cmF
-wpv
+arf
+njJ
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
 cmF
 xIt
-mSM
-gmI
-lmN
-npU
-lmN
-lmN
-gum
-yiB
-qFt
-aNR
-aNR
-wBt
-aNR
-aNR
-aNR
-rZj
-bvh
-uXf
-lmN
-lmN
-gEt
-vQK
-lmN
-yiB
-lmN
-yiB
-yiB
-yiB
-twP
-lmN
-yiB
-yiB
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+dao
+cmF
+wpv
+cmF
+uzr
 xIt
 xIt
 xIt
@@ -43847,84 +42951,84 @@ vaN
 vaN
 vaN
 gtj
-myA
-myA
-myA
-myA
-xIX
-myA
-myA
-csn
-ftO
-csL
-eUv
-ftO
-ftO
-sAE
-oYN
-uUj
-uUj
-uUj
-iOZ
-uUj
-pvp
-eEw
+vaN
+vaN
+vaN
+vaN
+rsp
+vaN
+vaN
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
+mMH
+tqi
+tqF
+qOV
 tqF
 nAJ
 nAJ
 tqi
-ckC
-wkg
-tlr
-lVD
-lVD
-sEO
-lVD
-lVD
-eqT
-wkg
-iDj
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
 tqi
 tqi
 hkj
-tqF
-siX
+npE
+npE
 wDw
+npE
 wOd
 wOd
 wOd
 wOd
 wOd
+npE
+npE
+npE
+npE
 wOd
-siX
-siX
-siX
-siX
-wOd
-siX
-siX
-wDw
-wDw
-siX
-siX
-siX
-wDw
-siX
-siX
+npE
+npE
 wDw
 wDw
+npE
+npE
+npE
+wDw
+npE
+npE
 wDw
 wDw
-siX
-siX
+wDw
+wDw
+npE
+npE
 wOd
 wOd
 wOd
 wOd
-siX
+npE
 ndb
 ndb
 ndb
@@ -43937,42 +43041,42 @@ xIt
 xIt
 cmF
 cmF
+eeT
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
 cmF
 xIt
-ttk
-lmN
-dQm
-npU
-npU
-npU
-npU
-lmN
-sUt
-oco
-pxr
-oco
-yiB
-bjn
-oco
-xKd
-pVA
-kuB
-lmN
-gEt
-lmN
-dQm
-lmN
-uXf
-uXf
-uXf
-uXf
-jaz
-eEX
-uXf
 xIt
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+anV
 xIt
 xIt
 xIt
@@ -43993,7 +43097,7 @@ eue
 tzc
 uew
 uew
-fZP
+vaE
 pKS
 eQr
 qcj
@@ -44040,7 +43144,7 @@ tzc
 tzc
 kTM
 uxt
-cpg
+fXy
 mQd
 qGN
 qjO
@@ -44076,45 +43180,45 @@ vaN
 vaN
 rMv
 gVv
-gVv
-tix
-bZn
-bZn
-bZn
-bZn
-cCC
-dZF
-tqi
-tqi
-tqi
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 tqF
-ndP
+qOV
 qOV
 nAJ
 tqF
 tqi
-ckC
-wkg
-tlr
-jkr
-lVD
-kjv
-jkr
-lVD
-eqT
-wkg
-gKU
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 tqF
 tqF
 pwy
 tqi
 ilJ
-qOV
+npE
 ngP
-siX
+npE
 wOd
 wOd
 wOd
@@ -44122,8 +43226,8 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wOd
 wOd
 wOd
@@ -44144,9 +43248,9 @@ csz
 xOE
 lOW
 xNN
-siX
-siX
-siX
+npE
+npE
+npE
 ndb
 ndb
 ndb
@@ -44156,44 +43260,44 @@ nsK
 (36,1,1) = {"
 cgS
 xIt
+anV
+cmF
+cmF
+eFS
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
 cmF
 cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
-xIt
-xIt
-deu
-lmN
-npU
-lmN
-lmN
-yiB
-deu
-qFt
-yiB
-yiB
-oco
-dOA
-oco
-oco
-gbt
-nLC
-fTM
-lmN
-dQm
-lmN
-lmN
-lUi
-lmN
-yiB
-uXf
-lmN
-yiB
-eEX
-uXf
-xIt
-xIt
-xIt
+cmF
+wpv
+cmF
+cmF
+cmF
 xIt
 xIt
 xIt
@@ -44215,7 +43319,7 @@ eue
 tzc
 uew
 uew
-laA
+pOe
 pKS
 pKS
 pKS
@@ -44297,37 +43401,37 @@ rMv
 vaN
 vaN
 gVv
-gHP
-tix
-uhx
+ndb
+ndb
+ndb
 vpI
-uhx
+ndb
 vpI
-uhx
+ndb
 vpI
-nSf
-dZF
-tqi
-tqi
+ndb
+ndb
+ndb
+kUd
 tqi
 tqi
 tqF
 kNj
-gVM
-gVM
-pvp
-uUj
-egm
-sZG
-uPq
-awQ
-elo
-nnL
-dqw
-lVD
-eqT
-wkg
-iDj
+qOV
+qOV
+tqF
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 nNF
 tqF
 tqF
@@ -44352,14 +43456,14 @@ wOd
 csz
 wOd
 wOd
-siX
+npE
 wDw
-siX
-siX
-siX
-siX
+npE
+npE
+npE
+npE
 wDw
-siX
+npE
 wOd
 tFU
 udK
@@ -44378,43 +43482,43 @@ nsK
 (37,1,1) = {"
 cgS
 xIt
-dOs
+anV
 wpv
-cmF
 dOs
+eeT
 xIt
 xIt
 xIt
-lUi
-npU
-dQm
-lmN
-lmN
-lID
-dmt
-cIy
-dao
-tuA
-cIy
-cIy
-cIy
-gbt
-bvh
-kuB
-lmN
-lmN
-gEt
-yiB
-lmN
-dQm
-lmN
-uXf
-lmN
-dQm
-eEX
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
 xIt
 xIt
 xIt
@@ -44437,7 +43541,7 @@ eue
 tzc
 uew
 uew
-fZP
+vaE
 pKS
 eue
 tzc
@@ -44528,9 +43632,9 @@ vpI
 vpI
 vpI
 vpI
-vOY
-dZF
-tqi
+ndb
+ndb
+kUd
 tqi
 tqi
 tqF
@@ -44539,17 +43643,17 @@ qOV
 tqF
 tqi
 tqi
-lEZ
-lEZ
-vUL
-lVD
-lEp
-lEp
-qHK
-lVD
-eRD
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 qOV
 tqF
@@ -44580,8 +43684,8 @@ wOd
 wOd
 wOd
 wOd
-siX
-siX
+npE
+npE
 wOd
 udK
 oas
@@ -44603,39 +43707,39 @@ xIt
 cmF
 cmF
 wpv
+eeT
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+dOs
 cmF
 cmF
 xIt
 xIt
-ijG
-lmN
-lmN
-yiB
-uXf
-lmN
-dQm
-lmN
-yiB
-lmN
-gEt
-yiB
-dQm
-oIn
-bvh
-uXf
-lmN
-dQm
-lmN
-yiB
-lmN
-gEt
-lmN
-uXf
-uXf
-jaz
-eEX
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+dOs
+cmF
+cmF
+cmF
+cmF
+dOs
 xIt
 xIt
 xIt
@@ -44659,7 +43763,7 @@ eue
 tzc
 kZp
 uew
-fZP
+vaE
 tzc
 tzc
 tzc
@@ -44752,7 +43856,7 @@ cNE
 vpI
 vpI
 pZH
-dZF
+gdv
 tqi
 tqi
 tqi
@@ -44761,23 +43865,23 @@ tqF
 tqi
 tqi
 tqi
-ckC
-wkg
-tlr
-lVD
-vsn
-xYi
-qHK
-lVD
-eqT
-wkg
-iDj
-qOV
-qOV
-qOV
-qOV
+tqi
+tqi
+tqi
+tqi
+dqv
+nAi
+sWt
+tqi
+tqi
+tqi
 tqF
-cNp
+qOV
+qOV
+qOV
+qOV
+ndb
+nvd
 ndb
 ndb
 oas
@@ -44802,7 +43906,7 @@ pgs
 eVj
 oSf
 wOd
-siX
+npE
 wOd
 wOd
 sCG
@@ -44825,38 +43929,38 @@ xIt
 xIt
 wpv
 cmF
+eeT
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
 cmF
+cmF
 xIt
 xIt
 xIt
-npU
-lmN
-yiB
-uXf
-rSK
-gEt
-oIn
-dkT
-yiB
-rSK
-lmN
-gEt
-lmN
-bvh
-uXf
-gEt
-lmN
-yiB
-dmh
-lmN
-yiB
-yiB
-uXf
-uXf
-lmN
-eEX
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
+cmF
+cmF
+cmF
 xIt
 xIt
 xIt
@@ -44881,7 +43985,7 @@ tzc
 tzc
 uew
 uew
-fZP
+vaE
 tzc
 tzc
 eue
@@ -44983,23 +44087,23 @@ tqF
 tqi
 tqi
 tqi
-lGp
-wkg
-tlr
-lVD
-bqw
-ewO
-kjv
-omp
-eqT
-wkg
-iDj
+tqi
+tqi
+tqi
+tqi
+wcb
+cek
+sJg
+tqi
+tqi
+tqi
+tqF
 tqF
 qOV
 qOV
 qOV
-qOV
-cNp
+ndb
+nvd
 ndb
 ndb
 oas
@@ -45024,7 +44128,7 @@ vEE
 wOd
 mKv
 wOd
-siX
+npE
 wOd
 lIC
 chg
@@ -45047,37 +44151,37 @@ xIt
 xIt
 cmF
 cmF
+eeT
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+wpv
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
+cmF
 wpv
 cmF
 cmF
-xIt
-xIt
-xIt
-yiB
-lmN
-uXf
-lmN
-yiB
-dmh
-dmh
-lmN
-lmN
-lmN
-cDx
-otr
-qaW
-uXf
-yiB
-lmN
-yiB
-yiB
-dmh
-yiB
-yiB
-uXf
-uXf
-jaz
-eEX
 xIt
 xIt
 xIt
@@ -45103,7 +44207,7 @@ tzc
 iiB
 uew
 iiB
-fZP
+vaE
 eue
 tzc
 eue
@@ -45205,24 +44309,24 @@ tqF
 tqF
 tqi
 tqi
-ckC
-wkg
-tlr
-jkr
-lVD
-lVD
-sEO
-lVD
-eqT
-wkg
-iDj
+tqi
+tqi
+tqi
+tqi
+qRn
+oUg
+ada
+tqi
+tqi
+tqi
 tqF
 tqF
+tqF
 qOV
 qOV
-qOV
-cNp
-qOV
+ndb
+nvd
+ndb
 ndb
 oas
 blU
@@ -45246,7 +44350,7 @@ acL
 imd
 bJk
 wOd
-siX
+npE
 wOd
 wOd
 chg
@@ -45269,9 +44373,22 @@ xIt
 xIt
 cmF
 cmF
+eeT
+cmF
+uzr
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
 cmF
-wpv
+cmF
+cmF
 cmF
 xIt
 xIt
@@ -45279,27 +44396,14 @@ xIt
 xIt
 xIt
 xIt
-yiB
-yiB
-yiB
-uXf
 xIt
 xIt
+cmF
+cmF
+cmF
+cmF
+cmF
 xIt
-xIt
-vqi
-vqi
-eEX
-eEX
-twP
-eEX
-twP
-pdD
-eEX
-eEX
-vqi
-vqi
-vqi
 xIt
 xIt
 xIt
@@ -45325,7 +44429,7 @@ tzc
 uew
 uew
 uew
-laA
+pOe
 uew
 tzc
 tzc
@@ -45427,24 +44531,24 @@ tqF
 tqF
 tqi
 tqi
-ckC
-wkg
-wkg
-omp
-lVD
-lVD
-kjv
-lVD
-wkg
-wkg
-iDj
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 tqF
 qOV
 qOV
-tqF
-ilJ
-tqF
+ndb
+nvd
+ndb
 ndb
 oas
 oas
@@ -45491,35 +44595,35 @@ xIt
 xIt
 xIt
 cmF
+eeT
+cmF
+uzr
+cmF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+cmF
+cmF
 wpv
 cmF
 cmF
 cmF
-cmF
 xIt
 xIt
 xIt
 xIt
-xIt
-xIt
-yiB
-yiB
-yiB
-yiB
 xIt
 xIt
 xIt
 xIt
 cmF
-yiB
-yiB
 wpv
-yiB
-yiB
 cmF
-yiB
-uXf
-xIt
+cmF
 xIt
 xIt
 xIt
@@ -45547,7 +44651,7 @@ tzc
 uew
 uew
 uew
-fZP
+vaE
 uew
 tzc
 tzc
@@ -45649,24 +44753,24 @@ tqi
 tqF
 tqF
 tqi
-lEZ
-lEZ
-xYi
-wkg
-dHk
-dHk
-wFK
-wkg
-xYi
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 qOV
 qOV
 tqF
 ndb
-ilJ
-tqi
+nvd
+ndb
 ndb
 ndb
 oas
@@ -45712,36 +44816,36 @@ cgS
 xIt
 xIt
 xIt
-cmF
 dOs
-wpv
-cmF
-cmF
-gaR
+eeT
+eeT
+fEZ
+gKU
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-cmF
-qhP
-yiB
-cmF
-xIt
 xIt
 cmF
 cmF
-wpv
 cmF
 cmF
 cmF
 cmF
-rSK
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 cmF
 cmF
-dOs
-uXf
+cmF
+cmF
+cmF
 xIt
 xIt
 xIt
@@ -45769,7 +44873,7 @@ tzc
 uew
 uew
 kZp
-fZP
+vaE
 tzc
 tzc
 tzc
@@ -45872,23 +44976,23 @@ tqF
 qOV
 qOV
 tqF
-lEZ
-rMD
-ogw
-wkg
-wkg
-cqM
-gGG
-lnz
-lEZ
-tqF
-tqF
-qOV
-qOV
-ndb
-ndb
-ilJ
 tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqF
+tqF
+qOV
+qOV
+ndb
+ndb
+nvd
+ndb
 ndb
 ndb
 ndb
@@ -45937,30 +45041,30 @@ xIt
 xIt
 cmF
 cmF
+uzr
+eeT
 cmF
-cmF
-cmF
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-yiB
-qhP
-cmF
-cmF
-yiB
 cmF
 wpv
 cmF
 cmF
 cmF
+cmF
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
 cmF
-yiB
+cmF
 cmF
 wpv
 cmF
@@ -46094,25 +45198,25 @@ qOV
 qOV
 tqF
 tqF
-lEZ
-lEZ
-lEZ
-pKl
-jKV
-lXy
-lEZ
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 wKz
 xyZ
 tqF
 tqi
 ndb
-hkj
-tqF
-tqF
-tqF
+nvd
+ndb
+ndb
+ndb
 ndb
 ndb
 ndb
@@ -46159,8 +45263,8 @@ xIt
 xIt
 xIt
 cmF
-wpv
-cmF
+pvC
+eeT
 cmF
 cmF
 xIt
@@ -46171,19 +45275,19 @@ xIt
 xIt
 dOs
 cmF
-rSK
+dOs
 cmF
-cmF
-cmF
-cmF
+wpv
 cmF
 xIt
 xIt
 xIt
 xIt
 xIt
+xIt
+xIt
 cmF
-yiB
+cmF
 cmF
 cmF
 cmF
@@ -46261,7 +45365,7 @@ yfp
 pBL
 cmy
 yfp
-gyo
+gcX
 hyG
 myO
 xmr
@@ -46315,16 +45419,16 @@ qOV
 qOV
 tqF
 tqi
-lEZ
-lEZ
-ipx
-udI
-hOM
-ssj
-xSn
-krB
-vHd
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqF
 tqF
 nNF
@@ -46332,8 +45436,8 @@ tqi
 tqi
 ndb
 nvd
-oHe
-oHe
+gEI
+gEI
 oHe
 tpJ
 tpJ
@@ -46381,8 +45485,8 @@ xIt
 xIt
 xIt
 cmF
-cmF
-cmF
+uzr
+eeT
 dOs
 cmF
 cmF
@@ -46397,7 +45501,7 @@ cmF
 fyL
 wpv
 cmF
-cmF
+xIt
 xIt
 xIt
 xIt
@@ -46410,8 +45514,8 @@ cmF
 wpv
 cmF
 cmF
-cmF
-cmF
+anV
+anV
 xIt
 xIt
 xIt
@@ -46469,7 +45573,7 @@ yfp
 gJD
 odg
 tkC
-odg
+oZd
 yfp
 lIA
 oDb
@@ -46535,26 +45639,26 @@ tqi
 tqF
 qOV
 qOV
-lEZ
-lEZ
-lEZ
-ogl
-jkr
-lVD
-jkr
-lVD
-kjv
-lVD
-vQV
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
 tqi
 tqi
 ndb
-tqi
+ndb
 tqi
 tqi
 tqi
@@ -46603,8 +45707,8 @@ xIt
 xIt
 xIt
 xIt
-cmF
-cmF
+uzr
+gKU
 wpv
 cmF
 wpv
@@ -46756,20 +45860,20 @@ tqi
 tqi
 tqi
 tqF
-lEZ
-lEZ
-bdt
-hOM
-lVD
-hsw
-awQ
-gLF
-awQ
-gsb
-awQ
-awQ
-tfP
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -46826,35 +45930,35 @@ xIt
 xIt
 xIt
 xIt
+qzH
 uGF
 uGF
 uGF
-uGF
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-uGF
-gfl
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
 uGF
 gfl
 uGF
 uGF
-loD
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+uGF
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
 uGF
 uGF
 uGF
@@ -46978,21 +46082,21 @@ tqi
 tqi
 tqi
 tqF
-lEZ
-bVM
-tDa
-tWG
-dKf
-rhH
-lVD
-lRq
-lVD
-tDa
-tWG
-dKf
-hOM
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -47048,7 +46152,7 @@ xIt
 xIt
 xIt
 xIt
-uGF
+qzH
 uGF
 gfl
 uGF
@@ -47075,7 +46179,7 @@ uGF
 uGF
 uGF
 xIt
-uGF
+loD
 uGF
 uGF
 uGF
@@ -47200,21 +46304,21 @@ tqi
 tqi
 tqi
 tqi
-ewI
-hOM
-lVD
-lVD
-bMh
-kjv
-lVD
-mli
-jkr
-kEl
-pbF
-lVD
-lVD
-hOM
-ewI
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 mMH
 tqi
 tqi
@@ -47270,7 +46374,7 @@ xIt
 xIt
 xIt
 xIt
-uGF
+qzH
 uGF
 uGF
 uGF
@@ -47324,8 +46428,8 @@ iiB
 uew
 mXU
 cxN
-ixc
-meH
+glo
+jeL
 qUE
 meH
 ixc
@@ -47422,36 +46526,36 @@ tqi
 tqi
 tqi
 tqi
-jKV
-hOM
-hOM
-tmt
-hOM
-xSn
-hNx
-gMi
-hOM
-hOM
-tmt
-hOM
-hOM
-hOM
-jKV
 tqi
 tqi
 tqi
 tqi
-wKz
-jDC
-pfm
-pfm
-pfm
-lAB
-pfm
-pfm
-xma
 tqi
-qOV
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 ndb
 qOV
 tqi
@@ -47491,8 +46595,8 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
+loD
+qzH
 gfl
 uGF
 uGF
@@ -47639,40 +46743,40 @@ vpI
 jph
 gdv
 jqs
-vYQ
-vYQ
-vYQ
-vYQ
-vYQ
-bXk
-eZB
-mmD
-awQ
-awQ
-daN
-lVD
-srp
-lVD
-lVD
-lVD
-lVD
-lVD
-hOM
-ewI
 tqi
 tqi
 tqi
 tqi
-jDC
-rZA
-gZd
-oBs
-oBs
-wWN
-oBs
-gZd
-qes
-xma
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 mMH
@@ -47713,15 +46817,15 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
+loD
+qzH
 uGF
 uGF
 gfl
 xIt
 xIt
 xIt
-uGF
+loD
 gfl
 uGF
 uGF
@@ -47866,36 +46970,36 @@ tqi
 tqi
 tqi
 tqi
-lEZ
-dEZ
-oTT
-tWG
-dKf
-lVD
-lVD
-eWM
-jDu
-tDa
-tWG
-dKf
-hOM
-lEZ
-lEZ
 tqi
 tqi
 tqi
-jDC
-rZA
-gZd
-gZd
-uCq
-pHo
-hXS
-oRO
-gZd
-gZd
-pkT
-xma
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 mMH
 tqi
 tqi
@@ -47935,15 +47039,15 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
+loD
+qzH
 asP
 uGF
 uGF
 xIt
 xIt
 xIt
-uGF
+loD
 uGF
 uGF
 uGF
@@ -48088,40 +47192,40 @@ tqi
 tqi
 tqi
 tqi
-lEZ
-lEZ
-tbM
-sgK
-lVD
-lVD
-lVD
-mli
-lVD
-lVD
-lVD
-lVD
-hOM
-lEZ
 tqi
 tqi
 tqi
 tqi
-fCu
-gZd
-gZd
-bFN
-vCG
-nBG
-lcg
-rkg
-qlT
-gZd
-gZd
-vgf
 tqi
 tqi
 tqi
 tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+dqv
+nAi
+sWt
 tqi
 tqi
 tqF
@@ -48158,7 +47262,7 @@ xIt
 xIt
 xIt
 xIt
-uGF
+qzH
 uGF
 uGF
 uGF
@@ -48311,39 +47415,39 @@ tqi
 tqi
 tqi
 tqi
-lEZ
-lEZ
-lEZ
-vHd
-hsH
-hOM
-hOM
-ssj
-hOM
-hsH
-vHd
-lEZ
-lEZ
 tqi
 tqi
 tqi
 tqi
-fCu
-gZd
-dUu
-hgq
-sil
-dUu
-muV
-hgq
-sil
-dUu
-gZd
-vgf
 tqi
 tqi
 tqi
 tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+wcb
+cek
+sJg
 tqi
 tqi
 tqi
@@ -48380,13 +47484,13 @@ xIt
 xIt
 xIt
 uGF
-uGF
+qzH
 uGF
 uGF
 uGF
 uGF
 xIt
-uGF
+ntJ
 uGF
 gfl
 uGF
@@ -48535,37 +47639,37 @@ tqi
 tqi
 tqi
 tqi
-lEZ
-lEZ
-lEZ
-lEZ
-kUo
-jKV
-pKl
-lEZ
-lEZ
-lEZ
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 nNF
 tqF
 tqF
-fCu
-gZd
-dUu
-hgq
-sil
-dUu
-muV
-hgq
-sil
-dUu
-gZd
-vgf
 tqi
 tqi
 tqi
 tqi
+tqi
+tqF
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+qRn
+oUg
+ada
 tqi
 tqi
 tqF
@@ -48602,16 +47706,16 @@ xIt
 xIt
 xIt
 xIt
+qzH
 uGF
-uGF
-uGF
+xEg
 gfl
 uGF
 uGF
+ntJ
 uGF
-uGF
-uGF
-uGF
+xEg
+xIt
 xIt
 xIt
 xIt
@@ -48772,18 +47876,18 @@ mMH
 tqF
 tqF
 qOV
-fCu
-gZd
-cQx
-bXz
-qzH
-nBG
-lcg
-bXz
-fXJ
-tlu
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqF
+qOV
+qOV
+tqF
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 gHj
@@ -48824,15 +47928,13 @@ xIt
 xIt
 xIt
 xIt
-uGF
+qzH
 xEg
 uGF
 uGF
 uGF
 uGF
-gfl
-uGF
-gzT
+bFY
 uGF
 xIt
 xIt
@@ -48844,12 +47946,14 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
 xIt
+xIt
+loD
+uGF
+uGF
+uGF
+uGF
+uGF
 xIt
 xIt
 xIt
@@ -48994,18 +48098,18 @@ tqi
 tqi
 tqi
 tqi
-fCu
-gZd
-hRV
-ngh
-cPM
-rDW
-pHo
-cPM
-cPM
-pzm
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqi
+qOV
+qOV
+qOV
+qOV
+tqF
+tqi
+tqi
 tqi
 sqH
 tqi
@@ -49045,33 +48149,33 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
+qzH
+qzH
 gfl
 uGF
 uGF
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
 uGF
 uGF
-uGF
-uGF
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -49216,18 +48320,18 @@ tqi
 tqi
 tqi
 tqi
-fCu
-gZd
-vjn
-khi
-ttF
-nBG
-lcg
-khi
-ttF
-eRN
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqF
+tqF
+qOV
+qOV
+qOV
+tqF
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -49267,33 +48371,33 @@ xIt
 xIt
 xIt
 xIt
-uGF
+qzH
 gfl
 uGF
 uGF
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
+gfl
 uGF
+gfl
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -49438,18 +48542,18 @@ tqF
 tqi
 tqi
 tqi
-fCu
-gZd
-dUu
-hgq
-sil
-dUu
-muV
-hgq
-sil
-dUu
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqF
+qOV
+qOV
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -49489,9 +48593,22 @@ xIt
 xIt
 xIt
 xIt
+qzH
 uGF
 uGF
 uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -49499,23 +48616,10 @@ xIt
 uGF
 uGF
 xEg
-gfl
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xEg
 uGF
 uGF
-xEg
 uGF
-xIt
-xIt
-xIt
+uGF
 xIt
 xIt
 xIt
@@ -49533,9 +48637,9 @@ uGF
 uGF
 uGF
 uGF
-atX
+uGF
 aQR
-bNN
+loD
 xIt
 xIt
 eue
@@ -49660,18 +48764,18 @@ tqF
 tqF
 tqi
 tqi
-fCu
-gZd
-dUu
-hgq
-rPO
-dUu
-muV
-hgq
-sil
-dUu
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqF
+tqF
+tqF
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -49710,34 +48814,34 @@ xIt
 xIt
 xIt
 xIt
-xIt
 uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-uGF
+qzH
 uGF
 uGF
 uGF
 xIt
 xIt
-xIt
-xIt
-xIt
-xIt
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
+vqi
 xIt
 uGF
 uGF
 uGF
 uGF
 uGF
-xIt
-xIt
-xIt
+uGF
 xIt
 xIt
 xIt
@@ -49746,7 +48850,7 @@ xIt
 vqi
 xIt
 xIt
-uGF
+xIt
 uGF
 uGF
 uGF
@@ -49755,11 +48859,11 @@ uGF
 uGF
 xEg
 uGF
-atX
+uGF
 bJh
-axk
-atX
-atX
+gfl
+uGF
+uGF
 tzc
 eue
 bPS
@@ -49882,18 +48986,18 @@ qOV
 tqF
 tqi
 tqi
-fCu
-gZd
-gZd
-njJ
-fXJ
-pyS
-lcg
-bem
-uLp
-gZd
-gZd
-vgf
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -49932,24 +49036,27 @@ xIt
 xIt
 xIt
 xIt
-xIt
 uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-uGF
+qzH
 uGF
 uGF
 uGF
 xIt
 xIt
+vqi
+xIt
+cqM
+ckC
+cqM
+ckC
+etT
+cqM
+cqM
+ckC
+ckC
 xIt
 xIt
-xIt
+vqi
 xIt
 xIt
 uGF
@@ -49957,18 +49064,15 @@ uGF
 gfl
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
+uGF
+uGF
 xIt
 xIt
 xIt
 vqi
 xIt
 xIt
-uGF
+xIt
 loD
 uGF
 uGF
@@ -49977,11 +49081,11 @@ uGF
 uGF
 uGF
 uGF
-axk
-bLc
-axk
-atX
-nAJ
+gfl
+qTf
+gfl
+uGF
+yjx
 tzc
 eue
 tzc
@@ -50104,18 +49208,18 @@ qOV
 tqF
 tqi
 tqi
-oZF
-peR
-gZd
-gZd
-qmz
-rDW
-pHo
-qmz
-gZd
-gZd
-srP
-xoy
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 mMH
 tqi
 tqi
@@ -50154,43 +49258,43 @@ xIt
 xIt
 xIt
 xIt
-xIt
 uGF
-qKf
+qzH
+uGF
 xEg
+xIt
+xIt
+xIt
+vqi
+cqM
+cqM
+ckC
+ckC
+cqM
+gbt
+elo
+mJj
+cqM
+ckC
+cqM
+ckC
+hXS
+xIt
+xIt
+uGF
 gfl
-xIt
-xIt
-xIt
-xIt
+uGF
+gfl
+uGF
+gfl
 uGF
 uGF
-loD
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 vqi
 xIt
 xIt
-uGF
+xIt
 gfl
 uGF
 uGF
@@ -50199,11 +49303,11 @@ loD
 uGF
 uGF
 uGF
-atX
-bLc
-atX
-atX
-nAJ
+uGF
+qTf
+uGF
+uGF
+yjx
 eue
 eue
 tzc
@@ -50327,16 +49431,16 @@ tqi
 tqi
 tqi
 tqi
-oZF
-peR
-gZd
-gZd
-xfn
-tAZ
-gZd
-gZd
-iJR
-xoy
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -50376,23 +49480,29 @@ xIt
 xIt
 xIt
 xIt
-xIt
 uGF
-xEg
-uGF
-uGF
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
+qzH
+asP
 uGF
 xIt
 xIt
-xIt
-xIt
-xIt
+cqM
+hXI
+cqM
+cqM
+egm
+elo
+cqM
+cqM
+mqp
+elo
+cqM
+elo
+etT
+ckC
+ivx
+jBU
+hCQ
 uGF
 uGF
 uGF
@@ -50400,19 +49510,13 @@ uGF
 uGF
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
+uGF
+uGF
+uGF
 vqi
 xIt
 xIt
-uGF
+xIt
 uGF
 uGF
 uGF
@@ -50422,9 +49526,9 @@ uGF
 gfl
 uGF
 xIt
-bLc
-atX
-axk
+qTf
+uGF
+gfl
 tzc
 tzc
 eue
@@ -50550,14 +49654,14 @@ nAi
 sWt
 tqi
 tqi
-ojk
-mqp
-mMd
-wsp
-wFG
-mMd
-mqp
-crF
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -50596,44 +49700,44 @@ cgS
 xIt
 xIt
 xIt
-xIt
-xIt
-xIt
+xEg
 uGF
 uGF
-gfl
+fZP
 uGF
 xIt
 xIt
 xIt
-gfl
+cqM
+hXS
+egm
+cqM
+khi
+etT
+egm
+gbt
+cqM
+elo
+cqM
+cqM
+egm
+cqM
+hXS
+dwS
+uGF
+pvp
 uGF
 uGF
-gfl
-xIt
-xIt
-xIt
 uGF
 uGF
 xEg
-uGF
 gfl
 uGF
 uGF
-uGF
-xEg
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
+gfl
+oFs
 vqi
 vqi
-qTf
 qTf
 qTf
 oFs
@@ -50772,14 +49876,14 @@ cek
 sJg
 tqi
 tqi
-ojk
-mqp
-mMd
-wsp
-wFG
-mMd
-mqp
-crF
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
+tqi
 tqi
 tqi
 tqi
@@ -50818,42 +49922,42 @@ cgS
 xIt
 xIt
 xIt
+qzH
+qzH
+qzH
+qAk
+xIt
+xIt
+xIt
+xIt
+cqM
+hXI
+dwS
+etT
+egm
+cqM
+egm
+dwS
+elo
+cqM
+mJj
+elo
+cqM
+cqM
+oya
+ckC
+ckC
+pxr
+gfl
+uGF
+xIt
 xIt
 xIt
 uGF
 gfl
 uGF
 uGF
-xIt
-xIt
-xIt
 uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
 uGF
 uGF
 uGF
@@ -50994,14 +50098,14 @@ oUg
 ada
 tqi
 tqi
-ojk
-mqp
-mMd
-wsp
-wFG
-mMd
-mqp
-crF
+wUu
+qHr
+qHr
+qHr
+qHr
+qHr
+qHr
+ixM
 tqi
 tqi
 tqi
@@ -51039,44 +50143,44 @@ nsK
 cgS
 xIt
 xIt
-xIt
-xIt
-xIt
 uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
+qzH
 gfl
 uGF
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-xIt
-uGF
-xEg
-uGF
-xEg
 xIt
 xIt
+ckC
+hXS
+cqM
+cqM
+cqM
+kio
+etT
+cqM
+cqM
+cqM
+cqM
+cqM
+mJj
+ckC
+ivx
+cqM
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-xEg
+xIt
+xIt
+uGF
+gfl
+uGF
+uGF
+gfl
 uGF
 uGF
 uGF
@@ -51097,7 +50201,7 @@ tzc
 sWa
 tXO
 vPO
-ams
+wii
 sKa
 sKa
 ams
@@ -51217,12 +50321,12 @@ tqi
 tqi
 wUu
 jph
-gZd
-gZd
-xfn
-tAZ
-gZd
-gZd
+jTv
+jTv
+fsy
+fsy
+jTv
+jTv
 jph
 ixM
 tqi
@@ -51261,34 +50365,8 @@ nsK
 cgS
 xIt
 xIt
-xIt
-xIt
 uGF
-uGF
-gfl
-uGF
-xIt
-xIt
-xIt
-uGF
-gfl
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-uGF
-uGF
-gfl
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-uGF
-uGF
+qzH
 uGF
 uGF
 xIt
@@ -51297,12 +50375,38 @@ xIt
 xIt
 xIt
 xIt
+hXS
+gVM
+cqM
+kio
+ckC
+gbt
+ckC
+cqM
+ckC
+cqM
+ckC
+cqM
+ckC
+ivx
+cqM
+cqM
+xIt
+xIt
+cqM
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
-gfl
 uGF
 uGF
+uGF
+cQd
 uGF
 uGF
 xIt
@@ -51442,7 +50546,7 @@ jTv
 jTv
 gzj
 dFT
-lEJ
+piP
 wFX
 jTv
 jTv
@@ -51483,50 +50587,50 @@ nsK
 cgS
 xIt
 xIt
+uGF
+qzH
+uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+hCQ
+igB
+ivx
+jAG
+igB
+igB
+igB
+lGp
+muV
+mKk
+igB
+igB
+igB
+ojk
+oBs
+hCQ
+hCQ
+hCQ
+xIt
+etT
+cqM
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xEg
 uGF
-uGF
+gfl
 xEg
-xIt
-xIt
-xIt
 uGF
 uGF
 uGF
 uGF
-gfl
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-gfl
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -51663,8 +50767,8 @@ jTv
 jTv
 hnW
 lEJ
-tqM
-tqM
+hNU
+hNU
 piP
 hnW
 jTv
@@ -51705,19 +50809,8 @@ nsK
 cgS
 xIt
 xIt
-xIt
-xIt
 uGF
-gfl
-uGF
-xIt
-xIt
-xIt
-xIt
-gfl
-uGF
-uGF
-gfl
+qzH
 uGF
 xIt
 xIt
@@ -51725,8 +50818,30 @@ xIt
 xIt
 xIt
 xIt
-ntJ
-ntJ
+hCQ
+laA
+cqM
+jBU
+cqM
+ckC
+ckC
+jBU
+cqM
+ckC
+cqM
+ckC
+ckC
+ckC
+jBU
+cqM
+icv
+hCQ
+laA
+cqM
+ckC
+cqM
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -51735,19 +50850,8 @@ uGF
 uGF
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
 uGF
 uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -51927,48 +51031,48 @@ nsK
 cgS
 xIt
 xIt
+uGF
+qzH
+uGF
+uGF
+xIt
+xIt
+fVm
+xIt
+ckC
+hCQ
+ckC
+iDj
+jDu
+jDu
+jDu
+jDu
+lHs
+jDu
+jDu
+jDu
+jDu
+jUt
+omp
+jDu
+oRO
+ckC
+hCQ
+ckC
+fXJ
+elo
+cqM
+xIt
+qaM
+xIt
+xIt
+xIt
 xIt
 xIt
 uGF
+xEg
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-ntJ
-ntJ
-ntJ
-ntJ
-ntJ
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-xIt
-xIt
-xIt
-xIt
-xIt
-qTf
-qTf
-qTf
-qTf
-vqi
-vqi
-qTf
-qTf
-qTf
-eVB
-qTf
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -52150,46 +51254,46 @@ cgS
 xIt
 xIt
 xIt
-xIt
+qzH
 gfl
 uGF
 uGF
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-vqi
-vqi
+xIt
+cqM
+elo
+ckC
+hCQ
+ckC
+iJR
+jDC
+vQe
+eqT
+vQe
+lID
+lID
+lID
+lID
+kPF
+ogl
+kPF
+oIs
+oTT
+etT
+hNx
+cqM
+eqE
+cqM
+etT
+etT
+qaW
 xIt
 xIt
 xIt
-qTf
-xEg
-gfl
-uGF
-uGF
-xEg
-uGF
-uGF
-uGF
-uGF
-oFs
 xIt
 xIt
-xIt
+uGF
+uGF
+uGF
 xIt
 xIt
 xIt
@@ -52371,46 +51475,46 @@ nsK
 cgS
 xIt
 xIt
-xIt
-xIt
+uGF
+qzH
 uGF
 uGF
 uGF
-vqi
+cqM
+elo
+bVQ
+ckC
+ckC
+ckC
+iLi
+eqT
+hCQ
+kEl
+hCQ
+lMM
+mli
+mMd
+lMM
+hCQ
+kEl
+hCQ
+eqT
+oXj
+ckC
+nyC
+ckC
+cqM
+ckC
+fXJ
+cqM
+cqM
 xIt
-xIt
-xIt
-xIt
-xIt
+hCQ
+hCQ
 xIt
 uGF
-xEg
+uGF
 gfl
-uGF
-uGF
-uGF
-loD
-uGF
-xEg
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-vqi
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-uGF
-uGF
-vqi
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -52592,47 +51696,47 @@ nsK
 (74,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-xIt
 uGF
 uGF
-gfl
-vqi
-xIt
-xIt
-xIt
-xIt
-xIt
+ewO
 uGF
 uGF
+dmt
+egm
+fXJ
+eqE
+gVM
+cqM
+ckC
+iOZ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+oZF
+cqM
+hCQ
+pzm
+kDZ
+fXJ
+ckC
+elo
+ckC
+cqM
+dwS
+ckC
+nyC
 uGF
 uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-uGF
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-vqi
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-xIt
-vqi
-xIt
-xIt
+xEg
 xIt
 xIt
 xIt
@@ -52814,47 +51918,47 @@ nsK
 (75,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-xIt
-xEg
-uGF
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-xIt
 uGF
 uGF
+qzH
 uGF
 uGF
-uGF
-uGF
-uGF
-uGF
-uGF
+cqM
+elo
+cqM
+gAr
+ckC
+hCQ
+cqM
+iPn
+eqT
+hCQ
+kUo
+hCQ
+lRq
+lMM
+lMM
+mli
+hCQ
+kUo
+hCQ
+eqT
+oTT
+ckC
+nyC
+dwS
+ckC
+cqM
+elo
+ckC
+cqM
+ckC
+cqM
+jBU
+uzr
+pxr
 gfl
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-vqi
 uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-xIt
-vqi
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -53036,47 +52140,47 @@ nsK
 (76,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
 uGF
 gfl
+qzH
 uGF
 uGF
-uGF
+ckC
+dqw
+gaR
+elo
+ckC
+hCQ
+cqM
+iLi
+eqT
+wcn
+lby
+wcn
+lVD
+gVM
+lID
+gVM
+wcn
+eqT
+wcn
+eqT
+oTT
+ckC
+hCQ
+cqM
+elo
+ckC
+ckC
+cqM
+hCQ
+hCQ
+cqM
+ckC
+xIt
+xIt
+pxr
 gfl
-uGF
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-vqi
-xIt
-uGF
-uGF
-uGF
-rvq
-uGF
-uGF
-xIt
-xIt
-vqi
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -53258,45 +52362,45 @@ nsK
 (77,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-xIt
-gfl
-uGF
-xIt
-vqi
-xIt
-xIt
-xIt
 uGF
 uGF
-uGF
-uGF
-vwm
-uGF
-uGF
-uGF
-loD
-loD
-uGF
-uGF
-uGF
+qzH
+bMh
+ckC
+dqw
+cqM
+egm
+bVQ
+hYa
+hCQ
+loy
+iLi
+jKV
+jKV
+jKW
+lAB
+jKW
+jKV
+mQj
+jKV
+cxU
+jKW
+otr
+jKW
+oTT
+icv
+hCQ
+xdv
+cqM
+elo
+cqM
+hCQ
+hCQ
+qih
+cqM
+icv
+hCQ
 xIt
-vqi
-xIt
-xIt
-xIt
-vqi
-xIt
-uGF
-gfl
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-vqi
 xIt
 xIt
 xIt
@@ -53480,45 +52584,45 @@ nsK
 (78,1,1) = {"
 cgS
 xIt
+uGF
+uGF
+qzH
+bVM
+cqM
+dwS
+eoI
 xIt
+eqE
+cqM
+hNx
+cqM
+iOZ
+jKW
+jKW
+jKW
+jKV
+lXy
+jKW
+ndP
+jKW
+jKW
+jKV
+jKW
+jKW
+oXj
+jBU
+hCQ
+cqM
+cqM
 xIt
+cqM
+pXd
+qes
+qkR
+ckC
+cqM
+ckC
 xIt
-uGF
-uGF
-xIt
-vqi
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-loD
-gfl
-uGF
-uGF
-loD
-loD
-gfl
-uGF
-uGF
-uGF
-xIt
-vqi
-xIt
-xIt
-xIt
-vqi
-xIt
-uGF
-uGF
-uGF
-hDd
-uGF
-uGF
-xIt
-xIt
-vqi
 xIt
 xIt
 xIt
@@ -53702,45 +52806,45 @@ nsK
 (79,1,1) = {"
 cgS
 xIt
+uGF
+gfl
+aEE
+bVQ
+cqM
+ckC
 xIt
 xIt
-uGF
-uGF
-uGF
-xIt
-vqi
-xIt
-uGF
-loD
+bdt
+dwS
 nyC
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-vqi
+ckC
+jaz
+eqT
+vQe
+lby
+vQe
+mdA
+lID
+mdA
+lID
+kPF
+ogw
+kPF
+ogl
+oTT
+dwS
+hCQ
+cqM
+cqM
 xIt
 xIt
+pXd
+qhP
+qkR
+cqM
+jBU
+jBU
 xIt
-vqi
-xIt
-xIt
-uGF
-gfl
-uGF
-uGF
-gfl
-uGF
-xIt
-vqi
 xIt
 xIt
 xIt
@@ -53924,45 +53028,45 @@ nsK
 (80,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-uGF
-gfl
-uGF
-xIt
-vqi
 uGF
 uGF
-loD
-loD
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-vqi
+qzH
+xEg
+cqM
 xIt
 xIt
 xIt
-vqi
+ckC
+ckC
+nyC
+ckC
+iLi
+eqT
+hCQ
+kEl
+hCQ
+mli
+lMM
+mli
+lMM
+hCQ
+kEl
+hCQ
+eqT
+pbF
+cqM
+hNx
+pBo
+cqM
+pKl
+cqM
+pXd
+qih
+eqT
+cqM
+ckC
+ckC
 xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-vqi
 xIt
 xIt
 xIt
@@ -54145,46 +53249,46 @@ nsK
 "}
 (81,1,1) = {"
 cgS
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-qTf
+loD
 gfl
 uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-qTf
-xIt
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
+qzH
 gfl
-uGF
-uGF
-qTf
+cqM
+cqM
+xIt
+gbt
+cqM
+cqM
+hCQ
+ckC
+iJR
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+oTT
+dwS
+hNx
+dwS
+cqM
+cqM
+cqM
+bVQ
+etT
+eqT
+dwS
+ckC
+hCQ
+xIt
 xIt
 xIt
 xIt
@@ -54367,47 +53471,47 @@ nsK
 "}
 (82,1,1) = {"
 cgS
-xIt
-xIt
-xIt
+loD
+loD
 uGF
-uGF
-uGF
-gfl
-qTf
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-gfl
-xEg
-uGF
-uGF
-qTf
-xIt
-xIt
-xIt
-vqi
+qzH
+qzH
 xIt
 xIt
 xIt
 xIt
-xEg
-uGF
-uGF
-uGF
-uGF
-eVB
-uGF
+xIt
+dwS
+hCQ
+ckC
+jaU
+eqT
+hCQ
+kUo
+hCQ
+mli
+lMM
+lMM
+mMd
+hCQ
+kUo
+hCQ
+eqT
+oTT
+cqM
+hCQ
+cqM
+cqM
+cqM
+cqM
+cqM
+cqM
+cqM
+etT
+icv
+hCQ
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -54593,47 +53697,47 @@ xIt
 xIt
 uGF
 uGF
-xEg
+eNo
 uGF
-uGF
-qTf
-xEg
-uGF
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+hCQ
+cqM
+iJR
+eqT
+wcn
+eqT
+wcn
+gVM
+gVM
+lID
+gVM
+oBM
+eqT
+wcn
+eqT
+oTT
+ckC
+hCQ
+pHo
+pBo
+cqM
+cqM
+pXd
+qhP
+cqM
+ckC
+ckC
+hCQ
+xIt
+xIt
+xIt
 gfl
 uGF
-xEg
 uGF
-xEg
-uGF
-uGF
-uGF
-uGF
-uGF
-xEg
-uGF
-uGF
-uGF
-qTf
-gfl
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-xIt
-xEg
-uGF
-uGF
-uGF
-aeZ
-uGF
-uGF
-gfl
-uGF
-xEg
 xIt
 xIt
 xIt
@@ -54814,44 +53918,44 @@ cgS
 xIt
 xIt
 uGF
-uGF
 gfl
-uGF
-xIt
-vqi
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
+qzH
 uGF
 loD
-ntJ
-ntJ
-loD
-uGF
-uGF
-uGF
-uGF
-uGF
-qTf
-uGF
-xIt
-xIt
-vqi
 xIt
 xIt
 xIt
+icv
+hCQ
+laA
+jcs
+jMk
+jMk
+jMk
+jMk
+jMk
+jMk
+ngh
+jMk
+jMk
+jMk
+jMk
+jMk
+pdD
+hYa
+hCQ
+laA
+cqM
+cqM
+cqM
+hCQ
+hCQ
+ckC
+cqM
+hCQ
+hCQ
 xIt
 xIt
-uGF
-qKf
-uGF
-uGF
-qTf
-gfl
 uGF
 uGF
 uGF
@@ -55036,48 +54140,48 @@ cgS
 xIt
 xIt
 uGF
+uGF
+ewO
+uGF
+uGF
+xIt
+xIt
+xIt
+ckC
+hCQ
+ncH
+njJ
+njJ
+kjv
+jNs
+whv
+njJ
+kjv
+kjv
+peR
+hXS
+hXS
+hXS
+hXS
+peR
+hXS
+igB
+igB
+igB
+igB
+igB
+igB
+hCQ
+ckC
+cqM
+hCQ
+uGF
+xEg
 gfl
 uGF
-xIt
-xIt
-qTf
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-hDd
-uGF
-ntJ
-uGF
-uGF
-ntJ
-uGF
 uGF
 gfl
-uGF
-uGF
-qTf
-uGF
-xIt
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-gfl
-uGF
-qTf
-uGF
-uGF
-uGF
-gfl
-uGF
+xEg
 ntJ
 gfl
 uGF
@@ -55258,51 +54362,51 @@ cgS
 xIt
 xIt
 uGF
-uGF
-uGF
-xIt
-xIt
-vqi
+gfl
+qzH
 uGF
 gfl
-uGF
-uGF
-gfl
-uGF
-uGF
-gfl
-ntJ
-uGF
-uGF
-ntJ
-uGF
-uGF
-uGF
 loD
-loD
-qTf
-uGF
-uGF
 xIt
-vqi
-xIt
-xIt
-xIt
+ckC
+gZd
+hCQ
+cqM
+dwS
+vih
+ckC
+cqM
+eqE
+gbt
+wHN
+ckC
+nBG
+njJ
+njJ
+kjv
+kjv
+njJ
+lEp
+pyS
+kjv
+lEp
+kjv
+pNV
+nEw
+cqM
+dwS
+ckC
+qoT
+ckC
 uGF
-gfl
-xEg
 uGF
-uGF
-uGF
-aeZ
-uGF
-xIt
-uGF
-uGF
-uGF
-ntJ
-uGF
-uGF
+qzH
+qzH
+qzH
+qzH
+eeF
+qzH
+qzH
 uGF
 xIt
 xIt
@@ -55480,64 +54584,64 @@ cgS
 xIt
 xIt
 uGF
+gfl
+ewO
 uGF
 uGF
-xIt
-xIt
-vqi
-uGF
-uGF
-uGF
-loD
-uGF
-uGF
-uGF
-uGF
-loD
-ntJ
-ntJ
-nyC
-uGF
-uGF
-uGF
-loD
-nyC
-qTf
-uGF
-uGF
-xIt
-vqi
-vqi
-vqi
-vqi
-qTf
-oFs
-qTf
-eVB
-qTf
-oFs
-qTf
-xIt
-xIt
+eqE
+cqM
+ckC
+ckC
+hCQ
+hCQ
+hCQ
+hCQ
+hCQ
+hNx
+hNx
+hCQ
+hCQ
+hCQ
+nEg
+hCQ
+hNx
+hNx
+hCQ
+hCQ
+hCQ
+hCQ
+etT
+cqM
+ckC
+ckC
+nEw
+kjv
+qlT
+qmz
+qvJ
+qzH
+aEE
+qzH
+qAk
 xIt
 xIt
 xEg
 ntJ
 gfl
-uGF
-xEg
-uGF
-uGF
-uGF
-gfl
-uGF
-gfl
-uGF
-gfl
-yjx
-ujh
-rsm
-jlM
+qzH
+ewO
+qzH
+qzH
+qzH
+eNo
+qzH
+eNo
+qzH
+eNo
+eRN
+eVp
+fpP
+fFR
 jlM
 dpw
 txH
@@ -55703,44 +54807,44 @@ xIt
 xIt
 uGF
 uGF
+qzH
+gfl
+ckC
+cqM
+ckC
+cqM
+ckC
+hCQ
+ihZ
+ckC
+vFl
+cqM
+lcg
+etT
+cqM
+pPB
+jBU
+nEw
+hCQ
+cqM
+cqM
+cqM
+ckC
+ckC
+cqM
+cqM
+cqM
+cqM
+etT
+ivx
+ckC
+etT
+gVM
+qxq
 uGF
-xIt
-xIt
-qTf
 uGF
 uGF
 uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-vwm
-uGF
-uGF
-uGF
-uGF
-qTf
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -55759,7 +54863,7 @@ uGF
 uGF
 ujh
 izf
-ujh
+eVp
 aKo
 wtG
 txH
@@ -55924,45 +55028,45 @@ cgS
 xIt
 xIt
 asP
-uGF
-xEg
-xIt
-xIt
-qTf
-uGF
+gfl
+qzH
+ckC
+ckC
+eqT
+eqT
+cqM
+gZy
+hCQ
+ijG
+elo
+jBU
+ckC
+cqM
+elo
+gbt
+cqM
+elo
+nEw
+hCQ
+elo
+etT
+cqM
+cqM
+elo
+cqM
+jBU
+cqM
+cqM
+cqM
+hXS
+cqM
+ckC
+wpv
+qxq
+ckC
 gfl
 uGF
 uGF
-uGF
-gfl
-uGF
-uGF
-qKf
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-qTf
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-gfl
-uGF
-uGF
-loD
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -55981,7 +55085,7 @@ gfl
 yjx
 ujh
 rsm
-jlM
+fFR
 dpw
 txH
 oER
@@ -56144,45 +55248,45 @@ nsK
 (90,1,1) = {"
 cgS
 xIt
-xIt
-uGF
-uGF
-gfl
-xIt
-xIt
-qTf
 uGF
 uGF
 uGF
+qzH
+cqM
+cqM
+dwS
+eqT
+ckC
+cqM
+cqM
+dwS
+jqF
+jNs
+kjv
+jkr
+lEp
+kjv
+mAk
+kjv
+nFV
+hCQ
+laA
+elo
+cqM
+elo
+dwS
+bVQ
+cqM
+dwS
+ckC
+cqM
+hXS
+jBU
+ckC
+gVM
+qoT
 uGF
 uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-qTf
-xIt
-xIt
-xIt
-xIt
-xIt
-gfl
-uGF
-uGF
-uGF
-gfl
-xIt
-xIt
-xIt
-xIt
 xIt
 xIt
 xIt
@@ -56203,7 +55307,7 @@ uGF
 yjx
 bBz
 eZJ
-nwP
+fIl
 omJ
 txH
 lMj
@@ -56366,42 +55470,42 @@ nsK
 (91,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-uGF
-uGF
-xIt
-xIt
-qTf
-xEg
-gfl
 uGF
 uGF
 uGF
-xEg
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-xEg
-uGF
-uGF
-gfl
-qTf
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-gfl
-uGF
-uGF
-xIt
+qzH
+csL
+dEZ
+cqM
+eqT
+cqM
+cqM
+hOM
+ckC
+siX
+jQd
+jQd
+lnz
+jQd
+jQd
+jQd
+nkH
+ivx
+hCQ
+cqM
+cqM
+elo
+pfm
+cqM
+ckC
+cqM
+ckC
+ckC
+ckC
+hXS
+cqM
+ckC
+ckC
 xIt
 xIt
 xIt
@@ -56425,7 +55529,7 @@ uGF
 yjx
 bBz
 eZJ
-ujh
+eVp
 oUq
 jzP
 cuz
@@ -56589,40 +55693,40 @@ nsK
 cgS
 xIt
 xIt
-xIt
-uGF
-uGF
-xIt
-xIt
-qTf
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
 uGF
 gfl
-uGF
-uGF
-uGF
-loD
-uGF
-uGF
-uGF
-uGF
-uGF
-qTf
+qzH
+cwT
+kjv
+hNw
+ogl
+ogl
+ogl
+ogl
+kjv
+uIz
+gbt
+krB
+gbt
+ckC
+mmD
+gbt
+nnL
+nJe
+hNx
+cqM
+elo
+cqM
+etT
+cqM
+hCQ
+hCQ
+hCQ
+hCQ
+pVA
+igB
+hCQ
 xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-vwm
 xIt
 xIt
 xIt
@@ -56810,42 +55914,42 @@ nsK
 (93,1,1) = {"
 cgS
 xIt
-xIt
-xIt
-gfl
-gfl
-xIt
-xIt
-vqi
-gfl
 uGF
 uGF
+uGF
+uGF
+uGF
+dHk
+cqM
+eqT
+cqM
+cqM
+ckC
+dHk
+iJR
+ckC
+ckC
+gbt
+lEZ
+gbt
+gbt
+ntU
+nLC
 nyC
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-loD
-gfl
-uGF
-uGF
-uGF
-uGF
-vqi
+cqM
+etT
+cqM
+cqM
+dwS
+cqM
+ckC
+hCQ
+cqM
+ckC
+igB
+hCQ
 xIt
 xIt
-xIt
-xIt
-gfl
-loD
-loD
-gfl
-uGF
-uGF
-uGF
 xIt
 xIt
 xIt
@@ -57032,47 +56136,47 @@ nsK
 (94,1,1) = {"
 cgS
 xIt
-xIt
-xIt
+gfl
 uGF
 uGF
-xIt
-xIt
-vqi
-xIt
+xEg
 uGF
 uGF
-uGF
-uGF
-uGF
-loD
-loD
-uGF
-uGF
-uGF
-loD
-uGF
-uGF
-uGF
-uGF
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-uGF
-nyC
-loD
-uGF
-uGF
-uGF
-uGF
-uGF
+dwS
+eqT
+etT
+bVQ
+cqM
+ipx
+jrq
+jUt
+kwJ
+lnC
+jUt
+jUt
+jUt
+ntU
+ivx
+hNx
+cqM
+bVQ
+elo
+ckC
+cqM
+etT
+cqM
+hCQ
+cqM
+etT
+igB
 xIt
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
@@ -57255,46 +56359,46 @@ nsK
 cgS
 xIt
 xIt
-xIt
+uGF
+xEg
 uGF
 uGF
 xIt
+eum
+cqM
+cqM
+ckC
+hCQ
+cqM
+etT
+cqM
+ckC
+cqM
+elo
+ckC
+etT
+egm
+ivx
+hCQ
+cqM
+etT
+cqM
+ckC
+cqM
+elo
+cqM
+hCQ
+hCQ
+pVA
+igB
 xIt
-vqi
-xIt
-xIt
-uGF
-uGF
-uGF
-gfl
-loD
-loD
-uGF
-uGF
-uGF
-loD
-uGF
-uGF
-uGF
-xIt
-xIt
-vqi
 xIt
 xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
 xIt
-uGF
-uGF
+xIt
 uGF
 gfl
 uGF
@@ -57478,45 +56582,45 @@ cgS
 xIt
 xIt
 xIt
-gfl
-xEg
 uGF
-xIt
-vqi
+uGF
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-gfl
-uGF
-uGF
-gfl
-uGF
-uGF
-gfl
+eqT
+cqM
+ckC
+hCQ
+eqE
+elo
+egm
+kDZ
+ckC
+eqE
+cqM
+elo
+cqM
+ivx
+hCQ
+aNl
+cqM
+ckC
+gVM
+cqM
+ckC
+ckC
+hCQ
+hCQ
+cqM
+igB
 xIt
 xIt
-vqi
 xIt
 xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-gfl
-loD
-loD
-uGF
-uGF
-uGF
-gfl
+xIt
 uGF
 uGF
 xIt
@@ -57700,43 +56804,43 @@ cgS
 xIt
 xIt
 xIt
-uGF
-uGF
-asP
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
 gfl
 uGF
 uGF
-uGF
-uGF
-uGF
-uGF
 xIt
 xIt
 xIt
-vqi
+ckC
+cqM
+hCQ
+cqM
+ckC
+gVM
+gVM
+cqM
+cqM
+cqM
+mCj
+mMd
+nRL
+hCQ
+ckC
+cqM
+ckC
+ckC
+gVM
+ckC
+ckC
+hCQ
+hCQ
+pVA
+igB
 xIt
 xIt
 xIt
 xIt
 xIt
-gfl
-uGF
-uGF
-xEg
-uGF
-loD
-loD
-uGF
-gfl
+xIt
 uGF
 uGF
 uGF
@@ -57922,44 +57026,44 @@ cgS
 xIt
 xIt
 xIt
-xIt
-uGF
-uGF
-xIt
-vqi
-vqi
-vqi
-vqi
-vqi
-qTf
-oFs
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-qTf
-oFs
-vqi
-vqi
-vqi
-vqi
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
 uGF
 uGF
 gfl
+loD
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+ckC
+hCQ
+xIt
+xIt
+xIt
+xIt
+vqi
+vqi
+igB
+igB
+hXS
+igB
+hXS
+xXi
+igB
+igB
+vqi
+vqi
+vqi
+xIt
+xIt
+xIt
+xIt
+xIt
+uGF
+uGF
 uGF
 uGF
 gfl
@@ -58144,26 +57248,34 @@ cgS
 xIt
 xIt
 xIt
-xIt
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
 gfl
 uGF
 uGF
+uGF
+loD
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 uGF
-uGF
-uGF
+ckC
+ckC
 gfl
+ckC
+ckC
 uGF
-xIt
+ckC
+hCQ
 xIt
 xIt
 xIt
@@ -58173,15 +57285,7 @@ xIt
 xIt
 xIt
 uGF
-uGF
-gfl
 xEg
-gfl
-uGF
-gfl
-xEg
-uGF
-uGF
 uGF
 uGF
 xEg
@@ -58366,25 +57470,11 @@ cgS
 xIt
 xIt
 xIt
-xIt
-xIt
+xEg
+gfl
 uGF
 uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-ntJ
-ntJ
-ntJ
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-uGF
+asP
 xIt
 xIt
 xIt
@@ -58394,17 +57484,31 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
+xIt
 uGF
 gfl
 uGF
-gfl
+uGF
+uGF
+uGF
+pkT
+uGF
+uGF
+xEg
+hCQ
+xIt
+xIt
+xIt
+xIt
+xIt
+uGF
+uGF
+uGF
+uGF
+uGF
 uGF
 uGF
 gfl
@@ -58598,34 +57702,34 @@ xIt
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
 uGF
 gfl
 uGF
-xIt
-xIt
-xIt
-uGF
-uGF
-uGF
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-xIt
-uGF
-gfl
+xEg
 uGF
 uGF
 uGF
 uGF
-xIt
-xIt
 uGF
-uGF
+xEg
 uGF
 uGF
 uGF
@@ -58820,34 +57924,34 @@ xIt
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
-xIt
-xIt
-xIt
-xIt
-ntJ
-ntJ
-xIt
-xIt
-vqi
-vqi
-vqi
-vqi
-vqi
-vqi
+uGF
+qTf
+qTf
+qTf
+qTf
+qTf
+qTf
 qTf
 qTf
 oiU
 oiU
 qTf
 qTf
-xIt
-xIt
-xIt
-xIt
-xIt
+uGF
+uGF
+uGF
+uGF
+uGF
 xIt
 uGF
 gfl
@@ -58955,7 +58059,7 @@ cbT
 oaK
 vst
 oaK
-loy
+oaK
 kzY
 nZO
 oaK
@@ -59042,9 +58146,9 @@ uGF
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -59052,13 +58156,13 @@ xIt
 uGF
 gfl
 uGF
-xIt
-vqi
-xIt
-xIt
-xIt
-xIt
-xIt
+uGF
+owj
+uGF
+uGF
+uGF
+uGF
+uGF
 uGF
 uGF
 loD
@@ -59066,9 +58170,9 @@ loD
 uGF
 qTf
 loD
-xIt
-xIt
-xIt
+uGF
+uGF
+uGF
 xIt
 xIt
 xIt
@@ -59255,7 +58359,7 @@ xIt
 xIt
 xIt
 xIt
-uGF
+xIt
 xEg
 uGF
 uGF
@@ -59278,9 +58382,9 @@ uGF
 qTf
 uGF
 uGF
-xIt
-xIt
 uGF
+uGF
+cQd
 gfl
 uGF
 uGF
@@ -59288,8 +58392,8 @@ gfl
 uGF
 qTf
 uGF
-xIt
-xIt
+uGF
+uGF
 xIt
 xIt
 xIt
@@ -59476,9 +58580,9 @@ cgS
 xIt
 xIt
 xIt
-uGF
-asP
-uGF
+xIt
+xIt
+xIt
 xIt
 uGF
 uGF
@@ -59698,9 +58802,9 @@ cgS
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
 xIt
 xIt
 uGF
@@ -59920,8 +59024,8 @@ cgS
 xIt
 xIt
 xIt
-uGF
-uGF
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -60142,8 +59246,8 @@ cgS
 xIt
 xIt
 xIt
-gfl
-uGF
+xIt
+xIt
 xIt
 xIt
 uGF
@@ -60363,12 +59467,12 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-uGF
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+loD
 uGF
 gfl
 uGF
@@ -60378,7 +59482,7 @@ uGF
 uGF
 uGF
 uGF
-uGF
+loD
 xIt
 xIt
 xIt
@@ -60585,12 +59689,12 @@ nsK
 cgS
 xIt
 xIt
-uGF
-gfl
-uGF
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+loD
 uGF
 uGF
 uGF
@@ -60600,7 +59704,7 @@ gfl
 uGF
 uGF
 gfl
-uGF
+loD
 xIt
 xIt
 xIt
@@ -60807,9 +59911,9 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-xEg
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -61029,9 +60133,9 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -61251,13 +60355,13 @@ nsK
 cgS
 xIt
 xIt
-gfl
-uGF
-uGF
 xIt
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+loD
 xEg
 uGF
 xEg
@@ -61451,15 +60555,15 @@ cqo
 xEZ
 ezR
 eZd
-fEZ
-uIz
-uIz
-uIz
-uIz
-uIz
-uIz
+siO
+kpl
+kpl
+kpl
+kpl
+kpl
+kpl
 eXT
-uIz
+kpl
 taY
 xZs
 pxY
@@ -61473,13 +60577,13 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-gfl
 xIt
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+loD
 uGF
 uGF
 uGF
@@ -61671,7 +60775,7 @@ pPX
 mju
 jGH
 xEZ
-qJs
+mqw
 xKK
 aWU
 kci
@@ -61682,7 +60786,7 @@ tKr
 kci
 tXa
 mku
-fgn
+xEZ
 xEZ
 pPX
 pPX
@@ -61694,15 +60798,15 @@ nsK
 (115,1,1) = {"
 cgS
 xIt
-uGF
-uGF
-uGF
-uGF
 xIt
 xIt
 xIt
 xIt
-uGF
+xIt
+xIt
+xIt
+xIt
+loD
 uGF
 uGF
 uGF
@@ -61893,7 +60997,7 @@ pPX
 tmV
 xEZ
 xEZ
-ctT
+jSP
 xEZ
 fZd
 kci
@@ -61904,7 +61008,7 @@ pPX
 pPX
 pPX
 pPX
-wcn
+lFD
 rFv
 pPX
 pPX
@@ -61916,26 +61020,26 @@ nsK
 (116,1,1) = {"
 cgS
 xIt
-xEg
-uGF
-gfl
-xEg
 xIt
 xIt
 xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-gfl
-uGF
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 uGF
 gfl
 uGF
+uGF
+uGF
+uGF
+gfl
+uGF
 xIt
 xIt
 xIt
@@ -61947,7 +61051,7 @@ xIt
 uGF
 uGF
 gfl
-uGF
+loD
 xIt
 xIt
 xIt
@@ -62115,7 +61219,7 @@ pPX
 bor
 kci
 xEZ
-ctT
+jSP
 hCt
 kci
 pPX
@@ -62126,7 +61230,7 @@ pPX
 eVl
 mcU
 pPX
-aaJ
+dzB
 dzB
 dzB
 pPX
@@ -62139,16 +61243,16 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
 xIt
 xIt
 xIt
 xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
-xEg
 uGF
 uGF
 uGF
@@ -62169,7 +61273,7 @@ xIt
 gfl
 uGF
 uGF
-uGF
+loD
 xIt
 xIt
 xIt
@@ -62335,8 +61439,8 @@ pPX
 pPX
 pPX
 pPX
-kci
-xEZ
+lPb
+fgn
 svr
 vUI
 jsB
@@ -62348,7 +61452,7 @@ pPX
 wLx
 mcU
 pPX
-aaJ
+dzB
 dzB
 dzB
 pPX
@@ -62361,17 +61465,17 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-gfl
 xIt
 xIt
-uGF
-gfl
-gfl
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 uGF
 uGF
 gfl
@@ -62557,7 +61661,7 @@ aQt
 kci
 sFK
 lFD
-xEZ
+fgn
 sXb
 gRH
 dot
@@ -62570,7 +61674,7 @@ pPX
 pPX
 aLN
 pPX
-aaJ
+dzB
 dzB
 dzB
 pPX
@@ -62583,17 +61687,17 @@ nsK
 cgS
 xIt
 xIt
-uGF
-uGF
-gfl
-uGF
-uGF
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 uGF
@@ -62779,7 +61883,7 @@ gCO
 dbK
 dbK
 rgs
-dbK
+tyV
 oFt
 szN
 bJY
@@ -62792,7 +61896,7 @@ mcU
 mcU
 bNT
 pPX
-aaJ
+dzB
 dzB
 xbQ
 pPX
@@ -62806,15 +61910,15 @@ cgS
 xIt
 xIt
 xIt
-uGF
-uGF
-uGF
-uGF
-uGF
-xEg
-uGF
-gfl
-xEg
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -62995,13 +62099,13 @@ xEZ
 xEZ
 xEZ
 xEZ
-xEZ
-xEZ
-ctT
+fgn
+fgn
+jSP
 rlA
-xEZ
-lFD
-xEZ
+fgn
+aQr
+fgn
 xEZ
 wPx
 xEZ
@@ -63014,7 +62118,7 @@ mcU
 mcU
 egQ
 ggk
-aaJ
+dzB
 dzB
 dzB
 pPX
@@ -63028,14 +62132,14 @@ cgS
 xIt
 xIt
 xIt
-uGF
-uGF
-qKf
-uGF
-gfl
-uGF
-gfl
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -63217,7 +62321,7 @@ sHi
 kpl
 kpl
 vWS
-vWS
+kky
 bHd
 xZs
 xEZ
@@ -63236,7 +62340,7 @@ qtB
 iJk
 pPX
 pPX
-eeT
+cEW
 dzB
 dzB
 pPX
@@ -63250,13 +62354,13 @@ cgS
 xIt
 xIt
 xIt
-uGF
-gfl
-uGF
-gfl
-uGF
-uGF
-uGF
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -63401,8 +62505,8 @@ xcj
 jJn
 sSk
 xcj
-ncG
-uet
+xcj
+ksh
 uGS
 uGS
 uGS
@@ -63439,7 +62543,7 @@ xEZ
 xEZ
 xEZ
 xEZ
-tZa
+gMw
 xEZ
 xEZ
 kci
@@ -63458,7 +62562,7 @@ pPX
 pPX
 pPX
 aZw
-aaJ
+dzB
 dzB
 dzB
 pPX
@@ -63472,12 +62576,12 @@ cgS
 xIt
 xIt
 xIt
-uGF
-xEg
-uGF
-uGF
-uGF
-xEg
+xIt
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -63623,8 +62727,8 @@ uEs
 wtk
 wEk
 ltL
-ubR
-uet
+cVG
+rHL
 uGS
 oMs
 uGS
@@ -63661,7 +62765,7 @@ kci
 xEZ
 xEZ
 xEZ
-xEZ
+fgn
 xEZ
 aXD
 pPX
@@ -63677,9 +62781,9 @@ dzB
 dzB
 dzB
 lSR
-aaJ
-aaJ
-aaJ
+dzB
+dzB
+dzB
 lSR
 dzB
 xbQ
@@ -63695,11 +62799,11 @@ xIt
 xIt
 xIt
 xIt
-uGF
-uGF
-gfl
-uGF
-gfl
+xIt
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 xIt
@@ -63845,8 +62949,8 @@ qKA
 pkE
 wEk
 ltL
-ubR
-uet
+azA
+rHL
 uGS
 oMs
 oMs
@@ -63883,7 +62987,7 @@ pPX
 hjf
 xEZ
 xEZ
-xEZ
+fgn
 xEZ
 lrT
 pPX
@@ -63898,7 +63002,7 @@ lFD
 dzB
 aZw
 dzB
-aaJ
+dzB
 dzB
 dzB
 dzB
@@ -63917,11 +63021,11 @@ xIt
 xIt
 xIt
 xIt
-qTf
-qTf
-qTf
-qTf
-qTf
+vqi
+vqi
+vqi
+vqi
+vqi
 vqi
 vqi
 vqi
@@ -64067,8 +63171,8 @@ xcj
 ubE
 nIx
 xcj
-ncG
-uet
+xcj
+err
 oMs
 uGS
 uGS
@@ -64105,7 +63209,7 @@ pPX
 pPX
 xtD
 xEZ
-xEZ
+fgn
 aYf
 aXD
 pPX
@@ -64119,8 +63223,8 @@ gpx
 pPX
 pPX
 pPX
-lFD
-bgd
+pPX
+pPX
 pPX
 pPX
 pPX
@@ -64141,10 +63245,10 @@ xIt
 xIt
 vqi
 xIt
-jqf
-jqf
-jqf
-jqf
+xIt
+xIt
+xIt
+xIt
 xIt
 xIt
 lnR
@@ -64318,33 +63422,33 @@ pOG
 eWY
 eWY
 eWY
-aBZ
-hCY
-hCY
-hCY
-hCY
-hCY
-eNo
-eeF
-vap
-vap
-vap
-vhR
-eNo
-xJD
-vap
-xJD
-nLw
-xJD
-vap
-ngv
-pPX
+eWY
+ndb
+ndb
+ndb
+ndb
 ndb
 pPX
-dzB
-aaJ
-tJH
+mCI
+xEZ
+fgn
+xEZ
+aXD
 pPX
+gpx
+xEZ
+gpx
+nLw
+gpx
+xEZ
+gpx
+pPX
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 ndb
@@ -64363,9 +63467,9 @@ xIt
 xIt
 vqi
 xIt
-jqf
-jqf
-uLt
+xIt
+xIt
+xIt
 jqf
 jqf
 jqf
@@ -64540,41 +63644,41 @@ pOG
 eWY
 udO
 eWY
-aBZ
+eWY
 ndb
-ndb
-ndb
-ndb
-ndb
-pPX
-pPX
-lFD
-bpY
-lFD
-pPX
-pPX
-pPX
-pPX
-pPX
-pPX
-pPX
-pPX
+hCY
+hCY
+hCY
+hCY
 mth
-pPX
-ndb
-pPX
-dzB
-aaJ
-xbQ
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
+mth
+nNn
+bpY
+nNn
+mth
+mth
+mth
+mth
+mth
+mth
+mth
+mth
+mth
+mth
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+rIi
 nsK
 "}
 (128,1,1) = {"
@@ -64586,7 +63690,7 @@ xIt
 vqi
 xIt
 xIt
-jqf
+xIt
 jqf
 uLt
 jqf
@@ -64756,39 +63860,24 @@ gpo
 uGS
 eWY
 eWY
-aBZ
-xNw
-tuc
-xNw
-xNw
-xNw
-aBZ
-ncH
-ndb
-ndb
-ndb
-ndb
-ndb
-dYh
-dYh
-dYh
-dYh
-dYh
-ndb
-ndb
-ndb
-npE
-npE
-ndb
+eWY
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
 ndb
 rIi
 ndb
 ndb
-pPX
-dzB
-aaJ
-cEW
-pPX
+ndb
+ndb
+dYh
+jUy
+rbw
+jUy
+avv
 ndb
 ndb
 ndb
@@ -64797,6 +63886,21 @@ ndb
 ndb
 ndb
 ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+rIi
 nsK
 "}
 (129,1,1) = {"
@@ -64978,47 +64082,47 @@ uGS
 mls
 eHy
 dfq
-aBZ
-fBC
-arf
-arf
-arf
-arf
-arf
-fBC
-fBC
+eWY
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
 ndb
 ndb
 ndb
 ndb
-kdQ
-npE
-npE
-npE
-npE
-npE
+fHK
+fHK
+hcL
+fHK
+fHK
 ndb
-npE
-npE
-xmm
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 rIi
-ndb
-xOO
-pPX
-dzB
-lSR
-xbQ
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (130,1,1) = {"
@@ -65200,47 +64304,47 @@ oMs
 idc
 ydx
 pOG
-rOn
-arf
-mOj
-mOj
-mOj
-mOj
-mOj
-mOj
-rkR
+uGS
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
 ndb
 ndb
-npE
-npE
-npE
-npE
-npE
-npE
-npE
-npE
-npE
-xmm
-xmm
-xmm
+fHK
+fHK
+fHK
+fHK
+hcL
+fHK
+fHK
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-aZw
-dzB
-aaJ
-xbQ
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (131,1,1) = {"
@@ -65422,47 +64526,47 @@ oMs
 lrX
 sQJ
 sQU
-fXy
-arf
-qsl
-nzX
-qfQ
-oAK
-jRU
-mOj
-rkR
+oMs
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
 ndb
 ndb
-npE
-npE
+fHK
+fHK
 xmm
-npE
-xmm
-xmm
-xmm
+fHK
+nKB
 xmm
 xmm
-xmm
-xmm
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-aZw
-dzB
-aaJ
-dzB
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (132,1,1) = {"
@@ -65644,47 +64748,47 @@ uGS
 oMs
 uGS
 uGS
-fXy
-arf
-pxX
-kqs
-bnc
-bnc
-rnV
-fBC
-fBC
-fBC
+oMs
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+eWY
+eWY
+eWY
+eWY
+fHK
+xmm
+nKB
+nRW
+xmm
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+fHK
+fHK
 jDt
-jDt
-jDt
-npE
-xmm
-xmm
-xmm
-xmm
-xmm
-xmm
-xmm
+ndb
+ndb
 ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-dhv
-dzB
-aaJ
-xmY
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (133,1,1) = {"
@@ -65866,47 +64970,47 @@ uGS
 uGS
 oMs
 oMs
-rOn
-arf
-bua
-kUd
-lie
-qAz
-ctu
-hdY
+uGS
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
 mDs
-kDw
-jDt
-jDt
+eWY
+eWY
+eWY
 npE
 apC
 xmm
-xmm
+nKB
 xmm
 xmm
 xmm
 nvl
+ndb
+fHK
+ndb
+ndb
+ndb
+fHK
+ndb
+fHK
+ndb
+fHK
+fHK
 xmm
+xmm
+fHK
+ndb
+ndb
 ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-wAp
-hNw
-qXc
-hNw
-veq
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (134,1,1) = {"
@@ -66088,47 +65192,47 @@ uGS
 uGS
 uGS
 uGS
-rOn
-arf
-jyY
-bic
-uOC
-qfQ
-sYS
-cLZ
-kRt
-kDw
-jDt
-npE
-npE
+uGS
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+eWY
+eWY
+fHK
+fHK
 xmm
 xmm
-npE
-npE
-npE
-npE
+hcL
+fHK
+fHK
+fHK
+xmm
+fHK
+fHK
+fHK
+fHK
+xmm
+fHK
+fHK
+fHK
 xmm
 xmm
+xmm
+xmm
+xmm
+fHK
+fHK
+fHK
 ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-pPX
-lFD
-nDB
-pPX
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (135,1,1) = {"
@@ -66310,47 +65414,47 @@ eWY
 uGS
 uGS
 uGS
-aBZ
-arf
-fIl
-kqs
-apA
-bFY
-jOV
-fBC
-fBC
-fBC
-npE
-npE
+eWY
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+eWY
+fHK
+fHK
 xmm
 xmm
-npE
-npE
-npE
+fHK
+hcL
+fHK
 jDt
-npE
-npE
+fHK
+fHK
+fHK
+fHK
 xmm
 xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-pPX
-kci
-fgn
-xRt
-pPX
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (136,1,1) = {"
@@ -66532,47 +65636,47 @@ eWY
 uGS
 uGS
 eWY
-aBZ
-arf
-fpP
-fVp
-pwt
-qhw
-sCl
-mOj
-rkR
-ndb
-ndb
-npE
-npE
-npE
-npE
+eWY
+eWY
+pOG
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+eWY
+fHK
+fHK
+fHK
+fHK
+fHK
+wGi
 jDt
 jDt
 jDt
-jDt
-npE
-npE
+fHK
+fHK
 xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+ndb
 ndb
 ndb
 ndb
 rIi
-ndb
-pPX
-mJV
-xEZ
-fgn
-xEZ
-vvA
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (137,1,1) = {"
@@ -66754,47 +65858,47 @@ sQJ
 sQJ
 sQJ
 sQJ
-gcX
-arf
-mOj
-mOj
-mOj
-mOj
-mOj
-mOj
-rkR
-ndb
-ndb
-ndb
+sQJ
+sQJ
+lie
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+eWY
+fHK
+fHK
+fHK
+jDt
+jDt
+wGi
 jDt
 jDt
 jDt
 jDt
-jDt
-jDt
-jDt
-jDt
-npE
+fHK
 xmm
-npE
-npE
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+ndb
+ndb
+ndb
 ndb
 rIi
-ndb
-pPX
-mFF
-sns
-aIJ
-xEZ
-rYN
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (138,1,1) = {"
@@ -66928,7 +66032,7 @@ tzW
 jZM
 eux
 jZM
-jZM
+wZK
 jcI
 jZM
 jIb
@@ -66976,16 +66080,16 @@ eWY
 eWY
 eWY
 eWY
-aBZ
-fBC
-arf
-arf
-arf
-arf
-arf
-fBC
-fBC
-fBC
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+mDs
+ndb
 ndb
 ndb
 jDt
@@ -66994,29 +66098,29 @@ jDt
 bGu
 jDt
 jDt
-bGu
+bzz
 jDt
-npE
-npE
+fHK
 xmm
 xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+ndb
+ndb
+ndb
 ndb
 rIi
-ndb
-pPX
-hYa
-xEZ
-uYc
-sXb
-uvy
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (139,1,1) = {"
@@ -67198,7 +66302,6 @@ eWY
 eWY
 eWY
 eWY
-aBZ
 eWY
 eWY
 eWY
@@ -67206,39 +66309,40 @@ eWY
 eWY
 eWY
 eWY
-rkR
+eWY
+mDs
+eWY
 ndb
 ndb
 jDt
 jDt
 jDt
-jDt
 tVR
-tVR
-tVR
+bdE
+bdE
 jDt
 jDt
-npE
-npE
+fHK
+fHK
 xmm
 xmm
 xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+xmm
+xmm
+xmm
+xmm
+ndb
+ndb
+ndb
+ndb
 rIi
-ndb
-pPX
-kgY
-xEZ
-fgn
-sXb
-anV
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
 nsK
 "}
 (140,1,1) = {"
@@ -67420,7 +66524,7 @@ eWY
 eWY
 eWY
 eWY
-aBZ
+eWY
 eWY
 eWY
 eWY
@@ -67428,38 +66532,38 @@ udO
 eWY
 eWY
 eWY
+mDs
+ndb
+ndb
 jDt
 jDt
+pcI
+jDt
+wGi
 jDt
 jDt
 jDt
 pcI
-jDt
-jDt
-jDt
-jDt
-jDt
-pcI
-npE
-npE
+fHK
+fHK
 xmm
-nvl
-npE
-tkX
-hCY
-eNo
-eNo
-peC
-aUs
-peC
-eNo
-eNo
-hCY
-hCY
-hCY
-hCY
-hCY
-hCY
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+ndb
+ndb
+ndb
+ndb
 rIi
 nsK
 "}
@@ -67642,7 +66746,6 @@ eWY
 eWY
 eWY
 eWY
-aBZ
 eWY
 eWY
 eWY
@@ -67650,39 +66753,40 @@ eWY
 eWY
 eWY
 eWY
-jDt
-jDt
-jDt
-jDt
-npE
-npE
-npE
-jDt
-jDt
-jDt
-jDt
-npE
-npE
-wNI
-xmm
-xmm
-wNI
-npE
-ndb
-rkR
-pPX
-lFD
-nDB
-pPX
-pPX
-pPX
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
+eWY
 rIi
+ndb
+ndb
+jDt
+fHK
+fHK
+fHK
+wGi
+jDt
+jDt
+jDt
+fHK
+fHK
+xmm
+xmm
+xmm
+xmm
+xmm
+xmm
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+ndb
+ndb
+ndb
+ndb
+rkG
 nsK
 "}
 (142,1,1) = {"
@@ -67864,7 +66968,6 @@ eWY
 eWY
 eWY
 eWY
-aBZ
 eWY
 eWY
 eWY
@@ -67872,39 +66975,40 @@ eWY
 eWY
 eWY
 eWY
-jDt
-jDt
-jDt
-npE
-npE
-xmm
-npE
-npE
-jDt
-jDt
-npE
-npE
-xmm
-bGr
-bGr
-bGr
-npE
-npE
-npE
-npE
-npE
-jDt
-wGi
-jDt
-jDt
-jDt
-ndb
-ndb
-ndb
-ndb
-ndb
-ndb
+eWY
 rIi
+ndb
+ndb
+fHK
+fHK
+xmm
+fHK
+hcL
+jDt
+jDt
+fHK
+fHK
+xmm
+bGr
+bGr
+bGr
+fHK
+fHK
+fHK
+fHK
+fHK
+jDt
+jDt
+jDt
+jDt
+jDt
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+rsR
 nsK
 "}
 (143,1,1) = {"
@@ -68086,7 +67190,6 @@ eWY
 uGS
 uGS
 uGS
-aBZ
 eWY
 eWY
 eWY
@@ -68094,29 +67197,30 @@ eWY
 eWY
 eWY
 eWY
-npE
-npE
-npE
-npE
-npE
+eWY
+rIi
+ndb
+ndb
+fHK
+fHK
 xmm
-npE
+fHK
+wGi
 jDt
 jDt
-jDt
-npE
-npE
+fHK
+fHK
 xmm
 xmm
 cKR
 xmm
-npE
+fHK
 jDt
 jDt
 jDt
 jDt
 jDt
-wGi
+jDt
 jDt
 jDt
 jDt
@@ -68126,7 +67230,7 @@ ndb
 ndb
 ndb
 ndb
-rIi
+rDx
 nsK
 "}
 (144,1,1) = {"
@@ -68308,7 +67412,7 @@ uGS
 uGS
 uGS
 uGS
-rOn
+uGS
 eWY
 eWY
 eWY
@@ -68316,39 +67420,39 @@ eWY
 eWY
 eWY
 eWY
-rkR
-npE
-xmm
-xmm
-xmm
-npE
-jDt
-jDt
-jDt
-jDt
-npE
-xmm
-xmm
-xmm
-nKB
-hcL
-hcL
-wGi
-wGi
-wGi
-wGi
-wGi
-wGi
-jDt
-jDt
-jDt
-jDt
-ndb
-ndb
-ndb
-ndb
-ndb
 rIi
+ndb
+xmm
+xmm
+nDB
+fHK
+jDt
+wGi
+wGi
+wGi
+hcL
+nKB
+nKB
+nKB
+nKB
+fHK
+fHK
+jDt
+jDt
+jDt
+jDt
+jDt
+jDt
+jDt
+jDt
+jDt
+jDt
+ndb
+ndb
+ndb
+ndb
+ndb
+rDW
 nsK
 "}
 (145,1,1) = {"
@@ -68526,34 +67630,34 @@ eWY
 eWY
 eWY
 uGS
-oMs
+aTr
 uGS
 uGS
 eWY
-aBZ
-fBC
-arf
-arf
-arf
-arf
-arf
-fBC
-fBC
-fBC
-npE
-npE
-npE
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+rIi
+ndb
+fHK
+fHK
+fHK
 jDt
 jDt
 jDt
 jDt
 jDt
 jDt
-npE
+fHK
 xmm
-npE
+fHK
 hcL
-npE
+fHK
 jDt
 jDt
 jDt
@@ -68570,7 +67674,7 @@ jDt
 ndb
 ndb
 ndb
-rIi
+rMD
 nsK
 "}
 (146,1,1) = {"
@@ -68752,37 +67856,37 @@ oMs
 uGS
 eWY
 eWY
-rOn
-arf
-bnc
-bnc
-qXe
-kqs
-kqs
-tiD
-kRt
-kDw
-npE
+uGS
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ndb
+rIi
+ndb
+fHK
 jDt
 jDt
 jDt
 jDt
 jDt
 jDt
-npE
-npE
-npE
+fHK
+fHK
+fHK
 xmm
-npE
+fHK
 wGi
 pcI
 jDt
 jDt
 jDt
-npE
-npE
-npE
-npE
+fHK
+fHK
+fHK
+fHK
 pcI
 jDt
 jDt
@@ -68792,7 +67896,7 @@ pcI
 ndb
 ndb
 ndb
-rIi
+rNG
 nsK
 "}
 (147,1,1) = {"
@@ -68974,25 +68078,25 @@ uGS
 uGS
 uGS
 eWY
-rOn
-arf
-bnc
-bnc
-xrD
-kqs
-kqs
-tiD
-kRt
-kDw
+uGS
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ndb
+rIi
+ndb
 jDt
 jDt
 jDt
 pcI
-npE
-npE
-npE
-npE
-npE
+fHK
+fHK
+fHK
+fHK
+fHK
 nvl
 iHW
 rmn
@@ -69001,20 +68105,20 @@ rmn
 vsX
 jDt
 nLz
-npE
-npE
+fHK
+fHK
 cuW
 cuW
-npE
+fHK
 jDt
 jDt
 jDt
 jDt
 jDt
-bGu
+bzz
 jDt
 ndb
-rIi
+rpe
 nsK
 "}
 (148,1,1) = {"
@@ -69196,23 +68300,23 @@ uGS
 oMs
 eWY
 uGS
-fXy
-arf
-qXe
-bnc
-kqs
-kqs
-kqs
-tiD
-kRt
-kDw
+oMs
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+rIi
+ndb
 jDt
 jDt
-npE
-npE
+fHK
+fHK
 xmm
 xmm
-xmm
+nDB
 jDt
 jDt
 jDt
@@ -69224,9 +68328,9 @@ oVE
 jDt
 jDt
 jDt
-npE
-npE
-npE
+fHK
+fHK
+fHK
 jDt
 jDt
 jwF
@@ -69418,22 +68522,22 @@ uGS
 eWY
 eWY
 eWY
-aBZ
-arf
-kqs
-kqs
-kqs
-kqs
-kqs
-tiD
-kRt
-kDw
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
 jDt
-npE
-npE
-npE
+jDt
+fHK
+fHK
+fHK
 xmm
-npE
+fHK
 jDt
 jDt
 fwH
@@ -69445,7 +68549,7 @@ jhS
 jhS
 hey
 xBY
-jDt
+nlQ
 jDt
 jDt
 jDt
@@ -69640,18 +68744,18 @@ uGS
 eWY
 eWY
 uGS
-fXy
-arf
-kqs
-kqs
-kqs
-kqs
-kqs
-tiD
-kRt
-kDw
+oMs
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
 jDt
-npE
+jDt
+fHK
 xmm
 xmm
 jDt
@@ -69668,7 +68772,7 @@ nIG
 jhS
 thk
 dci
-xBY
+oAK
 jDt
 jDt
 jDt
@@ -69862,17 +68966,17 @@ eWY
 eWY
 eWY
 oMs
-rOn
-arf
-kqs
-qXe
-xrD
-kqs
-kqs
-tiD
-kRt
-kDw
-npE
+uGS
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
+jDt
+fHK
 xmm
 xmm
 pcI
@@ -69891,7 +68995,7 @@ nkm
 eXl
 xAe
 xTr
-xBY
+nrb
 jDt
 pcI
 jDt
@@ -70084,16 +69188,16 @@ eWY
 eWY
 eWY
 uGS
-aBZ
-arf
-qXe
-qXe
-gzF
-bnc
-kqs
-tiD
-kRt
-kDw
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
+jDt
 xmm
 jDt
 jDt
@@ -70115,7 +69219,7 @@ mWd
 gCK
 mAF
 dci
-xBY
+nrb
 jDt
 jDt
 jDt
@@ -70306,16 +69410,16 @@ eWY
 eWY
 eWY
 uGS
-aBZ
-arf
-qXe
-qXe
-gzF
-gzF
-bnc
-tiD
-kRt
-kDw
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
+jDt
 jDt
 fwH
 orn
@@ -70339,7 +69443,7 @@ mWd
 gCK
 fpy
 dci
-xBY
+nrb
 jDt
 jDt
 jDt
@@ -70527,17 +69631,17 @@ eWY
 eWY
 eWY
 eWY
-xNw
-xNw
-arf
-kqs
-gzF
-kqs
-gzF
-gzF
-tiD
-kRt
-kDw
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+eWY
+ngv
+jDt
 fwH
 fbs
 uXB
@@ -70562,7 +69666,7 @@ oLu
 oLu
 qxM
 dci
-xBY
+nrb
 jDt
 jDt
 jDt
@@ -70750,16 +69854,16 @@ eWY
 eWY
 eWY
 rIi
-ndb
-fBC
-fBC
-fBC
-fBC
-fBC
-fBC
-fBC
-fBC
-fBC
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+hCY
+nzX
+jDt
 xRE
 nDu
 kqs
@@ -70788,7 +69892,7 @@ hey
 jDt
 jDt
 jDt
-npE
+fHK
 ndb
 rIi
 nsK
@@ -71009,8 +70113,8 @@ pUt
 gCK
 uUq
 jDt
-npE
-npE
+fHK
+fHK
 ndb
 rIi
 nsK
@@ -71145,7 +70249,7 @@ mhj
 oRm
 jIb
 eux
-eux
+nUn
 jZM
 dYO
 hjw
@@ -71187,7 +70291,7 @@ uGS
 uGS
 oMs
 uGS
-uGS
+hUC
 uGS
 ndb
 eWY
@@ -71232,7 +70336,7 @@ gCK
 kDw
 jDt
 jDt
-npE
+fHK
 ndb
 rIi
 nsK
@@ -71815,7 +70919,7 @@ jZM
 jIb
 gKW
 hjw
-gIY
+uNr
 mrh
 mrh
 hWR
@@ -71849,7 +70953,7 @@ eWY
 eWY
 eWY
 uGS
-oMs
+aTr
 oMs
 oMs
 oMs
@@ -72058,7 +71162,7 @@ bdf
 ekG
 cJz
 ekG
-lAq
+ksO
 mqu
 uHE
 nzi
@@ -72222,7 +71326,7 @@ xxR
 iDL
 krt
 oSV
-krt
+dDD
 krt
 krt
 krt
@@ -72280,7 +71384,7 @@ mqX
 wVG
 moh
 cJz
-lAq
+ksO
 mqu
 cnw
 jum
@@ -72443,7 +71547,7 @@ ilb
 ilb
 vby
 ilb
-ilb
+aof
 vby
 ilb
 ilb
@@ -72502,7 +71606,7 @@ mhK
 nDG
 bMU
 ybe
-lAq
+ksO
 mqu
 bvQ
 epv
@@ -72748,7 +71852,7 @@ ndb
 ndb
 ndb
 lFR
-ncH
+ndb
 rkR
 rkR
 rkR
@@ -72943,7 +72047,7 @@ hjw
 hjw
 hjw
 hjw
-dFv
+jRU
 lAq
 hjw
 mqu
@@ -73128,8 +72232,8 @@ tyz
 tyz
 tyz
 pPZ
-tyz
-jIg
+xYH
+eyQ
 eux
 bBV
 jIb
@@ -73152,20 +72256,20 @@ kpb
 kpb
 kpb
 kpb
+kpb
+txr
+kpb
+kpb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 snC
-qPo
-snC
-snC
-eVp
-snC
-snC
-snC
-snC
-snC
-qPo
-snC
-snC
-vOx
 snC
 snC
 snC
@@ -73230,7 +72334,7 @@ kVt
 jDt
 jDt
 jDt
-npE
+fHK
 ndb
 rIi
 nsK
@@ -73375,21 +72479,21 @@ jIb
 jIb
 vXT
 eux
+eux
+jZM
+jZM
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 uGS
 oMs
-oMs
-oMs
-oMs
 uGS
-eWY
-eWY
-udO
-eWY
 uGS
-eWY
-eWY
-eWY
-eWY
 eWY
 eWY
 eWY
@@ -73452,7 +72556,7 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 ndb
 rIi
 nsK
@@ -73573,7 +72677,7 @@ ilb
 ilb
 hmd
 uGI
-tyz
+uGI
 ilb
 ilb
 jIb
@@ -73597,22 +72701,22 @@ jIb
 jIb
 jIb
 jIb
-eWY
-hUC
+jIb
+nUn
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 uGS
 oMs
+oMs
+aTr
 uGS
-eWY
-eWY
-eWY
-eWY
-uGS
-uGS
-ncH
-eWY
-eWY
-eWY
-eWY
 eWY
 eWY
 eWY
@@ -73645,7 +72749,7 @@ ndb
 ndb
 ndb
 rkR
-npE
+fHK
 jDt
 jDt
 jDt
@@ -73673,7 +72777,7 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 ndb
 ndb
 rIi
@@ -73806,7 +72910,7 @@ ayL
 jIb
 jIb
 jZM
-eux
+nUn
 eux
 eux
 gpA
@@ -73821,20 +72925,20 @@ jIb
 jIb
 jIb
 gZW
-eWY
-eWY
-eWY
-eWY
-eWY
-eWY
-eWY
-eWY
+jIb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+oMs
+oMs
+oMs
 uGS
-uGS
-uGS
-eWY
-eWY
-eWY
 eWY
 eWY
 eWY
@@ -73895,7 +72999,7 @@ jDt
 jDt
 jDt
 pcI
-npE
+fHK
 ndb
 ndb
 rIi
@@ -74043,20 +73147,20 @@ jIb
 jIb
 jaT
 jIb
-eWY
-eWY
-eWY
-eWY
-eWY
-eWY
-udO
-hUC
+jIb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 uGS
 oMs
 uGS
-uGS
-eWY
-eWY
 eWY
 udO
 eWY
@@ -74091,9 +73195,9 @@ fBC
 fBC
 fBC
 jDt
-npE
-npE
-npE
+fHK
+fHK
+fHK
 jDt
 jDt
 bhm
@@ -74117,7 +73221,7 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 ndb
 ndb
 rIi
@@ -74266,25 +73370,25 @@ jIb
 jIb
 jaT
 evd
-eWY
-eWY
-eWY
-eWY
-tQB
-eWY
-uGS
-oMs
-oMs
-oMs
-uGS
-uGS
-uGS
-eWY
-eWY
-eWY
-eWY
+jIb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 uGS
 uGS
+uGS
+eWY
+eWY
+eWY
+uGS
+ndb
 ndb
 ndb
 ndb
@@ -74311,13 +73415,13 @@ ndb
 ndb
 ndb
 rkR
-npE
-npE
-npE
-npE
-npE
-npE
-npE
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
 jDt
 jDt
 bhm
@@ -74337,7 +73441,7 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 jDt
 xmm
 ndb
@@ -74488,18 +73592,18 @@ jhc
 jIb
 jIb
 jIb
-jIb
-eWY
-eWY
-eWY
-eWY
-lsi
-eWY
-uGS
-uGS
-uGS
-lsi
-oMs
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 uGS
 uGS
 ndb
@@ -74533,15 +73637,15 @@ ndb
 ndb
 ndb
 rkR
-npE
+fHK
 xmm
 xmm
 xmm
 xmm
 xmm
 xmm
-npE
-npE
+fHK
+fHK
 jDt
 jDt
 bhm
@@ -74554,12 +73658,12 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 jDt
 jDt
 jDt
-npE
-npE
+fHK
+fHK
 ndb
 ndb
 ndb
@@ -74709,18 +73813,18 @@ jIb
 jIb
 jIb
 jIb
-jIb
-jIb
 ndb
 ndb
 ndb
 ndb
-lsi
-mnD
-mnD
-mnD
-mnD
-lsi
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 ndb
@@ -74756,16 +73860,16 @@ ndb
 ndb
 ndb
 ndb
-npE
-npE
-npE
-npE
-npE
-npE
+fHK
+fHK
+fHK
+fHK
+fHK
+fHK
 xmm
 xmm
-npE
-npE
+fHK
+fHK
 jDt
 jDt
 jDt
@@ -74775,12 +73879,12 @@ jDt
 jDt
 jDt
 jDt
-npE
+fHK
 xmm
-npE
-npE
-npE
-npE
+fHK
+fHK
+fHK
+fHK
 xmm
 ndb
 ndb
@@ -74937,12 +74041,12 @@ ndb
 ndb
 ndb
 ndb
-lsi
-lsi
-lsi
-lsi
-lsi
-lsi
+ndb
+ndb
+ndb
+ndb
+ndb
+ndb
 ndb
 ndb
 ndb

--- a/code/game/area/gelida_iv.dm
+++ b/code/game/area/gelida_iv.dm
@@ -413,6 +413,20 @@
 	name = "Atmospheric Processor - Filtration System"
 	icon_state = "mechbay"
 
+/area/gelida/powergen
+	name = "Underground Power Generation"
+	icon_state = "ass_line"
+	ceiling = CEILING_DEEP_UNDERGROUND
+	minimap_color = MINIMAP_AREA_ENGI_CAVE
+	outside = FALSE
+
+/area/gelida/cavestructuretwo
+	name = "Underground Abandoned Structure"
+	icon_state = "garage"
+	ceiling = CEILING_DEEP_UNDERGROUND
+	minimap_color = MINIMAP_AREA_CAVES
+	outside = FALSE
+
 /area/gelida/caves
 	outside = FALSE
 	ceiling = CEILING_DEEP_UNDERGROUND


### PR DESCRIPTION

## About The Pull Request

Makes a bunch of Gelida changes in hopes of making it less awful.

Here's the new version of Gelida in screenshot form
![oldbr](https://github.com/tgstation/TerraGov-Marine-Corps/assets/49290523/94e9bfae-b808-48e7-94bc-7bbffb6a2b27)

The changes are as follows;
-Revamps LZ2 to be less of a straight shot into caves while also making the area around it slightly more open
-Revamps LZ1 to actually be somewhat viable compared to LZ2
-Changes the cave power generators to be in the center of caves instead of the side
-Extends no build zones near the LZs somewhat
-Gives underground power generator room some lights
-Fixes mismatched LZ zones

## Why It's Good For The Game

Gelida isn't in a good place currently, it's always the same push from LZ2 into caves (which is usually ruined by a combination of overextension and the larva generation giving the xenos 15+ new bodies by the time marines make it to power gen). This is unfun and most of the time marines don't even make it to any of the disks, let alone the silo. Hopefully the changes in this PR at least alter the flow so it's not the same push every time. 

## Changelog
:cl:
balance: Altered LZ1 on Gelida to be more defensible
balance: Altered the area round LZ2 on Gelida to be slightly more open
balance: Changed the location of underground power generation on Gelida to be in the center of caves.
balance: Changed a couple random disk generation locations on Gelida.
balance: The underground power generation plant in Gelida now has lights.
balance: Extended the preshutter no build zone on Gelida some
balance: Gelida landing zones now start with flares
fix: Fixed Gelida LZ areas being reversed
/:cl:
