### PR TITLE
AMR special ammo buffs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1119,9 +1119,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "flak sniper bullet"
 	hud_state = "sniper_flak"
 	damage = 90
-	penetration = 10
+	penetration = 0
 	sundering = 15
-	airburst_multiplier = 0.25
+	airburst_multiplier = 0.5
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
 	staggerstun(victim, proj,  slowdown = 2)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1111,19 +1111,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SNIPER|AMMO_SUNDERING
 	accuracy_var_high = 7
 	max_range = 20
-	damage = 50
-	penetration = 20
+	damage = 70
+	penetration = 30
 	sundering = 5
 
 /datum/ammo/bullet/sniper/flak
 	name = "flak sniper bullet"
 	hud_state = "sniper_flak"
 	damage = 90
-	penetration = 0
-	sundering = 25
-	airburst_multiplier = 0.2
+	penetration = 10
+	sundering = 15
+	airburst_multiplier = 0.25
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
+	staggerstun(victim, proj,  slowdown = 2)
 	airburst(victim, proj)
 
 /datum/ammo/bullet/sniper/svd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the sidegrade ammo types for AMR more distinct and useful.

Flak
+ 2 slowdown on direct hit.
+ Airburst multiplier is now .5 from a middling .25.
- It now does 15 sunder rather than 25.

This moves flak to being the crowd control round, with its rather middling pen it doesn't do much to highly armored castes unless they let you keep shooting at them, but it has some solid crowd control on it, rather than its current state where its just a crusher trolling round.

Incend
+ Damage increased to 70 from 50
+ Penetration increased to 30 (This is just the Pen it had with lase.)

The loss of Pen bonus makes this round even more terrible, it has awful sunder, all it does is deny pheros which is a semi-useful tool but there is little reason to pick this over normal rounds right now so this should ideally make it a better pick.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AMRs special ammo types got hit indirectly with #13109 a lot when they lost slowdown and the pen bonus, I don't think the normal rounds should have slowdown (as your mainly using them to kill whatever your target is) but this should ideally shift the trio of rounds into specialized focuses. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: AMR Flak now does slowdown and has a higher airburst multiplier, but has reduced sundering. AMR Incend does a bit more damage even if it is still less than normal ammo as well as slightly more pen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
