### PR TITLE
Make explosions not throw dead mobs

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -438,7 +438,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 							),
 						throw_turf[affected_turf][throw_source][1], // Distance
 						EXPLOSION_THROW_SPEED,
-						null, //Thrower
+						SSEXPLOSIONS_THROWS, //Thrower
 						TRUE //Spin
 					)
 		cost_throwTurf = MC_AVERAGE(cost_throwTurf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -473,7 +473,9 @@
 
 /mob/living/throw_at(atom/target, range, speed, thrower, spin, flying = FALSE)
 	if(!target)
-		return 0
+		return FALSE
+	if(stat == DEAD && thrower == SSEXPLOSIONS_THROWS)
+		return FALSE
 	if(pulling && !flying)
 		stop_pulling() //being thrown breaks pulls.
 	if(pulledby)


### PR DESCRIPTION

## About The Pull Request

The `DEAD` are no longer phased by the booms.. at least not enough to be bothered to move.

## Why It's Good For The Game

Using grenades to fish for bodies is a lame one sided mechanic.

Say it with me in the comments: cheese

## Changelog

:cl:
balance: Explosions no longer throw dead mobs.
/:cl:
