### PR TITLE
Minor theseus req remap

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -900,6 +900,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/green/corner{
 	dir = 4
 	},
@@ -8393,6 +8396,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
 "dbD" = (
@@ -13008,12 +13014,6 @@
 /obj/effect/turf_decal/warning_stripes/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
-"leS" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
 "lff" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -63622,7 +63622,7 @@ bnF
 aAP
 bnF
 bnF
-leS
+bnF
 bnF
 jiQ
 jiQ
@@ -63630,7 +63630,7 @@ jiQ
 cni
 jiQ
 bnF
-leS
+bnF
 bnF
 bnF
 twq

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -897,7 +897,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "adh" = (
-/obj/machinery/camera/autoname/mainship,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -1683,12 +1682,10 @@
 /turf/open/shuttle/escapepod/eight,
 /area/mainship/command/self_destruct)
 "avZ" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/green{
-	dir = 5
-	},
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/paper/factoryhowto,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "awa" = (
 /turf/open/floor/mainship/tcomms,
@@ -4367,7 +4364,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brl" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
@@ -4375,15 +4371,14 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brm" = (
 /obj/machinery/firealarm{
 	dir = 4
 	},
-/turf/open/floor/mainship/green{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -4976,10 +4971,11 @@
 	},
 /area/mainship/squads/req)
 "byh" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/green{
-	dir = 8
+/obj/machinery/light/mainship{
+	dir = 4
 	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "byi" = (
 /obj/machinery/disposal,
@@ -5551,10 +5547,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGk" = (
-/obj/machinery/camera/autoname/mainship,
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
-/turf/open/floor/mainship/green,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGl" = (
 /obj/machinery/camera/autoname/mainship{
@@ -5738,6 +5733,7 @@
 	dir = 1;
 	name = "\improper Requisitions Break Room"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "bIK" = (
@@ -5789,8 +5785,10 @@
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "bJI" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/green,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bJL" = (
 /obj/structure/closet/secure_closet/req_officer,
@@ -7889,7 +7887,10 @@
 	id = "qm_warehouse";
 	name = "\improper Warehouse Shutters"
 	},
-/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "cnU" = (
@@ -8389,9 +8390,6 @@
 	},
 /area/mainship/command/cic)
 "dbv" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -8531,13 +8529,13 @@
 	},
 /area/mainship/medical/operating_room_one)
 "dpC" = (
-/obj/machinery/light/mainship{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/cic_maptable,
-/turf/open/floor/mainship/green{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "dqA" = (
 /obj/structure/cable,
@@ -10117,19 +10115,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
 "gas" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/closed/wall/mainship,
+/area/mainship/living/cryo_cells)
+"gaR" = (
 /obj/structure/rack,
 /obj/item/conveyor_switch_construct,
 /obj/item/stack/conveyor/thirty,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
-"gaR" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/supplydrop_console,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "gaW" = (
 /obj/structure/cable,
@@ -10213,6 +10206,9 @@
 /area/mainship/hallways/hangar)
 "gfj" = (
 /obj/effect/landmark/start/job/shiptech,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "gfm" = (
@@ -10468,6 +10464,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
@@ -11687,14 +11686,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iLR" = (
-/obj/structure/rack,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wrench,
-/obj/item/tool/crowbar,
-/obj/item/paper/factoryhowto,
-/turf/open/floor/mainship/green{
-	dir = 8
+/obj/vehicle/ridden/motorbike{
+	dir = 4
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "iLV" = (
 /obj/machinery/vending/weapon,
@@ -12006,9 +12001,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_garden)
 "jnG" = (
-/turf/open/floor/mainship/green{
-	dir = 6
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "jnS" = (
 /obj/effect/ai_node,
@@ -12442,10 +12439,8 @@
 	},
 /area/mainship/hallways/port_hallway)
 "kkN" = (
-/obj/structure/supply_drop,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "klS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -12945,10 +12940,8 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/hallways/hangar)
 "kWq" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
 /area/mainship/squads/req)
 "kXm" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -13016,10 +13009,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
 "leS" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/turf/open/floor/mainship/green{
-	dir = 4
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
 	},
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "lff" = (
 /turf/open/floor/mainship/purple{
@@ -13319,7 +13312,8 @@
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
-/turf/open/floor/mainship/green,
+/obj/machinery/computer/camera_advanced/overwatch/req,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "lDQ" = (
 /obj/machinery/door/firedoor/mainship,
@@ -13644,10 +13638,8 @@
 	},
 /area/mainship/medical/medical_science)
 "may" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "mdp" = (
 /obj/effect/landmark/start/job/synthetic,
@@ -13889,9 +13881,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "mzG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -16956,12 +16946,9 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "rws" = (
-/obj/machinery/door_control/mainship/req{
-	dir = 4;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
-	},
-/turf/open/floor/mainship/green,
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/supplydrop_console,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "rxv" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
@@ -17521,6 +17508,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "swv" = (
@@ -18069,6 +18059,9 @@
 	},
 /obj/machinery/door/airlock/mainship/marine/requisitions{
 	name = "\improper Requisitions Storage"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
@@ -18993,8 +18986,13 @@
 	},
 /area/mainship/command/bridge)
 "vfW" = (
-/obj/structure/window/framed/mainship,
-/turf/open/floor/plating,
+/obj/machinery/door_control/mainship/req{
+	dir = 4;
+	id = "qm_warehouse";
+	name = "Requisition Warehouse Shutters"
+	},
+/obj/structure/supply_drop,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "vhI" = (
 /obj/structure/table/mainship/nometal,
@@ -19514,6 +19512,9 @@
 	},
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/chair/nometal{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -63375,7 +63376,7 @@ iZS
 dbv
 bnD
 bnD
-bBX
+dpC
 ace
 bnD
 ruj
@@ -63621,15 +63622,15 @@ bnF
 aAP
 bnF
 bnF
+leS
 bnF
-bnF
-cni
-cni
+jiQ
+jiQ
 jiQ
 cni
-cni
+jiQ
 bnF
-bnF
+leS
 bnF
 bnF
 twq
@@ -63877,7 +63878,7 @@ bnF
 adF
 bBX
 bnG
-bAG
+iWe
 brm
 bGh
 iWe
@@ -63885,7 +63886,7 @@ iWe
 iWe
 iWe
 iWe
-bGh
+vfW
 rws
 bnF
 tMR
@@ -64134,16 +64135,16 @@ bnF
 bpx
 bBX
 iWe
-bAG
-bDM
-pbV
-dpC
-gaR
-kkN
-leS
-mzi
-nmb
-bAG
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
 bnF
 bJN
 wfH
@@ -64391,15 +64392,15 @@ bnF
 bpz
 brn
 iWe
-bAG
-bDM
-bJI
-bnF
-vfW
-vfW
-vfW
-bnF
-dLP
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iLR
+kkN
 lDM
 bnF
 bJN
@@ -64648,16 +64649,16 @@ bnF
 bpB
 iWe
 iWe
-bAG
-bDM
-kzX
-gas
-iLR
-kWq
-may
-byh
-abz
-bAG
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+nmb
+dLP
 bnF
 bJO
 gDo
@@ -64905,8 +64906,8 @@ bnF
 bpw
 bta
 iWe
-bAG
-bDM
+iWe
+iWe
 iWe
 iWe
 iWe
@@ -64914,9 +64915,9 @@ bta
 iWe
 iWe
 iWe
-bAG
+bJI
 bIH
-tMR
+kWq
 gfj
 bMJ
 bnF
@@ -65164,13 +65165,13 @@ bro
 adg
 bGk
 avZ
-bnD
-ace
-bnD
+gaR
+byh
+bzq
 iWe
-bnD
-ace
-bnD
+otD
+mzi
+may
 jnG
 bnF
 bJP
@@ -65419,7 +65420,7 @@ blZ
 blZ
 blZ
 blZ
-blZ
+gas
 blZ
 blZ
 blZ


### PR DESCRIPTION

## About The Pull Request

Remapped Theseus' req operating area to not be a 1-tile corridor??? All consoles are now in a nice little overwatch corner, and all the vendors are grouped along the wall for easy access. The rest of the space is left open for reqtorio  or whatever else you wanna do with the space.

## Why It's Good For The Game

I HATE THESEUS REQ WHY DO I HAVE A 1X1 DOORWAY? WHY DO I HAVE A WALL SEPARATING THE SUPPLY CONSOLE FROM ALL THE VENDORS?

## Changelog
:cl:
balance: Theseus RO area is now more open and less cringe to navigate and use

/:cl:
