### PR TITLE
Status effects get deleted along with their owners

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -99,6 +99,8 @@
 	RegisterSignal(src, COMSIG_AURA_FINISHED, PROC_REF(remove_emitted_auras))
 
 /mob/living/Destroy()
+	for(var/datum/status_effect/effect AS in status_effects)
+		qdel(effect)
 	for(var/i in embedded_objects)
 		var/obj/item/embedded = i
 		if(embedded.embedding.embedded_flags & EMBEDDED_DEL_ON_HOLDER_DEL)


### PR DESCRIPTION

## About The Pull Request

Yeah. Not doing this means status effects keep trying to process despite the owner not existing anymore. Means we get a lot of runtimes.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
code: Status effects get deleted along with their owners
/:cl:
