### PR TITLE
Firedoors now have a delay when welding, minorly refactors hand washing

### DIFF
--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -44,7 +44,7 @@
 /obj/item/tool/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
 	icon_state = "[sprite_name][!safety]"
-	balloon_alert(user, "Safety [safety ? "off" : "on"]")
+	balloon_alert(user, "Safety [safety ? "on" : "off"]")
 
 /obj/item/tool/extinguisher/attack(mob/M, mob/user)
 	if(user.a_intent == INTENT_HELP && !safety) //If we're on help intent and going to spray people, don't bash them.

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -44,7 +44,7 @@
 /obj/item/tool/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
 	icon_state = "[sprite_name][!safety]"
-	balloon_alert(user, "[safety ? "on" : "off"]")
+	balloon_alert(user, "Safety [safety ? "off" : "on"]")
 
 /obj/item/tool/extinguisher/attack(mob/M, mob/user)
 	if(user.a_intent == INTENT_HELP && !safety) //If we're on help intent and going to spray people, don't bash them.

--- a/code/game/objects/machinery/doors/firedoor.dm
+++ b/code/game/objects/machinery/doors/firedoor.dm
@@ -211,7 +211,13 @@
 		if(!W.remove_fuel(0, user))
 			return
 
+		balloon_alert_to_viewers("Starts [blocked ? "unwelding" : "welding"]")
+		if(!do_after(user, 3 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+			balloon_alert_to_viewers("Stops welding")
+			return
+
 		blocked = !blocked
+		balloon_alert_to_viewers("[blocked ? "welds" : "unwelds"] the firedoor")
 		user.visible_message(span_danger("\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W]."),\
 		"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\
 		"You hear something being welded.")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -321,7 +321,8 @@
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
 	desc = "A sink used for washing one's hands and face."
-	var/busy = FALSE 	//Something's being washed at the moment
+	///is someone currently washing at this sink?
+	var/busy = FALSE
 
 /obj/structure/sink/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -321,8 +321,7 @@
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
 	desc = "A sink used for washing one's hands and face."
-	anchored = TRUE
-	var/busy = 0 	//Something's being washed at the moment
+	var/busy = FALSE 	//Something's being washed at the moment
 
 /obj/structure/sink/Initialize(mapload)
 	. = ..()
@@ -335,34 +334,32 @@
 			pixel_x = 11
 		if(SOUTH)
 			pixel_y = 25
+
 /obj/structure/sink/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
 		return
-	if(isAI(user))
-		return
 
-	if(!Adjacent(user))
+	if(!ishuman(user) || !Adjacent(user))
 		return
 
 	if(busy)
-		to_chat(user, span_warning("Someone's already washing here."))
+		balloon_alert_to_viewers("Someone else is washing")
 		return
 
-	to_chat(usr, span_notice("You start washing your hands."))
+	balloon_alert_to_viewers("Starts washing hands")
 	playsound(loc, 'sound/effects/sink_long.ogg', 25, 1)
-	
 
-	busy = 1
-	sleep(4 SECONDS)
-	busy = 0
-
-	if(!Adjacent(user)) return		//Person has moved away from the sink
+	busy = TRUE
+	if(!do_after(user, 4 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+		busy = FALSE
+		balloon_alert_to_viewers("Stops washing")
+		return
+	busy = FALSE
 
 	user.clean_blood()
-	if(ishuman(user))
-		user:update_inv_gloves()
-	visible_message(span_notice("[user] washes their hands using \the [src]."))
+	user:update_inv_gloves()
+	balloon_alert_to_viewers("Washes their hands")
 
 
 /obj/structure/sink/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## About The Pull Request

Title.

Firedoors are no longer insta-weld, handwashing code has been cleaned up some and no longer uses sleep().
 ~~Also kills some unintended interactions with handwashing, like being able to literally anything as long as you're adjacent to the sink by the end of the handwashing check~~

## Why It's Good For The Game

Better code is better, also firedoors shouldn't be instant weld, they should take a couple seconds for consistency sake.

## Changelog
:cl:
balance: Firedoors now take a few seconds to weld and unweld
refactor: Cleaned handwashing code up somewhat
fix: Fixed an incorrect balloon alert when operating a fire extinguisher 
/:cl:
