### PR TITLE
Minor autoburst bug fix

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -763,6 +763,7 @@
 		ADD_TRAIT(src, TRAIT_GUN_BURST_FIRING, GUN_TRAIT)
 		return
 	REMOVE_TRAIT(src, TRAIT_GUN_BURST_FIRING, GUN_TRAIT)
+	shots_fired = 0 //autofire component won't reset this when autobursting otherwise
 
 ///Update the target if you draged your mouse
 /obj/item/weapon/gun/proc/change_target(datum/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)


### PR DESCRIPTION

## About The Pull Request
Fixed autoburst not properly resetting shots fired between bursts.
## Why It's Good For The Game
Causes a bug or two.
## Changelog
:cl:
fix: Fixed autoburst not correctly resetting shots fired between bursts
/:cl:
