### PR TITLE
Makes the nuke call death() and deal more damage

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -317,5 +317,5 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.setFireLoss(victim.maxHealth*2)
+		victim.dust()
 		CHECK_TICK

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -317,5 +317,6 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.dust()
+		victim.setFireLoss(victim.maxHealth * 4)
+		victim.death()
 		CHECK_TICK

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -317,6 +317,6 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.setFireLoss(victim.maxHealth * 4)
+		victim.adjustFireLoss(victim.maxHealth * 4)
 		victim.death()
 		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request
Please don't be dumb like me and be too lazy to test your 1 liner PR.
Makes the nuke call death so you *definetely* cannot survive the nuke
## Why It's Good For The Game
How does one revive from a literal nuclear explosion, or simply survive it's blast with one's mortal body?
## Changelog
:cl:
fix: The nuclear explosion will actually, properly, goddamn, kill you, instead of just singing you slightly
/:cl:
