### PR TITLE
Blood regen changes

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -12,12 +12,6 @@
 		return
 
 	if(stat != DEAD && bodytemperature >= 170)	//Dead or cryosleep people do not pump the blood.
-
-
-
-		//Blood regeneration if there is some space
-		if(blood_volume < BLOOD_VOLUME_NORMAL)
-			blood_volume += 0.1 // regenerate blood VERY slowly
 		if(blood_volume > BLOOD_VOLUME_MAXIMUM) //Warning: contents under pressure.
 			var/spare_blood = blood_volume - ((BLOOD_VOLUME_MAXIMUM + BLOOD_VOLUME_NORMAL) / 2) //Knock you to the midpoint between max and normal to not spam.
 			if(drip(spare_blood))
@@ -76,8 +70,13 @@
 			switch(nutrition)
 				if(300 to INFINITY)
 					adjust_nutrition(-10)
+					blood_volume += 1 // regenerate blood quickly
 				if(200 to 300)
 					adjust_nutrition(-3)
+					blood_volume += 0.5 // regenerate blood slowly
+				if(0 to 200)
+					adjust_nutrition(-1)
+					blood_volume += 0.1 // Regenerate blood VERY slowly
 
 		//Bleeding out
 		var/blood_max = 0

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -65,18 +65,18 @@
 				death()
 
 
-		// Without enough blood you slowly go hungry.
+		// Blood regens using food, more food = more blood.
 		if(blood_volume < BLOOD_VOLUME_SAFE)
 			switch(nutrition)
-				if(300 to INFINITY)
+				if(450 to INFINITY)
 					adjust_nutrition(-10)
-					blood_volume += 1 // regenerate blood quickly
-				if(200 to 300)
-					adjust_nutrition(-3)
-					blood_volume += 0.5 // regenerate blood slowly
-				if(0 to 200)
+					blood_volume += 1 // regenerate blood quickly.
+				if(250 to 450)
+					adjust_nutrition(-5)
+					blood_volume += 0.5 // regenerate blood slowly.
+				if(0 to 250)
 					adjust_nutrition(-1)
-					blood_volume += 0.1 // Regenerate blood VERY slowly
+					blood_volume += 0.1 // Regenerate blood VERY slowly.
 
 		//Bleeding out
 		var/blood_max = 0

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -66,7 +66,7 @@
 
 
 		// Blood regens using food, more food = more blood.
-		if(blood_volume < BLOOD_VOLUME_SAFE)
+		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			switch(nutrition)
 				if(450 to INFINITY)
 					adjust_nutrition(-10)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -68,13 +68,13 @@
 		// Blood regens using food, more food = more blood.
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			switch(nutrition)
-				if(450 to INFINITY)
+				if(NUTRITION_OVERFED to INFINITY)
 					adjust_nutrition(-10)
 					blood_volume += 1 // regenerate blood quickly.
-				if(250 to 450)
+				if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
 					adjust_nutrition(-5)
 					blood_volume += 0.5 // regenerate blood slowly.
-				if(0 to 250)
+				if(0 to NUTRITION_HUNGRY)
 					adjust_nutrition(-1)
 					blood_volume += 0.1 // Regenerate blood VERY slowly.
 


### PR DESCRIPTION
## About The Pull Request
This pr moves blood regen from just happening very slowly (0.5) when you'd lost blood to now regen based on how much nutrition you have.
at 450 nutrition and up (fat) you regen 1 whole blood per life tick (or whatever blood works in).
250 to 450 nutrition (The green zone) You regen 0.5 per blood tick.
0 to 250 (starve zone) You regen 0.1 blood per blood tick.

## Why It's Good For The Game
It made no sense to ALWAYS regen 0.5 blood per tick no matter how much blood you have lost and randomly lose a LOT of nutrition for no tradeoff.
Now you regen blood based on how much food you have in you, which I believe is how it works on all other servers and lets regenning blood not SOLELY rely on a medic shoving iso and nano in you.

## Changelog

:cl:
balance: Natural blood regen now regens in tiers based on how much nutrition you have.
/:cl:

