### PR TITLE
Nutrition drains from kit regen

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -163,6 +163,7 @@ REAGENT SCANNER
 
 		"blood_type" = patient.blood_type,
 		"blood_amount" = patient.blood_volume,
+		"hungry" = patient.nutrition < NUTRITION_HUNGRY,
 
 		"hugged" = (locate(/obj/item/alien_embryo) in patient)
 	)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -70,15 +70,6 @@
 			if(0 to BLOOD_VOLUME_SURVIVE)
 				death()
 
-
-		// Without enough blood you slowly go hungry.
-		if(blood_volume < BLOOD_VOLUME_SAFE)
-			switch(nutrition)
-				if(300 to INFINITY)
-					adjust_nutrition(-10)
-				if(200 to 300)
-					adjust_nutrition(-3)
-
 		//Bleeding out
 		var/blood_max = 0
 		for(var/l in limbs)

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -20,7 +20,7 @@
 /mob/living/carbon/proc/adjust_nutrition_speed(old_nutrition)
 	switch(nutrition)
 		if(0 to NUTRITION_HUNGRY) //Level where a yellow food pip shows up, aka hunger level 3 at 250 nutrition and under
-			add_movespeed_modifier(MOVESPEED_ID_HUNGRY, TRUE, 0, NONE, TRUE, round(1.5 - (nutrition / 250), 0.1)) //From 0.5 to 1.5
+			add_movespeed_modifier(MOVESPEED_ID_HUNGRY, TRUE, 0, NONE, TRUE, round(1.5*(250-nutrition)/250, 0.1)) //From 0 to 1.5
 		if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
 			switch(old_nutrition)
 				if(NUTRITION_HUNGRY to NUTRITION_OVERFED)

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -322,7 +322,7 @@ export const MedScanner = (props, context) => {
             ) : null}
           </Section>
         ) : null}
-        {hungry ? <NoticeBox warning>Calorie intake recommended.</NoticeBox> : null}
+        {hungry ? <NoticeBox warning>Calorie intake recommended</NoticeBox> : null}
         {infection ? <NoticeBox warning>{infection}</NoticeBox> : null}
         {implants ? (
           <NoticeBox info>

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -27,6 +27,7 @@ export const MedScanner = (props, context) => {
 
     blood_type,
     blood_amount,
+    hungry,
     body_temperature,
     pulse,
     infection,
@@ -321,6 +322,7 @@ export const MedScanner = (props, context) => {
             ) : null}
           </Section>
         ) : null}
+        {hungry ? <NoticeBox warning>Calorie intake recommended.</NoticeBox> : null}
         {infection ? <NoticeBox warning>{infection}</NoticeBox> : null}
         {implants ? (
           <NoticeBox info>

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -322,7 +322,11 @@ export const MedScanner = (props, context) => {
             ) : null}
           </Section>
         ) : null}
-        {hungry ? <NoticeBox warning>Calorie intake recommended</NoticeBox> : null}
+        {hungry ? (
+          <NoticeBox warning>
+            Calorie intake recommended.
+          </NoticeBox>
+        ) : null}
         {infection ? <NoticeBox warning>{infection}</NoticeBox> : null}
         {implants ? (
           <NoticeBox info>


### PR DESCRIPTION

## About The Pull Request
The passive regeneration that happens on limbs after they've been kitted drains nutrition relative to the damage healed.
Nutrition drain from having low blood is removed.
Hunger slowdown ramps from 0 rather than starting at 0.5 at the yellow hunger threshold.
Health scanners show a warning if patient nutrition is low.
## Why It's Good For The Game
Moves nutrition further into being a resource that you use via specific actions (kitting and running) instead of it being a knock-on effect of a knock-on effect (low blood).
The slow rescaling is mostly caprice but it seems weird for an otherwise smooth slope to start at not zero.
This does make continuous low blood somewhat less annoying but it still causes unconsciousness and death, so it'll be fine for now.
## Changelog
:cl:
qol: Health scanner shows low nutrition
balance: Hunger slowdown ramps slower
balance: Low blood doesn't drain nutrition
balance: Kitted limbs passively regenerating drains nutrition
/:cl:
