### PR TITLE
Makes recyclers point in their relevant direction. 

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11784,7 +11784,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "oUt" = (
-/obj/machinery/recycler,
+/obj/machinery/recycler{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oUM" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -16556,7 +16556,9 @@
 /obj/machinery/conveyor{
 	id = "lower_garbage"
 	},
-/obj/machinery/recycler,
+/obj/machinery/recycler{
+	dir = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},

--- a/_maps/map_files/deltastation/deltastation.dmm
+++ b/_maps/map_files/deltastation/deltastation.dmm
@@ -50773,10 +50773,12 @@
 /turf/open/floor/iron,
 /area/deltastation/security/processing)
 "kpn" = (
-/obj/machinery/recycler,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "bunkerrecycle"
+	},
+/obj/machinery/recycler{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/deltastation/asteroidcaves/derelictwest)

--- a/code/modules/recycling/recycler.dm
+++ b/code/modules/recycling/recycler.dm
@@ -6,6 +6,8 @@
 	layer = ABOVE_MOB_LAYER
 	anchored = TRUE
 	density = TRUE
+	//Pointing west because that's the only sprite we got
+	dir = 8
 
 /obj/machinery/recycler/update_icon()
 	icon_state = "grinder-o[(machine_stat & (BROKEN|NOPOWER)) ? "0":"1"]"

--- a/code/modules/recycling/recycler.dm
+++ b/code/modules/recycling/recycler.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	density = TRUE
 	//Pointing west because that's the only sprite we got
-	dir = 8
+	dir = NORTH
 
 /obj/machinery/recycler/update_icon()
 	icon_state = "grinder-o[(machine_stat & (BROKEN|NOPOWER)) ? "0":"1"]"


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/10652

The issue was that recyclers only have sprites for 1 direction, and they point north by default, instead of west. I made the default point west and fixed minerva's one by forcing it to point north. Avoids us having to redo it. 

## Why It's Good For The Game
Working gear is good!

## Changelog

:cl:
fix: fixed some recyclers not working properly.
/:cl:
