### PR TITLE
Lawanka Changes (Version 1)

### DIFF
--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -1462,11 +1462,6 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/engineering)
-"bjk" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/lawankaoutpost/colony/engineering)
 "bjm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7439,6 +7434,7 @@
 /area/lawankaoutpost/outside/central)
 "ghU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/lawankaoutpost/colony/engineering)
 "gia" = (
@@ -11982,7 +11978,6 @@
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
 "kkV" = (
-/obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
@@ -24330,10 +24325,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/caves/west)
 "upP" = (
-/obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/lawankaoutpost/colony/engineering)
 "upX" = (
@@ -48890,7 +48885,7 @@ whJ
 vgu
 gnU
 upP
-lIK
+gnU
 gnU
 gor
 xGW
@@ -49106,7 +49101,7 @@ qDL
 skU
 nva
 ghU
-bjk
+aQx
 ehC
 hYG
 gor

--- a/code/game/area/lawankaoutpost.dm
+++ b/code/game/area/lawankaoutpost.dm
@@ -186,6 +186,7 @@
 	name = "Engineering"
 	icon_state = "engine"
 	minimap_color = MINIMAP_AREA_ENGI
+	ceiling = CEILING_UNDERGROUND_METAL
 
 /area/lawankaoutpost/colony/chapel
 	name = "Chapel"


### PR DESCRIPTION
## About The Pull Request
Removes nexus disk spawn
Makes engineering underground
Minor SMES changes (Zack yelled at me that they didn't work, they should now?)
## Why It's Good For The Game
There was a potential of the disks spawns to be a literal straight line to the nuke, this makes it so marines will have to go to the underground lab in order to get all disks; which is a tad ride away from nuke anywho. Breaks up the straight line flow that Lawanka can currently have. Nexus will still be a very good spot for xenos to stage flanks, as it is in the literal center of the map. In addition, tadpole landing in engineering was a bit too funny as it could control all the chokepoints leading into it.
## Changelog
:cl:
balance: Lawanka Outpost; 3 disk spawns, engineering is now underground
/:cl:
