### PR TITLE
Combat shotgun can fire one handed again

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -79,7 +79,7 @@
 	icon_state = "t39"
 	item_state = "t39"
 	fire_sound = 'sound/weapons/guns/fire/shotgun_automatic.ogg'
-	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	default_ammo_type = /datum/ammo/bullet/shotgun/buckshot
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,


### PR DESCRIPTION

## About The Pull Request
Juggling is dead. One handed combat shotgun is back.
## Why It's Good For The Game
Juggling is dead, and the TGMC bought better stocks for the combat shotguns again.
## Changelog
:cl:
balance: You can now fire combat shotguns one handed again.
/:cl:
