### PR TITLE
SMG-25 changes

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -185,8 +185,12 @@
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/burstfire_assembly,
+		/obj/item/weapon/gun/pistol/plasma_pistol,
+		/obj/item/weapon/gun/shotgun/combat/masterkey,
+		/obj/item/weapon/gun/flamer/mini_flamer,
+		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/attachable/gyro,
 	)
 
@@ -199,6 +203,9 @@
 	scatter_unwielded = 10
 	aim_slowdown = 0.15
 	burst_amount = 3
+	upper_akimbo_accuracy = 5
+	lower_akimbo_accuracy = 3
+	damage_falloff_mult = 0.5
 
 /obj/item/weapon/gun/smg/m25/holstered
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/compensator, /obj/item/attachable/gyro)

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -203,9 +203,10 @@
 	scatter_unwielded = 10
 	aim_slowdown = 0.15
 	burst_amount = 3
+	akimbo_additional_delay = 0.4
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.9
 
 /obj/item/weapon/gun/smg/m25/holstered
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/compensator, /obj/item/attachable/gyro)


### PR DESCRIPTION
## About The Pull Request
Changes -
- Has gained all the unbarreled gun attachments (masterkey/PP/masterkey/mini/UGL)
- Has rifle level akimbo maluses.
- Has carbine-level falloff damage multiplier. (0.9)
- Has .4 akimbo fire delay multiplier.
## Why It's Good For The Game
Makes the SMG-25 more unique in its class, its basically a rifle with the damage profile and handling of an SMG now.
## Changelog
:cl:
balance: SMG-25 can now fit underbarreled guns.
balance: SMG-25 and its elite version now have higher akimbo maluses, and have less damage falloff over distance.
/:cl:
