### PR TITLE
SOM General Storage Grammar

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -121,7 +121,7 @@
 
 /obj/item/armor_module/storage/general/som
 	name = "General Purpose Storage module"
-	desc = "Designed for mounting on SOM combat armor. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, pistols or magazines."
+	desc = "Designed for mounting on SOM combat armor. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like pistols or magazines."
 	icon_state = "mod_general_bag_som"
 	item_state = "mod_general_bag_som_a"
 


### PR DESCRIPTION

## About The Pull Request

Fixes a grammar mistake.

## Why It's Good For The Game

It isn't, this is actually the start of a power creep for the general storage module (SOM) that would eventually allow you to store the nuke inside the module. 

## Changelog
:cl:
spellcheck: Fix grammar mistake in SOM general armor storage module
/:cl:
