### PR TITLE
Fix King roar reliability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -226,7 +226,6 @@
 	var/source = get_turf(owner)
 	var/dir_to_target = Get_Angle(source, target)
 	var/list/turf/turfs_to_attack = generate_true_cone(source, SHATTERING_ROAR_RANGE, 1, SHATTERING_ROAR_ANGLE, dir_to_target, bypass_window = TRUE, air_pass = TRUE)
-	victims_hit.Cut()
 	execute_attack(1, turfs_to_attack, SHATTERING_ROAR_RANGE, target, source)
 
 	add_cooldown()
@@ -235,6 +234,7 @@
 ///Carries out the attack iteratively based on distance from source
 /datum/action/xeno_action/activable/shattering_roar/proc/execute_attack(iteration, list/turf/turfs_to_attack, range, target, turf/source)
 	if(iteration > range)
+		victims_hit.Cut()
 		return
 
 	for(var/turf/turf AS in turfs_to_attack)


### PR DESCRIPTION
## About The Pull Request

Applies the roar effects in a 2 tile wide band instead of 1 while tracking victims to make sure they are not hit more than once, so that simply moving towards the King does not negate what should be one of its most effective abilities.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: King's roar no longer misses things moving towards the King,
/:cl:
