### PR TITLE
Adds Medical Clothing into the Clothing Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1296,6 +1296,16 @@
 			/obj/item/clothing/head/beret/marine = -1,
 			/obj/item/clothing/head/tgmcberet = -1,
 		),
+		"Medical Clothing" = list(
+			/obj/item/clothing/under/rank/medical/blue = -1,
+			/obj/item/clothing/under/rank/medical/green = -1,
+			/obj/item/clothing/under/rank/medical/purple = -1,
+			/obj/item/clothing/suit/storage/labcoat = -1,
+			/obj/item/clothing/suit/surgical = -1,
+			/obj/item/clothing/mask/surgical = -1,
+			/obj/item/clothing/gloves/latex = -1,
+			/obj/item/clothing/shoes/white = -1,
+		),
 	)
 
 	prices = list()

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -218,16 +218,6 @@
 			/obj/item/clothing/glasses/hud/health = 6,
 			/obj/item/roller = 6,
 		),
-		"Medical Clothing" = list(
-			/obj/item/clothing/under/rank/medical/blue = -1,
-			/obj/item/clothing/under/rank/medical/green = -1,
-			/obj/item/clothing/under/rank/medical/purple = -1,
-			/obj/item/clothing/suit/storage/labcoat = -1,
-			/obj/item/clothing/suit/surgical = -1,
-			/obj/item/clothing/mask/surgical = -1,
-			/obj/item/clothing/gloves/latex = -1,
-			/obj/item/clothing/shoes/white = -1,
-		),
 	)
 	idle_power_usage = 211
 

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -218,6 +218,16 @@
 			/obj/item/clothing/glasses/hud/health = 6,
 			/obj/item/roller = 6,
 		),
+		"Medical Clothing" = list(
+			/obj/item/clothing/under/rank/medical/blue = -1,
+			/obj/item/clothing/under/rank/medical/green = -1,
+			/obj/item/clothing/under/rank/medical/purple = -1,
+			/obj/item/clothing/suit/storage/labcoat = -1,
+			/obj/item/clothing/suit/surgical = -1,
+			/obj/item/clothing/mask/surgical = -1,
+			/obj/item/clothing/gloves/latex = -1,
+			/obj/item/clothing/shoes/white = -1,
+		),
 	)
 	idle_power_usage = 211
 

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -86,7 +86,7 @@
 	permeability_coefficient = 0.50
 
 /obj/item/clothing/under/rank/medical/blue
-	name = "medical scrubs"
+	name = "blue medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."
 	icon_state = "scrubsblue"
 	adjustment_variants = list(
@@ -94,7 +94,7 @@
 	)
 
 /obj/item/clothing/under/rank/medical/green
-	name = "medical scrubs"
+	name = "green medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in dark green."
 	icon_state = "scrubsgreen"
 	adjustment_variants = list(
@@ -102,7 +102,7 @@
 	)
 
 /obj/item/clothing/under/rank/medical/purple
-	name = "medical scrubs"
+	name = "purple medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in deep purple."
 	icon_state = "scrubspurple"
 	adjustment_variants = list(


### PR DESCRIPTION
## About The Pull Request
Adds the MD's clothes into the vendor. In addition, fixes the medical scrub names as the different colors were the same name.
## Why It's Good For The Game
Being able to get these from loadout vendors is nice, and they are not gamebreaking in any fashion; they can help you with surgery but you can already find them on the map either way.
## Changelog
:cl:
add: Added Medical Doctor clothing to the Clothing Vendor in a new section called "Medical Clothing"
fix: Medical scrubs now have their respective color on their name.
/:cl:
