### PR TITLE
Sticky spit now spits thin sticky resin again

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3418,7 +3418,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		if(is_type_in_typecache(O, GLOB.no_sticky_resin))
 			return
 
-	new /obj/alien/resin/sticky(T)
+	new /obj/alien/resin/sticky/thin(T)
 
 /datum/ammo/xeno/sticky/turret
 	max_range = 9


### PR DESCRIPTION

## About The Pull Request
Apparently this broke ages ago and nobody noticed, sticky spits now spit thin sticky resin rather than sticky resin.
## Why It's Good For The Game
Thin sticky resin mostly existed to be spit out, so its kinda weird it got changed by accident by BM.
## Changelog
:cl:
fix: Sticky resin now spits out thin sticky resin again rather than normal sticky resin.
/:cl:
