### PR TITLE
Fixes AGLS Incendiary ammo not making fire.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1863,6 +1863,18 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/M, obj/projectile/proj)
 	return
 
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/M, obj/projectile/P)
+	drop_flame(get_turf(M))
+
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/O, obj/projectile/P)
+	drop_flame(get_turf(O))
+
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/T, obj/projectile/P)
+	drop_flame(get_turf(T))
+
+/datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/T, obj/projectile/P)
+	drop_flame(get_turf(T))
+
 /datum/ammo/bullet/ags_spread/incendiary/drop_flame(turf/T)
 	if(!istype(T))
 		return


### PR DESCRIPTION

## About The Pull Request
This ammo has a drop_flame() proc which seems to want to drop fire on tiles it hits, but it is never called anywhere.
I'm just gonna copy the flamer code for this so that it actually flames things as intended.
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: AGLS Incendiary ammo drops fire now.
/:cl:
