### PR TITLE
Smart Minions by default

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -118,8 +118,6 @@ GLOBAL_LIST_INIT(resin_images_list, list(
 #define UPGRADE_FLAG_MESSAGE_HIVE (1<<0)
 #define UPGRADE_FLAG_ONETIME (1<<0)
 
-#define GHOSTS_CAN_TAKE_MINIONS "Smart Minions"
-
 GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 	/mob/living/carbon/xenomorph/beetle/ai,
 	/mob/living/carbon/xenomorph/mantis/ai,

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -63,7 +63,7 @@
 			continue
 		if(isxeno(ssd_mob))
 			var/mob/living/carbon/xenomorph/potential_minion = ssd_mob
-			if((potential_minion.xeno_caste.caste_flags & CASTE_IS_A_MINION) && !potential_minion.hive.purchases.upgrades_by_name[GHOSTS_CAN_TAKE_MINIONS].times_bought)
+			if((potential_minion.xeno_caste.caste_flags & CASTE_IS_A_MINION))
 				continue
 		free_ssd_mobs += ssd_mob
 

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -61,8 +61,6 @@
 	for(var/mob/living/ssd_mob AS in GLOB.ssd_living_mobs)
 		if(is_centcom_level(ssd_mob.z) || ssd_mob.afk_status == MOB_RECENTLY_DISCONNECTED)
 			continue
-		if(isxeno(ssd_mob))
-			var/mob/living/carbon/xenomorph/potential_minion = ssd_mob
 		free_ssd_mobs += ssd_mob
 
 	if(!length(free_ssd_mobs))

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -63,8 +63,6 @@
 			continue
 		if(isxeno(ssd_mob))
 			var/mob/living/carbon/xenomorph/potential_minion = ssd_mob
-			if((potential_minion.xeno_caste.caste_flags & CASTE_IS_A_MINION))
-				continue
 		free_ssd_mobs += ssd_mob
 
 	if(!length(free_ssd_mobs))

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -308,6 +308,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	flags_gamemode = ABILITY_DISTRESS
 	flags_upgrade = UPGRADE_FLAG_ONETIME|UPGRADE_FLAG_MESSAGE_HIVE
 	psypoint_cost = 500
+	times_bought = 1
 
 /datum/hive_upgrade/primordial
 	category = "Xenos"

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -2,7 +2,6 @@
 #define PRIMORDIAL_TIER_TWO "Primordial tier two"
 #define PRIMORDIAL_TIER_THREE "Primordial tier three"
 #define PRIMORDIAL_TIER_FOUR "Primordial tier four"
-#define SPAWNER_BUILDING_LIMIT_MAX 2
 
 GLOBAL_LIST_INIT(upgrade_categories, list("Buildings", "Defences", "Xenos"))//, "Primordial"))//uncomment to unlock globally
 GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
@@ -233,17 +232,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	flags_upgrade = ABILITY_DISTRESS
 	building_type = /obj/structure/xeno/spawner
 
-/datum/hive_upgrade/building/spawner/can_buy(mob/living/carbon/xenomorph/buyer, silent)
-	. = ..()
-	if(!.)
-		return
-
-	if(length(GLOB.xeno_spawners_by_hive[buyer.hivenumber]) >= SPAWNER_BUILDING_LIMIT_MAX)
-		if(!silent)
-			to_chat(buyer, span_xenonotice("The hive cannot support another [src]!"))
-		return
-
-
 /datum/hive_upgrade/defence
 	category = "Defences"
 
@@ -348,5 +336,3 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Unlocks the primordial for the first tier"
 	psypoint_cost = 600
 	icon = "primosent"
-
-#undef SPAWNER_BUILDING_LIMIT_MAX

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -2,6 +2,7 @@
 #define PRIMORDIAL_TIER_TWO "Primordial tier two"
 #define PRIMORDIAL_TIER_THREE "Primordial tier three"
 #define PRIMORDIAL_TIER_FOUR "Primordial tier four"
+#define SPAWNER_BUILDING_LIMIT_MAX 2
 
 GLOBAL_LIST_INIT(upgrade_categories, list("Buildings", "Defences", "Xenos"))//, "Primordial"))//uncomment to unlock globally
 GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
@@ -231,6 +232,17 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	icon = "spawner"
 	flags_upgrade = ABILITY_DISTRESS
 	building_type = /obj/structure/xeno/spawner
+
+/datum/hive_upgrade/building/spawner/can_buy(mob/living/carbon/xenomorph/buyer, silent)
+	. = ..()
+	if(!.)
+		return
+
+	if(length(GLOB.xeno_spawners_by_hive[buyer.hivenumber]) >= SPAWNER_BUILDING_LIMIT_MAX)
+		if(!silent)
+			to_chat(buyer, span_xenonotice("The hive cannot support another [src]!"))
+		return
+
 
 /datum/hive_upgrade/defence
 	category = "Defences"

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -348,3 +348,5 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Unlocks the primordial for the first tier"
 	psypoint_cost = 600
 	icon = "primosent"
+
+#undef SPAWNER_BUILDING_LIMIT_MAX

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -301,15 +301,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/xenos
 	category = "Xenos"
 
-/datum/hive_upgrade/xenos/smart_minions
-	name = GHOSTS_CAN_TAKE_MINIONS
-	desc = "Allow ghosts to take control of minions"
-	icon = "smartminions"
-	flags_gamemode = ABILITY_DISTRESS
-	flags_upgrade = UPGRADE_FLAG_ONETIME|UPGRADE_FLAG_MESSAGE_HIVE
-	psypoint_cost = 500
-	times_bought = 1
-
 /datum/hive_upgrade/primordial
 	category = "Xenos"
 	flags_upgrade = UPGRADE_FLAG_ONETIME|UPGRADE_FLAG_MESSAGE_HIVE


### PR DESCRIPTION

## About The Pull Request
Smart Minions is enabled for by default.  
## Why It's Good For The Game
From my experience, Smart Minions is almost never purchased, and minion spawners are not always purchased. Even when Smart Minions is purchased, it may be ignored or overlooked in favor of spawning a larva, potentially wasting its purchase. I don't think it is such a huge advantage over AI-controlled minions, since they are slightly robust, and even if it is better than some of the AI's shortcomings, such as getting stuck, these aren't intended anyway.
## Changelog
:cl: Tanker
balance: Smart Minions is now enabled by default.
/:cl:
