### PR TITLE
No more explosive flips for mech/big xenos

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -431,7 +431,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 				continue
 			for(var/am in affected_turf)
 				var/atom/movable/thing_to_throw = am
-				if(thing_to_throw.anchored || thing_to_throw.move_resist == INFINITY)
+				if(thing_to_throw.anchored || thing_to_throw.move_resist >= MOVE_FORCE_EXTREMELY_STRONG)
 					continue
 
 				for(var/throw_source in throw_turf[affected_turf])

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -452,7 +452,7 @@
 
 	else if(isobj(hit_atom)) // Thrown object hits another object and moves it
 		var/obj/O = hit_atom
-		if(!O.anchored && !isxeno(src))
+		if(!O.anchored && !isxeno(src) && O.move_resist < MOVE_FORCE_EXTREMELY_STRONG)
 			step(O, dir)
 		O.hitby(src, speed)
 


### PR DESCRIPTION
## About The Pull Request

Mech and big xenos (i.e. king, queen, rav) will no longer do sick flips and no longer fly away from even the tinies explosion (claymore, stickies). 

Also fixes the ability to move mech by throwing stuff at it.

100% port of this https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/19

## Why It's Good For The Game

Explosion stacking can send multi ton mech/xeno flying tens of meters away, which is annoying to say the least, chain explosions like claymores can chain kill queen instantly, mech shooting rockets in front of it shouldn't fly either, this fixes it.

## Changelog

:cl:
add: mech and big xenos are immune to most knockback types (not stuns)
fix: mech is no longer moved when items are thrown at it
/:cl:
