### PR TITLE
Fixes unintended cell magic

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -495,7 +495,7 @@
 
 	if(!istype(I, /obj/item/cell))
 		return
-	if(istype(I, /obj/item/cell/rtg/large))
+	if(I.w_class > WEIGHT_CLASS_NORMAL)
 		balloon_alert(user, "Too large")
 		return
 	if(!user.drop_held_item())

--- a/code/modules/clothing/modular_armor/attachments/uniform.dm
+++ b/code/modules/clothing/modular_armor/attachments/uniform.dm
@@ -28,6 +28,7 @@
 		/obj/item/stack/sheet,
 		/obj/item/stack/sandbags,
 		/obj/item/stack/snow,
+		/obj/item/cell/lasgun/volkite/powerpack,
 	)
 
 /obj/item/armor_module/storage/uniform/black_vest


### PR DESCRIPTION

## About The Pull Request
Bulky sized cells no longer fit in webbings or small cell chargers.
## Why It's Good For The Game
Magic storage bad.
## Changelog
:cl:
fix: Large cells no longer fit in small cell chargers
/:cl:
