### PR TITLE
Gorger buff of the year (RUTGMC port)

### DIFF
--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -571,6 +571,7 @@
 
 		if(do_after(owner_xeno, KNOCKDOWN_DURATION, FALSE, target, ignore_turf_checks = FALSE))
 			owner_xeno.gain_plasma(plasma_gain_on_hit)
+			target.blood_volume -= 30
 
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		for(var/mob/living/carbon/xenomorph/target_xeno AS in cheap_get_xenos_near(owner_xeno, 4))
@@ -622,8 +623,13 @@
 		X.remove_status_effect(STATUS_EFFECT_XENO_FEAST)
 		return
 	var/heal_amount = X.maxHealth*0.08
-	HEAL_XENO_DAMAGE(X, heal_amount, FALSE)
-	adjustOverheal(X, heal_amount / 2)
+	for(var/mob/living/carbon/xenomorph/affected_xeno AS in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[X.z]"])
+		if(affected_xeno.faction != X.faction)
+			continue
+		if(!line_of_sight(X, affected_xeno, 4) || get_dist(X, affected_xeno) > 4)
+			continue
+		HEAL_XENO_DAMAGE(affected_xeno, heal_amount, FALSE)
+		adjustOverheal(affected_xeno, heal_amount / 2)
 	X.use_plasma(plasma_drain)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -207,7 +207,7 @@
 			to_chat(owner, span_notice("We can only help living sisters."))
 		return FALSE
 	target_health = target_xeno.health
-	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(extra_health_check), target_xeno)))
+	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(extra_health_check), target_xeno)))
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -20,8 +20,8 @@
 
 	// *** Plasma *** //
 	plasma_max = 200
-	plasma_gain = 0
-	plasma_regen_limit = 0
+	plasma_gain = 5
+	plasma_regen_limit = 0.1
 	plasma_icon_state = "fury"
 
 	// *** Health *** //
@@ -45,8 +45,8 @@
 
 	// *** Gorger Abilities *** //
 	overheal_max = 200
-	drain_plasma_gain = 20
-	carnage_plasma_gain = 25
+	drain_plasma_gain = 40
+	carnage_plasma_gain = 75
 	feast_plasma_drain = 20
 
 	actions = list(
@@ -88,8 +88,8 @@
 
 	// *** Gorger Abilities *** //
 	overheal_max = 225
-	drain_plasma_gain = 20
-	carnage_plasma_gain = 30
+	drain_plasma_gain = 45
+	carnage_plasma_gain = 90
 
 /datum/xeno_caste/gorger/elder
 	upgrade_name = "Elder"
@@ -114,8 +114,8 @@
 
 	// *** Gorger Abilities *** //
 	overheal_max = 250
-	drain_plasma_gain = 30
-	carnage_plasma_gain = 35
+	drain_plasma_gain = 55
+	carnage_plasma_gain = 110
 
 /datum/xeno_caste/gorger/ancient
 	upgrade_name = "Ancient"
@@ -139,8 +139,8 @@
 
 	// *** Gorger Abilities *** //
 	overheal_max = 275
-	drain_plasma_gain = 40
-	carnage_plasma_gain = 40
+	drain_plasma_gain = 75
+	carnage_plasma_gain = 150
 
 /datum/xeno_caste/gorger/primordial
 	upgrade_name = "Primordial"
@@ -161,8 +161,8 @@
 
 	// *** Gorger Abilities *** //
 	overheal_max = 275
-	drain_plasma_gain = 40
-	carnage_plasma_gain = 40
+	drain_plasma_gain = 75
+	carnage_plasma_gain = 150
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION
## About The Pull Request

- Feast now works on all xenos in 4 tile radius, cooldown decreased from 180 to 30
- Feast healing now has visual effect when it's active
- Drain and Carnage drain real blood from people (30u)
- Transfusion range increased from 2 tiles to 3
- You can move while casting Transfusion
- Psychic Link cooldown from 50 to 15
- Psychic Link doesn't require to stand still
- Gorger now has passive plasma regen up to 10% of maximum plasma

![dreamseeker_41t1jVpGkr](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/d5e3faa5-7c06-43b5-97e2-c9a617aa5869)

100% port of https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/122 and https://github.com/Cosmic-Overlord/TerraGov-Marine-Corps/pull/129

## Why It's Good For The Game

Gorger is really uncomfortable to play in general, these are merely QoL considering what state he is in right now, Gorger cannot sustain effectively neither offensive nor support abilities, some abilities are very rarely used in general, this tries to correct that (very successfully, considering RU experience with it). Probably needs a testmerge to estimate how good/bad these changes are. These changes are present on RU for 3 months without any balance issues.

## Changelog
:cl:
add: Drain and Carnage drain real blood from people (30u)
add: Feast now works on all xenos in 4 tile radius
qol: gorger can cast transfusion while moving
qol: gorger regenerates 10% of blood automatically
qol: Psychic Link doesn't require to stand still
balance: Transfusion range increased from 2 tiles to 3
balance: Feast cooldown lowered  from 180 to 30
balance: Psychic Link cooldown lowered from 50 to 15
/:cl:
