### PR TITLE
Fixes `COMSIG_MOB_CLICKON` sleeping when climbing

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -50,7 +50,7 @@
 
 /obj/structure/specialclick(mob/living/carbon/user)
 	. = ..()
-	do_climb(user)
+	INVOKE_ASYNC(src, PROC_REF(do_climb), user)
 
 /obj/structure/MouseDrop_T(mob/target, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This fixes #13120. Apparently when sending the signal it had to wait for the climbing `do_after` to return which made the whole `ClickOn` proc sleep.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed `COMSIG_MOB_CLICKON` sleeping when climbing, this should fix crate climbing/pulling
/:cl:
