### PR TITLE
Fixes a mounted gun runtime

### DIFF
--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -52,7 +52,7 @@
 	if(!ishuman(user))
 		return
 	var/obj/item/weapon/gun/internal_gun = internal_item
-	internal_gun.do_unique_action(internal_gun, user)
+	internal_gun.do_unique_action(user)
 
 /obj/machinery/deployable/mounted/attackby_alternate(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

`Runtime in code/modules/projectiles/gun_system.dm, line 1426: undefined proc or verb /obj/item/weapon/gun/heavymachinegun/put in any hand if possible(). `

Funny. Can be reproduced by right clicking a deployed gun (08 for example)
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed a mounted gun runtime
/:cl:
