### PR TITLE
sentries now need line of sight to actually acquire a target 

### DIFF
--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -420,22 +420,23 @@
 /obj/machinery/deployable/mounted/sentry/proc/check_target_path(mob/living/target)
 	var/list/turf/path = getline(src, target)
 	var/turf/starting_turf = get_turf(src)
+	var/turf/target_turf = path[length(path)-1]
 	path -= get_turf(src)
 	if(!length(path))
 		return FALSE
+
+	var/old_turf_dir_to_us = get_dir(starting_turf, target_turf)
+	if(ISDIAGONALDIR(old_turf_dir_to_us))
+		for(var/i in 0 to 2)
+			var/between_turf = get_step(target_turf, turn(old_turf_dir_to_us, i == 1 ? 45 : -45))
+			if(can_see_through(starting_turf, between_turf))
+				break
+			if(i==2)
+				return FALSE
 	for(var/turf/T AS in path)
 		var/obj/effect/particle_effect/smoke/smoke = locate() in T
 		if(smoke?.opacity)
 			return FALSE
-
-		var/old_turf_dir_to_us = get_dir(starting_turf, T)
-		if(ISDIAGONALDIR(old_turf_dir_to_us))
-			for(var/i in 0 to 2)
-				var/between_turf = get_step(T, turn(old_turf_dir_to_us, i == 1 ? 45 : -45))
-				if(can_see_through(starting_turf, between_turf))
-					break
-				if(i==2)
-					return FALSE
 
 		if(IS_OPAQUE_TURF(T) || T.density && !(T.allow_pass_flags & PASS_PROJECTILE) && !(T.type in ignored_terrains))
 			return FALSE

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -366,11 +366,11 @@
 	var/obj/item/weapon/gun/gun = internal_item
 	potential_targets.Cut()
 	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(src, range))
-		if(nearby_human.stat == DEAD || CHECK_BITFIELD(nearby_human.status_flags, INCORPOREAL)  || (CHECK_BITFIELD(gun.turret_flags, TURRET_SAFETY) || nearby_human.wear_id?.iff_signal & iff_signal))
+		if(nearby_human.stat == DEAD || !line_of_sight(src, nearby_human, range) || CHECK_BITFIELD(nearby_human.status_flags, INCORPOREAL)  || (CHECK_BITFIELD(gun.turret_flags, TURRET_SAFETY) || nearby_human.wear_id?.iff_signal & iff_signal))
 			continue
 		potential_targets += nearby_human
 	for (var/mob/living/carbon/xenomorph/nearby_xeno AS in cheap_get_xenos_near(src, range))
-		if(nearby_xeno.stat == DEAD || HAS_TRAIT(nearby_xeno, TRAIT_TURRET_HIDDEN) || CHECK_BITFIELD(nearby_xeno.status_flags, INCORPOREAL)) //So wraiths wont be shot at when in phase shift
+		if(nearby_xeno.stat == DEAD || !line_of_sight(src, nearby_xeno, range) || HAS_TRAIT(nearby_xeno, TRAIT_TURRET_HIDDEN) || CHECK_BITFIELD(nearby_xeno.status_flags, INCORPOREAL)) //So wraiths wont be shot at when in phase shift
 			continue
 		potential_targets += nearby_xeno
 	return potential_targets.len


### PR DESCRIPTION

## About The Pull Request

This fixes #13471

## Why It's Good For The Game

This bug makes it possible to cheese sentries by having them target you while you are behind a wall.

## Changelog

:cl:

fix: fixed sentries targeting mobs when they cant actually see and shoot them
/:cl:
