### PR TITLE
Gravity

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -36,8 +36,7 @@ SUBSYSTEM_DEF(mapping)
 	///The number of connected clients for the previous round
 	var/last_round_player_count
 
-	///shows the default gravity value for each z level. recalculated when gravity generators change.
-	///List in the form: list(z level num = max generator gravity in that z level OR the gravity level trait)
+	///shows the gravity value for each z level
 	var/list/gravity_by_z_level = list()
 
 //dlete dis once #39770 is resolved
@@ -385,10 +384,12 @@ SUBSYSTEM_DEF(mapping)
 		var/area/A = B
 		A.reg_in_areas_in_z()
 
+///Generates baseline gravity levels for all z-levels based off traits
 /datum/controller/subsystem/mapping/proc/calculate_default_z_level_gravities()
 	for(var/z_level in 1 to length(z_list))
 		calculate_z_level_gravity(z_level)
 
+///Calculates the gravity for a z-level
 /datum/controller/subsystem/mapping/proc/calculate_z_level_gravity(z_level_number)
 	if(!isnum(z_level_number) || z_level_number < 1)
 		return FALSE

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -36,6 +36,10 @@ SUBSYSTEM_DEF(mapping)
 	///The number of connected clients for the previous round
 	var/last_round_player_count
 
+	///shows the default gravity value for each z level. recalculated when gravity generators change.
+	///List in the form: list(z level num = max generator gravity in that z level OR the gravity level trait)
+	var/list/gravity_by_z_level = list()
+
 //dlete dis once #39770 is resolved
 /datum/controller/subsystem/mapping/proc/HACK_LoadMapConfig()
 	if(!configs)
@@ -71,6 +75,7 @@ SUBSYSTEM_DEF(mapping)
 	transit = add_new_zlevel("Transit/Reserved", list(ZTRAIT_RESERVED = TRUE))
 	repopulate_sorted_areas()
 	initialize_reserved_level(transit.z_value)
+	calculate_default_z_level_gravities()
 	return SS_INIT_SUCCESS
 
 //Loads the number of players we had last round, for use in modular mapping
@@ -282,7 +287,7 @@ SUBSYSTEM_DEF(mapping)
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S
-	
+
 	for(var/drop_path in typesof(/datum/map_template/shuttle/minidropship))
 		var/datum/map_template/shuttle/drop = new drop_path()
 		minidropship_templates += drop
@@ -379,3 +384,18 @@ SUBSYSTEM_DEF(mapping)
 	for(var/B in areas)
 		var/area/A = B
 		A.reg_in_areas_in_z()
+
+/datum/controller/subsystem/mapping/proc/calculate_default_z_level_gravities()
+	for(var/z_level in 1 to length(z_list))
+		calculate_z_level_gravity(z_level)
+
+/datum/controller/subsystem/mapping/proc/calculate_z_level_gravity(z_level_number)
+	if(!isnum(z_level_number) || z_level_number < 1)
+		return FALSE
+
+	var/max_gravity = 1 //we default to standard grav
+
+	max_gravity = level_trait(z_level_number, ZTRAIT_GRAVITY) ? level_trait(z_level_number, ZTRAIT_GRAVITY) : 1
+
+	gravity_by_z_level["[z_level_number]"] = max_gravity
+	return max_gravity

--- a/code/datums/components/stamina_behavior.dm
+++ b/code/datums/components/stamina_behavior.dm
@@ -1,6 +1,6 @@
 /datum/component/stamina_behavior
 	var/stamina_state = STAMINA_STATE_IDLE
-
+	///multiplier on stamina cost
 	var/drain_modifier = 1
 
 
@@ -58,6 +58,7 @@
 		return
 	stamina_holder.toggle_move_intent(MOVE_INTENT_WALK)
 
+///changes the drain modifier if gravity changes
 /datum/component/stamina_behavior/proc/on_change_z(datum/source, old_z, new_z)
 	SIGNAL_HANDLER
 	var/mob/living/stamina_holder = parent

--- a/code/datums/components/stamina_behavior.dm
+++ b/code/datums/components/stamina_behavior.dm
@@ -1,6 +1,8 @@
 /datum/component/stamina_behavior
 	var/stamina_state = STAMINA_STATE_IDLE
 
+	var/drain_modifier = 1
+
 
 /datum/component/stamina_behavior/Initialize()
 	. = ..()
@@ -9,8 +11,9 @@
 	var/mob/living/stamina_holder = parent
 	if(stamina_holder.m_intent == MOVE_INTENT_RUN)
 		stamina_active()
+	drain_modifier = stamina_holder.get_gravity()
 	RegisterSignal(parent, COMSIG_MOB_TOGGLEMOVEINTENT, PROC_REF(on_toggle_move_intent))
-
+	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_change_z))
 
 /datum/component/stamina_behavior/proc/on_toggle_move_intent(datum/source, new_intent)
 	SIGNAL_HANDLER
@@ -43,7 +46,7 @@
 	var/mob/living/stamina_holder = parent
 	if(oldloc == stamina_holder.loc)
 		return
-	stamina_holder.adjustStaminaLoss(1)
+	stamina_holder.adjustStaminaLoss(1 * drain_modifier)
 	if(stamina_holder.staminaloss >= 0)
 		stamina_holder.toggle_move_intent(MOVE_INTENT_WALK)
 
@@ -54,3 +57,8 @@
 	if(canmove || stamina_holder.m_intent == MOVE_INTENT_WALK)
 		return
 	stamina_holder.toggle_move_intent(MOVE_INTENT_WALK)
+
+/datum/component/stamina_behavior/proc/on_change_z(datum/source, old_z, new_z)
+	SIGNAL_HANDLER
+	var/mob/living/stamina_holder = parent
+	drain_modifier = stamina_holder.get_gravity()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -501,9 +501,9 @@
 
 	var/gravity = get_gravity()
 	if(gravity < 1)
-		range = round(range * 1.5)
+		range = round(range * (2 - gravity))
 	else if(gravity > 1)
-		range = ROUND_UP(range * 0.5)
+		range = ROUND_UP(range * (2 - gravity))
 
 	if(!targetted_throw)
 		target = get_turf_in_angle(Get_Angle(src, target), target, range - get_dist(src, target))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -499,6 +499,12 @@
 	if(!target || !src)
 		return FALSE
 
+	var/gravity = get_gravity()
+	if(gravity < 1)
+		range = round(range * 1.5)
+	else if(gravity > 1)
+		range = ROUND_UP(range * 0.5)
+
 	if(!targetted_throw)
 		target = get_turf_in_angle(Get_Angle(src, target), target, range - get_dist(src, target))
 
@@ -1182,3 +1188,7 @@
 
 	for(var/atom/movable/movable_loc as anything in get_nested_locs(src) + src)
 		LAZYREMOVEASSOC(movable_loc.important_recursive_contents, RECURSIVE_CONTENTS_CLIENT_MOBS, former_client.mob)
+
+///Checks the gravity the atom is subjected to
+/atom/movable/proc/get_gravity()
+	return SSmapping.gravity_by_z_level["[z]"]

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -438,17 +438,14 @@
 /mob/living/carbon/xenomorph/set_jump_component(duration = 0.5 SECONDS, cooldown = 2 SECONDS, cost = 0, height = 16, sound = null, flags = JUMP_SHADOW, flags_pass = PASS_LOW_STRUCTURE|PASS_FIRE)
 	var/gravity = get_gravity()
 	if(gravity < 1) //low grav
-		var/list/modifiers = GLOB.low_gravity_modifiers["jump_modifiers"]
-		duration *= modifiers[1]
-		cooldown *= modifiers[2]
-		cost *= modifiers[3]
-		height *= modifiers[4]
-		flags_pass |= modifiers[5]
+		duration *= 2.5 - gravity
+		cooldown *= 2 - gravity
+		height *= 2 - gravity
+		if(gravity <= 0.75)
+			flags_pass |= PASS_DEFENSIVE_STRUCTURE
 	else if(gravity > 1) //high grav
-		var/list/modifiers = GLOB.high_gravity_modifiers["jump_modifiers"]
-		duration *= modifiers[1]
-		cooldown *= modifiers[2]
-		cost *= modifiers[3]
-		height *= modifiers[4]
+		duration *= gravity * 0.5
+		cooldown *= gravity
+		height *= gravity * 0.5
 
 	AddComponent(/datum/component/jump, _jump_duration = duration, _jump_cooldown = cooldown, _stamina_cost = 0, _jump_height = height, _jump_sound = sound, _jump_flags = flags, _jumper_allow_pass_flags = flags_pass)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -436,4 +436,19 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/set_jump_component(duration = 0.5 SECONDS, cooldown = 2 SECONDS, cost = 0, height = 16, sound = null, flags = JUMP_SHADOW, flags_pass = PASS_LOW_STRUCTURE|PASS_FIRE)
+	var/gravity = get_gravity()
+	if(gravity < 1) //low grav
+		var/list/modifiers = GLOB.low_gravity_modifiers["jump_modifiers"]
+		duration *= modifiers[1]
+		cooldown *= modifiers[2]
+		cost *= modifiers[3]
+		height *= modifiers[4]
+		flags_pass |= modifiers[5]
+	else if(gravity > 1) //high grav
+		var/list/modifiers = GLOB.high_gravity_modifiers["jump_modifiers"]
+		duration *= modifiers[1]
+		cooldown *= modifiers[2]
+		cost *= modifiers[3]
+		height *= modifiers[4]
+
 	AddComponent(/datum/component/jump, _jump_duration = duration, _jump_cooldown = cooldown, _stamina_cost = 0, _jump_height = height, _jump_sound = sound, _jump_flags = flags, _jumper_allow_pass_flags = flags_pass)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -827,6 +827,10 @@ below 100 is not dizzy
 /mob/living/can_interact_with(datum/D)
 	return D == src || D.Adjacent(src)
 
+/mob/living/onTransitZ(old_z, new_z)
+	. = ..()
+	set_jump_component()
+
 /**
  * Changes the inclination angle of a mob, used by humans and others to differentiate between standing up and prone positions.
  *
@@ -971,4 +975,29 @@ below 100 is not dizzy
 
 ///Sets up the jump component for the mob. Proc args can be altered so different mobs have different 'default' jump settings
 /mob/living/proc/set_jump_component(duration = 0.5 SECONDS, cooldown = 1 SECONDS, cost = 8, height = 16, sound = null, flags = JUMP_SHADOW, flags_pass = PASS_LOW_STRUCTURE|PASS_FIRE)
+	var/gravity = get_gravity()
+	if(gravity < 1) //low grav
+		var/list/modifiers = GLOB.low_gravity_modifiers["jump_modifiers"]
+		duration *= modifiers[1]
+		cooldown *= modifiers[2]
+		cost *= modifiers[3]
+		height *= modifiers[4]
+		flags_pass |= modifiers[5]
+	else if(gravity > 1) //high grav
+		var/list/modifiers = GLOB.high_gravity_modifiers["jump_modifiers"]
+		duration *= modifiers[1]
+		cooldown *= modifiers[2]
+		cost *= modifiers[3]
+		height *= modifiers[4]
+
 	AddComponent(/datum/component/jump, _jump_duration = duration, _jump_cooldown = cooldown, _stamina_cost = cost, _jump_height = height, _jump_sound = sound, _jump_flags = flags, _jumper_allow_pass_flags = flags_pass)
+
+GLOBAL_LIST_INIT(low_gravity_modifiers, list(
+	"jump_modifiers" = list(2, 1.5, 0.25, 1.5, PASS_DEFENSIVE_STRUCTURE),
+	"throw_modifiers" = list(),
+))
+
+GLOBAL_LIST_INIT(high_gravity_modifiers, list(
+	"jump_modifiers" = list(0.75, 1.5, 1.5, 0.75),
+	"throw_modifiers" = list(),
+))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -977,27 +977,16 @@ below 100 is not dizzy
 /mob/living/proc/set_jump_component(duration = 0.5 SECONDS, cooldown = 1 SECONDS, cost = 8, height = 16, sound = null, flags = JUMP_SHADOW, flags_pass = PASS_LOW_STRUCTURE|PASS_FIRE)
 	var/gravity = get_gravity()
 	if(gravity < 1) //low grav
-		var/list/modifiers = GLOB.low_gravity_modifiers["jump_modifiers"]
-		duration *= modifiers[1]
-		cooldown *= modifiers[2]
-		cost *= modifiers[3]
-		height *= modifiers[4]
-		flags_pass |= modifiers[5]
+		duration *= 2.5 - gravity
+		cooldown *= 2 - gravity
+		cost *= gravity * 0.5
+		height *= 2 - gravity
+		if(gravity <= 0.75)
+			flags_pass |= PASS_DEFENSIVE_STRUCTURE
 	else if(gravity > 1) //high grav
-		var/list/modifiers = GLOB.high_gravity_modifiers["jump_modifiers"]
-		duration *= modifiers[1]
-		cooldown *= modifiers[2]
-		cost *= modifiers[3]
-		height *= modifiers[4]
+		duration *= gravity * 0.5
+		cooldown *= gravity
+		cost *= gravity
+		height *= gravity * 0.5
 
 	AddComponent(/datum/component/jump, _jump_duration = duration, _jump_cooldown = cooldown, _stamina_cost = cost, _jump_height = height, _jump_sound = sound, _jump_flags = flags, _jumper_allow_pass_flags = flags_pass)
-
-GLOBAL_LIST_INIT(low_gravity_modifiers, list(
-	"jump_modifiers" = list(2, 1.5, 0.25, 1.5, PASS_DEFENSIVE_STRUCTURE),
-	"throw_modifiers" = list(),
-))
-
-GLOBAL_LIST_INIT(high_gravity_modifiers, list(
-	"jump_modifiers" = list(0.75, 1.5, 1.5, 0.75),
-	"throw_modifiers" = list(),
-))


### PR DESCRIPTION

## About The Pull Request
Experimental PR to add variable gravity to the server.

Gravity is modified by z-level trait (it could be modified by other things in the future like tg grav gens), and effects a few different things:

### Low gravity

- Throw things further (this combo's with jump throw...)
- Jump higher and for longer, for less stamina
- Run for longer

### High gravity

- Can't throw as far
- Jump takes more stamina, and is shorter
- Runnning eats more stamina

Note that this is **everything** that uses 'throw' which includes jetpacks, all type of xeno lunges etc.

Because this is a z-level trait thing, its defined config side so isn't on by default.
Is this a good idea? Is it FUN? Walanced?

Who knows, but it can definitely change things up, and I think it could be interesting to have maps designed with altered gravity in mind.
## Why It's Good For The Game
Interesting thing maybe.
## Changelog
:cl:
add: Added variable gravity as a z-level based function to effect various things such as running, jumping and throwing
/:cl:
