### PR TITLE
laser carbine sunder fix

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2656,6 +2656,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 30
 	hitscan_effect_icon = "beam"
 
+/datum/ammo/energy/lasgun/marine/carbine
+	sundering = 1
+	max_range = 18
+
 /datum/ammo/energy/lasgun/marine/overcharge
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -648,7 +648,7 @@
 
 /datum/lasrifle/base/energy_carbine_mode/auto_burst
 	rounds_per_shot = 12
-	ammo_datum_type = /datum/ammo/energy/lasgun/marine
+	ammo_datum_type = /datum/ammo/energy/lasgun/marine/carbine
 	fire_delay = 0.2 SECONDS
 	burst_amount = 4
 	fire_sound = 'sound/weapons/guns/fire/Laser Rifle Standard.ogg'


### PR DESCRIPTION

## About The Pull Request
Restored carbine sunder back to 1 per shot instead of 1.5 (that should only apply to the rifle).

I somehow deleted this out of the main laser rework PR.
## Why It's Good For The Game
Unintended change bad.
## Changelog
:cl:
fix: Laser carbine does 1 sunder per shot on autoburst instead of 1.5
/:cl:
