### PR TITLE
Smart minigun now has reduced windup/slowdown

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -454,22 +454,13 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	wield_delay = 1.5 SECONDS
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
 	gun_skill_category = SKILL_SMARTGUN
-	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST) //full auto, fuller auto
 	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/motiondetector)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 19, "rail_y" = 29, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12) //Only has rail attachments so only the rail variables are properly aligned
-	aim_slowdown = 1.15
+	aim_slowdown = 1.2
 	actions_types = list()
 
 	fire_delay = 0.1 SECONDS
-	windup_delay = 0.5 SECONDS
-	scatter = 0
-
-	burst_amount = 2
-	burst_delay = 0.05 SECONDS
-	extra_delay = 0.1 SECONDS
-	autoburst_delay = 0.1 SECONDS //this makes it fuller auto
-	burst_accuracy_bonus = -0.3
-	burst_scatter_mult = 6
+	scatter = -5
 
 	recoil = 0
 	recoil_unwielded = 4

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -461,7 +461,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 	fire_delay = 0.1 SECONDS
 	scatter = -5
-
 	recoil = 0
 	recoil_unwielded = 4
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -444,7 +444,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 /obj/item/weapon/gun/minigun/smart_minigun
 	name = "\improper SG-85 smart handheld gatling gun"
-	desc = "A true monster of providing supportive suppresing fire, the SG-85 is the TGMC's newest IFF-capable weapon. Boasting a higher firerate than any other handheld weapon. It is chambered in 10x26 caseless."
+	desc = "A true monster of providing supportive suppresing fire, the SG-85 is the TGMC's IFF-capable minigun for heavy fire support duty. Boasting a higher firerate than any other handheld weapon. It is chambered in 10x26 caseless."
 	icon_state = "minigun_sg"
 	item_state = "minigun_sg"
 	fire_animation = "minigun_sg_fire"
@@ -454,14 +454,23 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	wield_delay = 1.5 SECONDS
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
 	gun_skill_category = SKILL_SMARTGUN
+	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST) //full auto, fuller auto
 	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/motiondetector)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 19, "rail_y" = 29, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12) //Only has rail attachments so only the rail variables are properly aligned
-	aim_slowdown = 1.5
+	aim_slowdown = 1.15
 	actions_types = list()
 
 	fire_delay = 0.1 SECONDS
-	windup_delay = 0.7 SECONDS
-	scatter = -5
+	windup_delay = 0.5 SECONDS
+	scatter = 0
+
+	burst_amount = 2
+	burst_delay = 0.05 SECONDS
+	extra_delay = 0.1 SECONDS
+	autoburst_delay = 0.1 SECONDS //this makes it fuller auto
+	burst_accuracy_bonus = -0.3
+	burst_scatter_mult = 6
+
 	recoil = 0
 	recoil_unwielded = 4
 


### PR DESCRIPTION
## About The Pull Request
Smart minigun now has superior handing statistics than before.

The windup has been made the same as the req minigun at .4 rather than .7.
It now has had its slowdown reduced by like, 20%~ from 1.5 to 1.2. at 1.5 it was incredibly awful. 1.2 is the same as the GPMG.
## Why It's Good For The Game
SG-85 damage on paper is fine, but the handling stats for it are all incredibly bad for it, this ideally should make it a more viable choice as a support weapon.
## Changelog
:cl:
balance: SG-85 now has 20%~ less slowdown when wielded, and has identical windup to req minigun.
/:cl:
