### PR TITLE
Throw fixes

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -273,7 +273,7 @@
 	desc = "Completely impassable - or are they?"
 	icon = 'icons/obj/stationobjs.dmi' //Change this.
 	icon_state = "plasticflaps"
-	density = FALSE
+	density = TRUE
 	anchored = TRUE
 	layer = MOB_LAYER
 	resistance_flags = XENO_DAMAGEABLE
@@ -283,17 +283,23 @@
 	if(istype(mover) && CHECK_BITFIELD(mover.pass_flags, PASS_GLASS))
 		return prob(60)
 
-	var/obj/structure/bed/B = mover
-	if(istype(B) && LAZYLEN(B.buckled_mobs))//if it's a bed/chair and someone is buckled, it will not pass
-		return FALSE
-
-	if(istype(mover, /obj/vehicle))	//no vehicles
-		return FALSE
-
-	if(isliving(mover)) // You Shall Not Pass!
+	if(isliving(mover))
 		var/mob/living/M = mover
-		if(!M.lying_angle && !istype(M, /mob/living/simple_animal/mouse) && !istype(M, /mob/living/carbon/xenomorph/larva) && !istype(M, /mob/living/carbon/xenomorph/runner))  //If your not laying down, or a small creature, no pass. //todo kill shitcode
+		if(M.lying_angle)
+			return TRUE
+		if(M.mob_size <= MOB_SIZE_SMALL)
+			return TRUE
+		if(isxenorunner(M)) //alas, snowflake
+			return TRUE
+		return FALSE
+
+	if(isobj(mover))
+		if(LAZYLEN(mover.buckled_mobs))
 			return FALSE
+		if(isvehicle(mover))
+			return FALSE
+
+		return TRUE
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -266,8 +266,8 @@
 
 	if(isobj(hit_atom)) //Deal with smacking into dense objects. This overwrites normal throw code.
 		var/obj/O = hit_atom
-		if(!O.density)
-			return FALSE//Not a dense object? Doesn't matter then, pass over it.
+		if(O.CanPass(src, O.loc))
+			return FALSE
 		if(!O.anchored)
 			step(O, dir) //Not anchored? Knock the object back a bit. Ie. canisters.
 		SEND_SIGNAL(src, COMSIG_XENO_OBJ_THROW_HIT, O, speed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some long standing xeno throw bugs.

Fixed getting stuck on plastic flaps if you try leap through them.
Fixed leaps failing to connect with a human target when standing behind some object you can leap over (such as a table/windowframe).

There's likely some similar issues in other cases that should also be fixed. Basically xeno throws weren't respecting proper object behavior.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed some issues with xeno leaps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
