### PR TITLE
Bench pressing makes you not fat anymore.

### DIFF
--- a/code/game/objects/structures/benchpress.dm
+++ b/code/game/objects/structures/benchpress.dm
@@ -129,7 +129,8 @@
 	var/finishmessage = pick("You feel stronger!","You feel like you're the boss of this gym!","You feel robust!","The challenge is real!")
 	var/mob/living/carbon/bencher = user
 	if(bencher.nutrition >= NUTRITION_OVERFED)
-		bencher.set_nutrition(NUTRITION_OVERFED-1)
+		var/weight_to_lose = NUTRITION_OVERFED - bencher.nutrition
+		bencher.adjust_nutrition(weight_to_lose)
 		finishmessage = pick("You no longer feel overweight.","You clothes are no longer too tight.","YOU BECOME LESS FAT!")
 	to_chat(user, finishmessage)
 

--- a/code/game/objects/structures/benchpress.dm
+++ b/code/game/objects/structures/benchpress.dm
@@ -127,6 +127,10 @@
 		ADD_TRAIT(user, TRAIT_WORKED_OUT, WEIGHTBENCH_TRAIT)
 		addtimer(CALLBACK(src, PROC_REF(undo_buff), WEAKREF(user)), 15 MINUTES)
 	var/finishmessage = pick("You feel stronger!","You feel like you're the boss of this gym!","You feel robust!","The challenge is real!")
+	var/mob/living/carbon/bencher = user
+	if(bencher.nutrition >= NUTRITION_OVERFED)
+		bencher.set_nutrition(NUTRITION_OVERFED-1)
+		finishmessage = pick("You no longer feel overweight.","You clothes are no longer too tight.","YOU BECOME LESS FAT!")
 	to_chat(user, finishmessage)
 
 ///proc to undo the cqc buff granted by the bench


### PR DESCRIPTION

## About The Pull Request
If you bench press you become not fat.
## Why It's Good For The Game
Credit akimomi on discord:
"Fat slowdown isn't a good mechanic, it's not enjoyable for marines and doesn't add anything to the game except as a way to punish new players for eating food and people taking advantage of the ability to have infinite nutrition.
It doesn't fit for TGMC."

Someone then said lifting should remove fat so here we go.
## Changelog
:cl:
add: Bench press is a great way to lose weight
/:cl:
