### PR TITLE
More weather fixes

### DIFF
--- a/code/datums/looping_sounds/weather_sounds.dm
+++ b/code/datums/looping_sounds/weather_sounds.dm
@@ -1,8 +1,8 @@
 /datum/looping_sound/active_ashstorm
 	mid_sounds = list(
 		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
-		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
-		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
+		'sound/weather/ashstorm/outside/active_mid2.ogg'=1,
+		'sound/weather/ashstorm/outside/active_mid3.ogg'=1,
 		'sound/weather/ashstorm/inside/active_mid1.ogg'=1,
 		'sound/weather/ashstorm/inside/active_mid2.ogg'=1,
 		'sound/weather/ashstorm/inside/active_mid3.ogg'=1,
@@ -29,8 +29,11 @@
 	volume = 40
 
 /datum/looping_sound/acidrain
+	start_sound = 'sound/weather/acidrain/acidrain_start.ogg'
+	start_length = 130
 	mid_sounds = list(
 		'sound/weather/acidrain/acidrain_mid.ogg'=1,
 	)
+	end_sound = 'sound/weather/acidrain/acidrain_end.ogg'
 	mid_length = 80
 	volume = 40

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -106,12 +106,12 @@
 	SSweather.processing |= src
 	update_areas()
 	for(var/mob/impacted_mob AS in GLOB.player_list)
+		var/turf/impacted_mob_turf = get_turf(impacted_mob)
+		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
+			continue
 		if(telegraph_message)
 			to_chat(impacted_mob, telegraph_message)
 		if(impacted_mob?.client?.prefs?.toggles_sound & SOUND_WEATHER)
-			continue
-		var/turf/impacted_mob_turf = get_turf(impacted_mob)
-		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
 			continue
 		if(telegraph_sound)
 			SEND_SOUND(impacted_mob, sound(telegraph_sound, volume = 60))
@@ -130,12 +130,12 @@
 	stage = MAIN_STAGE
 	update_areas()
 	for(var/mob/impacted_mob AS in GLOB.player_list)
+		var/turf/impacted_mob_turf = get_turf(impacted_mob)
+		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
+			continue
 		if(weather_message)
 			to_chat(impacted_mob, weather_message)
 		if(impacted_mob?.client?.prefs?.toggles_sound & SOUND_WEATHER)
-			continue
-		var/turf/impacted_mob_turf = get_turf(impacted_mob)
-		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
 			continue
 		if(weather_sound)
 			SEND_SOUND(impacted_mob, sound(weather_sound))
@@ -154,12 +154,12 @@
 	stage = WIND_DOWN_STAGE
 	update_areas()
 	for(var/mob/impacted_mob AS in GLOB.player_list)
+		var/turf/impacted_mob_turf = get_turf(impacted_mob)
+		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
+			continue
 		if(end_message)
 			to_chat(impacted_mob, end_message)
 		if(impacted_mob.client?.prefs.toggles_sound & SOUND_WEATHER)
-			continue
-		var/turf/impacted_mob_turf = get_turf(impacted_mob)
-		if(!impacted_mob_turf || !(impacted_mob.z in impacted_z_levels))
 			continue
 		if(end_sound)
 			SEND_SOUND(impacted_mob, sound(end_sound))

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -5,7 +5,6 @@
 
 	telegraph_duration = 400
 	telegraph_message = span_highdanger("Thunder rumbles far above. You hear acidic droplets hissing against the canopy. Seek shelter!")
-	telegraph_sound = 'sound/weather/acidrain/acidrain_start.ogg'
 	telegraph_overlay = "rain_med"
 	telegraph_sound = 'sound/effects/siren.ogg'
 
@@ -16,7 +15,6 @@
 
 	end_duration = 100
 	end_message = span_boldannounce("The downpour gradually slows to a light shower. It should be safe outside now.")
-	end_sound = 'sound/weather/acidrain/acidrain_end.ogg'
 	end_overlay = "rain_low"
 
 	area_type = /area


### PR DESCRIPTION
## About The Pull Request

- Sandstorm actually uses all variations of the looping sound now.
- Acid rain telegraph and start and end sounds are properly separate now.
- You don't get the flavor messages if you aren't on the impacted z levels anymore.
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
fix: Sandstorm actually uses all the sound variations
fix: Acid rain telegraph and start/end messages work properly
fix: You don't get the weather messages if you aren't on the weather's Z level anymore
/:cl:
