### PR TITLE
SH34 (DB) Nerf

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -204,7 +204,6 @@
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/gyro,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope,
@@ -215,11 +214,11 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 19, "under_x" = 21, "under_y" = 13, "stock_x" = 13, "stock_y" = 16)
 
-	fire_delay = 5
+	fire_delay = 0.65 SECONDS
 	burst_amount = 1
 	scatter = 3
 	scatter_unwielded = 10
-	recoil = 2
+	recoil = 1
 	recoil_unwielded = 4
 
 


### PR DESCRIPTION
## About The Pull Request
Slightly increases fire delay on the DB, by 0.15 seconds.
Removes gyro as an attachment.
Reduces recoil to 1 instead of 2 while wielded.
## Why It's Good For The Game
DB as it currently stands is the best vendor weapon due to it's frankly insane DPS with no downside due to it not being hit with the juggle nerf, and the ability to be reloaded very quickly with good keybinds. This keeps it as a burst weapon, but with less accuracy on the farther ranges if you are not running vgrip (which has a tradeoff of wield time) and overall less DPS.
## Changelog
:cl:
balance: Reduces the Double Barrel's firerate, removes gyro as an attachment, reduce base recoil.
/:cl:
