### PR TITLE
Add Medivac beds to Corpsmen vendors for all of their points.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/healthanalyzer/gloves = list(CAT_MEDSUP, "Health scanner gloves", 2, "black"),
 		/obj/item/defibrillator/gloves = list(CAT_MEDSUP, "Advanced medical gloves", 5, "black"),
+		/obj/effect/vendor_bundle/stretcher = list(CAT_ESS, "Medivac Stretcher", 50, "black"),
 	))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/healthanalyzer/gloves = list(CAT_MEDSUP, "Health scanner gloves", 2, "black"),
 		/obj/item/defibrillator/gloves = list(CAT_MEDSUP, "Advanced medical gloves", 5, "black"),
-		/obj/effect/vendor_bundle/stretcher = list(CAT_ESS, "Medivac Stretcher", 45, "black"),
+		/obj/effect/vendor_bundle/stretcher = list(CAT_MEDSUP, "Medivac Stretcher", 45, "black"),
 	))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/healthanalyzer/gloves = list(CAT_MEDSUP, "Health scanner gloves", 2, "black"),
 		/obj/item/defibrillator/gloves = list(CAT_MEDSUP, "Advanced medical gloves", 5, "black"),
-		/obj/effect/vendor_bundle/stretcher = list(CAT_ESS, "Medivac Stretcher", 50, "black"),
+		/obj/effect/vendor_bundle/stretcher = list(CAT_ESS, "Medivac Stretcher", 45, "black"),
 	))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -319,6 +319,7 @@
 	say("Linked AI spotter has relinquished targeting privileges. Ejecting targeting device.")
 	ai_targeter.forceMove(src.loc)
 	ai_targeter = null
+
 /// Handles the continuity transfer of linked binoculars from the mortar struct to the mortar item
 /obj/machinery/deployable/mortar/proc/handle_undeploy_references()
 	SIGNAL_HANDLER

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -679,6 +679,12 @@
 		/obj/item/clothing/glasses/hud/health,
 	)
 
+/obj/effect/vendor_bundle/stretcher
+	gear_to_spawn = list(
+		/obj/item/roller/medevac,
+		/obj/item/medevac_beacon,
+	)
+
 /obj/effect/vendor_bundle/engi
 	gear_to_spawn = list(
 		/obj/item/explosive/plastique,


### PR DESCRIPTION
## About The Pull Request
This PR allows corpsmen to buy a bundle of a bed, and a beacon for the low low price of their entire budget. 
I also added a space in some mortar code, because it was bothering me.

## Why It's Good For The Game
I always wanted to have two beds to chuck people up faster. I am absolutely willing to skimp on the other gear for that
It also gives more work to doctors shipside, which is good. While it is effectively a teleporter, and you could sooort of make a discount telepad with them, I do not think the cooldown makes it any viable for any substantial effect.  

## Changelog

:cl:
add: Added medivac beds to corpsmen vendor for their entire budget
code: Added a space to the mortar code :)
/:cl:
