### PR TITLE
Proper mob throw fix

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,9 +1,14 @@
 /mob/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
 	if(mover.pass_flags & PASS_MOB)
 		return TRUE
-	return . || (!mover.density || !density || lying_angle) //Parent handles buckling - if someone's strapped to us it can pass.
-
+	if(..())
+		return TRUE
+	if(lying_angle)
+		return TRUE
+	if(mover.throwing && !(allow_pass_flags & PASS_THROW))
+		return FALSE
+	if(!mover.density)
+		return TRUE
 
 /client/verb/swap_hand()
 	set hidden = 1


### PR DESCRIPTION

## About The Pull Request
Proper fix for the mob throw bug.

Throwing past mobs has different checks from throwing past other stuff, which meant not dense items would go through mobs.
## Why It's Good For The Game
Throws working properly is good.
## Changelog
:cl:
fix: fixed an issue with throwing past mobs
/:cl:
