### PR TITLE
allows for more than 2 squads when theseus is the ship map

### DIFF
--- a/_maps/theseus.json
+++ b/_maps/theseus.json
@@ -2,6 +2,5 @@
     "map_name": "Theseus",
     "map_path": "map_files/Theseus",
     "map_file": "TGS_Theseus.dmm",
-    "traits": [{"Marine Main Ship": true}],
-    "squads": 2
+    "traits": [{"Marine Main Ship": true}]
 }


### PR DESCRIPTION
## About The Pull Request

removes the limitation on theseus generating only two squads

## Why It's Good For The Game

allows for four teams. in the rare event that someone actually assigns teams to do things, there'll now be more teams to cover various parts of the operation.

mostly this is to allow for selecting four Squad Leader roles on join/roundstart like sulaco, or to allow for assigning up to four Squad Leader roles.

theseus is even thematically designed to support four squads, so i dunno why you never get to see all of them in action (i want to bully the alpha squaddies who don't follow the red tile pathway and come to the wrong prep room)

## Changelog

:cl:
balance:  Theseus can now support up to 4 squads roundstart
/:cl:
