### PR TITLE
Non humans don't fit in autodoc anymore

### DIFF
--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -735,7 +735,7 @@
 	go_out()
 
 /obj/machinery/autodoc/proc/move_inside_wrapper(mob/living/dropped, mob/dragger)
-	if(dragger.incapacitated() || !ishuman(dragger))
+	if(dragger.incapacitated() || !ishuman(dragger) || !ishuman(dropped))
 		return
 
 	if(occupant)
@@ -787,8 +787,7 @@
 
 
 /obj/machinery/autodoc/MouseDrop_T(mob/M, mob/user)
-	if(!ishuman(M) || !ishuman(user))
-		return
+	. = ..()
 	move_inside_wrapper(M, user)
 
 /obj/machinery/autodoc/verb/move_inside()

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -787,7 +787,7 @@
 
 
 /obj/machinery/autodoc/MouseDrop_T(mob/M, mob/user)
-	if(!isliving(M) || !ishuman(user))
+	if(!ishuman(M) || !ishuman(user))
 		return
 	move_inside_wrapper(M, user)
 


### PR DESCRIPTION

## About The Pull Request

It caused runtimes.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: You can't put dogs or other nonhumans into the autodoc anymore. Stop it.
/:cl:
