### PR TITLE
Fixes MLRS Rockets being unavailable

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -831,7 +831,7 @@ EXPLOSIVES
 	contains = list(/obj/item/storage/box/mlrs_rockets)
 	cost = 60
 
-/datum/supply_packs/explosives/mlrs_rockets
+/datum/supply_packs/explosives/mlrs_rockets_gas
 	name = "TA-40L X-50 MLRS Rocket Pack (x16)"
 	contains = list(/obj/item/storage/box/mlrs_rockets_gas)
 	cost = 60


### PR DESCRIPTION

## About The Pull Request

#13202 made a mistake and overwritten the original MLRS rockets, making it so only gas rockets can be used, this makes it so both can be ordered as intended.

## Why It's Good For The Game

It isnt

## Changelog
:cl:
fix: TA-40L standard rockets are orderable from requisitions again.
/:cl:
