### PR TITLE
Boomvest fix2

### DIFF
--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -128,7 +128,7 @@
 
 /datum/outfit/job/clf/standard/fanatic
 	head = /obj/item/clothing/head/headband/rambo
-	wear_suit = /obj/item/clothing/suit/storage/marine/harness/boomvest
+	wear_suit = /obj/item/clothing/suit/storage/marine/boomvest
 	belt = /obj/item/weapon/gun/shotgun/double/sawn
 	suit_store = /obj/item/weapon/gun/smg/skorpion/mag_harness
 

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -2,6 +2,8 @@
 	name = "tactical explosive vest"
 	desc = "Obviously someone just strapped a bomb to a marine harness and called it tactical. The light has been removed, and its switch used as the detonator.<br><span class='notice'>Control-Click to set a warcry.</span> <span class='warning'>This harness has no light, toggling it will detonate the vest!</span>"
 	icon_state = "boom_vest"
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	slowdown = 0
 	flags_item_map_variant = NONE
 	flags_armor_features = NONE
 	///Warcry to yell upon detonation

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/suit/storage/marine/harness/boomvest
+/obj/item/clothing/suit/storage/marine/boomvest
 	name = "tactical explosive vest"
 	desc = "Obviously someone just strapped a bomb to a marine harness and called it tactical. The light has been removed, and its switch used as the detonator.<br><span class='notice'>Control-Click to set a warcry.</span> <span class='warning'>This harness has no light, toggling it will detonate the vest!</span>"
 	icon_state = "boom_vest"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -881,7 +881,7 @@
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
-			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,
+			/obj/item/clothing/suit/storage/marine/boomvest = 20,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,
 			/obj/item/radio/headset/mainship/marine/charlie = -1,


### PR DESCRIPTION

## About The Pull Request
gives the boom vest the correct stats and repaths it
## Why It's Good For The Game
the harness got removed in the purge, and the boom vest inherited its stats from it. i fix.
## Changelog
:cl:
fix: tactical explosive vest now has the correct armour and slowdown stats
/:cl:
