### PR TITLE
Fix resin door bug

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -165,6 +165,9 @@
 	///The timer that tracks the delay above
 	var/closetimer
 
+/obj/structure/mineral_door/resin/smooth_icon()
+	. = ..()
+	update_icon()
 
 /obj/structure/mineral_door/resin/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Resin doors will no longer appear closed after being created, when they are actually open.
## Why It's Good For The Game
Bug bad.
## Changelog
:cl:
fix: fixed resin doors appearing closed when they are actuall open, after creation
/:cl:
