### PR TITLE
"Logistics Bike" balance

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -8,7 +8,7 @@
 	max_integrity = 300
 	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 0, BOMB = 30, FIRE = 60, ACID = 60)
 	resistance_flags = XENO_DAMAGEABLE
-	flags_atom = PREVENT_CONTENTS_EXPLOSION
+	flags_atom = BUMP_ATTACKABLE|PREVENT_CONTENTS_EXPLOSION
 	key_type = null
 	integrity_failure = 0.5
 	flags_pass = PASSABLE
@@ -124,6 +124,17 @@
 		return TRUE
 	if(user.a_intent != INTENT_HARM)
 		return motor_pack.attackby(I, user, params)
+
+/obj/vehicle/ridden/motorbike/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
+	. = ..()
+	if(!LAZYLEN(buckled_mobs))
+		return
+	for(var/mob/living/rider AS in buckled_mobs)
+		unbuckle_mob(rider)
+		// todo: if zooming do the following
+		rider.throw_at(get_step(rider, rider.dir), 2, spin = TRUE)
+		rider.Paralyze(0.5 SECONDS)
+		balloon_alert(rider, "You are thrown from the bike!")
 
 /obj/vehicle/ridden/motorbike/proc/sidecar_dir_change(datum/source, dir, newdir)
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -131,10 +131,13 @@
 		return
 	for(var/mob/living/rider AS in buckled_mobs)
 		unbuckle_mob(rider)
-		// todo: if zooming do the following
-		rider.throw_at(get_step(rider, rider.dir), 2, spin = TRUE)
+		if(world.time > last_move_time + move_delay)
+			balloon_alert(rider, "You are unbuckled by the alien attack!")
+			continue
+		// We zooming when unbuckled = fly off the handles
+		rider.throw_at(get_step(get_step(src, rider.dir), rider.dir), 2, 1, src, TRUE)
 		rider.Paralyze(0.5 SECONDS)
-		balloon_alert(rider, "You are thrown from the bike!")
+		balloon_alert(rider, "You are thrown from the bike by the alien attack!")
 
 /obj/vehicle/ridden/motorbike/proc/sidecar_dir_change(datum/source, dir, newdir)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Once upon a time I was told (by maints) the motorbike vehicle is meant to be used for logistics and carting around supplies on the surface.
Unfortunately, its abuse has only worsened since its introduction with the sidecar and fire extinguisher shenanigans.
This PR seeks to make taking it into front lines battle, or close up combat period, a fairer amount of risk compared to what is now.

Contrary to popular belief xenos cannot unbuckle with help intent, so please do not cite that bad info in the comments.

Alien attacks on the bike itself unbuckles the rider(s).
Additionally if they are in motion they are thrown off the bike in the direction of travel.

Closes: #13217

## Why It's Good For The Game

Long overdue semblance of balance.

## Changelog
:cl:
balance: Motorbikes unbuckle their rider(s) when attacked by xenos, and if they are moving are thrown forward from the vehicle. Not possible with bump attacks.
fix: When unoccupied Motorbikes are bump attackable by xenos on harm intent, otherwise redirects to the driver like usual.
/:cl:
