### PR TITLE
Self harm toggled off by default, default keybind for self harm toggle

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -336,6 +336,7 @@
 	full_name = "Toggle self harm"
 	description = "Toggle being able to hit yourself"
 	keybind_signal = COMSIG_KB_SELFHARM
+	hotkey_keys = list("0")
 
 /datum/keybinding/mob/toggle_self_harm/down(client/user)
 	. = ..()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -20,7 +20,7 @@
 	var/m_intent = MOVE_INTENT_RUN
 	var/in_throw_mode = FALSE
 	/// Whether or not the mob can hit themselves.
-	var/do_self_harm = TRUE
+	var/do_self_harm = FALSE
 	var/notransform = FALSE
 	///The list of people observing this mob.
 	var/list/observers


### PR DESCRIPTION

## About The Pull Request
See title.
## Why It's Good For The Game
More often than not you want self harm to be off rather than on (looking at melee users), adds an easy keybind if you want it on though. If you already have keybinds set, this won't change it.
## Changelog
:cl:
qol: Adds default keybind for toggling self harms, turns self harm off by default.
/:cl:
