### PR TITLE
Remove chat spam from order actions

### DIFF
--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -37,11 +37,9 @@
 
 /datum/action/innate/order/can_use_action()
 	. = ..()
-	if(TIMER_COOLDOWN_CHECK(owner, COOLDOWN_CIC_ORDERS))
-		to_chat(owner, span_warning("Your last order was too recent."))
-		return FALSE
-	if(owner.stat)
-		to_chat(owner, span_warning("You can not issue an order in your current state."))
+	if(!.)
+		return
+	if(owner.stat != CONSCIOUS || TIMER_COOLDOWN_CHECK(owner, COOLDOWN_CIC_ORDERS))
 		return FALSE
 
 ///Print order visual to all marines squad hud and give them an arrow to follow the waypoint

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -26,17 +26,11 @@
 /datum/action/innate/message_squad/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
 
-/datum/action/innate/message_squad/can_use_action(silent = FALSE)
+/datum/action/innate/message_squad/can_use_action()
 	. = ..()
 	if(!.)
 		return
-	if(owner.stat)
-		if(!silent)
-			owner.balloon_alert(owner, "You can't send orders right now")
-		return FALSE
-	if(TIMER_COOLDOWN_CHECK(owner, COOLDOWN_HUD_ORDER))
-		if(!silent)
-			owner.balloon_alert(owner, "Your last order was too recent")
+	if(owner.stat != CONSCIOUS || TIMER_COOLDOWN_CHECK(owner, COOLDOWN_HUD_ORDER))
 		return FALSE
 
 /datum/action/innate/message_squad/action_activate()
@@ -53,7 +47,7 @@
 		REPORT_CHAT_FILTER_TO_USER(src, filter_result)
 		log_filter("IC", text, filter_result)
 		return
-	if(!can_use_action(TRUE))
+	if(!can_use_action())
 		return
 	human_owner.playsound_local(owner, "sound/effects/CIC_order.ogg", 10, 1)
 	to_chat(owner, "<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>")


### PR DESCRIPTION
## About The Pull Request

Not sure feedback messages are needed for this, they spam your chat 4x when you re-enter your corpse as well. Could've added a silent argument to /datum/action/innate like /datum/action/xeno_action does but this is the only innate action that has feedback anyway

## Changelog

:cl:
del: removed chat feedback from order actions
/:cl: