### PR TITLE
makes garand clips smaller

### DIFF
--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -507,6 +507,7 @@
 	name = "C1 Garand enbloc clip"
 	desc = "A enbloc clip filled with .30 caliber rifle rounds for the C1 Garand."
 	caliber = CALIBER_3006
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "garand"
 	icon_state_mini = "clips"
 	default_ammo = /datum/ammo/bullet/rifle/garand


### PR DESCRIPTION

## About The Pull Request
Makes garand ammo weight class small
## Why It's Good For The Game
The garand ammo is fucking massive, despite having like 8 boolet.
This is misery.
## Changelog
:cl:
balance: Garand clips are smaller
/:cl:
