### PR TITLE
SADAR and its rockets are now cheaper across the board, disposables cost more

### DIFF
--- a/code/__DEFINES/supply.dm
+++ b/code/__DEFINES/supply.dm
@@ -2,4 +2,4 @@
 #define B18_PRICE 1200
 #define B17_PRICE 800
 #define MINIGUN_PRICE 800
-#define SADAR_PRICE 1200
+#define SADAR_PRICE 800

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -473,31 +473,31 @@ WEAPONS
 /datum/supply_packs/weapons/rpg_regular
 	name = "RL-152 SADAR HE rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar)
-	cost = 60
+	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_regular_unguided
 	name = "RL-152 SADAR HE rocket (Unguided)"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/unguided)
-	cost = 60
+	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_ap
 	name = "RL-152 SADAR AP rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/ap)
-	cost = 70
+	cost = 60
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_wp
 	name = "RL-152 SADAR WP rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp)
-	cost = 50
+	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_wp_unguided
 	name = "RL-152 SADAR WP rocket (Unguided)"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp/unguided)
-	cost = 50
+	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/zx76
@@ -643,7 +643,7 @@ WEAPONS
 /datum/supply_packs/weapons/rpgoneuse
 	name = "RL-72 Disposable RPG"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/oneuse)
-	cost = 50
+	cost = 100
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/mateba


### PR DESCRIPTION

## About The Pull Request
Disposable RPGs now cost 10(0) points rather than 5(0) points.
SADAR has been slashed from 1200 to 800 points, for reference B18 is 1200 and minigun is 800.
All sadar rockets are 10 points cheaper.
## Why It's Good For The Game
SADAR has lost a lot of its luster since losing miniscope and requiring full wielding, it can no longer really offscreen kill people reliabily and so its pointcost is very unwarranted.
DRPGs have needed a pointcost nerf for literally years by this point, they're incredibly efficient point for payload.
## Changelog
:cl:
balance: Disposable RPGs are now 100 points from 50.
balance: SADAR now costs 400 points less, SADAR rockets cost 10 points less across the board.
/:cl:
