### PR TITLE
Allows xenos to move through warlock during Psychic Shield

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -103,6 +103,7 @@
 			return
 
 	succeed_activate()
+	xeno_owner.allow_pass_flags |= PASS_XENO
 	playsound(owner,'sound/effects/magic.ogg', 75, 1)
 
 	action_icon_state = "psy_shield_reflect"
@@ -122,6 +123,7 @@
 /datum/action/xeno_action/activable/psychic_shield/proc/cancel_shield()
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	action_icon_state = "psy_shield"
+	xeno_owner.allow_pass_flags &= ~PASS_XENO
 	xeno_owner.update_glow()
 	update_button_icon()
 	add_cooldown()


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
This Caste can be extremely infuriating to play because this ability is both very buggy and is very easy to have teammates accidentally fuck up. It's a cool ability! I want to use it as an actual support tool! But I cant because I keep getting shuffled when I use it to try to cover for other xenos!
## Changelog
:cl:
balance: Xenos can now move through Warlocks that are using Psychic Shield
/:cl:
