### PR TITLE
Gives non speech channels first letter uppercase + automatic dot

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -137,6 +137,11 @@ GLOBAL_LIST_INIT(department_radio_keys_som, list(
 	if(!language)
 		language = get_default_language()
 
+	var/list/message_data = treat_message(message) // unfortunately we still need this
+	message = message_data["message"]
+	var/tts_message = message_data["tts_message"]
+	var/list/tts_filter = message_data["tts_filter"]
+
 	// Detection of language needs to be before inherent channels, because
 	// AIs use inherent channels for the holopad. Most inherent channels
 	// ignore the language argument however.
@@ -149,12 +154,7 @@ GLOBAL_LIST_INIT(department_radio_keys_som, list(
 
 	var/message_range = 7
 
-	log_talk(message, LOG_SAY)
-
-	var/list/message_data = treat_message(message) // unfortunately we still need this
-	message = message_data["message"]
-	var/tts_message = message_data["tts_message"]
-	var/list/tts_filter = message_data["tts_filter"]
+	log_talk(original_message, LOG_SAY)
 
 	var/last_message = message
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)


### PR DESCRIPTION

## About The Pull Request

So basically hivemind and silicon/holopad chats are now auto capitalized and have a dot at the end like radio.
## Why It's Good For The Game

This being standard with all the channels is good because standardization. Might also make people stop treating these slightly less like OOC channels hopefully.
## Changelog
:cl:
add: Hivemind and silicon chat now have automatic capitalization and end of dot punctuation
/:cl:
