### PR TITLE
Mark client as QDELING

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -358,6 +358,10 @@
 //////////////////
 /client/Del()
 	if(!gc_destroyed)
+		gc_destroyed = world.time
+		if (!QDELING(src))
+			stack_trace("Client does not purport to be QDELING, this is going to cause bugs in other places!")
+
 		// Yes this is the same as what's found in qdel(). Yes it does need to be here
 		// Get off my back
 		SEND_SIGNAL(src, COMSIG_QDELETING, TRUE)


### PR DESCRIPTION

## About The Pull Request

Clients will now be marked QDELING while in the process of deleting
## Why It's Good For The Game

It'll fix some runtimes with runechat mainly. Plus it's good to let the gc handle it properly.
## Changelog
:cl:
fix: Client is marked as QDELING properly now
/:cl:
