### PR TITLE
Fixes freezing on hit

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -50,13 +50,14 @@
 /mob/proc/clear_fullscreens()
 	for(var/category in fullscreens)
 		clear_fullscreen(category)
+	overlay_fullscreen("empty", /atom/movable/screen/fullscreen/empty)
 
 
 /mob/proc/hide_fullscreens()
 	if(client)
 		for(var/category in fullscreens)
 			client.screen -= fullscreens[category]
-
+		client.screen += fullscreens["empty"]
 
 /mob/proc/reload_fullscreens()
 	if(client)
@@ -68,6 +69,7 @@
 				client.screen |= screen
 			else
 				client.screen -= screen
+		client.screen += fullscreens["empty"]
 
 
 /atom/movable/screen/fullscreen
@@ -91,6 +93,9 @@
 		var/list/actualview = getviewsize(client_view)
 		fs_view = client_view
 		transform = matrix(actualview[1]/FULLSCREEN_OVERLAY_RESOLUTION_X, 0, 0, 0, actualview[2]/FULLSCREEN_OVERLAY_RESOLUTION_Y, 0)
+
+/atom/movable/screen/fullscreen/empty
+	icon_state = "empty" //always active, gets BYOND to keep the fullscreen icons loaded
 
 /atom/movable/screen/fullscreen/black
 	icon_state = "black" //just a black square, you can change this if you get better ideas

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -66,6 +66,8 @@
 	mymob = owner
 	hide_actions_toggle = new
 
+	owner.overlay_fullscreen("empty", /atom/movable/screen/fullscreen/empty)
+
 	for(var/mytype in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/rendering_plate)
 		var/atom/movable/screen/plane_master/instance = new mytype()
 		plane_masters["[instance.plane]"] = instance


### PR DESCRIPTION

## About The Pull Request

Fixes a significant bug which was the source of a _lot_ of freezing, particularly for xenos, upon hit. The cause was vignettes/etc. not being loaded in by BYOND, so whenever you'd be hit by any kind of projectile, BYOND's Very Funny Brilliant Code™️ would suddenly have to load every single screen icon ever, from pain to oxyloss to Gorger abilities.

This is probably not the correct solution, so please yell at me in discord to do whatever I need to do to get this PR to a workable state. It does work though. I tested it in local by smashing my head in with a machete and holy shit, it's so smooth. Usually I get a 10 second freeze on my awful laptop, when testing there was no freeze whatsoever.
## Why It's Good For The Game

Freezing very bad, especially when it can be in the double digit seconds.
## Changelog
:cl:
fix: Fixes a significant bug which caused freezing when hit.
/:cl:
