### PR TITLE
Fixes PoS CAS ammo storage lacking a button

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3414,6 +3414,9 @@
 /obj/structure/stairs/seamless/platform_vert{
 	dir = 1
 	},
+/obj/machinery/door_control/mainship/ammo{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "egW" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3414,9 +3414,6 @@
 /obj/structure/stairs/seamless/platform_vert{
 	dir = 1
 	},
-/obj/machinery/door_control/mainship/ammo{
-	dir = 8
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "egW" = (
@@ -3653,6 +3650,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"ewo" = (
+/obj/machinery/door_control/mainship/ammo,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "exv" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship{
@@ -54546,7 +54547,7 @@ tyN
 tyN
 ggf
 tyN
-dpY
+ewo
 dpY
 syc
 hFZ


### PR DESCRIPTION
## About The Pull Request
Read title. This is what it looks like fixed.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/44de4e3c-1055-410e-b654-749b49999ddf)
## Why It's Good For The Game
I am sick of getting ahelps for this. Bug bad.
## Changelog
:cl:
fix: Fixed PoS CAS ammo storage not having a button to open it.
/:cl:
