### PR TITLE
MG-27 improvements

### DIFF
--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -318,6 +318,7 @@
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/shield
 	suit_store = /obj/item/weapon/gun/standard_mmg/machinegunner
 	l_store = /obj/item/storage/pouch/construction
+	glasses = /obj/item/clothing/glasses/mgoggles
 
 /datum/outfit/quick/tgmc/marine/medium_machinegunner/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -373,6 +373,7 @@
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,
 		/obj/item/attachable/bayonetknife/som,
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/scope/unremovable/mmg,
 		/obj/item/attachable/stock/t27,

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -351,7 +351,7 @@
 	icon_state = "t27"
 	item_state = "t27"
 	caliber = CALIBER_10x27_CASELESS // codex
-	max_shells = 100 //codex
+	max_shells = 150 //codex
 	force = 40
 	aim_slowdown = 1.2
 	wield_delay = 2 SECONDS
@@ -386,7 +386,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.1 SECONDS
+	aim_fire_delay = 0.05 SECONDS
 	aim_speed_modifier = 5
 	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
@@ -399,13 +399,13 @@
 	fire_delay = 0.15 SECONDS
 	burst_amount = 1
 	deploy_time = 1 SECONDS
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.25
 	undeploy_time = 0.5 SECONDS
 	max_integrity = 200
 
 
 /obj/item/weapon/gun/standard_mmg/machinegunner
-	starting_attachment_types = list(/obj/item/attachable/stock/t27, /obj/item/attachable/scope/unremovable/mmg)
+	starting_attachment_types = list(/obj/item/attachable/stock/t27, /obj/item/attachable/scope/unremovable/mmg, /obj/item/attachable/heavy_barrel)
 
 //-------------------------------------------------------
 //AT-36 Anti Tank Gun

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -46,7 +46,7 @@
 	icon_state = "mag"
 	flags_magazine = NONE
 	caliber = CALIBER_10x27_CASELESS
-	max_rounds = 100
+	max_rounds = 150
 	default_ammo = /datum/ammo/bullet/rifle/heavy
 	reload_delay = 1 SECONDS
 


### PR DESCRIPTION
## About The Pull Request
Decreased MMG aimmode penalty from 0.1 to 0.05 seconds
Increased mag size from 100 to 150 rounds.
Decreased damage falloff from 0.5 to 0.25.
Can fit a railscope

Some minor improvements to make the MMG have a bit more use in light of current MG-60 performance.

Also related, added a BC to the MMG HvH loadout, so it can just rip people apart at long range with very fast projectiles and essentially no falloff.
## Why It's Good For The Game
When the MG-60 was buffed, the MMG was made somewhat obsolete due to being extremely similar in performance but requiring deployment to use.

These changes make a scoped MMG a better aim mode gun than a scoped MG-60, have a more notable advantage at long range, and have generally better ammo economy.
## Changelog
:cl:
balance: Improved MG-27 aimmode penalty, ammo per mag, and damage falloff. Can now fit a railscope
balance: HvH: MG-27 loadout has a barrel charger
/:cl:
