### PR TITLE
Fixes objects and turfs frequently not using damage or armour flags

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,7 +84,7 @@
 		span_warning("You hit [src] with [I]!"), visible_message_flags = COMBAT_MESSAGE)
 	log_combat(user, src, "attacked", I)
 	var/power = I.force + round(I.force * 0.3 * user.skills.getRating(SKILL_MELEE_WEAPONS)) //30% bonus per melee level
-	take_damage(power, I.damtype, "melee")
+	take_damage(power, I.damtype, MELEE)
 	return TRUE
 
 

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -174,5 +174,5 @@
 	)
 
 /obj/structure/foamedmetal/fire_act() //flamerwallhacks go BRRR
-	take_damage(10, BURN, "fire")
+	take_damage(10, BURN, FIRE)
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -73,11 +73,11 @@
 		return
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(INFINITY, BRUTE, "bomb", 0)
+			take_damage(INFINITY, BRUTE, BOMB, 0)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(100, 250), BRUTE, "bomb", 0)
+			take_damage(rand(100, 250), BRUTE, BOMB, 0)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(10, 90), BRUTE, "bomb", 0)
+			take_damage(rand(10, 90), BRUTE, BOMB, 0)
 
 
 /obj/hitby(atom/movable/AM)
@@ -89,7 +89,7 @@
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		tforce = I.throwforce
-	take_damage(tforce, BRUTE, "melee", 1, get_dir(src, AM))
+	take_damage(tforce, BRUTE, MELEE, 1, get_dir(src, AM))
 
 
 /obj/bullet_act(obj/projectile/P)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -193,9 +193,9 @@
 			deconstruct(FALSE)
 			return
 		if(EXPLODE_HEAVY)
-			take_damage(rand(33, 66))
+			take_damage(rand(33, 66), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(10, 33))
+			take_damage(rand(10, 33), BRUTE, BOMB)
 	update_icon()
 
 /obj/structure/barricade/setDir(newdir)
@@ -250,7 +250,7 @@
 	if(!.)
 		return
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
-		take_damage(base_acid_damage * S.strength)
+		take_damage(base_acid_damage * S.strength, BURN, ACID)
 
 
 /obj/structure/barricade/verb/rotate()
@@ -713,11 +713,11 @@
 /obj/structure/barricade/metal/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(rand(400, 600))
+			take_damage(rand(400, 600), BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(150, 350))
+			take_damage(rand(150, 350), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(50, 100))
+			take_damage(rand(50, 100), BRUTE, BOMB)
 
 	update_icon()
 
@@ -974,11 +974,11 @@
 /obj/structure/barricade/plasteel/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(rand(450, 650))
+			take_damage(rand(450, 650), BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(200, 400))
+			take_damage(rand(200, 400), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(50, 150))
+			take_damage(rand(50, 150), BRUTE, BOMB)
 
 	update_icon()
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -15,9 +15,9 @@
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			take_damage(15)
+			take_damage(15, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(5)
+			take_damage(5, BRUTE, BOMB)
 
 
 /obj/structure/displaycase/update_icon()
@@ -39,7 +39,7 @@
 		return
 
 	visible_message(span_warning("[user] kicks the display case."), span_notice("You kick the display case."))
-	take_damage(2)
+	take_damage(2, BRUTE, MELEE)
 
 //Quick destroyed case.
 /obj/structure/displaycase/destroyed

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -21,9 +21,9 @@
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(100, 125))//Almost broken or half way
+			take_damage(rand(100, 125), BRUTE, BOMB)//Almost broken or half way
 		if(EXPLODE_LIGHT)
-			take_damage(rand(50, 75))
+			take_damage(rand(50, 75), BRUTE, BOMB)
 
 /obj/structure/fence/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -81,20 +81,20 @@
 				M.visible_message(span_warning("[user] slams [M] against \the [src]!"))
 				M.apply_damage(7, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(10)
+				take_damage(10, BRUTE, MELEE)
 			if(GRAB_AGGRESSIVE)
 				M.visible_message(span_danger("[user] bashes [M] against \the [src]!"))
 				if(prob(50))
 					M.Paralyze(20)
 				M.apply_damage(10, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(25)
+				take_damage(25, BRUTE, MELEE)
 			if(GRAB_NECK)
 				M.visible_message(span_danger("<big>[user] crushes [M] against \the [src]!</big>"))
 				M.Paralyze(10 SECONDS)
 				M.apply_damage(20, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(50)
+				take_damage(50, BRUTE, MELEE)
 
 	else if(iswirecutter(I))
 		user.visible_message(span_notice("[user] starts cutting through [src] with [I]."),
@@ -160,5 +160,5 @@
 
 /obj/structure/fence/fire_act(exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 800)
-		take_damage(round(exposed_volume / 100), BURN, "fire")
+		take_damage(round(exposed_volume / 100), BURN, FIRE)
 	return ..()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -17,10 +17,10 @@
 
 
 /obj/structure/flora/flamer_fire_act(burnlevel)
-	take_damage(burnlevel, BURN, "fire")
+	take_damage(burnlevel, BURN, FIRE)
 
 /obj/structure/flora/fire_act()
-	take_damage(25, BURN, "fire")
+	take_damage(25, BURN, FIRE)
 
 
 //TREES
@@ -48,11 +48,11 @@
 /obj/structure/flora/tree/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(500)
+			take_damage(500, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(140, 300))
+			take_damage(rand(140, 300), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(50, 100))
+			take_damage(rand(50, 100), BRUTE, BOMB)
 	START_PROCESSING(SSobj, src)
 
 
@@ -89,7 +89,7 @@
 	qdel(src)
 
 /obj/structure/flora/tree/flamer_fire_act(burnlevel)
-	take_damage(burnlevel/6, BURN, "fire")
+	take_damage(burnlevel/6, BURN, FIRE)
 
 
 /obj/structure/flora/tree/update_overlays()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -348,9 +348,9 @@
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			take_damage(200)
+			take_damage(200, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(25)
+			take_damage(25, BRUTE, BOMB)
 
 
 /obj/structure/girder/displaced

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -137,7 +137,7 @@
 
 /obj/structure/grille/fire_act(exposed_temperature, exposed_volume)
 	if(obj_integrity > integrity_failure && exposed_temperature > T0C + 1500)
-		take_damage(1, BURN, "fire")
+		take_damage(1, BURN, FIRE)
 	return ..()
 
 

--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -31,10 +31,10 @@
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
 			if(prob(50))
-				take_damage(15)
+				take_damage(15, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
 			if(prob(50))
-				take_damage(5)
+				take_damage(5, BRUTE, BOMB)
 
 
 /obj/structure/lamarr/attack_hand(mob/living/user)
@@ -42,7 +42,7 @@
 	if(.)
 		return
 	user.visible_message(span_warning("[user] kicks the lab cage."), span_notice("You kick the lab cage."))
-	take_damage(2)
+	take_damage(2, BRUTE, MELEE)
 
 
 /obj/item/clothing/mask/facehugger/lamarr

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -92,7 +92,7 @@
 	if(W.damtype == BURN && istype(src, /obj/structure/mineral_door/resin)) //Burn damage deals extra vs resin structures (mostly welders).
 		multiplier += 1 //generally means we do double damage to resin doors
 
-	take_damage(max(0, W.force * multiplier - W.force), W.damtype)
+	take_damage(max(0, W.force * multiplier - W.force), W.damtype, MELEE)
 
 /obj/structure/mineral_door/Destroy()
 	if(material_type)

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -154,9 +154,9 @@
 		if(EXPLODE_DEVASTATE)
 			qdel(src)
 		if(EXPLODE_HEAVY)
-			take_damage(100)
+			take_damage(100, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(50)
+			take_damage(50, BRUTE, BOMB)
 
 ///Releases whatever is inside the tank
 /obj/structure/xenoautopsy/tank/proc/release_occupant()

--- a/code/game/objects/structures/plants.dm
+++ b/code/game/objects/structures/plants.dm
@@ -72,11 +72,11 @@
 
 		user.visible_message(span_warning(" [user] flails away at the  [src] with [I]."),span_warning(" You flail away at the [src] with [I]."))
 		playsound(loc, 'sound/effects/vegetation_hit.ogg', 25, 1)
-		take_damage(damage)
+		take_damage(damage, BRUTE, MELEE)
 
 
 /obj/structure/bush/flamer_fire_act(burnlevel)
-	take_damage(burnlevel, BURN, "fire")
+	take_damage(burnlevel, BURN, FIRE)
 
 //*******************************//
 // Strange, fruit-bearing plants //

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -208,9 +208,9 @@
 			deconstruct(FALSE)
 			return
 		if(EXPLODE_HEAVY)
-			take_damage(rand(33, 66))
+			take_damage(rand(33, 66), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(10, 33))
+			take_damage(rand(10, 33), BRUTE, BOMB)
 	update_icon()
 
 
@@ -237,4 +237,4 @@
 	if(!.)
 		return
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
-		take_damage(2 * S.strength)
+		take_damage(2 * S.strength, BURN, ACID)

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -134,10 +134,10 @@
 
 
 /obj/structure/bed/nest/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 2, BURN, "fire")
+	take_damage(burnlevel * 2, BURN, FIRE)
 
 /obj/structure/bed/nest/fire_act()
-	take_damage(50, BURN, "fire")
+	take_damage(50, BURN, FIRE)
 
 #undef NEST_RESIST_TIME
 #undef NEST_UNBUCKLED_COOLDOWN

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -63,11 +63,11 @@
 /obj/structure/window/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(rand(125, 250))
+			take_damage(rand(125, 250), BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(75, 125))
+			take_damage(rand(75, 125), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(25, 75))
+			take_damage(rand(25, 75), BRUTE, BOMB)
 
 //TODO: Make full windows a separate type of window.
 //Once a full window, it will always be a full window, so there's no point
@@ -140,7 +140,7 @@
 				log_combat(user, M, "slammed", "", "against \the [src]")
 				M.apply_damage(7, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(10)
+				take_damage(10, BRUTE, MELEE)
 			if(GRAB_AGGRESSIVE)
 				M.visible_message(span_danger("[user] bashes [M] against \the [src]!"))
 				log_combat(user, M, "bashed", "", "against \the [src]")
@@ -148,14 +148,14 @@
 					M.Paralyze(20)
 				M.apply_damage(10, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(25)
+				take_damage(25, BRUTE, MELEE)
 			if(GRAB_NECK)
 				M.visible_message(span_danger("<big>[user] crushes [M] against \the [src]!</big>"))
 				log_combat(user, M, "crushed", "", "against \the [src]")
 				M.Paralyze(10 SECONDS)
 				M.apply_damage(20, blocked = MELEE)
 				UPDATEHEALTH(M)
-				take_damage(50)
+				take_damage(50, BRUTE, MELEE)
 
 	else if(I.flags_item & NOBLUDGEON)
 		return
@@ -264,7 +264,7 @@
 
 /obj/structure/window/fire_act(exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 800)
-		take_damage(round(exposed_volume / 100), BURN, "fire")
+		take_damage(round(exposed_volume / 100), BURN, FIRE)
 	return ..()
 
 /obj/structure/window/GetExplosionBlock(explosion_dir)
@@ -282,7 +282,7 @@
 
 /obj/structure/window/phoronbasic/fire_act(exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 32000)
-		take_damage(round(exposed_volume / 1000), BURN, "fire")
+		take_damage(round(exposed_volume / 1000), BURN, FIRE)
 	return ..()
 
 /obj/structure/window/phoronreinforced

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -35,23 +35,23 @@
 		return I.attack_obj(src, user)
 
 /obj/alien/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 2, BURN, "fire")
+	take_damage(burnlevel * 2, BURN, FIRE)
 
 /obj/alien/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(500)
+			take_damage(500, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage((rand(140, 300)))
+			take_damage((rand(140, 300)), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage((rand(50, 100)))
+			take_damage((rand(50, 100)), BRUTE, BOMB)
 
 /obj/alien/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
 	if(!.)
 		return
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
-		take_damage(rand(2, 20) * 0.1)
+		take_damage(rand(2, 20) * 0.1, BURN, ACID)
 
 /*
 * Resin
@@ -201,7 +201,7 @@
 		qdel(src)
 
 /obj/structure/mineral_door/resin/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 2, BURN, "fire")
+	take_damage(burnlevel * 2, BURN, FIRE)
 
 /obj/structure/mineral_door/resin/ex_act(severity)
 	switch(severity)
@@ -210,10 +210,10 @@
 		if(EXPLODE_HEAVY)
 			qdel()
 		if(EXPLODE_LIGHT)
-			take_damage((rand(50, 60)))
+			take_damage((rand(50, 60)), BRUTE, BOMB)
 
 /turf/closed/wall/resin/fire_act()
-	take_damage(50, BURN, "fire")
+	take_damage(50, BURN, FIRE)
 
 /obj/structure/mineral_door/resin/try_toggle_state(atom/user)
 	if(isxeno(user))

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -243,7 +243,7 @@
 	for(var/thing in thing_to_check)
 		if(ismecha(thing))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
-			burned_mech.take_damage(rand(40, 120), BURN)
+			burned_mech.take_damage(rand(40, 120), BURN, FIRE)
 			. = TRUE
 
 		else if(isobj(thing))

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -27,7 +27,7 @@
 
 
 /turf/closed/wall/resin/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 1.25, BURN, "fire")
+	take_damage(burnlevel * 1.25, BURN, FIRE)
 
 
 /turf/closed/wall/resin/proc/thicken()
@@ -76,11 +76,11 @@
 /turf/closed/wall/resin/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(600) // Heavy and devastate instakill walls.
+			take_damage(600, BRUTE, BOMB) // Heavy and devastate instakill walls.
 		if(EXPLODE_HEAVY)
-			take_damage(rand(400))
+			take_damage(rand(400), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(75, 100))
+			take_damage(rand(75, 100), BRUTE, BOMB)
 
 
 /turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
@@ -127,7 +127,7 @@
 			P.cut_apart(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD)
 
 	damage *= max(0, multiplier)
-	take_damage(damage)
+	take_damage(damage, BRUTE, MELEE)
 	playsound(src, "alien_resin_break", 25)
 
 

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -176,11 +176,11 @@
 			ChangeTurf(/turf/open/floor/plating)
 		if(EXPLODE_HEAVY)
 			if(prob(75))
-				take_damage(rand(100, 250))
+				take_damage(rand(100, 250), BRUTE, BOMB)
 			else
 				dismantle_wall(1, 1)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(0, 250))
+			take_damage(rand(0, 250), BRUTE, BOMB)
 
 
 /turf/closed/wall/sulaco/hull

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -231,14 +231,18 @@
 	penetration = max(0, penetration - hard_armor.getRating(armor_type))
 	return clamp((damage_amount * (1 - ((soft_armor.getRating(armor_type) - penetration) * 0.01))), 0, damage_amount)
 
-/turf/closed/wall/proc/take_damage(damage)
+///Applies damage to the wall
+/turf/closed/wall/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", armour_penetration = 0)
 	if(resistance_flags & INDESTRUCTIBLE) //Hull is literally invincible
 		return
 
-	if(!damage)
+	if(!damage_amount)
 		return
 
-	wall_integrity = max(0, wall_integrity - damage)
+	if(damage_flag)
+		damage_amount = modify_by_armor(damage_amount, damage_flag, armour_penetration)
+
+	wall_integrity = max(0, wall_integrity - damage_amount)
 
 	if(wall_integrity <= 0)
 		// Xenos used to be able to crawl through the wall, should suggest some structural damage to the girder
@@ -249,7 +253,7 @@
 	else
 		update_icon()
 
-
+///Repairs the wall by an amount
 /turf/closed/wall/proc/repair_damage(repair_amount)
 	if(resistance_flags & INDESTRUCTIBLE) //Hull is literally invincible
 		return

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -295,11 +295,11 @@
 			dismantle_wall(FALSE, TRUE)
 		if(EXPLODE_HEAVY)
 			if(prob(75))
-				take_damage(rand(150, 250))
+				take_damage(rand(150, 250), BRUTE, BOMB)
 			else
 				dismantle_wall(TRUE, TRUE)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(0, 250))
+			take_damage(rand(0, 250), BRUTE, BOMB)
 
 /turf/closed/wall/attack_animal(mob/living/M as mob)
 	if(M.wall_smash)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -264,7 +264,7 @@
 			to_chat(carbon_victim, "You are smashed to the ground!")
 		else if(ismecha(victim))
 			var/obj/vehicle/sealed/mecha/mecha_victim = victim
-			mecha_victim.take_damage(SHATTERING_ROAR_DAMAGE * 5 * severity, MELEE)
+			mecha_victim.take_damage(SHATTERING_ROAR_DAMAGE * 5 * severity, BRUTE, MELEE)
 		else if(istype(victim, /obj/structure/window))
 			var/obj/structure/window/window_victim = victim
 			if(window_victim.damageable)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -394,7 +394,7 @@
 				carbon_victim.add_slowdown(6)
 			else if(ismecha(victim))
 				var/obj/vehicle/sealed/mecha/mecha_victim = victim
-				mecha_victim.take_damage(xeno_owner.xeno_caste.crush_strength * 5, BOMB)
+				mecha_victim.take_damage(xeno_owner.xeno_caste.crush_strength * 5, BRUTE, BOMB)
 	stop_crush()
 
 /// stops channeling and unregisters all listeners, resetting the ability

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -298,7 +298,7 @@
 			return precrush2signal(crushed_obj.post_crush_act(charger, src))
 		playsound(crushed_obj.loc, "punch", 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
-		crushed_obj.take_damage(precrush, BRUTE, "melee")
+		crushed_obj.take_damage(precrush, BRUTE, MELEE)
 		if(QDELETED(crushed_obj))
 			charger.visible_message(span_danger("[charger] crushes [preserved_name]!"),
 			span_xenodanger("We crush [preserved_name]!"))

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -396,7 +396,7 @@
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
 	if(!is_type_in_typecache(src, GLOB.acid_spray_hit))
 		return TRUE // normal density flag
-	take_damage(X.xeno_caste.acid_spray_structure_damage, "acid", "acid")
+	take_damage(X.xeno_caste.acid_spray_structure_damage, BURN, ACID)
 	return TRUE // normal density flag
 
 /obj/structure/razorwire/acid_spray_act(mob/living/carbon/xenomorph/X)
@@ -404,7 +404,7 @@
 	return FALSE // not normal density flag
 
 /obj/vehicle/multitile/root/cm_armored/acid_spray_act(mob/living/carbon/xenomorph/X)
-	take_damage_type(X.xeno_caste.acid_spray_structure_damage, "acid", src)
+	take_damage_type(X.xeno_caste.acid_spray_structure_damage, ACID, src)
 	healthcheck()
 	return TRUE
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1313,7 +1313,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
-		wall_victim.take_damage(autocannon_wall_bonus, proj.damtype, proj.armor_type)
+		wall_victim.take_damage(autocannon_wall_bonus, P.damtype, P.armor_type)
 
 /datum/ammo/bullet/auto_cannon/on_hit_mob(mob/M, obj/projectile/P)
 	P.proj_max_range -= 5

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1313,7 +1313,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
-		wall_victim.take_damage((autocannon_wall_bonus))
+		wall_victim.take_damage(autocannon_wall_bonus, proj.damtype, proj.armor_type)
 
 /datum/ammo/bullet/auto_cannon/on_hit_mob(mob/M, obj/projectile/P)
 	P.proj_max_range -= 5
@@ -2807,7 +2807,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/T, obj/projectile/proj)
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
-		wall_victim.take_damage((proj.damage))
+		wall_victim.take_damage(proj.damage, proj.damtype, proj.armor_type)
 
 /datum/ammo/energy/lasgun/marine/autolaser/melting
 	name = "melting machine laser bolt"
@@ -3029,7 +3029,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			var/obj/obj_victim = victim
 			if(!(obj_victim.resistance_flags & XENO_DAMAGEABLE))
 				continue
-			obj_victim.take_damage(aoe_damage, BURN, ENERGY, 0, armour_penetration = penetration)
+			obj_victim.take_damage(aoe_damage, BURN, ENERGY, TRUE, armour_penetration = penetration)
 		if(victim.anchored)
 			continue
 		var/throw_dir = get_dir(T, victim)
@@ -3067,7 +3067,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/O, obj/projectile/P)
 	if(ismecha(O))
 		var/obj/vehicle/sealed/mecha/mech_victim = O
-		mech_victim.take_damage(200, BURN, ENERGY, 0, armour_penetration = penetration)
+		mech_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
 	if(!isxeno(M))

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -487,11 +487,11 @@
 /obj/machinery/deployable/mounted/moveable/atgun/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(800)
+			take_damage(800, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(150, 200))
+			take_damage(rand(150, 200), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(10, 50))
+			take_damage(rand(10, 50), BRUTE, BOMB)
 
 //AGLS-37, or Automatic Grenade Launching System 37, a fully automatic mounted grenade launcher that fires fragmentation and HE shells, can't be turned.
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1220,7 +1220,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	if(prob(30))
 		visible_message(span_warning("[src] is damaged by [proj]!"), visible_message_flags = COMBAT_MESSAGE)
-	take_damage(damage)
+	take_damage(damage, proj.damtype, proj.armor_type)
 	return TRUE
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1220,7 +1220,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	if(prob(30))
 		visible_message(span_warning("[src] is damaged by [proj]!"), visible_message_flags = COMBAT_MESSAGE)
-	take_damage(damage, proj.damtype, proj.armor_type)
+	take_damage(damage)
 	return TRUE
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -696,9 +696,9 @@
 		if(EXPLODE_DEVASTATE)
 			qdel(src)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(5, 15))
+			take_damage(rand(5, 15), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(0, 15))
+			take_damage(rand(0, 15), BRUTE, BOMB)
 
 //Attack by item. Weldingtool: unfasten and convert to obj/disposalconstruct
 /obj/structure/disposalpipe/attackby(obj/item/I, mob/user, params)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -164,4 +164,4 @@
 /obj/vehicle/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
-		take_damage(20 * S.strength)
+		take_damage(20 * S.strength, BURN, ACID)

--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -182,7 +182,7 @@
 			var/obj/crushed_object = thing
 			if(crushed_object == chassis || crushed_object.loc == chassis)
 				continue
-			crushed_object.take_damage(150) //same as a hulk punch, makes sense to me
+			crushed_object.take_damage(150, BRUTE, MELEE) //same as a hulk punch, makes sense to me
 			continue
 		if(isliving(thing))
 			var/mob/living/crushed_victim = thing

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -55,7 +55,7 @@
 				playsound(src,'sound/effects/drill.ogg',40,TRUE)
 			else if(isobj(target))
 				var/obj/O = target
-				O.take_damage(15, BRUTE, 0, FALSE, get_dir(chassis, target))
+				O.take_damage(15, BRUTE, MELEE, FALSE, get_dir(chassis, target))
 				playsound(src,'sound/effects/drill.ogg',40,TRUE)
 
 			// If we caused a qdel drilling the target, we can stop drilling them.

--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -23,4 +23,4 @@
 			return 0
 	mecha_attacker.visible_message(span_danger("[mecha_attacker] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
 	..()
-	return take_damage(mecha_attacker.force * 3, mecha_attacker.damtype, "melee", FALSE, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+	return take_damage(mecha_attacker.force * 3, mecha_attacker.damtype, MELEE, FALSE, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -286,10 +286,10 @@
 	vis_contents -= flash
 
 /obj/vehicle/unmanned/flamer_fire_act(burnlevel)
-	take_damage(burnlevel / 2, BURN, "fire")
+	take_damage(burnlevel / 2, BURN, FIRE)
 
 /obj/vehicle/unmanned/fire_act()
-	take_damage(20, BURN, "fire")
+	take_damage(20, BURN, FIRE)
 
 /obj/vehicle/unmanned/welder_act(mob/living/user, obj/item/I)
 	return welder_repair_act(user, I, 35, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 1, 4 SECONDS)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -29,26 +29,26 @@
 /obj/structure/xeno/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(210)
+			take_damage(210, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(140)
+			take_damage(140, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(70)
+			take_damage(70, BRUTE, BOMB)
 
 /obj/structure/xeno/attack_hand(mob/living/user)
 	balloon_alert(user, "You only scrape at it")
 	return TRUE
 
 /obj/structure/xeno/flamer_fire_act(burnlevel)
-	take_damage(burnlevel / 3, BURN, "fire")
+	take_damage(burnlevel / 3, BURN, FIRE)
 
 /obj/structure/xeno/fire_act()
-	take_damage(10, BURN, "fire")
+	take_damage(10, BURN, FIRE)
 
 /// Destroy the xeno structure when the weed it was on is destroyed
 /obj/structure/xeno/proc/weed_removed()
 	SIGNAL_HANDLER
-	obj_destruction(damage_flag = "melee")
+	obj_destruction(damage_flag = MELEE)
 
 /obj/structure/xeno/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
 	if(!(HAS_TRAIT(X, TRAIT_VALHALLA_XENO) && X.a_intent == INTENT_HARM && (tgui_alert(X, "Are you sure you want to tear down [src]?", "Tear down [src]?", list("Yes","No"))) == "Yes"))
@@ -92,11 +92,11 @@
 /obj/structure/xeno/trap/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(400)
+			take_damage(400, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(200)
+			take_damage(200, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(100)
+			take_damage(100, BRUTE, BOMB)
 
 /obj/structure/xeno/trap/update_icon_state()
 	switch(trap_type)
@@ -338,11 +338,11 @@ TUNNEL
 /obj/structure/xeno/tunnel/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(210)
+			take_damage(210, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(140)
+			take_damage(140, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(70)
+			take_damage(70, BRUTE, BOMB)
 
 /obj/structure/xeno/tunnel/attackby(obj/item/I, mob/user, params)
 	if(!isxeno(user))
@@ -508,11 +508,11 @@ TUNNEL
 /obj/structure/xeno/acidwell/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(210)
+			take_damage(210, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(140)
+			take_damage(140, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(70)
+			take_damage(70, BRUTE, BOMB)
 
 /obj/structure/xeno/acidwell/flamer_fire_act(burnlevel) //Removes a charge of acid, but fire is extinguished
 	acid_well_fire_interaction()
@@ -523,7 +523,7 @@ TUNNEL
 ///Handles fire based interactions with the acid well. Depletes 1 charge if there are any to extinguish all fires in the turf while producing acid smoke.
 /obj/structure/xeno/acidwell/proc/acid_well_fire_interaction()
 	if(!charges)
-		take_damage(50, BURN, "fire")
+		take_damage(50, BURN, FIRE)
 		return
 
 	charges--
@@ -670,11 +670,11 @@ TUNNEL
 /obj/structure/xeno/resin_jelly_pod/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(210)
+			take_damage(210, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(140)
+			take_damage(140, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(70)
+			take_damage(70, BRUTE, BOMB)
 
 /obj/structure/xeno/resin_jelly_pod/examine(mob/user, distance, infix, suffix)
 	. = ..()
@@ -942,18 +942,18 @@ TUNNEL
 /obj/structure/xeno/xeno_turret/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(1500)
+			take_damage(1500, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(750)
+			take_damage(750, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(300)
+			take_damage(300, BRUTE, BOMB)
 
 /obj/structure/xeno/xeno_turret/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 2, BURN, "fire")
+	take_damage(burnlevel * 2, BURN, FIRE)
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
 /obj/structure/xeno/xeno_turret/fire_act()
-	take_damage(60, BURN, "fire")
+	take_damage(60, BURN, FIRE)
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
 /obj/structure/xeno/xeno_turret/update_overlays()
@@ -1007,7 +1007,7 @@ TUNNEL
 			P.cut_apart(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD)
 
 	damage *= max(0, multiplier)
-	take_damage(damage)
+	take_damage(damage, BRUTE, MELEE)
 	playsound(src, "alien_resin_break", 25)
 
 ///Signal handler for hard del of hostile
@@ -1156,11 +1156,11 @@ TUNNEL
 /obj/structure/xeno/evotower/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			take_damage(700)
+			take_damage(700, BRUTE, BOMB)
 		if(EXPLODE_HEAVY)
-			take_damage(500)
+			take_damage(500, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(300)
+			take_damage(300, BRUTE, BOMB)
 
 /obj/structure/xeno/maturitytower
 	name = "Maturity tower"
@@ -1187,9 +1187,9 @@ TUNNEL
 /obj/structure/xeno/maturitytower/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_HEAVY, EXPLODE_DEVASTATE)
-			take_damage(500)
+			take_damage(500, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(300)
+			take_damage(300, BRUTE, BOMB)
 
 /obj/structure/xeno/pherotower
 	name = "Pheromone tower"
@@ -1221,9 +1221,9 @@ TUNNEL
 /obj/structure/xeno/pherotower/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_HEAVY, EXPLODE_DEVASTATE)
-			take_damage(500)
+			take_damage(500, BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(300)
+			take_damage(300, BRUTE, BOMB)
 
 /obj/structure/xeno/pherotower/Destroy()
 	GLOB.hive_datums[hivenumber].pherotowers -= src


### PR DESCRIPTION

## About The Pull Request
So basically every instance of explosion damage, and just a shitload of other general instances of object or turf damage never actually uses a damage type or armour type arg, meaning armour is just ignored by almost everything. Turfs didn't even have the args at all.

This will mean many things suddenly appear notably stronger than before.

Fixes #13300

Also fixes a bunch of missing defines
## Why It's Good For The Game
Stuff working correctly is good.
## Changelog
:cl:
fix: fixed objects and turfs frequently not taking armour into account when being damaged
/:cl:
