### PR TITLE
Fixes `get_limb` getting a limb passed

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -325,7 +325,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 				break
 			if(!affected_limbs.Find(X.name) )
 				continue
-			if(istype(X) && X.take_damage_limb(0, H.modify_by_armor(raw_damage * rand(0.75, 1.25), ACID, def_zone = X)))
+			if(istype(X) && X.take_damage_limb(0, H.modify_by_armor(raw_damage * rand(0.75, 1.25), ACID, def_zone = X.name)))
 				H.UpdateDamageIcon()
 			limb_count++
 		UPDATEHEALTH(H)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -328,6 +328,8 @@ This function restores all limbs.
 	return
 
 /mob/living/carbon/human/get_limb(zone)
+	if(isorgan(zone))
+		return zone
 	zone = check_zone(zone)
 	for(var/X in limbs)
 		var/datum/limb/EO = X

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -328,8 +328,6 @@ This function restores all limbs.
 	return
 
 /mob/living/carbon/human/get_limb(zone)
-	if(isorgan(zone))
-		return zone
 	zone = check_zone(zone)
 	for(var/X in limbs)
 		var/datum/limb/EO = X


### PR DESCRIPTION
## About The Pull Request

`Runtime in code/modules/projectiles/projectile.dm, line 1203: Cannot read null.hard_armor`

## Why It's Good For The Game

Runtime bad.


## Changelog
:cl:
fix: Made get_limb just return the limb if its passed one, this fixes a hard armor runtime
/:cl:
