### PR TITLE
AI powerloader drones now function like proper powerloaders (mostly)

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -92,7 +92,7 @@
 		stack_trace("[attached_clamp] called attack_powerloader on [src] without a linked_powerloader.")
 		return TRUE
 
-	if(!Adjacent(user))
+	if(!Adjacent(attached_clamp.linked_powerloader))
 		return TRUE
 
 /*

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -252,7 +252,9 @@
 		var/duration_time = ship_base ? 70 : 10 //uninstalling equipment takes more time
 		if(!do_after(user, duration_time, FALSE, src, BUSY_ICON_BUILD))
 			return
-		if(attached_clamp.loaded || !LAZYLEN(attached_clamp.linked_powerloader?.buckled_mobs) || attached_clamp.linked_powerloader.buckled_mobs[1] != user)
+		//if we arent an actual powerloader (droid) we can assume we are just driven remotely so we just ignore driver checks
+		var/buckled_check = istype(attached_clamp.linked_powerloader) ? (!LAZYLEN(attached_clamp.linked_powerloader?.buckled_mobs) || attached_clamp.linked_powerloader.buckled_mobs[1] != user) : FALSE
+		if(attached_clamp.loaded || buckled_check)
 			return
 		forceMove(attached_clamp.linked_powerloader)
 		attached_clamp.loaded = src


### PR DESCRIPTION
## About The Pull Request

gives them an internal powerloader clamp and just hooks cargo handling to that instead
which allows them to handle stuff like ob warheads and such

## Why It's Good For The Game

AI can load ob if the STs are busy fucking off groundside

## Changelog
:cl:
balance: ai powerloaders can now handle most stuff a normal powerloader can
/:cl:
