### PR TITLE
Reverts the nuke call death(), once again lets you survive nuclear blast

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -317,6 +317,5 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.adjustFireLoss(victim.maxHealth * 4)
-		victim.death()
+		victim.setFireLoss(victim.maxHealth*2)
 		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request
For a controversial change that received a lot of negative feedback, I'm surprised the community didn't give a larger backlash for this. There is an overwhelming negativity about this PR and I think it's good we give post-match fun another chance; I mean,  it's not like the round is still ongoing once the nuke blows. -- Being able to survive nuke does not harm the game in any way. 
Even admins agree that forcing everyone to 100% die is dumb and pointless.
## Why It's Good For The Game
You can now again have fun after the match ends without forcing you to either get into the sweatfest that is EORD or be stuck shipside/on alamo/tad.
## Changelog
:cl:
fix: The nuclear explosion not kill you anymore
/:cl:
