### PR TITLE
Fix a fire overlay runtime

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -93,6 +93,8 @@
 	apply_temp_overlay(X_SUIT_LAYER, 1.2 SECONDS)
 
 /mob/living/carbon/xenomorph/update_fire()
+	if(!fire_overlay)
+		return
 	if(!on_fire)
 		fire_overlay.icon_state = ""
 		return


### PR DESCRIPTION

## About The Pull Request

Basically it gets deleted in the xeno's `Destroy`, but then when the mob is taken out of ssmobs processing further up the call stack it calls `ExtinguishMob` which calls this which causes a runtime.

`Runtime in code/modules/mob/living/carbon/xenomorph/update_icons.dm, line 97: Cannot modify null.icon_state.`
## Why It's Good For The Game

Runtime uncool.
## Changelog
:cl:
fix: Fixed a fire overlay runtime
/:cl:
