### PR TITLE
Shrinks Marine Command Text Size

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -9,7 +9,7 @@
 
 	letters_per_update = 2
 	fade_out_delay = 5 SECONDS
-	style_open = "<span class='maptext' style=font-size:20pt;text-align:center valign='top'>"
+	style_open = "<span class='maptext' style=font-size:16pt;text-align:center valign='top'>"
 	style_close = "</span>"
 
 /datum/action/innate/message_squad


### PR DESCRIPTION
## About The Pull Request
This pr adjusts the message text size for command orders from 20pt to 16 pt, same size as xeno orders.
Closes #13822
![Change Me - Pillar of Spring 8_20_2023 2_11_37 PM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/fbd552b3-d19e-4d0d-a633-072dd950c3de)


## Why It's Good For The Game
The current size often results in messages being cut off, most commonly the new asl message cutting off the name of the asl in question. This let's marines actually see important parts of the message, while having it still be a noticeable size.
## Changelog
:cl:
qol: Shrunk the size of the marine command orders, allowing longer messages.
/:cl:
