### PR TITLE
Remove awkwardness of suit pockets

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -498,7 +498,7 @@
 
 ///Output a message when an item is inserted into a storage object
 /obj/item/storage/proc/insertion_message(obj/item/item, mob/user)
-	var/visidist = item.w_class >= 3 ? 3 : 1
+	var/visidist = item.w_class >= WEIGHT_CLASS_NORMAL ? 3 : 1
 	user.visible_message(span_notice("[user] puts \a [item] into \the [name]."),\
 						span_notice("You put \the [item] into \the [name]."),\
 						null, visidist)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -484,10 +484,7 @@
 		if (user.s_active != src)
 			user.client?.screen -= item
 		if(!prevent_warning)
-			var/visidist = item.w_class >= 3 ? 3 : 1
-			user.visible_message(span_notice("[user] puts [item] into [src]."),\
-								span_notice("You put \the [item] into [src]."),\
-								null, visidist)
+			insertion_message(item, user)
 	orient2hud()
 	for(var/mob/M in can_see_content())
 		show_to(M)
@@ -498,6 +495,13 @@
 		if(istype(item, limited_type))
 			storage_type_limits[limited_type] -= 1
 	return TRUE
+
+///Output a message when an item is inserted into a storage object
+/obj/item/storage/proc/insertion_message(obj/item/item, mob/user)
+	var/visidist = item.w_class >= 3 ? 3 : 1
+	user.visible_message(span_notice("[user] puts \a [item] into \the [name]."),\
+						span_notice("You put \the [item] into \the [name]."),\
+						null, visidist)
 
 ///Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
 /obj/item/storage/proc/remove_from_storage(obj/item/item, atom/new_location, mob/user)

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -91,6 +91,33 @@
 		/obj/item/stack,
 	)
 
+/* Pockets */
+/obj/item/armor_module/storage/pocket
+	icon_state = ""
+	item_state = ""
+	storage = /obj/item/storage/internal/pocket
+
+/obj/item/storage/internal/pocket
+	max_storage_space = 6
+	storage_slots = 2
+	max_w_class = WEIGHT_CLASS_NORMAL
+	bypass_w_limit = list(
+		/obj/item/ammo_magazine/rifle,
+		/obj/item/cell/lasgun,
+		/obj/item/ammo_magazine/smg,
+		/obj/item/ammo_magazine/pistol,
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/sniper,
+		/obj/item/ammo_magazine/handful,
+	)
+
+/obj/item/storage/internal/pocket/insertion_message(obj/item/item, mob/user)
+	var/visidist = item.w_class >= 3 ? 3 : 1
+	//Grab the name of the object this pocket belongs to
+	user.visible_message(span_notice("[user] puts \a [item] into \the [master_item.name]."),\
+						span_notice("You put \the [item] into \the [master_item.name]."),\
+						null, visidist)
+
 /** General storage */
 /obj/item/armor_module/storage/general
 	name = "General Purpose Storage module"
@@ -112,12 +139,6 @@
 		/obj/item/ammo_magazine/sniper,
 		/obj/item/ammo_magazine/handful,
 	)
-
-/obj/item/armor_module/storage/general/irremovable
-	desc = "General storage module. Limited capacity but can hold some larger items like pistols or magazines."
-	icon_state = ""
-	item_state = ""
-	flags_attach_features = ATTACH_APPLY_ON_MOB
 
 /obj/item/armor_module/storage/general/som
 	name = "General Purpose Storage module"

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -95,6 +95,7 @@
 /obj/item/armor_module/storage/pocket
 	icon_state = ""
 	item_state = ""
+	flags_attach_features = ATTACH_APPLY_ON_MOB
 	storage = /obj/item/storage/internal/pocket
 
 /obj/item/storage/internal/pocket
@@ -112,11 +113,34 @@
 	)
 
 /obj/item/storage/internal/pocket/insertion_message(obj/item/item, mob/user)
-	var/visidist = item.w_class >= 3 ? 3 : 1
+	var/visidist = item.w_class >= WEIGHT_CLASS_NORMAL ? 3 : 1
 	//Grab the name of the object this pocket belongs to
 	user.visible_message(span_notice("[user] puts \a [item] into \the [master_item.name]."),\
 						span_notice("You put \the [item] into \the [master_item.name]."),\
 						null, visidist)
+
+/obj/item/armor_module/storage/pocket/medical
+	storage = /obj/item/storage/internal/pocket/medical
+
+/obj/item/storage/internal/pocket/medical
+	max_storage_space = 30
+	storage_slots = 5
+	max_w_class = WEIGHT_CLASS_SMALL
+	can_hold = list(
+		/obj/item/healthanalyzer,
+		/obj/item/stack/medical,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/hypospray/advanced,
+		/obj/item/reagent_containers/hypospray/autoinjector,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/pill,
+		/obj/item/storage/pill_bottle,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/tweezers,
+		/obj/item/whistle,
+	)
 
 /** General storage */
 /obj/item/armor_module/storage/general
@@ -249,12 +273,6 @@
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
 	storage = /obj/item/storage/internal/modular/medical
-
-/obj/item/armor_module/storage/medical/irremovable
-	desc = "Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
-	icon_state = ""
-	item_state = ""
-	flags_attach_features = ATTACH_APPLY_ON_MOB
 
 /obj/item/armor_module/storage/medical/freelancer/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -18,10 +18,10 @@
 		/obj/item/tank/emergency_oxygen,
 	)
 	attachments_allowed = list(
-		/obj/item/armor_module/storage/medical/irremovable,
+		/obj/item/armor_module/storage/pocket/medical,
 		/obj/item/armor_module/armor/badge,
 	)
-	starting_attachments = list(/obj/item/armor_module/storage/medical/irremovable)
+	starting_attachments = list(/obj/item/armor_module/storage/pocket/medical)
 	///If the coat is buttoned or not
 	var/open = FALSE
 

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -6,7 +6,7 @@
 		ATTACHMENT_SLOT_BADGE,
 	)
 	attachments_allowed = list(
-		/obj/item/armor_module/storage/general/irremovable,
+		/obj/item/armor_module/storage/pocket,
 		/obj/item/armor_module/armor/badge,
 	)
-	starting_attachments = list(/obj/item/armor_module/storage/general/irremovable)
+	starting_attachments = list(/obj/item/armor_module/storage/pocket)


### PR DESCRIPTION

## About The Pull Request

Originally this was just going to set the storage name to the armor name but my brain 2 cells continued rubbing. Made a new proc to handle displaying the message so there wouldn't be the headache of maintaining a large copy-pasted proc just so it could have a different message. Pockets are also now their own thing instead of just being a child of the general storage object. Found it weird that it was tied to it since internal suit pockets should not be handled as if they were your normal storage module. They can be balanced separately and such.

## Why It's Good For The Game

It bothered me how if you put an item into your normal looking coat it would say you put it into a "General Purpose Storage module" instead. Less jank is good.

## Changelog
:cl:
code: Suit pockets no longer appear as if they are just bolted-on storage modules. Are now their own independent object.
/:cl:
