### PR TITLE
Alamo fixes

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -823,6 +823,7 @@
 	density = TRUE
 	resistance_flags = RESIST_ALL
 	opacity = TRUE
+	allow_pass_flags = PASS_PROJECTILE|PASS_AIR
 
 /obj/structure/dropship_piece/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_SPARKS, -15, 8, 1)
@@ -917,7 +918,6 @@
 /obj/structure/dropship_piece/one/engine/rightbottom
 	icon_state = "brown_engine_rb"
 
-
 /obj/structure/dropship_piece/one/rearwing/lefttop
 	icon_state = "brown_rearwing_lt"
 
@@ -933,18 +933,22 @@
 /obj/structure/dropship_piece/one/rearwing/leftlbottom
 	icon_state = "brown_rearwing_llb"
 	opacity = FALSE
+	allow_pass_flags = PASSABLE
 
 /obj/structure/dropship_piece/one/rearwing/rightrbottom
 	icon_state = "brown_rearwing_rrb"
 	opacity = FALSE
+	allow_pass_flags = PASSABLE
 
 /obj/structure/dropship_piece/one/rearwing/leftllbottom
 	icon_state = "brown_rearwing_lllb"
 	opacity = FALSE
+	allow_pass_flags = PASSABLE
 
 /obj/structure/dropship_piece/one/rearwing/rightrrbottom
 	icon_state = "brown_rearwing_rrrb"
 	opacity = FALSE
+	allow_pass_flags = PASSABLE
 
 
 


### PR DESCRIPTION

## About The Pull Request
Fixed being able to throw through certain solid parts of the alamo.
For mysterious, probably CM reasons, the alamo is arbitrarily made out both turfs and structures, with zero way to tell which is which.
The little tail wing flaps at the back can still be thrown over, but the actual chunky tail section/engines/front corners are now impassable to throws.
## Why It's Good For The Game
Unintended behavior
## Changelog
:cl:
fix: You can no longer throw past certain dense parts of the alamo
/:cl:
