### PR TITLE
Mounted gun scope range increase 

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -748,7 +748,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "An unremovable set of long range ironsights for an HMG-08 machinegun."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
-	zoom_tile_offset = 3
+	zoom_tile_offset = 5
 
 /obj/item/attachable/scope/unremovable/mmg
 	name = "MG-27 rail scope"
@@ -766,20 +766,20 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "An unremovable set of long range scopes, very complex to properly range. Requires time to aim.."
 	icon_state = "sniperscope_invisible"
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 7
+	zoom_tile_offset = 8
 
 /obj/item/attachable/scope/unremovable/tl102
 	name = "HSG-102 smart sight"
 	desc = "An unremovable smart sight built for use with the tl102, it does nearly all the aiming work for the gun's integrated IFF systems."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
-	zoom_tile_offset = 3
+	zoom_tile_offset = 5
 	deployed_scope_rezoom = TRUE
 
 //all mounted guns with a nest use this
 /obj/item/attachable/scope/unremovable/tl102/nest
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 7
+	zoom_tile_offset = 8
 	zoom_viewsize = 2
 	deployed_scope_rezoom = FALSE
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -766,7 +766,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "An unremovable set of long range scopes, very complex to properly range. Requires time to aim.."
 	icon_state = "sniperscope_invisible"
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 8
+	zoom_tile_offset = 7
 
 /obj/item/attachable/scope/unremovable/tl102
 	name = "HSG-102 smart sight"
@@ -779,7 +779,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 //all mounted guns with a nest use this
 /obj/item/attachable/scope/unremovable/tl102/nest
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 8
+	zoom_tile_offset = 7
 	zoom_viewsize = 2
 	deployed_scope_rezoom = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Brings the mounted guns' "miniscope" to actual miniscope levels (3 -> 5) and increases by +1 the tadpole mounted/tat scope to keep a significant difference between the two (7 -> 8)

## Why It's Good For The Game

Lumi approved (at least the miniscope one). The issue is, the miniscope and the mounted gun scopes were the same and intended to be: 3 tile zoom range. However, the miniscope got buffed to 5, but the mounted variant got left behind cause no one cares. This means that the MG27, a "lower tier" mounted gun, can outrange the higher tier mounted guns (HSG and MG08 notably) because it can mount the 5-range miniscope instead of using a 3-range legacy scope. Nevermind the other handheld guns that don't have the disadvantage of being fixed in place and being able to be destroyed.

The +1 range to the long scope is so that the guns using it still have an more pronounced advantage over those with the now-buffed mini (from 3 and 7, to 5 and 8). It is still shorter than the boiler and rail scope, as intended (which are 10 tiles).
## Changelog
:cl:
balance: mounted gun miniscope has actual miniscope zoom now
balance: increased mounted gun rail scope zoom by 1
/:cl:
