### PR TITLE
More can_hold items for field utility pouch

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -609,7 +609,7 @@
 
 /obj/item/storage/pouch/field_pouch
 	name = "field utility pouch"
-	storage_slots = 5
+	storage_slots = 4
 	max_w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "utility"
 	draw_mode = 1
@@ -623,6 +623,20 @@
 		/obj/item/whistle,
 		/obj/item/binoculars,
 		/obj/item/beacon/supply_beacon,
+		/obj/item/compass,
+		/obj/item/deployable_camera,
+		/obj/item/hud_tablet,
+		/obj/item/minimap_tablet,
+		/obj/item/supplytablet,
+		/obj/item/megaphone,
+		/obj/item/storage/box/m94,
+		/obj/item/explosive/grenade/flare,
+		/obj/item/storage/box/m94/cas,
+		/obj/item/explosive/grenade/flare/cas,
+		/obj/item/tool/hand_labeler,
+		/obj/item/toy/deck,
+		/obj/item/paper,
+		/obj/item/clipboard,
 	)
 
 /obj/item/storage/pouch/field_pouch/full/Initialize(mapload)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -609,11 +609,11 @@
 
 /obj/item/storage/pouch/field_pouch
 	name = "field utility pouch"
-	storage_slots = 4
+	storage_slots = 5
 	max_w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "utility"
 	draw_mode = 1
-	desc = "It can contain a motion detector, signaller, beacons, maps, flares, radios and other handy battlefield communication and detection devices."
+	desc = "It can contain a motion detector, signaller, beacons, map tablets, radios, papers and other handy battlefield communication, navigation, and detection devices."
 	can_hold = list(
 		/obj/item/attachable/motiondetector,
 		/obj/item/radio,
@@ -629,10 +629,6 @@
 		/obj/item/minimap_tablet,
 		/obj/item/supplytablet,
 		/obj/item/megaphone,
-		/obj/item/storage/box/m94,
-		/obj/item/explosive/grenade/flare,
-		/obj/item/storage/box/m94/cas,
-		/obj/item/explosive/grenade/flare/cas,
 		/obj/item/tool/hand_labeler,
 		/obj/item/toy/deck,
 		/obj/item/paper,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1205,7 +1205,6 @@
 			/obj/item/storage/pouch/tools/full = -1,
 			/obj/item/storage/pouch/field_pouch = -1,
 			/obj/item/storage/pouch/general/large = -1,
-			/obj/item/storage/pouch/document = -1,
 			/obj/item/cell/lasgun/volkite/powerpack/marine = -1,
 			/obj/item/storage/pouch/general/medium = -1,
 		),


### PR DESCRIPTION
## About The Pull Request
The field utility pouch had an inaccurate description of what items it can contain, such as map tablets, compasses, and deployable cameras.
This adds several items to the can_hold list, including a compass, Undeployed "Huginn" ROC-58 Observer, hud tablet, minimap tablet, ASRS tablet, megaphone, hand labeller, and deck of cards, as well as papers and clipboard which was in can_hold list of document pouch. This also removes the document pouch from the marine vending machine.

## Why It's Good For The Game
The field utility pouch had a limited amount of can_hold which did not have even items that would not grant any advantage in combat, therefore limiting the viability of using it even as a meme loadout or for roleplay purposes.

I deem the document pouch to have a too niche purpose and bloated the vending machine menu, therefore the function of the document pouch is amalgamated into the field utility pouch. If someone wants to pack more papers, they can use a clipboard to store more papers.

I considered including the flares since the old description said you can store flares, but having able to store whole packs of flares would have destroyed the purpose of the flare gun pouch since it effectively makes the pouch an upgrade to flare gun pouch, and would allow marines to spam flares to the point xenos cannot melt enough flares to catch up with the speed of spamming, therefore the mention of flare in the description is omitted and the pouch will still not be able to hold flares.

This change would retain the pros and cons versus the general pouch because the field utility pouch still cannot hold items that are directly associated with the action such as small ammo, xeno structure pinpointer, and mini fire extinguisher.
## Changelog
:cl:
balance: The field utility pouch now can hold compass, "Huginn" ROC-58 Observer, the map tablets, ASRS tablet, megaphone, hand labeller, and deck of cards, as well as papers and clipboard.
del: Removed the document pouch from the vending machine.
/:cl:
