### PR TITLE
Fix Crusher charge closed turf damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -458,8 +458,8 @@
 
 /turf/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(charge_datum.valid_steps_taken >= charge_datum.max_steps_buildup)
-		return 2 //Should dismantle, or at least heavily damage it.
-	return 3 //Lighter damage.
+		return EXPLODE_DEVASTATE //Should dismantle, or at least heavily damage it.
+	return EXPLODE_HEAVY //Lighter, but still harsh damage.
 
 
 // ***************************************


### PR DESCRIPTION

## About The Pull Request

Increases crushers turf damage post #13302 because now heavy explosions do jack all to walls which is a big part of crushers role thereby acting as a stealth nerf to an entire caste. Next I will check acid timers, but I think those might be unaffected.

Ideally crusher would not use ex_act or there is a level between heave and deva however I'm working with what we have.

## Why It's Good For The Game

Currently it takes **5 full speed charges** to get a wall to just "moderate" damage
 > That's a reinforced wall.
A huge chunk of reinforced metal used to seperate rooms.
It looks **moderately** damaged.

Maintaining crushers role as a wall destroyer in places where a full speed charge is possible = good.

## Changelog
:cl:
fix: Fixed wall armor buff nerfing Crusher closed turf damage.
/:cl:
