### PR TITLE
Revert "Nerfs the MK88 Mod 4 Combat Pistol"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -407,7 +407,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 12.5
 	shrapnel_chance = 15
-	sundering = 0.5
+	sundering = 2
 
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -518,7 +518,6 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.3 SECONDS
 	burst_amount = 3
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.95


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#13816

This PR wasn't thought through at all.
It makes the mod4 literally worse than every other normal marine pistol by a significant margin, both in terms of DPS and sunder. It also additionally made the burst fire on the burst pistol worse in every way then semi auto...