### PR TITLE
resin traps concealable by common map items

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -71,7 +71,7 @@
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
-	layer = RESIN_STRUCTURE_LAYER
+	layer = ATMOS_DEVICE_LAYER
 	destroy_sound = "alien_resin_break"
 	///defines for trap type to trigger on activation
 	var/trap_type


### PR DESCRIPTION
## Gameplay change

makes resin holes able to be concealed by items such as fat guns, crates, wood sheets, lockers, and other miscellaneous items commonly found on most maps. Previously they would be layered Above the items in question.

## Why It's Good For The Game

allows traps to be traps, instead of "hey, shoot me!"
Enables more opportunities to bait
still cucked by fire and explosives
observant marines will notice suspicious piles of objects and act accordingly
potentially more things to do for the MO's
Salt Mines will be at an all time high production yield
Point and laugh at Urist McBald who ran before he looked

## Changelog

changes resin hole layer from XENO_STRUCTURE_LAYER to ATMOS_DEVICE_LAYER

:cl:
add: Enabled resin holes to be concealed by more objects. Look before you leap!
/:cl:

