### PR TITLE
Un-unfuns blood regen and adds more to it

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -81,12 +81,13 @@
 						adjust_nutrition(-1)
 						blood_volume += 0.1 // Regenerate blood VERY slowly.
 			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_OKAY)
+				switch(nutrition)
 					if(NUTRITION_OVERFED to INFINITY) //regens blood from death treshold to around 50% quickly using nutrition and tox
-						adjust_nutrition(-20)
+						adjust_nutrition(-12)
 						adjustToxLoss(1)
 						blood_volume += 5 // regenerate blood very quickly but quickly drains your nutrition and small amounts of tox to keep you alive.
 					if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
-						adjust_nutrition(-10)
+						adjust_nutrition(-8)
 						adjustToxLoss(3)
 						blood_volume += 4 // regenerate blood quickly in exchange for toxin and nutrition.
 					if(0 to NUTRITION_HUNGRY)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -66,17 +66,33 @@
 
 
 		// Blood regens using food, more food = more blood.
-		if(blood_volume < BLOOD_VOLUME_NORMAL)
-			switch(nutrition)
-				if(NUTRITION_OVERFED to INFINITY)
-					adjust_nutrition(-10)
-					blood_volume += 1 // regenerate blood quickly.
-				if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
-					adjust_nutrition(-5)
-					blood_volume += 0.5 // regenerate blood slowly.
-				if(0 to NUTRITION_HUNGRY)
-					adjust_nutrition(-1)
-					blood_volume += 0.1 // Regenerate blood VERY slowly.
+		switch(blood_volume)
+			if(BLOOD_VOLUME_SAFE to BLOOD_VOLUME_NORMAL) //Passively regens blood very slowly from 90% to 100% without a tradeoff.
+				blood_volume += 0.1
+			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE) //Regens blood from 50% ish to 90% using nutrition.
+				switch(nutrition)
+					if(NUTRITION_OVERFED to INFINITY)
+						adjust_nutrition(-10)
+						blood_volume += 1 // regenerate blood quickly.
+					if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
+						adjust_nutrition(-5)
+						blood_volume += 0.5 // regenerate blood slowly.
+					if(0 to NUTRITION_HUNGRY)
+						adjust_nutrition(-1)
+						blood_volume += 0.1 // Regenerate blood VERY slowly.
+			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_OKAY)
+					if(NUTRITION_OVERFED to INFINITY) //regens blood from death treshold to around 50% quickly using nutrition and tox
+						adjust_nutrition(-20)
+						adjustToxLoss(1)
+						blood_volume += 5 // regenerate blood very quickly but quickly drains your nutrition and small amounts of tox to keep you alive.
+					if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
+						adjust_nutrition(-10)
+						adjustToxLoss(3)
+						blood_volume += 4 // regenerate blood quickly in exchange for toxin and nutrition.
+					if(0 to NUTRITION_HUNGRY)
+						adjust_nutrition(-5)
+						adjustToxLoss(5)
+						blood_volume += 3 // Regenerate blood somewhat quickly in exchange for a lot of tox and a little nutrition.
 
 		//Bleeding out
 		var/blood_max = 0

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -69,7 +69,7 @@
 		switch(blood_volume)
 			if(BLOOD_VOLUME_SAFE to BLOOD_VOLUME_NORMAL) //Passively regens blood very slowly from 90% to 100% without a tradeoff.
 				blood_volume += 0.1
-			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE) //Regens blood from 50% ish to 90% using nutrition.
+			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_SAFE) //Regens blood from 60% ish to 90% using nutrition.
 				switch(nutrition)
 					if(NUTRITION_OVERFED to INFINITY)
 						adjust_nutrition(-10)
@@ -80,20 +80,6 @@
 					if(0 to NUTRITION_HUNGRY)
 						adjust_nutrition(-1)
 						blood_volume += 0.1 // Regenerate blood VERY slowly.
-			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_OKAY)
-				switch(nutrition)
-					if(NUTRITION_OVERFED to INFINITY) //regens blood from death treshold to around 50% quickly using nutrition and tox
-						adjust_nutrition(-12)
-						adjustToxLoss(1)
-						blood_volume += 5 // regenerate blood very quickly but quickly drains your nutrition and small amounts of tox to keep you alive.
-					if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
-						adjust_nutrition(-8)
-						adjustToxLoss(3)
-						blood_volume += 4 // regenerate blood quickly in exchange for toxin and nutrition.
-					if(0 to NUTRITION_HUNGRY)
-						adjust_nutrition(-5)
-						adjustToxLoss(5)
-						blood_volume += 3 // Regenerate blood somewhat quickly in exchange for a lot of tox and a little nutrition.
 
 		//Bleeding out
 		var/blood_max = 0


### PR DESCRIPTION

## About The Pull Request
Makes some adjustments to blood regen by making it 3 tiered based on your levels of blood.

## Why It's Good For The Game
The previous iteration made you starve when you went below 90% to regen your blood and players reported that it wasn't very fun. This aims to make the regen better when you are near full blood. It also makes blood regen better when you are close to death but with small amounts of tox.

## Changelog

:cl:
balance: Rebalances blood regen to be more player friendly above 90%
balance: Adds a tier below 50% blood to quickly bring you above 50%
/:cl:

