### PR TITLE
removes loose xeno structure pinpointers on canterbury and bigbury

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -179,7 +179,6 @@
 /area/shuttle/canterbury)
 "aR" = (
 /obj/structure/table/reinforced,
-/obj/item/pinpointer,
 /obj/item/tool/crowbar,
 /obj/item/radio,
 /obj/item/lightreplacer,
@@ -490,7 +489,6 @@
 /obj/item/clipboard,
 /obj/item/tool/pen,
 /obj/effect/spawner/random/misc/paperbin,
-/obj/item/pinpointer,
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
@@ -715,7 +713,6 @@
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/pinpointer,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "tP" = (
@@ -916,7 +913,6 @@
 /obj/machinery/air_alarm{
 	dir = 4
 	},
-/obj/item/pinpointer,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "KD" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -382,9 +382,7 @@
 /obj/machinery/cell_charger,
 /obj/item/radio,
 /obj/item/tool/crowbar,
-/obj/item/pinpointer,
 /obj/structure/table/reinforced,
-/obj/item/pinpointer,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bu" = (


### PR DESCRIPTION
## About The Pull Request

removes the loose xeno structure pinpointers on the canterbury and bigbury

## Why It's Good For The Game

i think they're pretty much a total noob trap. silos and all can't be destroyed on crash. 
whether spawncamping silos is behavior maints want to allow or not is a part of the considerations to be made for this and if it's decided that's intentional, then i get that.

only possibly used otherwise for the hivemind on crash that places their core not in the zones blocked off by fog.

## Changelog

:cl:
del: removed loose pinpointers on the crash ships
balance: rebalanced something
/:cl: