### PR TITLE
Increases GL-54 razor magazine price

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -343,7 +343,7 @@ WEAPONS
 /datum/supply_packs/weapons/tx54_razor
 	name = "GL-54 razorburn grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/razor)
-	cost = 96
+	cost = 180
 
 /datum/supply_packs/weapons/tx54_he
 	name = "GL-54 HE grenade magazine"


### PR DESCRIPTION
## About The Pull Request

changes GL-54's razorburn magazine price in req from 96 to 180

## Why It's Good For The Game

this shouldn't be this cheap for the area denial potential it has, a single marine can razorburn a giant room with just one magazine as seen in the pictures, all 5 are from different locations that were taken 1 hour and 30 minutes into the round
https://gyazo.com/9683b2c4157f42489646270ae4036a22
https://gyazo.com/d637e1aa0909c46f0076638858c9edf8
https://gyazo.com/c3b8fb2e56dd299ef3ac2a1ac29a3373
https://gyazo.com/3fd5a75db82191c930cf15e8aad1d965
https://gyazo.com/3fd5a75db82191c930cf15e8aad1d965

## Changelog

:cl:
balance: Increased GL-54 razor mag price from 96 to 180 in req
/:cl: