### PR TITLE
De-randomizes surgery step time on an operating table

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -178,6 +178,8 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 
 		//calculate step duration
 		var/step_duration = max(0.5 SECONDS, rand(surgery_step.min_duration, surgery_step.max_duration) - 1 SECONDS * user.skills.getRating(SKILL_SURGERY))
+		if((locate(/obj/machinery/optable, M.loc)) && user.skills.getRating(SKILL_SURGERY) >= SKILL_SURGERY_PROFESSIONAL)
+			step_duration = 0.5 SECONDS
 
 		//Multiply tool success rate with multipler
 		if(do_mob(user, M, step_duration, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, extra_checks = CALLBACK(user, TYPE_PROC_REF(/mob, break_do_after_checks), null, null, user.zone_selected)) && prob(surgery_step.tool_quality(tool) * CLAMP01(multipler)))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 
 		//calculate step duration
 		var/step_duration = max(0.5 SECONDS, rand(surgery_step.min_duration, surgery_step.max_duration) - 1 SECONDS * user.skills.getRating(SKILL_SURGERY))
-		if(locate(/obj/machinery/optable, M.loc))
+		if(locate(/obj/machinery/optable) in M.loc)
 			step_duration = max(0.5 SECONDS, surgery_step.min_duration - 1 SECONDS * user.skills.getRating(SKILL_SURGERY))
 
 		//Multiply tool success rate with multipler

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -178,8 +178,8 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 
 		//calculate step duration
 		var/step_duration = max(0.5 SECONDS, rand(surgery_step.min_duration, surgery_step.max_duration) - 1 SECONDS * user.skills.getRating(SKILL_SURGERY))
-		if((locate(/obj/machinery/optable, M.loc)) && user.skills.getRating(SKILL_SURGERY) >= SKILL_SURGERY_PROFESSIONAL)
-			step_duration = 0.5 SECONDS
+		if(locate(/obj/machinery/optable, M.loc))
+			step_duration = max(0.5 SECONDS, surgery_step.min_duration - 1 SECONDS * user.skills.getRating(SKILL_SURGERY))
 
 		//Multiply tool success rate with multipler
 		if(do_mob(user, M, step_duration, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, extra_checks = CALLBACK(user, TYPE_PROC_REF(/mob, break_do_after_checks), null, null, user.zone_selected)) && prob(surgery_step.tool_quality(tool) * CLAMP01(multipler)))


### PR DESCRIPTION
## About The Pull Request
Currently, regardless of where you do surgery, the time is randomized between the minimum and maximum time of how long a surgery step can take. This PR makes it so if you are on an operating table, it will always take the minimum.
P.S this is probably fairly shitcode, if there is a better way to do it please tell me
## Why It's Good For The Game
This aims to do two things:
1) Make it less frustrating for the person doing surgery to get used to step times. RNG while doing medical can be fun (see bone cracks when opening rib) but for the most part just adds tedium. However, this keeps another penalty to rollerbed and normal table surgery as those have the benefit of being *portable*, while already having some RNG with them as well (see: slip chance outside of synth, synth is a funny snowflake).
2) In a small way expedites a marine's journey through medbay after being sent. Quoting QV in a way, MD gameplay will always be flawed because it is one person not doing anything waiting while the other gets to do their job for a bit. The faster a marine goes through, less time spent in that gameplay loop, but the MD can still get the "satisfaction" of doing a surgery and getting a patient through ASAP.
## Changelog
:cl:
balance: Surgery time is no longer random on an operating tables specifically, always being the minimum for the doctor's skill
/:cl:
