### PR TITLE
Adds Bulletproof Vest to Standard Armor Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1270,6 +1270,7 @@
 			/obj/item/clothing/suit/modular/rownin = -1,
 			/obj/item/clothing/suit/modular/xenonauten/pilot = -1,
 			/obj/item/facepaint/green = -1,
+			/obj/item/clothing/suit/armor/bulletproof = -1,
 		),
 		"Armor modules" = list(
 			/obj/item/armor_module/storage/general = -1,


### PR DESCRIPTION

## About The Pull Request
Puts bulletproof vest in the standard armor vendor at unlimited quantity. 

## Why It's Good For The Game
Bulletproof vest is worn for the drip, it's pretty bad in terms of stats. Only covers chest, overall bad armor (MELEE = 30, BULLET = 55, LASER = 0, ENERGY = 0, BOMB = 30, BIO = 0, FIRE = 0, ACID = 15), no suit light, no armor modules, and limited suit storage options. The 20 bullet hard armor gave it a niche advantage, but I think #12720 makes this less of an advantage than before. As for the 5 acid hard armor, I don't think anything does acid damage and has AP anyways. 

This just makes it less annoying for people who want to wear the bulletproof vest for drip. 

## Changelog
Adds bulletproof vest to standard armor vendor

:cl:
add: adds bulletproof vest to standard armor vendor
/:cl:
