### PR TITLE
flooring fixes

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -37,15 +37,16 @@
 
 /obj/item/stack/tile/plasteel/welder_act(mob/living/user, obj/item/I)
 	. = ..()
-	var/obj/item/tool/weldingtool/welder = I
-
-	if(!(welder.use(1)))
-		to_chat(user, span_warning("You need more welding fuel to complete this task."))
-		return
 	if(!use(4))
 		balloon_alert(user, "Need 4 tiles")
 		return
 
+	var/obj/item/tool/weldingtool/welder = I
+	if(!(welder.use(1)))
+		to_chat(user, span_warning("You need more welding fuel to complete this task."))
+		return
+
+	welder.eyecheck(user)
 	to_chat(user, span_warning("You turn the floor plates back into a metal sheet."))
 	playsound(src, 'sound/items/welder.ogg', 25, 1)
 	new /obj/item/stack/sheet/metal(get_turf(src))

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -889,12 +889,12 @@
 	floor_tile = /obj/item/stack/tile/carpet
 
 /turf/open/floor/carpet/broken_states()
-	return "carpet-broken"
+	return icon_state
 
 /turf/open/floor/carpet/burnt_states()
-	return "carpet-broken"
+	return icon_state
 
-/turf/open/floor/ex_act(severity)
+/turf/open/floor/carpet/ex_act(severity)
 	if(hull_floor)
 		return ..()
 	switch(severity)

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -321,7 +321,7 @@
 /turf/open/floor/wood/broken_states()
 	if(!damaged_states)
 		return icon_state
-	return "[icon_state]_[rand(1, damaged_states)]"
+	return "[icon_state]_damaged_[rand(1, damaged_states)]"
 
 /turf/open/floor/wood/burnt_states()
 	if(!damaged_states)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Couple of flooring fixes.

Fixes incorrect damaged wood tile states and carpet.

Fixes welding floor tiles having a couple of checks in the wrong order and not doing an eye check.
Fixes #13028
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed damaged wood or carpet tiles not showing up correctly
fix: Fixed welding floor tiles not doing eye damage to the unprotected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
