### PR TITLE
Tad tile fix

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -25,7 +25,7 @@
 	if(!use(1))
 		return
 	playsound(T, 'sound/weapons/genhit.ogg', 25, 1)
-	T.ChangeTurf(turf_type, list(/turf/open/floor/plating))
+	T.PlaceOnTop(turf_type)
 
 /obj/item/stack/tile/plasteel
 	force = 6


### PR DESCRIPTION

## About The Pull Request
Fixes tad tiles getting left behind when plating is retiled.

Another reason why changeturf is lame.
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: fixed an issue with tad leaving behind turfs
/:cl:
