### PR TITLE
Doubles the cost of Runner's Pounce ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -72,7 +72,7 @@
 	action_icon_state = "pounce"
 	desc = "Leap at your target, tackling and disarming them."
 	ability_name = "pounce"
-	plasma_cost = 10
+	plasma_cost = 20
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_POUNCE,
 	)


### PR DESCRIPTION

## About The Pull Request
Right now it's way too easy for this T1 to secure kills by pouncing marines with a 2 second stun that it can use a lot more times during combat. This PR aims to reduce the combat effectiveness of runner off weeds while not hindering his usefulness on weeds (or when under the effects of plasma regen by a nearby teammate).
Pros:
-Nothing changes when fighting on weeds
Cons:
-Can't cycle through its kit more times during a single fight off weeds
Notes:
-Makes the runner rely more on weeds
## Why It's Good For The Game
Being extremely strong for a T1, I don't want to make the runner too weak, but his offweeds combat capability is just too strong as of now.
## Changelog
:cl:
balance: Doubled the cost of runner pounce
/:cl:
