### PR TITLE
Renames automatically generated tunnels

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -24,7 +24,7 @@
 	for(var/i in GLOB.xeno_tunnel_spawn_turfs)
 		var/obj/structure/xeno/tunnel/new_tunnel = new /obj/structure/xeno/tunnel(i, XENO_HIVE_NORMAL)
 		new_tunnel.name = "[get_area_name(new_tunnel)] tunnel"
-		new_tunnel.tunnel_desc = "["An old tunnel dug by a former member of the hive prior to our awakening at [get_area_name(new_tunnel)]"] (X: [new_tunnel.x], Y: [new_tunnel.y])"
+		new_tunnel.tunnel_desc = "["[get_area_name(new_tunnel)]"] (X: [new_tunnel.x], Y: [new_tunnel.y])"
 	for(var/i in GLOB.xeno_jelly_pod_turfs)
 		new /obj/structure/xeno/resin_jelly_pod(i, XENO_HIVE_NORMAL)
 


### PR DESCRIPTION
## About The Pull Request
Title
Xeno buff of the year
## Why It's Good For The Game
> open hive tunnels screen
> An old tunnel dug by a former member of the hive prior to our awakening at An old tunnel dug by a former member of the hive prior to our awakening at An old tunnel dug by a former member of the hive prior to our awakening at An old tunnel dug by a former member of the hive prior to our awakening at
> close hive tunnels screen

There's no reason to name it like this. It clogs up the hive tunnels screen and chat whenever it dies.
## Changelog
:cl:
qol: Prebuilt tunnels are no longer named as obtusely
/:cl:
