### PR TITLE
Increase the long range mounted scope by 1

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -766,7 +766,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "An unremovable set of long range scopes, very complex to properly range. Requires time to aim.."
 	icon_state = "sniperscope_invisible"
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 7
+	zoom_tile_offset = 8
 
 /obj/item/attachable/scope/unremovable/tl102
 	name = "HSG-102 smart sight"
@@ -779,7 +779,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 //all mounted guns with a nest use this
 /obj/item/attachable/scope/unremovable/tl102/nest
 	scope_delay = 2 SECONDS
-	zoom_tile_offset = 7
+	zoom_tile_offset = 8
 	zoom_viewsize = 2
 	deployed_scope_rezoom = FALSE
 


### PR DESCRIPTION

## About The Pull Request
TAT and nest guns scope range 7 --> 8. moved to new PR as advised
## Why It's Good For The Game
Main reason, as stated in the previous pr, was to make the heavier, sniper emplacements have an edge compared to the now-buffed shorter ranged. as it stands now, the shorter scope is 5 tiles which is only 2 less than the supposedly sniper ones, which are much harder to tote around (cant be picked up or have huge timers to do so) or downright fixed in place in the tadpole. In regards to the guns you can bring with you, which are the AC, AGLS and TAT, you can still field them from the backline and not have a poor time with slow guns when you can get cheaper HSG or minigun and stay just 2 tiles closer to the front, or simply let your bullets travel offscreen the extra 2 tiles you're missing in scope. for the tad guns, the change is mirrored to be in line with the aforementioned three guns; not only are tad guns locked period, but they also are restricted by the corners of regular tad, or whatever other variants PO chooses. AGLS, TAT (except apcr ammo) and AC (except HV ammo) cannot fire past their max scope range, as their ammo lands on the tile you target; tadpole HSG and minigun already can fire past.

Do note, its a mere +1 increase, which however brings the mini-sniper difference from 5 and 7, respectively, to 5 and 8, and this is still shorter than the regular rail and boiler scopes.
## Changelog
:cl:
balance: increased mounted guns long scope zoom from 7 tiles to 8
/:cl:
