### PR TITLE
Add a category for spare civilian clothing in the clothing vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1306,6 +1306,9 @@
 			/obj/item/clothing/gloves/latex = -1,
 			/obj/item/clothing/shoes/white = -1,
 		),
+		"Civilian Surplus Wear" = list(
+			/obj/item/clothing/under/rank/chaplain = -1
+		)
 	)
 
 	prices = list()


### PR DESCRIPTION
## About The Pull Request
It currently only holds chaplain outfits, because I severely lack drip judgement, and I do not know what would look good on marines. Or be useful. 

## Why It's Good For The Game
A little more drippyness for us. 

## Changelog

:cl:
qol: Added chaplain clothes to the clothing vendor
/:cl:
