### PR TITLE
Gives pistols full auto

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -37,6 +37,7 @@
 	scatter = -2
 	scatter_unwielded = 4
 	akimbo_additional_delay = 0.9
+	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 
 	placed_overlay_iconstate = "pistol"
 
@@ -195,6 +196,7 @@
 	fire_delay = 0.2 SECONDS
 	accuracy_mult = 1.20 //Has a forced laser sight.
 	accuracy_mult_unwielded = 0.95
+	scatter_unwielded = 4
 	recoil = -2
 	recoil_unwielded = -2
 
@@ -229,7 +231,7 @@
 	accuracy_mult_unwielded = 0.85
 	damage_mult = 1.15
 	recoil = -2
-	recoil_unwielded = -1
+	scatter_unwielded = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper P-1911A1 custom pistol"


### PR DESCRIPTION

## About The Pull Request

Also adjusts the unwielded scatter of 1911 and tp23 since they could be potentially problematic.
## Why It's Good For The Game

Pistols are kinda neglected right now, you see basically none carried. I think this is because of the harsh click gate they're locked behind, meaning you have to click for every shot, which isn't enjoyable to use. I tested out the feel and most pistols are still not more powerful than rifles even with full auto so the balance shouldn't be questionable. This doesn't affect revolvers. 
## Changelog
:cl:
balance: Pistols now have full auto! No more spam clicking
balance: Increased the unwielded scatter of the P23 and 1911
/:cl:
