### PR TITLE
Smart minigun now does true damage to walls.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1225,6 +1225,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 1
 	damage_falloff = 0.1
 
+/datum/ammo/bullet/smart_minigun/on_hit_turf(turf/T, obj/projectile/P)
+	if(istype(T, /turf/closed/wall))
+		var/turf/closed/wall/wall_victim = T
+		wall_victim.take_damage((6))
+
 /datum/ammo/bullet/turret
 	name = "autocannon bullet"
 	bullet_color = COLOR_SOFT_RED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Smart machinegun now does true damage to walls, this is mostly aimed at resin walls so the value is low, being 6.

This combined with the normal damage makes it do 10 damage to walls.

Mathematically this makes it probably the best wall clearing gun behind the autocannon, and should give it some level of niche beyond being a noobtrap when in a maze fight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the Smart Minigun a reason to exist as it can now help clear the maze much better than before when laying down fire.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Smart minigun now deals bonus damage to walls to improve its ability to destroy softer forms of walls like resin or wooden walls with ease.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
