### PR TITLE
Ammo fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1242,7 +1242,7 @@ will handle it, but:
  *	Variables:
  *	center - where the cone begins, or center of a circle drawn with this
  *	max_row_count - how many rows are checked
- *	starting_row - from how far should the turfs start getting included in the cone
+ *	starting_row - from how far should the turfs start getting included in the cone. -1 required to include center turf due to byond
  *	cone_width - big the angle of the cone is
  *	cone_direction - at what angle should the cone be made, relative to the game board's orientation
  *	blocked - whether the cone should take into consideration solid walls
@@ -1261,10 +1261,10 @@ will handle it, but:
 
 	if(left_angle < 0)
 		left_angle += 360
-
+	center = get_turf(center)
 	var/list/cardinals = GLOB.alldirs
-	var/list/turfs_to_check = list(get_turf(center))
-	var/list/cone_turfs = list()
+	var/list/turfs_to_check = list(center)
+	var/list/cone_turfs = list(center)
 
 	for(var/row in 1 to max_row_count)
 		if(row > 2)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3106,7 +3106,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		mech_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
-	if(!isxeno(M))
+	if(isxeno(M))
 		return
 	staggerstun(M, P, 9, stagger = 2, slowdown = 2, knockback = 1)
 


### PR DESCRIPTION
## About The Pull Request
Made SOM cluster nades and psyblast properly hit things as intended.

Not sure if the proc they used changed due to the spatial port, or if I just incorrectly used it a year ago.

They now use the cone proc to accurately find turfs they can actually hit.

Also made bomblets hit objects again.

Psylance now correctly staggerslows NON xenos instead of ONLY xenos. Whoops.

Finally, made the cone proc include the central turf by default (due to the mysteries of get_dist, this is interpreted as a distance of -1 however, as added to the autodoc).
## Why It's Good For The Game
Working code good.
## Changelog
:cl:
fix: SOM cluster grenades and warlock psyblast has more accurate code for what their AOE's will hit
fix: Psylance no longer staggerslows xenos instead of humans
balance: SOM cluster grenades hit objects again, instead of just mobs
