### PR TITLE
Makes a few things in valhalla indestructible

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1079,7 +1079,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/milk,
 /obj/item/reagent_containers/glass/bottle/lemoline,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_y = 7
 	},
 /turf/open/floor/mainship/sterile/dark,
@@ -3395,7 +3395,7 @@
 /area/centcom/valhalla/library)
 "epz" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -4917,7 +4917,7 @@
 /turf/open/floor/tile/red/redblue/full,
 /area/tdome/tdomeobserve)
 "gzk" = (
-/obj/machinery/vending/tool/nopower,
+/obj/machinery/vending/tool/nopower/valhalla,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/storage/primary)
 "gzl" = (
@@ -4983,9 +4983,7 @@
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/chapel/main)
 "gCD" = (
-/obj/machinery/chem_master/nopower{
-	resistance_flags = 1
-	},
+/obj/machinery/chem_master/nopower/valhalla,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "gDc" = (
@@ -5169,9 +5167,8 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_y = 7;
-	resistance_flags = 1
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
@@ -5797,7 +5794,7 @@
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
-/obj/machinery/chem_master/nopower,
+/obj/machinery/chem_master/nopower/valhalla,
 /turf/open/floor/tile/lightred,
 /area/centcom/valhalla/medical/chemistry)
 "hMr" = (
@@ -11943,9 +11940,7 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/primary/port)
 "qlP" = (
-/obj/machinery/vending/tool/nopower{
-	resistance_flags = 1
-	},
+/obj/machinery/vending/tool/nopower/valhalla,
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
 	},
@@ -14024,7 +14019,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_y = 5
 	},
 /turf/open/floor/tile/vault{
@@ -15118,7 +15113,7 @@
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/chem_master/nopower,
+/obj/machinery/chem_master/nopower/valhalla,
 /turf/open/floor/tile/lightred,
 /area/centcom/valhalla/medical/medbay)
 "ujt" = (
@@ -15498,9 +15493,7 @@
 /turf/closed/wall,
 /area/centcom/valhalla/janitor)
 "uOI" = (
-/obj/machinery/chem_master/nopower{
-	resistance_flags = 1
-	},
+/obj/machinery/chem_master/nopower/valhalla,
 /obj/structure/window/reinforced/extratoughened{
 	dir = 4
 	},
@@ -15740,7 +15733,7 @@
 	dir = 10
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_y = 7
 	},
 /turf/open/floor/tile/lightred,
@@ -17110,7 +17103,7 @@
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
-/obj/machinery/vending/tool/nopower,
+/obj/machinery/vending/tool/nopower/valhalla,
 /turf/open/floor/engine,
 /area/centcom/valhalla/engine/engineering)
 "wAR" = (
@@ -18254,7 +18247,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/black,
-/obj/machinery/reagentgrinder/nopower{
+/obj/machinery/reagentgrinder/nopower/valhalla{
 	pixel_x = -1;
 	pixel_y = 6
 	},

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1709,9 +1709,7 @@
 /area/centcom/valhalla/crew_quarters/heads/hop)
 "cnE" = (
 /obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/vending/engivend/nopower{
-	resistance_flags = 1
-	},
+/obj/machinery/vending/engivend/nopower/valhalla,
 /turf/open/floor/plating,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "cnL" = (

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -5166,7 +5166,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder/nopower/valhalla{
-	pixel_y = 7;
+	pixel_y = 7
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
@@ -5968,6 +5968,7 @@
 /area/centcom/valhalla/comms)
 "hXM" = (
 /obj/effect/turf_decal/warning_stripes/box/empty,
+/obj/machinery/vending/engivend/nopower/valhalla,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/engine/engineering)
 "hYu" = (

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1708,8 +1708,8 @@
 /turf/open/floor/wood,
 /area/centcom/valhalla/crew_quarters/heads/hop)
 "cnE" = (
-/obj/effect/turf_decal/warning_stripes/thick,
 /obj/machinery/vending/engivend/nopower/valhalla,
+/obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "cnL" = (

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1708,8 +1708,10 @@
 /turf/open/floor/wood,
 /area/centcom/valhalla/crew_quarters/heads/hop)
 "cnE" = (
-/obj/machinery/vending/engivend/nopower,
 /obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/vending/engivend/nopower{
+	resistance_flags = 1
+	},
 /turf/open/floor/plating,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "cnL" = (
@@ -4981,7 +4983,9 @@
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/chapel/main)
 "gCD" = (
-/obj/machinery/chem_master/nopower,
+/obj/machinery/chem_master/nopower{
+	resistance_flags = 1
+	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "gDc" = (
@@ -5166,7 +5170,8 @@
 	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder/nopower{
-	pixel_y = 7
+	pixel_y = 7;
+	resistance_flags = 1
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
@@ -5968,7 +5973,6 @@
 /area/centcom/valhalla/comms)
 "hXM" = (
 /obj/effect/turf_decal/warning_stripes/box/empty,
-/obj/machinery/vending/engivend/nopower,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/engine/engineering)
 "hYu" = (
@@ -11939,7 +11943,9 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/primary/port)
 "qlP" = (
-/obj/machinery/vending/tool/nopower,
+/obj/machinery/vending/tool/nopower{
+	resistance_flags = 1
+	},
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
 	},
@@ -15492,7 +15498,9 @@
 /turf/closed/wall,
 /area/centcom/valhalla/janitor)
 "uOI" = (
-/obj/machinery/chem_master/nopower,
+/obj/machinery/chem_master/nopower{
+	resistance_flags = 1
+	},
 /obj/structure/window/reinforced/extratoughened{
 	dir = 4
 	},

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1547,3 +1547,6 @@
 
 /obj/machinery/vending/tool/nopower
 	use_power = NO_POWER_USE
+
+/obj/machinery/vending/tool/nopower/valhalla
+	resistance_flags = INDESTRUCTIBLE

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -565,6 +565,9 @@
 /obj/machinery/vending/engivend/nopower
 	use_power = NO_POWER_USE
 
+/obj/machinery/vending/engivend/nopower/valhalla
+	resistance_flags = INDESTRUCTIBLE
+
 //This one's from bay12
 /obj/machinery/vending/robotics
 	name = "Robotech Deluxe"

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -423,5 +423,8 @@
 /obj/machinery/chem_master/nopower
 	use_power = NO_POWER_USE
 
+/obj/machinery/chem_master/nopower/valhalla
+	resistance_flags = INDESTRUCTIBLE
+
 /obj/machinery/chem_master/condimaster/nopower
 	use_power = NO_POWER_USE

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -385,3 +385,6 @@
 
 /obj/machinery/reagentgrinder/nopower
 	use_power = NO_POWER_USE
+
+/obj/machinery/reagentgrinder/nopower/valhalla
+	resistance_flags = INDESTRUCTIBLE


### PR DESCRIPTION

## About The Pull Request
Makes the engi-vend, youtool, chem master and chem grinder in valhalla have the INDESTRUCTIBLE flag.
## Why It's Good For The Game
So that vendors in the ghost-testing area don't die to explosives.
## Changelog
:cl:
qol: Valhalla vendors are more robust.
/:cl:
