### PR TITLE
CAS GAU N°1 'fix' - Increases the damage

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -252,7 +252,7 @@
 	for(var/i=1 to attack_width)
 		strafed = strafelist[1]
 		strafelist -= strafed
-		strafed.ex_act(EXPLODE_LIGHT)
+		strafed.ex_act(EXPLODE_MEDIUM)
 		new /obj/effect/temp_visual/heavyimpact(strafed)
 
 	if(length(strafelist))


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/13735

This PR made the CAS gau deal less damage in the process of fixing it a bug. I've made 2 pr's for the hell of it, offering EITHER of them, not both, to sort of bring the weapon power back to where it roughly was. This one simply increases the damage on the tiles. 


## Why It's Good For The Game
Fixes good, but fixes that change balance are a bit less good. 

## Changelog

:cl:
balance: increased CAS GAU damage to compensate for loss of double explosions
/:cl:
