### PR TITLE
Anti-juggling component

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -352,6 +352,7 @@
 
 // /obj/item/weapon/gun signals
 #define COMSIG_GUN_FIRE "gun_fire"
+#define COMSIG_MOB_GUN_FIRE "mob_gun_fire"
 #define COMSIG_GUN_STOP_FIRE "gun_stop_fire"
 #define COMSIG_GUN_FIRE_MODE_TOGGLE "gun_firemode_toggle"		//from /obj/item/weapon/gun/verb/toggle_firemode()
 #define COMSIG_GUN_AUTOFIREDELAY_MODIFIED "gun_firedelay_modified"
@@ -362,6 +363,7 @@
 #define COMSIG_GUN_USER_SET "gun_user_set"
 #define COMSIG_MOB_GUN_FIRED "mob_gun_fired"
 #define COMSIG_MOB_GUN_AUTOFIRED "mob_gun_autofired"
+#define COMSIG_MOB_GUN_COOLDOWN "mob_gun_cooldown"
 
 #define COMSIG_XENO_FIRE "xeno_fire"
 #define COMSIG_XENO_STOP_FIRE "xeno_stop_fire"

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -13,8 +13,8 @@
 /datum/component/anti_juggling/proc/on_fire(datum/source, obj/item/weapon/gun/fired_gun)
     SIGNAL_HANDLER
 
-    if(fired_gun.master_gun)
-        return
+    if(fired_gun.master_gun || fired_gun.dual_wield)
+        return //Attached guns and guns being dual wielded aren't taken into account.
     next_fire_time = world.time + fired_gun.fire_delay
 
 /// Checks if the cooldown of the gun we previously fired is up. 

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -13,7 +13,7 @@
 /datum/component/anti_juggling/proc/on_fire(datum/source, obj/item/weapon/gun/fired_gun)
 	SIGNAL_HANDLER
 
-	if(fired_gun.master_gun || fired_gun.dual_wield)
+	if(!isgun(fired_gun) || fired_gun.master_gun || fired_gun.dual_wield)
 		return //Attached guns and guns being dual wielded aren't taken into account.
 	next_fire_time = world.time + fired_gun.fire_delay
 

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -1,26 +1,26 @@
 /datum/component/anti_juggling
-    /// The next time the gun we just fired will be able to fire
-    var/next_fire_time = 0
+	/// The next time the gun we just fired will be able to fire
+	var/next_fire_time = 0
 
 /datum/component/anti_juggling/Initialize(...)
-    . = ..()
-    if(!ishuman(parent))
-        return COMPONENT_INCOMPATIBLE
-    RegisterSignal(parent, COMSIG_MOB_GUN_COOLDOWN, PROC_REF(check_cooldown))
-    RegisterSignal(parent, COMSIG_MOB_GUN_FIRE, PROC_REF(on_fire))
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_MOB_GUN_COOLDOWN, PROC_REF(check_cooldown))
+	RegisterSignal(parent, COMSIG_MOB_GUN_FIRE, PROC_REF(on_fire))
 
 /// Gets called when the mob fires a gun, we get the gun they fired and store the next time it'll be able to fire.
 /datum/component/anti_juggling/proc/on_fire(datum/source, obj/item/weapon/gun/fired_gun)
-    SIGNAL_HANDLER
+	SIGNAL_HANDLER
 
-    if(fired_gun.master_gun || fired_gun.dual_wield)
-        return //Attached guns and guns being dual wielded aren't taken into account.
-    next_fire_time = world.time + fired_gun.fire_delay
+	if(fired_gun.master_gun || fired_gun.dual_wield)
+		return //Attached guns and guns being dual wielded aren't taken into account.
+	next_fire_time = world.time + fired_gun.fire_delay
 
 /// Checks if the cooldown of the gun we previously fired is up. 
 /datum/component/anti_juggling/proc/check_cooldown(datum/source, obj/item/weapon/gun/cool_gun)
-    SIGNAL_HANDLER
+	SIGNAL_HANDLER
 
-    if(world.time < next_fire_time)
-        return FALSE
-    return TRUE
+	if(world.time < next_fire_time)
+		return FALSE
+	return TRUE

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -1,0 +1,26 @@
+/datum/component/anti_juggling
+    /// The next time the gun we just fired will be able to fire
+    var/next_fire_time = 0
+
+/datum/component/anti_juggling/Initialize(...)
+    . = ..()
+    if(!ishuman(parent))
+        return COMPONENT_INCOMPATIBLE
+    RegisterSignal(parent, COMSIG_MOB_GUN_COOLDOWN, PROC_REF(check_cooldown))
+    RegisterSignal(parent, COMSIG_MOB_GUN_FIRE, PROC_REF(on_fire))
+
+/// Gets called when the mob fires a gun, we get the gun they fired and store the next time it'll be able to fire.
+/datum/component/anti_juggling/proc/on_fire(datum/source, obj/item/weapon/gun/fired_gun)
+    SIGNAL_HANDLER
+
+    if(fired_gun.master_gun)
+        return
+    next_fire_time = world.time + fired_gun.fire_delay
+
+/// Checks if the cooldown of the gun we previously fired is up. 
+/datum/component/anti_juggling/proc/check_cooldown(datum/source, obj/item/weapon/gun/cool_gun)
+    SIGNAL_HANDLER
+
+    if(world.time < next_fire_time)
+        return FALSE
+    return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -48,6 +48,7 @@
 	AddElement(/datum/element/footstep, isrobot(src) ? FOOTSTEP_MOB_SHOE : FOOTSTEP_MOB_HUMAN, 1)
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/human)
 	AddElement(/datum/element/strippable, GLOB.strippable_human_items, GLOB.strippable_human_layout)
+	AddComponent(/datum/component/anti_juggling)
 	set_jump_component()
 
 /mob/living/carbon/human/proc/human_z_changed(datum/source, old_z, new_z)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -817,6 +817,7 @@
 
 	last_fired = world.time
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
+	SEND_SIGNAL(gun_user, COMSIG_MOB_GUN_FIRE, src)
 
 	if(!max_chamber_items)
 		in_chamber = null
@@ -1662,7 +1663,7 @@
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
 		delay += extra_delay
 
-	if(world.time >= delay)
+	if(world.time >= delay && SEND_SIGNAL(user, COMSIG_MOB_GUN_COOLDOWN, src))
 		return FALSE
 
 	if(world.time % 3 && !user?.client?.prefs.mute_self_combat_messages)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -357,6 +357,7 @@
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\admin_popup.dm"
 #include "code\datums\components\ai.dm"
+#include "code\datums\components\anti_juggling.dm"
 #include "code\datums\components\attachment_handler.dm"
 #include "code\datums\components\autofire.dm"
 #include "code\datums\components\blur_protection.dm"


### PR DESCRIPTION

## About The Pull Request

Adds a component to prevent the juggling of weapons to bypass firing rate limitations. Yes this is extremely silly and a mob var could just do the trick but hey ho :)
## Why It's Good For The Game

Juggling bad.
## Changelog
:cl:
balance: Added a component that prevents the juggling of weapons to bypass firing rate limitations
/:cl:
