### PR TITLE
Warlock shield transparency port from RU

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -213,7 +213,7 @@
 	proj.iff_signal = null
 	frozen_projectiles += proj
 	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, turn(proj.dir, 180), proj.ammo.penetration)
-	alpha = obj_integrity * 255 / 350
+	alpha = obj_integrity * 255 / max_integrity
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -213,6 +213,14 @@
 	proj.iff_signal = null
 	frozen_projectiles += proj
 	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, turn(proj.dir, 180), proj.ammo.penetration)
+	if(obj_integrity <= 300)
+		alpha = 192 // ~ 3/4 visibility
+	if(obj_integrity <= 175)
+		alpha = 128 // ~ 2/4 visibility
+	if(obj_integrity <= 126 && obj_integrity >= 124)
+		owner.balloon_alert(owner, "Our shield is almost broken!")
+	if(obj_integrity <= 125)
+		alpha = 64 // ~ 1/4 visibility
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -213,7 +213,7 @@
 	proj.iff_signal = null
 	frozen_projectiles += proj
 	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, turn(proj.dir, 180), proj.ammo.penetration)
-	alpha = obj_integrity * 255 / 300
+	alpha = obj_integrity * 255 / 350
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -213,14 +213,7 @@
 	proj.iff_signal = null
 	frozen_projectiles += proj
 	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, turn(proj.dir, 180), proj.ammo.penetration)
-	if(obj_integrity <= 300)
-		alpha = 192 // ~ 3/4 visibility
-	if(obj_integrity <= 175)
-		alpha = 128 // ~ 2/4 visibility
-	if(obj_integrity <= 126 && obj_integrity >= 124)
-		owner.balloon_alert(owner, "Our shield is almost broken!")
-	if(obj_integrity <= 125)
-		alpha = 64 // ~ 1/4 visibility
+	alpha = obj_integrity * 255 / 300
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)


### PR DESCRIPTION
## About The Pull Request

Warlock's shield now changes visually depending on the amount of integrity left

![dreamseeker_6UruAVGn5V](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/e671875b-f9ed-4046-ad22-27035ab7ed22)

100% port of https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/53

## Why It's Good For The Game

More visuals = good

## Changelog
:cl:
add: warlock's shield changes transparency depending on integrity
/:cl:
