### PR TITLE
Fixes Medium Pouch

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -47,6 +47,7 @@
 /obj/item/storage/pouch/general/medium
 	name = "medium general pouch"
 	storage_slots = 2
+	max_w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "medium_drop"
 	draw_mode = 0
 


### PR DESCRIPTION

## About The Pull Request
Medium general pouch can only hold small items because it inherits it from /obj/item/storage/pouch. When I tested it out once a long time ago, I must have had general armor storage module UI open while thinking it was the medium general pouch or something. 

Lets medium general pouch hold normal sized items, as intended. 

## Why It's Good For The Game
Storing two small items is useless since normal general pouch holds three small items. I was under the impression that it held two normal items and to my knowledge, maintainers also thought that when they approved #13283. Two normal sized items is still only 6 weight in total, which is worse than many other pouches like medkit pouch or magazine pouch, but it does have a niche for some loadouts as outlined by my previous PR. 

## Changelog
:cl:
fix: Medium general pouch can actually hold normal sized items now, not just small items. 
/:cl:
