### PR TITLE
Fixes medical item overlays not appearing when vended into storage

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -189,6 +189,10 @@
 		return
 	update_icon()
 
+/obj/item/reagent_containers/hypospray/on_enter_storage(mob/user, slot)
+	. = ..()
+	update_icon()
+
 /obj/item/reagent_containers/hypospray/pickup(mob/user)
 	. = ..()
 	update_icon()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -333,6 +333,10 @@
 	. = ..()
 	update_icon()
 
+/obj/item/storage/pill_bottle/on_enter_storage(mob/user, slot)
+	. = ..()
+	update_icon()
+
 /obj/item/storage/pill_bottle/removed_from_inventory()
 	. = ..()
 	update_icon()


### PR DESCRIPTION

## About The Pull Request

When items like pill packets and bottles, hyposprays, and autoinjectors are vended into storage the icon is not updated. This PR makes it update on enter storage.
## Why It's Good For The Game

No one wants to take an item out and back into storage just so you can see the content and how much is in it.

Before:
<img width="114" alt="image" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/55060961/7381c167-b700-4b73-b3ac-76895a0e307f">
After:
<img width="124" alt="image" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/55060961/df18d566-6fa0-4c3d-a30a-3c91b2970840">
Some more things:
1. There are probably other items where this is broken and I just forgot/don't know
2. This is probably a horrible way to fix it, this is my first TGMC PR

## Changelog
:cl:
fix: Medical items show overlays when vended into storage
/:cl:
