### PR TITLE
allows for more than 2 squads when Pillar of Spring is the ship map

### DIFF
--- a/_maps/pillar_of_spring.json
+++ b/_maps/pillar_of_spring.json
@@ -2,5 +2,5 @@
     "map_name": "Pillar of Spring",
     "map_path": "map_files/Pillar_of_Spring",
     "map_file": "TGS_Pillar_of_Spring.dmm",
-    "traits": [{"Marine Main Ship": true}],
+    "traits": [{"Marine Main Ship": true}]
 }

--- a/_maps/pillar_of_spring.json
+++ b/_maps/pillar_of_spring.json
@@ -3,5 +3,4 @@
     "map_path": "map_files/Pillar_of_Spring",
     "map_file": "TGS_Pillar_of_Spring.dmm",
     "traits": [{"Marine Main Ship": true}],
-    "squads": 2
 }


### PR DESCRIPTION
## About The Pull Request

removes the limitation on pillar of spring generating only two squads

## Why It's Good For The Game

allows for four teams. in the rare event that someone actually assigns teams to do things, there'll now be more teams to cover various parts of the operation.

mostly this is to allow for selecting four Squad Leader roles on join/roundstart like sulaco, or to allow for assigning up to four Squad Leader roles. Pillar of Spring gets played decently often enough on high pop that i think having four SLs is justified.

## Changelog

:cl:
balance: Pillar of Spring can now support up to 4 squads roundstart
/:cl: