### PR TITLE
add spaceacillin autoinjector to marinemed

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1106,6 +1106,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/isotonic = -1,
 			/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = -1,
 			/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = 30,
+			/obj/item/reagent_containers/hypospray/autoinjector/spaceacillin = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/alkysine = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/imidazoline = 20,


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

1) Niche medicine in autoinjectors like imidazoline, alkysine, quick clog, and hypervene are accessible to any marines but not spaceacillin
2) For the marine that really want to ensure that when he gets infection, he can deal with it himself
3) Permit corpsmen to have the chance to choose a tiny med item to deal with infection

## Changelog

:cl:
add: add spaceacillin autoinjector to marinemed
balance: squad marine can have easier access to spaceacillin, which makes it easier for them to deal with infection
/:cl:

