### PR TITLE
Remove a bad crash site from Big Red

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -47411,7 +47411,7 @@ sZJ
 lVe
 sZJ
 eEK
-irs
+gCQ
 gCQ
 gCQ
 gCQ


### PR DESCRIPTION
## About The Pull Request

![VXIUIfl](https://github.com/tgstation/TerraGov-Marine-Corps/assets/136390975/d58536fb-17c2-4c2e-850b-cbfaebd89018)

## Changelog

:cl:
del: Remove a bad crash site from Big Red
/:cl: