### PR TITLE
Stops playing card hands from magically disappearing

### DIFF
--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -271,7 +271,7 @@
 		overlays += I
 		return
 
-	var/offset = FLOOR(length(20/cards), 1)
+	var/offset = FLOOR(20/length(cards), 1)
 
 	var/matrix/M = matrix()
 	if(direction)


### PR DESCRIPTION

## About The Pull Request

Card hands will no longer runtime and work once more. Problem was caused by .len() conversions a few months back
## Why It's Good For The Game

Fixes good, fun good. I love the fun RP items like cards we have
## Changelog
:cl:
fix: Fixes a runtime regarding cards that was causing them to become invisible, playing cards work once more!
/:cl:
