### PR TITLE
Fob sentry landmark del

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -19474,7 +19474,6 @@
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/bball/garbledradio)
 "eeV" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/icefloor/warnplate,
 /area/ice_colony/exterior/surface/taxiway)
 "efk" = (
@@ -21869,7 +21868,6 @@
 /area/ice_colony/surface/hangar/alpha)
 "hKV" = (
 /obj/effect/turf_underlay/icefloor,
-/obj/effect/landmark/fob_sentry,
 /turf/closed/mineral/smooth/bluefrostwall,
 /area/ice_colony/exterior/underground/caves/rock)
 "hMm" = (
@@ -28451,7 +28449,6 @@
 /turf/open/floor/tile/dark,
 /area/ice_colony/surface/excavationbarracks)
 "qYn" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
@@ -34116,7 +34113,6 @@
 	},
 /area/ice_colony/surface/research)
 "xXd" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/surface/valley/southeast)
 "xXm" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -4700,7 +4700,6 @@
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/lv624/ground/compound/sw)
 "dyc" = (
-/obj/effect/landmark/fob_sentry,
 /turf/closed/gm/dense,
 /area/lv624/ground/caves/rock)
 "dys" = (
@@ -11829,7 +11828,6 @@
 /area/lv624/lazarus/sleep_male)
 "lFx" = (
 /obj/effect/ai_node,
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "lGM" = (
@@ -16031,7 +16029,6 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "qDY" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -10123,7 +10123,6 @@
 	},
 /area/magmoor/cargo/processing/south)
 "hps" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
 	},
@@ -24454,7 +24453,6 @@
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound)
 "rSq" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
 "rSA" = (

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -46462,7 +46462,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
 "sBT" = (
@@ -47018,7 +47017,6 @@
 /obj/effect/turf_decal/woodsiding{
 	dir = 4
 	},
-/obj/effect/landmark/fob_sentry,
 /turf/open/ground/grass,
 /area/prison/residential/central)
 "ubZ" = (
@@ -47444,7 +47442,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "vfM" = (

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -1530,7 +1530,6 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/north_west)
 "ho" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_west)
 "hq" = (
@@ -4134,7 +4133,6 @@
 	},
 /area/outpost/caves/south)
 "sN" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/east)
 "sO" = (
@@ -8698,7 +8696,6 @@
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals)
 "NW" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
 "NX" = (

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -2835,11 +2835,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "pR" = (
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "pT" = (
-/obj/effect/landmark/fob_sentry,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
@@ -7755,7 +7753,6 @@
 "Ns" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "Nt" = (

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -430,16 +430,6 @@
 						/obj/item/weapon/chainsword,
 						)
 
-/obj/effect/landmark/fob_sentry
-	name = "Fob sentry"
-	icon = 'icons/Marine/sentry.dmi'
-	icon_state = "sentry"
-
-/obj/effect/landmark/fob_sentry/Initialize(mapload)
-	. = ..()
-	GLOB.fob_sentries_loc += loc
-	return INITIALIZE_HINT_QDEL
-
 /obj/effect/landmark/sensor_tower
 	name = "Sensor tower"
 	icon = 'icons/obj/structures/sensor.dmi'


### PR DESCRIPTION

## About The Pull Request

Forgot to get this in the civil war pr.
## Why It's Good For The Game

Unused bad.
## Changelog
:cl:
del: fob sentry landmark is gone
/:cl:
