### PR TITLE
Bring resin door melee armor back down to previous values

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -155,7 +155,7 @@
 		SMOOTH_GROUP_SURVIVAL_TITANIUM_WALLS,
 		SMOOTH_GROUP_MINERAL_STRUCTURES,
 	)
-	soft_armor = list(MELEE = 50, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 33, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
 	trigger_sound = "alien_resin_move"
 	hit_sound = "alien_resin_move"
 	destroy_sound = "alien_resin_move"


### PR DESCRIPTION

## About The Pull Request

In https://github.com/tgstation/TerraGov-Marine-Corps/pull/12642 I kinda messed up the math. This should make the doors have the same amount of effective hp against melee as before.
## Why It's Good For The Game

Yeah this was a mistake on my part.
## Changelog
:cl:
balance: Bring resin door melee armor back down to previous values
/:cl:
