### PR TITLE
Fixes minimap not tracking mobs inside objects properly

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -212,15 +212,17 @@ SUBSYSTEM_DEF(minimaps)
 		earlyadds += CALLBACK(src, PROC_REF(add_marker), target, hud_flags, blip)
 		return
 
-	blip.pixel_x = MINIMAP_PIXEL_FROM_WORLD(target.x) + minimaps_by_z["[target.z]"].x_offset
-	blip.pixel_y = MINIMAP_PIXEL_FROM_WORLD(target.y) + minimaps_by_z["[target.z]"].y_offset
+	var/turf/target_turf = get_turf(target)
+
+	blip.pixel_x = MINIMAP_PIXEL_FROM_WORLD(target_turf.x) + minimaps_by_z["[target.z]"].x_offset
+	blip.pixel_y = MINIMAP_PIXEL_FROM_WORLD(target_turf.y) + minimaps_by_z["[target.z]"].y_offset
 
 	images_by_source[target] = blip
 	for(var/flag in bitfield2list(hud_flags))
-		minimaps_by_z["[target.z]"].images_assoc["[flag]"][target] = blip
-		minimaps_by_z["[target.z]"].images_raw["[flag]"] += blip
+		minimaps_by_z["[target_turf.z]"].images_assoc["[flag]"][target] = blip
+		minimaps_by_z["[target_turf.z]"].images_raw["[flag]"] += blip
 		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
-			if(target.z == updator.ztarget)
+			if(target_turf.z == updator.ztarget)
 				updator.raw_blips += blip
 	if(ismovableatom(target))
 		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
@@ -232,10 +234,11 @@ SUBSYSTEM_DEF(minimaps)
  * removes an image from raw tracked lists, invoked by callback
  */
 /datum/controller/subsystem/minimaps/proc/removeimage(image/blip, atom/target, hud_flags)
+	var/turf/target_turf = get_turf(target)
 	for(var/flag in bitfield2list(hud_flags))
-		minimaps_by_z["[target.z]"].images_raw["[flag]"] -= blip
+		minimaps_by_z["[target_turf.z]"].images_raw["[flag]"] -= blip
 		for(var/datum/minimap_updator/updator AS in update_targets["[flag]"])
-			if(updator.ztarget == target.z)
+			if(updator.ztarget == target_turf.z)
 				updator.raw_blips -= blip
 	blip.UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 	removal_cbs -= target
@@ -270,10 +273,9 @@ SUBSYSTEM_DEF(minimaps)
  */
 /image/proc/minimap_on_move(atom/movable/source, oldloc)
 	SIGNAL_HANDLER
-	if(!source.z)
-		return //this can happen legitimately when you go into pipes, it shouldnt but thats how it is
-	pixel_x = MINIMAP_PIXEL_FROM_WORLD(source.x) + SSminimaps.minimaps_by_z["[source.z]"].x_offset
-	pixel_y = MINIMAP_PIXEL_FROM_WORLD(source.y) + SSminimaps.minimaps_by_z["[source.z]"].y_offset
+	var/turf/source_turf = get_turf(source)
+	pixel_x = MINIMAP_PIXEL_FROM_WORLD(source_turf.x) + SSminimaps.minimaps_by_z["[source_turf.z]"].x_offset
+	pixel_y = MINIMAP_PIXEL_FROM_WORLD(source_turf.y) + SSminimaps.minimaps_by_z["[source_turf.z]"].y_offset
 
 /**
  * Removes an atom and it's blip from the subsystem
@@ -283,8 +285,9 @@ SUBSYSTEM_DEF(minimaps)
 	if(!removal_cbs[source]) //already removed
 		return
 	UnregisterSignal(source, list(COMSIG_QDELETING, COMSIG_MOVABLE_Z_CHANGED))
+	var/turf/source_turf = get_turf(source)
 	for(var/flag in GLOB.all_minimap_flags)
-		minimaps_by_z["[source.z]"].images_assoc["[flag]"] -= source
+		minimaps_by_z["[source_turf.z]"].images_assoc["[flag]"] -= source
 	images_by_source -= source
 	removal_cbs[source].Invoke()
 	removal_cbs -= source
@@ -382,10 +385,11 @@ SUBSYSTEM_DEF(minimaps)
 ///updates the screen loc of the locator so that it's on the movers location on the minimap
 /atom/movable/screen/minimap_locator/proc/update(atom/movable/mover, atom/oldloc, direction)
 	SIGNAL_HANDLER
-	var/x_coord = mover.x * 2
-	var/y_coord = mover.y * 2
-	x_coord += SSminimaps.minimaps_by_z["[mover.z]"].x_offset
-	y_coord += SSminimaps.minimaps_by_z["[mover.z]"].y_offset
+	var/turf/mover_turf = get_turf(mover)
+	var/x_coord = mover_turf.x * 2
+	var/y_coord = mover_turf.y * 2
+	x_coord += SSminimaps.minimaps_by_z["[mover_turf.z]"].x_offset
+	y_coord += SSminimaps.minimaps_by_z["[mover_turf.z]"].y_offset
 	// + 1 because tiles start at 1
 	var/x_tile = FLOOR(x_coord/32, 1) + 1
 	// -3 to center the image


### PR DESCRIPTION
## About The Pull Request

Basically going inside lockers, pipes, etc was fucky because your xyz vars would all get set to 0 which would result on you disappearing on the map. (it also caused runtimes)

Solved this by just `get_turf`ing the target, so the turf is tracked instead.

## Why It's Good For The Game

Runtime bad, more accurate minimap good.
## Changelog
:cl:
fix: You don't disappear on minimap anymore if you go inside an object like a locker or ventcrawl
/:cl:
