### PR TITLE
Removes the melee malus from the bipod.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1370,7 +1370,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	icon_state = "bipod"
 	slot = ATTACHMENT_SLOT_UNDER
 	size_mod = 2
-	melee_mod = -10
 	deploy_time = 1 SECONDS
 	accuracy_mod = 0.3
 	recoil_mod = -2


### PR DESCRIPTION

## About The Pull Request

Okay, so, way back when, the bipod had a melee malus, which meant it was less effective at bashing.

Once it became foldable, it doesn't actually do that unless it's deployed. So, for the sake of clarity I think removing it would be the right step. Until someone gets a better idea and has the know-how to do it, atleast.

## Why It's Good For The Game

It's misleading, doesn't do a whole lot and even if there was the 'ideal' scenario of being able to PB something while it's deployed. You can still get bump slashed and returned to your normal melee damage.

## Changelog
:cl:
del: Removes the damage malus from the bipod.
/:cl:
