### PR TITLE
Free Howitzer Kit Removal

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -134,7 +134,6 @@
 		),
 		"Heavy Weapons" = list(
 			/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
-			/obj/structure/closet/crate/mortar_ammo/howitzer_kit = 1,
 			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
 			/obj/item/storage/box/sentry = 4,
 			/obj/item/storage/box/tl102 = 1,


### PR DESCRIPTION

## About The Pull Request
Removes the free Howitzer Kit from the weapons vendor.
## Why It's Good For The Game
Probably controversial but it is what it is. Currently, the Howitzer is essentially an upgrade to the mortar outside of portability and a min range that can be somewhat mitigated by placing it in the back of the FOB. It is more than double the price in req for a reason, and I honestly see no need to give it for free.
## Changelog
:cl:
balance: Removed Howitzer Kit from Automated Weapons Vendor.
/:cl:
