### PR TITLE
Allows toggling of gimmick tads

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -59,6 +59,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/list/whitelist_ground_maps
 	///If the gamemode has a blacklist of disallowed ground maps
 	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST)
+	///if fun tads are enabled by default
+	var/enable_fun_tads = FALSE
 
 
 /datum/game_mode/New()

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -23,6 +23,7 @@
 		/datum/job/terragov/squad/leader = 4,
 		/datum/job/terragov/squad/standard = -1
 	)
+	enable_fun_tads = TRUE
 
 /datum/game_mode/extended/announce()
 	to_chat(world, "<b>The current game mode is - Extended Role-Playing!</b>")

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -124,6 +124,7 @@
 	description = "The plain and simple old Tadpole-03 model."
 	///shuttle switch console name
 	var/display_name = "Tadpole Standard Model"
+	var/admin_enable = TRUE
 
 /datum/map_template/shuttle/minidropship/old
 	suffix = "_big"
@@ -134,6 +135,7 @@
 	suffix = "_food"
 	description = "A Tadpole modified to provide foods and services. Who the hell let this on the military catalogue? Bounty on that guy."
 	display_name = "Tadpole Food-truck Model"
+	admin_enable = FALSE
 
 /datum/map_template/shuttle/minidropship/factorio
 	suffix = "_factorio"

--- a/code/game/objects/machinery/computer/dropship_picker.dm
+++ b/code/game/objects/machinery/computer/dropship_picker.dm
@@ -33,6 +33,8 @@
 	. = list()
 	var/list/shuttles = list()
 	for (var/datum/map_template/shuttle/minidropship/shuttle_template AS in SSmapping.minidropship_templates)
+		if(!shuttle_template.admin_enable && !SSticker.mode.enable_fun_tads)
+			continue
 		shuttles += list(list(
 			"name" = shuttle_template.display_name,
 			"description" = shuttle_template.description,
@@ -67,7 +69,7 @@
 	. = ..()
 	if(.)
 		return
-	
+
 	if(dropship_selected)
 		return FALSE
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1304,6 +1304,22 @@
 		return
 	togglebuildmode(mob)
 
+/client/proc/toggle_admin_tads()
+	set category = "Fun"
+	set name = "Toggle Tadpole Restrictions"
+
+	if(!check_rights(R_FUN))
+		return
+
+	if(SSticker.mode.enable_fun_tads)
+		message_admins("[ADMIN_TPMONTY(usr)] toggled Tadpole restrictions off.")
+		log_admin("[key_name(usr)] toggled Tadpole restrictions off.")
+		SSticker.mode.enable_fun_tads = FALSE
+	else
+		SSticker.mode.enable_fun_tads = TRUE
+		message_admins("[ADMIN_TPMONTY(usr)] toggled Tadpole restrictions on.")
+		log_admin("[key_name(usr)] toggled Tadpole restrictions on.")
+
 //returns TRUE to let the dragdrop code know we are trapping this event
 //returns FALSE if we don't plan to trap the event
 /datum/admins/proc/cmd_ghost_drag(mob/dead/observer/frommob, mob/tomob)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -482,6 +482,7 @@ GLOBAL_PROTECT(admin_verbs_sound)
 	/datum/admins/proc/spawn_atom,
 	/client/proc/get_togglebuildmode,
 	/client/proc/mass_replace,
+	/client/proc/toggle_admin_tads,
 	)
 GLOBAL_LIST_INIT(admin_verbs_spawn, world.AVspawn())
 GLOBAL_PROTECT(admin_verbs_spawn)


### PR DESCRIPTION

## About The Pull Request

Alternative to https://github.com/tgstation/TerraGov-Marine-Corps/pull/13650

This PR allows admins to toggle gimmick tadpoles on and off via a verb in the fun panel.
By default I've only added the restriction to the food tad. The extended game mode by default allows all tadpoles unless the admins manually toggle gimmick tads off again.

## Why It's Good For The Game

This option allows for fun tads without messing up normal rounds. Instead of outright denying or removing gimmick tads, they can stay locked away until admins need or want them for an event.

## Changelog
:cl:
add: Added the ability for admins to toggle gimmick tads
balance: The food tad is now classified as a gimmick tad
balance: Gimmick tads now require admin intervention before they can be selected
/:cl:
