### PR TITLE
Disallow xenos from latejoining post hijack

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -82,10 +82,6 @@
 				list(/obj/item/weapon/gun/shotgun/pump/bolt, /obj/item/ammo_magazine/rifle/bolt),\
 				list(/obj/item/weapon/gun/shotgun/pump/lever, /obj/item/ammo_magazine/packet/magnum))
 
-
-#define LATEJOIN_LARVA_DISABLED 0
-
-
 //Balance defines
 #define MARINE_GEAR_SCALING 30
 

--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -5,6 +5,7 @@ GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 GLOBAL_VAR_INIT(valhalla_allowed, TRUE)
 GLOBAL_VAR_INIT(ssd_posses_allowed, TRUE)
+GLOBAL_VAR_INIT(xeno_enter_allowed, TRUE)
 
 GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -561,7 +561,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished!<spawn>")
 		return FALSE
-	if(!GLOB.enter_allowed)
+	if(!GLOB.enter_allowed || (!GLOB.xeno_enter_allowed && istype(job, /datum/job/xenomorph)))
 		to_chat(usr, "<span class='warning'>Spawning currently disabled, please observe.<spawn>")
 		return FALSE
 	if(!NP.client.prefs.random_name)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1015,6 +1015,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 /datum/hive_status/normal/on_shuttle_hijack(obj/docking_port/mobile/marine_dropship/hijacked_ship)
 	SSticker.mode.update_silo_death_timer(src)
+	GLOB.xeno_enter_allowed = FALSE
 	xeno_message("Our Ruler has commanded the metal bird to depart for the metal hive in the sky! Run and board it to avoid a cruel death!")
 	RegisterSignal(hijacked_ship, COMSIG_SHUTTLE_SETMODE, PROC_REF(on_hijack_depart))
 


### PR DESCRIPTION
## About The Pull Request

\+ unused define deletion

Not using the other enter_allowed global because it get's set to true/false depending on if SD is on which is very unreliable.
## Why It's Good For The Game

Latejoin larvas spawned groundside which wasn't ideal on hijack
## Changelog
:cl:
fix: Fixed larvas being able to spawn groundside via latejoin post hijack
/:cl:
