### PR TITLE
[should probably TM] Macro optimizes get_hearers_in_view()

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -102,9 +102,6 @@
 
 	var/list/assigned_oranges_ears = SSspatial_grid.assign_oranges_ears(hearables_from_grid)
 
-	var/old_luminosity = center_turf.luminosity
-	center_turf.luminosity = 6 //man if only we had an inbuilt dview()
-
 	//this is the ENTIRE reason all this shit is worth it due to how view() and the contents list works and can be optimized
 	//internally, the contents list is secretly two linked lists, one for /obj's and one for /mob's (/atom/movable counts as /obj here)
 	//by default, for(var/atom/name in view()) iterates through both the /obj linked list then the /mob linked list of each turf
@@ -118,7 +115,6 @@
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess
 		remaining_ear.unassign()
 
-	center_turf.luminosity = old_luminosity
 	return .
 
 /**

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -110,11 +110,9 @@
 	//by default, for(var/atom/name in view()) iterates through both the /obj linked list then the /mob linked list of each turf
 	//but because what we want are only a tiny proportion of all movables, most of the things in the /obj contents list are not what we're looking for
 	//while every mob can hear. for this case view() has an optimization to only look through 1 of these lists if it can (eg youre only looking for mobs)
-	//so by representing every hearing contents on a turf with a single /mob/oranges_ear containing references to all of them, we are:
-	//1. making view() only go through the smallest of the two linked lists per turf, which contains the type we're looking for at the end
-	//2. typechecking all mobs in the output to only actually return mobs of type /mob/oranges_ear
-	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
-	for(var/mob/oranges_ear/ear in view(view_radius, center_turf))
+	//so by representing every hearing contents on a turf with a single /mob/oranges_ear containing references to all of them, we are
+	//able to use hearers() over view(), which is a huge speed increase.
+	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess


### PR DESCRIPTION

## About The Pull Request
Ports:
- https://github.com/DaedalusDock/daedalusdock/pull/421

### Explanation
One of the hottest procs in the game. The way it works is it uses the spatial grid to grab all hearers in a given range. Then, it assigns mobs called ears to every turf that contains a hearer. Then, it uses view() to determine who should actually hear the message based on sight. 

There's a pretty simple optimization here, given to us by Dantom back in the dark ages. `hearers()`. `hearers()` is a *very* fast proc that returns all mobs in view, ignoring darkness. We can't replace Ears with this entirely, because SS13/TGMC have objects that need to be aware of hearing, like Radios. But this is still a massive improvement.

### Benchmark
Benchmarked using Lohikar's closed-source benchmarking tools. Left-to-right:  Average Iterations, Harmonic Average Iterations, Standard Deviation, Standard Deviation As Percent.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/75460809/9def7c26-6a33-4a25-be2b-424d4c1c23fb)
The Code:
```
WORLD(5, 5, 1)
/mob/foo

/proc/_hearers()
  for(var/mob/foo/M in hearers(locate(3, 3, 1)))
    return

/proc/_view()
  for(var/mob/M in view(locate(3, 3, 1)))
    return

MAIN
  for(var/turf/T in world)
    new /mob/foo(T)
    new /obj(T)
    new /obj(T)
    new /obj(T)
  
  BEGIN_BENCH(2)
    BENCH_PHASE("view", _view())
    BENCH_PHASE("hearers", _hearers())
  END_BENCH
  ```
## Why It's Good For The Game
Speed is good.
## Changelog
:cl:
code: Saved a large amount of tick time in sound.
/:cl:
