### PR TITLE
Tad console visual fix

### DIFF
--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -79,18 +79,13 @@
 		..()
 		return 1
 
-/obj/machinery/computer/update_icon()
-	..()
-	icon_state = initial(icon_state)
-
-	// Broken
+/obj/machinery/computer/update_icon_state()
 	if(machine_stat & (BROKEN|DISABLED))
-		icon_state += "b"
-
-	// Powered
+		icon_state = "[initial(icon_state)]b"
 	else if(machine_stat & NOPOWER)
+		icon_state = "[initial(icon_state)]0"
+	else
 		icon_state = initial(icon_state)
-		icon_state += "0"
 
 /obj/machinery/computer/proc/set_broken()
 	machine_stat |= BROKEN

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -42,8 +42,6 @@
 	var/origin_port_id = SHUTTLE_TADPOLE
 	/// The user of the ui
 	var/mob/living/ui_user
-	/// If this computer was damaged by a xeno
-	var/damaged = FALSE
 	/// How long before you can launch tadpole after a landing
 	var/launching_delay = 10 SECONDS
 	///Minimap for use while in landing cam mode
@@ -61,12 +59,6 @@
 	QDEL_NULL(land_action)
 	QDEL_NULL(tadmap)
 	return ..()
-
-/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/update_icon_state()
-	if(damaged)
-		icon_state = "shuttlecomputerb"
-	else
-		icon_state = "shuttlecomputer"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/CreateEye()
 	. = ..()
@@ -174,7 +166,7 @@
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
 	. = ..()
-	if(damaged)
+	if(machine_stat & BROKEN)
 		return
 	if(X.status_flags & INCORPOREAL)
 		return
@@ -195,10 +187,9 @@
 	var/datum/effect_system/spark_spread/s2 = new /datum/effect_system/spark_spread
 	s2.set_up(3, 1, src)
 	s2.start()
-	damaged = TRUE
+	set_broken()
 	open_prompt = FALSE
 	clean_ui_user()
-	update_icon()
 
 	if(fly_state == SHUTTLE_IN_ATMOSPHERE && last_valid_ground_port)
 		visible_message("Autopilot detects loss of helm control. INITIATING EMERGENCY LANDING!")
@@ -213,7 +204,7 @@
 		visible_message("Autopilot detects loss of helm control. Halting take off!")
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/can_interact(mob/user)
-	if(damaged)
+	if(machine_stat & BROKEN)
 		to_chat(user, span_warning("The [src] blinks and lets out a crackling noise. Its broken!"))
 		return
 	return ..()

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -62,6 +62,12 @@
 	QDEL_NULL(tadmap)
 	return ..()
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/update_icon_state()
+	if(damaged)
+		icon_state = "shuttlecomputerb"
+	else
+		icon_state = "shuttlecomputer"
+
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/CreateEye()
 	. = ..()
 	tadmap.override_locator(eyeobj)
@@ -192,6 +198,7 @@
 	damaged = TRUE
 	open_prompt = FALSE
 	clean_ui_user()
+	update_icon()
 
 	if(fly_state == SHUTTLE_IN_ATMOSPHERE && last_valid_ground_port)
 		visible_message("Autopilot detects loss of helm control. INITIATING EMERGENCY LANDING!")

--- a/code/modules/tgui/states/dropship.dm
+++ b/code/modules/tgui/states/dropship.dm
@@ -7,7 +7,7 @@ GLOBAL_DATUM_INIT(dropship_state, /datum/ui_state/dropship_state, new)
 
 /datum/ui_state/dropship_state/can_use_topic(src_object, mob/user)
 	var/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/shuttle_computer = src_object
-	if(shuttle_computer.damaged)
+	if(shuttle_computer.machine_stat & BROKEN)
 		return UI_CLOSE
 	return user.dropship_can_use_topic(src_object)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So we've always had a broken tad console sprite. We just uh, didn't use it.

Now the console will actually look broken, so you don't have to click it to check.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/c1dd31a0-ff42-44a0-93b9-a3b792f021e7)

Plus some misc computer cleanup
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Visual clarity
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The tad console is now visually different when broken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
