### PR TITLE
Fixes debris runtime

### DIFF
--- a/code/datums/elements/debris.dm
+++ b/code/datums/elements/debris.dm
@@ -47,7 +47,7 @@
 	debris_velocity = _debris_velocity
 	debris_amount = _debris_amount
 	debris_scale = _debris_scale
-	RegisterSignal(target, COMSIG_ATOM_BULLET_ACT, PROC_REF(register_for_impact))
+	RegisterSignal(target, COMSIG_ATOM_BULLET_ACT, PROC_REF(register_for_impact), TRUE)
 
 /datum/element/debris/Detach(datum/source, force)
 	. = ..()

--- a/code/datums/elements/debris.dm
+++ b/code/datums/elements/debris.dm
@@ -47,7 +47,7 @@
 	debris_velocity = _debris_velocity
 	debris_amount = _debris_amount
 	debris_scale = _debris_scale
-	RegisterSignal(target, COMSIG_ATOM_BULLET_ACT, PROC_REF(register_for_impact), TRUE)
+	RegisterSignal(target, COMSIG_ATOM_BULLET_ACT, PROC_REF(register_for_impact), TRUE) //override because the element gets overriden
 
 /datum/element/debris/Detach(datum/source, force)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/3ccb2cd3-88df-436d-a3dc-feba8a13ed02)

AddElement gets called in the parents of all closed turfs, then on the children which overrides it. The element itself is highlander, the signal might as well be too.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed a debris runtime
/:cl:
