### PR TITLE
remove easy plat miner in Gelida IV

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -71919,7 +71919,7 @@ lnR
 jqf
 jqf
 uLt
-nYF
+jqf
 jqf
 jqf
 jqf


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/dfb480c5-6b86-4dc9-b1b8-3b86b304fcd7)


## Why It's Good For The Game

Too easy for engineers to gamer.

## Changelog

:cl:
del: remove easy plat miner in Gelida IV
balance: remove easy plat miner in Gelida IV
/:cl:

