### PR TITLE
Suppressor Tweak

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -111,7 +111,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	///the delay between shots, for attachments that fire stuff
 	var/attachment_firing_delay = 0
 	///modifier for the time it takes to enter aim mode
-	var/aim_mode_mod = 0
+	var/aim_time_mod = 0
 
 	///The specific sound played when activating this attachment.
 	var/activation_sound = 'sound/machines/click.ogg'

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -342,7 +342,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	recoil_unwielded_mod = -3
 	scatter_unwielded_mod = -2
 	damage_falloff_mod = 0.1
-	aim_time_mod = -0.5
+	aim_time_mod = -10                   ///this is in deciseconds
 
 /obj/item/attachable/suppressor/unremovable
 	flags_attach_features = NONE

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -219,6 +219,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.min_scatter_unwielded        += min_scatter_unwielded_mod
 		master_gun.aim_speed_modifier			+= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 		master_gun.iff_marine_damage_falloff	+= shot_marine_damage_falloff
+		master_gun.aim_time                     += aim_time_mod
 		master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay) * aim_mode_delay_mod)
 		if(add_aim_mode)
 			var/datum/action/item_action/aim_mode/A = new (master_gun)
@@ -272,6 +273,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.min_scatter_unwielded        -= min_scatter_unwielded_mod
 		master_gun.aim_speed_modifier			-= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 		master_gun.iff_marine_damage_falloff	-= shot_marine_damage_falloff
+		master_gun.aim_time                     -= aim_time_mod
 		master_gun.remove_aim_mode_fire_delay(name)
 		if(add_aim_mode)
 			var/datum/action/item_action/aim_mode/action_to_delete = locate() in master_gun.actions
@@ -332,13 +334,13 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	slot = ATTACHMENT_SLOT_MUZZLE
 	silence_mod = TRUE
 	pixel_shift_y = 16
-	attach_shell_speed_mod = -1
 	accuracy_mod = 0.1
 	recoil_mod = -2
 	scatter_mod = -2
 	recoil_unwielded_mod = -3
 	scatter_unwielded_mod = -2
 	damage_falloff_mod = 0.1
+	aim_time_mod = -0.5
 
 /obj/item/attachable/suppressor/unremovable
 	flags_attach_features = NONE

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -342,7 +342,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	recoil_unwielded_mod = -3
 	scatter_unwielded_mod = -2
 	damage_falloff_mod = 0.1
-	aim_time_mod = -10                   ///this is in deciseconds
+	aim_time_mod = -1 SECONDS
 
 /obj/item/attachable/suppressor/unremovable
 	flags_attach_features = NONE

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -110,6 +110,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/add_aim_mode = FALSE
 	///the delay between shots, for attachments that fire stuff
 	var/attachment_firing_delay = 0
+	///modifier for the time it takes to enter aim mode
+	var/aim_mode_mod = 0
 
 	///The specific sound played when activating this attachment.
 	var/activation_sound = 'sound/machines/click.ogg'


### PR DESCRIPTION

## About The Pull Request
Removes the bullet speed debuff from the suppressor. Gives it aim mode time reduction.

## Why It's Good For The Game
Even before suppressor's bullet speed nerf, it was just not useful at all because either you went for recoil compensator for stats, or now for barrel charger for the bullet speed + damage bonus due to the falloff reduction. Alternatively, bayonet to wack weeds. After the bullet speed nerf, the only usage it got was placing BAS T60 in smoke and hoping xenos didn't notice they were getting shot at, which already got it removed from the gun. Now gives it a niche as well as having a barrel attachment focused on aim mode playstyles given to complete the rail attachment and under attachment ones.

## Changelog
:cl:
balance: Removed bullet speed debuff for suppressor, gives it aim mode time reduction.
/:cl:
