### PR TITLE
rownin skeleton desc fixes; remove space in blood vendor phrase

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -966,7 +966,7 @@
 	icon_state = "bloodvendor"
 	icon_vend = "bloodvendor-vend"
 	icon_deny = "bloodvendor-deny"
-	product_slogans = "The best blood on the market!;Totally came from an ethical source!;O negative is the universal donor, use it!; Prevent hypovolemic shock starting today!"
+	product_slogans = "The best blood on the market!;Totally came from an ethical source!;O negative is the universal donor, use it!;Prevent hypovolemic shock starting today!"
 	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP)
 	products = list(
 		/obj/item/reagent_containers/blood/APlus = 5,

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -190,7 +190,7 @@
 
 /obj/item/clothing/suit/modular/rownin
 	name = "\improper Rownin Skeleton"
-	desc = "A light armor, if you can even called it that, for dedicated marines that want to travel light and have agility in exchange of protection. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
+	desc = "A light armor, if you can even call it that, for marines that want to have agility in exchange for protection. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
 	icon_state = "rownin_skeleton"
 	item_state = "rownin_skeleton"
 	allowed_uniform_type = /obj/item/clothing/under


### PR DESCRIPTION
## About The Pull Request

cleans up the rownin description

**new:**
```A light armor, if you can even call it that, for marines that want to have agility in exchange for protection. Alt-Click to remove attached items. Use it to toggle the built-in flashlight.```

**old:**
```A light armor, if you can even called it that, for dedicated marines that want to travel light and have agility in exchange of protection. Alt-Click to remove attached items. Use it to toggle the built-in flashlight.```

removes a space before one of the blood vendor phrases

## Why It's Good For The Game

me spell real good
consistency. maybe clarity on the rownin armor.

## Changelog

:cl:
spellcheck: fixed rownin armor description; extra space on one of the blood vendor slogans
/:cl: