### PR TITLE
Psylance vs mech tweak

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2889,7 +2889,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/O, obj/projectile/P)
 	if(ismecha(O))
 		var/obj/vehicle/sealed/mecha/mech_victim = O
-		mech_victim.take_damage(rand(200, 400), BURN, ENERGY, 0, armour_penetration = penetration)
+		mech_victim.take_damage(200, BURN, ENERGY, 0, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
 	if(!isxeno(M))


### PR DESCRIPTION

## About The Pull Request
Reduces mech bonus damage from 200-400 to just flat 200.
## Why It's Good For The Game
The bonus damage was added before several nerfs that reduced mech survivability. Its now kinda too strong for mechs as they currently are, although they'll still be extremely good against them.
## Changelog
:cl:
balance: Reduced Psylance effectiveness against mechs slightly
/:cl:
