### PR TITLE
Small Pillar of Spring Update

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -27,8 +27,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "acq" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/obj/structure/rack,
+/obj/item/toy/deck/kotahi,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "acv" = (
@@ -44,6 +44,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"adk" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "adr" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -737,6 +741,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "aSJ" = (
@@ -1399,11 +1409,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"bLw" = (
-/obj/item/toy/deck/kotahi,
-/obj/structure/table/gamblingtable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "bLz" = (
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
@@ -1712,6 +1717,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"bYJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "bYP" = (
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
@@ -2223,6 +2237,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "cQN" = (
@@ -2622,8 +2642,15 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "dkX" = (
-/obj/structure/rack,
-/obj/item/toy/deck/kotahi,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/revolver/standard_revolver,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dla" = (
@@ -2902,6 +2929,18 @@
 	dir = 1
 	},
 /area/mainship/command/self_destruct)
+"dEC" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "dFt" = (
 /turf/open/floor/mainship/green/corner{
 	dir = 8
@@ -2989,7 +3028,7 @@
 	},
 /area/mainship/squads/general)
 "dKF" = (
-/obj/machinery/computer/camera_advanced/remote_fob,
+/obj/structure/bed/chair/wood/normal,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dLg" = (
@@ -3223,6 +3262,12 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/living/numbertwobunks)
+"eaH" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "ebd" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -3248,6 +3293,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"edj" = (
+/obj/item/stack/tile/plasteel,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
 "edp" = (
 /obj/structure/filingcabinet,
 /obj/machinery/camera/autoname/mainship,
@@ -3677,6 +3727,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "eCc" = (
@@ -4051,8 +4104,8 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "feK" = (
-/obj/structure/rack,
-/obj/item/frame/table/gambling,
+/obj/item/toy/deck/kotahi,
+/obj/structure/table/gamblingtable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "feP" = (
@@ -4441,6 +4494,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -4471,6 +4530,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"fGe" = (
+/obj/structure/barricade/metal,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/boxingring)
 "fGV" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -4478,6 +4543,12 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
@@ -4562,6 +4633,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"fMh" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "fNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4616,6 +4692,7 @@
 "fTy" = (
 /obj/item/trash/cigbutt,
 /obj/item/storage/firstaid/adv,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "fUs" = (
@@ -5424,9 +5501,8 @@
 	},
 /area/mainship/medical/medical_science)
 "hap" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/camera,
-/obj/item/camera_film,
+/obj/structure/rack,
+/obj/item/frame/table/gambling,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hbh" = (
@@ -5686,6 +5762,15 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
+"htZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "hua" = (
 /obj/item/clothing/gloves/marine/som,
 /obj/structure/disposalpipe/segment{
@@ -5884,6 +5969,9 @@
 	dir = 4
 	},
 /obj/machinery/autodoc_console,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "hLE" = (
@@ -6405,6 +6493,13 @@
 /obj/structure/sink{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/operating_room_one)
 "iuG" = (
@@ -6425,6 +6520,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"ivW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "iwj" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
@@ -7427,7 +7527,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mainship,
+/obj/structure/computerframe,
+/turf/open/floor/plating,
 /area/mainship/squads/general)
 "jTl" = (
 /turf/closed/wall/mainship,
@@ -7721,6 +7822,15 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
+"ksa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "ksb" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -8109,9 +8219,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "kLu" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
+/obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kLK" = (
@@ -8317,18 +8425,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
-"kWq" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
-	},
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "kWu" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
@@ -9270,7 +9366,13 @@
 	dir = 4
 	},
 /obj/machinery/light/mainship,
-/obj/structure/closet/crate,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/tool/hand_labeler,
+/obj/item/facepaint/green,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lTt" = (
@@ -9509,6 +9611,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "mia" = (
@@ -9566,6 +9669,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
+"mng" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
 "mnH" = (
 /obj/machinery/door/airlock/mainship/secure/evac{
 	dir = 2
@@ -9826,6 +9933,13 @@
 /obj/structure/ship_ammo/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"mEk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "mEN" = (
 /obj/machinery/firealarm,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10076,6 +10190,13 @@
 /obj/machinery/light/mainship,
 /obj/structure/sink{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/operating_room_two)
@@ -10535,6 +10656,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"nwR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/computerframe,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
 "nwX" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/side,
@@ -10579,6 +10705,12 @@
 	dir = 6
 	},
 /area/mainship/hallways/hangar)
+"nzV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stack/tile/plasteel,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
 "nAb" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/mainship/sterile/side{
@@ -11917,13 +12049,9 @@
 	},
 /area/mainship/hallways/hangar)
 "plR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/robotic_cradle,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -12048,6 +12176,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"pvN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "pvW" = (
 /obj/item/toy/deck,
 /obj/structure/table/woodentable,
@@ -12122,7 +12259,6 @@
 /area/mainship/living/tankerbunks)
 "pzq" = (
 /obj/structure/prop/mainship/hangar_stencil,
-/obj/structure/closet/crate,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pzU" = (
@@ -12873,6 +13009,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "qwO" = (
@@ -13893,6 +14030,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "rIq" = (
@@ -14580,6 +14720,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -15156,6 +15297,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ttb" = (
@@ -15277,6 +15421,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"tAO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
 "tBb" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 1
@@ -15712,6 +15861,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -16096,6 +16251,9 @@
 	dir = 5
 	},
 /obj/machinery/autodoc,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -16140,6 +16298,12 @@
 	dir = 6
 	},
 /area/mainship/command/self_destruct)
+"uxC" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/camera,
+/obj/item/camera_film,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "uxI" = (
 /obj/structure/sign/poster,
 /turf/open/floor/mainship/cargo/arrow{
@@ -16149,6 +16313,11 @@
 "uyy" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
+"uza" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "uzm" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/cargo,
@@ -16208,6 +16377,7 @@
 /area/mainship/engineering/engineering_workshop)
 "uCj" = (
 /obj/item/storage/firstaid/adv,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "uCk" = (
@@ -16843,18 +17013,6 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"voU" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = -8
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/revolver/standard_revolver,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "vpm" = (
@@ -18224,6 +18382,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -18361,8 +18525,8 @@
 	},
 /area/mainship/command/self_destruct)
 "xmJ" = (
-/obj/structure/bed/chair/wood/normal,
-/turf/open/floor/mainship,
+/obj/structure/computerframe,
+/turf/open/floor/plating,
 /area/mainship/squads/general)
 "xnO" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
@@ -19241,12 +19405,8 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/facepaint/green,
-/obj/item/tool/hand_labeler,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = -6;
-	pixel_y = 3
+/obj/machinery/computer/cryopod{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -44787,7 +44947,7 @@ fAJ
 lJX
 lJX
 iTM
-vuM
+fGe
 jQH
 jQH
 jQH
@@ -45810,9 +45970,9 @@ dUf
 yld
 cfp
 dpY
-dpY
-eiU
 xIb
+eiU
+dpY
 dpY
 wpF
 wBE
@@ -47111,7 +47271,7 @@ aCM
 mvs
 rSg
 lAT
-lAT
+pvN
 uMj
 kyi
 dnQ
@@ -47368,8 +47528,8 @@ sdK
 cWC
 lxg
 tXl
-tXl
-tXl
+htZ
+ivW
 sDn
 uvB
 euF
@@ -48396,8 +48556,8 @@ foU
 dlz
 jUl
 hGO
-hGO
-hGO
+bYJ
+uza
 mgM
 plR
 fXX
@@ -48653,7 +48813,7 @@ aQX
 mvs
 kYM
 lAT
-lAT
+ksa
 pDg
 ieX
 jUP
@@ -49664,11 +49824,11 @@ dpY
 eAd
 mVM
 kOe
-eAd
 dpY
 dkX
-acq
 dpY
+acq
+fMh
 uKp
 wXN
 vZK
@@ -49921,11 +50081,11 @@ fwq
 fwq
 fwq
 dpY
-dpY
-dpY
+dKF
+feK
 dKF
 kLu
-dpY
+eaH
 uKp
 hiK
 kBO
@@ -50179,10 +50339,10 @@ osb
 xtm
 tzk
 dpY
+dEC
 dpY
-feK
 hap
-dpY
+uxC
 uKp
 bdS
 pDT
@@ -57155,7 +57315,7 @@ xJn
 pSX
 sbB
 aUp
-isK
+mEk
 isK
 rFS
 oGT
@@ -57410,10 +57570,10 @@ xRb
 cvj
 nJG
 eDg
-eYx
-cPg
-voU
-cPg
+mng
+xmJ
+xmJ
+mng
 buS
 fLM
 eMz
@@ -57667,10 +57827,10 @@ kAq
 qEu
 pko
 bSp
-eYx
+mng
 xmJ
-bLw
 xmJ
+edj
 tJA
 fLM
 eMz
@@ -57924,10 +58084,10 @@ oHj
 ylc
 dVo
 bSp
-eYx
-cPg
-kWq
-cPg
+mng
+xmJ
+xmJ
+mng
 bYP
 fLM
 eMz
@@ -58181,10 +58341,10 @@ nhn
 nbh
 eeX
 jEy
-bpK
-bpK
+nzV
+nwR
 jRR
-bpK
+tAO
 bpK
 weY
 brH
@@ -58441,7 +58601,7 @@ tis
 cPg
 cPg
 hcr
-cPg
+adk
 cPg
 cPg
 lOp


### PR DESCRIPTION
## About The Pull Request

Add vents and scrubber in operation room.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/017c4478-4a96-412d-87b5-e711cfadaeb3)

Add cryo console near Alamo.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/561693ec-48fc-4a00-b5bf-d6068de06d67)

Add where jaeger vendor will be. Keep your eyes out for the future!

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/f6745203-e156-4954-ac2a-7c27d1dbe629)

## Why It's Good For The Game

All shipside maps have OR with vent and scrubber, and I forgot to add that in PoS.

Cryo console is near Alamo so that marines who want to see what is inside before deployment don't have to run far.

Computer console frame will be replaced by jaeger vendor. It's a nice visual narrative.

## Changelog

:cl:
add: vents and scrubber in PoS operation room.
add: cryo console near PoS Alamo.
add: where jaeger vendor will be for PoS. Keep your eyes out for the future!
/:cl:

