### PR TITLE
give acid rain a siren warning like sand storm

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -7,6 +7,7 @@
 	telegraph_message = span_highdanger("Thunder rumbles far above. You hear acidic droplets hissing against the canopy. Seek shelter!")
 	telegraph_sound = 'sound/weather/acidrain/acidrain_start.ogg'
 	telegraph_overlay = "rain_med"
+	telegraph_sound = 'sound/effects/siren.ogg'
 
 	weather_message = span_highdanger("<i>Acidic rain pours down around you! Get inside!</i>")
 	weather_overlay = "acid_rain"


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Since sand storm and acid rain cause damage to both xenomorphs and marines, both sand storm and acid rain ought to sound an alarm. Also, since colonists previously lived in these two locations, it made sense that leadership wanted colonists to not die due to not hearing warning and get in shealter.

## Changelog

:cl:
add: give acid rain a siren warning like sand storm
/:cl:

