### PR TITLE
Fixes GL54 razor nade name in req

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -325,7 +325,7 @@ WEAPONS
 	cost = 48
 
 /datum/supply_packs/weapons/tx54_razor
-	name = "GL-54 smoke grenade magazine"
+	name = "GL-54 razorburn grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/razor)
 	cost = 96
 


### PR DESCRIPTION

## About The Pull Request

Its named wrong
## Why It's Good For The Game

Not being named wrong is neat
## Changelog
:cl:
fix: The GL54 razor nade magazines have the correct name in req now
/:cl:
