### PR TITLE
remove smoke effect from mini rocket impacts

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -526,14 +526,8 @@
 	var/datum/effect_system/expl_particles/P = new
 	P.set_up(4, 0, impact)
 	P.start()
-	addtimer(CALLBACK(src, PROC_REF(delayed_smoke_spread), impact), 0.5 SECONDS)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
-
-/obj/structure/ship_ammo/minirocket/proc/delayed_smoke_spread(turf/impact)
-	var/datum/effect_system/smoke_spread/S = new
-	S.set_up(1, impact)
-	S.start()
 
 /obj/structure/ship_ammo/minirocket/show_loaded_desc(mob/user)
 	// to_chat(user, "It's loaded with \a [src] containing [ammo_count] minirocket\s.")
@@ -613,7 +607,6 @@
 	var/datum/effect_system/expl_particles/P = new/datum/effect_system/expl_particles()
 	P.set_up(4, 0, impact)
 	P.start()
-	addtimer(CALLBACK(src, PROC_REF(delayed_smoke_spread), impact), 0.5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(drop_cas_flare), impact), 1.5 SECONDS)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.


### PR DESCRIPTION

## About The Pull Request
this also fixes illum flares not lighting up
## Why It's Good For The Game
this is the only explosion that does it and its breaking illum flares
## Changelog
:cl:
del: smoke effect from minirockets
/:cl:
