### PR TITLE
Removes extra disk location in LV

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -8486,7 +8486,6 @@
 "jjr" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/armory)
 "jjR" = (
@@ -15464,12 +15463,6 @@
 /obj/effect/turf_decal/sandytile,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
-"sre" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/research)
 "srR" = (
 /obj/structure/cargo_container/nt{
 	dir = 8
@@ -42328,7 +42321,7 @@ exl
 uYP
 rdh
 sSs
-sre
+tUO
 cwq
 eLr
 uxW


### PR DESCRIPTION

## About The Pull Request

Title.
**This is just an emergency measure until I can build enough modulars to have proper alternate locations for disks to spawn in.**

## Why It's Good For The Game

I'm being deluged with complaints about disk RNG placing all disks in the colony, this ruins the point of LV and makes winning the game nearly impossible for xenos.
![disk3](https://github.com/tgstation/TerraGov-Marine-Corps/assets/49290523/de477560-ed65-44eb-b9e8-6008440511a4)


## Changelog
:cl:
balance: Removed colony disk generators again.
/:cl:
