### PR TITLE
pistol tweaks

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -196,7 +196,6 @@
 	fire_delay = 0.2 SECONDS
 	accuracy_mult = 1.20 //Has a forced laser sight.
 	accuracy_mult_unwielded = 0.95
-	scatter_unwielded = 4
 	recoil = -2
 	recoil_unwielded = -2
 
@@ -231,7 +230,6 @@
 	accuracy_mult_unwielded = 0.85
 	damage_mult = 1.15
 	recoil = -2
-	scatter_unwielded = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper P-1911A1 custom pistol"
@@ -518,7 +516,6 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.3 SECONDS
 	burst_amount = 3
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.95

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -198,6 +198,7 @@
 	accuracy_mult_unwielded = 0.95
 	recoil = -2
 	recoil_unwielded = -2
+	lower_akimbo_accuracy = 2
 
 /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
 	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/flashlight) //Tacticool
@@ -230,6 +231,7 @@
 	accuracy_mult_unwielded = 0.85
 	damage_mult = 1.15
 	recoil = -2
+	lower_akimbo_accuracy = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper P-1911A1 custom pistol"
@@ -523,6 +525,8 @@
 	aim_slowdown = 0.2
 	scatter = 0
 	scatter_unwielded = 6
+	lower_akimbo_accuracy = 2
+	akimbo_additional_delay = 2
 
 /obj/item/weapon/gun/pistol/vp70/tactical
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight, /obj/item/attachable/compensator)


### PR DESCRIPTION
## About The Pull Request
Reverts some dubious pistol changes.

P-23 no longer has a unwield scatter var that does nothing.
1911 no longer has a LOWER unwield scatter than other pistols (the value for both of these guns was intended as a nerf from the autofire pr).

Mod4 no longer has a 0.3 extra delay on bursts. This made it HUGELY worse than either the P-14 or P-23. It still has trash sunder now though.
## Why It's Good For The Game
Funny number changes.
## Changelog
:cl:
fix: fixed 1911 having lower scatter than it should
balance: Mod4 no longer has an extra delay when burst firing
balance: Slight akimbo nerfs to the P-23, 1911 and Mod4
/:cl:
