### PR TITLE
Fix space dealing inconsistent damage

### DIFF
--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -90,8 +90,10 @@
 
 /turf/open/space/Exited(atom/movable/leaver, direction)
 	if(isliving(leaver))
-		var/mob/living/spaceman = leaver
-		spaceman.remove_status_effect(/datum/status_effect/spacefreeze)
+		var/step = get_step(src, direction)
+		if(!istype(step, /turf/open/space))
+			var/mob/living/spaceman = leaver
+			spaceman.remove_status_effect(/datum/status_effect/spacefreeze)
 
 
 /turf/open/space/sea //used on prison for flavor


### PR DESCRIPTION

## About The Pull Request

Space now always does damage by applying debuff on every step, no longer can you do weird damage evasion in space, which allowed some xenos to do abuses outside the ship. (wraith doing portals to space and xenos building a silo there)

## Why It's Good For The Game

Fix = good

## Changelog

:cl:
fix: fixed cases when damage from space turfs could've been negated
/:cl:
