### PR TITLE
Fixes attachments unloading on drop

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -424,9 +424,7 @@
 	. = ..()
 	set_gun_user(null)
 	active_attachable?.removed_from_inventory(user)
-	if(!length(chamber_items) || !chamber_items[current_chamber_position] || chamber_items[current_chamber_position].loc == src)
-		return
-	drop_connected_mag(chamber_items[current_chamber_position], user)
+	drop_connected_mag(null, user)
 
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)
@@ -1536,9 +1534,14 @@
 	max_rounds = total_max_rounds
 	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
-///Disconnects from a worn magazine.
+///Checks to see if the current object in chamber is a worn magazine and if so unloads it
 /obj/item/weapon/gun/proc/drop_connected_mag(datum/source, mob/user)
 	SIGNAL_HANDLER
+	if(!length(chamber_items) || !chamber_items[current_chamber_position])
+		return
+	var/obj/item/ammo_magazine/current_mag = chamber_items[current_chamber_position]
+	if(!istype(current_mag) || !(current_mag.flags_magazine & MAGAZINE_WORN))
+		return
 	unload(user, FALSE)
 
 ///Getter to draw current rounds. Overwrite if the magazine is not a /ammo_magazine


### PR DESCRIPTION
## About The Pull Request
Was checking whether it should or not in the wrong part of the chain, so signal calls in bypassed it
## Why It's Good For The Game
Fixes #13124 
Fixes #13119 
## Changelog
:cl:
fix: Dropping a gun won't make all the ammo fall out of attachments
/:cl:
