### PR TITLE
Crash vendor doesn't pull from shipside weapons vendor

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -856,7 +856,7 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "Fl" = (
-/obj/machinery/loadout_vendor,
+/obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "FQ" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -238,7 +238,7 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aO" = (
-/obj/machinery/loadout_vendor,
+/obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aP" = (
@@ -833,7 +833,7 @@
 /obj/structure/window/reinforced/toughened{
 	dir = 4
 	},
-/obj/machinery/loadout_vendor,
+/obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "KE" = (

--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -19,6 +19,7 @@
 #define FACTION_PIRATE "Pirate"
 #define FACTION_VALHALLA "Valhalla"
 #define FACTION_SPECFORCE "Special Forces"
+#define FACTION_CRASH "Crash"
 
 //Alignement are currently only used by req.
 ///Mob with a neutral alignement cannot be sold by anyone

--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -17,9 +17,7 @@
 #define FACTION_HIVEBOT "Hivebot"
 #define FACTION_HOSTILE "Hostile"
 #define FACTION_PIRATE "Pirate"
-#define FACTION_VALHALLA "Valhalla"
 #define FACTION_SPECFORCE "Special Forces"
-#define FACTION_CRASH "Crash"
 
 //Alignement are currently only used by req.
 ///Mob with a neutral alignement cannot be sold by anyone

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -238,6 +238,15 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 	),
 	SQUAD_CORPSMAN = list(
 		/obj/machinery/vending/medical/shipside,
+	),
+	FACTION_CRASH = list(
+		/obj/machinery/vending/weapon/crash,
+		/obj/machinery/vending/uniform_supply,
+		/obj/machinery/vending/armor_supply,
+		/obj/machinery/vending/marineFood,
+		/obj/machinery/vending/MarineMed,
+		/obj/machinery/vending/cigarette,
+		/obj/machinery/vending/tool,
 	)
 ))
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -26,6 +26,9 @@
 #define CAT_SMR "SUITS AND ARMOR" // Synth's suits
 #define CAT_SHN "HATS" // Synth's non-protective hats
 
+#define VENDOR_FACTION_NEUTRAL "Neutral"
+#define VENDOR_FACTION_CRASH "Valhalla"
+#define VENDOR_FACTION_VALHALLA "Crash"
 
 GLOBAL_LIST_INIT(marine_selector_cats, list(
 		CAT_MOD = 1,
@@ -219,7 +222,7 @@ GLOBAL_LIST_INIT(additional_admin_item_slot_list, list(
 
 ///All the vendor types which the automated loadout vendor can take items from.
 GLOBAL_LIST_INIT(loadout_linked_vendor, list(
-	FACTION_NEUTRAL = list(
+	VENDOR_FACTION_NEUTRAL = list(
 		/obj/machinery/vending/weapon,
 		/obj/machinery/vending/uniform_supply,
 		/obj/machinery/vending/armor_supply,
@@ -228,7 +231,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
 	),
-	FACTION_VALHALLA = list(
+	VENDOR_FACTION_VALHALLA = list(
 		/obj/machinery/vending/weapon/valhalla,
 		/obj/machinery/vending/uniform_supply,
 		/obj/machinery/vending/armor_supply,
@@ -239,7 +242,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 	SQUAD_CORPSMAN = list(
 		/obj/machinery/vending/medical/shipside,
 	),
-	FACTION_CRASH = list(
+	VENDOR_FACTION_CRASH = list(
 		/obj/machinery/vending/weapon/crash,
 		/obj/machinery/vending/uniform_supply,
 		/obj/machinery/vending/armor_supply,

--- a/code/game/objects/machinery/vending/loadout_vendor.dm
+++ b/code/game/objects/machinery/vending/loadout_vendor.dm
@@ -9,7 +9,7 @@
 	req_access = null
 	req_one_access = null
 	///The faction of this loadout vendor
-	var/faction = FACTION_NEUTRAL
+	var/faction = VENDOR_FACTION_NEUTRAL
 
 /obj/machinery/loadout_vendor/can_interact(mob/user)
 	. = ..()
@@ -38,8 +38,8 @@
 	user.client.prefs.loadout_manager.ui_interact(user)
 
 /obj/machinery/loadout_vendor/crash
-	faction = FACTION_CRASH
+	faction = VENDOR_FACTION_CRASH
 
 /obj/machinery/loadout_vendor/valhalla
 	resistance_flags = INDESTRUCTIBLE
-	faction = FACTION_VALHALLA
+	faction = VENDOR_FACTION_VALHALLA

--- a/code/game/objects/machinery/vending/loadout_vendor.dm
+++ b/code/game/objects/machinery/vending/loadout_vendor.dm
@@ -37,6 +37,9 @@
 	user.client.prefs.loadout_manager.loadout_vendor = src
 	user.client.prefs.loadout_manager.ui_interact(user)
 
+/obj/machinery/loadout_vendor/crash
+	faction = FACTION_CRASH
+
 /obj/machinery/loadout_vendor/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	faction = FACTION_VALHALLA

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -229,7 +229,6 @@
 	)
 
 /obj/machinery/vending/weapon/crash
-
 	products = list(
 		"Rifles" = list(
 			/obj/item/weapon/gun/rifle/standard_assaultrifle = -1,


### PR DESCRIPTION

## About The Pull Request

Title. 
## Why It's Good For The Game

So you can't get stuff the crash weapons vendor doesn't have thru the loadout vendor.
## Changelog
:cl:
fix: Crash vendor doesn't pull from shipside weapons vendor anymore
/:cl:
