### PR TITLE
limits ship technician to 1 slot roundstart, allows one ST per every 35 marines & Corpsmen

### DIFF
--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -10,7 +10,7 @@
 		/datum/job/terragov/command/staffofficer = 4,
 		/datum/job/terragov/command/pilot = 2,
 		/datum/job/terragov/engineering/chief = 1,
-		/datum/job/terragov/engineering/tech = 2,
+		/datum/job/terragov/engineering/tech = 1,
 		/datum/job/terragov/requisitions/officer = 1,
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/medical/medicalofficer = 6,

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -37,6 +37,7 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 		/datum/job/terragov/squad/engineer = SMARTIE_POINTS_REGULAR,
 		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
+		/datum/job/terragov/engineering/tech = SMARTIE_POINTS_REGULAR,
 	)
 	html_description = {"
 		<b>Difficulty</b>: Easy<br /><br />
@@ -158,6 +159,7 @@ Your squaddies will look to you when it comes to construction in the field of ba
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM,
+		/datum/job/terragov/engineering/tech = SMARTIE_POINTS_REGULAR,
 	)
 	job_points_needed = 5
 	html_description = {"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -484,7 +484,7 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	title = SHIP_TECH
 	comm_title = "ST"
 	paygrade = "PO3"
-	total_positions = 5
+	total_positions = 1
 	supervisors = "the chief ship engineer and the requisitions officer"
 	access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_ENGINEERING)
 	minimal_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_ENGINEERING)
@@ -492,6 +492,7 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	display_order = JOB_DISPLAY_ORDER_SHIP_TECH
 	outfit = /datum/outfit/job/engineering/tech
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD
+	job_points_needed = 35
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game

Sets ST's jobslots to 1 at roundstart

Sets their job_worth to 35, with 1 point gained per corpsman + marine 
If you've ST'd, you know why this is needed. 

ST'ing 95% of the time is a one person job max, with the 5% of the other time of when you need two ship techs being very high pop when RO needs help building factories and doing orders and you are too busy with that to handle OB's and other things.

This also lines up some later engi/shipside changes

## Changelog
:cl:
balance: limits ship technician to 1 slot roundstart, allows one ST per every 35 marines & Corpsmen
/:cl:
