### PR TITLE
Fixes hive threat reward

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -11,7 +11,7 @@
 
 /mob/living/carbon/xenomorph/on_death()
 	GLOB.alive_xeno_list -= src
-	LAZYREMOVE(GLOB.alive_xeno_list_hive[hivenumber], src)
+	GLOB.alive_xeno_list_hive[hivenumber] -= src
 	GLOB.dead_xeno_list += src
 
 	QDEL_NULL(current_aura)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -11,7 +11,7 @@
 
 /mob/living/carbon/xenomorph/on_death()
 	GLOB.alive_xeno_list -= src
-	GLOB.alive_xeno_list_hive[hivenumber] -= src
+	LAZYREMOVE(GLOB.alive_xeno_list_hive[hivenumber], src)
 	GLOB.dead_xeno_list += src
 
 	QDEL_NULL(current_aura)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -251,7 +251,7 @@
 	if(is_zoomed) zoom_out()
 
 	GLOB.alive_xeno_list -= src
-	LAZYREMOVE(GLOB.alive_xeno_list_hive[hivenumber], src)
+	GLOB.alive_xeno_list_hive[hivenumber] -= src
 	GLOB.xeno_mob_list -= src
 	GLOB.dead_xeno_list -= src
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -251,7 +251,7 @@
 	if(is_zoomed) zoom_out()
 
 	GLOB.alive_xeno_list -= src
-	GLOB.alive_xeno_list_hive[hivenumber] -= src
+	LAZYREMOVE(GLOB.alive_xeno_list_hive[hivenumber], src)
 	GLOB.xeno_mob_list -= src
 	GLOB.dead_xeno_list -= src
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -21,6 +21,11 @@
 	create_reagents(1000)
 	gender = NEUTER
 
+	if(is_centcom_level(z) && hivenumber == XENO_HIVE_NORMAL)
+		hivenumber = XENO_HIVE_ADMEME //so admins can safely spawn xenos in Thunderdome for tests.
+
+	set_initial_hivenumber()
+
 	switch(stat)
 		if(CONSCIOUS)
 			GLOB.alive_xeno_list += src
@@ -37,16 +42,11 @@
 	GLOB.round_statistics.total_xenos_created++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_xenos_created")
 
-	if(is_centcom_level(z) && hivenumber == XENO_HIVE_NORMAL)
-		hivenumber = XENO_HIVE_ADMEME //so admins can safely spawn xenos in Thunderdome for tests.
-
 	wound_overlay = new(null, src)
 	vis_contents += wound_overlay
 
 	fire_overlay = mob_size == MOB_SIZE_BIG ? new(null, src) : new /atom/movable/vis_obj/xeno_wounds/fire_overlay/small(null, src)
 	vis_contents += fire_overlay
-
-	set_initial_hivenumber()
 
 	generate_nicknumber()
 


### PR DESCRIPTION
## About The Pull Request
The reward from hive threat was failing sometimes, it turns out due to the order in which stuff happens during xeno init was leaving null entries in the normal hive list due to admeme/valhalla xenos.

## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed hive threat rewards not working some times
/:cl:
