### PR TITLE
Fixes typo in PD sentry description

### DIFF
--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -220,7 +220,7 @@
 
 /obj/item/weapon/gun/sentry/mini
 	name = "\improper ST-580 point defense sentry"
-	desc = "A deployable, automated turret with AI targeting capabilities. This is a lightweight portable model meant for rapid deployment and point defense. Armed with an light, high velocity machine gun and a 100-round drum magazine."
+	desc = "A deployable, automated turret with AI targeting capabilities. This is a lightweight portable model meant for rapid deployment and point defense. Armed with an light, high velocity machine gun and a 300-round drum magazine."
 	icon_state = "minisentry"
 
 	max_shells = 300


### PR DESCRIPTION

## About The Pull Request
Ditto
Fixes #12919

## Why It's Good For The Game
Less typo good

## Changelog
:cl:
spellcheck: PD sentry description says accurate max ammo
/:cl:
