### PR TITLE
Fixes some auto observe runtimes

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -842,6 +842,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	if(observetarget?.observers)
 		observetarget.observers -= src
 		UNSETEMPTY(observetarget.observers)
+	if(observetarget)
+		UnregisterSignal(observetarget, COMSIG_QDELETING)
 	observetarget = null
 
 /mob/dead/observer/verb/dnr()

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -38,7 +38,7 @@
 			. = TRUE
 		if("toggle_observe")
 			auto_observe = !auto_observe
-			if(auto_observe && !QDELETED(owner.orbiting.parent))
+			if(auto_observe && !QDELETED(owner?.orbiting?.parent))
 				owner.do_observe(owner.orbiting.parent)
 			else
 				owner.reset_perspective(null)


### PR DESCRIPTION

## About The Pull Request

The signal never got unregistered, so orbiting the same person twice in a row would override the signal with an error.

Also it'd runtime if you pressed the auto observe button without orbiting anyone.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixed some auto observe runtimes
/:cl:
