### PR TITLE
Refactor nuke to use timers

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -28,13 +28,13 @@
 
 /obj/effect/countdown/proc/start()
 	if(!started)
-		START_PROCESSING(SSobj, src)
+		START_PROCESSING(SSprocessing, src)
 		started = TRUE
 
 /obj/effect/countdown/proc/stop()
 	if(started)
 		maptext = null
-		STOP_PROCESSING(SSobj, src)
+		STOP_PROCESSING(SSprocessing, src)
 		started = FALSE
 
 /obj/effect/countdown/proc/get_value()
@@ -73,4 +73,4 @@
 	var/obj/machinery/nuclearbomb/N = attached_to
 	if(!N.timer_enabled)
 		return
-	return round(N.get_time_left())
+	return N.get_time_left()

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -20,11 +20,15 @@
 	var/deployable = TRUE
 	var/extended = FALSE
 	var/lighthack = FALSE
-	///Time currently left on the nuke
-	var/timeleft = 180
+	///Time to start the timer on
+	var/time = 180 SECONDS
+	///Min time for the nuke timer
+	var/timemin = 180 SECONDS
 	///Max time for the nuke timer
-	var/timemax = 180
+	var/timemax = 600 SECONDS
 	var/timer_enabled = FALSE
+	///ID of timer
+	var/timer
 	var/safety = TRUE
 	var/exploded = FALSE
 	var/removal_stage = NUKE_STAGE_NONE
@@ -49,41 +53,33 @@
 	QDEL_NULL(countdown)
 	return ..()
 
-/obj/machinery/nuclearbomb/process()
-	if(!timer_enabled)
-		stop_processing()
-		return
-	timeleft--
-	if(timeleft <= 0)
-		explode()
-		return
-	updateUsrDialog()
-
-/obj/machinery/nuclearbomb/start_processing()
-	. = ..()
+///Enables nuke timer
+/obj/machinery/nuclearbomb/proc/enable()
 	GLOB.active_nuke_list += src
 	countdown.start()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_START, src)
+	notify_ghosts("[usr] enabled the [src], it has [time] seconds on the timer.", source = src, action = NOTIFY_ORBIT, extra_large = TRUE)
+	timer_enabled = TRUE
+	timer = addtimer(CALLBACK(src, PROC_REF(explode)), time, TIMER_STOPPABLE)
 	update_minimap_icon()
-	notify_ghosts("[usr] enabled the [src], it has [timeleft] seconds on the timer.", source = src, action = NOTIFY_ORBIT, extra_large = TRUE)
 
-/obj/machinery/nuclearbomb/stop_processing()
+///Disables nuke timer
+/obj/machinery/nuclearbomb/proc/disable()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_STOP, src)
 	countdown.stop()
 	GLOB.active_nuke_list -= src
-	timeleft = timemax
+	timer_enabled = FALSE
+	if(timer)
+		deltimer(timer)
+		timer = null
 	update_minimap_icon()
-	return ..()
 
 ///Handles the boom
 /obj/machinery/nuclearbomb/proc/explode()
-	stop_processing()
+	disable()
 
 	if(safety)
-		timer_enabled = FALSE
-		update_minimap_icon()
 		return
-
 	if(exploded)
 		return
 	exploded = TRUE
@@ -100,8 +96,7 @@
 	machine_stat |= BROKEN
 	anchored = FALSE
 	if(timer_enabled)
-		timer_enabled = FALSE
-		stop_processing()
+		disable()
 
 /obj/machinery/nuclearbomb/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -121,8 +116,6 @@
 	if(r_auth && g_auth && b_auth)
 		has_auth = TRUE
 
-	updateUsrDialog()
-
 /obj/machinery/nuclearbomb/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL)
 		return FALSE
@@ -138,9 +131,7 @@
 	X.visible_message("[X] disabled the nuke",
 	"You disabled the nuke.")
 
-	timer_enabled = FALSE
-	stop_processing()
-	update_icon()
+	disable()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_DIFFUSED, src, X)
 
 /obj/machinery/nuclearbomb/can_interact(mob/user)
@@ -190,8 +181,8 @@
 /obj/machinery/nuclearbomb/ui_data(mob/user)
 	var/list/data = list()
 
-	data["time_left"] = timeleft
-	data["time_max"] = timemax
+	data["time"] = time MILLISECONDS
+	data["time_left"] = get_time_left()
 	data["timer_enabled"] = timer_enabled
 	data["has_auth"] = has_auth
 	data["safety"] = safety
@@ -214,7 +205,7 @@
 		else
 			status = "Auth. S1-[safe_text]"
 
-	if(timeleft <= 5)
+	if(timer && timeleft(timer) <= 5 SECONDS)
 		status = "Initializing nuclear explosion. Have a nice day :)"
 
 	data["status"] = status
@@ -236,7 +227,7 @@
 				return
 			if(!isnum(params["seconds"]))
 				CRASH("non-number passed")
-			change_time(params["seconds"])
+			change_time(params["seconds"] SECONDS)
 		if("toggle_safety")
 			if(!has_auth)
 				return
@@ -259,31 +250,27 @@
 		balloon_alert(user, "anchors not set")
 		return
 
-	timer_enabled = !timer_enabled
-
-	if(timer_enabled)
-		start_processing()
+	if(!timer_enabled)
+		enable()
 		balloon_alert(user, "timer started")
 	else
+		disable()
 		balloon_alert(user, "timer stopped")
 
 	if(!lighthack)
 		icon_state = (timer_enabled) ? "nuclearbomb2" : "nuclearbomb1"
 
 ///Modifies the nuke timer
-/obj/machinery/nuclearbomb/proc/change_time(time)
+/obj/machinery/nuclearbomb/proc/change_time(change)
 	if(!timer_enabled)
-		timemax += time
-		timemax = clamp(timemax, initial(timemax), 600)
-		timeleft = timemax
+		time = clamp(time + change, timemin, timemax)
 
 ///Toggles the safety on or off
 /obj/machinery/nuclearbomb/proc/toggle_safety(mob/user)
 	safety = !safety
 	if(safety)
-		timer_enabled = FALSE
 		balloon_alert(user, "safety enabled")
-		stop_processing()
+		disable()
 	else
 		balloon_alert(user, "safety disabled")
 
@@ -304,8 +291,7 @@
 	else
 		balloon_alert(user, "unanchored")
 		visible_message(span_warning("The anchoring bolts slide back into the depths of [src]."))
-		timer_enabled = FALSE
-		stop_processing()
+		disable()
 
 ///Handles disk insertion and removal
 /obj/machinery/nuclearbomb/proc/toggle_disk(mob/user, disk_colour)
@@ -351,9 +337,9 @@
 		if(r_auth && g_auth && b_auth)
 			has_auth = TRUE
 
-///Returns time left on the nuke
+///Returns time left on the nuke in seconds
 /obj/machinery/nuclearbomb/proc/get_time_left()
-	return timeleft
+	return timer ? round(timeleft(timer) MILLISECONDS) : time MILLISECONDS
 
 ///Change minimap icon if its on or off
 /obj/machinery/nuclearbomb/proc/update_minimap_icon()

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -21,11 +21,11 @@
 	var/extended = FALSE
 	var/lighthack = FALSE
 	///Time to start the timer on
-	var/time = 180 SECONDS
+	var/time = 360 SECONDS
 	///Min time for the nuke timer
-	var/timemin = 180 SECONDS
+	var/timemin = 360 SECONDS
 	///Max time for the nuke timer
-	var/timemax = 600 SECONDS
+	var/timemax = 1200 SECONDS
 	var/timer_enabled = FALSE
 	///ID of timer
 	var/timer

--- a/tgui/packages/tgui/interfaces/NuclearBomb.tsx
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.tsx
@@ -4,8 +4,8 @@ import { Window } from '../layouts';
 
 type NuclearBombData = {
   status: string;
+  time: number;
   time_left: number;
-  time_max: number;
   timer_enabled: boolean;
   has_auth: boolean;
   safety: boolean;
@@ -30,8 +30,8 @@ const NuclearBombContent = (props, context) => {
   const { act, data } = useBackend<NuclearBombData>(context);
   const {
     status,
+    time,
     time_left,
-    time_max,
     timer_enabled,
     has_auth,
     safety,
@@ -49,7 +49,7 @@ const NuclearBombContent = (props, context) => {
         <LabeledList>
           <LabeledList.Item label="Time left">
             <ProgressBar
-              value={time_left / time_max}
+              value={time_left / time}
               ranges={{
                 good: [0.6, Infinity],
                 average: [0.2, 0.6],
@@ -90,7 +90,7 @@ const NuclearBombContent = (props, context) => {
                 }
                 disabled={timer_enabled}
               />
-              <AnimatedNumber value={data.time_max} />
+              <AnimatedNumber value={data.time} />
               <Button
                 content="+5"
                 onClick={() =>


### PR DESCRIPTION
## About The Pull Request

Refactors the nuke to use timers, it shouldn't take twice the time set to explode anymore (i think)

## Changelog

:cl:
refactor: nuke uses timers
/:cl: