### PR TITLE
Explosive Vest description update in regards to riot shields

### DIFF
--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/suit/storage/marine/boomvest
 	name = "tactical explosive vest"
-	desc = "Obviously someone just strapped a bomb to a marine harness and called it tactical. The light has been removed, and its switch used as the detonator.<br><span class='notice'>Control-Click to set a warcry.</span> <span class='warning'>This harness has no light, toggling it will detonate the vest!</span>"
+	desc = "Obviously someone just strapped a bomb to a marine harness and called it tactical. The light has been removed, and its switch used as the detonator.<br><span class='notice'>Control-Click to set a warcry.</span> <span class='warning'>This harness has no light, toggling it will detonate the vest! Riot shields prevent detonation of the tactical explosive vest!!</span>"
 	icon_state = "boom_vest"
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	slowdown = 0


### PR DESCRIPTION


## About The Pull Request

Updates description of tactical explosive vest in that it cannot be used with riot shields from the marine vendor. This should be reflected in the item description.

## Why It's Good For The Game

This is not as the explosive vest is a shitpost item. But neither is obfuscation of features.

## Changelog>

:cl:
fix: Added the part that the description of the explosive vest that says you cannot use strapped on shields. 
/:cl:

Tested locally.