### PR TITLE
Fixes drone link double del

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -75,7 +75,7 @@
 	var/datum/action/xeno_action/enhancement/enhancement_action = X.actions_by_path[/datum/action/xeno_action/enhancement]
 	enhancement_action?.end_ability()
 	X.remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
-	QDEL_NULL(existing_link)
+	existing_link = null
 	linked_target = null
 	add_cooldown()
 
@@ -176,5 +176,8 @@
 /// Ends the ability if the Enhancement buff is removed.
 /datum/action/xeno_action/enhancement/proc/end_ability()
 	if(existing_enhancement)
-		QDEL_NULL(existing_enhancement)
+		var/mob/living/living_owner = owner
+		living_owner.remove_status_effect(STATUS_EFFECT_XENO_ENHANCEMENT)
+		essence_link_action.linked_target.remove_status_effect(STATUS_EFFECT_XENO_ENHANCEMENT)
+		existing_enhancement = null
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -176,8 +176,6 @@
 /// Ends the ability if the Enhancement buff is removed.
 /datum/action/xeno_action/enhancement/proc/end_ability()
 	if(existing_enhancement)
-		var/mob/living/living_owner = owner
-		living_owner.remove_status_effect(STATUS_EFFECT_XENO_ENHANCEMENT)
 		essence_link_action.linked_target.remove_status_effect(STATUS_EFFECT_XENO_ENHANCEMENT)
 		existing_enhancement = null
 		add_cooldown()


### PR DESCRIPTION

## About The Pull Request

The qdel nulls were causing double deletions, `remove_status_effect` handles their deletions, we don't need to do it again.
## Why It's Good For The Game

Double del bad.
## Changelog
:cl:
fix: Fixed drone link double del
/:cl:
