### PR TITLE
Xeno throw fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -80,12 +80,6 @@
 	var/mob/living/victim = source
 	victim.do_resist_grab()
 
-
-/mob/living/carbon/xenomorph/warrior/hitby(atom/movable/AM, speed = 5)
-	if(ishuman(AM))
-		return
-	..()
-
 // ***************************************
 // *********** Primordial procs
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -396,6 +396,11 @@
 	handle_weeds_on_movement()
 	return ..()
 
+/mob/living/carbon/xenomorph/CanAllowThrough(atom/movable/mover, turf/target)
+	if(mover.throwing && ismob(mover) && isxeno(mover.thrower)) //xenos can throw mobs past other xenos
+		return TRUE
+	return ..()
+
 /mob/living/carbon/xenomorph/set_stat(new_stat)
 	. = ..()
 	if(isnull(.))


### PR DESCRIPTION

## About The Pull Request
Xenos can once again throw mobs past other xenos.

Fixed a bug with throwing mobs past warriors.
## Why It's Good For The Game
Bug fixes.
## Changelog
:cl:
fix: Xenos can throw mobs past xenos once again
fix: Fixed an issue with throwing mobs past warriors specifically
/:cl:
