### PR TITLE
Combat patrol is no longer votable

### DIFF
--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/combat_patrol
 	name = "Combat Patrol"
 	config_tag = "Combat Patrol"
+	votable = FALSE
 	flags_round_type = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_TWO_HUMAN_FACTIONS
 	shutters_drop_time = 3 MINUTES
 	flags_xeno_abilities = ABILITY_CRASH

--- a/code/datums/gamemodes/sensor_capture.dm
+++ b/code/datums/gamemodes/sensor_capture.dm
@@ -3,6 +3,7 @@
 /datum/game_mode/combat_patrol/sensor_capture
 	name = "Sensor Capture"
 	config_tag = "Sensor Capture"
+	votable = TRUE
 	wave_timer_length = 2 MINUTES
 	max_game_time = 10 MINUTES
 	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST)


### PR DESCRIPTION

## About The Pull Request
makes combat patrol not votable anymore
## Why It's Good For The Game
it's a straight downgrade from SC. i believe that CP detracts from public opinion about HvH because it's just so ass comparatively.
## Changelog
:cl:
del: Combat patrol is no longer a votable gamemode
/:cl:
