### PR TITLE
Lagmoor Shitsite© --> Magmoor Digsite IV | Minor Balance Changes

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1008,9 +1008,16 @@
 	},
 /area/magmoor/landing/two)
 "aLv" = (
-/obj/structure/table/woodentable,
-/turf/open/floor/mainship/floor,
-/area/magmoor/hydroponics/south)
+/obj/structure/bed/chair/sofa/corsat/verticaltop{
+	name = "bench"
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/structure/curtain/open,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1095,6 +1102,10 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/magmoor/medical/chemistry)
+"aOY" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/west)
 "aPs" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/cult,
@@ -1364,7 +1375,6 @@
 	},
 /area/magmoor/command/office/main)
 "aXZ" = (
-/obj/machinery/vending/hydronutrients,
 /turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "aYh" = (
@@ -1681,6 +1691,10 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/engi/atmos)
+"bfP" = (
+/obj/structure/closet/wardrobe/green,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "bgh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -1983,6 +1997,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival/east)
+"brJ" = (
+/turf/closed/mineral/smooth,
+/area/magmoor/landing)
 "brR" = (
 /obj/machinery/door/window/right{
 	dir = 1;
@@ -2830,6 +2847,13 @@
 /obj/structure/barricade/guardrail,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound)
+"bXD" = (
+/obj/structure/bed/chair/sofa/corsat/verticalsouth{
+	name = "bench"
+	},
+/obj/structure/curtain/open,
+/turf/open/floor/tile/blue/whiteblue,
+/area/magmoor/civilian/clean/shower)
 "bXW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -2841,17 +2865,6 @@
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
-"bYo" = (
-/obj/effect/turf_decal/tile/pink{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/pink,
-/obj/structure/curtain/open,
-/obj/effect/turf_decal/tile/pink{
-	dir = 4
-	},
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
 "bYw" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -2884,12 +2897,6 @@
 	dir = 4
 	},
 /area/magmoor/civilian/arrival/east)
-"bZQ" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/magmoor/hydroponics/north)
 "cal" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/mainship/mono,
@@ -3291,9 +3298,9 @@
 	},
 /area/magmoor/research)
 "cnE" = (
-/obj/item/toy/plush/rouny,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound/northeast)
+/obj/item/shard,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/magmoor/compound/west)
 "cnM" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -3612,10 +3619,6 @@
 /obj/item/shard,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
-"cAc" = (
-/obj/item/shard,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/magmoor/compound/west)
 "cAl" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -3927,8 +3930,9 @@
 /turf/open/floor/freezer,
 /area/magmoor/civilian/bar)
 "cOn" = (
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "cOr" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -4051,6 +4055,20 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/magmoor/security/lobby)
+"cTd" = (
+/obj/structure/mirror{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "cTq" = (
 /obj/machinery/vending/hydroseeds,
 /obj/machinery/light{
@@ -5216,9 +5234,10 @@
 /turf/open/floor/plating,
 /area/magmoor/civilian/jani)
 "dGH" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/mainship/cargo,
-/area/magmoor/landing)
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/command/office/main)
 "dGL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -5343,10 +5362,6 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/storage)
-"dKQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/freezer,
-/area/magmoor/civilian/clean/toilet)
 "dLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -5961,6 +5976,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
+"elf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/green/full,
+/area/magmoor/hydroponics/south)
 "elL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6481,6 +6500,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"eCQ" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
+/area/magmoor/civilian/rnr)
 "eDc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -7128,10 +7155,10 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
 "eYO" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/engi/atmos)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/closet/crate/internals,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "eYR" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7263,12 +7290,6 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/carpet,
 /area/magmoor/command/office/main)
-"ffc" = (
-/obj/structure/curtain/open,
-/turf/open/floor/tile/blue/whiteblue{
-	dir = 10
-	},
-/area/magmoor/civilian/clean/shower)
 "ffk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7306,6 +7327,13 @@
 /obj/structure/cable,
 /turf/open/lavaland/catwalk,
 /area/magmoor/compound/southwest)
+"ffZ" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/magmoor/civilian/clean/shower)
 "fge" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating/icefloor/warnplate{
@@ -7483,15 +7511,6 @@
 	dir = 8
 	},
 /area/magmoor/hydroponics/south)
-"fni" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/bed/chair/sofa/corsat/verticaltop{
-	name = "bench"
-	},
-/turf/open/floor/tile/blue/whiteblue{
-	dir = 1
-	},
-/area/magmoor/civilian/clean/shower)
 "fnF" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin{
@@ -8553,14 +8572,6 @@
 	dir = 1
 	},
 /area/magmoor/civilian/arrival)
-"gbg" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/turf/open/floor/mainship/green{
-	dir = 1
-	},
-/area/magmoor/civilian/rnr)
 "gbk" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/mainship/mono,
@@ -9213,6 +9224,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"gAb" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "gAc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9410,6 +9428,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
+"gGS" = (
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "gHw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -9617,11 +9639,6 @@
 "gRT" = (
 /turf/closed/wall,
 /area/magmoor/civilian/dorms)
-"gRY" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/northwest)
 "gSG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -9743,12 +9760,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/southeast)
-"gXP" = (
-/obj/structure/flora/pottedplant/ten,
-/turf/open/floor/tile/blue/whiteblue{
-	dir = 9
-	},
-/area/magmoor/civilian/clean/shower)
 "gYy" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark2,
@@ -9784,6 +9795,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/landing)
+"hby" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "hbM" = (
 /obj/structure/table/mainship,
 /obj/item/healthanalyzer,
@@ -9823,8 +9839,11 @@
 /turf/open/floor/tile/arrival,
 /area/magmoor/civilian/pool)
 "hec" = (
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/landing)
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "hed" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/red/full,
@@ -9851,6 +9870,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange/corner,
 /area/magmoor/engi)
+"heD" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "heH" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -9964,12 +9991,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing/two)
-"hjU" = (
-/obj/structure/cable,
-/turf/open/floor/tile/blue/whitebluecorner{
-	dir = 4
-	},
-/area/magmoor/civilian/clean/shower)
 "hjW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -9994,6 +10015,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
+"hkL" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "hli" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side,
@@ -10221,12 +10249,6 @@
 	dir = 8
 	},
 /area/magmoor/compound/north)
-"htH" = (
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/magmoor/medical/treatment)
 "htR" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -10236,10 +10258,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
-"hus" = (
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/mainship/cargo,
-/area/magmoor/landing)
 "huv" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/donkpockets,
@@ -10912,10 +10930,12 @@
 	},
 /area/magmoor/research/rnd/lobby)
 "hXt" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whiteblue{
-	dir = 5
+	dir = 9
 	},
 /area/magmoor/civilian/clean/shower)
 "hXu" = (
@@ -11028,20 +11048,11 @@
 	},
 /area/magmoor/compound/east)
 "ibo" = (
-/obj/machinery/alarm{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/corsat/verticalsouth{
-	name = "bench"
-	},
-/obj/effect/turf_decal/tile/pink{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/pink{
-	dir = 4
-	},
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
+/area/magmoor/compound/southwest)
 "ibz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11080,11 +11091,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/patient)
-"idb" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/command/office/main)
 "idd" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -12067,6 +12073,21 @@
 	dir = 1
 	},
 /area/magmoor/compound/east)
+"iPj" = (
+/obj/machinery/alarm{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/corsat/verticalsouth{
+	name = "bench"
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "iPm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12428,13 +12449,6 @@
 	dir = 4
 	},
 /area/magmoor/command/commandroom)
-"jez" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/mainship,
-/area/magmoor/landing)
 "jeI" = (
 /obj/structure/sign/greencross,
 /turf/open/floor/mainship/sterile/dark,
@@ -12562,11 +12576,6 @@
 "jib" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/medical/treatment)
-"jin" = (
-/turf/open/floor/tile/blue/whitebluecorner{
-	dir = 1
-	},
-/area/magmoor/civilian/clean/shower)
 "jio" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes{
@@ -13342,9 +13351,14 @@
 	},
 /area/magmoor/engi/power)
 "jIr" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/west)
+/obj/machinery/power/apc/drained,
+/obj/structure/bed/chair/sofa/corsat/verticaltop{
+	name = "bench"
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/magmoor/civilian/clean/shower)
 "jIy" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light/small{
@@ -13606,13 +13620,6 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound)
-"jRw" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/magmoor/landing)
 "jRL" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
@@ -14269,11 +14276,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/magmoor/civilian/cook)
-"kpC" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/hydroponics/south)
 "kpH" = (
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/storage)
@@ -14408,6 +14410,11 @@
 "kxl" = (
 /turf/open/floor/mainship/mono,
 /area/magmoor/research/rnd/lobby)
+"kxm" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/medical/treatment)
 "kxn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -14880,6 +14887,10 @@
 	dir = 8
 	},
 /area/magmoor/civilian/clean/shower)
+"kOh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "kOi" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -15159,6 +15170,10 @@
 	dir = 5
 	},
 /area/magmoor/compound/east)
+"kWY" = (
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "kXi" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -16710,6 +16725,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/rnd)
+"mfG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/magmoor/civilian/clean/toilet)
 "mfM" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -16886,16 +16905,13 @@
 	dir = 1
 	},
 /area/magmoor/mining)
-"moI" = (
-/obj/effect/turf_decal/tile/pink{
+"moJ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
-"moJ" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship,
 /area/magmoor/landing)
 "mpa" = (
 /obj/effect/landmark/weed_node,
@@ -17126,6 +17142,12 @@
 /obj/item/reagent_containers/food/snacks/waffles,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
+"mAK" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/bag/plants,
+/obj/machinery/light,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "mBf" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/cult,
@@ -17793,6 +17815,10 @@
 	dir = 4
 	},
 /area/magmoor/research/rnd/lobby)
+"mZA" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "mZS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -18047,9 +18073,10 @@
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/thermal)
 "njG" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound)
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/command/lobby)
 "nka" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -18134,6 +18161,10 @@
 	dir = 8
 	},
 /area/magmoor/compound)
+"noa" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "noo" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -18195,9 +18226,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/surgery)
-"npN" = (
-/turf/closed/mineral/smooth/outdoor,
-/area/magmoor/cave/rock)
 "npQ" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -18287,10 +18315,12 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/north)
 "ntN" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/mining)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "ntR" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/dice,
@@ -19867,8 +19897,10 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
 "oEu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/bar,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluecorner{
+	dir = 4
+	},
 /area/magmoor/civilian/clean/shower)
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20238,18 +20270,10 @@
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
 "oRf" = (
-/obj/structure/mirror{
-	dir = 4
+/obj/structure/curtain/open,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/pink{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/pink,
-/obj/effect/turf_decal/tile/pink{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "oRi" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -20288,6 +20312,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/rnd)
+"oRO" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/medical/chemistry)
 "oRP" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 4
@@ -21259,6 +21288,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/magmoor/mining/garage)
+"pBo" = (
+/obj/structure/flora/pottedplant/ten,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 9
+	},
+/area/magmoor/civilian/clean/shower)
 "pBN" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
@@ -21325,14 +21360,8 @@
 	},
 /area/magmoor/engi/thermal)
 "pDq" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/blue/whiteblue{
-	dir = 9
-	},
-/area/magmoor/civilian/clean/shower)
+/turf/closed/mineral/smooth/outdoor,
+/area/magmoor/cave/rock)
 "pDs" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -21344,10 +21373,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/purple/taupepurple,
 /area/magmoor/civilian/jani)
-"pEd" = (
-/obj/structure/closet/crate/secure,
-/turf/open/floor/mainship/cargo,
-/area/magmoor/landing)
 "pEf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21841,12 +21866,6 @@
 /obj/item/tool/soap,
 /turf/open/floor/tile/cmo,
 /area/magmoor/security/infocenter)
-"pUV" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/magmoor/compound/southwest)
 "pUZ" = (
 /turf/open/floor/wood,
 /area/magmoor/command/office)
@@ -22118,6 +22137,17 @@
 	dir = 8
 	},
 /area/magmoor/compound)
+"qfJ" = (
+/obj/effect/turf_decal/tile/pink{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/structure/curtain/open,
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "qfR" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -22756,12 +22786,6 @@
 	dir = 8
 	},
 /area/magmoor/compound/southwest)
-"qBo" = (
-/obj/effect/turf_decal/tile/pink{
-	dir = 8
-	},
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
 "qBL" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
@@ -22796,19 +22820,13 @@
 /turf/open/floor/mainship/black,
 /area/magmoor/landing/two)
 "qDY" = (
+/obj/structure/table/woodentable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "qFf" = (
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
-"qFh" = (
-/obj/structure/bed/chair/sofa/corsat/verticalsouth{
-	name = "bench"
-	},
-/obj/structure/curtain/open,
-/turf/open/floor/tile/blue/whiteblue,
-/area/magmoor/civilian/clean/shower)
 "qFr" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
@@ -22946,6 +22964,12 @@
 	},
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/southwest)
+"qLa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/green/full,
+/area/magmoor/hydroponics/south)
 "qLd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23037,6 +23061,10 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/medical/lobby)
+"qPX" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "qPY" = (
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/power)
@@ -23254,12 +23282,6 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
-"qZl" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/bag/plants,
-/obj/machinery/light,
-/turf/open/floor/mainship/floor,
-/area/magmoor/hydroponics/south)
 "rah" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -23611,11 +23633,6 @@
 "roE" = (
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
-"roL" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/medical/treatment)
 "roT" = (
 /obj/structure/flora/pottedplant/one,
 /obj/effect/turf_decal/tile/blue{
@@ -24309,11 +24326,6 @@
 	dir = 1
 	},
 /area/magmoor/civilian/jani)
-"rOW" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/engi/power)
 "rPg" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,
@@ -24790,16 +24802,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/containment)
 "siX" = (
-/obj/structure/bed/chair/sofa/corsat/verticaltop{
-	name = "bench"
-	},
-/obj/effect/turf_decal/tile/pink{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/pink,
-/obj/structure/curtain/open,
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean/shower)
+/obj/structure/closet/crate/secure,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "sjg" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -25049,14 +25054,6 @@
 	dir = 4
 	},
 /area/magmoor/civilian/dorms)
-"sri" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/largecrate/random,
-/turf/open/floor/mainship,
-/area/magmoor/landing)
 "srz" = (
 /obj/structure/stairs{
 	dir = 8
@@ -25563,6 +25560,10 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi/storage)
+"sKZ" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "sLn" = (
 /obj/structure/sink/kitchen{
 	dir = 4
@@ -26672,13 +26673,6 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/civilian/rnr)
-"tBD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/bar,
-/area/magmoor/civilian/clean)
 "tBF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -26788,10 +26782,6 @@
 	dir = 1
 	},
 /area/magmoor/research)
-"tGu" = (
-/obj/structure/closet/wardrobe/green,
-/turf/open/floor/mainship/floor,
-/area/magmoor/hydroponics/south)
 "tGZ" = (
 /turf/closed/mineral/smooth,
 /area/magmoor/compound/west)
@@ -27459,10 +27449,6 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/command/office)
-"udU" = (
-/obj/structure/closet/crate,
-/turf/open/floor/mainship/cargo,
-/area/magmoor/landing)
 "uep" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -27732,6 +27718,11 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/mainship/floor,
 /area/magmoor/mining/storage)
+"ulC" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/mining)
 "umc" = (
 /turf/open/floor/freezer,
 /area/magmoor/civilian/cook)
@@ -27810,11 +27801,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/magmoor/cave/north)
-"uod" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/closet/crate/internals,
-/turf/open/floor/mainship,
-/area/magmoor/landing)
 "uof" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28013,13 +27999,6 @@
 /obj/effect/decal/cleanable/rune,
 /turf/open/floor/cult,
 /area/magmoor/cave/northwest)
-"uwj" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/random,
-/turf/open/floor/mainship,
-/area/magmoor/landing)
 "uwq" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/mainship/orange{
@@ -28464,11 +28443,12 @@
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
 "uLF" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/turf/open/floor/mainship/green,
-/area/magmoor/civilian/rnr)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean)
 "uLZ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering{
 	name = "\improper Engineering Lobby"
@@ -28728,13 +28708,10 @@
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "uVi" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
-/turf/open/floor/wood,
-/area/magmoor/civilian/basket)
+/turf/open/floor/plating,
+/area/magmoor/engi/power)
 "uVj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28865,6 +28842,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/cargo/processing/south)
+"uZA" = (
+/obj/machinery/light,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/magmoor/hydroponics/north)
 "uZI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -29046,6 +29029,11 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
+"vjN" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/engi/atmos)
 "vjP" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -29074,10 +29062,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/research)
-"vlA" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/mainship/cargo,
-/area/magmoor/landing)
 "vlF" = (
 /turf/open/floor/mainship/green{
 	dir = 4
@@ -29822,6 +29806,10 @@
 "vRc" = (
 /turf/open/lavaland/basalt/cave/autosmooth,
 /area/magmoor/cave/north)
+"vRf" = (
+/obj/item/toy/plush/rouny,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/northeast)
 "vRg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -29916,6 +29904,12 @@
 "vTr" = (
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound/east)
+"vTv" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/magmoor/medical/treatment)
 "vTP" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -30021,6 +30015,12 @@
 	dir = 1
 	},
 /area/magmoor/compound/east)
+"vWI" = (
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "vWT" = (
 /turf/open/floor/tile/chapel{
 	dir = 8
@@ -30284,6 +30284,11 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/magmoor/medical/lobby)
+"wgR" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/hydroponics/south)
 "whR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/vials,
@@ -30336,6 +30341,10 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/magmoor/civilian/cook)
+"wlj" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound)
 "wlF" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
@@ -30361,10 +30370,10 @@
 	},
 /area/magmoor/civilian/dorms)
 "wlW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/item/shard,
-/turf/open/floor/wood,
-/area/magmoor/civilian/basket)
+/turf/open/floor/tile/blue/whitebluecorner{
+	dir = 1
+	},
+/area/magmoor/civilian/clean/shower)
 "wmc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
@@ -30606,11 +30615,6 @@
 	dir = 9
 	},
 /area/magmoor/medical/treatment)
-"wvt" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/medical/chemistry)
 "wvH" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -31640,10 +31644,8 @@
 /turf/open/floor/cult,
 /area/magmoor/cave/north)
 "xep" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/command/lobby)
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "xeB" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -31763,10 +31765,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange/full,
 /area/magmoor/engi)
-"xih" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/green/full,
-/area/magmoor/hydroponics/south)
 "xij" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32248,6 +32246,11 @@
 	dir = 1
 	},
 /area/magmoor/command/lobby)
+"xwy" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/northwest)
 "xwP" = (
 /obj/structure/lattice,
 /obj/structure/barricade/guardrail,
@@ -32374,10 +32377,6 @@
 	dir = 1
 	},
 /area/magmoor/research)
-"xAb" = (
-/obj/item/shard,
-/turf/open/floor/wood,
-/area/magmoor/civilian/basket)
 "xAo" = (
 /turf/closed/wall,
 /area/magmoor/command/conference)
@@ -32450,12 +32449,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
-"xDd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/green/full,
-/area/magmoor/hydroponics/south)
 "xDq" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32952,6 +32945,12 @@
 /obj/machinery/light,
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
+"xUc" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/mainship/green,
+/area/magmoor/civilian/rnr)
 "xUd" = (
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/southeast)
@@ -33382,10 +33381,6 @@
 	dir = 4
 	},
 /area/magmoor/research/rnd)
-"ykj" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/mainship/floor,
-/area/magmoor/hydroponics/south)
 "ykk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -35394,7 +35389,7 @@ efw
 efw
 efw
 efw
-jIr
+aOY
 aZd
 aZd
 aZd
@@ -35627,7 +35622,7 @@ efw
 efw
 efw
 sUk
-jIr
+aOY
 aZd
 aZd
 jHZ
@@ -38647,7 +38642,7 @@ rxl
 efw
 efw
 sUk
-gRY
+xwy
 sUk
 efw
 vgf
@@ -41269,11 +41264,11 @@ dff
 ybU
 ygU
 ybU
-kpC
-aLv
+wgR
+qDY
 xTu
 xTu
-aLv
+qDY
 fme
 loS
 fOS
@@ -41284,8 +41279,8 @@ aRq
 lCK
 lCK
 lCK
-gbg
-uLF
+eCQ
+xUc
 lCK
 tPJ
 lCK
@@ -41503,10 +41498,10 @@ ybU
 ybU
 ybU
 fme
-aXZ
+cOn
 xTu
-xih
-tGu
+elf
+bfP
 fme
 vrl
 xQq
@@ -41736,10 +41731,10 @@ dff
 wwE
 dff
 fme
-tGu
+bfP
 xTu
 xTu
-aLv
+qDY
 fme
 vrl
 paQ
@@ -42433,7 +42428,7 @@ jMC
 dff
 tkJ
 cbr
-bZQ
+uZA
 fme
 tuv
 pkr
@@ -42668,15 +42663,15 @@ dff
 tEv
 dff
 fme
-qDY
+aXZ
+xTu
+aXZ
+xTu
+aXZ
+xTu
+aXZ
 xTu
 qDY
-xTu
-qDY
-xTu
-qDY
-xTu
-aLv
 bVz
 lCK
 lCK
@@ -42909,7 +42904,7 @@ ioE
 xTu
 ioE
 xTu
-qZl
+mAK
 bVz
 liW
 lCK
@@ -43134,15 +43129,15 @@ ugf
 xkI
 ybU
 oin
-qDY
-xih
-qDY
+aXZ
+elf
+aXZ
+xTu
+aXZ
+elf
+aXZ
 xTu
 qDY
-xih
-qDY
-xTu
-aLv
 bVz
 sPr
 lCK
@@ -43205,9 +43200,9 @@ ubz
 dTv
 dTv
 dTv
-vlA
-pEd
-pEd
+mZA
+siX
+siX
 dTv
 xpk
 xpk
@@ -43320,7 +43315,7 @@ waq
 xPH
 cZf
 alG
-xep
+njG
 waq
 waq
 fCK
@@ -43370,12 +43365,12 @@ fme
 wbx
 xTu
 ioE
-xDd
+qLa
 ioE
 xTu
 ioE
 xTu
-qDY
+aXZ
 bVz
 lCK
 lCK
@@ -43416,7 +43411,7 @@ rgm
 rgm
 tTU
 xJL
-hec
+rxl
 bss
 qys
 nlP
@@ -43608,7 +43603,7 @@ eXi
 eXi
 eXi
 fme
-ykj
+sKZ
 bVz
 aRq
 lCK
@@ -43649,7 +43644,7 @@ lWM
 lWM
 lWM
 vSq
-moJ
+rxl
 bss
 qys
 nlP
@@ -44071,7 +44066,7 @@ nHa
 ovw
 vtn
 aBX
-uVi
+heD
 gJr
 rkV
 eXi
@@ -44304,7 +44299,7 @@ dVo
 kRf
 dVo
 dVo
-uVi
+heD
 wEQ
 uDZ
 eXi
@@ -44586,8 +44581,8 @@ xxY
 nlP
 nlP
 bss
-uwj
-jRw
+gAb
+ntN
 dTv
 mub
 dzo
@@ -44770,7 +44765,7 @@ dVo
 aBX
 dVo
 dVo
-wlW
+hby
 ogV
 oQt
 xBX
@@ -44819,8 +44814,8 @@ bss
 mFY
 nlP
 bss
-udU
-uod
+noa
+eYO
 dTv
 jET
 dzo
@@ -45052,8 +45047,8 @@ xxY
 nlP
 nlP
 bss
-jez
-sri
+hkL
+moJ
 dTv
 cky
 dzo
@@ -45176,7 +45171,7 @@ vyy
 iks
 lqI
 oPq
-xep
+njG
 eyC
 cIn
 suu
@@ -45386,7 +45381,7 @@ lIq
 oRH
 dRi
 dzU
-ntN
+ulC
 xjJ
 gjk
 wFA
@@ -45461,7 +45456,7 @@ kmc
 mhS
 ygU
 bGe
-cAc
+cnE
 nHf
 cao
 dVo
@@ -45699,7 +45694,7 @@ eXi
 cao
 vVM
 lBX
-xAb
+kWY
 dVo
 dVo
 eNz
@@ -45933,9 +45928,9 @@ tXn
 dVo
 dVo
 dVo
-xAb
+kWY
 dVo
-wlW
+hby
 uHN
 uGZ
 eXi
@@ -46401,7 +46396,7 @@ dVo
 dVo
 dVo
 dVo
-uVi
+heD
 nrP
 wIH
 nrP
@@ -46467,9 +46462,9 @@ ubz
 dTv
 dTv
 dTv
-hus
-vlA
-dGH
+gGS
+mZA
+qPX
 dTv
 xpk
 xpk
@@ -47746,7 +47741,7 @@ dXE
 oZh
 oZh
 oZh
-idb
+dGH
 oZh
 oZh
 oZh
@@ -47858,7 +47853,7 @@ mTT
 mTT
 wvH
 yhV
-mTT
+brJ
 rxl
 rxl
 iLH
@@ -48076,19 +48071,19 @@ kVV
 mQq
 hxc
 tpI
-pUV
-pUV
-pUV
-pUV
-pUV
-pUV
-pUV
-pUV
+ibo
+ibo
+ibo
+ibo
+ibo
+ibo
+ibo
+ibo
 auF
 gvY
-pUV
-pUV
-pUV
+ibo
+ibo
+ibo
 auF
 ksJ
 amb
@@ -48180,7 +48175,7 @@ xeB
 xeB
 tMF
 xeB
-ntN
+ulC
 tMF
 tMF
 kcd
@@ -50355,8 +50350,8 @@ hIT
 jiE
 jiE
 jiE
-gXP
-oEu
+pBo
+kOh
 lKI
 jiE
 jiE
@@ -50586,13 +50581,13 @@ lGN
 xmr
 hIT
 jiE
-pDq
-ffc
-jin
-cOn
-moI
-bYo
+hXt
 oRf
+wlW
+xep
+vWI
+qfJ
+cTd
 jiE
 teP
 hIT
@@ -50819,13 +50814,13 @@ lGN
 xmr
 hIT
 jiE
-fni
-qFh
-cOn
-cOn
-cOn
-siX
-ibo
+jIr
+bXD
+xep
+xep
+xep
+aLv
+iPj
 jiE
 rjq
 hIT
@@ -51052,11 +51047,11 @@ lGN
 xmr
 hIT
 jiE
-hXt
+ffZ
 oXY
-hjU
+oEu
 amG
-qBo
+hec
 bNi
 iBd
 jiE
@@ -51992,7 +51987,7 @@ qiK
 vqd
 ivO
 jiE
-njG
+wlj
 ghU
 aje
 hIT
@@ -52369,7 +52364,7 @@ ymj
 xmI
 xmI
 nAP
-rOW
+uVi
 xmI
 xmI
 rxl
@@ -52832,7 +52827,7 @@ xRm
 oMg
 oMg
 bVQ
-rOW
+uVi
 tzc
 oEg
 hLK
@@ -53619,7 +53614,7 @@ eOl
 oRs
 klO
 oJc
-tBD
+uLF
 pty
 baY
 eNd
@@ -54549,7 +54544,7 @@ hIT
 obe
 spB
 sMK
-dKQ
+mfG
 pqc
 vcR
 sMK
@@ -55395,7 +55390,7 @@ ymj
 rJy
 oMg
 oMg
-rOW
+uVi
 kJE
 mwM
 leV
@@ -55947,7 +55942,7 @@ hIT
 obe
 vne
 sMK
-dKQ
+mfG
 tHo
 bdC
 sMK
@@ -57529,8 +57524,8 @@ ymj
 ymj
 ymj
 xrM
-npN
-npN
+pDq
+pDq
 xrM
 xrM
 xrM
@@ -59166,7 +59161,7 @@ dSo
 teT
 teT
 ikv
-eYO
+vjN
 ikv
 teT
 bvx
@@ -61507,7 +61502,7 @@ iCL
 twY
 vwH
 tLS
-eYO
+vjN
 uca
 dBh
 usz
@@ -62427,14 +62422,14 @@ lqI
 dXE
 teT
 teT
-eYO
-eYO
+vjN
+vjN
 ikv
 teT
 teT
 teT
 ikv
-eYO
+vjN
 ikv
 teT
 teT
@@ -64289,7 +64284,7 @@ wUY
 trh
 oGw
 dSo
-wvt
+oRO
 sBF
 ihH
 kAT
@@ -64309,7 +64304,7 @@ bvE
 uzX
 jib
 jib
-roL
+kxm
 ebh
 jib
 jib
@@ -65948,7 +65943,7 @@ okn
 itH
 vsW
 byE
-htH
+vTv
 pmk
 fdu
 fdu
@@ -68712,7 +68707,7 @@ rxl
 rxl
 rxl
 fJO
-cnE
+vRf
 fJO
 fJO
 rxl

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -556,7 +556,7 @@
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/magmoor/compound/west)
+/area/magmoor/hydroponics/north)
 "auv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1829,10 +1829,6 @@
 	dir = 1
 	},
 /area/magmoor/civilian/dorms)
-"blx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/magmoor/compound/east)
 "bly" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2673,8 +2669,7 @@
 	},
 /area/magmoor/compound/southwest)
 "bOI" = (
-/obj/structure/table/mainship,
-/obj/item/cell/super/empty,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/mainship/purple{
 	dir = 9
 	},
@@ -7245,7 +7240,7 @@
 /turf/closed/wall/r_wall,
 /area/magmoor/research/containment)
 "feR" = (
-/obj/structure/table/mainship,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/carpet,
 /area/magmoor/command/office/main)
 "ffk" = (
@@ -13826,7 +13821,7 @@
 	dir = 8
 	},
 /obj/structure/table/mainship,
-/obj/structure/nuke_disk_candidate,
+/obj/machinery/computer/med_data/laptop,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/commandroom)
 "kdc" = (
@@ -19025,9 +19020,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/cave/north)
-"ogv" = (
-/turf/open/lavaland/basalt,
-/area/magmoor/compound/southwest)
 "ogP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -19247,12 +19239,6 @@
 	dir = 8
 	},
 /area/magmoor/civilian/cryostasis)
-"oog" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/magmoor/compound/northeast)
 "opb" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -20879,7 +20865,7 @@
 "prG" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/magmoor/compound/west)
+/area/magmoor/hydroponics/north)
 "prK" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -21898,9 +21884,10 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/jani)
 "qdo" = (
-/obj/structure/flora/rock/alt3,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound/northeast)
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/northwest)
 "qdB" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -22537,7 +22524,6 @@
 	},
 /area/magmoor/engi/power)
 "qyV" = (
-/obj/machinery/computer/med_data/laptop,
 /obj/structure/table/mainship,
 /turf/open/floor/carpet/side{
 	dir = 1
@@ -26293,21 +26279,19 @@
 	},
 /area/magmoor/engi)
 "tuv" = (
-/obj/machinery/floodlight/colony{
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/mainship/green{
 	dir = 4
 	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/magmoor/compound)
+/area/magmoor/hydroponics/south)
 "tuH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/atmos)
 "tva" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/mainship/purple{
-	dir = 4
-	},
-/area/magmoor/research/rnd/lobby)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/magmoor/hydroponics/north)
 "tvj" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
@@ -29338,11 +29322,10 @@
 	},
 /area/magmoor/compound)
 "vGw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/magmoor/compound/north)
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/northeast)
 "vHe" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -34425,7 +34408,7 @@ efw
 efw
 efw
 efw
-efw
+tmo
 efw
 efw
 efw
@@ -34658,7 +34641,7 @@ efw
 efw
 efw
 efw
-efw
+sUk
 lfn
 efw
 efw
@@ -34891,8 +34874,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -35124,7 +35107,7 @@ efw
 efw
 qDf
 efw
-efw
+sUk
 efw
 efw
 efw
@@ -35357,7 +35340,7 @@ rxl
 rxl
 rxl
 wRt
-efw
+tmo
 efw
 efw
 efw
@@ -35596,8 +35579,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 lfn
 efw
@@ -35824,13 +35807,13 @@ rxl
 rxl
 rxl
 rxl
-efw
+lfn
 efw
 efw
 efw
 lfn
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -36059,13 +36042,13 @@ rxl
 rxl
 efw
 efw
+sUk
 efw
 efw
 efw
 efw
 efw
-efw
-efw
+sUk
 efw
 efw
 efw
@@ -36291,15 +36274,15 @@ rxl
 rxl
 rxl
 efw
-lfn
+sUk
+sUk
+sUk
 efw
 efw
 efw
-efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+sUk
 efw
 efw
 lfn
@@ -36525,13 +36508,13 @@ rxl
 rxl
 efw
 efw
-efw
-efw
-efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+tmo
+tmo
+tmo
+sUk
+sUk
 efw
 efw
 efw
@@ -36759,11 +36742,11 @@ rxl
 rxl
 efw
 efw
+tmo
 efw
 efw
-lfn
 efw
-efw
+tmo
 efw
 lfn
 efw
@@ -36990,13 +36973,13 @@ rxl
 rxl
 rxl
 rxl
+lfn
 efw
+tmo
 efw
+lfn
 efw
-efw
-efw
-efw
-efw
+tmo
 efw
 efw
 efw
@@ -37224,12 +37207,12 @@ rxl
 rxl
 efw
 efw
-lfn
+efw
+tmo
 efw
 efw
 efw
-efw
-efw
+tmo
 efw
 efw
 efw
@@ -37457,13 +37440,13 @@ rxl
 rxl
 efw
 efw
-efw
-efw
-efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+aMi
+tmo
+tmo
+sUk
+sUk
 efw
 efw
 efw
@@ -37689,15 +37672,15 @@ efw
 efw
 lfn
 efw
+sUk
+sUk
+hko
 efw
 efw
 efw
-efw
-efw
-lfn
-efw
-efw
-efw
+sUk
+sUk
+sUk
 efw
 wRt
 rxl
@@ -37928,7 +37911,7 @@ efw
 efw
 efw
 efw
-efw
+tmo
 efw
 efw
 qDf
@@ -38161,7 +38144,7 @@ efw
 efw
 efw
 efw
-qDf
+qdo
 efw
 qDf
 rxl
@@ -38387,14 +38370,14 @@ efw
 efw
 efw
 efw
+sUk
+sUk
 efw
 efw
 efw
-efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+sUk
 efw
 efw
 rxl
@@ -38619,14 +38602,14 @@ rxl
 rxl
 rxl
 efw
+sUk
+sUk
+sUk
 efw
 efw
 efw
 efw
-efw
-efw
-efw
-efw
+sUk
 lfn
 efw
 rxl
@@ -38853,11 +38836,11 @@ rxl
 rxl
 efw
 lfn
+sUk
 efw
 efw
-efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -38891,7 +38874,7 @@ ojW
 dPK
 mOt
 mOt
-mOt
+syO
 mOt
 mOt
 dPK
@@ -39088,10 +39071,10 @@ efw
 efw
 efw
 efw
-efw
-efw
-lfn
-efw
+sUk
+sUk
+evv
+sUk
 efw
 efw
 rxl
@@ -39322,8 +39305,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -39625,7 +39608,7 @@ dRz
 vzO
 dff
 auq
-ybU
+tva
 prG
 dff
 ybU
@@ -39659,7 +39642,7 @@ xMO
 kvI
 kvI
 kvI
-ogv
+wXM
 rgm
 rgm
 rgm
@@ -39837,9 +39820,9 @@ ncw
 aap
 ibO
 dze
-dze
-dze
-dze
+sdX
+sdX
+sdX
 dze
 dze
 dze
@@ -40071,10 +40054,10 @@ aap
 dze
 dze
 dze
-dze
-dze
-ibO
-dze
+sdX
+sdX
+sdX
+sdX
 dze
 dze
 dze
@@ -40304,10 +40287,10 @@ aap
 dze
 dze
 ibO
-dze
-dze
-dze
-dze
+sdX
+sdX
+sdX
+sdX
 dze
 dze
 sdX
@@ -40538,8 +40521,8 @@ dze
 dze
 dze
 dze
-dze
-dze
+sdX
+sdX
 dze
 dze
 dze
@@ -41474,8 +41457,8 @@ ibO
 dze
 dze
 dze
-dze
-dze
+sdX
+sdX
 ibO
 dze
 yge
@@ -41706,9 +41689,9 @@ dze
 dze
 dze
 dze
-dze
-dze
-dze
+sdX
+sdX
+sdX
 dze
 yge
 yge
@@ -41938,9 +41921,9 @@ dze
 dze
 dze
 dze
-dze
-dze
-dze
+sdX
+sdX
+sdX
 dze
 dze
 yge
@@ -42171,9 +42154,9 @@ dze
 dze
 dze
 dze
-dze
-dze
-ibO
+sdX
+sdX
+sdX
 dze
 dze
 yge
@@ -42196,7 +42179,7 @@ tkJ
 cbr
 cbr
 fme
-pkr
+tuv
 pkr
 pkr
 pkr
@@ -42404,8 +42387,8 @@ dze
 dze
 afn
 dze
-dze
-dze
+sdX
+sdX
 dze
 dze
 yge
@@ -42635,7 +42618,7 @@ dze
 dze
 dze
 dze
-dze
+sdX
 dze
 dze
 dze
@@ -42868,9 +42851,9 @@ dze
 ibO
 dze
 dze
-dze
-dze
-dze
+sdX
+sdX
+sdX
 dze
 dze
 yge
@@ -43102,7 +43085,7 @@ tWr
 tWr
 dze
 dze
-dze
+sdX
 dze
 ibO
 dze
@@ -47026,8 +47009,8 @@ xfT
 lqI
 lqI
 lqI
-kns
-kns
+lqI
+lqI
 dXE
 lQy
 vyy
@@ -47258,8 +47241,8 @@ xfT
 xfT
 lqI
 lqI
-kns
-kns
+lqI
+lqI
 lqI
 dXE
 lQy
@@ -47491,7 +47474,7 @@ xfT
 lqI
 oPq
 lqI
-kns
+lqI
 lqI
 oPq
 dXE
@@ -49401,7 +49384,7 @@ sBQ
 hIT
 sgB
 hiG
-vFy
+oTR
 syD
 syD
 vFy
@@ -49633,9 +49616,9 @@ uNc
 klj
 hIT
 pKb
-bgh
-vFy
-vFy
+oTR
+oTR
+oTR
 syD
 vFy
 hiG
@@ -49864,11 +49847,11 @@ rHX
 jGH
 fie
 klj
+aje
 hIT
-tuv
 sgB
 hiG
-vFy
+oTR
 syD
 vFy
 hiG
@@ -50567,7 +50550,7 @@ hiG
 hiG
 hiG
 hiG
-vFy
+oTR
 syD
 vFy
 hiG
@@ -50799,10 +50782,10 @@ hiG
 bgh
 hiG
 hiG
-hiG
-vFy
+oTR
+oTR
 syD
-vFy
+oTR
 hiG
 hiG
 bgh
@@ -51031,12 +51014,12 @@ ppN
 hiG
 hiG
 hiG
-hiG
-hiG
-vFy
+oTR
+oTR
+oTR
 syD
-vFy
-hiG
+oTR
+oTR
 hiG
 hiG
 hiG
@@ -51265,10 +51248,10 @@ hiG
 hiG
 hiG
 hiG
-rSf
-vFy
+oTR
+oTR
 syD
-vFy
+oTR
 hiG
 hiG
 hiG
@@ -51498,7 +51481,7 @@ hiG
 hiG
 hiG
 hiG
-vFy
+oTR
 syD
 syD
 vFy
@@ -51966,7 +51949,7 @@ hiG
 hiG
 vFy
 syD
-vFy
+oTR
 hiG
 hiG
 hiG
@@ -52199,7 +52182,7 @@ hiG
 hiG
 vFy
 syD
-vFy
+oTR
 hiG
 hiG
 hiG
@@ -59108,10 +59091,10 @@ lxN
 kcd
 pUu
 kcd
+sBd
+uUg
 kcd
-kxx
-kcd
-kcd
+rxl
 iXx
 kcd
 kcd
@@ -59189,8 +59172,8 @@ xSa
 xSa
 xSa
 xSa
-vqD
 gmf
+kik
 lbq
 bRC
 bRC
@@ -59341,11 +59324,11 @@ lxN
 kcd
 rxl
 kcd
+sBd
+sBd
 kcd
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
 kcd
 kcd
 kcd
@@ -59422,9 +59405,9 @@ smc
 fkr
 rVx
 xSa
-vqD
-hSF
-cVH
+nRk
+nRk
+nRk
 bRC
 aDQ
 bNJ
@@ -59577,8 +59560,8 @@ kcd
 kcd
 kcd
 kcd
-kcd
-kcd
+rxl
+rxl
 kxx
 kcd
 kcd
@@ -59655,9 +59638,9 @@ jVn
 dAI
 tgW
 xSa
-gmf
-dzM
-blx
+vTr
+vTr
+vTr
 bRC
 mAr
 qyb
@@ -59809,10 +59792,10 @@ rxl
 kxx
 kcd
 kcd
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
+rxl
+rxl
 kcd
 kcd
 kcd
@@ -59888,9 +59871,9 @@ dHs
 jVn
 uca
 xSa
-hSF
-cOx
-cVH
+nRk
+nRk
+nRk
 bVI
 tNJ
 mcA
@@ -60042,11 +60025,11 @@ kcd
 kcd
 kcd
 kcd
-kcd
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
+rxl
+rxl
+rxl
 kcd
 kcd
 kcd
@@ -60121,9 +60104,9 @@ dHs
 oil
 tnm
 xSa
-ubr
+hrp
 odB
-cVH
+cOx
 bRC
 bbL
 bIS
@@ -60271,16 +60254,16 @@ lxN
 lxN
 lxN
 kcd
+sBd
+sBd
 kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
+rxl
+rxl
+rxl
+rxl
+rxl
 kxx
 kcd
 kcd
@@ -60500,20 +60483,20 @@ kcd
 kcd
 kcd
 kxx
+sBd
+sBd
 kcd
 kcd
+sBd
+sBd
 kcd
 kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kxx
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
+rxl
+rxl
+rxl
+rxl
 kcd
 kcd
 kcd
@@ -60549,9 +60532,9 @@ rex
 uiL
 ikG
 weQ
-weQ
-xrM
-weQ
+iMG
+fVX
+liV
 teT
 bqT
 syA
@@ -60733,6 +60716,8 @@ kcd
 kcd
 kcd
 kcd
+sBd
+sBd
 kcd
 kcd
 kcd
@@ -60740,12 +60725,10 @@ kcd
 kcd
 kcd
 kcd
-kcd
-kcd
-kcd
-kcd
-kcd
-kcd
+rxl
+rxl
+rxl
+rxl
 kcd
 kcd
 kcd
@@ -60994,7 +60977,7 @@ kcd
 kcd
 kcd
 vRc
-ymj
+rxl
 ymj
 ymj
 xfT
@@ -61201,8 +61184,8 @@ kcd
 kcd
 kcd
 kcd
-kcd
-kcd
+sBd
+sBd
 kcd
 iXx
 kcd
@@ -61226,9 +61209,9 @@ kcd
 kcd
 kcd
 kcd
-vRc
-vRc
-ymj
+kcd
+rxl
+rxl
 ymj
 ymj
 xfT
@@ -61433,10 +61416,10 @@ rxl
 kcd
 kcd
 kcd
-kxx
-kcd
-kcd
-kcd
+uUg
+sBd
+sBd
+sBd
 kcd
 gxO
 cjN
@@ -61460,8 +61443,8 @@ lQv
 rju
 gwq
 kxx
-vRc
-vRc
+rxl
+rxl
 ymj
 ymj
 ymj
@@ -61666,10 +61649,10 @@ rxl
 rxl
 kcd
 kcd
-kcd
-kcd
-kcd
-kcd
+sBd
+sBd
+sBd
+sBd
 kcd
 pPr
 qcl
@@ -61693,9 +61676,9 @@ nKb
 dqE
 hrd
 kcd
-kcd
-vRc
-vRc
+rxl
+rxl
+rxl
 ymj
 ymj
 ymj
@@ -61900,8 +61883,8 @@ rxl
 kcd
 kcd
 kcd
-kcd
-kcd
+sBd
+sBd
 kcd
 kcd
 pPr
@@ -61927,9 +61910,9 @@ rnV
 hrd
 kcd
 kcd
-kcd
-vRc
-vRc
+rxl
+rxl
+rxl
 ymj
 uDn
 uDn
@@ -62424,9 +62407,9 @@ iyf
 iyf
 iyf
 iyf
-xfT
-iqO
-xfT
+lqI
+lqI
+lqI
 lqI
 dXE
 dSo
@@ -62658,7 +62641,7 @@ qHR
 lIB
 qHR
 qHR
-fVX
+qHR
 qHR
 lIB
 iXj
@@ -62891,7 +62874,7 @@ ctx
 ctx
 ctx
 ctx
-vGw
+ctx
 ctx
 ctx
 ctx
@@ -63123,9 +63106,9 @@ bQv
 bQv
 bQv
 iKT
-vBZ
-ruy
-xfT
+oPq
+lqI
+lqI
 bJU
 dSo
 cRP
@@ -65400,7 +65383,7 @@ nYo
 kxl
 roZ
 ksw
-tva
+cNI
 dhY
 cNI
 kxl
@@ -68730,7 +68713,7 @@ qFr
 ufp
 bLZ
 pVy
-oog
+pVy
 cFo
 rxl
 rxl
@@ -68962,8 +68945,8 @@ qFr
 hua
 oCh
 bLZ
-cDl
 fJO
+cDl
 fJO
 fJO
 rxl
@@ -69195,7 +69178,7 @@ qFr
 qFr
 rCt
 stw
-qyP
+vGw
 fJO
 fJO
 rxl
@@ -72219,7 +72202,7 @@ fJO
 fJO
 qSZ
 lTR
-pLJ
+fJO
 fJO
 fJO
 fJO
@@ -72452,7 +72435,7 @@ fJO
 fJO
 fJO
 lTR
-qdo
+fJO
 qyP
 fJO
 fJO

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1008,9 +1008,8 @@
 	},
 /area/magmoor/landing/two)
 "aLv" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/small,
-/turf/open/floor/grass,
+/obj/structure/table/woodentable,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1365,8 +1364,8 @@
 	},
 /area/magmoor/command/office/main)
 "aXZ" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/open/floor/grass,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "aYh" = (
 /obj/structure/rack,
@@ -2588,12 +2587,15 @@
 	},
 /area/magmoor/research/containment)
 "bNi" = (
-/obj/item/tool/soap,
-/obj/structure/mirror{
-	dir = 4
+/obj/effect/turf_decal/tile/pink{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/pink,
 /obj/structure/curtain/open,
-/turf/open/floor/freezer,
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "bNl" = (
 /obj/effect/ai_node,
@@ -2839,6 +2841,17 @@
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
+"bYo" = (
+/obj/effect/turf_decal/tile/pink{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/structure/curtain/open,
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "bYw" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -2871,6 +2884,12 @@
 	dir = 4
 	},
 /area/magmoor/civilian/arrival/east)
+"bZQ" = (
+/obj/machinery/light,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/magmoor/hydroponics/north)
 "cal" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/mainship/mono,
@@ -3272,11 +3291,9 @@
 	},
 /area/magmoor/research)
 "cnE" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/mainship/orange{
-	dir = 5
-	},
-/area/magmoor/engi)
+/obj/item/toy/plush/rouny,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/northeast)
 "cnM" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -3595,6 +3612,10 @@
 /obj/item/shard,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"cAc" = (
+/obj/item/shard,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/magmoor/compound/west)
 "cAl" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -3906,10 +3927,7 @@
 /turf/open/floor/freezer,
 /area/magmoor/civilian/bar)
 "cOn" = (
-/obj/machinery/alarm{
-	dir = 1
-	},
-/turf/open/floor/freezer,
+/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "cOr" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -4034,11 +4052,11 @@
 /turf/open/floor/plating,
 /area/magmoor/security/lobby)
 "cTq" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/light/small{
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "cTC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4342,7 +4360,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean)
 "dff" = (
@@ -5199,11 +5216,9 @@
 /turf/open/floor/plating,
 /area/magmoor/civilian/jani)
 "dGH" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/magmoor/compound)
+/obj/structure/largecrate/random/case,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "dGL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -5328,6 +5343,10 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/storage)
+"dKQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/magmoor/civilian/clean/toilet)
 "dLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -6638,7 +6657,6 @@
 "eHP" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
 "eIj" = (
@@ -6860,6 +6878,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 1
 	},
@@ -7109,9 +7128,10 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
 "eYO" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/magmoor/compound)
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/engi/atmos)
 "eYR" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7243,6 +7263,12 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/carpet,
 /area/magmoor/command/office/main)
+"ffc" = (
+/obj/structure/curtain/open,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/magmoor/civilian/clean/shower)
 "ffk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7457,6 +7483,15 @@
 	dir = 8
 	},
 /area/magmoor/hydroponics/south)
+"fni" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/bed/chair/sofa/corsat/verticaltop{
+	name = "bench"
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/magmoor/civilian/clean/shower)
 "fnF" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin{
@@ -8235,9 +8270,9 @@
 	},
 /area/magmoor/civilian/mosque)
 "fQW" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/light/small,
-/turf/open/floor/grass,
+/obj/machinery/bioprinter,
+/obj/machinery/light,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "fRs" = (
 /turf/open/floor/mainship/floor,
@@ -8499,8 +8534,8 @@
 /area/magmoor/compound)
 "gaP" = (
 /obj/structure/closet/crate/hydroponics,
-/obj/machinery/light/small,
 /obj/effect/landmark/weed_node,
+/obj/machinery/light,
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
@@ -8518,6 +8553,14 @@
 	dir = 1
 	},
 /area/magmoor/civilian/arrival)
+"gbg" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
+/area/magmoor/civilian/rnr)
 "gbk" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/mainship/mono,
@@ -8661,7 +8704,7 @@
 	},
 /area/magmoor/civilian/clean/shower)
 "ght" = (
-/obj/machinery/vending/engineering,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
@@ -9331,7 +9374,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/machinery/light/small,
 /turf/open/floor/mainship/green,
 /area/magmoor/hydroponics/north)
 "gFV" = (
@@ -9575,6 +9617,11 @@
 "gRT" = (
 /turf/closed/wall,
 /area/magmoor/civilian/dorms)
+"gRY" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/northwest)
 "gSG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -9696,6 +9743,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/southeast)
+"gXP" = (
+/obj/structure/flora/pottedplant/ten,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 9
+	},
+/area/magmoor/civilian/clean/shower)
 "gYy" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark2,
@@ -9911,6 +9964,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing/two)
+"hjU" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluecorner{
+	dir = 4
+	},
+/area/magmoor/civilian/clean/shower)
 "hjW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -10162,6 +10221,12 @@
 	dir = 8
 	},
 /area/magmoor/compound/north)
+"htH" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/magmoor/medical/treatment)
 "htR" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -10171,6 +10236,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
+"hus" = (
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "huv" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/donkpockets,
@@ -10843,13 +10912,11 @@
 	},
 /area/magmoor/research/rnd/lobby)
 "hXt" = (
-/obj/machinery/shower{
-	pixel_y = 15
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
 /area/magmoor/civilian/clean/shower)
 "hXu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -10961,11 +11028,20 @@
 	},
 /area/magmoor/compound/east)
 "ibo" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
+/obj/machinery/alarm{
+	dir = 1
 	},
-/area/magmoor/compound)
+/obj/structure/bed/chair/sofa/corsat/verticalsouth{
+	name = "bench"
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "ibz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11004,6 +11080,11 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/patient)
+"idb" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/command/office/main)
 "idd" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -11322,7 +11403,7 @@
 /area/magmoor/compound/southwest)
 "ioE" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/grass,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "ipd" = (
 /obj/structure/cable,
@@ -11656,13 +11737,16 @@
 	},
 /area/magmoor/research/containment)
 "iBd" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/tile/pink{
 	dir = 1
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pink{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "iBj" = (
 /obj/structure/bed/chair/office/dark{
@@ -12344,6 +12428,13 @@
 	dir = 4
 	},
 /area/magmoor/command/commandroom)
+"jez" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "jeI" = (
 /obj/structure/sign/greencross,
 /turf/open/floor/mainship/sterile/dark,
@@ -12471,6 +12562,11 @@
 "jib" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/medical/treatment)
+"jin" = (
+/turf/open/floor/tile/blue/whitebluecorner{
+	dir = 1
+	},
+/area/magmoor/civilian/clean/shower)
 "jio" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes{
@@ -13246,10 +13342,9 @@
 	},
 /area/magmoor/engi/power)
 "jIr" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/magmoor/landing)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/west)
 "jIy" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light/small{
@@ -13409,7 +13504,7 @@
 	},
 /area/magmoor/civilian/mosque)
 "jMC" = (
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/open/floor/mainship/green{
 	dir = 6
 	},
@@ -13511,6 +13606,13 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound)
+"jRw" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "jRL" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
@@ -14167,6 +14269,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/magmoor/civilian/cook)
+"kpC" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/hydroponics/south)
 "kpH" = (
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/storage)
@@ -14817,6 +14924,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 8
 	},
@@ -15397,7 +15505,7 @@
 /area/magmoor/civilian/cook)
 "llg" = (
 /obj/machinery/bioprinter,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship/green{
@@ -16022,9 +16130,15 @@
 /turf/open/floor/mainship/floor,
 /area/magmoor/research)
 "lKI" = (
-/obj/item/tool/soap,
-/obj/structure/table/mainship,
-/turf/open/floor/freezer,
+/obj/structure/flora/pottedplant/ten,
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pink,
+/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "lKQ" = (
 /obj/effect/landmark/weed_node,
@@ -16772,6 +16886,12 @@
 	dir = 1
 	},
 /area/magmoor/mining)
+"moI" = (
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "moJ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
@@ -17927,10 +18047,9 @@
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/thermal)
 "njG" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/magmoor/compound/west)
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound)
 "nka" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -18076,6 +18195,9 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/surgery)
+"npN" = (
+/turf/closed/mineral/smooth/outdoor,
+/area/magmoor/cave/rock)
 "npQ" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -18165,12 +18287,10 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/north)
 "ntN" = (
-/obj/machinery/floodlight/colony,
-/obj/structure/platform{
-	dir = 15
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/magmoor/compound/west)
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/mining)
 "ntR" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/dice,
@@ -18637,6 +18757,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/thermal)
 "nQO" = (
+/obj/structure/flora/pottedplant/ten,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 10
 	},
@@ -19746,7 +19867,8 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
 "oEu" = (
-/turf/open/floor/freezer,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20116,11 +20238,19 @@
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
 "oRf" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/obj/structure/mirror{
+	dir = 4
 	},
-/area/magmoor/compound)
+/obj/effect/turf_decal/tile/pink{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "oRi" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/cult,
@@ -20294,8 +20424,11 @@
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/treatment)
 "oXY" = (
-/obj/structure/curtain/shower,
-/turf/open/floor/freezer,
+/obj/structure/cable,
+/obj/structure/curtain/open,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 6
+	},
 /area/magmoor/civilian/clean/shower)
 "oYd" = (
 /obj/structure/rack,
@@ -20995,6 +21128,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -21191,10 +21325,14 @@
 	},
 /area/magmoor/engi/thermal)
 "pDq" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/obj/structure/mirror{
+	pixel_y = 28
 	},
-/area/magmoor/landing)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 9
+	},
+/area/magmoor/civilian/clean/shower)
 "pDs" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -21206,6 +21344,10 @@
 /obj/machinery/light,
 /turf/open/floor/tile/purple/taupepurple,
 /area/magmoor/civilian/jani)
+"pEd" = (
+/obj/structure/closet/crate/secure,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "pEf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21681,6 +21823,10 @@
 "pUr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Operating Theatre"
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/surgery)
 "pUu" = (
@@ -21695,6 +21841,12 @@
 /obj/item/tool/soap,
 /turf/open/floor/tile/cmo,
 /area/magmoor/security/infocenter)
+"pUV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/magmoor/compound/southwest)
 "pUZ" = (
 /turf/open/floor/wood,
 /area/magmoor/command/office)
@@ -22604,6 +22756,12 @@
 	dir = 8
 	},
 /area/magmoor/compound/southwest)
+"qBo" = (
+/obj/effect/turf_decal/tile/pink{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "qBL" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
@@ -22638,13 +22796,19 @@
 /turf/open/floor/mainship/black,
 /area/magmoor/landing/two)
 "qDY" = (
-/obj/machinery/light/small,
-/turf/open/floor/grass,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "qFf" = (
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
+"qFh" = (
+/obj/structure/bed/chair/sofa/corsat/verticalsouth{
+	name = "bench"
+	},
+/obj/structure/curtain/open,
+/turf/open/floor/tile/blue/whiteblue,
+/area/magmoor/civilian/clean/shower)
 "qFr" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
@@ -23090,6 +23254,12 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
+"qZl" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/bag/plants,
+/obj/machinery/light,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "rah" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -23441,6 +23611,11 @@
 "roE" = (
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
+"roL" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/medical/treatment)
 "roT" = (
 /obj/structure/flora/pottedplant/one,
 /obj/effect/turf_decal/tile/blue{
@@ -24134,6 +24309,11 @@
 	dir = 1
 	},
 /area/magmoor/civilian/jani)
+"rOW" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/engi/power)
 "rPg" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,
@@ -24610,11 +24790,16 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/containment)
 "siX" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+/obj/structure/bed/chair/sofa/corsat/verticaltop{
+	name = "bench"
 	},
-/area/magmoor/landing)
+/obj/effect/turf_decal/tile/pink{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/pink,
+/obj/structure/curtain/open,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean/shower)
 "sjg" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -24864,6 +25049,14 @@
 	dir = 4
 	},
 /area/magmoor/civilian/dorms)
+"sri" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "srz" = (
 /obj/structure/stairs{
 	dir = 8
@@ -26040,6 +26233,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
 "tkP" = (
@@ -26199,10 +26393,11 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/concrete/edge{
-	dir = 1
+	dir = 8
 	},
 /area/magmoor/compound/southwest)
 "tpM" = (
+/obj/structure/flora/pottedplant/ten,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 9
 	},
@@ -26269,8 +26464,8 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/structure/window/reinforced,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/item/shard,
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
 "ttP" = (
@@ -26477,6 +26672,13 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/civilian/rnr)
+"tBD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/magmoor/civilian/clean)
 "tBF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -26586,6 +26788,10 @@
 	dir = 1
 	},
 /area/magmoor/research)
+"tGu" = (
+/obj/structure/closet/wardrobe/green,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "tGZ" = (
 /turf/closed/mineral/smooth,
 /area/magmoor/compound/west)
@@ -27253,6 +27459,10 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/command/office)
+"udU" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "uep" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -27600,6 +27810,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/magmoor/cave/north)
+"uod" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/closet/crate/internals,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "uof" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27798,6 +28013,13 @@
 /obj/effect/decal/cleanable/rune,
 /turf/open/floor/cult,
 /area/magmoor/cave/northwest)
+"uwj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship,
+/area/magmoor/landing)
 "uwq" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/mainship/orange{
@@ -27895,6 +28117,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Operating Theatre"
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/magmoor/medical/surgery)
@@ -28239,11 +28464,11 @@
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
 "uLF" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
+/obj/structure/barricade/wooden{
+	dir = 8
 	},
-/area/magmoor/landing)
+/turf/open/floor/mainship/green,
+/area/magmoor/civilian/rnr)
 "uLZ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering{
 	name = "\improper Engineering Lobby"
@@ -28503,10 +28728,13 @@
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "uVi" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/area/magmoor/landing)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "uVj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28529,7 +28757,7 @@
 /area/magmoor/compound/southeast)
 "uVx" = (
 /obj/machinery/vending/hydronutrients,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship/green{
@@ -28846,6 +29074,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/research)
+"vlA" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/landing)
 "vlF" = (
 /turf/open/floor/mainship/green{
 	dir = 4
@@ -29884,10 +30116,10 @@
 /area/magmoor/cave/north)
 "wbx" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
 "wby" = (
 /turf/open/floor/mainship/orange{
@@ -30129,9 +30361,10 @@
 	},
 /area/magmoor/civilian/dorms)
 "wlW" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/dark,
-/area/magmoor/medical/treatment)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "wmc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
@@ -30373,6 +30606,11 @@
 	dir = 9
 	},
 /area/magmoor/medical/treatment)
+"wvt" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/medical/chemistry)
 "wvH" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -30648,6 +30886,9 @@
 "wEn" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mainship/green{
 	dir = 8
@@ -31399,13 +31640,10 @@
 /turf/open/floor/cult,
 /area/magmoor/cave/north)
 "xep" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/freezer,
-/area/magmoor/civilian/clean/shower)
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/command/lobby)
 "xeB" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -31525,6 +31763,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange/full,
 /area/magmoor/engi)
+"xih" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/green/full,
+/area/magmoor/hydroponics/south)
 "xij" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32022,6 +32264,7 @@
 /area/magmoor/security/storage)
 "xxj" = (
 /obj/structure/closet/crate/radiation,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 1
 	},
@@ -32131,6 +32374,10 @@
 	dir = 1
 	},
 /area/magmoor/research)
+"xAb" = (
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/magmoor/civilian/basket)
 "xAo" = (
 /turf/closed/wall,
 /area/magmoor/command/conference)
@@ -32203,6 +32450,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
+"xDd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/green/full,
+/area/magmoor/hydroponics/south)
 "xDq" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32678,8 +32931,7 @@
 /turf/open/floor/mainship/sterile/purple/side,
 /area/magmoor/research/containment)
 "xTu" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
+/turf/open/floor/mainship/green/full,
 /area/magmoor/hydroponics/south)
 "xTE" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -33130,6 +33382,10 @@
 	dir = 4
 	},
 /area/magmoor/research/rnd)
+"ykj" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/mainship/floor,
+/area/magmoor/hydroponics/south)
 "ykk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34433,8 +34689,8 @@ rxl
 rxl
 efw
 efw
-lfn
-efw
+evv
+sUk
 efw
 efw
 rxl
@@ -34665,10 +34921,10 @@ rxl
 rxl
 efw
 efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+sUk
+sUk
 efw
 efw
 efw
@@ -34899,8 +35155,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 rxl
@@ -35127,8 +35383,8 @@ rxl
 rxl
 lfn
 efw
-efw
-efw
+sUk
+sUk
 lfn
 efw
 efw
@@ -35138,7 +35394,7 @@ efw
 efw
 efw
 efw
-aZd
+jIr
 aZd
 aZd
 aZd
@@ -35370,8 +35626,8 @@ qDf
 efw
 efw
 efw
-efw
-aZd
+sUk
+jIr
 aZd
 aZd
 jHZ
@@ -35593,8 +35849,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -35826,8 +36082,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 lfn
@@ -36064,8 +36320,8 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 efw
 efw
@@ -36296,10 +36552,10 @@ rxl
 rxl
 efw
 efw
-efw
-efw
-efw
-efw
+sUk
+sUk
+sUk
+sUk
 efw
 efw
 rxl
@@ -36529,10 +36785,10 @@ rxl
 rxl
 rxl
 efw
-efw
-lfn
-efw
-efw
+sUk
+evv
+sUk
+sUk
 efw
 ehk
 rxl
@@ -36763,8 +37019,8 @@ rxl
 rxl
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 lfn
 rxl
@@ -37930,7 +38186,7 @@ efw
 lfn
 efw
 qel
-vgf
+rxl
 tYu
 tYu
 mlB
@@ -38158,14 +38414,14 @@ rxl
 efw
 pvY
 efw
+sUk
+sUk
 efw
 efw
-efw
-efw
-vgf
-tYu
-tYu
-tYu
+rxl
+rxl
+rxl
+rxl
 mlB
 ojW
 dPK
@@ -38390,16 +38646,16 @@ rxl
 rxl
 efw
 efw
+sUk
+gRY
+sUk
 efw
+vgf
 rxl
-efw
-efw
-vgf
-vgf
-tYu
-tYu
-mlB
-mlB
+rxl
+rxl
+rxl
+rxl
 dPK
 dPK
 dPK
@@ -38466,7 +38722,7 @@ dze
 dRz
 ybU
 ybU
-njG
+ygU
 ybU
 bGe
 dze
@@ -38623,15 +38879,15 @@ efw
 efw
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 vgf
-vgf
-tYu
-tYu
-tYu
-mlB
+rxl
+rxl
+rxl
+rxl
+rxl
 dPK
 dPK
 dPK
@@ -38853,17 +39109,17 @@ rxl
 rxl
 lfn
 efw
+sUk
+evv
 efw
-lfn
 efw
-rxl
 efw
 tQH
 vgf
-tYu
-tYu
-tYu
-mlB
+rxl
+rxl
+rxl
+rxl
 mlB
 ojW
 dPK
@@ -38929,9 +39185,9 @@ dze
 ibO
 dze
 dRz
-ygU
 ybU
-ybU
+tGZ
+tGZ
 ybU
 ybU
 ybU
@@ -39086,15 +39342,15 @@ rxl
 rxl
 rxl
 qDf
-efw
-efw
+sUk
+sUk
 qDf
 efw
 efw
 vgf
 tYu
 tYu
-tYu
+rxl
 tYu
 mlB
 dPK
@@ -39162,11 +39418,11 @@ tWr
 tWr
 dRz
 ybU
+tGZ
+tGZ
+tGZ
+tGZ
 ybU
-ybU
-ybU
-ybU
-ygU
 ybU
 bGe
 dze
@@ -39395,11 +39651,11 @@ ybU
 ybU
 ybU
 ybU
-ybU
-ybU
-ntN
-ybU
-ybU
+tGZ
+tGZ
+tGZ
+tGZ
+tGZ
 ybU
 bGe
 dze
@@ -39629,9 +39885,9 @@ ybU
 ygU
 ybU
 ybU
-ygU
-ybU
-ybU
+tGZ
+tGZ
+tGZ
 ybU
 ybU
 bGe
@@ -39863,7 +40119,7 @@ alo
 ybU
 ybU
 ybU
-ybU
+tGZ
 vzO
 ybU
 ybU
@@ -40330,7 +40586,7 @@ dze
 alo
 ygU
 ybU
-vzO
+ybU
 ybU
 fkP
 tWr
@@ -40782,8 +41038,8 @@ vzO
 ybU
 fme
 cTq
-xQq
-bur
+xTu
+xTu
 fQW
 fme
 iui
@@ -41013,11 +41269,11 @@ dff
 ybU
 ygU
 ybU
-oin
-ioE
-bur
-bur
-ioE
+kpC
+aLv
+xTu
+xTu
+aLv
 fme
 loS
 fOS
@@ -41025,11 +41281,11 @@ aSk
 paQ
 bVz
 aRq
-tPJ
-tPJ
 lCK
-fgC
-oOH
+lCK
+lCK
+gbg
+uLF
 lCK
 tPJ
 lCK
@@ -41177,7 +41433,7 @@ rxl
 rxl
 efw
 efw
-efw
+sUk
 efw
 efw
 qDf
@@ -41248,9 +41504,9 @@ ybU
 ybU
 fme
 aXZ
-bur
-xQq
-aXZ
+xTu
+xih
+tGu
 fme
 vrl
 xQq
@@ -41409,9 +41665,9 @@ rxl
 rxl
 rxl
 efw
-efw
-efw
-efw
+sUk
+sUk
+sUk
 qDf
 efw
 rxl
@@ -41480,15 +41736,15 @@ dff
 wwE
 dff
 fme
-wbx
-bur
-bur
+tGu
+xTu
+xTu
 aLv
 fme
 vrl
 paQ
 bur
-loS
+xQq
 bVz
 lCK
 lCK
@@ -41530,24 +41786,24 @@ rgm
 rgm
 kCQ
 rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
+iLH
 kCQ
 bmP
 hpN
@@ -41643,7 +41899,7 @@ rxl
 rxl
 efw
 efw
-efw
+sUk
 lfn
 efw
 rxl
@@ -41661,7 +41917,7 @@ ojW
 dPK
 dPK
 xMR
-vEo
+cSt
 byD
 ieA
 nEg
@@ -41762,8 +42018,8 @@ rgm
 rgm
 rgm
 kCQ
-rxl
-rxl
+iLH
+iLH
 bss
 bss
 bss
@@ -41780,7 +42036,7 @@ bss
 bss
 bss
 bss
-rxl
+iLH
 rxl
 iLH
 iLH
@@ -41995,7 +42251,7 @@ rgm
 rgm
 rgm
 kCQ
-rxl
+iLH
 bss
 bss
 nlP
@@ -42013,8 +42269,8 @@ qIT
 nlP
 nlP
 bss
-rxl
-rxl
+iLH
+iLH
 iLH
 nlP
 nlP
@@ -42109,7 +42365,7 @@ rxl
 rxl
 rxl
 efw
-efw
+sUk
 efw
 efw
 rxl
@@ -42177,7 +42433,7 @@ jMC
 dff
 tkJ
 cbr
-cbr
+bZQ
 fme
 tuv
 pkr
@@ -42342,8 +42598,8 @@ rxl
 rxl
 efw
 efw
-efw
-efw
+sUk
+sUk
 efw
 rxl
 rxl
@@ -42412,15 +42668,15 @@ dff
 tEv
 dff
 fme
-cTq
-bur
-aXZ
-bur
-aXZ
-bur
-bur
-bur
 qDY
+xTu
+qDY
+xTu
+qDY
+xTu
+qDY
+xTu
+aLv
 bVz
 lCK
 lCK
@@ -42646,14 +42902,14 @@ ybU
 ygU
 fme
 ioE
-xQq
-ioE
-bur
-ioE
-bur
 xTu
-bur
-xQq
+ioE
+xTu
+ioE
+xTu
+ioE
+xTu
+qZl
 bVz
 liW
 lCK
@@ -42694,7 +42950,7 @@ rgm
 rgm
 rgm
 xJL
-hec
+rxl
 bss
 nlP
 nlP
@@ -42878,15 +43134,15 @@ ugf
 xkI
 ybU
 oin
-aXZ
-bur
-aXZ
-xQq
-aXZ
-bur
-xQq
+qDY
+xih
+qDY
 xTu
-bur
+qDY
+xih
+qDY
+xTu
+aLv
 bVz
 sPr
 lCK
@@ -42927,7 +43183,7 @@ rgm
 rgm
 rgm
 xJL
-hec
+rxl
 bss
 iRS
 nlP
@@ -42949,9 +43205,9 @@ ubz
 dTv
 dTv
 dTv
-dTv
-dTv
-dTv
+vlA
+pEd
+pEd
 dTv
 xpk
 xpk
@@ -43064,7 +43320,7 @@ waq
 xPH
 cZf
 alG
-xPH
+xep
 waq
 waq
 fCK
@@ -43112,13 +43368,13 @@ dRz
 ybU
 fme
 wbx
-xQq
+xTu
 ioE
-xQq
+xDd
 ioE
-xQq
-bur
-xQq
+xTu
+ioE
+xTu
 qDY
 bVz
 lCK
@@ -43352,7 +43608,7 @@ eXi
 eXi
 eXi
 fme
-bur
+ykj
 bVz
 aRq
 lCK
@@ -43627,7 +43883,7 @@ mQq
 hyF
 cRe
 mTT
-xxY
+bss
 qys
 nlP
 ydh
@@ -43815,7 +44071,7 @@ nHa
 ovw
 vtn
 aBX
-lyj
+uVi
 gJr
 rkV
 eXi
@@ -44048,7 +44304,7 @@ dVo
 kRf
 dVo
 dVo
-lyj
+uVi
 wEQ
 uDZ
 eXi
@@ -44329,9 +44585,9 @@ mTT
 xxY
 nlP
 nlP
-ydh
-dTv
-dTv
+bss
+uwj
+jRw
 dTv
 mub
 dzo
@@ -44514,7 +44770,7 @@ dVo
 aBX
 dVo
 dVo
-eNz
+wlW
 ogV
 oQt
 xBX
@@ -44562,9 +44818,9 @@ mTT
 bss
 mFY
 nlP
-ydh
-dTv
-dTv
+bss
+udU
+uod
 dTv
 jET
 dzo
@@ -44795,9 +45051,9 @@ mTT
 xxY
 nlP
 nlP
-ydh
-dTv
-dTv
+bss
+jez
+sri
 dTv
 cky
 dzo
@@ -44920,7 +45176,7 @@ vyy
 iks
 lqI
 oPq
-xPH
+xep
 eyC
 cIn
 suu
@@ -45130,7 +45386,7 @@ lIq
 oRH
 dRi
 dzU
-xeB
+ntN
 xjJ
 gjk
 wFA
@@ -45205,7 +45461,7 @@ kmc
 mhS
 ygU
 bGe
-tky
+cAc
 nHf
 cao
 dVo
@@ -45443,7 +45699,7 @@ eXi
 cao
 vVM
 lBX
-dVo
+xAb
 dVo
 dVo
 eNz
@@ -45491,7 +45747,7 @@ mQq
 hxc
 kvj
 nio
-xxY
+bss
 nlP
 nlP
 ydh
@@ -45604,7 +45860,7 @@ kcd
 kcd
 kxx
 kcd
-kcd
+rxl
 aWO
 lYp
 kWl
@@ -45677,9 +45933,9 @@ tXn
 dVo
 dVo
 dVo
+xAb
 dVo
-dVo
-eNz
+wlW
 uHN
 uGZ
 eXi
@@ -45723,7 +45979,7 @@ obs
 mQq
 hxc
 hRi
-uVi
+rxl
 bss
 nlP
 nlP
@@ -45836,9 +46092,9 @@ atW
 kcd
 kcd
 kcd
-vRc
-vRc
-tDp
+rxl
+rxl
+aLP
 tDp
 tDp
 xyy
@@ -45956,7 +46212,7 @@ kVV
 mQq
 ewm
 kvj
-uVi
+rxl
 bss
 eZt
 nlP
@@ -46068,9 +46324,9 @@ kcd
 kcd
 kcd
 kcd
-vRc
-vRc
-xyy
+rxl
+rxl
+rxl
 xyy
 xyy
 xyy
@@ -46145,7 +46401,7 @@ dVo
 dVo
 dVo
 dVo
-lyj
+uVi
 nrP
 wIH
 nrP
@@ -46189,7 +46445,7 @@ kVV
 mQq
 hxc
 jFX
-uVi
+rxl
 bss
 nlP
 nlP
@@ -46211,9 +46467,9 @@ ubz
 dTv
 dTv
 dTv
-dTv
-dTv
-dTv
+hus
+vlA
+dGH
 dTv
 xpk
 xpk
@@ -46300,10 +46556,10 @@ kcd
 kcd
 kcd
 kcd
-kxx
-vRc
-xyy
-xyy
+rxl
+rxl
+rxl
+rxl
 xyy
 xyy
 xyy
@@ -46422,7 +46678,7 @@ kVV
 mQq
 pGS
 kvj
-uVi
+rxl
 bss
 bEs
 nlP
@@ -46534,7 +46790,7 @@ kcd
 kcd
 kcd
 vRc
-vRc
+rxl
 xyy
 xyy
 xyy
@@ -46655,9 +46911,9 @@ kVV
 mQq
 hxc
 kvj
-uVi
+rxl
 bss
-nlP
+bss
 nlP
 bAz
 xSV
@@ -46888,10 +47144,10 @@ kVV
 mQq
 sCA
 kvj
-uVi
+rxl
 bss
-nlP
-nlP
+bss
+bss
 nlP
 nlP
 nlP
@@ -47121,11 +47377,11 @@ kVV
 mQq
 hxc
 kvj
-uVi
+rxl
+rxl
+rxl
 bss
 bss
-nlP
-nlP
 nlP
 nlP
 nlP
@@ -47139,8 +47395,8 @@ qIT
 nlP
 nlP
 bss
-rxl
-rxl
+iLH
+iLH
 iLH
 pjh
 nlP
@@ -47354,26 +47610,26 @@ kVV
 mQq
 hxc
 kvj
-uVi
-pDq
-bss
-bss
-bss
-bss
-bss
-siX
-ydh
-gHP
-uLF
-bss
-siX
-ydh
-gHP
-siX
-bss
-bss
 rxl
 rxl
+rxl
+bss
+bss
+bss
+bss
+bss
+ydh
+gHP
+xxY
+bss
+xxY
+ydh
+gHP
+bss
+bss
+bss
+iLH
+iLH
 iLH
 iLH
 iLH
@@ -47490,7 +47746,7 @@ dXE
 oZh
 oZh
 oZh
-rhG
+idb
 oZh
 oZh
 oZh
@@ -47587,26 +47843,26 @@ kVV
 mQq
 hxc
 kvj
-jIr
-moJ
 mTT
-mTT
-mTT
-mTT
-mTT
-mTT
-wvH
-yhV
-mTT
-mTT
-mTT
-wvH
-yhV
-mTT
-uVi
-hec
 rxl
-kCQ
+rxl
+rxl
+rxl
+rxl
+rxl
+mTT
+wvH
+yhV
+mTT
+mTT
+mTT
+wvH
+yhV
+mTT
+rxl
+rxl
+iLH
+vzW
 hpN
 hpN
 hpN
@@ -47784,10 +48040,10 @@ ohT
 ohT
 woH
 ohT
-woH
+ohT
 cnO
 khT
-woH
+ohT
 qxc
 pKU
 qxc
@@ -47820,26 +48076,26 @@ kVV
 mQq
 hxc
 tpI
-ksJ
-ksJ
-ksJ
-ksJ
-ksJ
-ksJ
-ksJ
-ksJ
+pUV
+pUV
+pUV
+pUV
+pUV
+pUV
+pUV
+pUV
 auF
 gvY
-ksJ
-ksJ
-ksJ
+pUV
+pUV
+pUV
 auF
 ksJ
 amb
 qWg
 mZS
 mZS
-kCQ
+vzW
 iLH
 iLH
 iLH
@@ -47924,7 +48180,7 @@ xeB
 xeB
 tMF
 xeB
-xeB
+ntN
 tMF
 tMF
 kcd
@@ -50099,7 +50355,7 @@ hIT
 jiE
 jiE
 jiE
-lKI
+gXP
 oEu
 lKI
 jiE
@@ -50330,13 +50586,13 @@ lGN
 xmr
 hIT
 jiE
-hXt
-lvZ
-oEu
-oEu
-oEu
-tWh
-bCK
+pDq
+ffc
+jin
+cOn
+moI
+bYo
+oRf
 jiE
 teP
 hIT
@@ -50563,15 +50819,15 @@ lGN
 xmr
 hIT
 jiE
-jiE
-jiE
-xep
-amG
+fni
+qFh
 cOn
+cOn
+cOn
+siX
+ibo
 jiE
-jiE
-jiE
-eYO
+rjq
 hIT
 hIT
 hIT
@@ -50798,16 +51054,16 @@ hIT
 jiE
 hXt
 oXY
-oEu
+hjU
 amG
-oEu
+qBo
 bNi
 iBd
 jiE
 kKp
 hIT
 hIT
-ibo
+kkl
 pNC
 oNd
 qlY
@@ -51268,7 +51524,7 @@ vyU
 pxo
 qiK
 tWh
-iBd
+bCK
 jiE
 rjq
 hIT
@@ -51736,8 +51992,8 @@ qiK
 vqd
 ivO
 jiE
-pNC
-oRf
+njG
+ghU
 aje
 hIT
 sgB
@@ -51970,7 +52226,7 @@ jiE
 jiE
 jiE
 pNC
-dGH
+cJW
 hIT
 hIT
 sgB
@@ -52113,7 +52369,7 @@ ymj
 xmI
 xmI
 nAP
-nAP
+rOW
 xmI
 xmI
 rxl
@@ -52576,7 +52832,7 @@ xRm
 oMg
 oMg
 bVQ
-nAP
+rOW
 tzc
 oEg
 hLK
@@ -53363,7 +53619,7 @@ eOl
 oRs
 klO
 oJc
-klO
+tBD
 pty
 baY
 eNd
@@ -54293,7 +54549,7 @@ hIT
 obe
 spB
 sMK
-vcR
+dKQ
 pqc
 vcR
 sMK
@@ -55139,7 +55395,7 @@ ymj
 rJy
 oMg
 oMg
-nAP
+rOW
 kJE
 mwM
 leV
@@ -55691,7 +55947,7 @@ hIT
 obe
 vne
 sMK
-vcR
+dKQ
 tHo
 bdC
 sMK
@@ -56143,7 +56399,7 @@ hiG
 hiG
 hiG
 hiG
-vFy
+oTR
 syD
 rSf
 hiG
@@ -56375,8 +56631,8 @@ hiG
 hiG
 oTR
 oTR
-bgh
-vFy
+oTR
+oTR
 syD
 vFy
 hiG
@@ -56605,11 +56861,11 @@ hiG
 hiG
 hiG
 hiG
+bgh
 hiG
 oTR
-cna
-vFy
-vFy
+oTR
+oTR
 syD
 vFy
 hiG
@@ -56837,11 +57093,11 @@ hiG
 hiG
 hiG
 hiG
-bgh
+oTR
 hiG
-hiG
-hiG
-vFy
+oTR
+oTR
+oTR
 syD
 mQt
 vFy
@@ -57070,10 +57326,10 @@ hiG
 kmg
 vFy
 vFy
-vFy
-vFy
-vFy
-vFy
+oTR
+oTR
+oTR
+oTR
 vFy
 syD
 kxk
@@ -57273,8 +57529,8 @@ ymj
 ymj
 ymj
 xrM
-xrM
-xrM
+npN
+npN
 xrM
 xrM
 xrM
@@ -57538,8 +57794,8 @@ xSe
 ydd
 vFy
 vFy
-vFy
-vFy
+oTR
+oTR
 vFy
 vFy
 vFy
@@ -58910,7 +59166,7 @@ dSo
 teT
 teT
 ikv
-ikv
+eYO
 ikv
 teT
 bvx
@@ -61028,7 +61284,7 @@ xSa
 qnp
 ttP
 xSa
-cnE
+dVP
 aqr
 uRg
 aqr
@@ -61251,7 +61507,7 @@ iCL
 twY
 vwH
 tLS
-ikv
+eYO
 uca
 dBh
 usz
@@ -62171,14 +62427,14 @@ lqI
 dXE
 teT
 teT
-ikv
-ikv
+eYO
+eYO
 ikv
 teT
 teT
 teT
 ikv
-ikv
+eYO
 ikv
 teT
 teT
@@ -63857,7 +64113,7 @@ jCp
 hYy
 xyC
 vqD
-tQU
+lEj
 jtI
 hdl
 iOa
@@ -64033,7 +64289,7 @@ wUY
 trh
 oGw
 dSo
-kaC
+wvt
 sBF
 ihH
 kAT
@@ -64053,7 +64309,7 @@ bvE
 uzX
 jib
 jib
-ebh
+roL
 ebh
 jib
 jib
@@ -65692,11 +65948,11 @@ okn
 itH
 vsW
 byE
-ake
+htH
 pmk
 fdu
 fdu
-wlW
+hRp
 jeI
 fQn
 rzx
@@ -68164,8 +68420,8 @@ rxl
 rxl
 rxl
 rxl
-rxl
-rxl
+lwH
+lwH
 rxl
 rxl
 hin
@@ -68396,10 +68652,10 @@ lwH
 rxl
 rxl
 rxl
-rxl
-rxl
-rxl
-rxl
+lwH
+xaR
+lwH
+lwH
 rxl
 hin
 iHz
@@ -68456,7 +68712,7 @@ rxl
 rxl
 rxl
 fJO
-fJO
+cnE
 fJO
 fJO
 rxl
@@ -68630,10 +68886,10 @@ lwH
 rxl
 rxl
 rxl
-rxl
-rxl
-rxl
-rxl
+bZr
+lwH
+lwH
+lwH
 hin
 xxj
 fSa
@@ -68758,8 +69014,8 @@ rxl
 rxl
 rxl
 rxl
-sih
-sih
+rxl
+rxl
 sih
 gge
 uxy
@@ -68859,14 +69115,14 @@ rxl
 lwH
 lwH
 lwH
+bZr
 lwH
 lwH
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
+bZr
+lwH
+xaR
+lwH
+lwH
 hin
 vik
 sqs
@@ -69094,11 +69350,11 @@ lwH
 lwH
 lwH
 lwH
-rxl
-rxl
-rxl
-rxl
-rxl
+xaR
+lwH
+lwH
+lwH
+lwH
 rxl
 hin
 kEL
@@ -69327,10 +69583,10 @@ lwH
 lwH
 lwH
 lwH
-rxl
-rxl
-rxl
-rxl
+lwH
+lwH
+lwH
+lwH
 rxl
 rxl
 hin
@@ -70365,7 +70621,7 @@ cOx
 cVH
 jCp
 jtY
-sih
+rxl
 qGn
 ogT
 ogT
@@ -70598,7 +70854,7 @@ cOx
 cVH
 hps
 jtY
-sih
+rxl
 qGn
 ogT
 ogT
@@ -70956,7 +71212,7 @@ lwH
 lwH
 lwH
 lwH
-lwH
+bZr
 tik
 tik
 tik
@@ -71443,8 +71699,8 @@ lwH
 lwH
 lwH
 lwH
-xaR
-lwH
+uOD
+rEV
 lwH
 lwH
 lwH
@@ -72928,7 +73184,7 @@ cOx
 cOx
 cOx
 pYT
-sih
+rxl
 qGn
 ogT
 ogT
@@ -73068,7 +73324,7 @@ rxl
 rxl
 lwH
 lwH
-lwH
+rEV
 lwH
 lwH
 lwH
@@ -73300,11 +73556,11 @@ rxl
 rxl
 xaR
 lwH
-lwH
-lwH
+rEV
+rEV
 xaR
-lwH
-lwH
+rEV
+rEV
 rxl
 rxl
 rxl
@@ -73536,8 +73792,8 @@ lwH
 lwH
 lwH
 lwH
-lwH
-lwH
+rEV
+rEV
 rxl
 rxl
 rxl
@@ -73747,10 +74003,10 @@ lwH
 lwH
 lwH
 rxl
+rEV
 lwH
 lwH
 lwH
-lwH
 rxl
 rxl
 rxl
@@ -73765,8 +74021,8 @@ rxl
 rxl
 lwH
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -73998,8 +74254,8 @@ rxl
 rxl
 lwH
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -74134,8 +74390,8 @@ qGn
 qGn
 qGn
 qGn
-oGr
-glQ
+iLH
+lbz
 oGr
 lKQ
 oGr
@@ -74213,12 +74469,12 @@ rxl
 lwH
 lwH
 rxl
+rEV
 lwH
 lwH
 lwH
 lwH
-lwH
-lwH
+rEV
 rxl
 rxl
 rxl
@@ -74364,10 +74620,10 @@ iLH
 iLH
 iLH
 iLH
-oGr
-oGr
-oGr
-oGr
+iLH
+iLH
+iLH
+iLH
 glQ
 oGr
 oGr
@@ -74450,9 +74706,9 @@ lwH
 lwH
 lwH
 lwH
-lwH
-lwH
-xaR
+rEV
+rEV
+uOD
 rxl
 rxl
 rxl
@@ -74597,8 +74853,8 @@ ngh
 ngh
 ngh
 ngh
-kae
-kae
+ngh
+ngh
 kae
 kae
 glQ
@@ -74694,12 +74950,12 @@ rxl
 rxl
 rxl
 lwH
+rEV
+rEV
 lwH
 lwH
 lwH
-lwH
-lwH
-lwH
+rEV
 rxl
 rxl
 rxl
@@ -74915,7 +75171,7 @@ lwH
 xaR
 lwH
 lwH
-lwH
+rEV
 lwH
 lwH
 lwH
@@ -74927,12 +75183,12 @@ rxl
 rxl
 xaR
 lwH
-lwH
-lwH
-lwH
-lwH
-lwH
-xaR
+rEV
+rEV
+hdk
+hdk
+rEV
+uOD
 rxl
 rxl
 rxl
@@ -75147,9 +75403,9 @@ rxl
 lwH
 lwH
 lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -75164,7 +75420,7 @@ lwH
 lwH
 lwH
 lwH
-lwH
+rEV
 rxl
 rxl
 rxl
@@ -75381,13 +75637,13 @@ rxl
 rxl
 lwH
 lwH
-lwH
+rEV
 lwH
 xaR
+rEV
 lwH
 lwH
-lwH
-lwH
+rEV
 rxl
 rxl
 rxl
@@ -75616,16 +75872,16 @@ xaR
 lwH
 lwH
 lwH
+rEV
+rEV
 lwH
 lwH
-lwH
-lwH
-lwH
+rEV
 rxl
 rxl
 rxl
 rxl
-lwH
+rEV
 lwH
 bZr
 lwH
@@ -75853,12 +76109,12 @@ lwH
 lwH
 lwH
 lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
 rxl
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -75877,16 +76133,16 @@ lwH
 lwH
 xaR
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
 rxl
 lwH
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -76088,10 +76344,10 @@ bZr
 lwH
 xaR
 lwH
-lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
+rEV
 lwH
 lwH
 rxl
@@ -76109,17 +76365,17 @@ xaR
 lwH
 lwH
 lwH
-lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
+rEV
 lwH
 lwH
 rxl
 rxl
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 bZr
@@ -76323,7 +76579,7 @@ lwH
 lwH
 lwH
 lwH
-lwH
+hdk
 xaR
 lwH
 bZr
@@ -76343,9 +76599,9 @@ lwH
 rxl
 lwH
 lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
 lwH
 rxl
 rxl
@@ -76553,10 +76809,10 @@ rxl
 lwH
 lwH
 lwH
+rEV
+rEV
 lwH
-lwH
-lwH
-lwH
+hdk
 lwH
 lwH
 lwH
@@ -76577,7 +76833,7 @@ rxl
 rxl
 lwH
 lwH
-lwH
+rEV
 xaR
 lwH
 rxl
@@ -76786,10 +77042,10 @@ rxl
 lwH
 lwH
 lwH
+rEV
+rEV
 lwH
-lwH
-lwH
-lwH
+hdk
 lwH
 lwH
 lwH
@@ -77022,18 +77278,18 @@ lwH
 bZr
 lwH
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 xaR
 lwH
 bZr
 lwH
-xaR
+uOD
+rEV
 lwH
-lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -77255,18 +77511,18 @@ lwH
 lwH
 bZr
 xaR
+rEV
+rEV
 lwH
 lwH
 lwH
 lwH
 lwH
+rEV
+rEV
 lwH
-lwH
-lwH
-lwH
-lwH
-xaR
-lwH
+uOD
+rEV
 lwH
 lwH
 lwH
@@ -77276,8 +77532,8 @@ rxl
 rxl
 aNg
 lwH
-lwH
-lwH
+rEV
+rEV
 lwH
 bZr
 lwH
@@ -77488,7 +77744,7 @@ lwH
 lwH
 lwH
 bZr
-lwH
+hdk
 lwH
 lwH
 lwH
@@ -77508,10 +77764,10 @@ rxl
 lwH
 lwH
 lwH
-lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -77721,7 +77977,7 @@ rxl
 lwH
 lwH
 lwH
-lwH
+hdk
 lwH
 lwH
 rxl
@@ -77741,10 +77997,10 @@ lwH
 lwH
 lwH
 bZr
-lwH
-lwH
-lwH
-lwH
+rEV
+rEV
+rEV
+rEV
 lwH
 lwH
 lwH
@@ -77954,7 +78210,7 @@ rxl
 rxl
 rxl
 lwH
-lwH
+rEV
 rxl
 rxl
 rxl
@@ -77975,8 +78231,8 @@ xaR
 lwH
 lwH
 lwH
-xaR
-lwH
+uOD
+rEV
 lwH
 lwH
 xaR


### PR DESCRIPTION
## About The Pull Request

After the remake of Magmoor Digsite IV, the new rendition was put into rotation and has had a fair few games played on it. The common consensus on the results of the remake seem to be that it is a major improvement on what the map once was, however that doesn't say very much. This PR aims to reduce certain flaws and flow issues the new Magmoor Digsite IV rendition has and hopefully be a step in the right direction to a path toward clearing Magmoor of its Lagmoor© legacy.

## Why It's Good For The Game

Currently, Lagmoor suffers from being incredibly Marine sided. The games, inbetween full-stack xenostatics, are usually Marine Majors where the game is decided in the first 12 minutes. Having both played the map, and (rarely) interacted with other players voicing their opinions on it, a few issues have been silhouetted.

### **1. Lava-River Camping.**

- Lava generates a fair bit of light. A lot of the southern parts of the map have small ribbons of lava meant to separate open areas and add a unique obstacle. What has instead occurred is, in most cases, giving Marines a one way barrier to shoot over, with added light.

- To fix this, or at least alleviate part of the problem, the lava rivers have received a sprinkling of rock formations in important locations; This encourages balance between xenos Trolling© Marines (epicly) by throwing them into lava and marines counter-firing across what is still left open. 

_Image to better detail the changes:_
![rocks](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/1f92cf0b-f47c-486c-b791-2a21ff88abb3)

### **2. Lava Tile Proximity to High Density Areas**

- This is a bit of a niche issue, there is mainly 1 place this occurs in:

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/67bd9b38-22d8-4a5a-94ba-d2c18868c594)

- I don't think I have to give a detailed explanation to why this is bad. The only reason it was there was to continue on an existing lava river; This is not enough reason to keep such a detrimental obstacle.

### **3. Disk Placement Advantages**

- Even before the introduction of extended random disk placement, the disks where an issue on Magmoor. The main issue of the disks was that each disk was placed in a large, modular, and well flowing structure, but always towards the side marines approached from.

- To remedy this, 2 disks have been moved further up(north) from their respective locations.

- The disk location in admin has been moved into the Command Office, encouraging play throughout the building:
![bef1](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/c16c51fc-5b18-4852-9500-29fbb0949569)
_Remedied order of before-after images due to several complaints_

- The disk location in engineering has been moved further up into the engineering section, into the neighbouring building (coincidentally one of the more enjoyed parts of previous Magmoor). This disk placement was the most problematic, always being first taken and unconquerable once acquired.
![bef2](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/42b9a400-d02a-4de2-9ec3-1b6cabdcdc5b)

### **4. Xeno-side Flow Issues**

- A lot of Xeno losses on Magmoor are attributed to ~~skill issue~~ lack of proper map preparation (Mazing, Acid, etc...). The issue is that A LOT of preparation has to be done by Xenos to make the battle manageable. This works when there's a full-stack of experienced Xeno players on, but not for the majority of games.

- To remedy this, a lot of places have been pre-prepped. A few windows broken, barricades removed, mazes added to caves, etc... The most notable examples are Botany in RNR being remade to be more easily prepped, and caves receiving a sprinkle of pre-maze.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/a4b6f576-0637-41fd-9945-5d0bb594d62f)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/964b8888-773f-4e56-975b-ab1873add0d9)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/ff5ef7dd-c315-40c2-bee8-7a463fd10feb)

### **5. Marine Space-Port Balancing**

- Another notable issue is just how incredibly trash both Marine LZs are when it comes to defence. This means that if Marines ever are pushed back to their FOB, they get steamrolled most of the time. This encourages the sort of 'Marine-Major, Xeno-Major' results that Magmoor has shown. To encourage play on the map itself, both LZs have received a bit of bolstering to their natural defences.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/00f3ccac-067f-48e6-b97f-bd3b6e3367ec)

_The cavern rocks have extended to cover all the walls around the entrances on both LZs, LZ 2 lost its backside vulnerability due to larger front doors compared to LZ1_

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/a7257e10-4b77-4848-893c-3589000e750a)

## Special ~~Thanks~~ Section
![bef233](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61062429/773dcf1c-7639-4b80-b2b0-e5d604b2029f)


## Changelog
:cl:
add: Added rocks to lava rivers
del: Removed infuriating lavaspaces
balance: Marine LZs bulked
balance: Moved diskys
/:cl: