### PR TITLE
Removes (most) easy plats on LV

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -8919,11 +8919,6 @@
 "iqt" = (
 /turf/closed/wall,
 /area/lv624/lazarus/toilet)
-"iqI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/white,
-/area/lv624/ground/compound/c)
 "iqY" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -12312,12 +12307,6 @@
 "mhk" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand6/garbledradio)
-"mhV" = (
-/obj/structure/table,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/ground/compound/c)
 "mib" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/catwalk,
@@ -18122,7 +18111,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
-/area/lv624/ground/compound/c)
+/area/lv624/lazarus/research)
 "sOK" = (
 /obj/machinery/door_control{
 	dir = 4;
@@ -44822,7 +44811,7 @@ svN
 egy
 tUO
 tvF
-mhV
+bba
 tZD
 xKv
 ygp
@@ -44999,7 +44988,7 @@ qfS
 joM
 boL
 joM
-iqI
+joM
 pQq
 xhp
 iBl

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -296,10 +296,6 @@
 "akq" = (
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
-"akF" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central4/garbledradio)
 "akI" = (
 /turf/closed/wall,
 /area/lv624/ground/sand8)
@@ -727,10 +723,6 @@
 /area/lv624/ground/sand2)
 "avu" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central3/garbledradio)
-"avz" = (
-/obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3/garbledradio)
 "avJ" = (
@@ -3265,11 +3257,6 @@
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage/dome)
-"bQd" = (
-/turf/open/floor/tile/blue/whiteblue{
-	dir = 1
-	},
-/area/lv624/lazarus/corporate_affairs)
 "bQu" = (
 /obj/structure/bed/stool,
 /turf/open/floor/tile/bar,
@@ -3494,10 +3481,6 @@
 "ceV" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple/garbledradio)
-"cfH" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1/garbledradio)
 "cgd" = (
 /obj/effect/spawner/random/weaponry/gun/machineguns,
 /turf/open/floor/tile/blue/whiteblue{
@@ -4699,9 +4682,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/lv624/ground/compound/sw)
-"dyc" = (
-/turf/closed/gm/dense,
-/area/lv624/ground/caves/rock)
 "dys" = (
 /turf/open/floor/plating/warning{
 	dir = 2
@@ -11826,10 +11806,6 @@
 	dir = 2
 	},
 /area/lv624/lazarus/sleep_male)
-"lFx" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle9)
 "lGM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/ai_node,
@@ -26920,7 +26896,7 @@ lXk
 noU
 xnp
 noU
-akF
+noU
 xCC
 xCC
 sYe
@@ -38474,7 +38450,7 @@ mOs
 mOs
 mOs
 mOs
-dyc
+mOs
 mOs
 avd
 ncS
@@ -39368,7 +39344,7 @@ avd
 xWM
 xVL
 cIl
-lFx
+oDS
 cIl
 cIl
 vfk
@@ -40089,7 +40065,7 @@ aRg
 mgb
 vCm
 dTK
-bQd
+qDY
 sjX
 pJt
 xVF
@@ -40793,7 +40769,7 @@ ggT
 rAx
 xYX
 gbp
-bQd
+qDY
 hyS
 lwx
 tJT
@@ -42467,7 +42443,7 @@ pBV
 pBV
 pBV
 pBV
-avz
+pBV
 pBV
 pBV
 pBV
@@ -47948,7 +47924,7 @@ evp
 gKr
 pBV
 pBV
-avz
+pBV
 qFt
 pBV
 qFt
@@ -50948,7 +50924,7 @@ gKr
 gKr
 gKr
 nwU
-cfH
+fdU
 ahg
 ahg
 ahg
@@ -56079,7 +56055,7 @@ aaH
 gsr
 snv
 snv
-aZd
+snv
 snv
 snv
 snv
@@ -60159,7 +60135,7 @@ lTT
 snv
 snv
 snv
-aZd
+snv
 snv
 snv
 wsX

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -905,7 +905,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/office_complex)
 "Nq" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -905,7 +905,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/e)
 "Nq" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9

--- a/_maps/modularmaps/lv624/newcavevar10.dmm
+++ b/_maps/modularmaps/lv624/newcavevar10.dmm
@@ -2,22 +2,6 @@
 "aa" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
-"ab" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral,
-/area/lv624/ground/caves/rock)
-"ac" = (
-/turf/closed/mineral,
-/area/lv624/ground/caves/rock)
-"ad" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1)
-"ae" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "af" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/tritium{
@@ -51,25 +35,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/lv624/ground/caves/rock)
-"al" = (
-/obj/structure/rack,
-/obj/item/tool/shovel,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/vault{
-	dir = 8
-	},
-/area/lv624/ground/caves/central1)
 "am" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "an" = (
 /turf/open/floor/tile/dark,
-/area/lv624/ground/caves/central1)
-"ao" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "ap" = (
 /obj/structure/rack,
@@ -80,67 +51,15 @@
 	dir = 8
 	},
 /area/lv624/ground/caves/central1)
-"aq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1)
-"ar" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
-"as" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1)
-"at" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/iron{
-	amount = 5
-	},
-/obj/item/stack/sheet/mineral/platinum,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/vault{
-	dir = 8
-	},
-/area/lv624/ground/caves/central1)
 "au" = (
 /turf/closed/mineral/smooth/indestructible,
-/area/lv624/ground/caves/rock)
-"av" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/mineral,
 /area/lv624/ground/caves/rock)
 "aw" = (
 /turf/closed/wall/r_wall,
 /area/lv624/ground/caves/rock)
-"ax" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/lv624/ground/caves/rock)
-"ay" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "az" = (
 /turf/open/floor,
 /area/lv624/ground/caves/central1)
-"aA" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central3)
-"aB" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
-"aC" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "aD" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -159,11 +78,6 @@
 /turf/open/floor/tile/vault{
 	dir = 8
 	},
-/area/lv624/ground/caves/central1)
-"aF" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "aG" = (
 /obj/effect/landmark/weed_node,
@@ -185,22 +99,11 @@
 	dir = 8
 	},
 /area/lv624/ground/caves/central1)
-"aK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "aL" = (
 /turf/closed/wall/r_wall,
 /area/lv624/ground/caves/central1)
 "aM" = (
 /turf/closed/wall,
-/area/lv624/ground/caves/central1)
-"aN" = (
-/obj/structure/rack,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/vault{
-	dir = 8
-	},
 /area/lv624/ground/caves/central1)
 "aO" = (
 /obj/structure/rack,
@@ -218,10 +121,6 @@
 /area/lv624/ground/caves/central1)
 "aP" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
-"aQ" = (
-/obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
 "aR" = (
@@ -263,9 +162,6 @@
 	dir = 8
 	},
 /area/lv624/ground/caves/central1)
-"aX" = (
-/turf/closed/mineral/indestructible,
-/area/lv624/ground/caves/rock)
 "aY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -299,25 +195,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
-"sj" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "su" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
-"yh" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "Ai" = (
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1)
-"As" = (
-/obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "DE" = (
@@ -344,11 +228,6 @@
 	dir = 8
 	},
 /area/lv624/ground/caves/central1)
-"Nn" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central2)
 "PA" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/smooth,
@@ -506,10 +385,10 @@ aT
 aT
 aT
 ah
-aQ
+ag
 ah
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -716,7 +595,7 @@ aT
 aT
 aT
 aT
-aQ
+ag
 ah
 ah
 ah
@@ -752,9 +631,9 @@ aT
 aT
 aT
 ah
-aQ
+ag
 aG
-aQ
+ag
 ah
 aG
 ah
@@ -862,7 +741,7 @@ aG
 ah
 ah
 ah
-Nn
+aZ
 ah
 aT
 aT
@@ -898,7 +777,7 @@ ah
 ah
 aG
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -1031,16 +910,16 @@ ah
 ah
 ah
 aG
-yh
-sj
+aR
+aY
 ah
 ah
 ah
 aV
 aV
-aQ
+ag
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -1066,8 +945,8 @@ aG
 ah
 ah
 ah
-yh
-sj
+aR
+aY
 aV
 aG
 ah
@@ -1095,18 +974,18 @@ aT
 PA
 aT
 aT
-aQ
+ag
 ah
 fk
 ah
 ah
-aQ
-yh
-sj
+ag
+aR
+aY
 ah
 ah
 ah
-aQ
+ag
 ah
 ah
 aV
@@ -1214,7 +1093,7 @@ ah
 ah
 Kf
 aV
-Nn
+aZ
 ah
 ah
 aG
@@ -1281,11 +1160,11 @@ PA
 aT
 ah
 ah
-aQ
+ag
 aG
 ah
 ah
-aQ
+ag
 ah
 sb
 aT
@@ -1320,7 +1199,7 @@ ah
 aV
 aV
 aV
-Nn
+aZ
 ah
 ah
 ah
@@ -1380,13 +1259,13 @@ aT
 aT
 aT
 aT
-Nn
-aQ
+aZ
+ag
 ah
 aG
 ah
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -1486,7 +1365,7 @@ aT
 aV
 sb
 ah
-aQ
+ag
 ah
 aT
 aT
@@ -1517,7 +1396,7 @@ aT
 aT
 aT
 aT
-Nn
+aZ
 aV
 ah
 ah
@@ -1526,13 +1405,13 @@ aT
 aT
 aT
 aG
-aQ
+ag
 ah
 aG
 ah
-aQ
+ag
 ah
-aQ
+ag
 aV
 aT
 aT
@@ -1692,7 +1571,7 @@ aT
 aT
 aT
 aT
-Nn
+aZ
 ah
 ah
 ah
@@ -1704,7 +1583,7 @@ aT
 aT
 aT
 aT
-Nn
+aZ
 ah
 ah
 ah
@@ -1764,7 +1643,7 @@ aT
 aT
 aV
 ah
-aQ
+ag
 ah
 aT
 aT
@@ -1777,7 +1656,7 @@ aT
 aT
 ah
 aV
-Nn
+aZ
 ah
 ah
 aT
@@ -1810,7 +1689,7 @@ aT
 aT
 aT
 aT
-aQ
+ag
 ah
 aG
 ah
@@ -1846,13 +1725,13 @@ aT
 aT
 aV
 aG
-aQ
+ag
 ah
 ah
 ah
 aG
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -1879,7 +1758,7 @@ aT
 aT
 aT
 aT
-Nn
+aZ
 ah
 ah
 aT
@@ -1923,10 +1802,10 @@ aT
 aT
 ah
 ah
-Nn
+aZ
 ah
 aG
-aP
+ah
 aG
 "}
 (46,1,1) = {"
@@ -1939,10 +1818,10 @@ aT
 aT
 aT
 aT
-aQ
+ag
 aG
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -2047,7 +1926,7 @@ aT
 aT
 ah
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -2056,17 +1935,17 @@ aT
 aT
 aT
 aT
-aQ
+ag
 ah
 ah
 ah
 ah
 ah
-aQ
+ag
 ah
 ah
 ah
-aQ
+ag
 ah
 "}
 (50,1,1) = {"
@@ -2083,7 +1962,7 @@ ah
 ah
 aG
 ah
-Nn
+aZ
 aT
 aT
 aT
@@ -2092,7 +1971,7 @@ aT
 aT
 ah
 ah
-Nn
+aZ
 aV
 ah
 ah
@@ -2223,7 +2102,7 @@ aT
 ah
 ah
 ah
-aQ
+ag
 aG
 ah
 aV
@@ -2235,7 +2114,7 @@ ah
 aG
 aV
 ah
-Nn
+aZ
 aT
 aT
 aT
@@ -2257,12 +2136,12 @@ aT
 aT
 ah
 aG
-aQ
+ag
 ah
 ah
 ah
 ah
-aQ
+ag
 ah
 ah
 ah
@@ -2302,9 +2181,9 @@ aG
 ah
 aV
 aV
-aQ
+ag
 ah
-Nn
+aZ
 aV
 aT
 aT
@@ -2363,11 +2242,11 @@ aT
 aT
 ah
 ah
-aQ
+ag
 ah
 ah
 ah
-aQ
+ag
 ah
 ah
 ah
@@ -2466,9 +2345,9 @@ aT
 aT
 aT
 ah
-aQ
+ag
 ah
-aQ
+ag
 ah
 aV
 aT
@@ -2505,7 +2384,7 @@ ah
 ah
 aV
 aV
-Nn
+aZ
 aT
 aT
 aT
@@ -2547,7 +2426,7 @@ aT
 sb
 ah
 ah
-aQ
+ag
 aG
 aT
 aT
@@ -2573,7 +2452,7 @@ aT
 aT
 ah
 ah
-Nn
+aZ
 aT
 aT
 aT
@@ -2641,7 +2520,7 @@ aT
 aT
 aT
 ah
-aQ
+ag
 ah
 aV
 aT
@@ -2722,9 +2601,9 @@ aT
 aT
 aT
 ah
-aQ
+ag
 ah
-aQ
+ag
 aT
 aT
 aT
@@ -2793,7 +2672,7 @@ aT
 aT
 ah
 aV
-Nn
+aZ
 ah
 ah
 aT
@@ -2896,10 +2775,10 @@ aT
 aT
 aT
 aI
-As
+aH
 Ft
 aI
-As
+aH
 aI
 aT
 aT
@@ -2921,7 +2800,7 @@ au
 au
 aT
 Ft
-As
+aH
 aI
 aI
 eD
@@ -2940,8 +2819,8 @@ aT
 ga
 ak
 Kr
-at
-aN
+aU
+aW
 ak
 "}
 (75,1,1) = {"
@@ -3032,7 +2911,7 @@ aI
 Ft
 aI
 aT
-As
+aH
 aI
 aI
 aI
@@ -3134,14 +3013,14 @@ aT
 aT
 aT
 aI
-As
+aH
 aI
 aI
 eD
 aI
 aI
 aI
-As
+aH
 It
 aI
 aT


### PR DESCRIPTION
## About The Pull Request
Read title.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/a9ef9594-24c8-4156-9451-364ea0445f36)
This is what (minus the x'd) LV caves look like, for the most part because muh modulars. I say most because I might have missed a modular, tell me if I did.
Also does a minor fix on the Research Lab area east of LV 2 as there was an unroofed area.
## Why It's Good For The Game
Muh xope. In all seriousness,
With LV already being focused on the cave fight as Xenos cannot contest colony, these miners just enable the Marines to cave fight much easier with less attrition.
## Changelog
:cl:
del: Removed some Platinum Miners on LV.
fix: Fixes LV research lab area not being entirely roofed.
/:cl:
