### PR TITLE
Fix human armour checks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -341,32 +341,27 @@ This function restores all limbs.
 	return species.apply_damage(damage, damagetype, def_zone, blocked, sharp, edge, updating_health, penetration, src)
 
 /mob/living/carbon/human/get_soft_armor(armor_type, proj_def_zone)
-	if(proj_def_zone)
-		var/datum/limb/affected_limb
+	if(!proj_def_zone)
+		return ..()
 
-		if(isorgan(proj_def_zone))
-			affected_limb = proj_def_zone
-		else
-			affected_limb = get_limb(proj_def_zone)
+	var/datum/limb/affected_limb
 
-		return affected_limb.soft_armor.getRating(armor_type)
-		//If a specific bodypart is targeted, check how that bodypart is protected and return the value.
-
-	//If you don't specify a bodypart, it checks ALL your available bodyparts for protection, and averages out the values
+	if(isorgan(proj_def_zone))
+		affected_limb = proj_def_zone
 	else
-		var/armor_val = 0
-		var/total_weight = 0
+		affected_limb = get_limb(proj_def_zone)
 
-		var/list/datum/limb/parts = get_damageable_limbs()
-
-		while(length(parts))
-			var/datum/limb/picked = pick_n_take(parts)
-			var/weight = GLOB.organ_rel_size[picked.name]
-			armor_val += picked.soft_armor.getRating(armor_type) * weight
-			total_weight += weight
-		//Note, in the case of limbs missing, this will increase average armor if remaining armor is higher than if fully limbed.
-		return armor_val / total_weight
+	return affected_limb.soft_armor.getRating(armor_type)
 
 /mob/living/carbon/human/get_hard_armor(armor_type, proj_def_zone)
-	var/datum/limb/affected_limb = get_limb(check_zone(proj_def_zone))
+	if(!proj_def_zone)
+		return ..()
+
+	var/datum/limb/affected_limb
+
+	if(isorgan(proj_def_zone))
+		affected_limb = proj_def_zone
+	else
+		affected_limb = get_limb(proj_def_zone)
+
 	return affected_limb.hard_armor.getRating(armor_type)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -1,8 +1,8 @@
-///Returns the soft armor for the given mob. If human and no limb is specified, it takes the weighted average of all available limbs.
+///Returns the soft armor for the given mob. If human and a limb is specified, gets the armor for that specific limb.
 /mob/living/proc/get_soft_armor(armor_type, proj_def_zone)
 	return soft_armor.getRating(armor_type)
 
-///Returns the hard armor for the given mob. If human and no limb is specified, it takes the weighted average of all available limbs.
+///Returns the hard armor for the given mob. If human and a limb is specified, gets the armor for that specific limb.
 /mob/living/proc/get_hard_armor(armor_type, proj_def_zone)
 	return hard_armor.getRating(armor_type)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes armour getters for humans actually work properly.

So human armour getters were kinda fucked in 2 ways.

1: Hard armour simply had no code to retrieve a number if no limb was specified.
2: Soft armour did this bizarre calculation to get some weighted average armour value when no limb was specified.

But the correct overall armour is already calculated... it's what the mob's soft/hard armour value is.

The procs will now just call parent if no limb is specified, meaning they get the actual, accurate figure. This means in some cases the value will be slightly different from what you'd get currently.

For example on my SOM test guy, melee soft armour is 61, but currently the proc returns a value of 63.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better code.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a couple of issues with human total armour calculations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
