### PR TITLE
Fixes jobs not scaling if nobody readies up + fix a thing I broke

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -155,12 +155,13 @@ SUBSYSTEM_DEF(job)
 
 	initial_players_assigned += length(GLOB.ready_players)
 
+	SSticker.mode.scale_roles()
+
 	JobDebug("DO, Len: [length(unassigned)]")
 	if(!initial_players_assigned)
 		clean_roundstart_occupations()
 		return FALSE
 
-	SSticker.mode.scale_roles()
 
 	//Jobs will use the default access unless the population is below a certain level.
 	var/mat = CONFIG_GET(number/minimal_access_threshold)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -664,7 +664,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(length(SSjob.active_squads[FACTION_TERRAGOV]))
 		scale_squad_jobs()
 	for(var/job_type in job_points_needed_by_job_type)
-		if(!istype(job_type, /datum/job))
+		if(!(job_type in subtypesof(/datum/job)))
 			stack_trace("Invalid job type in job_points_needed_by_job_type. Current mode : [name], Invalid type: [job_type]")
 			continue
 		var/datum/job/scaled_job = SSjob.GetJobType(job_type)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -16,8 +16,8 @@
 	)
 	job_points_needed_by_job_type = list(
 		/datum/job/terragov/squad/smartgunner = 20,
-		/datum/job/terragov/squad/corpsman = 10,
-		/datum/job/terragov/squad/engineer = 10,
+		/datum/job/terragov/squad/corpsman = 5,
+		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
 

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -29,8 +29,8 @@
 	)
 	job_points_needed_by_job_type = list(
 		/datum/job/terragov/squad/smartgunner = 20,
-		/datum/job/terragov/squad/corpsman = 10,
-		/datum/job/terragov/squad/engineer = 10,
+		/datum/job/terragov/squad/corpsman = 5,
+		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
 

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -96,6 +96,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM,
+		/datum/job/terragov/squad/corpsman = SMARTIE_POINTS_REGULAR,
 		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 	)
@@ -158,6 +159,7 @@ Your squaddies will look to you when it comes to construction in the field of ba
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM,
+		/datum/job/terragov/squad/engineer = SMARTIE_POINTS_REGULAR,
 	)
 	job_points_needed = 5
 	html_description = {"
@@ -214,6 +216,8 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
+		/datum/job/terragov/squad/corpsman = SMARTIE_POINTS_REGULAR,
+		/datum/job/terragov/squad/engineer = SMARTIE_POINTS_REGULAR,
 	)
 	job_points_needed = 10 //Redefined via config.
 	html_description = {"
@@ -308,6 +312,8 @@ You can serve a variety of roles, so choose carefully."})
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_HIGH,
+		/datum/job/terragov/squad/corpsman = SMARTIE_POINTS_REGULAR,
+		/datum/job/terragov/squad/engineer = SMARTIE_POINTS_REGULAR,
 		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 	)


### PR DESCRIPTION
## About The Pull Request

- Fixed the job scaling check, thanks istype
- Engineers contribute to corpsman slots and vice versa
- Fixed jobs not scaling if nobody readies up
- Fixes engi/corps taking twice as many points as intended

## Why It's Good For The Game

Bug bad. I forgor istype is more strict when comparing types.
## Changelog
:cl:
fix: Fixed jobs not scaling if nobody readies up
fix: Fixed jobs not being scaled properly
/:cl:
