### PR TITLE
Adds a tip about tiers to the Xeno tip section. It's very tippy.

### DIFF
--- a/strings/tips/xeno.txt
+++ b/strings/tips/xeno.txt
@@ -63,3 +63,4 @@ Tileswapping marines via help intent can have interesting consequences.
 As a boiler, you'll begin to glow with the more globules you have stored.
 If you see a red dot, RUN!
 Allowing marines to push caves only to block off their exit is hillariously effective.
+As a xeno, a Tier 3 unit takes up both a Tier 3 and Tier 2 slot.


### PR DESCRIPTION

## About The Pull Request

Behold, the solution to all of our tier based woes. A tip!

"As a xeno, a Tier 3 unit takes up both a Tier 3 and Tier 2 slot." - Sun Tzu, probably.

## Why It's Good For The Game

Er...Look, coding an actual thing isn't my forte. Fortunately, we have roundstart tips.

## Changelog
:cl: Skye
qol: Adds a single tip to the xeno section, regarding tier slots.
/:cl:
