### PR TITLE
Removes old map definitions in default config

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,10 +17,6 @@ map lv624
 	minplayers 25
 endmap
 
-map desertdam
-	minplayers 90
-endmap
-
 map bigred_v2
 	minplayers 25
 endmap

--- a/config/shipmaps.txt
+++ b/config/shipmaps.txt
@@ -23,9 +23,6 @@ endmap
 map pillar_of_spring
 endmap
 
-map risingstar
-endmap
-
 map sulaco
 endmap
 


### PR DESCRIPTION

## About The Pull Request

These are old and shouldn't exist anymore. Causes warnings.
## Why It's Good For The Game

Warnings not cool.
## Changelog
:cl:
config: Removed old map definitions in default config
/:cl:
