### PR TITLE
Focus order buff

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -627,6 +627,8 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 ///Removes an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/remove_aim_mode_fire_delay(source)
+	if(!(source in aim_fire_delay_mods))
+		return
 	aim_fire_delay_mods -= source
 	recalculate_aim_mode_fire_delay()
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1753,6 +1753,9 @@
 			gun_accuracy_mod -= round(min(20, (shooter_human.shock_stage * 0.2))) //Accuracy declines with pain, being reduced by 0.2% per point of pain.
 			if(shooter_human.marksman_aura)
 				gun_accuracy_mod += 10 + max(5, shooter_human.marksman_aura * 5) //Accuracy bonus from active focus order
+				add_aim_mode_fire_delay(AURA_HUMAN_FOCUS, initial(aim_fire_delay) * -0.5)
+			else
+				remove_aim_mode_fire_delay(AURA_HUMAN_FOCUS)
 
 /obj/item/weapon/gun/proc/simulate_recoil(recoil_bonus = 0, firing_angle)
 	if(CHECK_BITFIELD(flags_item, IS_DEPLOYED) || !gun_user)


### PR DESCRIPTION

## About The Pull Request
Focus order now reduces the aimmode fire rate penalty by 50%, the same as a RDS or bipod. (This is still limited to 0, you can't have all 3 and shoot faster!)
## Why It's Good For The Game
The focus order is pretty bad currently. It currently boosts your accurate which is a pretty limited benefit, and removes the delay to toggling aim mode. This is compared to a 20% or 30% damage damage reduction from hold order, or speed boost from move order, which are both extremely powerful.

This change means you're actively making aimmode stronger for your team. Still worse than the other two orders? Yeah almost certainly, but at least it has some more actual use now.
## Changelog
:cl:
balance: The focus order now reduces the fire rate penalty of aimmode
/:cl:
