### PR TITLE
Heavy minimap fire() optimization

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -12,7 +12,6 @@
  * tracking of the actual atoms you want to be drawn on is done by means of datums holding info pertaining to them with [/datum/hud_displays]
  *
  * Todo
- * *: batch images on add to remove list additons in fire()
  * *: add fetching of images to allow stuff like adding/removing xeno crowns easily
  * *: add a system for viscontents so things like minimap draw are more responsive
  */
@@ -28,8 +27,8 @@ SUBSYSTEM_DEF(minimaps)
 	var/list/image/images_by_source = list()
 	///the update target datums, sorted by update flag type
 	var/list/update_targets = list()
-	///Nonassoc list of targets we want to be stripped of their overlays during the SS fire
-	var/list/atom/update_targets_unsorted = list()
+	///Nonassoc list of updators we want to have their overlays reapplied
+	var/list/datum/minimap_updator/update_targets_unsorted = list()
 	///Assoc list of removal callbacks to invoke to remove images from the raw lists
 	var/list/datum/callback/removal_cbs = list()
 	///list of holders for data relating to tracked zlevel and tracked atum
@@ -67,7 +66,9 @@ SUBSYSTEM_DEF(minimaps)
 		icon_gen.Scale(480*2,480*2) //scale it up x2 to make it easer to see
 		icon_gen.Crop(1, 1, min(icon_gen.Width(), 480), min(icon_gen.Height(), 480)) //then cut all the empty pixels
 
-		//generation is done, now we need to center the icon to someones view, this can be left out if you like it ugly and will halve SSinit time
+		//generation is done, now we need to center the icon to someones view,
+		//this can be left out if you like it ugly and will halve SSinit time
+
 		//calculate the offset of the icon
 		var/largest_x = 0
 		var/smallest_x = SCREEN_PIXEL_SIZE
@@ -98,11 +99,11 @@ SUBSYSTEM_DEF(minimaps)
 
 	for(var/i=1 to length(earlyadds)) //lateload icons
 		earlyadds[i].Invoke()
-	earlyadds = null //then clear them
+	earlyadds = null
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/minimaps/stat_entry(msg)
-	msg = "Upd:[length(update_targets_unsorted)] Mark: [length(removal_cbs)]"
+	msg = "Upd:[length(update_targets_unsorted)] Mark:[length(removal_cbs)]"
 	return ..()
 
 /datum/controller/subsystem/minimaps/Recover()
@@ -116,21 +117,12 @@ SUBSYSTEM_DEF(minimaps)
 
 /datum/controller/subsystem/minimaps/fire(resumed)
 	var/static/iteration = 0
-	if(!iteration) //on first iteration clear all overlays
-		for(var/iter=1 to length(update_targets_unsorted))
-			update_targets_unsorted[iter].overlays.Cut() //clear all the old overlays, no we cant cache it because they wont update
-	//checks last fired flag to make sure under high load that things are performed in stages
 	var/depthcount = 0
-	for(var/flag in update_targets)
+	for(var/datum/minimap_updator/updator AS in update_targets_unsorted)
 		if(depthcount < iteration) //under high load update in chunks
 			depthcount++
 			continue
-		for(var/datum/minimap_updator/updator AS in update_targets[flag])
-			//assignment is crazy fast compared to += and it automatically copies for overlays
-			if(length(updator.minimap.overlays))
-				updator.minimap.overlays += minimaps_by_z["[updator.ztarget]"].images_raw[flag]
-			else
-				updator.minimap.overlays = minimaps_by_z["[updator.ztarget]"].images_raw[flag]
+		updator.minimap.overlays = updator.raw_blips
 		depthcount++
 		iteration++
 		if(MC_TICK_CHECK)
@@ -148,8 +140,9 @@ SUBSYSTEM_DEF(minimaps)
 	var/datum/minimap_updator/holder = new(target, ztarget)
 	for(var/flag in bitfield2list(flags))
 		LAZYADD(update_targets["[flag]"], holder)
+		holder.raw_blips += minimaps_by_z["[ztarget]"].images_raw["[flag]"]
 	updators_by_datum[target] = holder
-	update_targets_unsorted += target
+	update_targets_unsorted += holder
 	RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(remove_updator))
 
 /**
@@ -162,7 +155,7 @@ SUBSYSTEM_DEF(minimaps)
 	updators_by_datum -= target
 	for(var/key in update_targets)
 		LAZYREMOVE(update_targets[key], holder)
-	update_targets_unsorted -= target
+	update_targets_unsorted -= holder
 
 /**
  * Holder datum for a zlevels data, concerning the overlays and the drawn level itself
@@ -196,11 +189,14 @@ SUBSYSTEM_DEF(minimaps)
 	var/atom/minimap
 	///Target zlevel we want to be updating to
 	var/ztarget = 0
+	/// list of overlays we update
+	var/raw_blips
 
 /datum/minimap_updator/New(minimap, ztarget)
 	..()
 	src.minimap = minimap
 	src.ztarget = ztarget
+	raw_blips = list()
 
 /**
  * Adds an atom we want to track with blips to the subsystem
@@ -223,35 +219,50 @@ SUBSYSTEM_DEF(minimaps)
 	for(var/flag in bitfield2list(hud_flags))
 		minimaps_by_z["[target.z]"].images_assoc["[flag]"][target] = blip
 		minimaps_by_z["[target.z]"].images_raw["[flag]"] += blip
+		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
+			updator.raw_blips += blip
 	if(ismovableatom(target))
 		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
 		blip.RegisterSignal(target, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/image, minimap_on_move))
-	removal_cbs[target] = CALLBACK(src, PROC_REF(removeimage), blip, target)
+	removal_cbs[target] = CALLBACK(src, PROC_REF(removeimage), blip, target, hud_flags)
 	RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(remove_marker))
-
-
 
 /**
  * removes an image from raw tracked lists, invoked by callback
  */
-/datum/controller/subsystem/minimaps/proc/removeimage(image/blip, atom/target)
-	for(var/flag in GLOB.all_minimap_flags)
+/datum/controller/subsystem/minimaps/proc/removeimage(image/blip, atom/target, hud_flags)
+	for(var/flag in bitfield2list(hud_flags))
 		minimaps_by_z["[target.z]"].images_raw["[flag]"] -= blip
+		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
+			if(updator.ztarget == target.z)
+				updator.raw_blips -= blip
 	blip.UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 	removal_cbs -= target
 
 /**
  * Called on zlevel change of a blip-atom so we can update the image lists as needed
+ *
+ * TODO gross amount of assoc usage and unneeded ALL FLAGS iteration
  */
 /datum/controller/subsystem/minimaps/proc/on_z_change(atom/movable/source, oldz, newz)
 	SIGNAL_HANDLER
+	var/image/blip
 	for(var/flag in GLOB.all_minimap_flags)
 		if(!minimaps_by_z["[oldz]"]?.images_assoc["[flag]"][source])
 			continue
-		minimaps_by_z["[newz]"].images_assoc["[flag]"][source] = minimaps_by_z["[oldz]"].images_assoc["[flag]"][source]
-		minimaps_by_z["[oldz]"].images_raw["[flag]"] -= minimaps_by_z["[oldz]"].images_assoc["[flag]"][source]
-		minimaps_by_z["[newz]"].images_raw["[flag]"] += minimaps_by_z["[oldz]"].images_assoc["[flag]"][source]
+		if(!blip)
+			blip = minimaps_by_z["[oldz]"].images_assoc["[flag]"][source]
+		// todo maybe make update_targets also sort by zlevel?
+		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
+			if(updator.ztarget == oldz)
+				updator.raw_blips -= blip
+			else if(updator.ztarget == newz)
+				updator.raw_blips += blip
+		minimaps_by_z["[newz]"].images_assoc["[flag]"][source] = blip
 		minimaps_by_z["[oldz]"].images_assoc["[flag]"] -= source
+
+		minimaps_by_z["[newz]"].images_raw["[flag]"] += blip
+		minimaps_by_z["[oldz]"].images_raw["[flag]"] -= blip
 
 /**
  * Simple proc, updates overlay position on the map when a atom moves

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -220,7 +220,8 @@ SUBSYSTEM_DEF(minimaps)
 		minimaps_by_z["[target.z]"].images_assoc["[flag]"][target] = blip
 		minimaps_by_z["[target.z]"].images_raw["[flag]"] += blip
 		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
-			updator.raw_blips += blip
+			if(target.z == updator.ztarget)
+				updator.raw_blips += blip
 	if(ismovableatom(target))
 		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
 		blip.RegisterSignal(target, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/image, minimap_on_move))


### PR DESCRIPTION

## About The Pull Request
Minimap fire() is about 6-7 times faster when testing with ~150 AIs

## Why It's Good For The Game

Makes minimap fire scale better by moving the fire list operations into less often called add and z move procs

## Changelog
:cl:
code: Minimap has been heavily optimized
/:cl:
