### PR TITLE
Marines can read send order in text ui

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -56,7 +56,7 @@
 	if(!can_use_action(TRUE))
 		return
 	human_owner.playsound_local(owner, "sound/effects/CIC_order.ogg", 10, 1)
-	to_chat(owner, span_boldnotice("<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>"))
+	to_chat(owner, "<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>")
 	TIMER_COOLDOWN_START(owner, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 	log_game("[key_name(human_owner)] has broadcasted the hud message [text] at [AREACOORD(human_owner)]")
 	deadchat_broadcast(" has sent the command order \"[text]\"", human_owner, human_owner)

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -56,6 +56,7 @@
 	if(!can_use_action(TRUE))
 		return
 	human_owner.playsound_local(owner, "sound/effects/CIC_order.ogg", 10, 1)
+	to_chat(owner, span_boldnotice("<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>"))
 	TIMER_COOLDOWN_START(owner, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 	log_game("[key_name(human_owner)] has broadcasted the hud message [text] at [AREACOORD(human_owner)]")
 	deadchat_broadcast(" has sent the command order \"[text]\"", human_owner, human_owner)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/c45c2276-7868-40db-ba72-cce144cd43ca

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/8c47d312-36ba-479e-b82e-c2be0f71e020)


## Why It's Good For The Game

Xenomorph's hive message appears in the visual UI and the text UI, but the marine's send order only appear in the visual UI. This PR adds that marines receiving sent order can read it in their text UI for better coordination and utilization of the highlight function.

## Changelog

:cl:
add: Send order is added in text ui so that marines can read
/:cl:

