### PR TITLE
Xenos can no longer spam click miners to break them faster

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -318,6 +318,8 @@
 		span_notice("We can't slash through [src]'s reinforced plating!"))
 		return
 	while(miner_status != MINER_DESTROYED)
+		if(X.do_actions)
+			return balloon_alert(X, "busy")
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
 			return
 		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)


### PR DESCRIPTION

## About The Pull Request
Xenos can no longer left click spam a miner to break it in < half the required time.
## Why It's Good For The Game
I'd call this a bugfix, if miners are intended to be destroyed at the faster rate (of left click spam), then the amount of time it takes to slash it should be reduced.
## Changelog
:cl:
fix: Xenos can no longer spam left click miners to break them faster than normally.
/:cl:
