### PR TITLE
Adds the dead mob list to the server maint SS

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -153,6 +153,8 @@
 
 #if DM_VERSION < 515
 /proc/listclearnulls(list/list_to_clear)
+	if(!list_to_clear)
+		return
 	var/start_len = length(list_to_clear)
 	var/list/new_list[start_len]
 	list_to_clear -= new_list

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -146,23 +146,15 @@
 			return TRUE
 	return FALSE
 
-
-//Empties the list by setting the length to 0. Hopefully the elements get garbage collected
-/proc/clearlist(list/L)
-	if(!istype(L))
-		return
-
-	L.len = 0
-
-
-//Removes any null entries from the list
-/proc/listclearnulls(list/L)
-	if(!istype(L))
-		return
-
-	while(null in L)
-		L -= null
-
+/**
+ * Removes any null entries from the list
+ * Returns TRUE if the list had nulls, FALSE otherwise
+**/
+/proc/listclearnulls(list/list_to_clear)
+	var/start_len = length(list_to_clear)
+	var/list/new_list[start_len]
+	list_to_clear -= new_list
+	return length(list_to_clear) < start_len
 
 /*
 * Returns list containing all the entries from first list that are not present in second.

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -150,11 +150,16 @@
  * Removes any null entries from the list
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/
+
+#if DM_VERSION < 515
 /proc/listclearnulls(list/list_to_clear)
 	var/start_len = length(list_to_clear)
 	var/list/new_list[start_len]
 	list_to_clear -= new_list
 	return length(list_to_clear) < start_len
+#else
+#define listclearnulls(list) list.RemoveAll(null)
+#endif
 
 /*
 * Returns list containing all the entries from first list that are not present in second.

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -70,6 +70,10 @@ SUBSYSTEM_DEF(server_maint)
 					log_world("Found a null in observers_by_zlevel!")
 				cleanup_ticker++
 			if(35)
+				if(listclearnulls(GLOB.dead_mob_list))
+					log_world("Found a null in GLOB.dead_mob_list!")
+				cleanup_ticker++
+			if(40)
 				cleanup_ticker = 0
 			else
 				cleanup_ticker++


### PR DESCRIPTION

## About The Pull Request

\+ deletes an unused helper and makes `listclearnulls` actually return TRUE/FALSE so nulls in global lists actually get logged.
## Why It's Good For The Game

Nulls in this list cause issues like completely breaking emotes. It's not really feasible to track down why there are nulls since they are most likely the results of harddels.
## Changelog
:cl:
fix: Fixed emotes breaking at random
/:cl:
