### PR TITLE
Fixes burstauto and burst guns not resetting their shots fired properly

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -970,6 +970,9 @@
 
 	projectile_to_fire.fire_at(target, master_gun ? gun_user : loc, src, projectile_to_fire.ammo.max_range, projectile_to_fire.projectile_speed, firing_angle, suppress_light = HAS_TRAIT(src, TRAIT_GUN_SILENCED))
 
+	if((gun_firemode == GUN_FIREMODE_AUTOBURST || gun_firemode == GUN_FIREMODE_BURSTFIRE) && shots_fired >= burst_amount)
+		shots_fired = 0
+
 	shots_fired++
 
 	if(fire_animation) //Fires gun firing animation if it has any. ex: rotating barrel


### PR DESCRIPTION

## About The Pull Request

Yeah. This causes some bugs with the machine laser and bas.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixes burstauto and burst guns not resetting their shots fired properly
/:cl:
