### PR TITLE
Jungle walls are now unacidable.

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -144,6 +144,7 @@
 	icon = 'icons/turf/walls/jungle.dmi'
 	icon_state = "junglewall-0"
 	desc = "Some thick jungle."
+	resistance_flags = UNACIDABLE
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_FLORA)
 	canSmoothWith = list(SMOOTH_GROUP_FLORA)
@@ -167,7 +168,7 @@
 
 /turf/closed/gm/dense
 	name = "dense jungle wall"
-	resistance_flags = PLASMACUTTER_IMMUNE
+	resistance_flags = PLASMACUTTER_IMMUNE|UNACIDABLE
 	minimap_color = NONE
 	icon_state = "wall-dense"
 


### PR DESCRIPTION

## About The Pull Request
Seems like https://github.com/tgstation/TerraGov-Marine-Corps/pull/12893 made it so you could acid jungle walls, I saw a few people using this. So I've come and fixed it.
## Why It's Good For The Game
Being able to acid walls placed to stop you from aciding or accessing tiles is probably not the best thing to leave in the game.
## Changelog
:cl:
fix: Jungle walls are now unacidable again.
/:cl:
