### PR TITLE
Adds Russian Red autoinjectors to Marinemed Vendor

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -265,6 +265,7 @@
 		/datum/reagent/medicine/ryetalyn = 5,
 	)
 	description_overlay = "Rr"
+	free_refills = FALSE
 
 /obj/item/reagent_containers/hypospray/autoinjector/polyhexanide
 	name = "polyhexanide autoinjector"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1111,6 +1111,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/imidazoline = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites = 20,
+			/obj/item/reagent_containers/hypospray/autoinjector/russian_red = 30,
 		),
 		"Heal Pack" = list(
 			/obj/item/stack/medical/heal_pack/gauze = -1,


### PR DESCRIPTION
## About The Pull Request
Puts 30 RR autoinjectors into the marinemed vendor. 

## Why It's Good For The Game
RR is available in relatively large quantities because of the 6 RR pill bottles in Medplus vendor and 1 RR pill bottle in tadpole medical vendor. The squad marine only vendor also lets you choose injector pouch with your 2 options of pouches, which contains an RR injector. It contains 10u of RR and 5u of ryet, 15u dose setting by default. 

As per QV's request, I have made the RR injectors unable to be restocked to prevent people from farming RR and ryet. 

## Changelog
:cl:
add: Added 30 RR autoinjectors to Marinemed vendor, which cannot be restocked. 
/:cl:
