### PR TITLE
Fix leading space in chat when no paygrade

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -125,7 +125,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		if(!istype(J))
 			return ""
 
-		return "[get_paygrades(J.paygrade, TRUE, gender)] "
+		paygrade = get_paygrades(J.paygrade, TRUE, gender)
+		return paygrade ? "[paygrade] " : ""
 	else if(istype(speaker, /atom/movable/virtualspeaker))
 		var/atom/movable/virtualspeaker/VT = speaker
 		if(!ishuman(VT.source))
@@ -139,7 +140,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		if(!istype(J))
 			return ""
 
-		return "[get_paygrades(J.paygrade, TRUE, gender)] "
+		paygrade = get_paygrades(J.paygrade, TRUE, gender)
+		return paygrade ? "[paygrade] " : ""
 	else
 		return ""
 


### PR DESCRIPTION

## About The Pull Request

If a role has no paygrade, it leaves behind a space in chat before a character's name when sending a message. This PR just appends the space after a rank on the condition that a character actually has one.

## Why It's Good For The Game

It is quite annoying.

## Changelog
:cl:
fix: Remove empty space before character name if they don't have a rank.
/:cl:
