### PR TITLE
Removes AMR bullet slowdown and laser penetration bonus

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -137,8 +137,6 @@
 //Define sniper laser multipliers
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
-#define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -878,8 +878,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	if(proj.shot_from && src == proj.shot_from.sniper_target(src))
 		damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
-		proj.penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
-		add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
 
 	if(iscarbon(proj.firer))
 		var/mob/living/carbon/shooter_carbon = proj.firer


### PR DESCRIPTION
## About The Pull Request
- Removes the slowdown inflicted when an AMR bullet hits a xenomorph.
- Removes the bullet penetration bonus associated with an active laser.

## Why It's Good For The Game
The AMR is a bit too oppressive as it stands right now, and has been for the longest time.
About damn time someone gave it the heavy hand.

## Changelog
:cl: Lewdcifer
balance: AMR slowdown removed, bullet penetration bonus from laser removed.
/:cl: