### PR TITLE
Remove Jaeger vendor bundle and clean up vendor naming

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -260,8 +260,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 ))
 
 GLOBAL_LIST_INIT(marine_clothes_listed_products, list(
-		/obj/effect/vendor_bundle/basic = list(CAT_STD, "Standard Kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic = list(CAT_STD, "Essential Human Kit", 0, "white"),
 		/obj/effect/vendor_bundle/robot/essentials = list(CAT_STD, "Essential Combat Robot Kit", 0, "white"),
 		/obj/effect/vendor_bundle/xenonauten_light = list(CAT_AMR, "Xenonauten light armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_medium = list(CAT_AMR, "Xenonauten medium armor kit", 0, "orange"),
@@ -329,8 +328,7 @@ GLOBAL_LIST_INIT(marine_clothes_listed_products, list(
 	))
 
 GLOBAL_LIST_INIT(engineer_clothes_listed_products, list(
-		/obj/effect/vendor_bundle/basic_engineer = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger_engineer = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic_engineer = list(CAT_STD, "Essential Human Engineer kit", 0, "white"),
 		/obj/effect/vendor_bundle/robot/essentials = list(CAT_STD, "Essential Combat Robot Kit", 0, "white"),
 		/obj/item/clothing/glasses/welding = list(CAT_GLA, "Welding Goggles", 0, "white"),
 		/obj/item/clothing/glasses/meson = list(CAT_GLA, "Optical Meson Scanner", 0, "white"),
@@ -396,8 +394,7 @@ GLOBAL_LIST_INIT(engineer_clothes_listed_products, list(
 	))
 
 GLOBAL_LIST_INIT(medic_clothes_listed_products, list(
-		/obj/effect/vendor_bundle/basic_medic = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger_medic = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic_medic = list(CAT_STD, "Essential Human Corpsman kit", 0, "white"),
 		/obj/effect/vendor_bundle/robot/essentials = list(CAT_STD, "Essential Combat Robot Kit", 0, "white"),
 		/obj/effect/vendor_bundle/xenonauten_light = list(CAT_AMR, "Xenonauten light armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_medium = list(CAT_AMR, "Xenonauten medium armor kit", 0, "orange"),
@@ -447,8 +444,7 @@ GLOBAL_LIST_INIT(medic_clothes_listed_products, list(
 	))
 
 GLOBAL_LIST_INIT(smartgunner_clothes_listed_products, list(
-		/obj/effect/vendor_bundle/basic_smartgunner = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger_smartgunner = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic_smartgunner = list(CAT_STD, "Essential Human Smartgunner Kit", 0, "white"),
 		/obj/effect/vendor_bundle/robot/essentials = list(CAT_STD, "Essential Combat Robot Kit", 0, "white"),
 		/obj/effect/vendor_bundle/xenonauten_light = list(CAT_AMR, "Xenonauten light armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_medium = list(CAT_AMR, "Xenonauten medium armor kit", 0, "orange"),
@@ -502,8 +498,7 @@ GLOBAL_LIST_INIT(smartgunner_clothes_listed_products, list(
 	))
 
 GLOBAL_LIST_INIT(leader_clothes_listed_products, list(
-		/obj/effect/vendor_bundle/basic_squadleader = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger_squadleader = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic_squadleader = list(CAT_STD, "Essential Human Squad Leader", 0, "white"),
 		/obj/effect/vendor_bundle/robot/essentials = list(CAT_STD, "Essential Combat Robot Kit", 0, "white"),
 		/obj/effect/vendor_bundle/xenonauten_light/leader = list(CAT_AMR, "Xenonauten light armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_medium/leader = list(CAT_AMR, "Xenonauten medium armor kit", 0, "orange"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -408,8 +408,7 @@
 /obj/machinery/marine_selector/clothes/commander/Initialize(mapload)
 	. = ..()
 	listed_products = list(
-		/obj/effect/vendor_bundle/basic_commander = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/vendor_bundle/basic_jaeger_commander = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/vendor_bundle/basic_commander = list(CAT_STD, "Essential Human Commander", 0, "white"),
 		/obj/effect/vendor_bundle/xenonauten_light/leader = list(CAT_AMR, "Xenonauten light armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_medium/leader = list(CAT_AMR, "Xenonauten medium armor kit", 0, "orange"),
 		/obj/effect/vendor_bundle/xenonauten_heavy/leader = list(CAT_AMR, "Xenonauten heavy armor kit", 0, "orange"),
@@ -622,16 +621,6 @@
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
-		/obj/item/paper/tutorial/medical,
-		/obj/item/paper/tutorial/mechanics,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/clothing/gloves/marine,
-		/obj/item/storage/box/MRE,
 		/obj/item/facepaint/green,
 		/obj/item/paper/tutorial/medical,
 		/obj/item/paper/tutorial/mechanics,
@@ -640,14 +629,6 @@
 /obj/effect/vendor_bundle/basic_smartgunner
 	gear_to_spawn = list(
 		/obj/item/clothing/under/marine,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/clothing/gloves/marine,
-		/obj/item/storage/box/MRE,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger_smartgunner
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
@@ -660,28 +641,12 @@
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger_squadleader
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/clothing/gloves/marine,
-		/obj/item/storage/box/MRE,
 		/obj/item/facepaint/green,
 	)
 
 /obj/effect/vendor_bundle/basic_medic
 	gear_to_spawn = list(
 		/obj/item/clothing/under/marine/corpsman,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/clothing/gloves/marine,
-		/obj/item/storage/box/MRE,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger_medic
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
@@ -693,26 +658,12 @@
 		/obj/item/clothing/under/marine/engineer,
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/storage/box/MRE,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger_engineer
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/storage/box/MRE,
 		/obj/item/facepaint/green,
 	)
 
 /obj/effect/vendor_bundle/basic_commander
 	gear_to_spawn = list(
 		/obj/item/clothing/under/marine,
-		/obj/item/clothing/shoes/marine/full,
-		/obj/item/storage/box/MRE,
-	)
-
-/obj/effect/vendor_bundle/basic_jaeger_commander
-	gear_to_spawn = list(
-		/obj/item/clothing/under/marine/jaeger,
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/storage/box/MRE,
 		/obj/item/facepaint/green,
@@ -936,6 +887,7 @@
 		/obj/item/clothing/under/marine/robotic,
 		/obj/item/tool/weldingtool,
 		/obj/item/stack/cable_coil,
+		/obj/item/facepaint/green,
 	)
 
 /obj/effect/vendor_bundle/robot/light_armor


### PR DESCRIPTION

## About The Pull Request

Remove all Jaeger vendor bundles.

All vendor bundles have green facepaint.

Rename vendor bundle that can only be used for humans from "Standard Kit" to "Essential Human Kit". Applies to jobs as well; if there is a vendor bundle for corpsman, name for that will be "Essential Human Corpsman Kit".

## Why It's Good For The Game

Long time ago, the essential Jaeger kit had the Jaeger XM-02 combat exoskeleton, which all Jaeger armor used to put modules, armors, and storage in. 

With the turn of Lumi's Jaeger rework, the Jaeger XM-02 combat exoskeleton was irrelevant save for the few marines who use MK. I Jaegar which are accessible in the surplus vendors. New marines now use MK. II, and to be quite freaking honest, no one really freaking care about the TGMC jaeger undersuit.

The standard kits now spawn with green facepaint, but I have changed the name to reflect different species in TGMC. It only makes sense.

## Changelog

:cl:
del: Remove Jaeger vendor bundle
add: green facepaint to standard kit
add: green facepaint to Essential Combat Robot kit
add: change the name from "Standard kit" to "Essential Human [INSERT JOB HERE] Kit" to reflect different species kit
/:cl:

