### PR TITLE
adds barricade level armor to mortars

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -411,7 +411,7 @@
 	icon = 'icons/Marine/mortar.dmi'
 	icon_state = "mortar"
 	max_integrity = 200
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 15, BIO = 100, FIRE = 100, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 15, BIO = 100, FIRE = 0, ACID = 0)
 	flags_item = IS_DEPLOYABLE
 	/// What item is this going to deploy when we put down the mortar?
 	var/deployable_item = /obj/machinery/deployable/mortar

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -411,6 +411,7 @@
 	icon = 'icons/Marine/mortar.dmi'
 	icon_state = "mortar"
 	max_integrity = 200
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 15, BIO = 100, FIRE = 100, ACID = 0)
 	flags_item = IS_DEPLOYABLE
 	/// What item is this going to deploy when we put down the mortar?
 	var/deployable_item = /obj/machinery/deployable/mortar


### PR DESCRIPTION


## About The Pull Request

Adds barricade level armor to mortars. 

## Why It's Good For The Game

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/33578623/bce1e61b-abe6-4256-8e63-71f6ece40746)

Oh my lord I have never wanted to murder a marine as much as when they destroy my mortar. This PR would make it so mortars are harder for marines to kill, but that they still take damage. Also Lumi approved.

## Changelog
:cl:

balance: TA-50 mortar now has 400 effective health against marines, because it has 50 laser, bullet, and energy armor plus other ones on 200 health, with the howitzer and MLRS also having 2x increases against marines. 

/:cl:
