### PR TITLE
fix siren playing in normal rain

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -61,6 +61,7 @@
 
 	telegraph_message = span_boldannounce("Thunder rumbles far above. You hear droplets drumming against the canopy.")
 	telegraph_overlay = "rain_med"
+	telegraph_sound = null
 
 	weather_message = span_boldannounce("<i>Rain pours down around you!</i>")
 	weather_overlay = "rain_high"


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

Players expect siren to play in acid rain when they are in LV-624, but they do not expect siren to play in normal rain.

Pavlov approves.

## Changelog

:cl:
fix: siren playing in normal rain in LV-624
/:cl:

