### PR TITLE
Changes Russian Red Autoinjector Mix

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -259,10 +259,10 @@
 	desc = "An autoinjector loaded with a single use of Russian Red. Restores a significant amount of stamina and heals a large amount of damage, but causes slight permanent damage."
 	icon_state = "Redwood"
 	amount_per_transfer_from_this = 15
-	volume = 15
+	volume = 30
 	list_reagents = list(
-		/datum/reagent/medicine/russian_red = 10,
-		/datum/reagent/medicine/ryetalyn = 5,
+		/datum/reagent/medicine/russian_red = 20,
+		/datum/reagent/medicine/oxycodone = 10,
 	)
 	description_overlay = "Rr"
 	free_refills = FALSE


### PR DESCRIPTION

## About The Pull Request
Old RR autoinjector:
-15u total capacity
-15u dose
-10u RR and 5u ryetalyn

New RR autoinjector:
-30u total capacity
-15u dose
-20u RR and 10u oxycodone
-10u RR and 5u oxycodone per dose

## Why It's Good For The Game
Ryetalyn being in the RR autoinjectors didn't really make sense. RR is an emergency chem to heal you quickly but at a cost, then ryet is a slow metabolism anti toxin chem. It just doesn't fit the injector's role well. Also, 150u of free ryet from the injectors is a bit weird, considering it is supposed to be lemolocked. 

Oxycodone meanwhile is a strong painkiller that lowers shock and recovers some stamina on addition to body. The "downside" of it is that it metabolizes fast and is generally hard to rely on as your main painkiller. But for an emergency pick me up, it fits the role perfectly. Advanced combat autoinjectors have meraderm and oxy, similar role to quickly fix up someone that is messed up. 

I'm going with 30u total in the injector since it having 15u injectors just adds tedium. Drink a canteen empty, empty two 15u RR injectors into it, then draw it up using an injector with 30u capacity. 

## Changelog
:cl:
balance: Changes russian red autoinjectors to 20u RR and 10u oxycodone with 15u dose from 10u RR and 5u ryetalyn on 15u dose. 
/:cl:
