### PR TITLE
adds cradle to canterbury and bigbury; fixes a tile in PoS medbay

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11914,7 +11914,9 @@
 	dir = 5
 	},
 /obj/machinery/robotic_cradle,
-/turf/open/floor/mainship/sterile,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "pmY" = (
 /obj/structure/table/mainship/nometal,

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -86,8 +86,7 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "ax" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/start/job/crash/medicalofficer,
+/obj/machinery/robotic_cradle,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "ay" = (
@@ -319,6 +318,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/crash/medicalofficer,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bp" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -403,9 +403,10 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "by" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/machinery/vending/nanomed,
-/obj/effect/landmark/start/job/crash/medicalofficer,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/robotic_cradle,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bz" = (
@@ -420,11 +421,9 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/machinery/firealarm,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker/cryomix,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bA" = (
@@ -507,6 +506,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/job/crash/medicalofficer,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bU" = (


### PR DESCRIPTION
## About The Pull Request

adds a robotic cradle to the canterbury
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/dea1aed2-2591-4ae4-a75e-3ca7ab49d069)
(MO loses their seat but i believe it's fair since the ST north of them also has no seat; nanomed is still present, just on the wall above the table so it's hidden under all the Stuff in the map viewer)

adds a robotic cradle to the bigbury
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/c535eb1e-ce5f-4f2a-812e-fb9fdc4f3470)

switches a tile in the PoS medbay out from full color green to side green to retain the cross pattern in the center of the medbay

## Why It's Good For The Game

way for robots to heal cloneloss on crash gamemode
Fixes #13562

## Changelog
:cl:
fix: added the missing robotic cradle to the canterbury and bigbury for robots to heal cloneloss on the crash gamemode
fix: changed a tile out in the PoS medbay to fix the tile design
/:cl:
