### PR TITLE
Silo scaling

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -15,18 +15,26 @@ SUBSYSTEM_DEF(silo)
 
 /datum/controller/subsystem/silo/fire(resumed = 0)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	var/active_humans = length(GLOB.humans_by_zlevel[SSmonitor.gamestate == SHIPSIDE ? "3" : "2"])
+	var/active_xenos = length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) + (xeno_job.total_positions - xeno_job.current_positions)
 	//The larval spawn is based on the amount of silo, ponderated with a define. Larval follow a f(x) = (x + a)/(1 + a) * something law, which is smoother that f(x) = x * something
 	current_larva_spawn_rate = length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]) ? SILO_OUTPUT_PONDERATION + length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]) : 0
 	//We then are normalising with the number of alive marines, so the balance is roughly the same whether or not we are in high pop
-	current_larva_spawn_rate *= SILO_BASE_OUTPUT_PER_MARINE * length(GLOB.humans_by_zlevel[SSmonitor.gamestate == SHIPSIDE ? "3" : "2"])
+	current_larva_spawn_rate *= SILO_BASE_OUTPUT_PER_MARINE * active_humans
 	//We normalize the larval output for one silo, so the value for silo = 1 is independant of SILO_OUTPUT_PONDERATION
 	current_larva_spawn_rate /=  (1 + SILO_OUTPUT_PONDERATION)
 	//We are processing wether we hijacked or not (hijacking gives a bonus)
 	current_larva_spawn_rate *= SSmonitor.gamestate == SHIPSIDE ? 3 : 1
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
+	//We scale the rate based on the current ratio of humans to xenos
+	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
+
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
+
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
+
 	xeno_job.add_job_points(current_larva_spawn_rate)
+
 	var/datum/hive_status/normal_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	normal_hive.update_tier_limits()
 

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSmonitor.gamestate == SHIPSIDE ? 3 : 1
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
-	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
+	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
 
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes silo larva gen scale based off the ratio of active marines to xenos.

In what has become much more apparent due to our more regular very high pop numbers, xenos can often get into a situation where they have somewhat absurd larva regen, making it extremely difficult for marines to actually reduce their numbers in any meaningful way.

This is caused by a few factors, but most important to understand is that:

1. Larva gen scales off the number of active marines on the z-level, but has **no scaling for the number of xenos**
2. Xenos directly get more larva for killing and draining/cocooning marines which **does not scale with pop**

These two points means growing xenos numbers snowballs much easier at high pop compared to lowpop.

This PR uses an 'ideal' ratio which is based on the number of larva points received from human spawns (which is about 3.077 humans per xeno). This the ratio that you should see before shutters drop.

So with this PR, if the ratio is say 2 ungas for every xeno, the larva gen would be about 65% of what it would currently be (in addition to all the extra larva points for murdering enough marines to get to that ratio).

**Note**: This is specifically to make it scale **down** to a minimum of 50% of normal gen. It won't scale above normal generation as there are already various factors to offset that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less overwhelming snowballing in xeno numbers at highpop.

Ultimately, this might not be needed, or may not be the ideal solution, but the issue of super high larva gen at high pop crops up more often these days, so I thought this may be an interesting solution to at least test out.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Silo larva gen now scales down with the ratio of marines to xenos, where xeno numbers are high
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
