### PR TITLE
Prevents shutter open button from working before the shuttles can even take off

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -128,6 +128,11 @@
 /obj/machinery/button/door/open_only/landing_zone/attack_hand(mob/living/user)
 	if((machine_stat & (NOPOWER|BROKEN)))
 		return
+	#ifndef TESTING
+	if(world.time < SSticker.round_start_time + SSticker.mode.deploy_time_lock)
+		to_chat(user, span_notice("The containment shutters can't open yet!"))
+		return
+	#endif
 	if(!allowed(user))
 		to_chat(user, span_danger("Access Denied"))
 		flick("[initial(icon_state)]-denied", src)


### PR DESCRIPTION

## About The Pull Request

Title. There were some AIs opening shutters before 12:10 even apparently.
## Why It's Good For The Game

Limiting (mainly) AI grief capacity good.
## Changelog
:cl:
fix: You can't open the shutters before the alamo can even take off anymore
/:cl:
