### PR TITLE
No mind burst larva auto burrow

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -220,7 +220,7 @@
 	log_combat(src, null, "chestbursted as a larva.")
 	log_game("[key_name(src)] chestbursted as a larva at [AREACOORD(src)].")
 
-	if((locate(/obj/structure/bed/nest) in loc) && hive.living_xeno_queen?.z == loc.z)
+	if(((locate(/obj/structure/bed/nest) in loc) && hive.living_xeno_ruler?.z == loc.z) || (!mind))
 		burrow()
 
 	victim.death()


### PR DESCRIPTION
## About The Pull Request

SSD larva that bursts out grounside, will automatically burrow, instead of being non controlled and dying instantly.

Does not work shipside.

Basically 100% port of this <https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/15>

## Why It's Good For The Game

Ssd larva that cannot do anything isn't really useful, this fixes the issue.

## Changelog


:cl:
add: if burst groundside larva has no player, it'd automatically burrow and give a larva point
/:cl:
