### PR TITLE
Removes SVD from the Cold War seasonal

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -231,8 +231,6 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/rifle/m16 = -1,
 		/obj/item/ammo_magazine/rifle/m16 = -1,
 		/obj/item/ammo_magazine/packet/pnato = -1,
-		/obj/item/weapon/gun/rifle/sniper/svd = -1,
-		/obj/item/ammo_magazine/sniper/svd = -1,
 		)
 
 /datum/season_datum/weapons/guns/pistol_seasonal_one


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
When about everyone changes from the normal sniper to the SVD when its in seasonal, ya know something is up. It is everything the TL127 wants to be, but better.
## Changelog
:cl:
balance: Removed SVD from the Cold War seasonals.
/:cl:
