### PR TITLE
Fix reciever closing message

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1167,7 +1167,7 @@
 		ENABLE_BITFIELD(reciever_flags, AMMO_RECIEVER_CLOSED)
 		playsound(src, cocked_sound, 25, 1)
 		if(chamber_closed_message)
-			to_chat(user, span_notice(chamber_opened_message))
+			to_chat(user, span_notice(chamber_closed_message))
 		cycle(user, FALSE)
 	update_ammo_count()
 	update_icon()


### PR DESCRIPTION

## About The Pull Request

Apparently I am the only one who uses chambering messages so no one noticed this oopsie.

## Why It's Good For The Game

Display the proper message.

## Changelog
:cl:
fix: Chamber closing message instead of the opening message is shown when closing the reciever.
/:cl:
