### PR TITLE
The alamo doesn't get locked as it is taking off if manually hijacked

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -425,8 +425,10 @@
 			to_chat(user, span_warning("The bird has left meanwhile, try again."))
 			return FALSE
 		D.unlock_all()
-		D.set_hijack_state(HIJACK_STATE_UNLOCKED)
-		D.do_start_hijack_timer(GROUND_LOCKDOWN_TIME)
+		if(M.mode != SHUTTLE_IGNITING)
+			D.set_hijack_state(HIJACK_STATE_UNLOCKED)
+			D.do_start_hijack_timer(GROUND_LOCKDOWN_TIME)
+			to_chat(user, span_warning("We were unable to prevent the bird from flying as it is already taking off."))
 		D.silicon_lock_airlocks(TRUE)
 		to_chat(user, span_warning("We have overriden the shuttle lockdown!"))
 		playsound(user, "alien_roar", 50)
@@ -499,8 +501,9 @@
 	var/dat = "Status: [M ? M.getStatusText() : "*Missing*"]<br><br>"
 	if(M)
 		dat += "<A href='?src=[REF(src)];hijack=1'>Launch to [SSmapping.configs[SHIP_MAP].map_name]</A><br>"
-		M.unlock_all()
 		dat += "<A href='?src=[REF(src)];abduct=1'>Capture the [M]</A><br>"
+		M.unlock_all()
+		M.silicon_lock_airlocks(TRUE)
 		if(M.hijack_state != HIJACK_STATE_CALLED_DOWN)
 			to_chat(X, span_xenowarning("We corrupt the bird's controls, unlocking the doors[(M.mode != SHUTTLE_IGNITING) ? "and preventing it from flying." : ", but we are unable to prevent it from flying as it is already taking off!"]"))
 			SEND_GLOBAL_SIGNAL(COMSIG_GLOB_DROPSHIP_CONTROLS_CORRUPTED, src)

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -425,7 +425,7 @@
 			to_chat(user, span_warning("The bird has left meanwhile, try again."))
 			return FALSE
 		D.unlock_all()
-		if(M.mode != SHUTTLE_IGNITING)
+		if(D.mode != SHUTTLE_IGNITING)
 			D.set_hijack_state(HIJACK_STATE_UNLOCKED)
 			D.do_start_hijack_timer(GROUND_LOCKDOWN_TIME)
 			to_chat(user, span_warning("We were unable to prevent the bird from flying as it is already taking off."))


### PR DESCRIPTION
## About The Pull Request

Basically if you did the manual hijack from all sides locked and the alamo was igniting when you finished the alamo would end up hijack locked shipside, meaning you'd be unable to call it down for the duration. Made it so it only unlocks doors and disables AI door control instead (if the alamo is igniting when you finish the do_after).

Added disabling AI door control to touching the console too.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
balance: AI loses door control of alamo when xenos touch the alamo console
fix: Alamo should no longer get locked shipside if your manual hijack ends just as the alamo is taking off
/:cl:
