### PR TITLE
CAS GAU N°2 'fix' - Lowers the price

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -210,7 +210,7 @@
 	max_ammo_count = 200
 	transferable_ammo = TRUE
 	ammo_used_per_firing = 20
-	point_cost = 75
+	point_cost = 50
 	///Radius of the square that the bullets will strafe
 	var/bullet_spread_range = 2
 	///Width of the square we are attacking, so you can make rectangular attacks later
@@ -264,7 +264,7 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	travelling_time = 3 SECONDS
-	point_cost = 150
+	point_cost = 115
 
 
 //railgun


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/13735

This PR made the CAS gau deal less damage in the process of fixing it a bug. I've made [2 pr's](13770) for the hell of it, offering EITHER of them, not both, to sort of bring the weapon power back to where it roughly was. 
This one simply lowers the price of refills. 


## Why It's Good For The Game
Fixes good, but fixes that change balance are a bit less good. 

## Changelog

:cl:
balance: lowered CAS GAU price to compensate for loss of double explosions
/:cl: