### PR TITLE
Separates the Dropship Fabricator Into Dropship/Condor Categories. Repaths Dropship Equipment/Ammo

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -57,7 +57,7 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "aj" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ak" = (
@@ -846,7 +846,7 @@
 	pixel_x = -2;
 	pixel_y = -6
 	},
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "cu" = (
@@ -1317,7 +1317,7 @@
 	},
 /area/mainship/hallways/hangar)
 "dR" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /obj/item/ammo_casing/bullet{
 	pixel_x = -3
 	},
@@ -1335,7 +1335,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dS" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
 	pixel_x = -2;
@@ -1394,7 +1394,7 @@
 	},
 /area/mainship/medical/lower_medical)
 "dX" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dY" = (
@@ -1779,7 +1779,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "ff" = (
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "fg" = (
@@ -2175,7 +2175,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "go" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "gp" = (
@@ -3045,7 +3045,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iE" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -3287,11 +3287,11 @@
 	},
 /area/mainship/squads/general)
 "jv" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "jw" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -5224,7 +5224,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "pe" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "pf" = (
@@ -5608,7 +5608,7 @@
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
 "qp" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "qq" = (
@@ -5772,7 +5772,7 @@
 /turf/open/floor/mainship_hull,
 /area/mainship/powered)
 "qR" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -6316,7 +6316,7 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "sJ" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
@@ -6749,7 +6749,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "tZ" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
@@ -7725,7 +7725,7 @@
 /obj/machinery/door_control/mainship/ammo{
 	dir = 1
 	},
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "wJ" = (
@@ -10066,7 +10066,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Dy" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Dz" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -57,7 +57,7 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "aj" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ak" = (
@@ -846,7 +846,7 @@
 	pixel_x = -2;
 	pixel_y = -6
 	},
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "cu" = (
@@ -1317,7 +1317,7 @@
 	},
 /area/mainship/hallways/hangar)
 "dR" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /obj/item/ammo_casing/bullet{
 	pixel_x = -3
 	},
@@ -1335,7 +1335,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dS" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
 	pixel_x = -2;
@@ -1394,7 +1394,7 @@
 	},
 /area/mainship/medical/lower_medical)
 "dX" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dY" = (
@@ -1779,7 +1779,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "ff" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "fg" = (
@@ -2175,7 +2175,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "go" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "gp" = (
@@ -3045,7 +3045,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iE" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -3287,11 +3287,11 @@
 	},
 /area/mainship/squads/general)
 "jv" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "jw" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -5224,7 +5224,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "pe" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "pf" = (
@@ -5608,7 +5608,7 @@
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
 "qp" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "qq" = (
@@ -5772,7 +5772,7 @@
 /turf/open/floor/mainship_hull,
 /area/mainship/powered)
 "qR" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -6316,7 +6316,7 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "sJ" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
@@ -6735,7 +6735,7 @@
 	},
 /area/mainship/medical/chemistry)
 "tW" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "tX" = (
@@ -6749,7 +6749,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "tZ" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
@@ -7725,7 +7725,7 @@
 /obj/machinery/door_control/mainship/ammo{
 	dir = 1
 	},
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "wJ" = (
@@ -9677,7 +9677,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/briefing)
 "Ch" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -10059,14 +10059,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "Dx" = (
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Dy" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Dz" = (
@@ -14181,7 +14181,7 @@
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "Py" = (
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Pz" = (
@@ -14202,7 +14202,7 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "PB" = (
-/obj/structure/dropship_equipment/weapon_holder/machinegun,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "PC" = (
@@ -14872,7 +14872,7 @@
 	},
 /area/mainship/command/cic)
 "RF" = (
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "RG" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -10059,7 +10059,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "Dx" = (
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -14181,7 +14181,7 @@
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "Py" = (
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Pz" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -7728,7 +7728,7 @@
 "kdC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "kdF" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4582,7 +4582,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fJI" = (
@@ -5323,7 +5323,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gPw" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "gPQ" = (
@@ -5600,7 +5600,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "hhh" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "hhR" = (
@@ -5632,7 +5632,7 @@
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "hiO" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -6132,7 +6132,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "hSQ" = (
@@ -7056,7 +7056,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "jaz" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jaA" = (
@@ -8533,7 +8533,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kZz" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "lal" = (
@@ -8619,7 +8619,7 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "leF" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "leW" = (
@@ -9098,7 +9098,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "lET" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "lFg" = (
@@ -9964,7 +9964,7 @@
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "mEj" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "mEk" = (
@@ -9989,7 +9989,7 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "mHa" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -12196,7 +12196,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "ptb" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "puR" = (
@@ -12693,7 +12693,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pWo" = (
@@ -13301,7 +13301,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "qKp" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /obj/effect/decal/cleanable/blood/writing{
 	desc = "It looks like a writing in blood. It says, 'We live as we dream, alone.'";
 	dir = 4
@@ -16500,7 +16500,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "uDq" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -17892,7 +17892,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "wtq" = (
@@ -19322,7 +19322,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "yao" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "yaw" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1947,7 +1947,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ctR" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -4582,7 +4582,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fJI" = (
@@ -5323,7 +5323,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gPw" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "gPQ" = (
@@ -5600,7 +5600,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "hhh" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "hhR" = (
@@ -5632,7 +5632,7 @@
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "hiO" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -6132,7 +6132,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "hSQ" = (
@@ -7056,7 +7056,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "jaz" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jaA" = (
@@ -7728,7 +7728,7 @@
 "kdC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "kdF" = (
@@ -8533,7 +8533,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kZz" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "lal" = (
@@ -8619,7 +8619,7 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "leF" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "leW" = (
@@ -9098,7 +9098,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "lET" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "lFg" = (
@@ -9964,7 +9964,7 @@
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "mEj" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "mEk" = (
@@ -9989,7 +9989,7 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "mHa" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -11372,7 +11372,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/briefing)
 "osb" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -12044,7 +12044,7 @@
 "phr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/weapon_holder/machinegun,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "pid" = (
@@ -12196,7 +12196,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "ptb" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "puR" = (
@@ -12693,7 +12693,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pWo" = (
@@ -13301,7 +13301,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "qKp" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /obj/effect/decal/cleanable/blood/writing{
 	desc = "It looks like a writing in blood. It says, 'We live as we dream, alone.'";
 	dir = 4
@@ -14187,7 +14187,7 @@
 /turf/closed/wall/mainship/white,
 /area/medical/morgue)
 "rSQ" = (
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -16500,7 +16500,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "uDq" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -17892,7 +17892,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "wtq" = (
@@ -18711,7 +18711,7 @@
 	},
 /area/mainship/living/briefing)
 "xtm" = (
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -19322,7 +19322,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "yao" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "yaw" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -18202,7 +18202,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mwI" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -7284,7 +7284,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "aMP" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "aMS" = (
@@ -9437,7 +9437,7 @@
 /area/sulaco/engineering/atmos)
 "bew" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bex" = (
@@ -9493,7 +9493,7 @@
 /area/sulaco/cargo)
 "bhA" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bhG" = (
@@ -9808,7 +9808,7 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar)
 "bFu" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bGR" = (
@@ -11598,7 +11598,7 @@
 /turf/open/floor/prison/marked,
 /area/mainship/command/self_destruct)
 "dZG" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "dZI" = (
@@ -11828,7 +11828,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "eqh" = (
@@ -14868,7 +14868,7 @@
 /area/sulaco/medbay)
 "ilD" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "imd" = (
@@ -15370,7 +15370,7 @@
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
 "iNC" = (
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "iNW" = (
@@ -16288,7 +16288,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "jWd" = (
@@ -16690,7 +16690,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "kut" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "kvB" = (
@@ -16718,7 +16718,7 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay/west)
 "kwh" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "kwG" = (
@@ -18879,7 +18879,7 @@
 	},
 /area/sulaco/hangar)
 "npi" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nps" = (
@@ -18891,7 +18891,7 @@
 /area/sulaco/marine)
 "nqJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nrh" = (
@@ -18913,7 +18913,7 @@
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "ntA" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nug" = (
@@ -19025,7 +19025,7 @@
 /area/sulaco/engineering/engine)
 "nCl" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nCN" = (
@@ -21140,7 +21140,7 @@
 /area/shuttle/distress/arrive_2)
 "qku" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "qkC" = (
@@ -21351,7 +21351,7 @@
 /area/sulaco/medbay/surgery_two)
 "qAV" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "qAW" = (
@@ -23063,7 +23063,7 @@
 /area/sulaco/hangar)
 "sCO" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "sEr" = (
@@ -25056,7 +25056,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "vfr" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -7284,7 +7284,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "aMP" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "aMS" = (
@@ -9437,7 +9437,7 @@
 /area/sulaco/engineering/atmos)
 "bew" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bex" = (
@@ -9493,7 +9493,7 @@
 /area/sulaco/cargo)
 "bhA" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bhG" = (
@@ -9808,7 +9808,7 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar)
 "bFu" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "bGR" = (
@@ -11598,7 +11598,7 @@
 /turf/open/floor/prison/marked,
 /area/mainship/command/self_destruct)
 "dZG" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "dZI" = (
@@ -11828,7 +11828,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "eqh" = (
@@ -12359,7 +12359,7 @@
 /area/sulaco/maintenance/lower_maint)
 "eRL" = (
 /obj/effect/turf_decal/warning_stripes,
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "eTC" = (
@@ -14868,7 +14868,7 @@
 /area/sulaco/medbay)
 "ilD" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "imd" = (
@@ -15370,7 +15370,7 @@
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
 "iNC" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "iNW" = (
@@ -16288,7 +16288,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "jWd" = (
@@ -16690,7 +16690,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "kut" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "kvB" = (
@@ -16718,7 +16718,7 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay/west)
 "kwh" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "kwG" = (
@@ -17676,7 +17676,7 @@
 /area/sulaco/engineering/engine)
 "lIg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/weapon_holder/machinegun,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},
@@ -18202,7 +18202,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mwI" = (
@@ -18879,7 +18879,7 @@
 	},
 /area/sulaco/hangar)
 "npi" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nps" = (
@@ -18891,7 +18891,7 @@
 /area/sulaco/marine)
 "nqJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nrh" = (
@@ -18913,7 +18913,7 @@
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "ntA" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nug" = (
@@ -19025,7 +19025,7 @@
 /area/sulaco/engineering/engine)
 "nCl" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "nCN" = (
@@ -21140,7 +21140,7 @@
 /area/shuttle/distress/arrive_2)
 "qku" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "qkC" = (
@@ -21351,7 +21351,7 @@
 /area/sulaco/medbay/surgery_two)
 "qAV" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "qAW" = (
@@ -23063,7 +23063,7 @@
 /area/sulaco/hangar)
 "sCO" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "sEr" = (
@@ -24580,7 +24580,7 @@
 /area/sulaco/maintenance/upperdeck_north_maint)
 "uwV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /obj/effect/turf_decal/warning_stripes,
 /obj/machinery/light/mainship{
 	dir = 4
@@ -25056,7 +25056,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "vfr" = (
@@ -26921,7 +26921,7 @@
 	},
 /area/sulaco/engineering/atmos)
 "xCr" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -27283,7 +27283,7 @@
 /area/mainship/living/basketball)
 "yfI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -27468,7 +27468,7 @@
 /area/sulaco/hangar/storage)
 "yle" = (
 /obj/effect/turf_decal/warning_stripes,
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "ylT" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -20341,7 +20341,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "xCC" = (
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xCV" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1366,11 +1366,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/bow_hallway)
 "ann" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "anQ" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -2772,7 +2772,7 @@
 	},
 /area/mainship/living/basketball)
 "bdj" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bdk" = (
@@ -2859,7 +2859,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "bdW" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bdX" = (
@@ -3777,7 +3777,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
 "blo" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "blq" = (
@@ -5340,7 +5340,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "bCK" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bCL" = (
@@ -8974,7 +8974,7 @@
 	},
 /area/mainship/hallways/port_hallway)
 "dZK" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ead" = (
@@ -10814,7 +10814,7 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/cic)
 "hhA" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "hiF" = (
@@ -13908,7 +13908,7 @@
 	},
 /area/mainship/command/cic)
 "myv" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mzi" = (
@@ -16741,7 +16741,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "qYe" = (
-/obj/structure/dropship_equipment/flare_launcher,
+/obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qZy" = (
@@ -19368,7 +19368,7 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/port_point_defense)
 "vNA" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "vND" = (
@@ -19786,7 +19786,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
 "wCq" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wDA" = (
@@ -20166,7 +20166,7 @@
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/hangar)
 "xjo" = (
-/obj/structure/dropship_equipment/weapon_holder/machinegun,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xjw" = (
@@ -20341,7 +20341,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "xCC" = (
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xCV" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1366,11 +1366,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/bow_hallway)
 "ann" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "anQ" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -2772,7 +2772,7 @@
 	},
 /area/mainship/living/basketball)
 "bdj" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bdk" = (
@@ -2859,7 +2859,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "bdW" = (
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bdX" = (
@@ -3777,7 +3777,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
 "blo" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "blq" = (
@@ -5340,7 +5340,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "bCK" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bCL" = (
@@ -8974,7 +8974,7 @@
 	},
 /area/mainship/hallways/port_hallway)
 "dZK" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ead" = (
@@ -10814,7 +10814,7 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/cic)
 "hhA" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "hiF" = (
@@ -13908,7 +13908,7 @@
 	},
 /area/mainship/command/cic)
 "myv" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mzi" = (
@@ -19786,7 +19786,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
 "wCq" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wDA" = (

--- a/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
+++ b/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
@@ -925,7 +925,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base)
 "or" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/mainship/black,
 /area/mainship/patrol_base)
 "oK" = (
@@ -2098,7 +2098,7 @@
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base)
 "Fi" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "Fj" = (
@@ -2410,7 +2410,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/mainship/patrol_base/som)
 "JY" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /obj/machinery/light,
 /turf/open/floor/mainship/black,
 /area/mainship/patrol_base)

--- a/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
+++ b/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
@@ -925,7 +925,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base)
 "or" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship/black,
 /area/mainship/patrol_base)
 "oK" = (
@@ -2098,7 +2098,7 @@
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base)
 "Fi" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "Fj" = (
@@ -2410,7 +2410,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/mainship/patrol_base/som)
 "JY" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /obj/machinery/light,
 /turf/open/floor/mainship/black,
 /area/mainship/patrol_base)

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -244,18 +244,18 @@
 /turf/open/floor/grass,
 /area/mainship/living/port_garden)
 "aaY" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "aaZ" = (
-/obj/structure/ship_ammo/CAS/minirocket/illumination,
+/obj/structure/ship_ammo/cas/minirocket/illumination,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "aba" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "abb" = (
@@ -369,7 +369,7 @@
 /turf/open/floor/mainship,
 /area/mainship/living/port_garden)
 "abz" = (
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "abC" = (
@@ -563,11 +563,11 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/engineering_workshop)
 "acB" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acD" = (
-/obj/structure/dropship_equipment/CAS/weapon/heavygun,
+/obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acE" = (
@@ -584,7 +584,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acJ" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acK" = (
@@ -701,7 +701,7 @@
 /turf/open/floor/mainship,
 /area/mainship/command/telecomms)
 "adm" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "ado" = (
@@ -801,7 +801,7 @@
 /turf/open/floor/mainship,
 /area/mainship/command/telecomms)
 "adF" = (
-/obj/structure/ship_ammo/CAS/rocket/keeper,
+/obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "adG" = (
@@ -2501,7 +2501,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "ljx" = (
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /obj/machinery/light,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
@@ -2632,7 +2632,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "rmt" = (
-/obj/structure/ship_ammo/CAS/heavygun,
+/obj/structure/ship_ammo/cas/heavygun,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
@@ -2767,7 +2767,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "wpk" = (
-/obj/structure/ship_ammo/CAS/minirocket,
+/obj/structure/ship_ammo/cas/minirocket,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -244,18 +244,18 @@
 /turf/open/floor/grass,
 /area/mainship/living/port_garden)
 "aaY" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "aaZ" = (
-/obj/structure/ship_ammo/minirocket/illumination,
+/obj/structure/ship_ammo/CAS/minirocket/illumination,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "aba" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "abb" = (
@@ -369,7 +369,7 @@
 /turf/open/floor/mainship,
 /area/mainship/living/port_garden)
 "abz" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "abC" = (
@@ -448,7 +448,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/exoarmor)
 "abV" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
@@ -522,7 +522,7 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/engineering_workshop)
 "acs" = (
-/obj/structure/dropship_equipment/operatingtable,
+/obj/structure/dropship_equipment/CAS/operatingtable,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acu" = (
@@ -563,11 +563,11 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/engineering_workshop)
 "acB" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acD" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/CAS/weapon/heavygun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acE" = (
@@ -584,7 +584,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acJ" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acK" = (
@@ -701,7 +701,7 @@
 /turf/open/floor/mainship,
 /area/mainship/command/telecomms)
 "adm" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "ado" = (
@@ -801,7 +801,7 @@
 /turf/open/floor/mainship,
 /area/mainship/command/telecomms)
 "adF" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/CAS/rocket/keeper,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "adG" = (
@@ -2288,7 +2288,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "bEy" = (
-/obj/structure/dropship_equipment/weapon_holder/machinegun,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "bOe" = (
@@ -2501,7 +2501,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "ljx" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod,
 /obj/machinery/light,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
@@ -2632,7 +2632,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "rmt" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/CAS/heavygun,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
@@ -2767,7 +2767,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "wpk" = (
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/CAS/minirocket,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -522,7 +522,7 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/engineering_workshop)
 "acs" = (
-/obj/structure/dropship_equipment/CAS/operatingtable,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "acu" = (

--- a/_maps/modularmaps/big_red/bigredsecornervar6.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar6.dmm
@@ -226,7 +226,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "nn" = (
-/obj/structure/ship_ammo/CAS/rocket/fatty,
+/obj/structure/ship_ammo/cas/rocket/fatty,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "nY" = (
@@ -270,7 +270,7 @@
 	},
 /area/bigredv2/caves/secomplex)
 "rJ" = (
-/obj/structure/ship_ammo/CAS/rocket/napalm,
+/obj/structure/ship_ammo/cas/rocket/napalm,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "sc" = (
@@ -331,7 +331,7 @@
 	},
 /area/bigredv2/caves/secomplex)
 "ud" = (
-/obj/structure/ship_ammo/CAS/rocket/widowmaker,
+/obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "ur" = (
@@ -350,7 +350,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "uX" = (
-/obj/structure/ship_ammo/CAS/rocket/banshee,
+/obj/structure/ship_ammo/cas/rocket/banshee,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
@@ -808,7 +808,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "Wt" = (
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Wz" = (

--- a/_maps/modularmaps/big_red/bigredsecornervar6.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar6.dmm
@@ -226,7 +226,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "nn" = (
-/obj/structure/ship_ammo/rocket/fatty,
+/obj/structure/ship_ammo/CAS/rocket/fatty,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "nY" = (
@@ -270,7 +270,7 @@
 	},
 /area/bigredv2/caves/secomplex)
 "rJ" = (
-/obj/structure/ship_ammo/rocket/napalm,
+/obj/structure/ship_ammo/CAS/rocket/napalm,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "sc" = (
@@ -331,7 +331,7 @@
 	},
 /area/bigredv2/caves/secomplex)
 "ud" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/CAS/rocket/widowmaker,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "ur" = (
@@ -350,7 +350,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "uX" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/CAS/rocket/banshee,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
@@ -808,7 +808,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "Wt" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Wz" = (

--- a/code/game/objects/machinery/computer/dropship_weapons.dm
+++ b/code/game/objects/machinery/computer/dropship_weapons.dm
@@ -94,7 +94,7 @@
 					if(!(selected_equipment?.dropship_equipment_flags & IS_WEAPON))
 						to_chat(L, span_warning("No weapon selected."))
 						return
-					var/obj/structure/dropship_equipment/CAS/weapon/DEW = selected_equipment
+					var/obj/structure/dropship_equipment/cas/weapon/DEW = selected_equipment
 					if(!DEW.ammo_equipped || DEW.ammo_equipped.ammo_count <= 0)
 						to_chat(L, span_warning("[DEW] has no ammo."))
 						return

--- a/code/game/objects/machinery/computer/dropship_weapons.dm
+++ b/code/game/objects/machinery/computer/dropship_weapons.dm
@@ -94,7 +94,7 @@
 					if(!(selected_equipment?.dropship_equipment_flags & IS_WEAPON))
 						to_chat(L, span_warning("No weapon selected."))
 						return
-					var/obj/structure/dropship_equipment/weapon/DEW = selected_equipment
+					var/obj/structure/dropship_equipment/CAS/weapon/DEW = selected_equipment
 					if(!DEW.ammo_equipped || DEW.ammo_equipped.ammo_count <= 0)
 						to_chat(L, span_warning("[DEW] has no ammo."))
 						return

--- a/code/game/objects/machinery/dropship_part_fabricator.dm
+++ b/code/game/objects/machinery/dropship_part_fabricator.dm
@@ -35,8 +35,8 @@
 	dat += "<a href='byond://?src=\ref[src];choice=clear'>CLEAR PRINT QUEUE</a><br>"
 
 	dat += "<h3>Condor Equipment:</h3>"
-	for(var/build_type in typesof(/obj/structure/dropship_equipment/CAS))
-		var/obj/structure/dropship_equipment/CAS/DEC = build_type
+	for(var/build_type in typesof(/obj/structure/dropship_equipment/cas))
+		var/obj/structure/dropship_equipment/cas/DEC = build_type
 		var/build_name = initial(DEC.name)
 		var/build_cost = initial(DEC.point_cost)
 		if(build_cost)
@@ -51,8 +51,8 @@
 			dat += "<a href='byond://?src=\ref[src];choice=[build_type]'>[build_name] ([build_cost])</a><br>"
 
 	dat += "<h3>Condor Ammo:</h3>"
-	for(var/build_type in typesof(/obj/structure/ship_ammo/CAS))
-		var/obj/structure/ship_ammo/CAS/SAC = build_type
+	for(var/build_type in typesof(/obj/structure/ship_ammo/cas))
+		var/obj/structure/ship_ammo/cas/SAC = build_type
 		var/build_name = initial(SAC.name)
 		var/build_cost = initial(SAC.point_cost)
 		if(build_cost)

--- a/code/game/objects/machinery/dropship_part_fabricator.dm
+++ b/code/game/objects/machinery/dropship_part_fabricator.dm
@@ -34,19 +34,27 @@
 	dat += "<h4>Points Available: [SSpoints.dropship_points]</h4>"
 	dat += "<a href='byond://?src=\ref[src];choice=clear'>CLEAR PRINT QUEUE</a><br>"
 
-	dat += "<h3>Dropship Equipment:</h3>"
-	for(var/build_type in typesof(/obj/structure/dropship_equipment))
-		var/obj/structure/dropship_equipment/DE = build_type
-		var/build_name = initial(DE.name)
-		var/build_cost = initial(DE.point_cost)
+	dat += "<h3>Condor Equipment:</h3>"
+	for(var/build_type in typesof(/obj/structure/dropship_equipment/CAS))
+		var/obj/structure/dropship_equipment/CAS/DEC = build_type
+		var/build_name = initial(DEC.name)
+		var/build_cost = initial(DEC.point_cost)
 		if(build_cost)
 			dat += "<a href='byond://?src=\ref[src];choice=[build_type]'>[build_name] ([build_cost])</a><br>"
 
-	dat += "<h3>Dropship Ammo:</h3>"
-	for(var/build_type in typesof(/obj/structure/ship_ammo))
-		var/obj/structure/ship_ammo/SA = build_type
-		var/build_name = initial(SA.name)
-		var/build_cost = initial(SA.point_cost)
+	dat += "<h3>Dropship Equipment:</h3>"
+	for(var/build_type in typesof(/obj/structure/dropship_equipment/shuttle))
+		var/obj/structure/dropship_equipment/shuttle/DES = build_type
+		var/build_name = initial(DES.name)
+		var/build_cost = initial(DES.point_cost)
+		if(build_cost)
+			dat += "<a href='byond://?src=\ref[src];choice=[build_type]'>[build_name] ([build_cost])</a><br>"
+
+	dat += "<h3>Condor Ammo:</h3>"
+	for(var/build_type in typesof(/obj/structure/ship_ammo/CAS))
+		var/obj/structure/ship_ammo/CAS/SAC = build_type
+		var/build_name = initial(SAC.name)
+		var/build_cost = initial(SAC.point_cost)
 		if(build_cost)
 			dat += "<a href='byond://?src=\ref[src];choice=[build_type]'>[build_name] ([build_cost])</a><br>"
 

--- a/code/game/objects/structures/cas_plane_parts.dm
+++ b/code/game/objects/structures/cas_plane_parts.dm
@@ -209,9 +209,9 @@
 	desc = " A terrifying radial-mounted GAU-30mm minigun. You don't want to be on the wrong end of this."
 	icon_state = "1"
 	///static weapon we start with at the tip
-	var/static_weapon_type = /obj/structure/dropship_equipment/weapon/heavygun/radial_cas
+	var/static_weapon_type = /obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas
 	///ref to the static weapon
-	var/obj/structure/dropship_equipment/weapon/static_weapon
+	var/obj/structure/dropship_equipment/CAS/weapon/static_weapon
 
 /obj/structure/caspart/minigun/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/cas_plane_parts.dm
+++ b/code/game/objects/structures/cas_plane_parts.dm
@@ -209,9 +209,9 @@
 	desc = " A terrifying radial-mounted GAU-30mm minigun. You don't want to be on the wrong end of this."
 	icon_state = "1"
 	///static weapon we start with at the tip
-	var/static_weapon_type = /obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas
+	var/static_weapon_type = /obj/structure/dropship_equipment/cas/weapon/heavygun/radial_cas
 	///ref to the static weapon
-	var/obj/structure/dropship_equipment/CAS/weapon/static_weapon
+	var/obj/structure/dropship_equipment/cas/weapon/static_weapon
 
 /obj/structure/caspart/minigun/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -200,11 +200,11 @@
 
 //30mm gun
 
-/obj/structure/ship_ammo/CAS/heavygun
+/obj/structure/ship_ammo/cas/heavygun
 	name = "\improper 30mm ammo crate"
 	icon_state = "30mm_crate"
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
-	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/heavygun
+	equipment_type = /obj/structure/dropship_equipment/cas/weapon/heavygun
 	travelling_time = 6 SECONDS
 	ammo_count = 200
 	max_ammo_count = 200
@@ -218,14 +218,14 @@
 	ammo_type = CAS_30MM
 	cas_effect = /obj/effect/overlay/blinking_laser/heavygun
 
-/obj/structure/ship_ammo/CAS/heavygun/examine(mob/user)
+/obj/structure/ship_ammo/cas/heavygun/examine(mob/user)
 	. = ..()
 	. += "It has [ammo_count] round\s."
 
-/obj/structure/ship_ammo/CAS/heavygun/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/cas/heavygun/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] containing [ammo_count] round\s."
 
-/obj/structure/ship_ammo/CAS/heavygun/get_turfs_to_impact(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/heavygun/get_turfs_to_impact(turf/impact, attackdir = NORTH)
 	var/turf/beginning = impact
 	var/revdir = REVERSE_DIR(attackdir)
 	for(var/i=0 to bullet_spread_range)
@@ -241,12 +241,12 @@
 
 	return strafelist
 
-/obj/structure/ship_ammo/CAS/heavygun/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/heavygun/detonate_on(turf/impact, attackdir = NORTH)
 	playsound(impact, 'sound/effects/casplane_flyby.ogg', 40)
 	strafe_turfs(get_turfs_to_impact(impact, attackdir))
 
 ///Takes the top 3 turfs and miniguns them, then repeats until none left
-/obj/structure/ship_ammo/CAS/heavygun/proc/strafe_turfs(list/strafelist)
+/obj/structure/ship_ammo/cas/heavygun/proc/strafe_turfs(list/strafelist)
 	var/turf/strafed
 	playsound(strafelist[1], get_sfx("explosion"), 40, 1, 20, falloff = 3)
 	for(var/i=1 to attack_width)
@@ -259,7 +259,7 @@
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 2)
 
 
-/obj/structure/ship_ammo/CAS/heavygun/highvelocity
+/obj/structure/ship_ammo/cas/heavygun/highvelocity
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
@@ -273,7 +273,7 @@
 	desc = "This is not meant to exist. Moving this will require some sort of lifter."
 	icon_state = "30mm_crate_hv"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
+	equipment_type = /obj/structure/dropship_equipment/cas/weapon/minirocket_pod
 	ammo_count = 400
 	max_ammo_count = 400
 	ammo_name = "railgun"
@@ -303,7 +303,7 @@
 
 //laser battery
 
-/obj/structure/ship_ammo/CAS/laser_battery
+/obj/structure/ship_ammo/cas/laser_battery
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons. Moving this will require some sort of lifter."
@@ -311,7 +311,7 @@
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40
-	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun
+	equipment_type = /obj/structure/dropship_equipment/cas/weapon/laser_beam_gun
 	ammo_name = "charge"
 	transferable_ammo = TRUE
 	ammo_used_per_firing = 10
@@ -322,15 +322,15 @@
 	ammo_type = CAS_LASER_BATTERY
 	cas_effect = /obj/effect/overlay/blinking_laser/laser
 
-/obj/structure/ship_ammo/CAS/laser_battery/examine(mob/user)
+/obj/structure/ship_ammo/cas/laser_battery/examine(mob/user)
 	. = ..()
 	. += "It's at [round(100*ammo_count/max_ammo_count)]% charge."
 
 
-/obj/structure/ship_ammo/CAS/laser_battery/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/cas/laser_battery/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] at [round(100*ammo_count/max_ammo_count)]% charge."
 
-/obj/structure/ship_ammo/CAS/laser_battery/get_turfs_to_impact(turf/epicenter, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/laser_battery/get_turfs_to_impact(turf/epicenter, attackdir = NORTH)
 	var/turf/beginning = epicenter
 	var/turf/end = epicenter
 	var/revdir = REVERSE_DIR(attackdir)
@@ -339,21 +339,21 @@
 		end = get_step(end, attackdir)
 	return getline(beginning, end)
 
-/obj/structure/ship_ammo/CAS/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
 	var/list/turf/lazertargets = get_turfs_to_impact(impact, attackdir)
 	process_lazer(lazertargets)
 	if(!ammo_count)
 		QDEL_IN(src, laze_radius+1) //deleted after last laser beam is fired and impact the ground.
 
 ///takes the top lazertarget on the stack and fires the lazer at it
-/obj/structure/ship_ammo/CAS/laser_battery/proc/process_lazer(list/lazertargets)
+/obj/structure/ship_ammo/cas/laser_battery/proc/process_lazer(list/lazertargets)
 	laser_burn(lazertargets[1])
 	lazertargets -= lazertargets[1]
 	if(length(lazertargets))
 		INVOKE_NEXT_TICK(src, PROC_REF(process_lazer), lazertargets)
 
 ///Lazer ammo acts on the turf passed in
-/obj/structure/ship_ammo/CAS/laser_battery/proc/laser_burn(turf/T)
+/obj/structure/ship_ammo/cas/laser_battery/proc/laser_burn(turf/T)
 	playsound(T, 'sound/effects/pred_vision.ogg', 30, 1)
 	for(var/mob/living/L in T)
 		L.adjustFireLoss(120)
@@ -364,11 +364,11 @@
 
 //Rockets
 
-/obj/structure/ship_ammo/CAS/rocket
+/obj/structure/ship_ammo/cas/rocket
 	name = "abstract rocket"
 	icon_state = "single"
 	icon = 'icons/Marine/mainship_props64.dmi'
-	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/rocket_pod
+	equipment_type = /obj/structure/dropship_equipment/cas/weapon/rocket_pod
 	ammo_count = 1
 	max_ammo_count = 1
 	ammo_name = "rocket"
@@ -379,12 +379,12 @@
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
-/obj/structure/ship_ammo/CAS/rocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/detonate_on(turf/impact, attackdir = NORTH)
 	qdel(src)
 
 
 //this one is air-to-air only
-/obj/structure/ship_ammo/CAS/rocket/widowmaker
+/obj/structure/ship_ammo/cas/rocket/widowmaker
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly. Moving this will require some sort of lifter."
 	icon_state = "single"
@@ -397,12 +397,12 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/widowmaker
 
-/obj/structure/ship_ammo/CAS/rocket/widowmaker/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/widowmaker/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range)
 	qdel(src)
 
-/obj/structure/ship_ammo/CAS/rocket/banshee
+/obj/structure/ship_ammo/cas/rocket/banshee
 	name = "\improper AGM-227 'Banshee'"
 	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas. Moving this will require some sort of lifter."
 	icon_state = "banshee"
@@ -415,12 +415,12 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/banshee
 
-/obj/structure/ship_ammo/CAS/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range) //more spread out, with flames
 	qdel(src)
 
-/obj/structure/ship_ammo/CAS/rocket/keeper
+/obj/structure/ship_ammo/cas/rocket/keeper
 	name = "\improper GBU-67 'Keeper II'"
 	desc = "The GBU-67 'Keeper II' is the latest in a generation of laser guided weaponry that spans all the way back to the 20th century. Earning its nickname from a shortening of 'Peacekeeper' which comes from the program that developed its guidance system and the various uses of it during peacekeeping conflicts. Its payload is designed to devastate armored targets. Moving this will require some sort of lifter."
 	icon_state = "keeper"
@@ -431,12 +431,12 @@
 	light_explosion_range = 5
 	prediction_type = CAS_AMMO_EXPLOSIVE
 
-/obj/structure/ship_ammo/CAS/rocket/keeper/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/keeper/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //tighter blast radius, but more devastating near center
 	qdel(src)
 
-/obj/structure/ship_ammo/CAS/rocket/fatty
+/obj/structure/ship_ammo/cas/rocket/fatty
 	name = "\improper SM-17 'Fatty'"
 	desc = "The SM-17 'Fatty' is the most devestating rocket in TGMC arsenal, only second after its big cluster brother in Orbital Cannon. These rocket are also known for highest number of Friendly-on-Friendly incidents due to secondary cluster explosions as well as range of these explosions, TGMC recommends pilots to encourage usage of signal flares or laser for 'Fatty' support. Moving this will require some sort of lifter."
 	icon_state = "fatty"
@@ -448,7 +448,7 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/fatty
 
-/obj/structure/ship_ammo/CAS/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //first explosion is small to trick xenos into thinking its a minirocket.
 	addtimer(CALLBACK(src, PROC_REF(delayed_detonation), impact), 3 SECONDS)
@@ -460,7 +460,7 @@
  * * (turf/impact): targets impacted turf from first explosion
  */
 
-/obj/structure/ship_ammo/CAS/rocket/fatty/proc/delayed_detonation(turf/impact)
+/obj/structure/ship_ammo/cas/rocket/fatty/proc/delayed_detonation(turf/impact)
 	var/list/impact_coords = list(list(-3,3),list(0,4),list(3,3),list(-4,0),list(4,0),list(-3,-3),list(0,-4), list(3,-3))
 	for(var/i=1 to 8)
 		var/list/coords = impact_coords[i]
@@ -469,7 +469,7 @@
 		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)
 	qdel(src)
 
-/obj/structure/ship_ammo/CAS/rocket/napalm
+/obj/structure/ship_ammo/cas/rocket/napalm
 	name = "\improper XN-99 'Napalm'"
 	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time. Moving this will require some sort of lifter."
 	icon_state = "napalm"
@@ -482,7 +482,7 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/incendiary
 
-/obj/structure/ship_ammo/CAS/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //relatively weak
 	flame_radius(fire_range, impact, 60, 30) //cooking for a long time
@@ -494,12 +494,12 @@
 
 //minirockets
 
-/obj/structure/ship_ammo/CAS/minirocket
+/obj/structure/ship_ammo/cas/minirocket
 	name = "mini rocket stack"
 	desc = "A pack of explosive laser guided mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure//obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
+	equipment_type = /obj/structure//obj/structure/dropship_equipment/cas/weapon/minirocket_pod
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
@@ -513,21 +513,21 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/minirocket
 
-/obj/structure/ship_ammo/CAS/minirocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)//no messaging admin, that'd spam them.
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
-/obj/structure/ship_ammo/CAS/minirocket/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/cas/minirocket/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] containing [ammo_count] minirocket\s."
 
-/obj/structure/ship_ammo/CAS/minirocket/examine(mob/user)
+/obj/structure/ship_ammo/cas/minirocket/examine(mob/user)
 	. = ..()
 	. += "It has [ammo_count] minirocket\s."
 
 
-/obj/structure/ship_ammo/CAS/minirocket/incendiary
+/obj/structure/ship_ammo/cas/minirocket/incendiary
 	name = "incendiary mini rocket stack"
 	desc = "A pack of laser guided incendiary mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_inc"
@@ -537,11 +537,11 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/incendiary
 
-/obj/structure/ship_ammo/CAS/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH)
 	. = ..()
 	flame_radius(fire_range, impact)
 
-/obj/structure/ship_ammo/CAS/minirocket/smoke
+/obj/structure/ship_ammo/cas/minirocket/smoke
 	name = "smoke mini rocket stack"
 	desc = "A pack of laser guided screening smoke mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_smoke"
@@ -551,13 +551,13 @@
 	heavy_explosion_range = 0
 	light_explosion_range = 2
 
-/obj/structure/ship_ammo/CAS/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	var/datum/effect_system/smoke_spread/tactical/S = new
 	S.set_up(7, impact)// Large radius, but dissipates quickly
 	S.start()
 
-/obj/structure/ship_ammo/CAS/minirocket/tangle
+/obj/structure/ship_ammo/cas/minirocket/tangle
 	name = "Tanglefoot mini rocket stack"
 	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
@@ -567,14 +567,14 @@
 	light_explosion_range = 2
 	cas_effect = /obj/effect/overlay/blinking_laser/tfoot
 
-/obj/structure/ship_ammo/CAS/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0)
 	var/datum/effect_system/smoke_spread/plasmaloss/S = new
 	S.set_up(9, impact, 9)// Between grenade and mortar
 	S.start()
 
-/obj/structure/ship_ammo/CAS/minirocket/illumination
+/obj/structure/ship_ammo/cas/minirocket/illumination
 	name = "illumination rocket-launched flare stack"
 	desc = "A pack of laser guided mini rockets, each loaded with a payload of white-star illuminant and a parachute, while extremely ineffective at damaging the enemy, it is very effective at lighting the battlefield so marines can damage the enemy. Moving this will require some sort of lifter."
 	icon_state = "minirocket_ilm"
@@ -585,11 +585,11 @@
 	light_explosion_range = 0
 	prediction_type = CAS_AMMO_HARMLESS
 
-/obj/structure/ship_ammo/CAS/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	addtimer(CALLBACK(src, PROC_REF(drop_cas_flare), impact), 1.5 SECONDS)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
-/obj/structure/ship_ammo/CAS/minirocket/illumination/proc/drop_cas_flare(turf/impact)
+/obj/structure/ship_ammo/cas/minirocket/illumination/proc/drop_cas_flare(turf/impact)
 	new /obj/effect/temp_visual/above_flare(impact)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -200,11 +200,11 @@
 
 //30mm gun
 
-/obj/structure/ship_ammo/heavygun
+/obj/structure/ship_ammo/CAS/heavygun
 	name = "\improper 30mm ammo crate"
 	icon_state = "30mm_crate"
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
-	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
+	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/heavygun
 	travelling_time = 6 SECONDS
 	ammo_count = 200
 	max_ammo_count = 200
@@ -218,14 +218,14 @@
 	ammo_type = CAS_30MM
 	cas_effect = /obj/effect/overlay/blinking_laser/heavygun
 
-/obj/structure/ship_ammo/heavygun/examine(mob/user)
+/obj/structure/ship_ammo/CAS/heavygun/examine(mob/user)
 	. = ..()
 	. += "It has [ammo_count] round\s."
 
-/obj/structure/ship_ammo/heavygun/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/CAS/heavygun/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] containing [ammo_count] round\s."
 
-/obj/structure/ship_ammo/heavygun/get_turfs_to_impact(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/heavygun/get_turfs_to_impact(turf/impact, attackdir = NORTH)
 	var/turf/beginning = impact
 	var/revdir = REVERSE_DIR(attackdir)
 	for(var/i=0 to bullet_spread_range)
@@ -241,12 +241,12 @@
 
 	return strafelist
 
-/obj/structure/ship_ammo/heavygun/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/heavygun/detonate_on(turf/impact, attackdir = NORTH)
 	playsound(impact, 'sound/effects/casplane_flyby.ogg', 40)
 	strafe_turfs(get_turfs_to_impact(impact, attackdir))
 
 ///Takes the top 3 turfs and miniguns them, then repeats until none left
-/obj/structure/ship_ammo/heavygun/proc/strafe_turfs(list/strafelist)
+/obj/structure/ship_ammo/CAS/heavygun/proc/strafe_turfs(list/strafelist)
 	var/turf/strafed
 	playsound(strafelist[1], get_sfx("explosion"), 40, 1, 20, falloff = 3)
 	for(var/i=1 to attack_width)
@@ -259,7 +259,7 @@
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 2)
 
 
-/obj/structure/ship_ammo/heavygun/highvelocity
+/obj/structure/ship_ammo/CAS/heavygun/highvelocity
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
@@ -273,7 +273,7 @@
 	desc = "This is not meant to exist. Moving this will require some sort of lifter."
 	icon_state = "30mm_crate_hv"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
+	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
 	ammo_count = 400
 	max_ammo_count = 400
 	ammo_name = "railgun"
@@ -303,7 +303,7 @@
 
 //laser battery
 
-/obj/structure/ship_ammo/laser_battery
+/obj/structure/ship_ammo/CAS/laser_battery
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons. Moving this will require some sort of lifter."
@@ -311,7 +311,7 @@
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40
-	equipment_type = /obj/structure/dropship_equipment/weapon/laser_beam_gun
+	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun
 	ammo_name = "charge"
 	transferable_ammo = TRUE
 	ammo_used_per_firing = 10
@@ -322,15 +322,15 @@
 	ammo_type = CAS_LASER_BATTERY
 	cas_effect = /obj/effect/overlay/blinking_laser/laser
 
-/obj/structure/ship_ammo/laser_battery/examine(mob/user)
+/obj/structure/ship_ammo/CAS/laser_battery/examine(mob/user)
 	. = ..()
 	. += "It's at [round(100*ammo_count/max_ammo_count)]% charge."
 
 
-/obj/structure/ship_ammo/laser_battery/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/CAS/laser_battery/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] at [round(100*ammo_count/max_ammo_count)]% charge."
 
-/obj/structure/ship_ammo/laser_battery/get_turfs_to_impact(turf/epicenter, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/laser_battery/get_turfs_to_impact(turf/epicenter, attackdir = NORTH)
 	var/turf/beginning = epicenter
 	var/turf/end = epicenter
 	var/revdir = REVERSE_DIR(attackdir)
@@ -339,21 +339,21 @@
 		end = get_step(end, attackdir)
 	return getline(beginning, end)
 
-/obj/structure/ship_ammo/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
 	var/list/turf/lazertargets = get_turfs_to_impact(impact, attackdir)
 	process_lazer(lazertargets)
 	if(!ammo_count)
 		QDEL_IN(src, laze_radius+1) //deleted after last laser beam is fired and impact the ground.
 
 ///takes the top lazertarget on the stack and fires the lazer at it
-/obj/structure/ship_ammo/laser_battery/proc/process_lazer(list/lazertargets)
+/obj/structure/ship_ammo/CAS/laser_battery/proc/process_lazer(list/lazertargets)
 	laser_burn(lazertargets[1])
 	lazertargets -= lazertargets[1]
 	if(length(lazertargets))
 		INVOKE_NEXT_TICK(src, PROC_REF(process_lazer), lazertargets)
 
 ///Lazer ammo acts on the turf passed in
-/obj/structure/ship_ammo/laser_battery/proc/laser_burn(turf/T)
+/obj/structure/ship_ammo/CAS/laser_battery/proc/laser_burn(turf/T)
 	playsound(T, 'sound/effects/pred_vision.ogg', 30, 1)
 	for(var/mob/living/L in T)
 		L.adjustFireLoss(120)
@@ -364,11 +364,11 @@
 
 //Rockets
 
-/obj/structure/ship_ammo/rocket
+/obj/structure/ship_ammo/CAS/rocket
 	name = "abstract rocket"
 	icon_state = "single"
 	icon = 'icons/Marine/mainship_props64.dmi'
-	equipment_type = /obj/structure/dropship_equipment/weapon/rocket_pod
+	equipment_type = /obj/structure/dropship_equipment/CAS/weapon/rocket_pod
 	ammo_count = 1
 	max_ammo_count = 1
 	ammo_name = "rocket"
@@ -379,12 +379,12 @@
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
-/obj/structure/ship_ammo/rocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/detonate_on(turf/impact, attackdir = NORTH)
 	qdel(src)
 
 
 //this one is air-to-air only
-/obj/structure/ship_ammo/rocket/widowmaker
+/obj/structure/ship_ammo/CAS/rocket/widowmaker
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly. Moving this will require some sort of lifter."
 	icon_state = "single"
@@ -397,12 +397,12 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/widowmaker
 
-/obj/structure/ship_ammo/rocket/widowmaker/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/widowmaker/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range)
 	qdel(src)
 
-/obj/structure/ship_ammo/rocket/banshee
+/obj/structure/ship_ammo/CAS/rocket/banshee
 	name = "\improper AGM-227 'Banshee'"
 	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas. Moving this will require some sort of lifter."
 	icon_state = "banshee"
@@ -415,12 +415,12 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/banshee
 
-/obj/structure/ship_ammo/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range) //more spread out, with flames
 	qdel(src)
 
-/obj/structure/ship_ammo/rocket/keeper
+/obj/structure/ship_ammo/CAS/rocket/keeper
 	name = "\improper GBU-67 'Keeper II'"
 	desc = "The GBU-67 'Keeper II' is the latest in a generation of laser guided weaponry that spans all the way back to the 20th century. Earning its nickname from a shortening of 'Peacekeeper' which comes from the program that developed its guidance system and the various uses of it during peacekeeping conflicts. Its payload is designed to devastate armored targets. Moving this will require some sort of lifter."
 	icon_state = "keeper"
@@ -431,12 +431,12 @@
 	light_explosion_range = 5
 	prediction_type = CAS_AMMO_EXPLOSIVE
 
-/obj/structure/ship_ammo/rocket/keeper/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/keeper/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //tighter blast radius, but more devastating near center
 	qdel(src)
 
-/obj/structure/ship_ammo/rocket/fatty
+/obj/structure/ship_ammo/CAS/rocket/fatty
 	name = "\improper SM-17 'Fatty'"
 	desc = "The SM-17 'Fatty' is the most devestating rocket in TGMC arsenal, only second after its big cluster brother in Orbital Cannon. These rocket are also known for highest number of Friendly-on-Friendly incidents due to secondary cluster explosions as well as range of these explosions, TGMC recommends pilots to encourage usage of signal flares or laser for 'Fatty' support. Moving this will require some sort of lifter."
 	icon_state = "fatty"
@@ -448,7 +448,7 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/fatty
 
-/obj/structure/ship_ammo/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //first explosion is small to trick xenos into thinking its a minirocket.
 	addtimer(CALLBACK(src, PROC_REF(delayed_detonation), impact), 3 SECONDS)
@@ -460,7 +460,7 @@
  * * (turf/impact): targets impacted turf from first explosion
  */
 
-/obj/structure/ship_ammo/rocket/fatty/proc/delayed_detonation(turf/impact)
+/obj/structure/ship_ammo/CAS/rocket/fatty/proc/delayed_detonation(turf/impact)
 	var/list/impact_coords = list(list(-3,3),list(0,4),list(3,3),list(-4,0),list(4,0),list(-3,-3),list(0,-4), list(3,-3))
 	for(var/i=1 to 8)
 		var/list/coords = impact_coords[i]
@@ -469,7 +469,7 @@
 		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)
 	qdel(src)
 
-/obj/structure/ship_ammo/rocket/napalm
+/obj/structure/ship_ammo/CAS/rocket/napalm
 	name = "\improper XN-99 'Napalm'"
 	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time. Moving this will require some sort of lifter."
 	icon_state = "napalm"
@@ -482,7 +482,7 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/incendiary
 
-/obj/structure/ship_ammo/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //relatively weak
 	flame_radius(fire_range, impact, 60, 30) //cooking for a long time
@@ -494,12 +494,12 @@
 
 //minirockets
 
-/obj/structure/ship_ammo/minirocket
+/obj/structure/ship_ammo/CAS/minirocket
 	name = "mini rocket stack"
 	desc = "A pack of explosive laser guided mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
+	equipment_type = /obj/structure//obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
@@ -513,21 +513,21 @@
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/minirocket
 
-/obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/minirocket/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)//no messaging admin, that'd spam them.
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
-/obj/structure/ship_ammo/minirocket/show_loaded_desc(mob/user)
+/obj/structure/ship_ammo/CAS/minirocket/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src] containing [ammo_count] minirocket\s."
 
-/obj/structure/ship_ammo/minirocket/examine(mob/user)
+/obj/structure/ship_ammo/CAS/minirocket/examine(mob/user)
 	. = ..()
 	. += "It has [ammo_count] minirocket\s."
 
 
-/obj/structure/ship_ammo/minirocket/incendiary
+/obj/structure/ship_ammo/CAS/minirocket/incendiary
 	name = "incendiary mini rocket stack"
 	desc = "A pack of laser guided incendiary mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_inc"
@@ -537,11 +537,11 @@
 	prediction_type = CAS_AMMO_INCENDIARY
 	cas_effect = /obj/effect/overlay/blinking_laser/incendiary
 
-/obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH)
 	. = ..()
 	flame_radius(fire_range, impact)
 
-/obj/structure/ship_ammo/minirocket/smoke
+/obj/structure/ship_ammo/CAS/minirocket/smoke
 	name = "smoke mini rocket stack"
 	desc = "A pack of laser guided screening smoke mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_smoke"
@@ -551,13 +551,13 @@
 	heavy_explosion_range = 0
 	light_explosion_range = 2
 
-/obj/structure/ship_ammo/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	var/datum/effect_system/smoke_spread/tactical/S = new
 	S.set_up(7, impact)// Large radius, but dissipates quickly
 	S.start()
 
-/obj/structure/ship_ammo/minirocket/tangle
+/obj/structure/ship_ammo/CAS/minirocket/tangle
 	name = "Tanglefoot mini rocket stack"
 	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
@@ -567,14 +567,14 @@
 	light_explosion_range = 2
 	cas_effect = /obj/effect/overlay/blinking_laser/tfoot
 
-/obj/structure/ship_ammo/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0)
 	var/datum/effect_system/smoke_spread/plasmaloss/S = new
 	S.set_up(9, impact, 9)// Between grenade and mortar
 	S.start()
 
-/obj/structure/ship_ammo/minirocket/illumination
+/obj/structure/ship_ammo/CAS/minirocket/illumination
 	name = "illumination rocket-launched flare stack"
 	desc = "A pack of laser guided mini rockets, each loaded with a payload of white-star illuminant and a parachute, while extremely ineffective at damaging the enemy, it is very effective at lighting the battlefield so marines can damage the enemy. Moving this will require some sort of lifter."
 	icon_state = "minirocket_ilm"
@@ -585,11 +585,11 @@
 	light_explosion_range = 0
 	prediction_type = CAS_AMMO_HARMLESS
 
-/obj/structure/ship_ammo/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/CAS/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	addtimer(CALLBACK(src, PROC_REF(drop_cas_flare), impact), 1.5 SECONDS)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
-/obj/structure/ship_ammo/minirocket/illumination/proc/drop_cas_flare(turf/impact)
+/obj/structure/ship_ammo/CAS/minirocket/illumination/proc/drop_cas_flare(turf/impact)
 	new /obj/effect/temp_visual/above_flare(impact)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -499,7 +499,7 @@
 	desc = "A pack of explosive laser guided mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure/obj/structure/dropship_equipment/cas/weapon/minirocket_pod
+	equipment_type = /obj/structure/dropship_equipment/cas/weapon/minirocket_pod
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -499,7 +499,7 @@
 	desc = "A pack of explosive laser guided mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket"
 	icon = 'icons/Marine/mainship_props.dmi'
-	equipment_type = /obj/structure//obj/structure/dropship_equipment/cas/weapon/minirocket_pod
+	equipment_type = /obj/structure/obj/structure/dropship_equipment/cas/weapon/minirocket_pod
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -296,7 +296,7 @@
 		to_chat(user, span_notice("You select [src]."))
 
 //////////////////////////////////// flare launcher //////////////////////////////////////
-/obj/structure/dropship_equipment/flare_launcher
+/obj/structure/dropship_equipment/shuttle/flare_launcher
 	equip_category = DROPSHIP_WEAPON
 	name = "flare launcher system"
 	desc = "A system that deploys flares stronger than the inputted flares. Fits on the weapon attach points of dropships. You need a powerloader to lift it."
@@ -310,7 +310,7 @@
 	///max capacity of flares in system
 	var/max_amount = 4
 
-/obj/structure/dropship_equipment/flare_launcher/equipment_interact(mob/user)
+/obj/structure/dropship_equipment/shuttle/flare_launcher/equipment_interact(mob/user)
 	if(!COOLDOWN_CHECK(src, deploy_cooldown)) //prevents spamming deployment
 		user.balloon_alert(user, "[src] is busy.")
 		return
@@ -321,14 +321,14 @@
 	user.balloon_alert(user, "You deploy [src], remaining flares [stored_amount].")
 	COOLDOWN_START(src, deploy_cooldown, 5 SECONDS)
 
-/obj/structure/dropship_equipment/flare_launcher/attackby(obj/item/I, mob/user, params)
+/obj/structure/dropship_equipment/shuttle/flare_launcher/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(istype(I, /obj/item/explosive/grenade/flare) && stored_amount < max_amount)
 		stored_amount++
 		user.balloon_alert(user, "You insert a flare, remaining flares [stored_amount].")
 		qdel(I)
 
-/obj/structure/dropship_equipment/flare_launcher/update_equipment()
+/obj/structure/dropship_equipment/shuttle/flare_launcher/update_equipment()
 	. = ..()
 	if(ship_base)
 		setDir(ship_base.dir)
@@ -336,7 +336,7 @@
 		setDir(initial(dir))
 	update_icon()
 
-/obj/structure/dropship_equipment/flare_launcher/update_icon_state()
+/obj/structure/dropship_equipment/shuttle/flare_launcher/update_icon_state()
 	. = ..()
 	if(ship_base)
 		icon_state = "flare_system_installed"
@@ -344,7 +344,7 @@
 		icon_state = "flare_system"
 
 ///gets target and deploy the flare launcher
-/obj/structure/dropship_equipment/flare_launcher/proc/deploy_flare()
+/obj/structure/dropship_equipment/shuttle/flare_launcher/proc/deploy_flare()
 	playsound(loc, 'sound/weapons/guns/fire/tank_smokelauncher.ogg', 40, 1)
 	var/turf/target = get_ranged_target_turf(src, dir, 10)
 	var/obj/item/explosive/grenade/flare/strongerflare/flare_to_launch = new(loc)
@@ -354,7 +354,7 @@
 
 //////////////////////////////////// turret holders //////////////////////////////////////
 
-/obj/structure/dropship_equipment/sentry_holder
+/obj/structure/dropship_equipment/shuttle/sentry_holder
 	equip_category = DROPSHIP_WEAPON
 	name = "sentry deployment system"
 	desc = "A box that deploys a sentry turret. Fits on the weapon attach points of dropships. You need a powerloader to lift it."
@@ -365,7 +365,7 @@
 	var/obj/machinery/deployable/mounted/sentry/deployed_turret
 	var/sentry_type = /obj/item/weapon/gun/sentry/big_sentry/dropship
 
-/obj/structure/dropship_equipment/sentry_holder/Initialize(mapload)
+/obj/structure/dropship_equipment/shuttle/sentry_holder/Initialize(mapload)
 	. = ..()
 	if(!deployed_turret)
 		var/obj/new_gun = new sentry_type(src)
@@ -373,21 +373,21 @@
 		RegisterSignal(deployed_turret, COMSIG_OBJ_DECONSTRUCT, PROC_REF(clean_refs))
 
 ///This cleans the deployed_turret ref when the sentry is destroyed.
-/obj/structure/dropship_equipment/sentry_holder/proc/clean_refs(atom/source, disassembled)
+/obj/structure/dropship_equipment/shuttle/sentry_holder/proc/clean_refs(atom/source, disassembled)
 	SIGNAL_HANDLER
 	UnregisterSignal(deployed_turret, COMSIG_OBJ_DECONSTRUCT)
 	deployed_turret = null
 	dropship_equipment_flags &= ~IS_NOT_REMOVABLE
 
-/obj/structure/dropship_equipment/sentry_holder/examine(mob/user)
+/obj/structure/dropship_equipment/shuttle/sentry_holder/examine(mob/user)
 	. = ..()
 	if(!deployed_turret)
 		. += "Its turret is missing."
 
-/obj/structure/dropship_equipment/sentry_holder/on_launch()
+/obj/structure/dropship_equipment/shuttle/sentry_holder/on_launch()
 	undeploy_sentry()
 
-/obj/structure/dropship_equipment/sentry_holder/equipment_interact(mob/user)
+/obj/structure/dropship_equipment/shuttle/sentry_holder/equipment_interact(mob/user)
 	if(!deployed_turret)
 		to_chat(user, span_warning("[src] is unresponsive."))
 		return
@@ -405,7 +405,7 @@
 		undeploy_sentry()
 
 
-/obj/structure/dropship_equipment/sentry_holder/update_equipment()
+/obj/structure/dropship_equipment/shuttle/sentry_holder/update_equipment()
 	if(ship_base)
 		setDir(ship_base.dir)
 		icon_state = "sentry_system_installed"
@@ -442,7 +442,7 @@
 		else
 			icon_state = "sentry_system_destroyed"
 
-/obj/structure/dropship_equipment/sentry_holder/proc/deploy_sentry()
+/obj/structure/dropship_equipment/shuttle/sentry_holder/proc/deploy_sentry()
 	if(!deployed_turret)
 		return
 	setDir(ship_base.dir)
@@ -456,7 +456,7 @@
 	dropship_equipment_flags |= IS_NOT_REMOVABLE
 	deployed_turret.update_minimap_icon()
 
-/obj/structure/dropship_equipment/sentry_holder/proc/undeploy_sentry()
+/obj/structure/dropship_equipment/shuttle/sentry_holder/proc/undeploy_sentry()
 	if(!deployed_turret)
 		return
 	playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, 1)
@@ -468,7 +468,7 @@
 	icon_state = "sentry_system_installed"
 	dropship_equipment_flags &= ~IS_NOT_REMOVABLE
 
-/obj/structure/dropship_equipment/weapon_holder
+/obj/structure/dropship_equipment/shuttle/weapon_holder
 	equip_category = DROPSHIP_CREW_WEAPON
 	///The type of deployable that this holder holds
 	var/obj/machinery/deployable/deployable_type
@@ -479,19 +479,19 @@
 	///The sprite used when we aren't deployed
 	var/undeployed_icon_state = "mg_system"
 
-/obj/structure/dropship_equipment/weapon_holder/Initialize(mapload)
+/obj/structure/dropship_equipment/shuttle/weapon_holder/Initialize(mapload)
 	. = ..()
 	if(held_deployable)
 		return
 	var/obj/machinery/deployable/new_deployable = new deployable_type(src)
 	held_deployable = new_deployable.loc //new_deployable.loc, since it deploys on new(), is located within the held_deployable. Therefore new_deployable.loc = held_deployable.
 
-/obj/structure/dropship_equipment/weapon_holder/examine(mob/user)
+/obj/structure/dropship_equipment/shuttle/weapon_holder/examine(mob/user)
 	. = ..()
 	if(!held_deployable)
 		. += "Its [initial(deployable_type.name)] is missing."
 
-/obj/structure/dropship_equipment/weapon_holder/update_equipment()
+/obj/structure/dropship_equipment/shuttle/weapon_holder/update_equipment()
 	if(!held_deployable)
 		return
 	if(ship_base)
@@ -500,30 +500,30 @@
 		held_deployable.loc = src
 	update_icon()
 
-/obj/structure/dropship_equipment/weapon_holder/update_icon_state()
+/obj/structure/dropship_equipment/shuttle/weapon_holder/update_icon_state()
 	if(ship_base)
 		icon_state = deployed_icon_state
 	else
 		icon_state = undeployed_icon_state
 
-/obj/structure/dropship_equipment/weapon_holder/Destroy()
+/obj/structure/dropship_equipment/shuttle/weapon_holder/Destroy()
 	if(held_deployable)
 		QDEL_NULL(held_deployable)
 	return ..()
 
-/obj/structure/dropship_equipment/weapon_holder/CanAllowThrough(atom/movable/mover, turf/target)
+/obj/structure/dropship_equipment/shuttle/weapon_holder/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
 	if(held_deployable.loc != src)
 		return TRUE
 
-/obj/structure/dropship_equipment/weapon_holder/machinegun
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun
 	name = "machinegun deployment system"
 	desc = "A box that deploys a modified M56D crewserved machine gun. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "mg_system"
 	point_cost = 300
 	deployable_type = /obj/item/weapon/gun/tl102/hsg_nest
 
-/obj/structure/dropship_equipment/weapon_holder/minigun
+/obj/structure/dropship_equipment/shuttle/weapon_holder/minigun
 	name = "minigun deployment system"
 	desc = "A box that deploys a modified MG-2005 crewserved minigun. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "minigun_system"
@@ -531,7 +531,7 @@
 	deployable_type = /obj/item/weapon/gun/standard_minigun/nest
 	undeployed_icon_state = "minigun_system"
 
-/obj/structure/dropship_equipment/weapon_holder/heavylaser
+/obj/structure/dropship_equipment/shuttle/weapon_holder/heavylaser
 	name = "heavy laser deployment system"
 	desc = "A box that deploys a modified TE-9001 crewserved heavylaser. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "hl_system"
@@ -539,7 +539,7 @@
 	deployable_type = /obj/item/weapon/gun/heavy_laser
 	undeployed_icon_state = "hl_system"
 
-/obj/structure/dropship_equipment/weapon_holder/heavy_rr
+/obj/structure/dropship_equipment/shuttle/weapon_holder/heavy_rr
 	name = "heavy recoilless rifle deployment system"
 	desc = "A box that deploys a modified RR-15 crewserved recoilless rifle. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "rr_system"
@@ -547,7 +547,7 @@
 	deployable_type = /obj/item/weapon/gun/launcher/rocket/heavy_rr
 	undeployed_icon_state = "rr_system"
 
-/obj/structure/dropship_equipment/weapon_holder/mortar_holder
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder
 	name = "mortar deployment system"
 	desc = "A box that deploys a TA-55DB mortar. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "mortar_system"
@@ -642,7 +642,7 @@
 
 ////////////////////////////////////// WEAPONS ///////////////////////////////////////
 
-/obj/structure/dropship_equipment/weapon
+/obj/structure/dropship_equipment/CAS/weapon
 	name = "abstract weapon"
 	icon = 'icons/Marine/mainship_props64.dmi'
 	equip_category = DROPSHIP_WEAPON
@@ -654,7 +654,7 @@
 	var/firing_sound
 	var/firing_delay = 20 //delay between firing. 2 seconds by default
 
-/obj/structure/dropship_equipment/weapon/update_equipment()
+/obj/structure/dropship_equipment/CAS/weapon/update_equipment()
 	if(ship_base)
 		setDir(ship_base.dir)
 		bound_width = 32
@@ -665,14 +665,14 @@
 		bound_height = initial(bound_height)
 	update_icon()
 
-/obj/structure/dropship_equipment/weapon/equipment_interact(mob/user)
+/obj/structure/dropship_equipment/CAS/weapon/equipment_interact(mob/user)
 	if(dropship_equipment_flags & IS_INTERACTABLE)
 		if(linked_console.selected_equipment == src)
 			linked_console.selected_equipment = null
 		else
 			linked_console.selected_equipment = src
 
-/obj/structure/dropship_equipment/weapon/examine(mob/user)
+/obj/structure/dropship_equipment/CAS/weapon/examine(mob/user)
 	. = ..()
 	if(ammo_equipped)
 		. += ammo_equipped.show_loaded_desc(user)
@@ -681,12 +681,12 @@
 
 
 
-/obj/structure/dropship_equipment/weapon/proc/deplete_ammo()
+/obj/structure/dropship_equipment/CAS/weapon/proc/deplete_ammo()
 	if(ammo_equipped)
 		ammo_equipped.ammo_count = max(ammo_equipped.ammo_count-ammo_equipped.ammo_used_per_firing, 0)
 	update_icon()
 
-/obj/structure/dropship_equipment/weapon/proc/open_fire(obj/selected_target, attackdir)
+/obj/structure/dropship_equipment/CAS/weapon/proc/open_fire(obj/selected_target, attackdir)
 	var/turf/target_turf = get_turf(selected_target)
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
@@ -712,7 +712,7 @@
 	addtimer(CALLBACK(SA, TYPE_PROC_REF(/obj/structure/ship_ammo, detonate_on), target_turf, attackdir), ammo_travelling_time)
 	QDEL_LIST_IN(effects_to_delete, ammo_travelling_time)
 
-/obj/structure/dropship_equipment/weapon/heavygun
+/obj/structure/dropship_equipment/CAS/weapon/heavygun
 	name = "\improper GAU-21 30mm cannon"
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
@@ -721,7 +721,7 @@
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 
-/obj/structure/dropship_equipment/weapon/heavygun/update_icon()
+/obj/structure/dropship_equipment/CAS/weapon/heavygun/update_icon()
 	if(ammo_equipped)
 		icon_state = "30mm_cannon_loaded[ammo_equipped.ammo_count?"1":"0"]"
 	else
@@ -730,16 +730,16 @@
 		else
 			icon_state = "30mm_cannon"
 
-/obj/structure/dropship_equipment/weapon/heavygun/radial_cas
+/obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas
 	name = "Condor Jet Radial minigun"
 	point_cost = 0
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE|IS_NOT_REMOVABLE
 
-/obj/structure/dropship_equipment/weapon/heavygun/radial_cas/Initialize(mapload)
+/obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas/Initialize(mapload)
 	. = ..()
-	ammo_equipped = new /obj/structure/ship_ammo/heavygun(src)
+	ammo_equipped = new /obj/structure/ship_ammo/CAS/heavygun(src)
 
-/obj/structure/dropship_equipment/weapon/rocket_pod
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod
 	name = "rocket pod"
 	icon_state = "rocket_pod"
 	desc = "A rocket pod weapon system capable of launching a single laser-guided rocket. Moving this will require some sort of lifter."
@@ -748,11 +748,11 @@
 	point_cost = 600
 	ammo_type_used = CAS_MISSILE
 
-/obj/structure/dropship_equipment/weapon/rocket_pod/deplete_ammo()
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod/deplete_ammo()
 	ammo_equipped = null //nothing left to empty after firing
 	update_icon()
 
-/obj/structure/dropship_equipment/weapon/rocket_pod/update_icon()
+/obj/structure/dropship_equipment/CAS/weapon/rocket_pod/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "rocket_pod_loaded[ammo_equipped.ammo_id]"
 	else
@@ -762,7 +762,7 @@
 			icon_state = "rocket_pod"
 
 
-/obj/structure/dropship_equipment/weapon/minirocket_pod
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
 	name = "minirocket pod"
 	icon_state = "minirocket_pod"
 	desc = "A mini rocket pod capable of launching six laser-guided mini rockets. Moving this will require some sort of lifter."
@@ -772,7 +772,7 @@
 	point_cost = 600
 	ammo_type_used = CAS_MINI_ROCKET
 
-/obj/structure/dropship_equipment/weapon/minirocket_pod/update_icon()
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "minirocket_pod_loaded"
 	else
@@ -781,12 +781,12 @@
 		else
 			icon_state = "minirocket_pod"
 
-/obj/structure/dropship_equipment/weapon/minirocket_pod/deplete_ammo()
+/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod/deplete_ammo()
 	..()
 	if(ammo_equipped && !ammo_equipped.ammo_count) //fired last minirocket
 		ammo_equipped = null
 
-/obj/structure/dropship_equipment/weapon/laser_beam_gun
+/obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun
 	name = "laser beam gun"
 	icon_state = "laser_beam"
 	desc = "State of the art technology recently acquired by the TGMC, it fires a battery-fed pulsed laser beam at near lightspeed setting on fire everything it touches. Moving this will require some sort of lifter."
@@ -797,7 +797,7 @@
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_LASER_BATTERY
 
-/obj/structure/dropship_equipment/weapon/laser_beam_gun/update_icon()
+/obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "laser_beam_loaded"
 	else
@@ -808,7 +808,7 @@
 
 
 
-/obj/structure/dropship_equipment/weapon/launch_bay
+/obj/structure/dropship_equipment/CAS/weapon/launch_bay //This isn't printable, so having it under CAS shouldn't cause issues
 	name = "launch bay"
 	icon_state = "launch_bay"
 	desc = "A launch bay to drop special ordnance. Fits inside the dropship's crew weapon emplacement. Moving this will require some sort of lifter."
@@ -818,7 +818,7 @@
 	equip_category = DROPSHIP_CREW_WEAPON //fits inside the central spot of the dropship
 	point_cost = 0
 
-/obj/structure/dropship_equipment/weapon/launch_bay/update_icon()
+/obj/structure/dropship_equipment/CAS/weapon/launch_bay/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "launch_bay_loaded"
 	else
@@ -832,7 +832,7 @@
 
 //////////////// OTHER EQUIPMENT /////////////////
 
-/obj/structure/dropship_equipment/operatingtable
+/obj/structure/dropship_equipment/CAS/operatingtable
 	name = "Dropship Operating Table Deployment System"
 	desc = "Used for advanced medical procedures. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	equip_category = DROPSHIP_CREW_WEAPON
@@ -841,25 +841,25 @@
 	point_cost = 100
 	var/obj/machinery/optable/deployed_table
 
-/obj/structure/dropship_equipment/operatingtable/Initialize(mapload)
+/obj/structure/dropship_equipment/CAS/operatingtable/Initialize(mapload)
 	. = ..()
 	if(!deployed_table)
 		deployed_table = new(src)
 		RegisterSignal(deployed_table, COMSIG_ATOM_ATTACKBY, PROC_REF(attackby_wrapper))//if something (like a powerloader) clicks on the deployed thing relay it
 
-/obj/structure/dropship_equipment/operatingtable/proc/attackby_wrapper(datum/source, obj/item/I, mob/user, params)
+/obj/structure/dropship_equipment/CAS/operatingtable/proc/attackby_wrapper(datum/source, obj/item/I, mob/user, params)
 	attackby(I, user, params)
 
-/obj/structure/dropship_equipment/operatingtable/examine(mob/user)
+/obj/structure/dropship_equipment/CAS/operatingtable/examine(mob/user)
 	. = ..()
 	if(!deployed_table)
 		. += "Its table is broken."
 
-/obj/structure/dropship_equipment/operatingtable/Destroy()
+/obj/structure/dropship_equipment/CAS/operatingtable/Destroy()
 	QDEL_NULL(deployed_table)
 	return ..()
 
-/obj/structure/dropship_equipment/operatingtable/update_equipment()
+/obj/structure/dropship_equipment/CAS/operatingtable/update_equipment()
 	if(!deployed_table)
 		return
 	deployed_table.layer = ABOVE_OBJ_LAYER + 0.01 //make sure its directly ABOVE the layer

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -642,7 +642,7 @@
 
 ////////////////////////////////////// WEAPONS ///////////////////////////////////////
 
-/obj/structure/dropship_equipment/CAS/weapon
+/obj/structure/dropship_equipment/cas/weapon
 	name = "abstract weapon"
 	icon = 'icons/Marine/mainship_props64.dmi'
 	equip_category = DROPSHIP_WEAPON
@@ -654,7 +654,7 @@
 	var/firing_sound
 	var/firing_delay = 20 //delay between firing. 2 seconds by default
 
-/obj/structure/dropship_equipment/CAS/weapon/update_equipment()
+/obj/structure/dropship_equipment/cas/weapon/update_equipment()
 	if(ship_base)
 		setDir(ship_base.dir)
 		bound_width = 32
@@ -665,14 +665,14 @@
 		bound_height = initial(bound_height)
 	update_icon()
 
-/obj/structure/dropship_equipment/CAS/weapon/equipment_interact(mob/user)
+/obj/structure/dropship_equipment/cas/weapon/equipment_interact(mob/user)
 	if(dropship_equipment_flags & IS_INTERACTABLE)
 		if(linked_console.selected_equipment == src)
 			linked_console.selected_equipment = null
 		else
 			linked_console.selected_equipment = src
 
-/obj/structure/dropship_equipment/CAS/weapon/examine(mob/user)
+/obj/structure/dropship_equipment/cas/weapon/examine(mob/user)
 	. = ..()
 	if(ammo_equipped)
 		. += ammo_equipped.show_loaded_desc(user)
@@ -681,12 +681,12 @@
 
 
 
-/obj/structure/dropship_equipment/CAS/weapon/proc/deplete_ammo()
+/obj/structure/dropship_equipment/cas/weapon/proc/deplete_ammo()
 	if(ammo_equipped)
 		ammo_equipped.ammo_count = max(ammo_equipped.ammo_count-ammo_equipped.ammo_used_per_firing, 0)
 	update_icon()
 
-/obj/structure/dropship_equipment/CAS/weapon/proc/open_fire(obj/selected_target, attackdir)
+/obj/structure/dropship_equipment/cas/weapon/proc/open_fire(obj/selected_target, attackdir)
 	var/turf/target_turf = get_turf(selected_target)
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
@@ -712,7 +712,7 @@
 	addtimer(CALLBACK(SA, TYPE_PROC_REF(/obj/structure/ship_ammo, detonate_on), target_turf, attackdir), ammo_travelling_time)
 	QDEL_LIST_IN(effects_to_delete, ammo_travelling_time)
 
-/obj/structure/dropship_equipment/CAS/weapon/heavygun
+/obj/structure/dropship_equipment/cas/weapon/heavygun
 	name = "\improper GAU-21 30mm cannon"
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
@@ -721,7 +721,7 @@
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 
-/obj/structure/dropship_equipment/CAS/weapon/heavygun/update_icon()
+/obj/structure/dropship_equipment/cas/weapon/heavygun/update_icon()
 	if(ammo_equipped)
 		icon_state = "30mm_cannon_loaded[ammo_equipped.ammo_count?"1":"0"]"
 	else
@@ -730,16 +730,16 @@
 		else
 			icon_state = "30mm_cannon"
 
-/obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas
+/obj/structure/dropship_equipment/cas/weapon/heavygun/radial_cas
 	name = "Condor Jet Radial minigun"
 	point_cost = 0
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE|IS_NOT_REMOVABLE
 
-/obj/structure/dropship_equipment/CAS/weapon/heavygun/radial_cas/Initialize(mapload)
+/obj/structure/dropship_equipment/cas/weapon/heavygun/radial_cas/Initialize(mapload)
 	. = ..()
-	ammo_equipped = new /obj/structure/ship_ammo/CAS/heavygun(src)
+	ammo_equipped = new /obj/structure/ship_ammo/cas/heavygun(src)
 
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod
 	name = "rocket pod"
 	icon_state = "rocket_pod"
 	desc = "A rocket pod weapon system capable of launching a single laser-guided rocket. Moving this will require some sort of lifter."
@@ -748,11 +748,11 @@
 	point_cost = 600
 	ammo_type_used = CAS_MISSILE
 
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod/deplete_ammo()
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod/deplete_ammo()
 	ammo_equipped = null //nothing left to empty after firing
 	update_icon()
 
-/obj/structure/dropship_equipment/CAS/weapon/rocket_pod/update_icon()
+/obj/structure/dropship_equipment/cas/weapon/rocket_pod/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "rocket_pod_loaded[ammo_equipped.ammo_id]"
 	else
@@ -762,7 +762,7 @@
 			icon_state = "rocket_pod"
 
 
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod
 	name = "minirocket pod"
 	icon_state = "minirocket_pod"
 	desc = "A mini rocket pod capable of launching six laser-guided mini rockets. Moving this will require some sort of lifter."
@@ -772,7 +772,7 @@
 	point_cost = 600
 	ammo_type_used = CAS_MINI_ROCKET
 
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod/update_icon()
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "minirocket_pod_loaded"
 	else
@@ -781,12 +781,12 @@
 		else
 			icon_state = "minirocket_pod"
 
-/obj/structure/dropship_equipment/CAS/weapon/minirocket_pod/deplete_ammo()
+/obj/structure/dropship_equipment/cas/weapon/minirocket_pod/deplete_ammo()
 	..()
 	if(ammo_equipped && !ammo_equipped.ammo_count) //fired last minirocket
 		ammo_equipped = null
 
-/obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun
+/obj/structure/dropship_equipment/cas/weapon/laser_beam_gun
 	name = "laser beam gun"
 	icon_state = "laser_beam"
 	desc = "State of the art technology recently acquired by the TGMC, it fires a battery-fed pulsed laser beam at near lightspeed setting on fire everything it touches. Moving this will require some sort of lifter."
@@ -797,7 +797,7 @@
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_LASER_BATTERY
 
-/obj/structure/dropship_equipment/CAS/weapon/laser_beam_gun/update_icon()
+/obj/structure/dropship_equipment/cas/weapon/laser_beam_gun/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "laser_beam_loaded"
 	else
@@ -808,7 +808,7 @@
 
 
 
-/obj/structure/dropship_equipment/CAS/weapon/launch_bay //This isn't printable, so having it under CAS shouldn't cause issues
+/obj/structure/dropship_equipment/cas/weapon/launch_bay //This isn't printable, so having it under CAS shouldn't cause issues
 	name = "launch bay"
 	icon_state = "launch_bay"
 	desc = "A launch bay to drop special ordnance. Fits inside the dropship's crew weapon emplacement. Moving this will require some sort of lifter."
@@ -818,7 +818,7 @@
 	equip_category = DROPSHIP_CREW_WEAPON //fits inside the central spot of the dropship
 	point_cost = 0
 
-/obj/structure/dropship_equipment/CAS/weapon/launch_bay/update_icon()
+/obj/structure/dropship_equipment/cas/weapon/launch_bay/update_icon()
 	if(ammo_equipped?.ammo_count)
 		icon_state = "launch_bay_loaded"
 	else

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -832,7 +832,7 @@
 
 //////////////// OTHER EQUIPMENT /////////////////
 
-/obj/structure/dropship_equipment/CAS/operatingtable
+/obj/structure/dropship_equipment/shuttle/operatingtable
 	name = "Dropship Operating Table Deployment System"
 	desc = "Used for advanced medical procedures. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	equip_category = DROPSHIP_CREW_WEAPON
@@ -841,25 +841,25 @@
 	point_cost = 100
 	var/obj/machinery/optable/deployed_table
 
-/obj/structure/dropship_equipment/CAS/operatingtable/Initialize(mapload)
+/obj/structure/dropship_equipment/shuttle/operatingtable/Initialize(mapload)
 	. = ..()
 	if(!deployed_table)
 		deployed_table = new(src)
 		RegisterSignal(deployed_table, COMSIG_ATOM_ATTACKBY, PROC_REF(attackby_wrapper))//if something (like a powerloader) clicks on the deployed thing relay it
 
-/obj/structure/dropship_equipment/CAS/operatingtable/proc/attackby_wrapper(datum/source, obj/item/I, mob/user, params)
+/obj/structure/dropship_equipment/shuttle/operatingtable/proc/attackby_wrapper(datum/source, obj/item/I, mob/user, params)
 	attackby(I, user, params)
 
-/obj/structure/dropship_equipment/CAS/operatingtable/examine(mob/user)
+/obj/structure/dropship_equipment/shuttle/operatingtable/examine(mob/user)
 	. = ..()
 	if(!deployed_table)
 		. += "Its table is broken."
 
-/obj/structure/dropship_equipment/CAS/operatingtable/Destroy()
+/obj/structure/dropship_equipment/shuttle/operatingtable/Destroy()
 	QDEL_NULL(deployed_table)
 	return ..()
 
-/obj/structure/dropship_equipment/CAS/operatingtable/update_equipment()
+/obj/structure/dropship_equipment/shuttle/operatingtable/update_equipment()
 	if(!deployed_table)
 		return
 	deployed_table.layer = ABOVE_OBJ_LAYER + 0.01 //make sure its directly ABOVE the layer

--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -31,7 +31,7 @@
 	///How much fuel we can hold maximum
 	var/fuel_max = 40
 	///Our currently selected weapon we will fire
-	var/obj/structure/dropship_equipment/weapon/active_weapon
+	var/obj/structure/dropship_equipment/CAS/weapon/active_weapon
 	///Minimap for the pilot to know where the marines have ran off to
 	var/datum/action/minimap/marine/external/cas_mini
 
@@ -259,7 +259,7 @@
 	var/element_nbr = 1
 	.["all_weapons"] = list()
 	for(var/i in equipments)
-		var/obj/structure/dropship_equipment/weapon/weapon = i
+		var/obj/structure/dropship_equipment/CAS/weapon/weapon = i
 		.["all_weapons"] += list(list("name"= sanitize(copytext(weapon.name,1,MAX_MESSAGE_LEN)), "ammo" = weapon?.ammo_equipped?.ammo_count, "eqp_tag" = element_nbr))
 		if(weapon == active_weapon)
 			.["active_weapon_tag"] = element_nbr

--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -31,7 +31,7 @@
 	///How much fuel we can hold maximum
 	var/fuel_max = 40
 	///Our currently selected weapon we will fire
-	var/obj/structure/dropship_equipment/CAS/weapon/active_weapon
+	var/obj/structure/dropship_equipment/cas/weapon/active_weapon
 	///Minimap for the pilot to know where the marines have ran off to
 	var/datum/action/minimap/marine/external/cas_mini
 
@@ -259,7 +259,7 @@
 	var/element_nbr = 1
 	.["all_weapons"] = list()
 	for(var/i in equipments)
-		var/obj/structure/dropship_equipment/CAS/weapon/weapon = i
+		var/obj/structure/dropship_equipment/cas/weapon/weapon = i
 		.["all_weapons"] += list(list("name"= sanitize(copytext(weapon.name,1,MAX_MESSAGE_LEN)), "ammo" = weapon?.ammo_equipped?.ammo_count, "eqp_tag" = element_nbr))
 		if(weapon == active_weapon)
 			.["active_weapon_tag"] = element_nbr

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -179,7 +179,7 @@
 	ammo_datum_type = /datum/ammo/bullet/turret/gauss
 	sentry_iff_signal = TGMC_LOYALIST_IFF
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE|DEPLOYED_NO_PICKUP
-	var/obj/structure/dropship_equipment/sentry_holder/deployment_system
+	var/obj/structure/dropship_equipment/shuttle/sentry_holder/deployment_system
 	turret_flags = TURRET_HAS_CAMERA|TURRET_IMMOBILE
 	density = FALSE
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1904,22 +1904,22 @@ VEHICLES
 
 /datum/supply_packs/vehicles/mounted_hsg
 	name = "Mounted HSG"
-	contains = list(/obj/structure/dropship_equipment/weapon_holder/machinegun)
+	contains = list(/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun)
 	cost = 500
 
 /datum/supply_packs/vehicles/minigun_nest
 	name = "Mounted Minigun"
-	contains = list(/obj/structure/dropship_equipment/weapon_holder/minigun)
+	contains = list(/obj/structure/dropship_equipment/shuttle/weapon_holder/minigun)
 	cost = 750
 
 /datum/supply_packs/vehicles/mounted_heavy_laser
 	name = "Mounted Heavy Laser"
-	contains = list(/obj/structure/dropship_equipment/weapon_holder/heavylaser)
+	contains = list(/obj/structure/dropship_equipment/shuttle/weapon_holder/heavylaser)
 	cost = 900
 
 /datum/supply_packs/vehicles/mounted_rr
 	name = "Mounted Heavy Recoilless Rifle"
-	contains = list(/obj/structure/dropship_equipment/weapon_holder/heavy_rr)
+	contains = list(/obj/structure/dropship_equipment/shuttle/weapon_holder/heavy_rr)
 	cost = 1800
 
 /datum/supply_packs/vehicles/hsg_ammo


### PR DESCRIPTION
## About The Pull Request
This pr separates the dropship fabricator items into 3 categories, Condor Equipment, Dropship Equipment, and Condor Ammo. Also repaths condor equipment into /obj/structure/dropship_equipment/CAS, dropship equipment into /obj/structure/dropship_equipment/shuttle, and most dropship ammo into /obj/structure/ship_ammo/CAS (exception being the railgun ammo)
![Change Me - Pillar of Spring 8_29_2023 11_46_07 AM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/3a6cf94b-011c-4440-9843-739c2a579d49)
## Why It's Good For The Game
Currently all printable items are under "Dropship", meaning it can be rather confusing for new players whether something can be used on the Condor or the Tad/Alamo. This helps to clarify this.
## Changelog
:cl:
qol: The dropship fabricator has had it's items separated into more distinct categories.
code: Repathed dropship/condor equipment, dropship/condor weapons, and condor ammo.
/:cl:
