### PR TITLE
GL fix

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -104,7 +104,7 @@
 		),
 		"Grenades" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = -1,
-			/obj/item/weapon/gun/grenade_launcher/multinade_launcher = -1,
+			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = -1,
 			/obj/item/weapon/gun/rifle/tx54 = 2,
 			/obj/item/ammo_magazine/rifle/tx54 = 10,
 			/obj/item/ammo_magazine/rifle/tx54/incendiary = 4,
@@ -325,7 +325,7 @@
 		),
 		"Grenades" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = -1,
-			/obj/item/weapon/gun/grenade_launcher/multinade_launcher = -1,
+			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = -1,
 			/obj/item/explosive/grenade = 600,
 			/obj/item/explosive/grenade/m15 = 30,
 			/obj/item/explosive/grenade/sticky = 125,
@@ -520,7 +520,7 @@
 		),
 		"Grenades" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = -1,
-			/obj/item/weapon/gun/grenade_launcher/multinade_launcher = -1,
+			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = -1,
 			/obj/item/weapon/gun/rifle/tx54 = -1,
 			/obj/item/ammo_magazine/rifle/tx54 = -1,
 			/obj/item/ammo_magazine/rifle/tx54/incendiary = -1,

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -122,6 +122,8 @@ The Grenade Launchers
 	fire_delay = 1.2 SECONDS
 	max_chamber_items = 5
 
+/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded
+	default_ammo_type = null
 
 /obj/item/weapon/gun/grenade_launcher/underslung
 	name = "underslung grenade launcher"


### PR DESCRIPTION

## About The Pull Request
Fixes the grenade loadout exploit.

A better long term solution would be to have loadouts actually vend ammo, but there's some complication to that, and WYCI.
## Why It's Good For The Game
exploit bad.
## Changelog
:cl:
fix: Grenade launchers will no longer vend free grenades through the loadout vendor
/:cl:
