### PR TITLE
Early synth health stats differentation

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -573,16 +573,17 @@
 	return TRUE
 
 
-/datum/species/early_synthetic // Worse at medical, better at engineering.
+/datum/species/early_synthetic // Worse at medical, better at engineering. Tougher in general than later synthetics.
 	name = "Early Synthetic"
 	name_plural = "Early Synthetics"
 	icobase = 'icons/mob/human_races/r_synthetic.dmi'
 	default_language_holder = /datum/language_holder/synthetic
 	unarmed_type = /datum/unarmed_attack/punch
 	rarity_value = 1.5
-	total_health = 125
-	brute_mod = 0.70
-	burn_mod = 0.70
+	slowdown = 1.15 //Slower than Late Synths.
+	total_health = 200 //Tough boys, very tough boys.
+	brute_mod = 0.6
+	burn_mod = 0.6
 
 	cold_level_1 = -1
 	cold_level_2 = -1


### PR DESCRIPTION

## About The Pull Request
This is in effect a redo of the species changes in https://github.com/tgstation/TerraGov-Marine-Corps/pull/10149
Early synth is *much* tankier, at the expensive of being a very, very slow boy.

Max HP is doubled to 200 from 125.
Brute/Burn mod is .6 from .7.
Inherient Slowdown of 1.15.
## Why It's Good For The Game
Early/Late synth should have noticeable gameplay differences beyond their skill set and this accomplishes that in a nice and simple way that is clearly noticeable to the player.
## Changelog
:cl:
balance: Early synth is now properly slower and tankier than late synth.
/:cl:
