### PR TITLE
Fix non ASCII regex

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -14,7 +14,7 @@ GLOBAL_VAR_INIT(custom_info, "")
 GLOBAL_VAR_INIT(motd, "")
 
 ///Regex for detecting non-ASCII symbols
-GLOBAL_VAR_INIT(non_ascii_regex, regex("\[^\\x00-\\x7F]", "g"))
+GLOBAL_VAR_INIT(non_ascii_regex, regex(@"[^\x00-\x7F]"))
 GLOBAL_PROTECT(non_ascii_regex)
 
 ///Returns true if this contains text that is not ASCII


### PR DESCRIPTION
## About The Pull Request

It was working only half the time because /g and findtext don't work together. Fixes #13871, you were never meant to be sending emojis
```dm
world.log << NON_ASCII_REGEX("😀") // 1
world.log << NON_ASCII_REGEX("😀") // 0
```

## Changelog

:cl:
fix: You can no longer use non-ASCII characters in OOC
/:cl: