### PR TITLE
Fixes SOM Underwear

### DIFF
--- a/code/datums/jobs/job/sonsofmars.dm
+++ b/code/datums/jobs/job/sonsofmars.dm
@@ -7,8 +7,8 @@
 
 /datum/outfit/job/som/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.underwear = 10
-	H.undershirt = H.undershirt ? 10 : 0
+	H.underwear = 2
+	H.undershirt = H.undershirt ? 6 : 0
 	H.regenerate_icons()
 
 //Base job for normal gameplay SOM, not ERT.


### PR DESCRIPTION
## About The Pull Request

This PR Fixes the following issue caused by PR #13569:
     SOM doesn't have any underwears #13634

This is why you don't just change the name of sprites without checking what the FUCK THEY'RE USED FOR! Sorry for being aggressive I am TIRED!
## Why It's Good For The Game

No more SOM ERP

## Changelog

:cl: Meowosers
fix: Removes Nudist SOM Members.
/:cl:

