### PR TITLE
Reverts #12170 (Chem skill lock)

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -134,10 +134,6 @@
 		dispensable_reagents -= emagged_reagents
 
 /obj/machinery/chem_dispenser/ui_interact(mob/user, datum/tgui/ui)
-	if(needs_medical_training && ishuman(usr) && user.skills.getRating(SKILL_MEDICAL) < SKILL_MEDICAL_PRACTICED)
-		balloon_alert(user, "You don't know how to use this")
-		return
-
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ChemDispenser", name)
@@ -185,6 +181,15 @@
 	. = ..()
 	if(.)
 		return
+
+	if(needs_medical_training && ishuman(usr))
+		var/mob/living/carbon/human/user = usr
+		if(user.skills.getRating("medical") < SKILL_MEDICAL_NOVICE)
+			if(user.do_actions)
+				return
+			to_chat(user, span_notice("You start fiddling with \the [src]..."))
+			if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
+				return
 
 	switch(action)
 		if("amount")

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -121,6 +121,11 @@
 
 	var/mob/living/user = usr
 
+	if(user.skills.getRating("medical") < SKILL_MEDICAL_NOVICE)
+		to_chat(user, span_notice("You start fiddling with \the [src]..."))
+		if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
+			return
+
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
 			loaded_pill_bottle.loc = loc
@@ -341,9 +346,6 @@
 /obj/machinery/chem_master/interact(mob/user)
 	. = ..()
 	if(.)
-		return
-	if(user.skills.getRating(SKILL_MEDICAL) < SKILL_MEDICAL_PRACTICED)
-		balloon_alert(user, "skill issue")
 		return
 
 	if(!(user.client in has_sprites))


### PR DESCRIPTION

## About The Pull Request
Reverts the skill lock for chemistry introduced to marines.
## Why It's Good For The Game
As it turns out, most people don't powergame chem, it simply is a QoL benefit that some marines choose to optimize their loudout slightly.
The old PR was argued in favor of since it would "encourage roleplay and interaction", but this is a terrible way of going at it. Artificially forcing roleplay on a non-roleplay server is just distasteful. If people want to roleplay there is nothing stopping them, but it should not be forced.
The people who "powergamed" chemistry as a marine now simply pick corpsman for access, which ends up harming marines more than doing good, as you expect a corpsman to revive people, but the powergamers who pick it for chems simply let corpses go DNR.
## Changelog
:cl:
balance: Chemistry machines no longer require skill to operate
/:cl:
