### PR TITLE
Makes t-foot clear gasses in a useful time period, changes t-foot nades to play better

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -308,7 +308,7 @@
 	if(!.)
 		return
 	if(S.smoke_traits & SMOKE_PLASMALOSS)
-		lifetime -= 2
+		lifetime -= 4
 
 //Xeno acid smoke.
 /obj/effect/particle_effect/smoke/xeno/burn

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -330,11 +330,12 @@
 
 /obj/item/explosive/grenade/smokebomb/drain
 	name = "\improper M40-T smoke grenade"
-	desc = "The M40-T is a small, but powerful Tanglefoot grenade, designed to remove plasma with minimal side effects. Based off the same platform as the M40 HEDP. It is set to detonate in 6 seconds."
+	desc = "The M40-T is a small, but powerful Tanglefoot grenade, designed to remove plasma from xenomorphs with minimal lab proven side-effects. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
 	icon_state = "grenade_pgas"
 	item_state = "grenade_pgas"
 	hud_state = "grenade_drain"
-	det_time = 6 SECONDS
+	det_time = 2 SECONDS
+	smoke_duration = 8
 	icon_state_mini = "grenade_blue"
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss
@@ -344,6 +345,7 @@
 	desc = "A small tiny smart grenade, it is about to blow up in your face, unless you found it inert. Otherwise a pretty normal grenade, other than it is somehow in a primeable state."
 	icon_state = "ags_pgas"
 	det_time = 3 SECONDS
+	smoke_duration = 11
 	smokeradius = 4
 
 /obj/item/explosive/grenade/phosphorus


### PR DESCRIPTION
## About The Pull Request
right now t-foot when deployed BEFORE a xenogas hits directly in the middle of it, will take around 4-5 seconds (30-40% of a boiler gas cloud lifespan) to clear the gas. For acid clouds, it takes around 5 seconds MAX for a marine in the clouds center to actually escape it, meaning that every bit of acid damage will actually do damage

this basically means, even if you have the sense to apply T-foot BEFORE the gas cloud hits, its basically useless as all its effects will be applied to the marines in the gas

this PR seeks to fix that by doubling the speed at which t-foot clears gas

T-foot nade changes:

Goes off in 2 seconds instead of 6 so that way it can be deployed post xeno-gassing and you dont have to wait 6 seconds

Lasts for 15 seconds (starts decaying ~12 seconds)

Instead of lasting for 21 seconds (starts decaying at ~19 seconds)

## Why It's Good For The Game

This PR is good for the game because it gives benefit to deploying t-foot BEFORE a gas cloud hits besides just removing the opaque smoke screen, by making marines inhale less of whatever hostile cloud they're in.

This smokening was an awful change for the game and removed all counters to gas spam, the PR following the smokening mad practically 0 change as marines who were entirely surrounded by gas would still take the FULL damage that comes from being in acid/other gasses, meaning pre-firing tfoot was near useless besides clearing the opaque smoke screen.

The T-Foot nade changes are just to make them play better, 6 seconds det time is absolutely not necessary but also as seen in that round earlier, they last way too long. 

## Changelog
:cl:
balance: t-foot clears gasses at a faster rate
balance: t-foot nades now activate faster but last for ~6 less seconds

/:cl:
