### PR TITLE
Fixes resin hole chain stun

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -173,7 +173,7 @@
 	if(iscarbon(AM))
 		var/mob/living/carbon/crosser = AM
 		crosser.visible_message(span_warning("[crosser] trips on [src]!"), span_danger("You trip on [src]!"))
-		crosser.Paralyze(4 SECONDS)
+		crosser.ParalyzeNoChain(4 SECONDS)
 	switch(trap_type)
 		if(TRAP_HUGGER)
 			if(!AM)


### PR DESCRIPTION

## About The Pull Request
I dunno why this stuns for 4 whole seconds but uh, chain stunning is generally bad.
## Why It's Good For The Game
Infinite brazil memes bad.
## Changelog
:cl:
balance: Resin holes can no longer chain stun
/:cl:
