### PR TITLE
Reverts SADAR price reduction

### DIFF
--- a/code/__DEFINES/supply.dm
+++ b/code/__DEFINES/supply.dm
@@ -2,4 +2,4 @@
 #define B18_PRICE 1200
 #define B17_PRICE 800
 #define MINIGUN_PRICE 800
-#define SADAR_PRICE 800
+#define SADAR_PRICE 1200


### PR DESCRIPTION
### About The Pull Request
Reverts SADAR price reduction implemented in #13396 from 800 back to 1200.

The slightly reduced rocket prices remain untouched however.

### Why It's Good For The Game

The SADAR remains the highest single hit damage spike weapon in the game, capable of instantly killing T3 xenos with AP rockets or critting T2s with just HE rockets, complete with dealing 100 sunder on a direct hit. This kind of firepower is really something that should be reserved for after marines have established a proper source of req income from the ground and not something marines can reach for during prep in order to score easy kills on still elder T3s and quickly fuel req with cash to continue a rain of rockets.

### Changelog

:cl:
balance: SADAR now costs 400 points more again back to 1200 (was 800)
/:cl:
