### PR TITLE
Fix nuke being activable post hijack

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -142,6 +142,9 @@
 	if(!extended)
 		return FALSE
 
+	if(machine_stat & BROKEN)
+		return FALSE
+
 	return TRUE
 
 /obj/machinery/nuclearbomb/attack_hand(mob/living/user)


### PR DESCRIPTION

## About The Pull Request

Title. Marines could just reenable the nuke.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed nuke being activable post hijack
/:cl:
