### PR TITLE
Resin doors are destroyed in 1 second

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -196,7 +196,7 @@
 
 	src.balloon_alert(X, "Destroying...")
 	playsound(src, "alien_resin_break", 25)
-	if(do_after(X, 4 SECONDS, FALSE, src, BUSY_ICON_HOSTILE))
+	if(do_after(X, 1 SECONDS, FALSE, src, BUSY_ICON_HOSTILE))
 		src.balloon_alert(X, "Destroyed")
 		qdel(src)
 


### PR DESCRIPTION

## About The Pull Request

Title, as it turns out they use a different attack_alien proc.
## Why It's Good For The Game

Consistency and also this is a bug lol.
## Changelog
:cl:
fix: Doors are now destroyed in 1 second just like everything else.
/:cl:
