### PR TITLE
Adds a cap to nutrition and removes fat slowdown

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -25,6 +25,7 @@
 #define NUTRITION_HUNGRY 250
 #define NUTRITION_WELLFED 400
 #define NUTRITION_OVERFED 450
+#define NUTRITION_MAXIMUM 700
 
 //=================================================
 /*

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -6,27 +6,3 @@
 
 /mob/living/carbon/set_Losebreath(amount, forced = FALSE)
 	losebreath = max(amount, 0)
-
-/mob/living/carbon/proc/adjust_nutrition(amount)
-	. = nutrition
-	nutrition = max(nutrition + amount, 0)
-	adjust_nutrition_speed(.)
-
-/mob/living/carbon/proc/set_nutrition(amount)
-	. = nutrition
-	nutrition = max(amount, 0)
-	adjust_nutrition_speed(.)
-
-/mob/living/carbon/proc/adjust_nutrition_speed(old_nutrition)
-	switch(nutrition)
-		if(0 to NUTRITION_HUNGRY) //Level where a yellow food pip shows up, aka hunger level 3 at 250 nutrition and under
-			add_movespeed_modifier(MOVESPEED_ID_HUNGRY, TRUE, 0, NONE, TRUE, round(1.5 - (nutrition / 250), 0.1)) //From 0.5 to 1.5
-		if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
-			switch(old_nutrition)
-				if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
-					return
-			remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)
-		if(NUTRITION_OVERFED to INFINITY) //Overeating
-			if(old_nutrition > NUTRITION_OVERFED)
-				return
-			add_movespeed_modifier(MOVESPEED_ID_HUNGRY, TRUE, 0, NONE, TRUE, 0.5)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -20,6 +20,8 @@
 			handle_breath()
 			//blood
 			handle_blood()
+			//nutrition
+			handle_nutrition()
 
 			if(stat == CONSCIOUS && getToxLoss() >= 45 && nutrition > 20)
 				vomit()

--- a/code/modules/mob/living/nutrition.dm
+++ b/code/modules/mob/living/nutrition.dm
@@ -20,7 +20,7 @@
 					do_vomit()
 				if(100 to INFINITY)
 					visible_message(span_notice("A violent stream of puke shoots out of [src]'s mouth. How'd [p_they()] do that?"), \
-						span_notice("Several jets of blood open up across your body and paint your surroundings red. You feel like you aren't under as much pressure any more."))
+						span_notice("A violent flood of puke spews out of your mouth. You feel like your stomach isn't going to burst anymore."))
 					do_vomit()
 
 /mob/living/carbon/proc/adjust_nutrition(amount)

--- a/code/modules/mob/living/nutrition.dm
+++ b/code/modules/mob/living/nutrition.dm
@@ -1,0 +1,44 @@
+//This file handles most Nutrition stuff.
+/mob/living/proc/handle_nutrition()
+	return
+
+
+// Takes care blood loss and regeneration
+/mob/living/carbon/human/handle_nutrition()
+	if(species.species_flags & NO_BLOOD)
+		return
+
+	if(stat != DEAD && bodytemperature >= 170)	//Dead or cryosleep people do not pump the blood.
+		if(nutrition > NUTRITION_MAXIMUM) //Warning: contents under pressure.
+			var/spare_nutrition = nutrition - ((NUTRITION_MAXIMUM + NUTRITION_OVERFED) / 2 + 40) //Knock you to the midpoint between max and normal to not spam.
+			switch(spare_nutrition)
+				if(0 to 30) //20 is the functional minimum due to midpoint calc
+					to_chat(src, span_notice("Your overfilled stomach regurgitates food."))
+					do_vomit()
+				if(30 to 100)
+					to_chat(src, span_notice("Spare food gushes out of mouth. Must've had too much."))
+					do_vomit()
+				if(100 to INFINITY)
+					visible_message(span_notice("A violent stream of puke shoots out of [src]'s mouth. How'd [p_they()] do that?"), \
+						span_notice("Several jets of blood open up across your body and paint your surroundings red. You feel like you aren't under as much pressure any more."))
+					do_vomit()
+
+/mob/living/carbon/proc/adjust_nutrition(amount)
+	. = nutrition
+	nutrition = max(nutrition + amount, 0)
+	adjust_nutrition_speed(.)
+
+/mob/living/carbon/proc/set_nutrition(amount)
+	. = nutrition
+	nutrition = max(amount, 0)
+	adjust_nutrition_speed(.)
+
+/mob/living/carbon/proc/adjust_nutrition_speed(old_nutrition)
+	switch(nutrition)
+		if(0 to NUTRITION_HUNGRY) //Level where a yellow food pip shows up, aka hunger level 3 at 250 nutrition and under
+			add_movespeed_modifier(MOVESPEED_ID_HUNGRY, TRUE, 0, NONE, TRUE, round(1.5 - (nutrition / 250), 0.1)) //From 0.5 to 1.5
+		if(NUTRITION_HUNGRY to INFINITY)
+			switch(old_nutrition)
+				if(NUTRITION_HUNGRY to NUTRITION_OVERFED)
+					return
+			remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1456,6 +1456,7 @@
 #include "code\modules\mob\living\living_verbs.dm"
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"
+#include "code\modules\mob\living\nutrition.dm"
 #include "code\modules\mob\living\say.dm"
 #include "code\modules\mob\living\status_procs.dm"
 #include "code\modules\mob\living\brain\brain.dm"


### PR DESCRIPTION

## About The Pull Request
This pr puts a cap on nutrition, previously you could have a stupidly high amount and be permanently fat if you so desired, now you can have 700 before you puke out the excess putting you back down to around 600.
Pr also collects a few nutrition procs and puts them in a file with this to make finding nutrition specific stuff a bit easier.
## Why It's Good For The Game
Slowdown is not fun, especially not because of something as simple as eating. Punishing people for being fat only really impacts new players or powergaming players and its not something we need here on TGMC.
Now you will simply puke out the excess nutrition plus a bit more so you don't get spammed by puking and that's that, you can go back to playing the game and not get punished for doing something the game WANTS you to do.
Punishing someone for starving makes sense, but not eating.
## Changelog
:cl:
balance: Instead of being able to have infinite nutrition, you are now capped at 700 before puking.
balance: You no longer get slowed down for being fat.
code: Moved some nutrition code to nutrition specific file from random ish file.
/:cl:
