### PR TITLE
change broken computer warning to be a bit less misleading.

### DIFF
--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -35,7 +35,7 @@
 		. += span_warning("It is currently disabled, and can be fixed with a welder.")
 
 	if(machine_stat & BROKEN)
-		. += span_warning("It is broken and needs to be rebuilt.")
+		. += span_warning("It is broken.")
 
 /obj/machinery/computer/process()
 	if(machine_stat & (NOPOWER|BROKEN|DISABLED))


### PR DESCRIPTION

## About The Pull Request
"It is broken" instead of "It is broken and needs to be rebuilt."
## Why It's Good For The Game
You can't rebuild tad computer, this is misleading.
## Changelog
:cl:
spellcheck: change broken computer warning to be a bit less misleading.
/:cl:
