### PR TITLE
Resting via bind as a xeno now respects the use flags of the rest action

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -61,13 +61,6 @@
 	H.throw_at(get_turf(target_turf), 4, 70, H)
 	H.Paralyze(40)
 
-
-/mob/living/carbon/xenomorph/defender/lay_down()
-	if(fortify) // Ensure the defender isn't fortified while laid down
-		to_chat(src, span_warning("You can't do that right now."))
-		return
-	return ..()
-
 /mob/living/carbon/xenomorph/defender/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/throw_parry)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -102,9 +102,6 @@
 /mob/living/carbon/xenomorph/hivemind/gib()
 	return_to_core()
 
-/mob/living/carbon/xenomorph/hivemind/lay_down()
-	return
-
 /mob/living/carbon/xenomorph/hivemind/set_resting()
 	return
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -428,3 +428,9 @@
 	SIGNAL_HANDLER
 	var/obj/alien/weeds/found_weed = locate(/obj/alien/weeds) in loc
 	loc_weeds_type = found_weed?.type
+
+/mob/living/carbon/xenomorph/lay_down()
+	var/datum/action/xeno_action/xeno_resting/resting_action = actions_by_path[/datum/action/xeno_action/xeno_resting]
+	if(!resting_action || !resting_action.can_use_action())	
+		return
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Addresses inconsistencies between the bind and the action, clicking the action would get blocked in cases where pressing the bind wouldn't.
## Why It's Good For The Game

Prevents unintended behaviour like resting while rooted and other cases.
## Changelog
:cl:
fix: Resting via bind as a xeno now respects the use flags of the rest action
/:cl:
