### PR TITLE
Wall fix for modulars

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -278,7 +278,7 @@
 	if(!reinforcement)
 		reinforcement = GIRDER_REINF_METAL
 	var/turf/source_turf = get_turf(src)
-	source_turf.ChangeTurf(reinforcement_to_wall(reinforcement))
+	source_turf.PlaceOnTop(reinforcement_to_wall(reinforcement))
 	qdel(src)
 
 


### PR DESCRIPTION

## About The Pull Request
Yet another funny modular/turf bug.

Building walls will no longer mess with the baseturfs in odd ways.
This also in general means building walls will no longer delete what's under them. i.e. a wall on sand will still have sand under it.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed a bug with human built walls in modular map errors
/:cl:
