### PR TITLE
Impact Hud lingers longer

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -276,7 +276,7 @@
 	impact_cam.forceMove(get_turf(target))
 	current_shots++
 	addtimer(CALLBACK(src, PROC_REF(falling), target, shell), fall_time)
-	addtimer(CALLBACK(src, PROC_REF(return_cam)), fall_time + 2 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(return_cam)), fall_time + 5 SECONDS)
 	addtimer(VARSET_CALLBACK(src, firing, FALSE), cool_off_time)
 
 ///Proc called by tactical binoculars to send targeting information.


### PR DESCRIPTION

## About The Pull Request

Partically fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12972 by extending the time before impact hud returns camera to deployable

## Changelog
:cl:
add: Impact Hud now stays at the impact site for slightly longer.
/:cl:
