### PR TITLE
Reduced miner slash time

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -320,7 +320,7 @@
 	while(miner_status != MINER_DESTROYED)
 		if(X.do_actions)
 			return balloon_alert(X, "busy")
-		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
+		if(!do_after(X, 1.5 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
 			return
 		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
 		X.visible_message(span_danger("[X] slashes \the [src]!"), \


### PR DESCRIPTION
## About The Pull Request
Now you can no longer bypass the while loop, slashing miners takes notably longer.
Halves the time to make it a bit quicker, also in particular means its possible to do hit and run attacks on miners to chip it down.
## Why It's Good For The Game
walance
## Changelog
:cl:
balance: Miner slash time reduced to 1.5 seconds per cycle
/:cl:
