### PR TITLE
adds a dot to 7.62x39 and 5.56 ammo boxes

### DIFF
--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -16,8 +16,8 @@
 	max_rounds = 150
 
 /obj/item/ammo_magazine/packet/pnato
-	name = "box of 556x45mm"
-	desc = "A box containing 150 rounds of 556x45mm."
+	name = "box of 5.56x45mm"
+	desc = "A box containing 150 rounds of 5.56x45mm."
 	caliber = CALIBER_556X45
 	icon_state = "box_556mm"
 	default_ammo = /datum/ammo/bullet/rifle
@@ -25,8 +25,8 @@
 	max_rounds = 150
 
 /obj/item/ammo_magazine/packet/pwarsaw
-	name = "box of 762x39mm"
-	desc = "A box containing 120 rounds of 762x39mm."
+	name = "box of 7.62x39mm"
+	desc = "A box containing 120 rounds of 7.62x39mm."
 	caliber = CALIBER_762X39
 	icon_state = "box_76239mm"
 	default_ammo = /datum/ammo/bullet/rifle/mpi_km


### PR DESCRIPTION

## About The Pull Request
556->5.56
762->7.62
## Why It's Good For The Game
dumb cat accosting me
## Changelog
:cl:
spellcheck: 5.56 and 7.62 boxes now have their dots in their name and description.
/:cl:
