### PR TITLE
Fixes marines surviving nuke

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -324,5 +324,5 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.adjustFireLoss(victim.maxHealth*2)
+		victim.setFireLoss(victim.maxHealth*2)
 		CHECK_TICK


### PR DESCRIPTION

## About The Pull Request
Makes the nuke setFireLoss instead of adjusting, setFireLoss cares about armor, and that causes marines to often survive the nuke, which is no good at all.

## Why It's Good For The Game
If fucking monsters that are 2 times or more size of a marine get obliterated by the nuke, why can marines barely just survive it?
Tempting also to make it gib, but that's far more performance intensive for humans than xenos methinks.

## Changelog

:cl:
fix: Marines will no longer survive nuke by the sheer strength of their unga.
/:cl:

