### PR TITLE
Fix squeak toys not squeaking when jumped on w/ new turf jump ended signal

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -257,6 +257,7 @@
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_WEED_REMOVED "turf_weed_removed"
 #define COMSIG_TURF_THROW_ENDED_HERE "turf_throw_ended_here"						//From atom/movable/throw_at, sent right after a throw ends
+#define COMSIG_TURF_JUMP_ENDED_HERE "turf_jump_ended_here"      //from datum/element/jump/end_jump(): (jumper)
 #define COMSIG_TURF_RESUME_PROJECTILE_MOVE "resume_projetile"
 #define COMSIG_TURF_PROJECTILE_MANIPULATED "projectile_manipulated"
 

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -14,6 +14,7 @@
 	///what we set connect_loc to if parent is a movable
 	var/static/list/item_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(play_squeak_crossed),
+		COMSIG_TURF_JUMP_ENDED_HERE = PROC_REF(play_squeak),
 	)
 
 /datum/component/squeak/Initialize(sound_to_play, volume_override, chance_override, step_delay_override, use_delay_override)

--- a/code/datums/elements/jump.dm
+++ b/code/datums/elements/jump.dm
@@ -86,3 +86,4 @@
 	jumper.flags_pass &= ~jumper_flags_pass
 	REMOVE_TRAIT(jumper, TRAIT_SILENT_FOOTSTEPS, JUMP_ELEMENT)
 	SEND_SIGNAL(jumper, COMSIG_ELEMENT_JUMP_ENDED, TRUE, 1.5, 2)
+	SEND_SIGNAL(jumper.loc, COMSIG_TURF_JUMP_ENDED_HERE, jumper)


### PR DESCRIPTION

## About The Pull Request

Adds a new turf signal for jump landings.
Hooked up to the squeak component because I want things to squeak when I jump on them in place.

## Why It's Good For The Game

More jump interaction possibilities.

## Changelog
:cl:
add: Added a signal for jump landings on turfs, and implemented for squeak toys.
/:cl:
