### PR TITLE
Fixes stagger and slowdown recovery

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -161,7 +161,6 @@
 		if(81 to INFINITY)
 			reagent_shock_modifier += PAIN_REDUCTION_HEAVY
 
-	handle_stagger()
 	handle_disabilities()
 
 /mob/living/carbon/proc/handle_impaired_vision()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -34,11 +34,6 @@
 	update_action_button_icons()
 	update_icons(FALSE)
 
-/mob/living/carbon/xenomorph/handle_status_effects()
-	. = ..()
-	handle_stagger() // 1 each time
-	handle_slowdown() // 0.4 each time
-
 /mob/living/carbon/xenomorph/handle_fire()
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Fixes stagger and slowdown.
So for the last couple of years, humans have recovered from stagger twice as fast as they should.
Xenos on the other hand have recovered from stagger THREE times as fast as they should, on top of recovering from slowdown twice as fast as they should.

Funny copy proc calls.

Yes this means stagger and slow in general will be a lot better, but if they need adjustments thats out of scope of this pr.
## Why It's Good For The Game
Copy paste code when it calls to parent is bad.
soft stuns not working correctly is also not ideal.
## Changelog
:cl:
fix: fixed humans recovering from stagger twice as fast as they should
fix: fixed xenos recovering from stagger three times as fast as they should, and recovering from slowdown twice as fast as they should
/:cl:
