### PR TITLE
Underbarrel weapon fix

### DIFF
--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -17,10 +17,12 @@
 		return //Attached guns and guns being dual wielded aren't taken into account.
 	next_fire_time = world.time + fired_gun.fire_delay
 
-/// Checks if the cooldown of the gun we previously fired is up. 
+/// Checks if the cooldown of the gun we previously fired is up.
 /datum/component/anti_juggling/proc/check_cooldown(datum/source, obj/item/weapon/gun/cool_gun)
 	SIGNAL_HANDLER
 
+	if(cool_gun.master_gun)
+		return TRUE
 	if(world.time < next_fire_time)
 		return FALSE
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Underbarrel weapons no longer get caught by the anti-juggle component.

This was making underbarrels next tro unusable on low rate of fire weapons (most notably the flamer).
## Why It's Good For The Game
floride staring the burning man for 2 seconds before you can extinguish them is bad.
## Changelog
:cl:
fix: Underbarrel weapons no longer get delayed by the anti-juggle component
/:cl:
