### PR TITLE
Adds cloneloss to marines over time while they are cocooned

### DIFF
--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -42,8 +42,8 @@
 	var/psych_points_output = COCOON_PSY_POINTS_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (COCOON_PSY_POINTS_REWARD_MAX - COCOON_PSY_POINTS_REWARD_MIN))
 	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
-	//Gives marine cloneloss for a total of 30.
-	victim.adjustCloneLoss(0.1)
+	//Gives marine cloneloss for a total of 40.
+	victim.adjustCloneLoss(0.13)
 
 /obj/structure/cocoon/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)
 	. = ..()

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -42,6 +42,8 @@
 	var/psych_points_output = COCOON_PSY_POINTS_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (COCOON_PSY_POINTS_REWARD_MAX - COCOON_PSY_POINTS_REWARD_MIN))
 	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
+	//Gives marine cloneloss for a total of 30.
+	victim.adjustCloneLoss(0.1)
 
 /obj/structure/cocoon/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)
 	. = ..()

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -42,7 +42,7 @@
 	var/psych_points_output = COCOON_PSY_POINTS_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (COCOON_PSY_POINTS_REWARD_MAX - COCOON_PSY_POINTS_REWARD_MIN))
 	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
-	//Gives marine cloneloss for a total of 40.
+	//Gives marine cloneloss for a total of 30.
 	victim.adjustCloneLoss(0.5)
 
 /obj/structure/cocoon/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -43,7 +43,7 @@
 	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
 	//Gives marine cloneloss for a total of 40.
-	victim.adjustCloneLoss(0.13)
+	victim.adjustCloneLoss(0.5)
 
 /obj/structure/cocoon/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1298,8 +1298,6 @@
 		X.eject_victim(FALSE, starting_turf)
 		X.stop_sound_channel(channel)
 		return fail_activate()
-	//Gives marine cloneloss.
-	victim.adjustCloneLoss(10)
 	victim.dead_ticks = 0
 	ADD_TRAIT(victim, TRAIT_STASIS, TRAIT_STASIS)
 	X.eject_victim(TRUE, starting_turf)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1298,6 +1298,8 @@
 		X.eject_victim(FALSE, starting_turf)
 		X.stop_sound_channel(channel)
 		return fail_activate()
+	//Gives marine cloneloss.
+	victim.adjustCloneLoss(10)
 	victim.dead_ticks = 0
 	ADD_TRAIT(victim, TRAIT_STASIS, TRAIT_STASIS)
 	X.eject_victim(TRUE, starting_turf)


### PR DESCRIPTION
## About The Pull Request
This PR adds cloneloss while you stay inside the cocoon. For the duration of the cocoon you get a total of 40, Double of psydrain.
## Why It's Good For The Game
Finally adds cloneloss to cocoon which I was originally gonna do last year or so when I added it to psydrain but I couldn't wrap my head around process()
Now cocoon isn't just straight up a worse option than psydrain unless the marine is garuanteed to never be rescued, now it _might_ be worth it to cocoon someone relatively close to the front lines. A freshly rescued marine might not have any impactful cloneloss, While a fully cocooned but still rescued marine (cocoon resets defib timer if you didn't know) has 40 cloneloss, or double that of psydrain.
## Changelog
:cl:
add: Adds cloneloss to cocoon.
/:cl:
