### PR TITLE
Scout ammo changes

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -720,11 +720,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "A19 high velocity bullet"
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
-	shrapnel_chance = 0
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	accurate_range_min = 6
 	damage = 40
 	penetration = 20
 	sundering = 10
@@ -732,22 +730,21 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/tx8/incendiary
 	name = "high velocity incendiary bullet"
 	hud_state = "hivelo_fire"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING|AMMO_PASS_THROUGH_MOB
 	damage = 25
-	accuracy = -10
 	penetration = 20
 	sundering = 2.5
 
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_MOVABLE
-	damage = 25
-	penetration = 30
-	sundering = 5
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
+	damage = 30
+	penetration = 10
+	sundering = 12.5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, slowdown = 1)
+	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/rifle/mpi_km
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -738,7 +738,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 30
 	penetration = 10
 	sundering = 12.5

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -726,6 +726,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 40
 	penetration = 20
 	sundering = 10
+	bullet_color = COLOR_SOFT_RED
 
 /datum/ammo/bullet/rifle/tx8/incendiary
 	name = "high velocity incendiary bullet"
@@ -734,6 +735,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 25
 	penetration = 20
 	sundering = 2.5
+	bullet_color = LIGHT_COLOR_FIRE
 
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"


### PR DESCRIPTION

## About The Pull Request
Probably TM this first.

Scout ammo no longer has a minimum accurate range. It's had this for 6 years but it didn't even work until I fixed the mechanic, and I'm not entirely sure why the scout has it when its explicitly described as a gun that 'can be used at any range'.

Incendiary ammo now pierces mobs. Currently is completely over shadowed by base ammo in general usefulness, and completely overshadowed in terms of fire application by funny rapid fire incend xray laser.

High impact rounds no longer pierce mobs. They have slightly higher damage, lower AP and better sunder, but most significantly do knockback on top of the current slowdown. This makes it quite a strong soft CC tool against smaller xenos, but it'll need a TM to see if it's too much.

Also removed the 0% shrap chance. No real change in HvX, but this is another ?? stat.

And some important bullet color changes.
## Why It's Good For The Game
Acc minimum range was ?? for this req gun.
Incend ammo and high impact were both pretty meh compared to basic ammo. Should now have a more distinct niches of (more effective) incendiary application, and soft CC/sunder.
## Changelog
:cl:
balance: Scout no longer has an accurate minimum range
balance: Scout incendiary ammo pierces mobs
Balance: Scout high impact ammo now inflicts knockback and slowdown on smaller xenos, but no longer pierces. Also has better sunder but lower AP, and slightly higher damage
/:cl:
