### PR TITLE
Lets the TE Powerpack (laspouch) be recharged manually

### DIFF
--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -174,3 +174,22 @@
 	slowdown = 0
 	maxcharge = 2400
 	self_recharge = FALSE
+
+/obj/item/cell/lasgun/volkite/powerpack/marine/attack_self(mob/user)
+	if(charge >= maxcharge)
+		balloon_alert(user, "Fully charged")
+		return
+
+	if(user.do_actions)
+		balloon_alert(user, "Too busy")
+		return
+
+	balloon_alert(user, "Begins charging the cell")
+	while(do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+		charge = min(charge + 40, maxcharge)
+		playsound(user, 'sound/weapons/guns/interact/rifle_reload.ogg', 15, 1, 5)
+		flick("handheldcharger_black_pumping", src)
+		if(charge >= maxcharge)
+			balloon_alert(user, "Fully charged")
+			return
+	balloon_alert(user, "Stops charging")


### PR DESCRIPTION
## About The Pull Request
TE powerpack can now be used in hand to recharge as if it was a handheld recharger. Charge rate is much lower than an actual engineer's cell charger (40 vs 200). The rate is such that it's still worse than recharger cells as the req option given that:

- You need full dedication to the act of recharging. You can't do it while doing something else, you have to hold the item in hand and stay still for the duration.
- Because you have to have it in hand, this means that you are open to getting knocked down and losing it. Even if you don't permanently lose it by xenodrag. it still disconnects it from your gun leaving you completely defenseless, so mid-combat recharging is extremely risky. I think xenos can see the icon while recharging but I have no way to confirm it currently. If they can, that's another "hit me" sign.
- Recharger cells recharge on their own 24/7 from the safety of your storage and even inside your gun, and though they recharge at 12 energy per second, you can get 4 (1 in gun, 3 in pouch) to recharge 48 energy overall. Or go nuts and get a full ammo belt of them.

## Why It's Good For The Game
So after they were introduced I talked with a bunch of people that also run them and, it turns out the laspouch is just 4 lasgun cells taped together. Like, that's it. You already get the same ammo count by running a normal pouch + your own gun's cell. It gets worse, because the moment you deplete your laspouch it's just dead weight with a lost pouch storage slot since you still need to either pack more laspouches or find a machine that xenos will want to destroy to recharge them, compared to packing 4 normal cells in your backpack to move into your pouch slot as you use them to have twice that capacity already. Or run ammo belt for 6 cells, that's already more.

## Changelog

:cl:
balance: TE Powerpack can now be recharged manually by using it in hand. 40 energy recharged per crank.
/:cl:

