### PR TITLE
Diagonal throw improvement

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -502,6 +502,8 @@
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_THROW) & COMPONENT_MOVABLE_BLOCK_PRE_THROW)
 		return FALSE
 
+	var/turf/origin = get_turf(src)
+
 	if(spin)
 		animation_spin(5, 1)
 
@@ -531,11 +533,14 @@
 		dy = NORTH
 	else
 		dy = SOUTH
-	var/dist_travelled = 0
+
 	var/dist_since_sleep = 0
+
+	//while(get_dist_euclide_square(origin, src) < range)
+
 	if(dist_x > dist_y)
 		var/error = dist_x/2 - dist_y
-		while(!gc_destroyed && target &&((((x < target.x && dx == EAST) || (x > target.x && dx == WEST)) && dist_travelled < range) || isspaceturf(loc)) && (throwing||flying) && istype(loc, /turf))
+		while(!gc_destroyed && target &&((get_dist_euclide(origin, src) < range) || isspaceturf(loc)) && (throwing||flying) && istype(loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dy)
@@ -547,7 +552,6 @@
 					parrier = hit_check_return
 					break
 				error += dist_x
-				dist_travelled++
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
 					dist_since_sleep = 0
@@ -562,14 +566,13 @@
 					parrier = hit_check_return
 					break
 				error -= dist_y
-				dist_travelled++
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
 					dist_since_sleep = 0
 					sleep(0.1 SECONDS)
 	else
 		var/error = dist_y/2 - dist_x
-		while(!gc_destroyed && target &&((((y < target.y && dy == NORTH) || (y > target.y && dy == SOUTH)) && dist_travelled < range) || isspaceturf(loc)) && (throwing||flying) && istype(loc, /turf))
+		while(!gc_destroyed && target &&((get_dist_euclide(origin, src) < range) || isspaceturf(loc)) && (throwing||flying) && istype(loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dx)
@@ -581,7 +584,6 @@
 					parrier = hit_check_return
 					break
 				error += dist_y
-				dist_travelled++
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
 					dist_since_sleep = 0
@@ -596,7 +598,6 @@
 					parrier = hit_check_return
 					break
 				error -= dist_x
-				dist_travelled++
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
 					dist_since_sleep = 0


### PR DESCRIPTION

## About The Pull Request
Changes throw to use get_dist_euclide instead of turfs crossed.
This means throwing diagonally will no longer comically reduce your effective range.

For a 7 throw range nade, we go from this:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/931d6911-6c59-402c-91b5-8de6d157f715)
To this:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/c1427765-1895-4b13-a754-89af65c2aad0)
## Why It's Good For The Game
Diagonal throwing less jank.
## Changelog
:cl:
balance: Made throwing perform more accurately in diagonal directions
/:cl:
