### PR TITLE
Fix head stuns

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -200,7 +200,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		switch(hit_area)
 			if("head")//Harder to score a stun but if you do it lasts a bit longer
 				if(prob(applied_damage) && stat == CONSCIOUS)
-					Paralyze(modify_by_armor(16, MELEE, def_zone = target_zone))
+					apply_effect(modify_by_armor(10, MELEE, def_zone = target_zone), WEAKEN)
 					visible_message(span_danger("[src] has been knocked unconscious!"),
 									span_danger("You have been knocked unconscious!"), null, 5)
 					hit_report += "(KO)"


### PR DESCRIPTION
## About The Pull Request
Head stuns correctly apply a longer stun than chest stuns.

Head stuns (when humans donk humans) are supposed to be longer lasting than chest stuns, at the cost of being harder to land.
It used a different proc from chest stuns however, which due to shittery relies on a multiplier, meaning it was actually significantly shorter than chest stuns, so simply worse.

Reduced it down to 10 as 16 would be giga high, but again keep in mind the duration is modified by armour, and does not consider AP, unlike stun CHANCE.

Looks like I inadvertantly nerfed this back when I refactored armour.
## Why It's Good For The Game
Bug fix
## Changelog
:cl:
fix: HvH - Fixed melee head stuns being far shorter than intended
/:cl:
