### PR TITLE
Fixes `adjust_fire_stacks` trying to affect qdeleted mobs

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -129,6 +129,8 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
+	if(QDELETED(src))
+		return
 	if(status_flags & GODMODE) //Invulnerable mobs don't get fire stacks
 		return
 	if(add_fire_stacks > 0)	//Fire stack increases are affected by armor, end result rounded up.


### PR DESCRIPTION

## About The Pull Request

This causes runtimes.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed adjust_fire_stacks trying to affect qdeleted mobs
/:cl:
