### PR TITLE
Adds the Harvester Knife to Valhalla and Crash

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -303,6 +303,7 @@
 			/obj/item/weapon/powerfist = -1,
 			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/weapon/shield/riot/marine/deployable = 6,
+			/obj/item/weapon/combat_knife/harvester = 12,
 		),
 		"Sidearm" = list(
 			/obj/item/weapon/gun/pistol/standard_pistol = -1,
@@ -498,6 +499,7 @@
 			/obj/item/weapon/powerfist = -1,
 			/obj/item/weapon/shield/riot/marine = -1,
 			/obj/item/weapon/shield/riot/marine/deployable = -1,
+			/obj/item/weapon/combat_knife/harvester = -1,
 		),
 		"Sidearm" = list(
 			/obj/item/weapon/gun/pistol/standard_pistol = -1,


### PR DESCRIPTION
## About The Pull Request
Read title.
## Why It's Good For The Game
Seems like an oversight given all the other harvester weapons are in Valhalla and Crash. If I need to remove them from crash for whatever reason (I really don't see why I would need to), then I'll make the necessary edits.
## Changelog
:cl:
add: Harvester Knives are now in your local Valhalla and Crash vendors.
/:cl:
