### PR TITLE
Vali can load from pills

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -421,8 +421,8 @@
 		return
 
 	var/obj/item/held_item = wearer.get_held_item()
-	if((!istype(held_item, /obj/item/reagent_containers) && !meds_beaker.reagents.total_volume) || istype(held_item, /obj/item/reagent_containers/pill))
-		wearer.balloon_alert(wearer, "You must be holding a glass reagent container")
+	if((!istype(held_item, /obj/item/reagent_containers) && !meds_beaker.reagents.total_volume))
+		wearer.balloon_alert(wearer, "You must be holding a suitable reagent container")
 		return
 
 	if(!istype(held_item, /obj/item/reagent_containers) && meds_beaker.reagents.total_volume)
@@ -439,7 +439,7 @@
 		wearer.balloon_alert(wearer, "Both the held reagent container and the system's reagent storage are empty")
 		return
 
-	if(!held_beaker.reagents.total_volume && meds_beaker.reagents.total_volume)
+	if(!held_beaker.reagents.total_volume && meds_beaker.reagents.total_volume) //Pills should never be empty so we don't worry about loading into them
 		var/pick = tgui_input_list(wearer, "Unload internal reagent storage into held container:", "Vali system", list("Yes", "No"))
 		if(pick == "Yes")
 			if(!do_after(wearer, 0.5 SECONDS, TRUE, held_item, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS, ignore_turf_checks = TRUE))
@@ -458,6 +458,8 @@
 	var/trans = held_beaker.reagents.trans_to(meds_beaker, held_beaker.amount_per_transfer_from_this)
 	wearer.balloon_alert(wearer, "Loaded [trans] units")
 	to_chat(wearer, get_meds_beaker_contents())
+	if(istype(held_beaker, /obj/item/reagent_containers/pill))
+		qdel(held_beaker)
 
 ///Shows the loaded reagents to the person examining the parent/wearer
 /datum/component/chem_booster/proc/get_meds_beaker_contents()

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -76,7 +76,7 @@
 	if(user.do_actions)
 		return
 
-	if(!isreagentcontainer(cont) || istype(cont, /obj/item/reagent_containers/pill))
+	if(!isreagentcontainer(cont))
 		user.balloon_alert(user, "incompatible")
 		return
 
@@ -113,6 +113,8 @@
 	user.balloon_alert(user, "[loaded_reagents[reagent_to_load]]u")
 	if(length(loaded_reagents) == 1)
 		update_selected_reagent(reagent_to_load)
+	if(istype(container, /obj/item/reagent_containers/pill))
+		qdel(container)
 
 ///Handles behavior when activating the weapon
 /datum/component/harvester/proc/activate_blade_async(datum/source, mob/user)

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -8,6 +8,7 @@
 	icon_state = "pill1"
 	item_state = "pill"
 	possible_transfer_amounts = null
+	amount_per_transfer_from_this = 15
 	init_reagent_flags = AMOUNT_SKILLCHECK
 	w_class = WEIGHT_CLASS_TINY
 	volume = 60


### PR DESCRIPTION

## About The Pull Request
Applies to both harvester weapons and the armor module. The full pill is always consumed, even when there's only space for part of it.
## Why It's Good For The Game
Restricting chem gear from using the chem form marines are generally supplied with the most is kinda weird.
## Changelog
:cl:
balance: Vali armor and weapons can load reagents from pills
/:cl:
