### PR TITLE
Prevents alamo crashing from deleting mobs and AI nodes

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -359,9 +359,9 @@
 
 	return ChangeTurf(baseturfs, baseturfs, flags) // The bottom baseturf will never go away
 
-/turf/proc/empty(turf_type=/turf/open/space, baseturf_type, list/ignore_typecache, flags)
-	// Remove all atoms except observers, landmarks, docking ports
-	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port))
+/turf/proc/empty(turf_type = /turf/open/space, baseturf_type, list/ignore_typecache, flags)
+	// Remove all atoms except mobs, landmarks, docking ports, ai nodes
+	var/static/list/ignored_atoms = typecacheof(list(/mob, /obj/effect/landmark, /obj/docking_port, /obj/effect/ai_node))
 	var/list/allowed_contents = typecache_filter_list_reverse(GetAllContentsIgnoring(ignore_typecache), ignored_atoms)
 	allowed_contents -= src
 	for(var/i in 1 to length(allowed_contents))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -360,8 +360,8 @@
 	return ChangeTurf(baseturfs, baseturfs, flags) // The bottom baseturf will never go away
 
 /turf/proc/empty(turf_type = /turf/open/space, baseturf_type, list/ignore_typecache, flags)
-	// Remove all atoms except mobs, landmarks, docking ports, ai nodes
-	var/static/list/ignored_atoms = typecacheof(list(/mob, /obj/effect/landmark, /obj/docking_port, /obj/effect/ai_node))
+	// Remove all atoms except  landmarks, docking ports, ai nodes
+	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port, /obj/effect/ai_node))
 	var/list/allowed_contents = typecache_filter_list_reverse(GetAllContentsIgnoring(ignore_typecache), ignored_atoms)
 	allowed_contents -= src
 	for(var/i in 1 to length(allowed_contents))

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -64,7 +64,7 @@
 	var/turf/right = locate(C.x + leftright, C.y, C.z)
 
 	for(var/turf/T in range(3, rear)+range(3, left)+range(3, right)+range(2, front))
-		T.empty(/turf/open/floor/plating, ignore_typecache = list(/mob))
+		T.empty(/turf/open/floor/plating, ignore_typecache = typecacheof(/mob))
 
 	SSmonitor.process_human_positions()
 	SSevacuation.initial_human_on_ship = SSmonitor.human_on_ship

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -64,7 +64,7 @@
 	var/turf/right = locate(C.x + leftright, C.y, C.z)
 
 	for(var/turf/T in range(3, rear)+range(3, left)+range(3, right)+range(2, front))
-		T.empty(/turf/open/floor/plating)
+		T.empty(/turf/open/floor/plating, ignore_typecache = list(/mob))
 
 	SSmonitor.process_human_positions()
 	SSevacuation.initial_human_on_ship = SSmonitor.human_on_ship


### PR DESCRIPTION

## About The Pull Request

Basically alamo straight up deleting people who are outside the doors can be kinda lame. AI nodes are abstract and shouldn't be getting influenced.
## Why It's Good For The Game

Getting deleted upon crash isn't exactly engaging. If it's meant to be punishing to be caught near alamo when it crashes then have the xenos do a punishing instead of a mechanic designed to make sure xenos can leave alamo. 
## Changelog
:cl:
balance: Alamo shouldn't delete you if you stand near the doors when it crashes
fix: Fixed AI nodes being deleted when turfs get emptied
/:cl:
