### PR TITLE
Egg laying for Queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -57,6 +57,7 @@
 		/datum/action/xeno_action/activable/secrete_resin,
 		/datum/action/xeno_action/blessing_menu,
 		/datum/action/xeno_action/place_acidwell,
+		/datum/action/xeno_action/lay_egg,
 		/datum/action/xeno_action/call_of_the_burrowed,
 		/datum/action/xeno_action/activable/screech,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,


### PR DESCRIPTION
## About The Pull Request

Egg laying now that there is less Queen button bloat. Egg laying was removed for bloat.

## Why It's Good For The Game

So Queen has something to do while building, also it's fun. Anyone who brings a plasma pistol will be immune to huggers anyways.

## Changelog

:cl:
balance: Queen egg laying added back.
/:cl:

