### PR TITLE
Changing soldiers to marines in some item and description

### DIFF
--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -82,7 +82,7 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 
 /datum/job/terragov/squad/standard/radio_help_message(mob/M)
 	. = ..()
-	to_chat(M, {"\nYou are a rank-and-file soldier of the TGMC, and that is your strength.
+	to_chat(M, {"\nYou are a rank-and-file marine the TGMC, and that is your strength.
 What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"})
 
 

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -82,8 +82,8 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 
 /datum/job/terragov/squad/standard/radio_help_message(mob/M)
 	. = ..()
-	to_chat(M, {"\nYou are a rank-and-file marine the TGMC, and that is your strength.
-What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"})
+	to_chat(M, {"\nYou are a rank-and-file marine of the TGMC, and that is your strength.
+What you lack alone, you gain standing shoulder to shoulder with the men and women of the TerraGov Marine Corps. Ooh-rah!"})
 
 
 /datum/outfit/job/marine/standard

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -367,7 +367,7 @@
 
 /obj/item/storage/box/m94
 	name = "\improper M40 FLDP flare pack"
-	desc = "A packet of seven M40 FLDP Flares. Carried by TGMC soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp. Can be launched from an underslung grenade launcher."
+	desc = "A packet of seven M40 FLDP Flares. Carried by TGMC marines to light dark areas that cannot be reached with the usual TNR Shoulder Lamp. Can be launched from an underslung grenade launcher."
 	icon_state = "m40"
 	w_class = WEIGHT_CLASS_SMALL
 	max_storage_space = 14

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -795,7 +795,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	if(!command_aura)
 		command_aura = tgui_input_list(src, "Choose an order", items = command_aura_allowed + "help")
 		if(command_aura == "help")
-			to_chat(src, span_notice("<br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br>"))
+			to_chat(src, span_notice("<br>Orders give a buff to nearby marines for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br>"))
 			return
 		if(!command_aura)
 			return

--- a/code/game/objects/machinery/vending/loadout_vendor.dm
+++ b/code/game/objects/machinery/vending/loadout_vendor.dm
@@ -1,6 +1,6 @@
 /obj/machinery/loadout_vendor
 	name = "automated loadout vendor"
-	desc = "An advanced vendor used by the TGMC to rapidly equip their soldiers"
+	desc = "An advanced vendor used by the TGMC to rapidly equip their marines"
 	icon = 'icons/obj/machines/vending.dmi'
 	icon_state = "specialist"
 	density = TRUE

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -284,7 +284,7 @@
 				faltext += "[fallen_list[i]], "
 			else
 				faltext += fallen_list[i]
-		. += "[span_notice("To our fallen soldiers:")] <b>[faltext]</b>."
+		. += "[span_notice("To our fallen marines:")] <b>[faltext]</b>."
 
 
 /obj/structure/prop/mainship/particle_cannon

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -610,7 +610,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 /obj/item/storage/backpack/marine/radiopack
 	name = "\improper TGMC radio operator backpack"
-	desc = "A backpack that resembles the ones old-age radio operator soldiers would use."
+	desc = "A backpack that resembles the ones old-age radio operator marines would use."
 	icon_state = "radiopack"
 	item_state = "radiopack"
 	///Var for the window pop-up


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

My lore and immersion.

For the non-military players that don't understand why the correction is made so that we make reference to marines instead of soldiers:

1) This is the TerraGov Marine Corps, not TerraGov Army.
2) Junior enlisted ranks reflect Marine Corps junior enlisted ranks, not Army junior enlisted ranks, so it would be absurd to call an E3 lance corporal (or terminal lance for people who know) a soldier when in the Army there is E3 private first class. Don't get me started on Army E4.
3) E7 in Marine Corps is Gunnery Sergeant, E7 in the Army is Sergeant First Class. We have gunny.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/7c753b1c-7d46-4b03-8623-485d817b0f5c)
4) Marine Corps has corpsmen, Army has combat medics.

Realism is not the focus, it is consistency. You can go call a marine a soldier, but see what happen.

Still waiting on IRL Army to make a marine tab to replace the Marine Corps.

## Changelog

:cl:
fix: change soldiers to marines in some item and description
/:cl:

