### PR TITLE
Fixes targetting breaking when another module inserted

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -421,8 +421,7 @@
 /mob/living/silicon/ai/proc/associate_artillery(mortar)
 	if(linked_artillery)
 		UnregisterSignal(linked_artillery, COMSIG_PARENT_QDELETING)
-		linked_artillery = null
-		return FALSE
+		linked_artillery.unset_targeter()
 	linked_artillery = mortar
 	RegisterSignal(linked_artillery, COMSIG_PARENT_QDELETING, PROC_REF(clean_artillery_refs))
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Currently the AI targetting beacon for artillery breaks if you try to link another deployable after the first one, this makes it so the code doesnt break and can transition to the newest linked deloyable

## Why It's Good For The Game

Why should it be good for the game?

## Changelog
:cl:
fix: Attempting to link multiple deployables to AI no longer breaks the system.
/:cl:
