### PR TITLE
Fixes inhands when wielding

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -52,6 +52,8 @@
 	SEND_SIGNAL(src, COMSIG_ITEM_WIELD, user)
 	name = "[name] (Wielded)"
 	update_item_state()
+	user.update_inv_l_hand()
+	user.update_inv_r_hand()
 	return TRUE
 
 
@@ -79,8 +81,6 @@
 	to_chat(user, span_notice("You grab [src] with both hands."))
 	offhand.name = "[name] - offhand"
 	offhand.desc = "Your second grip on [src]."
-	user.update_inv_l_hand()
-	user.update_inv_r_hand()
 	return TRUE
 
 /obj/item/proc/remove_offhand(mob/user)


### PR DESCRIPTION

## About The Pull Request

Basically the behaviour we have pre wield fix. Inhand appears wielded the moment you start wielding instead of updating after you're finished wielding.
## Why It's Good For The Game

People preferred the old behaviour.
## Changelog
:cl:
fix: Fixed inhand wielding sprites
/:cl:
