### PR TITLE
Fixes a ssmonitor runtime

### DIFF
--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(monitor)
 
 
 	//Automatic respawn buff, if a stalemate is detected and a lot of ghosts are waiting to play
-	if(current_state != STATE_BALANCED || !stalemate || GLOB.observer_list <= 0.5 * total_living_players)
+	if(current_state != STATE_BALANCED || !stalemate || length(GLOB.observer_list) <= 0.5 * total_living_players)
 		SSsilo.larva_spawn_rate_temporary_buff = 0
 		return
 	for(var/mob/dead/observer/observer AS in GLOB.observer_list)


### PR DESCRIPTION

## About The Pull Request

`Runtime in code/controllers/subsystem/monitor.dm, line 83: type mismatch: cannot compare /list (/list) to 30`
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed a ssmonitor runtime
/:cl:
