### PR TITLE
Gives PO the same timelock as Captain

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -273,7 +273,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	skills_type = /datum/skills/pilot
 	display_order = JOB_DISPLAY_ORDER_PILOT_OFFICER
 	outfit = /datum/outfit/job/command/pilot
-	exp_requirements = XP_REQ_INTERMEDIATE
+	exp_requirements = XP_REQ_EXPERT
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE_STRONG,


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
In the original PR for adding timelock, it was stated:
"These hours are not much too ask if you compare to the griefing power these roles have."
I believe that Bravemole severely underestimated, in this case, the griefing power of PO. This is a grievance as admin due to the amount of ahelps I get about under 10 hour living PO's, throwing entire op's due to the low timelock and not understanding the game properly. This will not solve all of the issue with new PO, it is a game after all, but hopefully new PO's can have more experience.
## Changelog
:cl:
admin:  Gives PO the same timelock as Captain
/:cl:
