### PR TITLE
bayoknife two-shots weeds

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -189,23 +189,6 @@
 	hitsound = 'sound/weapons/slash.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
-
-/obj/item/weapon/combat_knife/attackby(obj/item/I, mob/user)
-	if(!istype(I,/obj/item/stack/cable_coil))
-		return ..()
-	var/obj/item/stack/cable_coil/CC = I
-	if(!CC.use(5))
-		to_chat(user, span_notice("You don't have enough cable for that."))
-		return
-	to_chat(user, "You wrap some cable around the bayonet. It can now be attached to a gun.")
-	if(loc == user)
-		user.temporarilyRemoveItemFromInventory(src)
-	var/obj/item/attachable/bayonet/F = new(src.loc)
-	user.put_in_hands(F) //This proc tries right, left, then drops it all-in-one.
-	if(F.loc != user) //It ended up on the floor, put it whereever the old flashlight is.
-		F.loc = get_turf(src)
-	qdel(src) //Delete da old knife
-
 /obj/item/weapon/combat_knife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -177,7 +177,7 @@
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "combat_knife"
 	item_state = "combat_knife"
-	desc = "A standard survival knife of high quality. You can slide this knife into your boots, and can be field-modified to attach to the end of a rifle with cable coil."
+	desc = "A standard survival knife of high quality. You can slide this knife into your boots or strap it onto your helmet."
 	flags_atom = CONDUCT
 	sharp = IS_SHARP_ITEM_ACCURATE
 	force = 30

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -355,6 +355,7 @@
 	bypass_w_limit = list(
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/food/snacks,
+		/obj/item/weapon/combat_knife,
 	)
 	cant_hold = list(
 		/obj/item/stack,

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -375,16 +375,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	sharp = IS_SHARP_ITEM_ACCURATE
 	variants_by_parent_type = list(/obj/item/weapon/gun/shotgun/pump/t35 = "bayonet_t35")
 
-/obj/item/attachable/bayonet/screwdriver_act(mob/living/user, obj/item/I)
-	to_chat(user, span_notice("You modify the bayonet back into a combat knife."))
-	if(loc == user)
-		user.dropItemToGround(src)
-	var/obj/item/weapon/combat_knife/knife = new(loc)
-	user.put_in_hands(knife) //This proc tries right, left, then drops it all-in-one.
-	if(knife.loc != user) //It ended up on the floor, put it whereever the old flashlight is.
-		knife.forceMove(loc)
-	qdel(src) //Delete da old bayonet
-
 /obj/item/attachable/bayonetknife
 	name = "M-22 bayonet"
 	desc = "A sharp knife that is the standard issue combat knife of the TerraGov Marine Corps can be attached to a variety of weapons at will or used as a standard knife."

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -393,7 +393,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		slot_l_hand_str = 'icons/mob/inhands/weapons/melee_left.dmi',
 		slot_r_hand_str = 'icons/mob/inhands/weapons/melee_right.dmi',
 	)
-	force = 25
+	force = 30
 	throwforce = 20
 	throw_speed = 3
 	throw_range = 6


### PR DESCRIPTION

## About The Pull Request

Bayoknives now deal as much damage as the combat knife, enough to destroy weed nodes in two hits

Combat knives can no longer be made into attachments using cable coil, but now fit inside your helmet. Because it is a small (not tiny) item, placing it in your helmet will occupy all storage slots in it and prevent you from putting anything else inside

## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/91615253/0bd06ed0-76f7-4bab-95fd-85a3a8c8cc96)
This post was made before the sprites were changed, but the point still stands that some people just prefer some sprites over others, especially now that they look so different

This PR justifies both knives existing by giving them a specific characteristic over the other without taking away the core advantage that makes any knife even worth using, **killing the damned weed nodes**

Will you sacrifice space for potentially life saving hyper/dylo shots so that you can fit an MRE in your boot, will you use the bayoknife so you can change attachments on the fly, or are you just using one because you think it looks better? Doesn't matter, because both can be just as efficient as the other

## Changelog
:cl:
balance: combat knive now fits into your helmet, and can no longer be made into an attachment
balance: bayoknife now deals enough dmg to kill weed nodes in two hits
/:cl:
