### PR TITLE
Fix gear preferences not showing the right slots

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
@@ -7,10 +7,11 @@ export const GearCustomization = (props, context) => {
   const { gearsets, gear, clothing, underwear, undershirt, backpack, gender } =
     data;
 
+  //these correspond to the gear slot and you need to update them if the defines change
   const slotMapping = {
-    11: 'Head',
-    9: 'Eyewear',
-    10: 'Mouth',
+    10: 'Head',
+    8: 'Eyewear',
+    9: 'Mouth',
   };
 
   const bySlot = {};

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
@@ -7,7 +7,7 @@ export const GearCustomization = (props, context) => {
   const { gearsets, gear, clothing, underwear, undershirt, backpack, gender } =
     data;
 
-  //these correspond to the gear slot and you need to update them if the defines change
+  // These correspond to the gear slot and you need to update them if the defines change
   const slotMapping = {
     10: 'Head',
     8: 'Eyewear',


### PR DESCRIPTION

## About The Pull Request

Couldn't select glasses and such. 
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed gear preferences not showing everything
/:cl:
