### PR TITLE
Small sectoid buff

### DIFF
--- a/code/datums/jobs/job/sectoid.dm
+++ b/code/datums/jobs/job/sectoid.dm
@@ -38,7 +38,7 @@
 
 /datum/outfit/job/sectoid/grunt/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
@@ -73,7 +73,7 @@
 
 /datum/outfit/job/sectoid/leader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/sectoid_rifle, SLOT_IN_BELT)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1279,6 +1279,10 @@
 	accuracy_mult_unwielded = 0.8
 	movement_acc_penalty_mult = 3
 
+/obj/item/weapon/gun/rifle/sectoid_rifle/Initialize(mapload, spawn_empty)
+	. = ..()
+	AddComponent(/datum/component/reequip, list(SLOT_BACK)) //Sectoids have alien powers that make them not lose their gun
+
 //only sectoids can fire it
 /obj/item/weapon/gun/rifle/sectoid_rifle/able_to_fire(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Gives sectoid gun innate mag harness.
Fills the sectoid belt with another magazine (It has an empty slot usually)
## Why It's Good For The Game
Sectoids have ammo issues and "oh no I lost my gun and now I'm useless" issues, I feel like this is a reasonable buff.
## Changelog
:cl:
balance: Sectoids have 1 more magazine and innate mag harness for their gun.
/:cl:
