### PR TITLE
Cover buffs

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -60,7 +60,8 @@
 	icon_state = "generic"
 	anchored = TRUE
 	density = TRUE
-	coverage = 70
+	coverage = 80
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 0, ACID = 0)
 	layer = BELOW_OBJ_LAYER
 
 	use_power = IDLE_POWER_USE

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -322,19 +322,20 @@
 
 /obj/machinery/vending/proc/tip_over()
 	var/matrix/A = matrix()
-	tipped_level = 2
 	A.Turn(90)
 	transform = A
-	allow_pass_flags |= PASS_LOW_STRUCTURE
+
+	tipped_level = 2
+	allow_pass_flags |= (PASS_LOW_STRUCTURE|PASS_MOB)
 	coverage = 50
 
 /obj/machinery/vending/proc/flip_back()
 	icon_state = initial(icon_state)
-	tipped_level = 0
-	density = TRUE
 	var/matrix/A = matrix()
 	transform = A
-	allow_pass_flags &= ~PASS_LOW_STRUCTURE
+
+	tipped_level = 0
+	allow_pass_flags &= ~(PASS_LOW_STRUCTURE|PASS_MOB)
 	coverage = initial(coverage)
 
 /obj/machinery/vending/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -225,8 +225,9 @@
 		if(EXPLODE_DEVASTATE)
 			qdel(src)
 		if(EXPLODE_HEAVY)
-			if(prob(50))
-				qdel(src)
+			take_damage(rand(150, 250), BRUTE, BOMB)
+		if(EXPLODE_LIGHT)
+			take_damage(rand(75, 125), BRUTE, BOMB)
 
 /**
  * Builds shared vendors inventory
@@ -286,10 +287,6 @@
 	if(X.status_flags & INCORPOREAL)
 		return FALSE
 
-	if(tipped_level)
-		to_chat(X, span_warning("There's no reason to bother with that old piece of trash."))
-		return FALSE
-
 	if(X.a_intent == INTENT_HARM)
 		X.do_attack_animation(src, ATTACK_EFFECT_SMASH)
 		if(prob(X.xeno_caste.melee_damage))
@@ -303,6 +300,10 @@
 			span_danger("We slash \the [src]!"), null, 5)
 			playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
 		return TRUE
+
+	if(tipped_level)
+		to_chat(X, span_warning("There's no reason to bother with that old piece of trash."))
+		return FALSE
 
 	X.visible_message(span_warning("\The [X] begins to lean against \the [src]."), \
 	span_warning("You begin to lean against \the [src]."), null, 5)
@@ -322,9 +323,10 @@
 /obj/machinery/vending/proc/tip_over()
 	var/matrix/A = matrix()
 	tipped_level = 2
-	density = FALSE
 	A.Turn(90)
 	transform = A
+	allow_pass_flags |= PASS_LOW_STRUCTURE
+	coverage = 50
 
 /obj/machinery/vending/proc/flip_back()
 	icon_state = initial(icon_state)
@@ -332,6 +334,8 @@
 	density = TRUE
 	var/matrix/A = matrix()
 	transform = A
+	allow_pass_flags &= ~PASS_LOW_STRUCTURE
+	coverage = initial(coverage)
 
 /obj/machinery/vending/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -118,10 +118,14 @@
 	if((allow_pass_flags & PASS_LOW_STRUCTURE) && (mover.pass_flags & PASS_LOW_STRUCTURE))
 		return TRUE
 
-	if((allow_pass_flags & PASS_WALKOVER) && ismob(mover) && SEND_SIGNAL(target, COMSIG_OBJ_TRY_ALLOW_THROUGH))
+	if(!ismob(mover))
+		return FALSE
+
+	if((allow_pass_flags & PASS_MOB))
 		return TRUE
 
-	return FALSE
+	if((allow_pass_flags & PASS_WALKOVER) && SEND_SIGNAL(target, COMSIG_OBJ_TRY_ALLOW_THROUGH))
+		return TRUE
 
 ///Handles extra checks for things trying to exit this objects turf
 /obj/proc/on_try_exit(datum/source, atom/movable/mover, direction, list/knownblockers)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -391,7 +391,7 @@
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon_state = "metal_0"
 	max_integrity = 200
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/metal
 	stack_amount = 4
@@ -495,7 +495,7 @@
 		if(CADE_TYPE_BOMB)
 			soft_armor = soft_armor.modifyRating(bomb = 50)
 		if(CADE_TYPE_MELEE)
-			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30)
+			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30, laser = 30, energy = 30)
 		if(CADE_TYPE_ACID)
 			soft_armor = soft_armor.modifyRating(acid = 20)
 			resistance_flags |= UNACIDABLE
@@ -666,7 +666,7 @@
 				if(CADE_TYPE_BOMB)
 					soft_armor = soft_armor.modifyRating(bomb = -50)
 				if(CADE_TYPE_MELEE)
-					soft_armor = soft_armor.modifyRating(melee = -30, bullet = -30)
+					soft_armor = soft_armor.modifyRating(melee = -30, bullet = -30, laser = -30, energy = -30)
 				if(CADE_TYPE_ACID)
 					soft_armor = soft_armor.modifyRating(acid = -20)
 					resistance_flags &= ~UNACIDABLE
@@ -706,7 +706,7 @@
 	desc = "A very sturdy barricade made out of plasteel panels, the pinnacle of strongpoints. Use a blowtorch to repair. Can be flipped down to create a path."
 	icon_state = "plasteel_closed_0"
 	max_integrity = 500
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/plasteel
 	stack_amount = 5
@@ -966,7 +966,7 @@
 	desc = "A bunch of bags filled with sand, stacked into a small wall. Surprisingly sturdy, albeit labour intensive to set up. Trusted to do the job since 1914."
 	icon_state = "sandbag_0"
 	max_integrity = 300
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
@@ -1039,7 +1039,7 @@
 	barricade_type = "folding"
 	can_wire = TRUE
 	is_wired = FALSE
-	soft_armor = list(MELEE = 35, BULLET = 30, LASER = 20, ENERGY = 40, BOMB = 25, BIO = 100, FIRE = 100, ACID = 30)
+	soft_armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 25, BIO = 100, FIRE = 100, ACID = 30)
 	///Whether this item can be deployed or undeployed
 	var/flags_item = IS_DEPLOYABLE
 	///What it deploys into. typecast version of internal_item

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -706,7 +706,7 @@
 	desc = "A very sturdy barricade made out of plasteel panels, the pinnacle of strongpoints. Use a blowtorch to repair. Can be flipped down to create a path."
 	icon_state = "plasteel_closed_0"
 	max_integrity = 500
-	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 100, FIRE = 80, ACID = 40)
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/plasteel
 	stack_amount = 5

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -9,9 +9,10 @@
 	density = TRUE
 	resistance_flags = DROPSHIP_IMMUNE | XENO_DAMAGEABLE
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
-	max_integrity = 150
-	climbable = 1 //Small enough to vault over, but you do need to vault over it
-	climb_delay = 15 //One second and a half, gotta vault fast
+	max_integrity = 200
+	climbable = TRUE
+	climb_delay = 1.5 SECONDS
+	soft_armor = list(MELEE = 0, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 100, FIRE = 50, ACID = 0)
 	var/obj/item/stack/sheet/sheet_type = /obj/item/stack/sheet/glass/reinforced
 	var/obj/structure/window/framed/mainship/window_type = /obj/structure/window/framed/mainship
 	var/basestate = "window"
@@ -142,7 +143,7 @@
 	basestate = "col_rwindow_frame"
 	base_icon_state = "col_rwindow_frame"
 	reinforced = TRUE
-	max_integrity = 300
+	max_integrity = 400
 
 /obj/structure/window_frame/colony/reinforced/weakened
 	max_integrity = 150
@@ -167,7 +168,7 @@
 
 /obj/structure/window_frame/prison/reinforced
 	reinforced = TRUE
-	max_integrity = 300
+	max_integrity = 400
 
 /obj/structure/window_frame/prison/hull
 	climbable = FALSE

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -9,10 +9,10 @@
 	density = TRUE
 	resistance_flags = DROPSHIP_IMMUNE | XENO_DAMAGEABLE
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
-	max_integrity = 200
+	max_integrity = 150
 	climbable = TRUE
 	climb_delay = 1.5 SECONDS
-	soft_armor = list(MELEE = 0, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 100, FIRE = 50, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 50, BIO = 100, FIRE = 50, ACID = 0)
 	var/obj/item/stack/sheet/sheet_type = /obj/item/stack/sheet/glass/reinforced
 	var/obj/structure/window/framed/mainship/window_type = /obj/structure/window/framed/mainship
 	var/basestate = "window"
@@ -143,7 +143,7 @@
 	basestate = "col_rwindow_frame"
 	base_icon_state = "col_rwindow_frame"
 	reinforced = TRUE
-	max_integrity = 400
+	max_integrity = 300
 
 /obj/structure/window_frame/colony/reinforced/weakened
 	max_integrity = 150
@@ -168,7 +168,7 @@
 
 /obj/structure/window_frame/prison/reinforced
 	reinforced = TRUE
-	max_integrity = 400
+	max_integrity = 300
 
 /obj/structure/window_frame/prison/hull
 	climbable = FALSE


### PR DESCRIPTION
## About The Pull Request
Mainly targetted at HvH.

Improved the quality of cover of several objects.

**Barricades**
Both metal and plasteel barricades now have starting bullet/laser/energy armour now, and the melee armour addon now boosts laser and energy armour (it already buffed bullet armour). Normalised the deployable shield armour.

**Windowframes**
Have good armour against bullet/laser/energy, as they're basically just short walls. Unchanged against melee/acid.

Windowframes used to be much stronger overall, but were nerfed to make them easier to clear for xeno movement. Now we have jumping, that's really not an issue anymore, so this makes them into durable but less reliable cover compared to barricades.

**Vending machines**
Vending machines have low armour and slightly higher coverage, making them more useful cover generally (they have the probably the highest coverage of general shit you'll find around th map).

Also changed how vendor tipping works. A tipped vendor now remains dense, but can be walked over by mobs. However a tipped vendor has reduced coverage.

Light explosions now actually damage vendors, which means you can grenade them for a 50/50 chance to tip them over.
## Why It's Good For The Game
Better/longer lasting cover makes for more interesting fights in HvH.
## Changelog
:cl:
balance: Improved the armor of windowframes
balance: Barricades start with some bullet/laser/energy armor
balance: Melee upgrades for metal barricades upgrade laser and energy armor like they already do for bullet
balance: Vending machines have slightly higher coverage
/:cl:
