### PR TITLE
adds a missing wire to the pillar's medbay store room

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -10947,6 +10947,7 @@
 /obj/machinery/power/apc/mainship{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request

adds missing the wire that connects the APC terminal to the power grid.

## Why It's Good For The Game

bug bad

## Changelog

:cl:
fix: adds a missing wire to the pillar of spring medbay store room
/:cl: