### PR TITLE
Fixes gravity giving infinite stamina

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1164,4 +1164,5 @@
 
 ///Checks the gravity the atom is subjected to
 /atom/movable/proc/get_gravity()
-	return SSmapping.gravity_by_z_level["[z]"]
+	var/turf/src_turf = get_turf(src)
+	return SSmapping.gravity_by_z_level["[src_turf.z]"]


### PR DESCRIPTION

## About The Pull Request

Never rely on the z var for anything ever. It's unreliable as fuck because byond nulls it if you're inside an object, it sucks.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed gravity giving infinite stamina
/:cl:
