### PR TITLE
Allows respawning into EORD directly

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -50,6 +50,8 @@
 #define COOLDOWN_RAVAGER_FLAMER_ACT "cooldown_ravager_flamer_act"
 #define COOLDOWN_DROPPOD_TARGETTING "cooldown_droppod_targetting"
 #define COOLDOWN_TRY_TTS "cooldown_try_tts"
+#define COOLDOWN_EORD_RESPAWN "cooldown_eord_respawn"
+
 
 //Mecha cooldowns
 #define COOLDOWN_MECHA "mecha"

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -96,12 +96,21 @@
 	set name = "EORD Respawn"
 	set category = "OOC"
 
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EORD_RESPAWN))
+		to_chat(src, "You just respawned recently. Give it a second.")
+		return FALSE
+
+	TIMER_COOLDOWN_START(src, COOLDOWN_EORD_RESPAWN, 5 SECONDS)
+
+
 	var/mob/living/liver
-	if(isliving(usr))
-		liver = usr
-		if(liver.health >= liver.health_threshold_crit)
-			to_chat(src, "You can only use this when you're dead or crit.")
-			return
+	// if(isliving(usr))
+	// 	liver = usr
+	// 	if(liver.health >= liver.health_threshold_crit)
+	// 		to_chat(src, "You can only use this when you're dead or crit.")
+	// 		return
+
+
 
 	if(usr)
 		do_eord_respawn(usr)

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -96,11 +96,10 @@
 	set name = "EORD Respawn"
 	set category = "OOC"
 
-	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EORD_RESPAWN))
+	if(TIMER_COOLDOWN_CHECK(src.client, COOLDOWN_EORD_RESPAWN))
 		to_chat(src, "You just respawned recently. Give it a second.")
 		return FALSE
-
-	TIMER_COOLDOWN_START(src, COOLDOWN_EORD_RESPAWN, 5 SECONDS)
+	TIMER_COOLDOWN_START(src.client, COOLDOWN_EORD_RESPAWN, 5 SECONDS)
 
 	if(usr)
 		do_eord_respawn(usr)

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -102,16 +102,6 @@
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_EORD_RESPAWN, 5 SECONDS)
 
-
-	var/mob/living/liver
-	// if(isliving(usr))
-	// 	liver = usr
-	// 	if(liver.health >= liver.health_threshold_crit)
-	// 		to_chat(src, "You can only use this when you're dead or crit.")
-	// 		return
-
-
-
 	if(usr)
 		do_eord_respawn(usr)
 


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/24830358/9aefa82a-84c7-4e54-90f8-1794f31e4005)
For some reason, you can only spawn into EORD wjhen you are ghosted. If you are like me, and you do not always want to get roped into the stuff, that can be a little annoying, as a bit of the fun if that is testing your loadout on people. 

This PR (hopefully) makes it possible. I made it by simply removing the living check of the verb, and slapping a cooldown I stole from code down below.  The timer is here to avoid people being able to spam endless hordes of EORD'd people. Kept it short to avoid it taking you out of the fun. Still plenty of time to die. 

I did NOT test it, given I couldn't figure out how to start a proper running game without it ending instantly, ya know? But it should work? 

## Why It's Good For The Game
Lets you jump into EORD at willing instead of having to ghost to spawn in. I think. 

## Changelog


:cl:
add: Made it possible to spawn into EORD without ghosting. 
/:cl:
