### PR TITLE
"Logistics Bike" balance v2

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -40,6 +40,11 @@
 	. += "To access internal storage click with an empty hand or drag the bike onto self."
 	. += "The fuel gauge on the bike reads \"[fuel_count/fuel_max*100]%\""
 
+/obj/vehicle/ridden/motorbike/user_buckle_mob(mob/living/M, mob/user, check_loc)
+	if(!do_after(user, 2 SECONDS, target = M))
+		return FALSE
+	return ..()
+
 /obj/vehicle/ridden/motorbike/post_buckle_mob(mob/living/M)
 	add_overlay(motorbike_cover)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Adds a short windup time to buckling mobs to the bike.
An alternative idea to the approach of "more unbuckle" which a lot of riders see as too far.

Closes: #13206

## Why It's Good For The Game

Makes the Motorbike logistics vehicle less viable in combat. Making its benefits of slowdown negation from all kinds of sources a little harder to re-attain if lost to the enemy.

## Changelog
:cl:
balance: Buckling to the Motorbike now has a windup. Be careful buckling in a busy place.
/:cl:
