### PR TITLE
removes engine in minerva OB room

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -15735,9 +15735,7 @@
 	dir = 6
 	},
 /obj/effect/ai_node,
-/turf/closed/shuttle/ert/engines/right{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
 "Up" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{


### PR DESCRIPTION
## About The Pull Request

removes erroneous engine in minerva's ob room

## Why It's Good For The Game

it's in the way, also bug bad

## Changelog

:cl:
fix: removed misplaced engine in Minerva's OB room
/:cl: