### PR TITLE
Makes the parent flamer fit the hydro cannon

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -24,6 +24,7 @@
 		/obj/item/attachable/flamer_nozzle/wide,
 		/obj/item/attachable/flamer_nozzle/wide/red,
 		/obj/item/attachable/shoulder_mount,
+		/obj/item/weapon/gun/flamer/hydro_cannon,
 		)
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_MUZZLE,


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Does not make all flamers start with it attached.
## Why It's Good For The Game
the reason why I made this pr, is because the old FL240 flamer can still spawn in crates and I sometimes like to use it. it is 100% identical to the normal marine one, so no reason you should not be able to remove the hydro from a marine flamer and attach it to that one. Also because of tye rework, SOM and marine flamer will be identical, for now, and if a marine flamer is killed in HvH modes an SOM flamer can take his hydro cannon and use it. again, he does not start with it.

addendum; this also means that the x fuel flamer can fit a hydro cannon, since its a new flamer
## Changelog
:cl:
add: added the hydro cannon to the universal list of flamer attachment options
/:cl:
