### PR TITLE
Probably final throw fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -526,8 +526,7 @@
 				var/atom/step = get_step(src, dy)
 				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 					break
-				if(!Move(step))
-					break
+				Move(step)
 				error += dist_x
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
@@ -537,8 +536,7 @@
 				var/atom/step = get_step(src, dx)
 				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 					break
-				if(!Move(step))
-					break
+				Move(step)
 				error -= dist_y
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
@@ -552,8 +550,7 @@
 				var/atom/step = get_step(src, dx)
 				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 					break
-				if(!Move(step))
-					break
+				Move(step)
 				error += dist_y
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)
@@ -563,8 +560,7 @@
 				var/atom/step = get_step(src, dy)
 				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 					break
-				if(!Move(step))
-					break
+				Move(step)
 				error -= dist_x
 				dist_since_sleep++
 				if(dist_since_sleep >= speed)


### PR DESCRIPTION

## About The Pull Request
Fixes certain throws like defender or ravager charge stopping after hitting one person.

There was a set of breaks that should have been purged in the original pr, as the stop is handled by bump/throw_impact in all cases.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed defender and rav charge stopping after one hit
/:cl:
