### PR TITLE
AI xenos no longer gib on death every time

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -62,9 +62,6 @@
 				if(XENO_TIER_FOUR)
 					SSmonitor.stats.ancient_T4--
 
-	if(GetComponent(/datum/component/ai_controller))
-		gib()
-
 	eject_victim()
 
 	to_chat(src,"<b>[span_deadsay("<p style='font-size:1.5em'><big>We have perished.</big><br><small>But it is not the end of us yet... wait until a newborn can rise in this world...</small></p>")]</b>")


### PR DESCRIPTION

## About The Pull Request

I have no idea how they weren't gibbing before honestly. These lines of code are 3 years old.
## Why It's Good For The Game

Not intended afaik. Minions should leave a corpse.
## Changelog
:cl:
balance: AI xenos no longer gib on death every time
/:cl:
