### PR TITLE
Fixes an intoxication status effect runtime

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -522,7 +522,9 @@
 	if(length(debuff_owner.do_actions))
 		return
 	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
-		debuff_owner.balloon_alert(debuff_owner, "Interrupted")
+		debuff_owner?.balloon_alert(debuff_owner, "Interrupted")
+		return
+	if(!debuff_owner)
 		return
 	playsound(debuff_owner, 'sound/effects/slosh.ogg', 30)
 	debuff_owner.balloon_alert(debuff_owner, "Succeeded")


### PR DESCRIPTION

## About The Pull Request

If you started the do_after and the debuff ran out in the meantime it'd end up a runtime. Not cool.

`Runtime in code/datums/status_effects/debuffs.dm, line 528: Cannot execute null.balloon alert().`
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed an intoxication status effect runtime
/:cl:
