### PR TITLE
Fix some DNR bugs

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -28,7 +28,7 @@
 /datum/mind
 	var/key
 	var/name
-	var/mob/living/current
+	var/mob/living/current //TODO: Sanity check this var. Observers can be current, but living procs are called on it
 	var/active = FALSE
 
 	var/memory

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -268,10 +268,10 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if(!wearer.job || !wearer.job.minimap_icon)
 		return
 	var/marker_flags = initial(minimap_type.marker_flags)
-	if(HAS_TRAIT(wearer, TRAIT_UNDEFIBBABLE))
-		SSminimaps.add_marker(wearer, marker_flags, image('icons/UI_icons/map_blips.dmi', null, "undefibbable"))
-		return
 	if(wearer.stat == DEAD)
+		if(HAS_TRAIT(wearer, TRAIT_UNDEFIBBABLE))
+			SSminimaps.add_marker(wearer, marker_flags, image('icons/UI_icons/map_blips.dmi', null, "undefibbable"))
+			return
 		SSminimaps.add_marker(wearer, marker_flags, image('icons/UI_icons/map_blips.dmi', null, "defibbable"))
 		return
 	if(wearer.assigned_squad)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -862,14 +862,14 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	set desc = "Noone will be able to revive you."
 
 	if(!isnull(can_reenter_corpse) && tgui_alert(usr, "Are you sure? You won't be able to get revived.", "Confirmation", list("Yes", "No")) == "Yes")
+		var/mob/living/carbon/human/human_current = can_reenter_corpse.resolve()
+		if(istype(human_current))
+			human_current.set_undefibbable()
+
 		can_reenter_corpse = null
 		to_chat(usr, span_notice("You can no longer be revived."))
-
-		if(istype(mind.current))
-			var/mob/living/carbon/human/human_current = mind.current
-			human_current.set_undefibbable()
-		mind.current.med_hud_set_status()
 		return
+
 	to_chat(usr, span_warning("You already can't be revived."))
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -962,7 +962,7 @@ below 100 is not dizzy
 		stack_trace("[candidate] was put into a qdeleted mob [src]")
 		return
 	if(stat != DEAD)
-		REMOVE_TRAIT(src, TRAIT_UNDEFIBBABLE)
+		REMOVE_TRAIT(src, TRAIT_UNDEFIBBABLE, TRAIT_UNDEFIBBABLE)
 	candidate.mind.transfer_to(src, TRUE)
 
 /mob/living/carbon/xenomorph/transfer_mob(mob/candidate)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -961,6 +961,8 @@ below 100 is not dizzy
 	if(QDELETED(src))
 		stack_trace("[candidate] was put into a qdeleted mob [src]")
 		return
+	if(stat != DEAD)
+		REMOVE_TRAIT(src, TRAIT_UNDEFIBBABLE)
 	candidate.mind.transfer_to(src, TRUE)
 
 /mob/living/carbon/xenomorph/transfer_mob(mob/candidate)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

Ghosting out of a living body not show as DNR.
Going DNR after death properly shows this.
Fixed taking over a living body still being marked as DNR in some cases


At some point mind.current was changed so that ghosts would get set as current instead of the actual former body, so the body is only connected via weakref.

I'm not entirely sure if its better for current to be typecast as just mob instead of mob/living or not (there are procs that assume its living, and other code that assumes it can be a ghost), but that's out of scope of this PR.
## Why It's Good For The Game
Bug fixes good.
## Changelog
:cl:
fix: fixed some DNR bugs
/:cl:
