### PR TITLE
Changes SG-85 sundering amount from 1 -> 1.75

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1220,7 +1220,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accurate_range = 12
 	damage = 10
 	penetration = 25
-	sundering = 1
+	sundering = 1.75
 	damage_falloff = 0.1
 
 /datum/ammo/bullet/smarttargetrifle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changes SG-85 Sundering amount from 1 -> 1.75

for those of you who are math inclined, this is a 75% increase of sundering capability

Against: ancient queen (65 bullet armor, SG-85 has 25 AP)

BEFORE: 1 SUNDER


https://github.com/tgstation/TerraGov-Marine-Corps/assets/120620754/fcf53cc3-0bdd-4b3f-b20c-49d9b7255466

AFTER: 1.75 SUNDER



https://github.com/tgstation/TerraGov-Marine-Corps/assets/120620754/afb21211-3a7a-4f4a-bfb6-1371e6fffea8





## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This further seperates the SG-85 from SG-29 by making sure their sundering amounts aren't equivalent, its no secret that the SG-85 sucks (a lot).

It occupies a niche in the game of a Smartgun that actually functions as a suppression weapon, but due to many many issues of it always losing its ammo, kinda sucking, not being able to chase at all, I feel like this change is very appropriate since it encourages xenos getting shot by the SG-85 to probably try and not get shot by the SG-85.

SG-85 will always be the worst choice for nearly every situation but this hopefully makes its niche a bit stronger and stop SG's from shouting at new players when they take the SG-85. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: changes SG-85 Sundering from 1 -> 1.75
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
