### PR TITLE
Complete and utter annihilation of melee weapon knockdown (from humans)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -198,13 +198,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 
 		switch(hit_area)
-			if("head")//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(applied_damage) && stat == CONSCIOUS)
-					Paralyze(modify_by_armor(16, MELEE, def_zone = target_zone))
-					visible_message(span_danger("[src] has been knocked unconscious!"),
-									span_danger("You have been knocked unconscious!"), null, 5)
-					hit_report += "(KO)"
-
+			if("head")
 				if(bloody)//Apply blood
 					if(wear_mask)
 						wear_mask.add_mob_blood(src)
@@ -216,13 +210,7 @@ Contains most of the procs that are called when a mob is attacked by something
 						glasses.add_mob_blood(src)
 						update_inv_glasses(0)
 
-			if("chest")//Easier to score a stun but lasts less time
-				if(prob((applied_damage + 5)) && !incapacitated())
-					apply_effect(modify_by_armor(6, MELEE, def_zone = target_zone), WEAKEN)
-					visible_message(span_danger("[src] has been knocked down!"),
-									span_danger("You have been knocked down!"), null, 5)
-					hit_report += "(KO)"
-
+			if("chest")
 				if(bloody)
 					bloody_body(src)
 


### PR DESCRIPTION

## About The Pull Request

Removes knockdown from being randomly hit by a melee weapon
The way this worked was shit in the first place because a boarding axe which is common in HvH where melee weapon combat between humans actually just resulted in a 85% chance to knockdown for like 10 seconds

## Why It's Good For The Game

this just sucks to fight against because their silly axe can stun you for a considerable duration with a 85% chance so you cant do shit against them
also the same with other melee weapons where the esword had a 55% chance + the loadout starts with a vortex drive or whatever the fuck it was called so you can just win ranged engagements with a melee weapon

this in no way affects nuclear war or any other HvX gamemodes because humans shouldnt kill eachother on HvX

## Changelog
:cl:
balance: removed melee weapon knockdown
/:cl:
