### PR TITLE
Fix tad window

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -998,6 +998,7 @@
 /obj/structure/dropship_piece/singlewindow/tadpole
 	icon = 'icons/turf/dropship2.dmi'
 	icon_state = "shuttle_single_window"
+	allow_pass_flags = PASS_GLASS
 	resistance_flags = NONE
 	opacity = FALSE
 


### PR DESCRIPTION

## About The Pull Request
The front window inherited some funny flags so you could shoot through it/flame through it.
Fixes #13797

P.S. Please someone reorganise tad and alamo structures/turfs, its the most cursed organisation possible with absolutely no rhyme or reason.
## Why It's Good For The Game
bug bad.
## Changelog
:cl:
fix: fixed the front tad window allow fire and projectiles through
/:cl:
