### PR TITLE
fire/lava funny damage fix

### DIFF
--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -258,7 +258,7 @@
 
 			if(!L.on_fire || L.getFireLoss() <= 200)
 				var/damage_amount = max(L.modify_by_armor(LAVA_TILE_BURN_DAMAGE, FIRE), LAVA_TILE_BURN_DAMAGE * 0.3) //snowflakey interaction to stop complete lava immunity
-				L.take_overall_damage(damage_amount, BURN, updating_health = TRUE)
+				L.take_overall_damage(damage_amount, BURN, updating_health = TRUE, max_limbs = 3)
 				if(!CHECK_BITFIELD(L.flags_pass, PASSFIRE))//Pass fire allow to cross lava without igniting
 					L.adjust_fire_stacks(20)
 					L.IgniteMob()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -203,7 +203,7 @@
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return
 
-	take_overall_damage(rand(10, burnlevel), BURN, FIRE, updating_health = TRUE)
+	take_overall_damage(rand(10, burnlevel), BURN, FIRE, updating_health = TRUE, max_limbs = 4)
 	to_chat(src, span_warning("You are burned!"))
 
 	if(flags_pass & PASSFIRE) //Pass fire allow to cross fire without being ignited


### PR DESCRIPTION

## About The Pull Request
Fixes hold orders being so powerful, they can stop lava from doing damage.
Same thing applies to fire.
## Why It's Good For The Game
Laval doing no damage because someone shouted at you is bad.
## Changelog
:cl:
fix: Lava and fire can no longer be made to do 0 damage due to the hold order
/:cl:
