### PR TITLE
Fixes new character slots being uneditable (minus species)

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -230,7 +230,7 @@
 				. = "Jeri"
 		to_chat(prefs.parent, span_warning("You forgot to set your synthetic name in your preferences. Please do so next time."))
 
-/datum/species/proc/on_species_gain(mob/living/carbon/human/H, /datum/species/old_species)
+/datum/species/proc/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	SHOULD_CALL_PARENT(TRUE) //remember to call base procs kids
 	for(var/slot_id in no_equip)
 		var/obj/item/thing = H.get_item_by_slot(slot_id)


### PR DESCRIPTION

## About The Pull Request

Okay so this is a doozy. Apparently the `/datum/species/old_species` counted as a brand new species definition, so when the global list of all species did `subtypesof(/datum/species)` this "species" got added to the list which then didn't have a name, so the key in the assoc list was null, so when you made a new character and it looked for an entry under the null key it picked this and you'd end up with an invalid species selected in your prefs which fucked character editing because it's not a real species datum. Guh. 

Fixes #13343
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed new character slots/characters being uneditable in prefs
/:cl:
