### PR TITLE
Improves caste limits slightly

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -97,7 +97,8 @@ GLOBAL_LIST_EMPTY(randomized_pill_icons)
 			"minimap" = icon2base64(xeno_minimap),
 			"sort_mod" = per_tier_counter[tier]++,
 			"tier" = GLOB.tier_as_number[tier],
-			"is_unique" = caste.maximum_active_caste == 1,
+			"is_unique" = caste.maximum_active == 1,
+			"maximum_active" = caste.maximum_active,
 			"can_transfer_plasma" = CHECK_BITFIELD(initial(caste.can_flags), CASTE_CAN_BE_GIVEN_PLASMA),
 			"evolution_max" = initial(caste.evolution_threshold)
 		))

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -20,7 +20,7 @@
 	// *** Health *** //
 	max_health = 100
 
-	maximum_active_caste = 1
+	maximum_active = 1
 	// *** Flags *** //
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_FIRE_IMMUNE|CASTE_IS_BUILDER|CASTE_DO_NOT_ALERT_LOW_LIFE
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -23,7 +23,7 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
-	maximum_active_caste = 1
+	maximum_active = 1
 	evolve_min_xenos = 12
 	death_evolution_delay = 7 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -25,7 +25,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
 	evolve_min_xenos = 8
-	maximum_active_caste = 1
+	maximum_active = 1
 	death_evolution_delay = 5 MINUTES
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -26,7 +26,7 @@
 	// *** Evolution *** //
 	// The only evolution path does not require threshold
 	// evolution_threshold = 180
-	maximum_active_caste = 1
+	maximum_active = 1
 	upgrade_threshold = TIER_TWO_YOUNG_THRESHOLD
 
 	evolves_to = list(/mob/living/carbon/xenomorph/queen)

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -276,9 +276,15 @@
 		if(death_timer)
 			to_chat(src, span_warning("The hivemind is still recovering from the last [initial(new_caste_type.display_name)]'s death. We must wait [DisplayTimeText(timeleft(death_timer))] before we can evolve."))
 			return FALSE
-	var/maximum_active_caste = new_caste_type.maximum_active_caste
-	if(maximum_active_caste != INFINITY && maximum_active_caste <= length(hive.xenos_by_typepath[new_mob_type]))
-		to_chat(src, span_warning("There is already a [initial(new_caste_type.display_name)] in the hive. We must wait for it to die."))
+	var/maximum_active = new_caste_type.maximum_active
+	if(maximum_active != -1 && maximum_active <= length(hive.xenos_by_typepath[new_mob_type]))
+		switch(maximum_active)
+			if(0)
+				to_chat(src, span_warning("Evolving into a [initial(new_caste_type.display_name)] is not possible."))
+			if(1)
+				to_chat(src, span_warning("There is already a [initial(new_caste_type.display_name)] in the hive. We must wait for it to die."))
+			else
+				to_chat(src, span_warning("There are already too many [initial(new_caste_type.display_name)]s in the hive. We must wait for one of them to die."))
 		return FALSE
 	var/turf/T = get_turf(src)
 	if(CHECK_BITFIELD(new_caste_flags, CASTE_REQUIRES_FREE_TILE) && T.check_alien_construction(src))

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -231,10 +231,10 @@
 	var/vent_exit_speed = XENO_DEFAULT_VENT_EXIT_TIME
 	///Whether the caste enters and crawls through vents silently
 	var/silent_vent_crawl = FALSE
-	// The amount of xenos that must be alive in the hive for this caste to be able to evolve
+	///The amount of xenos that must be alive in the hive for this caste to be able to evolve
 	var/evolve_min_xenos = 0
-	// How many of this caste may be alive at once
-	var/maximum_active_caste = INFINITY
+	///How many of this caste may be alive at once. -1 = unlimited.
+	var/maximum_active = -1
 
 ///Add needed component to the xeno
 /datum/xeno_caste/proc/on_caste_applied(mob/xenomorph)

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -567,9 +567,10 @@ const PopulationPyramid = (_props, context) => {
                       return null;
                     }
                     const static_entry = static_info[value];
-                    return (static_entry.maximum_active === -1 
-                      ? `${static_entry.name}: ${count}`
-                      : `${static_entry.name}: ${count} / ${static_entry.maximum_active}`
+                    return (
+                      static_entry.maximum_active === -1 
+                        ? `${static_entry.name}: ${count}`
+                        : `${static_entry.name}: ${count} / ${static_entry.maximum_active}`
                     );
                   })
                   .filter((ti) => ti !== null)

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -567,9 +567,10 @@ const PopulationPyramid = (_props, context) => {
                       return null;
                     }
                     const static_entry = static_info[value];
-                    return static_entry.maximum_active === -1 
+                    return (static_entry.maximum_active === -1 
                       ? `${static_entry.name}: ${count}`
-                      : `${static_entry.name}: ${count} / ${static_entry.maximum_active}`;
+                      : `${static_entry.name}: ${count} / ${static_entry.maximum_active}`
+                    );
                   })
                   .filter((ti) => ti !== null)
                   .join(' | ')}

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -62,6 +62,7 @@ type StaticData = {
   sort_mod: number;
   tier: number;
   is_unique: boolean;
+  maximum_active: number;
   can_transfer_plasma: boolean;
   evolution_max: number;
 };
@@ -566,7 +567,9 @@ const PopulationPyramid = (_props, context) => {
                       return null;
                     }
                     const static_entry = static_info[value];
-                    return `${static_entry.name}: ${count}`;
+                    return static_entry.maximum_active === -1 
+                      ? `${static_entry.name}: ${count}`
+                      : `${static_entry.name}: ${count} / ${static_entry.maximum_active}`;
                   })
                   .filter((ti) => ti !== null)
                   .join(' | ')}
@@ -624,7 +627,10 @@ const PopulationPyramid = (_props, context) => {
                           ? count >= 1
                             ? 'Active'
                             : 'N/A'
-                          : count}
+                          : static_entry.maximum_active === -1
+                            ? `${count}`
+                            : `${count} / ${static_entry.maximum_active}`
+                        }
                       </Box>
                     </Flex.Item>
                   );


### PR DESCRIPTION
## About The Pull Request
This PR improves the per-caste maximum code to better facilitate numbers that aren't 1 or INFINITY for the limit of a xeno caste.
Additionally, makes the number display in the hive status if limited.

Backendwise, "no limit" now also is symbolized by -1 instead of INFINITY, as I'd not like to pass infinity to tgui out of fear of different infinities.
## Why It's Good For The Game
While this feature is not currently in use except for "unique" castes. fixing it up should support those who may want to use it.
## Changelog
:cl:
code: Per-caste xeno limits should now be slightly more convenient to use and also display in the hive status for non-unique (but still limited) castes.
/:cl:
