### PR TITLE
Nuke disk fix

### DIFF
--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -211,6 +211,7 @@ GLOBAL_LIST_INIT(nuke_disk_generator_types, list(/obj/machinery/computer/nuke_di
 	desc = "Some dusty old computer. Looks non-functional"
 	density = TRUE
 	anchored = TRUE
+	resistance_flags = RESIST_ALL
 
 //Randomised spawn points for nuke disk generators
 /obj/structure/nuke_disk_candidate/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Makes base computers indestructable, so they can't be destroyed by xenos before nuke disk machines are actually spawned.
## Why It's Good For The Game
Bug fix good
## Changelog
:cl:
fix: fixed nuke disk gens being destructable before the ship crashes
/:cl:
