### PR TITLE
Fixes BAS (and probably other sentries) not losing target when undeployed

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -722,7 +722,7 @@
 ///Set the target and take care of hard delete
 /obj/item/weapon/gun/proc/set_target(atom/object)
 	active_attachable?.set_target(object)
-	if(object == target || object == gun_user)
+	if(object == target || (gun_user && object == gun_user))
 		return
 	if(target)
 		UnregisterSignal(target, COMSIG_PARENT_QDELETING)


### PR DESCRIPTION

## About The Pull Request

Funny bug. Gun would keep shooting even when in your hands and while undeploying.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed BAS (and probably other sentries) not losing target when undeployed
/:cl:
