### PR TITLE
Storage exploit fix

### DIFF
--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,5 +1,6 @@
 //base suit for those that have some form of internal storage
 /obj/item/clothing/suit/storage
+	w_class = WEIGHT_CLASS_BULKY
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_STORAGE,
 		ATTACHMENT_SLOT_BADGE,


### PR DESCRIPTION

## About The Pull Request
Some suits are normal sized items, which meant they can fit inside their own storage.
## Why It's Good For The Game
Exploit bad
## Changelog
:cl:
fix: fixed a storage bug with some misc suits
/:cl:
