### PR TITLE
Adds chemistry request lines to (most) shipmaps

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5093,6 +5093,9 @@
 /area/mainship/command/corporateliaison)
 "oM" = (
 /obj/machinery/light/mainship,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 4
 	},
@@ -11327,6 +11330,15 @@
 "Hd" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lounge)
+"He" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Hf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12881,6 +12893,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
+"LJ" = (
+/obj/structure/barricade/metal,
+/obj/machinery/line_nexter{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "LK" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -15920,6 +15939,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
+"UI" = (
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "UJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16650,6 +16675,13 @@
 	dir = 8
 	},
 /area/mainship/command/airoom)
+"WQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/secure/medical{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "WR" = (
 /obj/machinery/door/airlock/mainship/generic/glass{
 	dir = 1
@@ -23778,7 +23810,7 @@ Jt
 lV
 HQ
 Is
-Is
+WQ
 HQ
 pU
 iy
@@ -23874,9 +23906,9 @@ dt
 VC
 VC
 NA
-dt
-VC
-VC
+He
+UI
+LJ
 QB
 VC
 iy

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4311,6 +4311,11 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"ftK" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "ftT" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/tile/chapel{
@@ -6142,6 +6147,15 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
+"hTV" = (
+/obj/machinery/line_nexter{
+	dir = 2
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "hUf" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -11268,6 +11282,10 @@
 	dir = 8
 	},
 /area/mainship/squads/req)
+"opd" = (
+/obj/structure/barricade/metal,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "ope" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
@@ -12766,20 +12784,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "qfF" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/box/syringes{
-	pixel_x = -7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/mass_spectrometer,
-/obj/item/mass_spectrometer,
+/obj/structure/bed/chair/office/dark,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "qfG" = (
@@ -17118,7 +17123,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vwL" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/secure/medical{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "vxx" = (
@@ -48826,7 +48838,7 @@ fZP
 uVk
 xXt
 tkS
-hGT
+ftK
 hUf
 nTx
 jwA
@@ -49084,7 +49096,7 @@ xqW
 nIF
 qfF
 vwL
-hUf
+hTV
 cNy
 hUf
 ylp
@@ -49341,7 +49353,7 @@ pJs
 xXt
 tkS
 hGT
-hUf
+opd
 rPu
 hUf
 mqD
@@ -49598,7 +49610,7 @@ uWK
 wNn
 sFM
 hGT
-hUf
+opd
 nTx
 uDl
 fyR

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -92,9 +92,10 @@
 /area/sulaco/engineering/engine)
 "aaq" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/mass_spectrometer,
-/obj/item/reagent_scanner,
-/obj/item/tool/hand_labeler,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -146,13 +147,11 @@
 	},
 /area/sulaco/medbay/west)
 "aav" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -200,9 +199,12 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay)
 "aaM" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/secure/medical{
+	dir = 8
+	},
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay/chemistry)
 "aaN" = (
@@ -15380,9 +15382,6 @@
 	},
 /area/sulaco/hallway/central_hall)
 "iOv" = (
-/obj/structure/bed/chair/nometal{
-	dir = 4
-	},
 /obj/machinery/air_alarm,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
@@ -16778,7 +16777,6 @@
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "kzw" = (
-/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -16789,6 +16787,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -4895,8 +4895,6 @@
 "bxw" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/smartfridge/chemistry,
-/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "bxH" = (
@@ -7483,11 +7481,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/delta)
 "cbA" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/recharger,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating,
 /area/mainship/medical/lower_medical)
 "cbE" = (
 /turf/open/floor/mainship/sterile/side{
@@ -8205,6 +8201,15 @@
 	dir = 8
 	},
 /area/mainship/hallways/bow_hallway)
+"cNM" = (
+/obj/machinery/line_nexter{
+	dir = 8
+	},
+/obj/structure/barricade/metal,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "cNZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -8840,6 +8845,14 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
+"dPt" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "dPz" = (
 /obj/machinery/crema_switch{
 	pixel_x = -24
@@ -10784,7 +10797,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "hiF" = (
-/obj/structure/bed/stool,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -11900,11 +11915,8 @@
 /area/mainship/hallways/aft_hallway)
 "jfZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/machinery/door/window/secure,
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/window/secure/medical,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "jgp" = (
@@ -12792,6 +12804,16 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/bow_hallway)
+"kMt" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/structure/table/mainship/nometal,
+/obj/machinery/recharger,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "kMC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -15432,6 +15454,9 @@
 "pdX" = (
 /obj/machinery/light/mainship{
 	dir = 4
+	},
+/obj/structure/barricade/metal{
+	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
@@ -52593,16 +52618,16 @@ buo
 yeW
 mBx
 pdX
+dPt
+cNM
 vuV
-vuV
-cbA
 xpi
 eMf
 xpi
 oAM
 whN
 gEJ
-pdX
+kMt
 uEy
 tZb
 uQx
@@ -52852,7 +52877,7 @@ ost
 nSl
 bxw
 jfZ
-mUE
+cbA
 nSl
 nSl
 mUE

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -252,3 +252,7 @@
 /obj/machinery/door/window/secure/engineering/right
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
+
+// Med Doors
+/obj/machinery/door/window/secure/medical
+	req_access = list(ACCESS_MARINE_CHEMISTRY)


### PR DESCRIPTION

## About The Pull Request
Read title.
Here is what chem looks like now on the shipmaps:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/5963f7ca-2c3c-4553-8521-3f89969cbf46)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/da40d0b8-7b5d-47ac-bfa3-494497dcdd9d)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/d0941b4e-4f42-48bf-9d6b-e425c8185472)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/067a0b81-e15c-48b3-90bc-2f3772345319)
## Why It's Good For The Game
Since there are still req lines (on PoS, for example), if we ever need chemical request lines they are there; smartfridge only is sort of sad.
## Changelog
:cl:
add: Added chemistry request lines to most shipmaps.
/:cl:
