### PR TITLE
G8 from storage_slots=3 to max_storage_space=9

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -964,7 +964,8 @@
 /obj/item/storage/belt/sparepouch
 	name = "\improper G8 general utility pouch"
 	desc = "A small, lightweight pouch that can be clipped onto Armat Systems M3 Pattern armor or your belt to provide additional storage for miscellaneous gear or box and drum magazines."
-	storage_slots = 3
+	storage_slots = null
+	max_storage_space = 9
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "sparepouch"


### PR DESCRIPTION
## About The Pull Request

Changes the G8 General utility pouches storage behavior from 3 slots to 9 storage space, same functional space, just divisible into smaller pieces.

## Why It's Good For The Game

Makes the G8 General utility pouch storage behave like the normal general pouches, just bigger and can hold normal weight class items. Good because one injector shouldn't fill the same amount of space as a GPMG ammo box.

## Changelog

G8 General utility pouch storage

:cl:
balance: G8 belt is no longer slot based, so can hold more smaller items
/:cl: