### PR TITLE
Slight Thesseus changes and a piece of wire on Minerva. (And the Pillar of Spring)

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -15524,6 +15524,7 @@
 /area/mainship/engineering/engineering_workshop)
 "TF" = (
 /obj/machinery/power/monitor,
+/obj/structure/cable,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11926,6 +11926,9 @@
 /obj/machinery/firealarm{
 	dir = 8
 	},
+/obj/structure/bed/chair/nometal{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "pvW" = (
@@ -13874,12 +13877,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"rUm" = (
-/obj/structure/bed/chair/nometal{
-	dir = 8
-	},
-/turf/closed/wall/mainship,
-/area/mainship/hull/lower_hull)
 "rUw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15573,6 +15570,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -43634,7 +43632,7 @@ bsG
 rKn
 tCK
 rKn
-rUm
+rKn
 rKn
 rKn
 rKn

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -5321,9 +5321,7 @@
 /area/mainship/squads/alpha)
 "bCt" = (
 /obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
-/area/mainship/engineering/lower_engine_monitoring)
-"bCu" = (
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/lower_engine_monitoring)
 "bCv" = (
@@ -5331,12 +5329,14 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/shiptech,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/lower_engine_monitoring)
 "bCw" = (
 /obj/machinery/power/monitor{
 	name = "Core Power Monitoring"
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -12871,7 +12871,6 @@
 	},
 /area/mainship/squads/alpha)
 "kQd" = (
-/obj/structure/prop/mainship/halfbuilt_mech/vanguard,
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -13994,6 +13993,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -16229,6 +16229,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/bow_hallway)
 "qrI" = (
+/obj/structure/prop/mainship/halfbuilt_mech/vanguard,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -17297,9 +17298,6 @@
 	},
 /area/mainship/command/cic)
 "shW" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -73388,7 +73386,7 @@ brN
 crY
 bpX
 bBe
-bCu
+lfP
 aNO
 bpX
 qQK


### PR DESCRIPTION
## About The Pull Request

Starting off, deletes a rogue APC from the Minerva's mech bay and moves a mech prop that was covering the actual one.

![Rogue APC - Mech Bay](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/5c747c3c-07e8-4d8a-ae4d-ff671e9eee9e)

![New Mech Bay](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/71909e1c-e06b-4a89-921c-296be240fce6)

Additionally, adds some wires to Minerva and Thesseus' engineering zones, this connects the power monitoring consoles to the grid. (Minerva image not included. It's one piece of wire, check the checks section.)

![Engineering](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/28e3bef4-7b6b-4fdc-81e7-024a27798f13)

**11:06PM :** Moves a wall chair from the maints of the Pillar of Spring, along with fixing a wire in one of the surgical rooms.


## Why It's Good For The Game

Hiccups being fixed is good, I guess. That and not having to fix the wires each round.

## Changelog
:cl: Skye
qol: A secret has been revealed! You can now find the mech bay's APC on the Thesseus map.
fix: Added wires to the power monitoring computers in Thesseus and Minerva's engineering zones.
/:cl:
