### PR TITLE
Allow MRE to hold its food

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -405,9 +405,8 @@
 	desc = "Meal Ready-to-Eat, meant to be consumed in the field, and has an expiration that is two decades past a marine's average combat life expectancy."
 	icon_state = "mealpack"
 	w_class = WEIGHT_CLASS_SMALL
-	can_hold = list()
+	can_hold = list(/obj/item/reagent_containers/food/snacks/packaged_meal)
 	storage_slots = 4
-	max_w_class = 0
 	foldable = 0
 	var/isopened = 0
 	///the item left behind when this is used up


### PR DESCRIPTION

## About The Pull Request

When you take packaged or unpackaged MRE meal out of MRE, you can put it back in.

## Why It's Good For The Game

muy immersion

It never made sense to me why you can't put the MRE food back into the MRE. I have eaten MRE before (source: it was revealed to me in my dream about FX, for which I have never went to), and the MRE can definitely hold its stuff back.

Can also be balance since marines were forced to put the unpackaged MRE meal inside a backpack | satchel, so this PR is also a storage balance.

## Changelog

:cl:
add: Allow marines to put packaged or unpackaged MRE meal back inside of MRE
balance: Permit marines to have more storage by not forcing marines to use backpack | satchel space for MRE food
/:cl:

