### PR TITLE
Makes deconstructing xeno structures as a xeno faster

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -92,7 +92,7 @@
 		return
 	X.visible_message(span_xenonotice("\The [X] starts tearing down \the [src]!"), \
 	span_xenonotice("We start to tear down \the [src]."))
-	if(!do_after(X, 4 SECONDS, TRUE, X, BUSY_ICON_GENERIC))
+	if(!do_after(X, 1 SECONDS, TRUE, X, BUSY_ICON_GENERIC))
 		return
 	if(!istype(src)) // Prevent jumping to other turfs if do_after completes with the wall already gone
 		return


### PR DESCRIPTION

## About The Pull Request

Makes the delay 1s instead of 4s.
To avoid people accidentally tearing things down during combat, I couldn't make it instant, so 1s it is.
## Why It's Good For The Game

A bug was found in #13173 that made deconstruction instant.
As it turns out, this improved xeno game flow, at least from my perspective.
Less stupid sabotage, faster gameplay, very good.
## Changelog
:cl:
balance: Deconstructing xeno structures as a xeno now takes 1s instead of 4s.
/:cl:
