### PR TITLE
Add per client vote choice randomization 

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(vote)
 	var/forced_popup = FALSE
 	/// Shuffle vote choices separately for each client? (topvoting NPC mitigation)
 	var/shuffle_choices = FALSE
-	/// Shuffle vote choices per ckey cache.
+	/// Shuffle vote choices per ckey cache
 	var/list/shuffle_cache = list()
 
 // Called by master_controller
@@ -424,8 +424,9 @@ SUBSYSTEM_DEF(vote)
 			data["choices"] = shuffle_cache[user.client?.ckey]
 			return data
 		shuffle_inplace(data["choices"])
-		shuffle_cache[user.client?.ckey] = data["choices"]
-		return data
+		if(!user.client)
+			return data
+		shuffle_cache[user.client.ckey] = data["choices"]
 
 	return data
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -32,6 +32,10 @@ SUBSYSTEM_DEF(vote)
 	var/shipmap_timer_id
 	/// Pop up this vote screen on everyone's screen?
 	var/forced_popup = FALSE
+	/// Shuffle vote choices separately for each client? (topvoting NPC mitigation)
+	var/shuffle_choices = FALSE
+	/// Shuffle vote choices per ckey cache.
+	var/list/shuffle_cache = list()
 
 // Called by master_controller
 /datum/controller/subsystem/vote/fire()
@@ -55,6 +59,8 @@ SUBSYSTEM_DEF(vote)
 	voted.Cut()
 	voting.Cut()
 	vote_happening = FALSE
+	shuffle_choices = FALSE
+	shuffle_cache.Cut()
 
 	remove_action_buttons()
 
@@ -280,7 +286,7 @@ SUBSYSTEM_DEF(vote)
 						if(VM.config_min_users && players < VM.config_min_users)
 							continue
 					maps += VM.map_name
-					shuffle_inplace(maps)
+					shuffle_choices = TRUE
 				for(var/valid_map in maps)
 					choices.Add(valid_map)
 			if("shipmap")
@@ -309,7 +315,7 @@ SUBSYSTEM_DEF(vote)
 						if(VM.config_min_users && players < VM.config_min_users)
 							continue
 					maps += VM.map_name
-					shuffle_inplace(maps)
+					shuffle_choices = TRUE
 				for(var/valid_map in maps)
 					choices.Add(valid_map)
 			if("custom")
@@ -386,6 +392,7 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/ui_data(mob/user)
 	var/list/data = list(
 		"choices" = list(),
+		"vote_counts" = list(),
 		"lower_admin" = !!user.client?.holder,
 		"mode" = mode,
 		"question" = question,
@@ -403,11 +410,22 @@ SUBSYSTEM_DEF(vote)
 	if(!!user.client?.holder)
 		data["voting"] = voting
 
+	var/choice_num = 1
 	for(var/key in choices)
 		data["choices"] += list(list(
 			"name" = key,
-			"votes" = choices[key] || 0
+			"num_index" = choice_num++
 		))
+		data["vote_counts"] += choices[key] || 0
+
+	if(shuffle_choices)
+		// if useLocalState can be made to work with Vote.js this could be pure clientside
+		if(user.client?.ckey in shuffle_cache)
+			data["choices"] = shuffle_cache[user.client?.ckey]
+			return data
+		shuffle_inplace(data["choices"])
+		shuffle_cache[user.client?.ckey] = data["choices"]
+		return data
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/Vote.js
+++ b/tgui/packages/tgui/interfaces/Vote.js
@@ -181,7 +181,7 @@ const VotersList = (props, context) => {
 // Display choices
 const ChoicesPanel = (props, context) => {
   const { act, data } = useBackend(context);
-  const { choices, selected_choice } = data;
+  const { choices, selected_choice, vote_counts } = data;
 
   return (
     <Stack.Item grow>
@@ -189,22 +189,24 @@ const ChoicesPanel = (props, context) => {
         {choices.length !== 0 ? (
           <LabeledList>
             {choices.map((choice, i) => (
-              <Box key={choice.id}>
+              <Box key={choice.num_index}>
                 <LabeledList.Item
                   label={choice.name.replace(/^\w/, (c) => c.toUpperCase())}
                   textAlign="right"
                   buttons={
                     <Button
                       color={
-                        selected_choice.includes(i + 1) ? 'green' : 'orange'
+                        selected_choice.includes(choice.num_index)
+                          ? 'green'
+                          : 'orange'
                       }
                       onClick={() => {
-                        act('vote', { index: i + 1 });
+                        act('vote', { index: choice.num_index });
                       }}>
                       Vote
                     </Button>
                   }>
-                  {selected_choice.includes(i + 1) && (
+                  {selected_choice.includes(choice.num_index) && (
                     <Icon
                       alignSelf="right"
                       mr={2}
@@ -212,7 +214,7 @@ const ChoicesPanel = (props, context) => {
                       name="vote-yea"
                     />
                   )}
-                  {choice.votes} Votes
+                  {vote_counts[choice.num_index - 1]} Votes
                 </LabeledList.Item>
                 <LabeledList.Divider />
               </Box>


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/assets/64715958/63851e51-4d43-4780-8c79-2a2512e1cf05

## Why It's Good For The Game

Eliminate indiscriminate voters blindly bandwagoning for what ever map happens to be listed first in the shared shuffled choice list. Looking at you Gelida.

## Changelog

:cl:
add: Added per client vote choice randomization.
/:cl:
