### PR TITLE
quick_equip prioritizes prefs

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -23,11 +23,11 @@
 				next_move = world.time + 1
 				return
 	else //store item
-		if(s_active?.attackby(I, src)) //stored in currently open storage
-			return TRUE
 		if(slot_requested)
 			if(equip_to_slot_if_possible(I, slot_requested, FALSE, FALSE, FALSE))
 				return
+		if(s_active?.attackby(I, src)) //stored in currently open storage
+			return TRUE
 		if(!equip_to_appropriate_slot(I, FALSE))
 			return
 		if(hand)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -275,7 +275,7 @@
 	return FALSE
 
 /**
- * This is a SAFE proc. Use this instead of equip_to_splot()!
+ * This is a SAFE proc. Use this instead of equip_to_slot()!
  * set del_on_fail to have it delete W if it fails to equip
  * unset redraw_mob to prevent the mob from being redrawn at the end.
  */


### PR DESCRIPTION
## About The Pull Request
Makes your client preferences matter in the case of storing an item using quick equip.
## Why It's Good For The Game
If you have a keybind to put an item in a specific storage, it will now prioritize your keybind rather than dump anything it can into a valid open storage.
## Changelog
:cl:
qol: Quick equipping into your belt now puts things into your belt and not your backpack.
/:cl:
