### PR TITLE
Mentors no longer get automuted by using private message

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -85,6 +85,9 @@
 #define SPAM_TRIGGER_WEIGHT_WARNING 2.5 //The weight required per the time period before the spam-prevention will warn you
 #define SPAM_TRIGGER_WEIGHT_AUTOMUTE 4 //The weight required per the time period before the spam-prevention will automute you
 
+#define MESSAGE_FLAG_ADMIN (1<<0) //! Spam filter info that this message is admin-related and shouldn't count towards admin spam limit (not needed currently due to admins bypassing it but eh!)
+#define MESSAGE_FLAG_MENTOR (1<<1) //! Spam filter info that this message is mentor-related and shouldn't count towards a mentor's spam limit.
+
 #define MAX_LENGTH_REQ_REASON 250
 
 ///Max length of a keypress command before it's considered to be a forged packet/bogus command

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -937,7 +937,7 @@
 					current_ticket.MessageNoRecipient(msg)
 				return
 
-	if(handle_spam_prevention(msg, MUTE_ADMINHELP))
+	if(handle_spam_prevention(msg, MUTE_ADMINHELP, MESSAGE_FLAG_MENTOR|MESSAGE_FLAG_ADMIN))
 		return
 
 	//clean the message if it's not sent by a high-rank admin

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -932,10 +932,10 @@ GLOBAL_VAR_INIT(automute_on, null)
 	if(isnull(GLOB.automute_on))
 		GLOB.automute_on = CONFIG_GET(flag/automute_on)
 
-	if((special_message_flag & MESSAGE_FLAG_MENTOR) && check_rights(R_MENTOR))
+	if((special_message_flag & MESSAGE_FLAG_MENTOR) && check_rights(R_MENTOR, FALSE))
 		return //Please stop muting me in my own responses.
 
-	if((special_message_flag & MESSAGE_FLAG_ADMIN) && check_rights(R_ADMIN))
+	if((special_message_flag & MESSAGE_FLAG_ADMIN) && check_rights(R_ADMIN, FALSE))
 		return //Technically not needed due to admin bypasses later in this proc, but I'll throw it in if for some reason someone changes their immunity.
 
 	total_message_count += 1

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -927,10 +927,16 @@
 	return TRUE
 
 GLOBAL_VAR_INIT(automute_on, null)
-/client/proc/handle_spam_prevention(message, mute_type)
+/client/proc/handle_spam_prevention(message, mute_type, special_message_flag)
 	//Performance
 	if(isnull(GLOB.automute_on))
 		GLOB.automute_on = CONFIG_GET(flag/automute_on)
+
+	if((special_message_flag & MESSAGE_FLAG_MENTOR) && check_rights(R_MENTOR))
+		return //Please stop muting me in my own responses.
+
+	if((special_message_flag & MESSAGE_FLAG_ADMIN) && check_rights(R_ADMIN))
+		return //Technically not needed due to admin bypasses later in this proc, but I'll throw it in if for some reason someone changes their immunity.
 
 	total_message_count += 1
 


### PR DESCRIPTION
## About The Pull Request
This PR makes the private messages of mentors bypass the spam filter. This applies to both adminpms aswell as mentorpms, as both use the same framework after what tg did to them and I have not seen any way to clearly distinguish the two.
Done via private messages sending another arg to the spam filter check, which checks for it. Also done for admins, however admins generally bypass the filter anyways. I did do it nonetheless to ensure better futureproofing if someone for some reason removes general admin spam filter bypassing.
## Why It's Good For The Game
Any mentor will tell you how annoying it is to be writing up a long response, only for "Automute triggered, muted from adminpms / adminhelp". Please actually let people write long responses for things that warrant one instead of having to artificially truncate out important parts.
If someone writes malicious messages that would correctly trigger this filter, they shouldn't be staff in the first place, and it should be handled via that line instead.
## Changelog
:cl:
admin: Mentors now bypass spam filters when using private messages.
/:cl:
