### PR TITLE
Adds cleaning supplies to the NanotrasenMed Plus

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -215,6 +215,8 @@
 			/obj/item/tool/research/excavation_tool = -1,
 			/obj/item/storage/pouch/surgery = -1,
 			/obj/item/armor_module/storage/uniform/surgery_webbing = -1,
+			/obj/item/reagent_containers/spray/surgery = -1,
+			/obj/item/tool/soap = 3,
 			/obj/item/clothing/glasses/hud/health = 6,
 			/obj/item/roller = 6,
 		),


### PR DESCRIPTION
## About The Pull Request
Adds sterilizing spray (100u spray bottle) and ***limited*** amounts of Soap to the vendor.
## Why It's Good For The Game
Nice to keep the Medbay clean, and I made sure the soap is limited to limit grief by slipping people. Good on the conscious to not have to take from Medbay when you want to clean yourself for field surgery, too; even if there is usually some spray bottles there. Soap is already available on the shipmap, just making it more easily accessible to doctors who don't memorize the spawns.
## Changelog
:cl:
add: Added soap and sterilizing spray bottles to the NanotrasenMed Plus
/:cl:
