### PR TITLE
Fixes a hugger timer runtime

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -569,7 +569,7 @@
 	else
 		reset_attach_status(as_planned)
 		playsound(loc, 'sound/voice/alien_facehugger_dies.ogg', 25, 1)
-		activetimer = addtimer(CALLBACK(src, PROC_REF(go_active)), activate_time)
+		activetimer = addtimer(CALLBACK(src, PROC_REF(go_active)), activate_time, TIMER_STOPPABLE|TIMER_UNIQUE)
 		update_icon()
 
 	if(as_planned)


### PR DESCRIPTION

## About The Pull Request

This instance didn't have `TIMER_STOPPABLE`
## Why It's Good For The Game

Runtime bad
## Changelog
:cl:
fix: Fixed a hugger timer runtime
/:cl:
