### PR TITLE
Fixes various valhalla/ghostize runtimes + valhalla menu being janky

### DIFF
--- a/code/datums/jobs/job/fallen.dm
+++ b/code/datums/jobs/job/fallen.dm
@@ -25,6 +25,8 @@
 ///Delete the mob when you log out or when it's dead
 /datum/job/fallen/proc/delete_mob(mob/living/source)
 	SIGNAL_HANDLER
+	if(QDELING(source))
+		return
 	source.visible_message(span_danger("[source] suddenly disappears!"))
 	qdel(source)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -296,7 +296,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 /mob/living/carbon/human/ghostize(can_reenter_corpse = TRUE, aghosting = FALSE)
 	. = ..()
-	if(!can_reenter_corpse)
+	if(!can_reenter_corpse && !QDELING(src))
 		set_undefibbable()
 
 /mob/dead/observer/Move(atom/newloc, direct)
@@ -902,6 +902,9 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		return
 
 	var/choice = tgui_input_list(usr, "You are about to embark to the ghastly walls of Valhalla. Xenomorph or Marine?", "Join Valhalla", list("Xenomorph", "Marine"))
+
+	if(!choice)
+		return
 
 	if(choice == "Xenomorph")
 		var/mob/living/carbon/xenomorph/xeno_choice = tgui_input_list(usr, "You are about to embark to the ghastly walls of Valhalla. What xenomorph would you like to have?", "Join Valhalla", GLOB.all_xeno_types)


### PR DESCRIPTION

## About The Pull Request

First one addresses various runtimes where it'd try to read the reagents of the deleting mob, which wouldn't exist because it's being deleted. No good.

Other issue is closing the valhalla join menu would open the marine job choice menu, no good.
## Why It's Good For The Game

Runtime bad and unintended behaviour bad.
## Changelog
:cl:
fix: Fixes various ghostize runtimes
fix: Fixed closing the valhalla join menu opening the marine job choice menu
/:cl:
