### PR TITLE
Increased Mortar Factory Viability 

### DIFF
--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -491,6 +491,15 @@ GLOBAL_LIST_INIT(mortar_shell, list(
 	. = ..()
 	recipe = GLOB.mortar_shell
 
+/obj/item/factory_part/mortar_shell_tfoot
+	name = "mortar shell"
+	desc = "An unfinished flare mortar shell."
+	result = /obj/item/mortal_shell/plasmaloss
+
+/obj/item/factory_part/mortar_shell_tfoot/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.mortar_shell
+
 /obj/item/factory_part/mortar_shell_flare
 	name = "mortar shell"
 	desc = "An unfinished flare mortar shell."
@@ -500,14 +509,16 @@ GLOBAL_LIST_INIT(mortar_shell, list(
 	. = ..()
 	recipe = GLOB.mortar_shell
 
-/obj/item/factory_part/mortar_shell_tfoot
+/obj/item/factory_part/mortar_shell_smoke
 	name = "mortar shell"
-	desc = "An unfinished flare mortar shell."
-	result = /obj/item/mortal_shell/plasmaloss
+	desc = "An unfinished smoke mortar shell."
+	result = /obj/item/mortal_shell/smoke
 
-/obj/item/factory_part/mortar_shell_tfoot/Initialize(mapload)
+/obj/item/factory_part/mortar_shell_smoke/Initialize(mapload)
 	. = ..()
 	recipe = GLOB.mortar_shell
+
+
 
 GLOBAL_LIST_INIT(mlrs_rocket, list(
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "uncutplate"),

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -312,25 +312,31 @@
 
 /obj/item/factory_refill/mortar_shell_he_refill
 	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become High Explosive shells used in mortars, once finished."
 	refill_type = /obj/item/factory_part/mortar_shell_he
 	refill_amount = 30
 
 /obj/item/factory_refill/mortar_shell_incen_refill
 	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become Incendiary shells used in mortars, once finished."
 	refill_type = /obj/item/factory_part/mortar_shell_incen
 	refill_amount = 30
 
 /obj/item/factory_refill/mortar_shell_tfoot_refill
 	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become Tanglefoot smoke shells used in mortars, once finished."
 	refill_type = /obj/item/factory_part/mortar_shell_tfoot
 	refill_amount = 30
 
 /obj/item/factory_refill/mortar_shell_flare_refill
 	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become Flare shells used in mortars, once finished."
+	refill_type = /obj/item/factory_part/mortar_shell_flare
+	refill_amount = 30
+
+/obj/item/factory_refill/mortar_shell_smoke_refill
+	name = "box of rounded metal plates"
+	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become Smoke shells used in mortars, once finished."
 	refill_type = /obj/item/factory_part/mortar_shell_flare
 	refill_amount = 30
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2167,12 +2167,12 @@ FACTORY
 /datum/supply_packs/factory/mortar_shell_he_refill
 	name = "Mortar High Explosive shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_he_refill)
-	cost = 150
+	cost = 120
 
 /datum/supply_packs/factory/mortar_shell_incen_refill
 	name = "Mortar Incendiary shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_incen_refill)
-	cost = 150
+	cost = 120
 
 /datum/supply_packs/factory/mortar_shell_tfoot_refill
 	name = "Mortar Tanglefoot Gas shell assembly refill"
@@ -2180,9 +2180,14 @@ FACTORY
 	cost = 200
 
 /datum/supply_packs/factory/mortar_shell_flare_refill
-	name = "Mortar High Explosive shell assembly refill"
+	name = "Mortar Flare shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_flare_refill)
-	cost = 150
+	cost = 100
+
+/datum/supply_packs/factory/mortar_shell_smoke_refill
+	name = "Mortar Smoke shell assembly refill"
+	contains = list(/obj/item/factory_refill/mortar_shell_smoke_refill)
+	cost = 100
 
 /datum/supply_packs/factory/mlrs_rocket_refill
 	name = "MLRS High Explosive rocket assembly refill"


### PR DESCRIPTION
## About The Pull Request
This PR did the following, and yes, it is my commit message : 
- Added smoke shells to the factory
- Added some flavor text to make things easier to handle
- Reduced the price of refills from 150 to 120 for HE and INC
- Reduced the price of refills for flare from 150 to 100
- Fixed the flare refills being called HE in the supply computer

Here is the math for HE, flares, and incendiary shells : 

For 10 pts, you get 2 in the req elevator. That's 5 pts per shell. 
For 150 pts, you can get a refill that becomes 30 shells. 150/30 = 5pts per shell. 

The new math for refills is that you start with 120 for HE and INC, meaning you get shells for 4 points each, roughly 20% of discount, without counting possible factory machines, and the bother to actually set it up. Given that tanglefoot shells currently enjoy an effective 40% discount via the factory, I think this is more than fair. 

The howitzer has actual discounts, so I didn't have to touch it. 


## Why It's Good For The Game
Factories are good for 2 things, making things you can't get otherwise, or making things in bulk for cheaper. 
Currently, the mortar factory was straight up worse for everything, save tanglefoot shells. This PR makes it something besides a noob trap. Especially if you factor in that some RO's likely bought machines to make said factories, worsening the ratio. 

## Changelog

:cl:
add: Added mortar smoke shells to the factory
qol: Improved refills flavor text, so you know what's actually in your hands
fix: fixed the Flares refills being wrongly called High Explosives
balance: Actually implemented a discount for HE, INC, Flare and Smoke mortar shells via factory
/:cl:
