### PR TITLE
Xray rifle std firerate increase

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -801,7 +801,7 @@
 	wield_delay = 0.5 SECONDS
 	scatter = 0
 	scatter_unwielded = 10
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.25 SECONDS
 	accuracy_mult_unwielded = 0.55
 	damage_falloff_mult = 0.3
 	mode_list = list(
@@ -812,7 +812,7 @@
 /datum/lasrifle/base/energy_rifle_mode/xray
 	rounds_per_shot = 15
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.25 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	message_to_user = "You set the xray rifle's charge mode to standard fire."
 	fire_mode = GUN_FIREMODE_AUTOMATIC


### PR DESCRIPTION
## About The Pull Request
Xray rifle standard shot firerate is now 0.25. Piercing mode unchanged.

## Why It's Good For The Game
Gives it an actual reason to be used over piercing given it had AR12 stats for OVER TWICE the firedelay, giving it the same reasons to not be used as heat mode from the laspistol and lassniper. The firestacks don't even do enough damage to make up for it, funnily enough, and the low firerate makes it unwieldy against fast xenos like rouny that on paper it'd be supposed to be ok against. Assuming you didn't just set the 5 marines around you on fire with ff.

Final stats still deliberatedly worse than AR12.

## Changelog

:cl:
balance: xray rifle standard shot firerate now 0.25 (Comparison: AR12 has 0.2)
/:cl:

