### PR TITLE
fixes a tile area on magmoor

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -25723,8 +25723,8 @@
 	},
 /area/magmoor/command/office/main)
 "sPW" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/security/infocenter)
 "sQh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -41750,7 +41750,7 @@ pLU
 jJJ
 akY
 guy
-sPW
+mOt
 dPK
 dPK
 dPK
@@ -42217,7 +42217,7 @@ pIQ
 fCK
 sYz
 dPK
-dPK
+sPW
 dPK
 dPK
 dPK


### PR DESCRIPTION
## About The Pull Request

fixes a single tile's area on magmoor
## Why It's Good For The Game

it had fullbright; which was weird.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/9675986c-0a00-4974-b975-79a444c7d646)


## Changelog

:cl:
fix: fixed the area for a single tile in magmoor's security building
/:cl:
