### PR TITLE
mortars now automatically link and save deployed binoculars

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -312,12 +312,14 @@
 	QDEL_NULL(laser)
 
 ///Sets or unsets the binocs linked mortar.
-/obj/item/binoculars/tactical/proc/set_mortar(mortar)
+/obj/item/binoculars/tactical/proc/set_mortar(var/obj/machinery/deployable/mortar/mortar)
 	if(mortar in linked_mortars)
 		UnregisterSignal(mortar, COMSIG_PARENT_QDELETING)
 		linked_mortars -= mortar
+		LAZYREMOVE(mortar.linked_struct_binoculars, src)
 		return FALSE
 	linked_mortars += mortar
+	LAZYADD(mortar.linked_struct_binoculars, src)
 	RegisterSignal(mortar, COMSIG_PARENT_QDELETING, PROC_REF(clean_refs))
 	return TRUE
 

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -312,7 +312,7 @@
 	QDEL_NULL(laser)
 
 ///Sets or unsets the binocs linked mortar.
-/obj/item/binoculars/tactical/proc/set_mortar(var/obj/machinery/deployable/mortar/mortar)
+/obj/item/binoculars/tactical/proc/set_mortar(obj/machinery/deployable/mortar/mortar)
 	if(mortar in linked_mortars)
 		UnregisterSignal(mortar, COMSIG_PARENT_QDELETING)
 		linked_mortars -= mortar

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -2,7 +2,7 @@
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
 	hud_possible = list(MACHINE_HEALTH_HUD)
 	obj_flags = CAN_BE_HIT
-	flags_pass = PASSAIR
+	flags_pass = PASSABLE
 	///Since /obj/machinery/deployable aquires its sprites from an item and are set in New(), initial(icon_state) would return null. This var exists as a substitute.
 	var/default_icon_state
 	///Item that is deployed to create src.

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -2,7 +2,7 @@
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
 	hud_possible = list(MACHINE_HEALTH_HUD)
 	obj_flags = CAN_BE_HIT
-	flags_pass = PASSABLE
+	flags_pass = PASSAIR
 	///Since /obj/machinery/deployable aquires its sprites from an item and are set in New(), initial(icon_state) would return null. This var exists as a substitute.
 	var/default_icon_state
 	///Item that is deployed to create src.

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -318,9 +318,9 @@
 	say("Linked AI spotter has relinquished targeting privileges. Ejecting targeting device.")
 	ai_targeter.forceMove(src.loc)
 	ai_targeter = null
-
+/// Handles the continuity transfer of linked binoculars from the mortar struct to the mortar item
 /obj/machinery/deployable/mortar/proc/handle_undeploy_references()
-
+	SIGNAL_HANDLER
 	LAZYINITLIST(get_internal_item().linked_item_binoculars)
 	LAZYCLEARLIST(get_internal_item().linked_item_binoculars)
 	get_internal_item().linked_item_binoculars = linked_struct_binoculars.Copy()

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -79,7 +79,8 @@
 
 	RegisterSignal(src, COMSIG_ITEM_UNDEPLOY, PROC_REF(handle_undeploy_references))
 	LAZYINITLIST(linked_struct_binoculars)
-	for (var/obj/item/binoculars/tactical/binoc in get_internal_item().linked_item_binoculars)
+	var/obj/item/mortar_kit/mortar = get_internal_item()
+	for (var/obj/item/binoculars/tactical/binoc in mortar.linked_item_binoculars)
 		binoc.set_mortar(src)
 	impact_cam = new
 	impact_cam.forceMove(src)
@@ -321,9 +322,10 @@
 /// Handles the continuity transfer of linked binoculars from the mortar struct to the mortar item
 /obj/machinery/deployable/mortar/proc/handle_undeploy_references()
 	SIGNAL_HANDLER
-	LAZYINITLIST(get_internal_item().linked_item_binoculars)
-	LAZYCLEARLIST(get_internal_item().linked_item_binoculars)
-	get_internal_item().linked_item_binoculars = linked_struct_binoculars.Copy()
+	var/obj/item/mortar_kit/mortar = get_internal_item()
+	LAZYINITLIST(mortar.linked_item_binoculars)
+	LAZYCLEARLIST(mortar.linked_item_binoculars)
+	mortar.linked_item_binoculars = linked_struct_binoculars.Copy()
 	UnregisterSignal(src, COMSIG_ITEM_UNDEPLOY)
 
 /obj/machinery/deployable/mortar/attack_hand_alternate(mob/living/user)

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -10,7 +10,6 @@
 /obj/machinery/deployable/mortar
 	anchored = TRUE
 	density = TRUE
-	flags_pass = PASSABLE
 	coverage = 20
 	layer = ABOVE_MOB_LAYER //So you can't hide it under corpses
 	/// list of the target x and y, and the dialing we can do to them

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -72,7 +72,7 @@
 	// used for keeping track of different mortars and their types for cams
 	var/static/list/id_by_type = list()
 	/// list of linked binoculars to the structure of the mortar, used for continuity to item
-	var/list/linked_struct_binoculars = list()
+	var/list/linked_struct_binoculars
 
 /obj/machinery/deployable/mortar/Initialize(mapload, _internal_item, deployer)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Mortars now automatically link to saved binoculars and keep track of them in item state as well as structure state

## Why It's Good For The Game

Massive QOL, plus bug fix, plus I need street credit with the engineers

## Changelog

:cl:

qol: mortars now automatically set save binoculars to them, linking with saved binoculars, and keeping track of them, no more need to use a binocular on a mortar before firing.

/:cl:
