### PR TITLE
Plasteel cade fix

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -64,7 +64,7 @@
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/barricade/CanAllowThrough(atom/movable/mover, turf/target)
-	if(is_wired && ismob(mover) && (get_dir(loc, target) & dir))
+	if(is_wired && density && ismob(mover) && (get_dir(loc, target) & dir))
 		return FALSE
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request
Fix a funny with barbed wire blocking movement even if the cade is open.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: Barb wired plasteel cades are no longer one way doors
/:cl:
