### PR TITLE
Fixes TTS stat panel runtime

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -44,8 +44,9 @@ SUBSYSTEM_DEF(tts)
 	return ..()
 
 /datum/controller/subsystem/tts/stat_entry(msg)
-	msg = "Active:[length(in_process_http_messages)]|Standby:[length(queued_http_messages.L)]|Avg:[average_tts_messages_time]"
-	return ..()
+	if(!CONFIG_GET(string/tts_http_url))
+		return ..()
+	return ..("Active:[length(in_process_http_messages)]|Standby:[length(queued_http_messages.L)]|Avg:[average_tts_messages_time]")
 
 /proc/cmp_word_length_asc(datum/tts_request/a, datum/tts_request/b)
 	return length(b.message) - length(a.message)


### PR DESCRIPTION

## About The Pull Request

Would runtime because this SS wouldn't have these vars because it didn't init if we didn't have this config entry.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed TTS stat panel runtime
/:cl:
