### PR TITLE
Mounted guns are dense again

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -192,7 +192,7 @@
 
 /obj/machinery/deployable/mounted/moveable/auto_cannon
 	resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
-	coverage = 75 //has a shield
+	coverage = 85 //has a shield
 
 //-------------------------------------------------------
 //TE-9001 mounted heavy laser
@@ -454,7 +454,7 @@
 /obj/machinery/deployable/mounted/moveable/atgun
 	var/obj/item/storage/internal/ammo_rack/sponson = /obj/item/storage/internal/ammo_rack
 	resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
-	coverage = 75 //has a shield
+	coverage = 85 //has a shield
 	anchor_time = 1 SECONDS
 
 /obj/item/storage/internal/ammo_rack

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -126,6 +126,7 @@
 	if(!user.Move(loc)) //Move instead of forcemove to ensure we can actually get to the object's turf
 		density = initial(density)
 		return
+	density = initial(density)
 
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, TRUE, 7)
 	do_attack_animation(src, ATTACK_EFFECT_GRAB)


### PR DESCRIPTION
## About The Pull Request
What is says on the tin.

Mounted guns are no longer magically nondense when mounted.
This had the incredibly negative outcome of making crushers (previously the strongest counter to a mounted gun) not only entirely ineffective against mounted weapons, but it was actually almost guaranteed suicide to charge one as they'd act as one way doors.

Guns are normal objects to they have coverage like everything else. So being dense still means you can shoot the gunner (although TAT/AA gun have good coverage due to their shields), but now you can once again more easily destroy the guns 
themselves.

Closes #12762
## Why It's Good For The Game
Crushers can actually crush mounted guns again instead of just suiciding.
Easier to actually shoot a mounted gun.
## Changelog
:cl:
balance: Mounted guns are dense when mounted again. Crushers rejoice
/:cl:
