### PR TITLE
Comments out TTS in default config

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -29,7 +29,7 @@ ALLOW_SHUTDOWN
 #AGGRESSIVE_CHANGELOG
 
 ## Link to a HTTP server that's been set up on a server. Docker-compose file can be found in tools/tts
-TTS_HTTP_URL http://localhost:5002
+#TTS_HTTP_URL http://localhost:5002
 
 ## Token that can be used to prevent misuse of your TTS server that you've set up.
 TTS_HTTP_TOKEN coolio

--- a/config/config.txt
+++ b/config/config.txt
@@ -32,10 +32,10 @@ ALLOW_SHUTDOWN
 #TTS_HTTP_URL http://localhost:5002
 
 ## Token that can be used to prevent misuse of your TTS server that you've set up.
-TTS_HTTP_TOKEN coolio
+#TTS_HTTP_TOKEN coolio
 
 ## The maximum number of concurrent tts http requests that can be made by the server at once.
-TTS_MAX_CONCURRENT_REQUESTS 4
+#TTS_MAX_CONCURRENT_REQUESTS 4
 
 ## If you use /tg/station-server 3 and you want to allow the shutdown server verb,
 ##	the server needs to be able to tell tgs3 that the shutdown is not a crash.


### PR DESCRIPTION

## About The Pull Request

Causes a runtime currently if you don't have TTS set up on your local, tivi forgor
## Why It's Good For The Game

Runtime bad
## Changelog
:cl:
config: Commented out TTS in default config
/:cl:
