### PR TITLE
evolution without client

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -249,7 +249,7 @@
 	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + hive.get_evolution_boost() + spec_evolution_boost()
 	evolution_stored = min(evolution_stored + evolution_points, xeno_caste.evolution_threshold)
 
-	if(!client || !ckey) // stop evolve progress for ssd/ghosted xenos
+	if(!client || !ckey)
 		return
 
 	if(evolution_stored == xeno_caste.evolution_threshold)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -238,8 +238,6 @@
 
 
 /mob/living/carbon/xenomorph/proc/update_evolving()
-	if(!client || !ckey) // stop evolve progress for ssd/ghosted xenos
-		return
 	if(evolution_stored >= xeno_caste.evolution_threshold || !(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		return
 	if(!hive.check_ruler() && caste_base_type != /mob/living/carbon/xenomorph/larva) // Larva can evolve without leaders at round start.
@@ -250,6 +248,9 @@
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
 	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + hive.get_evolution_boost() + spec_evolution_boost()
 	evolution_stored = min(evolution_stored + evolution_points, xeno_caste.evolution_threshold)
+
+	if(!client || !ckey) // stop evolve progress for ssd/ghosted xenos
+		return
 
 	if(evolution_stored == xeno_caste.evolution_threshold)
 		to_chat(src, span_xenodanger("Our carapace crackles and our tendons strengthen. We are ready to evolve!"))


### PR DESCRIPTION
## About The Pull Request

Enables evolution points collecting even when there is no client/soul.

100% port of this https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/174

## Why It's Good For The Game

Good thing for cases when a client crashes and has to reload, or during any other unforseen disconnecting issues, which compensates the time client wasn't connected, additionally, would lower the damage to the hive by having ssd xeno ready to evolve if a ghost takes it, without any need to wait for evolution.

## Changelog


:cl:
add: evolution points tick even if xeno has no client/soul
/:cl:
