### PR TITLE
Dynamic sprite revert for SOM and ICC pouches

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -69,11 +69,13 @@
 	name = "mining general pouch"
 	desc = "A general purpose pouch used to carry small items used during mining."
 	icon_state = "general_som"
+	sprite_slots = null
 	draw_mode = 1
 
 /obj/item/storage/pouch/general/large/som
 	desc = "A general purpose pouch used to carry small items used during mining."
 	icon_state = "large_drop_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/bayonet
 	name = "bayonet sheath"
@@ -154,6 +156,7 @@
 	name = "mining first aid pouch"
 	desc = "A basic first aid pouch originally used by miners due to dangerous working conditions on the mining colonies. This one is marked as belonging to the SOM."
 	icon_state = "firstaid_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/firstaid/som/full/Initialize(mapload)
 	. = ..()
@@ -207,10 +210,12 @@
 /obj/item/storage/pouch/pistol/som
 	desc = "It can contain a pistol or revolver. Useful for emergencies, and made out of stylish leather in the old SOM tradition."
 	icon_state = "pistol_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/pistol/icc
 	desc = "It can contain a pistol or revolver. Useful for emergencies, and made is out of a syntheic tan fabric."
 	icon_state = "pistol_icc"
+	sprite_slots = null
 
 //// MAGAZINE POUCHES /////
 
@@ -255,10 +260,12 @@
 /obj/item/storage/pouch/magazine/large/som
 	desc = "This pouch can contain three ammo magazines. Made with traditional SOM leather."
 	icon_state = "mag_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/magazine/large/icc
 	desc = "This pouch can contain three ammo magazines, appears to be made with a synthetic tan fiber."
 	icon_state = "mag_icc"
+	sprite_slots = null
 
 /obj/item/storage/pouch/magazine/pistol
 	name = "pistol magazine pouch"
@@ -388,10 +395,12 @@
 	name = "\improper S26 explosive pouch"
 	desc = "A leather pouch for storing grenades, rockets, mine boxes, and other explosives."
 	icon_state = "explosive_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/explosive/icc
 	desc = "It can contain grenades, plastiques, mine boxes, and other explosives. Clearly made from with a synthetic tan fiber."
 	icon_state = "large_explosive_icc"
+	sprite_slots = null
 
 /obj/item/storage/pouch/grenade
 	name = "grenade pouch"
@@ -419,6 +428,7 @@
 /obj/item/storage/pouch/grenade/som
 	desc = "It can contain grenades. This one looks to be made out of traditional SOM leather."
 	icon_state = "grenade_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/grenade/som/combat_patrol/Initialize(mapload)
 	. = ..()
@@ -484,6 +494,7 @@
 /obj/item/storage/pouch/medkit/som
 	desc = "A standard use medkit pouch that can contain all kinds of medical supplies and equipment. Made with traditional SOM leather."
 	icon_state = "medkit_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/medical_injectors
 	name = "medical injector pouch"
@@ -522,6 +533,7 @@
 /obj/item/storage/pouch/medical_injectors/som
 	desc = "A specialized medical pouch that can only hold auto-injectors. This one looks to be made out of traditional SOM leather."
 	icon_state = "firstaid_injector_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/medical_injectors/som/firstaid/Initialize(mapload)
 	. = ..()
@@ -548,6 +560,7 @@
 /obj/item/storage/pouch/medical_injectors/icc
 	desc = "A specialized medical pouch that can only hold auto-injectors. This one looks to be made out of a synthetic tan fabric."
 	icon_state = "firstaid_injector_icc"
+	sprite_slots = null
 
 /obj/item/storage/pouch/medical_injectors/icc/firstaid/Initialize(mapload)
 	. = ..()
@@ -709,10 +722,12 @@
 /obj/item/storage/pouch/construction/som
 	desc = "It's designed to hold construction materials - glass/metal sheets, metal rods, barbed wire, cable coil, and empty sandbags. It also has a hook for an entrenching tool. Made with traditional SOM leather."
 	icon_state = "construction_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/construction/icc
 	desc = "It's designed to hold construction materials - glass/metal sheets, metal rods, barbed wire, cable coil, and empty sandbags. It also has a hook for an entrenching tool. Made with synthetic tan."
 	icon_state = "construction_icc"
+	sprite_slots = null
 
 /obj/item/storage/pouch/construction/icc/full/Initialize(mapload)
 	. = ..()
@@ -754,6 +769,7 @@
 /obj/item/storage/pouch/tools/som
 	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool. Made with traditional SOM leather."
 	icon_state = "tools_som"
+	sprite_slots = null
 
 /obj/item/storage/pouch/tools/som/full/Initialize(mapload)
 	. = ..()
@@ -766,6 +782,7 @@
 /obj/item/storage/pouch/tools/icc
 	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool. Made with a synthetic tan fiber."
 	icon_state = "tools_icc"
+	sprite_slots = null
 
 /obj/item/storage/pouch/tools/icc/full/Initialize(mapload)
 	. = ..()
@@ -818,3 +835,4 @@
 /obj/item/storage/pouch/shotgun/som
 	desc = "A pouch specialized for holding shotgun ammo. Made with traditional SOM leather."
 	icon_state = "shotshells_som"
+	sprite_slots = null


### PR DESCRIPTION

## About The Pull Request

This will fix the SOM and ICC pouches going invisible when they are empty.
## Why It's Good For The Game

SOM operatives would appreciate a stealth camouflage but not if it is only applied to their pouches.
## Changelog
:cl:
fix: Fixed SOM and ICC pouches going invisible when they are empty
/:cl:
