### PR TITLE
PPsh changes

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -367,15 +367,16 @@
 		/obj/item/attachable/stock/ppsh,
 	)
 
-	fire_delay = 0.15 SECONDS
-	burst_amount = 6
+	fire_delay = 0.1 SECONDS
+	burst_amount = 1
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.8
-	scatter = 5
-	scatter_unwielded = 15
-	aim_slowdown = 0.3
-	wield_delay = 0.35 SECONDS
 
+	min_scatter = 2
+	max_scatter = 15
+	scatter_increase = 2
+	scatter_decay = 0.5
+	scatter_decay_unwielded = 0.5
 
 //-------------------------------------------------------
 //GENERIC UZI //Based on the uzi submachinegun, of course.

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -374,6 +374,7 @@
 	akimbo_additional_delay = 0.5
 
 	min_scatter = 2
+	min_scatter_unwielded = 3
 	max_scatter = 15
 	max_scatter_unwielded = 25
 	scatter_increase = 2

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -371,13 +371,15 @@
 	burst_amount = 1
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.8
+	akimbo_additional_delay = 0.5
 
 	min_scatter = 2
 	max_scatter = 15
 	max_scatter_unwielded = 25
 	scatter_increase = 2
+	scatter_increase_unwielded = 8
 	scatter_decay = 0.5
-	scatter_decay_unwielded = 0.5
+	scatter_decay_unwielded = 0.1
 
 //-------------------------------------------------------
 //GENERIC UZI //Based on the uzi submachinegun, of course.

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -374,6 +374,7 @@
 
 	min_scatter = 2
 	max_scatter = 15
+	max_scatter_unwielded = 25
 	scatter_increase = 2
 	scatter_decay = 0.5
 	scatter_decay_unwielded = 0.5

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -96,10 +96,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 78
 	bonus_overlay = "ppsh_ex"
-	scatter_mod = 5
-	scatter_unwielded_mod = 10
-	wield_delay_mod = 0.2 SECONDS
-	aim_speed_mod = 0.3
+	aim_speed_mod = 0.2
 
 //-------------------------------------------------------
 //GENERIC UZI //Based on the uzi submachinegun, of course.


### PR DESCRIPTION

## About The Pull Request
Changes
- Fire delay dropped to .1 (+)
- Drum magazine maluses for wield delay removed, reduced slowdown from .3 to .2 (+)
- Removed autoburst entirely. (-)
- Reworked to use scatter buildup. It scatters a lot even on short bursts, though.
## Why It's Good For The Game
Gives the PPsh a gimmick beyond being a trolling autoburst gun which is an OLD holdover from long ago when we had no full auto. The gun is now a dedicated shock weapon meant for CQC engagements, its high scatter makes it really bad beyond mid range...
..I mean, you could also bipod it and use it as a dollar store MG, I guess?? I don't know why you would.. but the option is there.
## Changelog
:cl:
balance: PPsh rebalanced, removed autoburst, fires faster, it now builds up scatter as it fires.
/:cl:
