### PR TITLE
Adds Medium General Pouch to White Clothing Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1432,6 +1432,7 @@
 			/obj/item/storage/pouch/general/large = -1,
 			/obj/item/storage/pouch/document = -1,
 			/obj/item/cell/lasgun/volkite/powerpack/marine = -1,
+			/obj/item/storage/pouch/general/medium = -1,
 		),
 		"Headwear" = list(
 			/obj/item/clothing/head/modular/style/beret = -1,


### PR DESCRIPTION

## About The Pull Request
Adds medium general pouch to white clothing vendor in unlimited quantities. It is a pouch with 2 slots of storage that can hold normal sized items. 

## Why It's Good For The Game
My understanding is that the medium general pouch was replaced by current general pouch, which was supposed to be a straight upgrade to the medium general pouch. So medium general pouch was mostly removed because it was thought to be bloat. I don't know if this was an unintended change at some point, but the current general pouch cannot hold normal sized items except for ammo boxes (ex. 10x24 ammo box to refill T12 magazines). 

There is a niche for being able to carry normal sized items in a pouch slot. Weapons with normal sized magazines like the T29 (SG-29), T60 (MG-60), T42 (MG-42), HMG-08 for the 250 round drums, and large flamerthrower tanks for flamers cannot fit in magazine pouch, so there is no option to store ammo for them in pouch slot. Also corpsman if they can't use defib gloves (robot or using another type of gloves), probably better to use a medkit pouch in most cases, but it would probably have a niche for some loadouts. There's probably some other use cases that I can't think of right now. 

Squad engineer can already get it from their specific role's free vendor, probably an oversight when trying to remove the medium general pouch. I personally find it kinda silly that you have to ask a squad engi to vend medium general pouch for you currently if you want to use it, not like squad engis often use up both their pouch options anyways. 

## Changelog
:cl:
add: Medium general pouch to white clothing vendor, which has 2 slots for normal sized items. 
/:cl:
