### PR TITLE
Fixes cas gau exploding contents of turfs twice

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -254,8 +254,6 @@
 		strafelist -= strafed
 		strafed.ex_act(EXPLODE_LIGHT)
 		new /obj/effect/temp_visual/heavyimpact(strafed)
-		for(var/atom/movable/AM AS in strafed)
-			AM.ex_act(EXPLODE_LIGHT)
 
 	if(length(strafelist))
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 2)


### PR DESCRIPTION

## About The Pull Request

Causes deleted objects to try to take damage which causes runtimes.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed cas gau exploding contents of turfs twice
/:cl:
