### PR TITLE
add xenomorph tunnel landmarks in Big Red

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3486,10 +3486,6 @@
 	dir = 8
 	},
 /area/bigredv2/caves/lambda_lab)
-"aGz" = (
-/obj/effect/landmark/xeno_tunnel_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/north)
 "aGF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -8950,10 +8946,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
-"fQQ" = (
-/obj/effect/landmark/xeno_tunnel_spawn,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
 "fRt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -9478,10 +9470,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
-"hkr" = (
-/obj/effect/landmark/xeno_tunnel_spawn,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/virology)
 "hkN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19604,7 +19592,7 @@ aSu
 aSz
 aNc
 aNc
-hkr
+aNc
 dRR
 aXv
 aMz
@@ -36558,7 +36546,7 @@ wzM
 oxP
 raC
 bkt
-fQQ
+bkE
 mGp
 lUs
 xwD
@@ -42977,7 +42965,7 @@ jnj
 bKH
 qRX
 qRX
-aGz
+qRX
 qRX
 azQ
 qRX

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3486,6 +3486,10 @@
 	dir = 8
 	},
 /area/bigredv2/caves/lambda_lab)
+"aGz" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/north)
 "aGF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -8946,6 +8950,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"fQQ" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor,
+/area/bigredv2/outside/filtration_plant)
 "fRt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -9216,6 +9224,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2,
 /area/bigredv2/caves/lambda_lab)
+"gGk" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/southwest)
 "gGl" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -9466,6 +9478,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
+"hkr" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/virology)
 "hkN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10564,8 +10580,10 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "knO" = (
-/obj/machinery/recharge_station,
 /obj/effect/landmark/weed_node,
+/obj/structure/toilet{
+	pixel_y = 8
+	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/dorms)
 "kog" = (
@@ -11877,6 +11895,10 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
+"ojF" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "okf" = (
 /obj/effect/spawner/modularmap/bigred/lambdalock,
 /turf/open/space/basic,
@@ -12853,6 +12875,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"rpO" = (
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/dorms)
 "rrc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -12912,6 +12942,10 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"rAy" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northeast)
 "rBl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -12962,6 +12996,11 @@
 	dir = 5
 	},
 /area/bigredv2/outside/nw)
+"rJM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
 "rKr" = (
 /obj/machinery/door/window,
 /obj/effect/landmark/weed_node,
@@ -19565,7 +19604,7 @@ aSu
 aSz
 aNc
 aNc
-aNc
+hkr
 dRR
 aXv
 aMz
@@ -19614,7 +19653,7 @@ aaa
 aaa
 aaa
 aaa
-dSm
+gGk
 aaa
 aaa
 aaa
@@ -36519,7 +36558,7 @@ wzM
 oxP
 raC
 bkt
-bkE
+fQQ
 mGp
 lUs
 xwD
@@ -37316,7 +37355,7 @@ akt
 acp
 lGe
 luR
-lGe
+ojF
 tbH
 luR
 lGe
@@ -38858,7 +38897,7 @@ asH
 aBo
 vbk
 asH
-hDv
+rpO
 aEN
 bKz
 asH
@@ -42938,7 +42977,7 @@ jnj
 bKH
 qRX
 qRX
-qRX
+aGz
 qRX
 azQ
 qRX
@@ -44587,7 +44626,7 @@ gCQ
 jnj
 gCQ
 sQi
-kJU
+rJM
 sQi
 sQi
 sQi
@@ -60948,7 +60987,7 @@ gCQ
 gCQ
 gCQ
 gCQ
-vyZ
+rAy
 vyZ
 bfc
 vyZ
@@ -62498,7 +62537,7 @@ aaa
 aaa
 aaa
 aaa
-vyZ
+rAy
 vyZ
 vyZ
 mtc

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -60975,7 +60975,7 @@ gCQ
 gCQ
 gCQ
 gCQ
-rAy
+vyZ
 vyZ
 bfc
 vyZ
@@ -61192,7 +61192,7 @@ gCQ
 gCQ
 gCQ
 gCQ
-vyZ
+rAy
 vyZ
 vyZ
 vyZ

--- a/_maps/modularmaps/big_red/bigredatmosvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar1.dmm
@@ -130,6 +130,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/s)
+"mm" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "mv" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -998,7 +1002,7 @@ WO
 "}
 (17,1,1) = {"
 GX
-ik
+mm
 ia
 ik
 Hp

--- a/_maps/modularmaps/big_red/bigredatmosvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar2.dmm
@@ -839,6 +839,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"Yf" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "YQ" = (
 /obj/structure/table,
 /turf/open/floor,
@@ -1295,7 +1299,7 @@ kO
 "}
 (17,1,1) = {"
 mx
-Nw
+Yf
 jO
 Nw
 Nw

--- a/_maps/modularmaps/big_red/bigredatmosvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar3.dmm
@@ -193,6 +193,10 @@
 /obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
+"la" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "lo" = (
 /obj/machinery/door/airlock/mainship/engineering{
 	name = "\improper Filtration Facility";
@@ -1259,7 +1263,7 @@ pg
 (17,1,1) = {"
 bz
 bz
-bz
+la
 bz
 bz
 tm

--- a/_maps/modularmaps/big_red/bigredatmosvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar4.dmm
@@ -440,6 +440,10 @@
 /obj/structure/table,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"Pq" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "Qd" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
@@ -999,7 +1003,7 @@ Qq
 "}
 (17,1,1) = {"
 Vb
-VI
+Pq
 IP
 VI
 OJ

--- a/_maps/modularmaps/big_red/bigredatmosvar5.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar5.dmm
@@ -815,6 +815,10 @@
 /obj/effect/turf_decal/warning_stripes/box/empty,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"TN" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "Uc" = (
 /obj/effect/ai_node,
 /turf/open/floor,
@@ -1419,7 +1423,7 @@ Jk
 "}
 (17,1,1) = {"
 zy
-Db
+TN
 Db
 Db
 EP

--- a/_maps/modularmaps/big_red/bigredatmosvar6.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar6.dmm
@@ -192,6 +192,10 @@
 	dir = 9
 	},
 /area/bigredv2/outside/se)
+"om" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "ou" = (
 /obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -1144,7 +1148,7 @@ rV
 "}
 (17,1,1) = {"
 Rk
-Ok
+om
 jL
 Ok
 Ll

--- a/_maps/modularmaps/big_red/bigredcaveswvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredcaveswvar1.dmm
@@ -99,6 +99,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
+"N" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "P" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
@@ -401,7 +405,7 @@ h
 h
 h
 h
-h
+N
 p
 P
 P

--- a/_maps/modularmaps/big_red/bigredcaveswvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredcaveswvar2.dmm
@@ -50,6 +50,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"v" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "w" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -1353,7 +1357,7 @@ j
 j
 S
 g
-S
+v
 j
 j
 t

--- a/_maps/modularmaps/big_red/bigredcaveswvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredcaveswvar3.dmm
@@ -84,6 +84,10 @@
 "K" = (
 /turf/closed/mineral/smooth/bigred/indestructible,
 /area/space)
+"L" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "M" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
@@ -466,7 +470,7 @@ l
 l
 l
 l
-l
+L
 d
 Q
 Q

--- a/_maps/modularmaps/big_red/bigredcaveswvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredcaveswvar4.dmm
@@ -121,6 +121,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
+"hG" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/southwest)
 
 (1,1,1) = {"
 au
@@ -373,7 +377,7 @@ aH
 aB
 aR
 aR
-aR
+hG
 aR
 ae
 aH

--- a/_maps/modularmaps/big_red/bigredcaveswvar5.dmm
+++ b/_maps/modularmaps/big_red/bigredcaveswvar5.dmm
@@ -78,6 +78,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"K" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "L" = (
 /obj/effect/landmark/patrol_point{
 	id = "SOM_14";
@@ -582,7 +586,7 @@ f
 f
 f
 V
-T
+K
 w
 T
 T

--- a/_maps/modularmaps/big_red/bigredcavevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredcavevar1.dmm
@@ -147,6 +147,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
+"GC" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/east/garbledradio)
+"Hg" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east/garbledradio)
 
 (1,1,1) = {"
 ao
@@ -783,7 +791,7 @@ aj
 aN
 aN
 at
-ab
+Hg
 ab
 ab
 ab
@@ -1846,7 +1854,7 @@ ab
 ab
 ab
 ab
-aa
+GC
 aN
 aN
 at

--- a/_maps/modularmaps/big_red/bigredcavevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredcavevar2.dmm
@@ -154,10 +154,18 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"xE" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east/garbledradio)
 "DC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
+"JU" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east)
 
 (1,1,1) = {"
 aA
@@ -794,7 +802,7 @@ ap
 ar
 ar
 aX
-ab
+xE
 ab
 ab
 ab
@@ -2119,7 +2127,7 @@ aX
 ar
 ar
 ar
-aN
+JU
 aV
 aN
 aN

--- a/_maps/modularmaps/big_red/bigredcavevar4.dmm
+++ b/_maps/modularmaps/big_red/bigredcavevar4.dmm
@@ -151,6 +151,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
+"rp" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east)
 "sT" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -159,6 +164,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
+"DH" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east/garbledradio)
 "PO" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -496,7 +505,7 @@ kb
 aR
 aR
 aM
-ad
+DH
 ad
 ad
 aI
@@ -1782,7 +1791,7 @@ aR
 aR
 aM
 aR
-ac
+rp
 aj
 ac
 aj

--- a/_maps/modularmaps/big_red/bigredcavevar5.dmm
+++ b/_maps/modularmaps/big_red/bigredcavevar5.dmm
@@ -152,6 +152,10 @@
 "aZ" = (
 /turf/closed/mineral/smooth/bigred/indestructible,
 /area/space)
+"uH" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east/garbledradio)
 "wM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -883,7 +887,7 @@ au
 ad
 ac
 ac
-ac
+uH
 ac
 ac
 ad
@@ -1555,7 +1559,7 @@ ac
 ac
 ac
 ac
-ac
+uH
 ad
 au
 ad


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

RipGrayson have blesssed us with tunnels that I couldn't have code otherwise. It's time for other maps to prespawn tunnels.

## Changelog

:cl:
add: xenomorphs tunnel landmarks in Big Red to help with xenomorphs create manuever around maps
/:cl:

