### PR TITLE
Gives defiler enough plasma to use all abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -17,7 +17,7 @@
 	speed = -0.7
 
 	// *** Plasma *** //
-	plasma_max = 400
+	plasma_max = 500
 	plasma_gain = 20
 
 	// *** Health *** //
@@ -83,7 +83,7 @@
 	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 500
+	plasma_max = 550
 	plasma_gain = 25
 
 	// *** Health *** //
@@ -111,7 +111,7 @@
 	speed = -0.9
 
 	// *** Plasma *** //
-	plasma_max = 550
+	plasma_max = 625
 	plasma_gain = 30
 
 	// *** Health *** //
@@ -139,7 +139,7 @@
 	speed = -1
 
 	// *** Plasma *** //
-	plasma_max = 575
+	plasma_max = 675
 	plasma_gain = 35
 
 	// *** Health *** //
@@ -168,7 +168,7 @@
 	speed = -1
 
 	// *** Plasma *** //
-	plasma_max = 575
+	plasma_max = 675
 	plasma_gain = 35
 
 	// *** Health *** //


### PR DESCRIPTION

## About The Pull Request
This Pr gives defiler enough plasma to use all it's "attack" abilities ONCE per all-in.
## Why It's Good For The Game
Gives the defiler more ability to combo all the way by letting high-skill players the ability to use all the castes abilities when they go all in due to the high cost of tentacle. Now they should be able to use all frontline abilities ONCE each before needing to run away. 
## Changelog
:cl:
balance: Rebalances defiler plasma
/:cl:
