### PR TITLE
Hunter illusions now work as intended

### DIFF
--- a/code/modules/ai/ai_behaviors/xeno/xeno_illusion.dm
+++ b/code/modules/ai/ai_behaviors/xeno/xeno_illusion.dm
@@ -20,6 +20,7 @@
 				attack_target(src, victim)
 				set_escorted_atom(src, victim)
 				return
+
 /datum/ai_behavior/xeno/illusion/attack_target(datum/soure, atom/attacked)
 	if(!attacked)
 		attacked = atom_to_walk_to

--- a/code/modules/ai/ai_behaviors/xeno/xeno_illusion.dm
+++ b/code/modules/ai/ai_behaviors/xeno/xeno_illusion.dm
@@ -2,12 +2,24 @@
 	target_distance = 3 //We attack only nearby
 	base_action = ESCORTING_ATOM
 	is_offered_on_creation = FALSE
+	/// How close a human has to be in order for illusions to react
+	var/illusion_react_range = 5
 
 /datum/ai_behavior/xeno/illusion/New(loc, parent_to_assign, escorted_atom)
 	if(!escorted_atom)
 		base_action = MOVING_TO_NODE
 	..()
 
+/// We want a separate look_for_new_state in order to make illusions behave as we wish
+/datum/ai_behavior/xeno/illusion/look_for_new_state()
+	switch(current_action)
+		if(ESCORTING_ATOM)
+			for(var/mob/living/carbon/human/victim in view(illusion_react_range, mob_parent))
+				if(victim.stat == DEAD)
+					continue
+				attack_target(src, victim)
+				set_escorted_atom(src, victim)
+				return
 /datum/ai_behavior/xeno/illusion/attack_target(datum/soure, atom/attacked)
 	if(!attacked)
 		attacked = atom_to_walk_to

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -457,15 +457,10 @@
 
 /// Spawns a set of illusions around the hunter
 /datum/action/xeno_action/mirage/proc/spawn_illusions()
-	switch(owner.a_intent)
-		if(INTENT_HARM) //Escort us and attack nearby enemy
-			var/mob/illusion/xeno/center_illusion = new (owner.loc, owner, owner, illusion_life_time)
-			for(var/i in 1 to (illusion_count - 1))
-				illusions += new /mob/illusion/xeno(owner.loc, owner, center_illusion, illusion_life_time)
-			illusions += center_illusion
-		if(INTENT_HELP, INTENT_GRAB, INTENT_DISARM) //Disperse
-			for(var/i in 1 to illusion_count)
-				illusions += new /mob/illusion/xeno(owner.loc, owner, null, illusion_life_time)
+	var/mob/illusion/xeno/center_illusion = new (owner.loc, owner, owner, illusion_life_time)
+	for(var/i in 1 to (illusion_count - 1))
+		illusions += new /mob/illusion/xeno(owner.loc, owner, center_illusion, illusion_life_time)
+	illusions += center_illusion
 	addtimer(CALLBACK(src, PROC_REF(clean_illusions)), illusion_life_time)
 
 /// Clean up the illusions list


### PR DESCRIPTION

## About The Pull Request

Bugfix good and very much overdue.

Mirage illusions now always follow hunter until they find a marine within range ( 5 tiles as of now ).
When that happens, they will stick to them and attack until they die.
## Why It's Good For The Game
bugfix good
## Changelog
:cl:
fix: hunter mirage now works as intended
/:cl:
