### PR TITLE
SG pistol buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -427,6 +427,29 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shrapnel_chance = 15
 	sundering = 2
 
+/datum/ammo/bullet/pistol/frag
+	name = "frag pistol bullet"
+	hud_state = "pistol_ap"
+	damage = 30
+	penetration = 12.5
+	shrapnel_chance = 15
+	sundering = 2
+	bonus_projectiles_type = /datum/ammo/bullet/frag_spread
+	bonus_projectiles_scatter = 20
+	var/bonus_projectile_quantity = 4
+
+/datum/ammo/bullet/pistol/frag/on_hit_mob(mob/M, obj/projectile/proj)
+	playsound(proj, sound(get_sfx("explosion_micro")), 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M) )
+
+/datum/ammo/bullet/pistol/frag/do_at_max_range(turf/T, obj/projectile/proj)
+	playsound(proj, sound(get_sfx("explosion_micro")), 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, get_turf(proj)) )
+
+/datum/ammo/tx54/on_hit_obj(obj/O, obj/projectile/proj)
+	playsound(proj, sound(get_sfx("explosion_micro")), 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O) )
+
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"
 	hud_state = "pistol_heavy"
@@ -1508,6 +1531,18 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	drop_nade(T.density ? P.loc : T)
 
 //The secondary projectiles
+/datum/ammo/bullet/frag_spread
+	name = "Shrapnel"
+	icon_state = "buckshot"
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_MOB
+	accuracy_var_low = 5
+	accuracy_var_high = 5
+	max_range = 4
+	damage = 5
+	penetration = 20
+	sundering = 2
+	damage_falloff = 0
+
 /datum/ammo/bullet/tx54_spread
 	name = "Shrapnel"
 	icon_state = "flechette"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -733,7 +733,7 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 	icon_state = "sp13"
 	item_state = "sp13"
 	caliber = CALIBER_9X19 //codex
-	max_shells = 30 //codex
+	max_shells = 15 //codex
 	fire_sound = 'sound/weapons/guns/fire/tp14.ogg' //same bullets, same sound
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol
@@ -742,11 +742,15 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/motiondetector,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/verticalgrip,
-		/obj/item/attachable/lasersight,
 		/obj/item/attachable/gyro,
+		/obj/item/attachable/reddot,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/lasersight,
+		/obj/item/attachable/compensator,
 		/obj/item/attachable/lace,
+		/obj/item/attachable/buildasentry,
+		/obj/item/attachable/shoulder_mount,
 	)
 
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_IFF
@@ -758,10 +762,10 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 
 	aim_slowdown = 0.2
 	wield_delay = 0.4 SECONDS
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.3 SECONDS
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.85
 	scatter = 3
-	scatter_unwielded = 7
+	scatter_unwielded = 5
 	recoil = -2
-	recoil_unwielded = 2
+	recoil_unwielded = 1

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -242,9 +242,9 @@
 
 //SP-13 (Calico)
 /obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol
-	name = "\improper SP-13 magazine (9mm AP)"
+	name = "\improper SP-13 magazine (9mm)"
 	caliber = CALIBER_9X19
 	icon_state = "tx13"
-	max_rounds = 30
+	max_rounds = 15
 	w_class = WEIGHT_CLASS_SMALL
-	default_ammo = /datum/ammo/bullet/pistol/ap
+	default_ammo = /datum/ammo/bullet/pistol/frag


### PR DESCRIPTION

## About The Pull Request

Buffs and adds a gimmick to SG pistol, adds more attachments to SG pistol. SG pistol bullets do increased damage and split into four shrapnel pieces, decrease mag size to compensate. Adjusts one handed recoil to me marginally better.
## Why It's Good For The Game

gives a reason for the SG pistol to exist now, as well as making it more effective to use and allows more outfitting to preform specific niches for an SG's needs.
## Changelog
:cl:
add: SG pistol now has fragmenting rounds
balance: SG pistol rounds deal increased damage with shrapnel rounds, ammo per mag decreased as well as fire delay increased, along with balancing of one handed recoil.
/:cl:
