### PR TITLE
Nerfs the MK88 Mod 4 Combat Pistol

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -407,7 +407,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 12.5
 	shrapnel_chance = 15
-	sundering = 2
+	sundering = 0.5
 
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -516,6 +516,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
+	extra_delay = 0.3 SECONDS
 	burst_amount = 3
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.95


### PR DESCRIPTION
## About The Pull Request
Per title.
Sunder per bullet reduced from 2 to 0.5.
Burst fire now has an additional delay of 0.3 seconds between bursts.

## Why It's Good For The Game
This is option 2 of two PRs I intend to put out for the 88M4 (see: #13815). This thing is allegedly meant to be an ERT-only sidearm that somehow became common access. It currently is hands down one of the best weapons in the game, and xenos aren't having a fun time fighting it in its current state... if they even get the chance to, considering how fast this kills.

## Changelog
:cl: Lewdcifer
balance: MK88 Mod 4 Combat Pistol nerfed. Sunder reduced from 2 > 0.5, burst fire now has a 0.3s delay between bursts.
/:cl: