### PR TITLE
Martini Rework MK.IV - Revenge of the Tea

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1155,7 +1155,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration = 20
 	accurate_range_min = 0
 	///shatter effection duration when hitting mobs
-	var/shatter_duration = 15 SECONDS
+	var/shatter_duration = 10 SECONDS
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/proj)
 	if(!isliving(M))

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1150,13 +1150,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	handful_icon_state = "crude heavy sniper bullet"
 	hud_state = "sniper_crude"
 	handful_amount = 5
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC
 	damage = 120
 	penetration = 20
-	sundering = 10
+	accurate_range_min = 0
+	///shatter effection duration when hitting mobs
+	var/shatter_duration = 15 SECONDS
 
-/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5)
+/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/proj)
+	if(!isliving(M))
+		return
+
+	var/mob/living/living_victim = M
+	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)
 
 /datum/ammo/bullet/sniper/elite
 	name = "supersonic sniper bullet"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -437,7 +437,7 @@
 
 /obj/item/weapon/gun/shotgun/double/martini
 	name = "\improper Martini Henry lever action rifle"
-	desc = "A lever action with room for a single round of .557/440 ball. Perfect for any kind of hunt, be it elephant or xeno."
+	desc = "A lever action with room for a single round of .557/440 ball. Perfect for any kind of hunt, be it elephant or xeno with how quick to the draw it is."
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "martini"
@@ -469,6 +469,10 @@
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 19, "under_y" = 14, "stock_x" = 15, "stock_y" = 12)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_slowdown = 0.35
+	aim_time = 0.25 SECONDS
+
 
 	fire_delay = 1 SECONDS
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -471,7 +471,7 @@
 	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 19, "under_y" = 14, "stock_x" = 15, "stock_y" = 12)
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_slowdown = 0.35
-	aim_time = 0.25 SECONDS
+	aim_time = 0.5 SECONDS
 
 
 	fire_delay = 1 SECONDS


### PR DESCRIPTION

## About The Pull Request
Reworks Martini from a meme with no purpose beyond FF and triple juggle memes to something resembling a gun with a gimmick
- Ammo no longer has minimum range
- Sundering and staggerstun are entirely removed from the ammo.
- It now does 10 seconds of Shatter on hit.
- It now has aim mode, with an incredibly fast aiming time.
## Why It's Good For The Game
Martini now has some level of niche in the marine arsenal, it breaks through a large chunk of armor to allow teammates to follow up.
I removed the minimum range since it doesn't really feel like it fits here.
## Changelog
:cl:
balance: Martini rework, no longer has staggerstun nor minimum range. It now deals the shattering effect on hit instead.
/:cl:
