### PR TITLE
Increase Dropship Points generation rate. Gives 500 Dropship Points to start.

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,5 +1,5 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
+#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/3) //24 p/s worst case, 48 p/s best case
 #define SUPPLY_POINT_RATE 20 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)
@@ -9,7 +9,10 @@ SUBSYSTEM_DEF(points)
 	flags = SS_KEEP_TIMING
 
 	wait = 10 SECONDS
+
+	///The amount of points the dropship fabricator has. Default value set by [/datum/gamemode/proc/setup]
 	var/dropship_points = 0
+
 	///Assoc list of supply points
 	var/supply_points = list()
 	///Assoc list of xeno points: xeno_points_by_hive["hivenum"]

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -105,7 +105,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	spawn_characters()
 	transfer_characters()
 	SSpoints.prepare_supply_packs_list(CHECK_BITFIELD(flags_round_type, MODE_HUMAN_ONLY))
-	SSpoints.dropship_points = 0
+	SSpoints.dropship_points = 500
 	SSpoints.supply_points[FACTION_TERRAGOV] = 0
 
 	for(var/hivenum in GLOB.hive_datums)


### PR DESCRIPTION
## About The Pull Request
CAS is really sad. It's the only role in the game where your job is less fun the more fun you have. This is primarily because of how extremely limited ammo is. 

I've doubled the generation rate of dropship points, as well as normalized the math with supply points the process. In addition, the pilots get 500 points to start with.

Worst Case from 12 to 24 p/s
Best Case from 24 to 48 p/s

### Rationale:
Let's start with the easier one, 500 starting points. I believe that POs should have something to work off of to start to improve gameplay variety. Want to bump it all on 2 fatmans? Okay. Go for it. Want to save for an early laser gun? Go for it.

As for the point generation rate, lets look at some numbers. Previously, best case scenario, it would take you 12.5 minutes to generate enough points for a _single_ Keeper II rocket. That's pathetic. Really pathetic. And that is *best case*. If you are in Low Orbit, you can expect to wait **25 minutes** for that. Wow. 

I don't think it's very contentious to say that CAS isn't very strong and is primarily a support role that focuses on area denial, akin to a less powerful, more frequent Orbital Bombardment. CAS gets less use as the op goes on if marines are winning, because of caves. If marines are losing, CAS gets to actually play the game, but because it's late in the op, you're either strapped for ammo because you spent it all trying to gain the upper hand, or you have enough ammo but had to pull punches hard for the whole op.


## Why It's Good For The Game
CAS NEEDS LOOOOOVE

## Changelog
:cl:
balance: Doubled Dropship Point generation rate.
balance: Dropship Points start at 500 instead of 0.
/:cl:
