### PR TITLE
Adds a recipe to medical nanites

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -309,6 +309,7 @@
 	amount_per_transfer_from_this = 1
 	volume = 1
 	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1)
+	free_refills = FALSE
 
 /obj/item/reagent_containers/hypospray/autoinjector/pain //made for debugging
 	name = "liquid pain autoinjector"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -215,8 +215,9 @@
 
 /datum/chemical_reaction/medicalnanites
 	name = "Medical Nanites"
-	results = list(/datum/reagent/medicine/research/medicalnanites = 10)
-	required_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1, /datum/reagent/iron = 5, /datum/reagent/medicine/lemoline = 1)
+	results = list(/datum/reagent/medicine/research/medicalnanites = 9)
+	required_reagents = list(/datum/reagent/iron = 10, /datum/reagent/medicine/lemoline = 1)
+	required_catalysts = list(/datum/reagent/medicine/research/medicalnanites = 1)
 
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -215,7 +215,7 @@
 
 /datum/chemical_reaction/medicalnanites
 	name = "Medical Nanites"
-	results = list(/datum/reagent/medicine/research/medicalnanites = 5)
+	results = list(/datum/reagent/medicine/research/medicalnanites = 10)
 	required_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1, /datum/reagent/iron = 5, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/stimulum

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -215,8 +215,8 @@
 
 /datum/chemical_reaction/medicalnanites
 	name = "Medical Nanites"
-	results = list(/datum/reagent/medicine/research/medicalnanites = 1)
-	required_reagents = list(/datum/reagent/toxin/nanites = 10, /datum/reagent/radium = 5, /datum/reagent/iron = 100, /datum/reagent/medicine/lemoline = 5)
+	results = list(/datum/reagent/medicine/research/medicalnanites = 5)
+	required_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1, /datum/reagent/iron = 5, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"


### PR DESCRIPTION
## About The Pull Request

changes the medical nanites recipe from: 
10 parts nanites (not medical, razorburn for whatever reason), 100 parts iron, 5 parts radium and 5 parts lemoline = 1u of nanites
to: 
1 part medical nanites catalyst, 10 part iron and 1 part lemoline = 9u of nanites

## Why It's Good For The Game

nanites are already free in the vendor, this recipe is a just a QOL feature incase you want bigger quantities of nanites but don't want to be sitting at the vendor injecting beaker, restocking, vending and repeat while also keeping the small cost of lemo

## Changelog

:cl:
add: Added an actual recipe for medical nanites
/:cl:
