### PR TITLE
Engineer and corpsman slots actually scale properly now

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -14,6 +14,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/round_finished
 	var/list/round_end_states = list()
 	var/list/valid_job_types = list()
+	var/list/job_points_needed_by_job_type = list()
 
 	var/round_time_fog
 	var/flags_round_type = NONE
@@ -662,6 +663,12 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		return FALSE
 	if(length(SSjob.active_squads[FACTION_TERRAGOV]))
 		scale_squad_jobs()
+	for(var/job_type in job_points_needed_by_job_type)
+		if(!istype(job_type, /datum/job))
+			stack_trace("Invalid job type in job_points_needed_by_job_type. Current mode : [name], Invalid type: [job_type]")
+			continue
+		var/datum/job/scaled_job = SSjob.GetJobType(job_type)
+		scaled_job.job_points_needed = job_points_needed_by_job_type[job_type]
 	return TRUE
 
 /datum/game_mode/proc/scale_squad_jobs()

--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -18,6 +18,9 @@
 		/datum/job/som/squad/medic = 8,
 		/datum/job/som/squad/standard = -1,
 	)
+	job_points_needed_by_job_type = list(
+		/datum/job/som/squad/veteran = 5, //Every 5 non vets join, a new vet slot opens
+	)
 	whitelist_ship_maps = list(MAP_COMBAT_PATROL_BASE)
 	blacklist_ship_maps = null
 	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST)
@@ -49,13 +52,6 @@
 				area_to_lit.set_base_lighting(COLOR_WHITE, 75)
 			if(CEILING_DEEP_UNDERGROUND to CEILING_DEEP_UNDERGROUND_METAL)
 				area_to_lit.set_base_lighting(COLOR_WHITE, 50)
-
-/datum/game_mode/combat_patrol/scale_roles()
-	. = ..()
-	if(!.)
-		return
-	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/som/squad/veteran)
-	scaled_job.job_points_needed = 5 //Every 5 non vets join, a new vet slot opens
 
 /datum/game_mode/combat_patrol/announce()
 	to_chat(world, "<b>The current game mode is - Combat Patrol!</b>")

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -5,14 +5,20 @@
 	flags_xeno_abilities = ABILITY_CRASH
 	valid_job_types = list(
 		/datum/job/terragov/squad/standard = -1,
-		/datum/job/terragov/squad/engineer = 8,
-		/datum/job/terragov/squad/corpsman = 8,
+		/datum/job/terragov/squad/engineer = 1,
+		/datum/job/terragov/squad/corpsman = 1,
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/fieldcommander = 1,
 		/datum/job/xenomorph = FREE_XENO_AT_START
+	)
+	job_points_needed_by_job_type = list(
+		/datum/job/terragov/squad/smartgunner = 20,
+		/datum/job/terragov/squad/corpsman = 10,
+		/datum/job/terragov/squad/engineer = 10,
+		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
 
 	// Round end conditions
@@ -30,15 +36,6 @@
 	///Last time larva balance was checked
 	var/last_larva_check
 	bioscan_interval = 0
-
-
-/datum/game_mode/infestation/crash/scale_roles()
-	. = ..()
-	if(!.)
-		return
-	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	xeno_job.job_points_needed = CRASH_LARVA_POINTS_NEEDED
-
 
 /datum/game_mode/infestation/crash/pre_setup()
 	. = ..()

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -1,5 +1,10 @@
 /datum/game_mode/infestation
 	round_end_states = list(MODE_INFESTATION_X_MAJOR, MODE_INFESTATION_M_MAJOR, MODE_INFESTATION_X_MINOR, MODE_INFESTATION_M_MINOR, MODE_INFESTATION_DRAW_DEATH)
+	job_points_needed_by_job_type = list(
+		/datum/job/terragov/squad/smartgunner = 20,
+		/datum/job/terragov/squad/corpsman = 10,
+		/datum/job/terragov/squad/engineer = 10,
+	)
 	/// If we are shipside or groundside
 	var/round_stage = INFESTATION_MARINE_DEPLOYMENT
 	/// Timer used to calculate how long till the hive collapse due to no ruler
@@ -27,13 +32,6 @@
 		new_tunnel.tunnel_desc = "["An old tunnel dug by a former member of the hive prior to our awakening at [get_area_name(new_tunnel)]"] (X: [new_tunnel.x], Y: [new_tunnel.y])"
 	for(var/i in GLOB.xeno_jelly_pod_turfs)
 		new /obj/structure/xeno/resin_jelly_pod(i, XENO_HIVE_NORMAL)
-
-/datum/game_mode/infestation/scale_roles()
-	. = ..()
-	if(!.)
-		return
-	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/smartgunner)
-	scaled_job.job_points_needed = 20 //For every 10 marine late joins, 1 extra SG
 
 /datum/game_mode/infestation/process()
 	if(round_finished)

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -19,13 +19,19 @@
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
 		/datum/job/terragov/silicon/ai = 1,
-		/datum/job/terragov/squad/engineer = 8,
-		/datum/job/terragov/squad/corpsman = 8,
+		/datum/job/terragov/squad/engineer = 1,
+		/datum/job/terragov/squad/corpsman = 1,
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
 		/datum/job/xenomorph = FREE_XENO_AT_START,
 		/datum/job/xenomorph/queen = 1
+	)
+	job_points_needed_by_job_type = list(
+		/datum/job/terragov/squad/smartgunner = 20,
+		/datum/job/terragov/squad/corpsman = 10,
+		/datum/job/terragov/squad/engineer = 10,
+		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
 
 /datum/game_mode/infestation/nuclear_war/post_setup()
@@ -46,13 +52,6 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_EXPLODED, PROC_REF(on_nuclear_explosion))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
-
-/datum/game_mode/infestation/nuclear_war/scale_roles(initial_players_assigned)
-	. = ..()
-	if(!.)
-		return
-	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/xenomorph) //Xenos
-	scaled_job.job_points_needed = NUCLEAR_WAR_LARVA_POINTS_NEEDED
 
 /datum/game_mode/infestation/nuclear_war/orphan_hivemind_collapse()
 	if(round_finished)


### PR DESCRIPTION

## About The Pull Request

Makes them actually need 5 marines per, so there won't be 14 corpsmen and engi slots on 30 marines.
## Why It's Good For The Game

This is the intended way I'm pretty sure when https://github.com/tgstation/TerraGov-Marine-Corps/pull/13050 was made.
## Changelog
:cl:
fix: Engineer and corpsman slots actually scale properly now
/:cl:
