### PR TITLE
BIG BOOTY BOILER BUFFS(it can now zoom, root, and unroot faster)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	else
 		X.visible_message(span_notice("[X] starts looking off into the distance."), \
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
-		if(!do_after(X, 1 SECONDS, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
+		if(X.is_zoomed)
 			return
 		X.zoom_in(11)
 		..()
@@ -287,7 +287,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 /datum/action/xeno_action/activable/bombard/proc/root()
 	if(HAS_TRAIT_FROM(owner, TRAIT_IMMOBILE, BOILER_ROOTED_TRAIT))
 		owner.balloon_alert_to_viewers("Rooting out of place...")
-		if(!do_after(owner, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
+		if(!do_after(owner, 2 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 			owner.balloon_alert(owner, "Interrupted!")
 			return
 		owner.balloon_alert(owner, "Unrooted!")
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		return
 
 	owner.balloon_alert_to_viewers("Rooting into place...")
-	if(!do_after(owner, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
+	if(!do_after(owner, 1 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 		owner.balloon_alert(owner, "Interrupted!")
 		return
 


### PR DESCRIPTION

## About The Pull Request
removes the timer from boiler zoom, makes boiler root 1 second, and unroot 2 seconds

## Why It's Good For The Game
nobody plays boiler anymore. new players that try it die instantly. the experienced players still die more than ravagers. marine players laugh at how easy it is to run them down. it basically needs a babysitter now. 

if your first reaction to this PR is negative, i would encourage you to go play boiler during a few normal rounds

## Changelog
:cl: imsxz
balance: some of boilers actions are now faster
/:cl:
