### PR TITLE
Fixes an oversight with a resistance_flag

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -18,7 +18,7 @@
 #define PROJECTILE_IMMUNE (1<<8) //Cannot be hit by projectiles
 #define PORTAL_IMMUNE (1<<9) //Cannot be teleported by wraith's portals
 
-#define RESIST_ALL (UNACIDABLE|INDESTRUCTIBLE)
+#define RESIST_ALL (UNACIDABLE|INDESTRUCTIBLE|PLASMACUTTER_IMMUNE)
 
 //projectile flags
 #define PROJECTILE_FROZEN (1<<0) //indicates a projectile is no longer moving

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -272,7 +272,7 @@
 
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
+		if(CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
 		else if(!P.start_cut(user, name, src))


### PR DESCRIPTION

## About The Pull Request

Title.
I have merged PLASMACUTTER_IMMUNE into RESIST_ALL as it didn't make sense that our all purpose indestructible flag was allowing things to be destroyed via plasma cutter.

## Why It's Good For The Game

It's more logically consistent, also fixes a nasty bug with https://github.com/tgstation/TerraGov-Marine-Corps/pull/12893 preventing mineral walls from being cut.

## Changelog
:cl:
fix: Fixed walls with the UNACIDABLE flags being also immune to plasma cutters
code: Added PLASMACUTTER_IMMUNE to RESIST_ALL
/:cl:
