### PR TITLE
Gives the Sulaco Medbay a map table and a shower.

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -22468,10 +22468,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/sulaco/bridge/office)
-"rXQ" = (
-/obj/machinery/cryopod/right,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/hallway/lower_foreship)
 "rYR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -49376,7 +49372,7 @@ iXf
 xHk
 aKM
 aKM
-rXQ
+aKM
 eqq
 aYN
 mvV

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -1885,7 +1885,8 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "aiA" = (
-/obj/machinery/computer/med_data,
+/obj/machinery/cic_maptable,
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -12797,6 +12798,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
+"eTN" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/prison/whitegreen/corner,
+/area/sulaco/medbay)
 "eTW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -16369,6 +16374,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/marked,
 /area/sulaco/marine)
+"jQi" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "jQK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -22454,6 +22468,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/sulaco/bridge/office)
+"rXQ" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/lower_foreship)
 "rYR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -49358,7 +49376,7 @@ iXf
 xHk
 aKM
 aKM
-aKM
+rXQ
 eqq
 aYN
 mvV
@@ -50904,9 +50922,9 @@ ntk
 ntk
 ntk
 acG
-acA
-add
 acT
+add
+jQi
 vHb
 mDu
 qDO
@@ -55783,7 +55801,7 @@ mgi
 qMM
 afc
 fzo
-ade
+eTN
 aco
 ade
 fzI


### PR DESCRIPTION

## About The Pull Request

Due to Rosa Borden (whatever their discord tag is.) having troubles, I made this as closely as possible to their version.

It adds a map table to the main lobby, next to the crew computer.

![Lobby](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/87b987e0-d761-4294-9cc2-4d20bfb178fb)

And a shower in the hypersleep room. (Though I don't think it'll help with germs much there.)

![Shower](https://github.com/tgstation/TerraGov-Marine-Corps/assets/38842059/82f38316-4ac0-4b95-bf7d-01e3cd01c015)

## Why It's Good For The Game

I guess it'll be more in line with the PoS and it's map table? Maybe?

## Changelog
:cl:
add: Adds a shower and map table to the Sulaco medbay. Stop stinking.
/:cl:
