### PR TITLE
Tones down super rage shake radius + tiny refactor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -374,7 +374,7 @@
 	for(var/turf/affected_tiles AS in RANGE_TURFS(rage_power_radius / 2, X.loc))
 		affected_tiles.Shake(duration = 1 SECONDS) //SFX
 
-	for(var/mob/living/affected_mob in cheap_get_humans_near(X, rage_power_radius)) //Roar that applies cool SFX
+	for(var/mob/living/affected_mob in cheap_get_humans_near(X, rage_power_radius) + cheap_get_xenos_near(X, rage_power_radius)) //Roar that applies cool SFX
 		if(affected_mob.stat) //We don't care about the dead/unconsious
 			continue
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -238,11 +238,15 @@
 
 ///Warns the player when Endure is about to end
 /datum/action/xeno_action/endure/proc/endure_warning()
+	if(QDELETED(owner))
+		return
 	to_chat(owner,span_highdanger("We feel the plasma draining from our veins... [ability_name] will last for only [timeleft(endure_duration) * 0.1] more seconds!"))
 	owner.playsound_local(owner, 'sound/voice/hiss4.ogg', 50, 0, 1)
 
 ///Turns off the Endure buff
 /datum/action/xeno_action/endure/proc/endure_deactivate()
+	if(QDELETED(owner))
+		return
 	var/mob/living/carbon/xenomorph/X = owner
 
 	UnregisterSignal(X, COMSIG_XENOMORPH_BRUTE_DAMAGE)
@@ -367,20 +371,19 @@
 			ravage.clear_cooldown() //Reset ravage cooldown
 		RegisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(drain_slash))
 
-	for(var/turf/affected_tiles AS in RANGE_TURFS(rage_power_radius, X.loc))
+	for(var/turf/affected_tiles AS in RANGE_TURFS(rage_power_radius / 2, X.loc))
 		affected_tiles.Shake(duration = 1 SECONDS) //SFX
 
-	for(var/mob/living/L AS in GLOB.mob_living_list) //Roar that applies cool SFX
-		if(L.stat == DEAD || !L.hud_used || (get_dist(L, X) > rage_power_radius)) //We don't care about the dead
+	for(var/mob/living/affected_mob in cheap_get_humans_near(X, rage_power_radius)) //Roar that applies cool SFX
+		if(affected_mob.stat) //We don't care about the dead/unconsious
 			continue
 
-		shake_camera(L, 1 SECONDS, 1)
-		L.Shake(duration = 1 SECONDS) //SFX
+		shake_camera(affected_mob, 1 SECONDS, 1)
+		affected_mob.Shake(duration = 1 SECONDS) //SFX
 
 		if(rage_power >= RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
-
-			var/atom/movable/screen/plane_master/floor/OT = L.hud_used.plane_masters["[FLOOR_PLANE]"]
-			var/atom/movable/screen/plane_master/game_world/GW = L.hud_used.plane_masters["[GAME_PLANE]"]
+			var/atom/movable/screen/plane_master/floor/OT = affected_mob.hud_used.plane_masters["[FLOOR_PLANE]"]
+			var/atom/movable/screen/plane_master/game_world/GW = affected_mob.hud_used.plane_masters["[GAME_PLANE]"]
 
 			addtimer(CALLBACK(OT, TYPE_PROC_REF(/atom, remove_filter), "rage_outcry"), 1 SECONDS)
 			GW.add_filter("rage_outcry", 2, radial_blur_filter(0.07))
@@ -417,6 +420,8 @@
 
 ///Warns the user when his rage is about to end.
 /datum/action/xeno_action/rage/proc/rage_warning(bonus_duration = 0)
+	if(QDELETED(owner))
+		return
 	to_chat(owner,span_highdanger("Our rage begins to subside... [ability_name] will only last for only [(RAVAGER_RAGE_DURATION + bonus_duration) * (1-RAVAGER_RAGE_WARNING) * 0.1] more seconds!"))
 	owner.playsound_local(owner, 'sound/voice/hiss4.ogg', 50, 0, 1)
 
@@ -449,7 +454,8 @@
 
 ///Called when we want to end the Rage effect
 /datum/action/xeno_action/rage/proc/rage_deactivate()
-
+	if(QDELETED(owner))
+		return
 	var/mob/living/carbon/xenomorph/X = owner
 
 	X.do_jitter_animation(1000)


### PR DESCRIPTION

## About The Pull Request

For some reason shaking a lot of tiles in a wide radius causes severe clientside lag in certain cases. Smaller radius seems to work alright though.

Adds checks to the callback procs to make sure owner didn't get deleted (read: gibbed) in the meantime.

Also makes the for loop that makes the nearby people get the funny screenoverlay from super rage use `cheap_get_[humans/xenos]_near`.
## Why It's Good For The Game

Toning down potential clientside lag should be good.
## Changelog
:cl:
fix: Toned down super rage shake radius to help with potential clientside lag
/:cl:
