### PR TITLE
Fixes underground power station nuke disk location on the hit map Ice Colony.

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -21769,6 +21769,13 @@
 	dir = 4
 	},
 /area/ice_colony/surface/hangar/hallway)
+"cEY" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ice_colony/underground/engineering/substation)
 "cGg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -54543,7 +54550,7 @@ btz
 lHO
 bSV
 caD
-aqv
+cEY
 buE
 btz
 rOI


### PR DESCRIPTION
## About The Pull Request

It adds an APC to an area that didn't have it. There's not much besides that.

On more practical terms, this means the disk generator isn't permanently powered.

![Capture](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/963fb0bc-f534-4f4a-9fc4-873edc8b4b21)


## Why It's Good For The Game

Well...I mean....Bugs bad and all that?

## Changelog
:cl:
fix: Gives an APC to a area that didn't have it on Ice Colony
/:cl:
