### PR TITLE
Reorganised xeno keybindings and added a few new default ones 

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -897,7 +897,7 @@
 	keybind_signal = COMSIG_XENOABILITY_JAB
 	hotkey_keys = list("E")
 
-	/datum/keybinding/xeno/burrow
+/datum/keybinding/xeno/burrow
 	name = "burrow"
 	full_name = "Widow: Burrow"
 	description = "Dig to the ground, making you invisible."

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -819,6 +819,33 @@
 	description = "Fires a scattershot of 6 acid globules which create acid puddles on impact or at the end of their range."
 	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
 
+/datum/keybinding/xeno/psychic_shield
+	name = "Psychic Shield"
+	full_name = "Warlock: Psychic Shield"
+	description = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_SHIELD
+	hotkey_keys = list("E")
+
+/datum/keybinding/xeno/trigger_psychic_shield
+	name = "Trigger Psychic Shield"
+	full_name = "Warlock: Trigger Psychic Shield"
+	description = "Triggers the Psychic Shield ability without selecting it."
+	keybind_signal = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD
+
+/datum/keybinding/xeno/psychic_blast
+	name = "Psychic Blast"
+	full_name = "Warlock: Psychic Blast"
+	description = "Fire a lightly-damaging AOE psychic beam which knocks back enemies after a short charge-up."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_BLAST
+	hotkey_keys = list("R")
+
+/datum/keybinding/xeno/psychic_crush
+	name = "Psychic Crush"
+	full_name = "Warlock: Psychic Crush"
+	description = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CRUSH
+	hotkey_keys = list("Q")
+
 /datum/keybinding/xeno/toggle_agility
 	name = "toggle_agility"
 	full_name = "Warrior: Toggle Agility"
@@ -860,75 +887,6 @@
 	description = "Precisely strike your target from further away, slowing and confusing them. Resets punch cooldown."
 	keybind_signal = COMSIG_XENOABILITY_JAB
 	hotkey_keys = list("E")
-
-/datum/keybinding/xeno/rewind
-	name = "rewind"
-	full_name = "Wraith: Time Shift"
-	description = "Save the location and status of the target. When the time is up, the target location and status are restored"
-	keybind_signal = COMSIG_XENOABILITY_REWIND
-
-/datum/keybinding/xeno/portal
-	name = "portal"
-	full_name = "Wraith: Portal"
-	description = "Place the first portal on your location. You can travel from portal one to portal two and vice versa."
-	keybind_signal =COMSIG_XENOABILITY_PORTAL
-
-/datum/keybinding/xeno/portal_two
-	name = "portal_two"
-	full_name = "Wraith: Portal two"
-	description = "Place the second portal on your location. You can travel from portal one to portal two and vice versa."
-	keybind_signal =COMSIG_XENOABILITY_PORTAL_ALTERNATE
-
-/datum/keybinding/xeno/blink
-	name = "wraith_blink"
-	full_name = "Wraith: Blink"
-	description = "Teleport to a space a short distance away within line of sight. Can teleport mobs you're dragging with you at the cost of higher cooldown."
-	keybind_signal = COMSIG_XENOABILITY_BLINK
-
-/datum/keybinding/xeno/banish
-	name = "banish"
-	full_name = "Wraith: Banish"
-	description = "Banish a creature or object a short distance away within line of sight to null space. Can target oneself and allies. Can be manually cancelled with Recall."
-	keybind_signal = COMSIG_XENOABILITY_BANISH
-
-/datum/keybinding/xeno/recall
-	name = "recall"
-	full_name = "Wraith: Recall"
-	description = "Recall a target from netherspace, ending Banish's effect."
-	keybind_signal = COMSIG_XENOABILITY_RECALL
-
-/datum/keybinding/xeno/timestop
-	name = "timestop"
-	full_name = "Wraith: Time stop"
-	description = "Freezes bullets in their course, and they will start to move again only after a certain time"
-	keybind_signal = COMSIG_XENOABILITY_TIMESTOP
-
-/datum/keybinding/xeno/psychic_shield
-	name = "Psychic Shield"
-	full_name = "Warlock: Psychic Shield"
-	description = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_SHIELD
-	hotkey_keys = list("E")
-
-/datum/keybinding/xeno/trigger_psychic_shield
-	name = "Trigger Psychic Shield"
-	full_name = "Warlock: Trigger Psychic Shield"
-	description = "Triggers the Psychic Shield ability without selecting it."
-	keybind_signal = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD
-
-/datum/keybinding/xeno/psychic_blast
-	name = "Psychic Blast"
-	full_name = "Warlock: Psychic Blast"
-	description = "Fire a lightly-damaging AOE psychic beam which knocks back enemies after a short charge-up."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_BLAST
-	hotkey_keys = list("R")
-
-/datum/keybinding/xeno/psychic_crush
-	name = "Psychic Crush"
-	full_name = "Warlock: Psychic Crush"
-	description = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CRUSH
-	hotkey_keys = list("Q")
 
 	/datum/keybinding/xeno/burrow
 	name = "burrow"
@@ -977,3 +935,45 @@
 	full_name = "Widow: Spiderling Mark"
 	description = "Signal your spawn to a target they shall attack."
 	keybind_signal = COMSIG_XENOABILITY_SPIDERLING_MARK
+
+/datum/keybinding/xeno/rewind
+	name = "rewind"
+	full_name = "Wraith: Time Shift"
+	description = "Save the location and status of the target. When the time is up, the target location and status are restored"
+	keybind_signal = COMSIG_XENOABILITY_REWIND
+
+/datum/keybinding/xeno/portal
+	name = "portal"
+	full_name = "Wraith: Portal"
+	description = "Place the first portal on your location. You can travel from portal one to portal two and vice versa."
+	keybind_signal =COMSIG_XENOABILITY_PORTAL
+
+/datum/keybinding/xeno/portal_two
+	name = "portal_two"
+	full_name = "Wraith: Portal two"
+	description = "Place the second portal on your location. You can travel from portal one to portal two and vice versa."
+	keybind_signal =COMSIG_XENOABILITY_PORTAL_ALTERNATE
+
+/datum/keybinding/xeno/blink
+	name = "wraith_blink"
+	full_name = "Wraith: Blink"
+	description = "Teleport to a space a short distance away within line of sight. Can teleport mobs you're dragging with you at the cost of higher cooldown."
+	keybind_signal = COMSIG_XENOABILITY_BLINK
+
+/datum/keybinding/xeno/banish
+	name = "banish"
+	full_name = "Wraith: Banish"
+	description = "Banish a creature or object a short distance away within line of sight to null space. Can target oneself and allies. Can be manually cancelled with Recall."
+	keybind_signal = COMSIG_XENOABILITY_BANISH
+
+/datum/keybinding/xeno/recall
+	name = "recall"
+	full_name = "Wraith: Recall"
+	description = "Recall a target from netherspace, ending Banish's effect."
+	keybind_signal = COMSIG_XENOABILITY_RECALL
+
+/datum/keybinding/xeno/timestop
+	name = "timestop"
+	full_name = "Wraith: Time stop"
+	description = "Freezes bullets in their course, and they will start to move again only after a certain time"
+	keybind_signal = COMSIG_XENOABILITY_TIMESTOP

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -125,6 +125,7 @@
 	full_name = "Transfer Plasma"
 	description = "Give some of your plasma to a teammate."
 	keybind_signal = COMSIG_XENOABILITY_TRANSFER_PLASMA
+	hotkey_keys = list("N")
 
 /datum/keybinding/xeno/pounce
 	name = "pounce"
@@ -448,18 +449,21 @@
 	full_name = "Drone: Essence Link"
 	description = "Establish a link of plasma with a sister."
 	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/essence_link_remove
 	name = "essence_link_remove"
 	full_name = "Drone: End Essence Link"
 	description = "Forcibly end an Essence Link."
 	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK_REMOVE
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/enhancement
 	name = "enhancement"
 	full_name = "Drone: Enhancement"
 	description = "Using an Essence Link, increase a sister's capabilities beyond their limits."
 	keybind_signal = COMSIG_XENOABILITY_ENHANCEMENT
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/devour
 	name = "devour"
@@ -644,17 +648,25 @@
 	description = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
 	keybind_signal = COMSIG_XENOABILITY_HIVE_SUMMON
 
+/datum/keybinding/xeno/acid_dash
+	name = "acid_dash"
+	full_name = "Praetorian : Acid Dash"
+	description = "Quickly dash, leaving acid in your path and knocking down the first marine hit. Has reset potential."
+	keybind_signal = COMSIG_XENOABILITY_ACID_DASH
+
 /datum/keybinding/xeno/screech
 	name = "screech"
 	full_name = "Queen: Screech"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/toggle_queen_zoom
 	name = "toggle_queen_zoom"
 	full_name = "Queen: Toggle Zoom"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_QUEEN_ZOOM
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/xeno_leaders
 	name = "xeno_leaders"
@@ -667,12 +679,14 @@
 	full_name = "Queen: Give Heal"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HEAL
+	hotkey_keys = list("H")
 
 /datum/keybinding/xeno/queen_give_plasma
 	name = "queen_give_plasma"
 	full_name = "Queen: Give Plasma"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_PLASMA
+	hotkey_keys = list("N")
 
 /datum/keybinding/xeno/queen_hive_message
 	name = "queen_hive_message"
@@ -685,6 +699,7 @@
 	full_name = "Queen: Bulwark"
 	description = "Forms an area around you that reduces damage taken by friendly xenomorphs."
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_BULWARK
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/deevolve
 	name = "deevolve"
@@ -731,12 +746,6 @@
 	full_name = "Ravager: Select Ravage"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_RAVAGE_SELECT
-
-/datum/keybinding/xeno/acid_dash
-	name = "acid_dash"
-	full_name = "Praetorian : Acid Dash"
-	description = "Quickly dash, leaving acid in your path and knocking down the first marine hit. Has reset potential."
-	keybind_signal = COMSIG_XENOABILITY_ACID_DASH
 
 /datum/keybinding/xeno/toggle_savage
 	name = "toggle_savage"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -2,11 +2,16 @@
 	category = CATEGORY_XENO
 	weight = WEIGHT_MOB
 
+//
+// Universal or multi-caste
+//
+
 /datum/keybinding/xeno/headbite
 	name = "headbite"
 	full_name = "Headbite / Psydrain"
 	description = "Permanently kill a target. / Gather psy and larva points from a body."
 	keybind_signal = COMSIG_XENOABILITY_HEADBITE
+	hotkey_keys = list("J")
 
 /datum/keybinding/xeno/regurgitate
 	name = "regurgitate"
@@ -19,13 +24,14 @@
 	full_name = "Open Blessings Menu"
 	description = "Opens the Queen Mothers Blessings menu, where hive upgrades are bought"
 	keybind_signal = COMSIG_XENOABILITY_BLESSINGSMENU
+	hotkey_keys = list("P")
 
 /datum/keybinding/xeno/drop_weeds
-	hotkey_keys = list("V")
 	name = "drop_weeds"
 	full_name = "Drop Weed"
 	description = "Drop weeds to help grow your hive."
 	keybind_signal = COMSIG_XENOABILITY_DROP_WEEDS
+	hotkey_keys = list("V")
 
 /datum/keybinding/xeno/choose_weeds
 	hotkey_keys = list("Space")
@@ -39,6 +45,7 @@
 	full_name = "Secrete Resin"
 	description = "Builds whatever you’ve selected with (choose resin structure) on your tile."
 	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/recycle
 	name = "Recycle"
@@ -59,18 +66,21 @@
 	full_name = "Emit Recovery Pheromones"
 	description = "Increases healing for yourself and nearby teammates."
 	keybind_signal = COMSIG_XENOABILITY_EMIT_RECOVERY
+	hotkey_keys = list("7")
 
 /datum/keybinding/xeno/emit_warding
 	name = "emit_warding"
 	full_name = "Emit Warding Pheromones"
 	description = "Increases armor for yourself and nearby teammates."
 	keybind_signal = COMSIG_XENOABILITY_EMIT_WARDING
+	hotkey_keys = list("8")
 
 /datum/keybinding/xeno/emit_frenzy
 	name = "emit_frenzy"
 	full_name = "Emit Frenzy Pheromones"
 	description = "Increases damage for yourself and nearby teammates."
 	keybind_signal = COMSIG_XENOABILITY_EMIT_FRENZY
+	hotkey_keys = list("9")
 
 /datum/keybinding/xeno/corrosive_acid
 	name = "corrosive_acid"
@@ -89,12 +99,14 @@
 	full_name = "Spit"
 	description = "Spit neurotoxin or acid at your target up to 7 tiles away."
 	keybind_signal = COMSIG_XENOABILITY_XENO_SPIT
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/xenohide
 	name = "xenohide"
 	full_name = "Hide"
 	description = "Causes your sprite to hide behind certain objects and under tables. Not the same as stealth. Does not use plasma."
 	keybind_signal = COMSIG_XENOABILITY_HIDE
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/neurotox_sting
 	name = "neurotox_sting"
@@ -132,70 +144,88 @@
 	keybind_signal = COMSIG_XENOABILITY_TOXIC_SPIT
 	hotkey_keys = list("E")
 
-/datum/keybinding/xeno/toxic_slash
-	name = "toxic_slash"
-	full_name = "Sentinel: Toxic Slash"
-	description = "Imbue your claws with toxins, inflicting the Intoxicated debuff on hit and dealing damage over time."
-	keybind_signal = COMSIG_XENOABILITY_TOXIC_SLASH
-	hotkey_keys = list("R")
+/datum/keybinding/xeno/vent
+	name = "vent"
+	full_name = "Vent crawl"
+	description = "Enter an air vent and crawl through the pipe system."
+	keybind_signal = COMSIG_XENOABILITY_VENTCRAWL
 
-/datum/keybinding/xeno/drain_sting
-	name = "drain_sting"
-	full_name = "Sentinel: Drain Sting"
-	description = "Sting a victim, draining any Intoxicated debuffs they may have, restoring you and dealing damage."
-	keybind_signal = COMSIG_XENOABILITY_DRAIN_STING
-	hotkey_keys = list("F")
+/datum/keybinding/xeno/vent/down(client/user)
+	. = ..()
+	if(!isxeno(user.mob))
+		return
+	var/mob/living/carbon/xenomorph/xeno = user.mob
+	xeno.vent_crawl()
 
-/datum/keybinding/xeno/toxicgrenade
-	name = "toxic_grenade"
-	full_name = "Sentinel: Toxic Grenade"
-	description = "Throws a ball of resin containing a toxin that inflicts the Intoxicated debuff, dealing damage over time."
-	keybind_signal = COMSIG_XENOABILITY_TOXIC_GRENADE
-	hotkey_keys = list("Q")
+/datum/keybinding/xeno/psychic_whisper
+	name = "psychic_whisper"
+	full_name = "Psychic Whisper"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_WHISPER
 
-/datum/keybinding/xeno/acidic_salve
-	name = "acidic_salve"
-	full_name = "Drone: Acidic Salve"
-	description = "Heal a xenomorph with this."
-	keybind_signal = COMSIG_XENOABILITY_ACIDIC_SALVE
-	hotkey_keys = list("F")
+/datum/keybinding/xeno/lay_egg
+	name = "lay_egg"
+	full_name = "Lay Egg"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_LAY_EGG
 
-/datum/keybinding/xeno/essence_link
-	name = "essence_link"
-	full_name = "Drone: Essence Link"
-	description = "Establish a link of plasma with a sister."
-	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK
+/datum/keybinding/xeno/call_of_the_burrowed
+	name = "call_of_the_burrowed"
+	full_name = "Call of the Burrowed"
+	description = "Attempts to summon all currently burrowed larva."
+	keybind_signal = COMSIG_XENOABILITY_CALL_OF_THE_BURROWED
 
-/datum/keybinding/xeno/essence_link_remove
-	name = "essence_link_remove"
-	full_name = "Drone: End Essence Link"
-	description = "Forcibly end an Essence Link."
-	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK_REMOVE
+/datum/keybinding/xeno/inject_egg_neurogas
+	name = "inject_egg_neurogas"
+	full_name = "Inject Egg (Neurogas)"
+	description = "Inject an egg with neurogas, killing the little one inside"
+	keybind_signal = COMSIG_XENOABILITY_INJECT_EGG_NEUROGAS
 
-/datum/keybinding/xeno/enhancement
-	name = "enhancement"
-	full_name = "Drone: Enhancement"
-	description = "Using an Essence Link, increase a sister's capabilities beyond their limits."
-	keybind_signal = COMSIG_XENOABILITY_ENHANCEMENT
+/datum/keybinding/xeno/rally_hive
+	name = "rally_hive"
+	full_name = "Rally Hive"
+	description = "Rallies the hive to a target location."
+	keybind_signal = COMSIG_XENOABILITY_RALLY_HIVE
 
+/datum/keybinding/xeno/rally_minion
+	name = "rally_minion"
+	full_name = "Rally Minions"
+	description = "Rallies the minions to a target location, or yourself."
+	keybind_signal = COMSIG_XENOABILITY_RALLY_MINION
 
-/datum/keybinding/xeno/plow_charge
-	name = "plow_charge"
-	full_name = "Bull: Plow Charge"
-	description = "A charge that plows through the victims."
-	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
+/datum/keybinding/xeno/command_minions
+	name = "command_minion"
+	full_name = "Command Minions"
+	description = "Order the minions escorting you to be either agressive or passive."
+	keybind_signal = COMSIG_XENOABILITY_MINION_BEHAVIOUR
 
-/datum/keybinding/xeno/headbutt_charge
-	name = "headbutt_charge"
-	full_name = "Bull: Headbutt Charge"
-	description = "A charge that tosses the victim forward or backwards, depending on intent."
-	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
+//
+// Single caste, alphabetical order
+//
 
-/datum/keybinding/xeno/gore_charge
-	name = "gore_charge"
-	full_name = "Bull: Gore Charge"
-	description = "A charge that gores the victim."
-	keybind_signal = COMSIG_XENOABILITY_BULLGORE
+/datum/keybinding/xeno/dash_explosion
+	name = "Dash Explosion"
+	full_name = "Baneling: Dash Explode"
+	description = "Aim in a direction, charge up and dash, knocking down any humans hit and detonate yourself. "
+	keybind_signal = COMSIG_XENOABILITY_BANELING_DASH_EXPLOSION
+
+/datum/keybinding/xeno/spawn_pod
+	name = "Spawn Pod"
+	full_name = "Baneling: Spawn Pod"
+	description = "Spawn a pod on your current position, when you die from any source you will respawn on this pod. Activate again to change its location. "
+	keybind_signal = COMSIG_XENOABILITY_BANELING_SPAWN_POD
+
+/datum/keybinding/xeno/baneling_explode
+	name = "Explode"
+	full_name = "Baneling: Explode"
+	description = "Detonate yourself, spreading your currently selected reagent. Size depends on current stored plasma, more plasma is more reagent."
+	keybind_signal = COMSIG_XENOABILITY_BANELING_EXPLODE
+
+/datum/keybinding/xeno/select_reagent/baneling
+	name = "Select Reagent"
+	full_name = "Baneling: Select Reagent"
+	description = "Choose a reagent that will be spread upon death. Costs plasma to change."
+	keybind_signal = COMSIG_XENOABILITY_BANELING_CHOOSE_REAGENT
 
 /datum/keybinding/xeno/long_range_sight
 	name = "long_range_sight"
@@ -237,6 +267,24 @@
 	description = "Fire globules."
 	keybind_signal = COMSIG_XENOABILITY_BOMBARD
 	hotkey_keys = list("R")
+
+/datum/keybinding/xeno/plow_charge
+	name = "plow_charge"
+	full_name = "Bull: Plow Charge"
+	description = "A charge that plows through the victims."
+	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
+
+/datum/keybinding/xeno/headbutt_charge
+	name = "headbutt_charge"
+	full_name = "Bull: Headbutt Charge"
+	description = "A charge that tosses the victim forward or backwards, depending on intent."
+	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
+
+/datum/keybinding/xeno/gore_charge
+	name = "gore_charge"
+	full_name = "Bull: Gore Charge"
+	description = "A charge that gores the victim."
+	keybind_signal = COMSIG_XENOABILITY_BULLGORE
 
 /datum/keybinding/xeno/throw_hugger
 	name = "throw_hugger"
@@ -305,48 +353,6 @@
 	description = "Charges up the crushers charge, then unleashes the full bulk of the crusher into a direction."
 	keybind_signal = COMSIG_XENOABILITY_ADVANCE
 	hotkey_keys = list("F")
-
-/datum/keybinding/xeno/devour
-	name = "devour"
-	full_name = "Gorger: Devour"
-	description = "Devour your victim to be able to carry it faster."
-	keybind_signal = COMSIG_XENOABILITY_DEVOUR
-
-/datum/keybinding/xeno/drain
-	name = "drain"
-	full_name = "Gorger: Drain"
-	description = "Stagger a marine and drain some of their blood. When used on a dead human, you heal gradually and don't gain blood."
-	keybind_signal = COMSIG_XENOABILITY_DRAIN
-
-/datum/keybinding/xeno/transfusion
-	name = "transfusion"
-	full_name = "Gorger: Transfusion"
-	description = "Restores some of the health of another xenomorph, or overheals, at the cost of blood."
-	keybind_signal = COMSIG_XENOABILITY_TRANSFUSION
-
-/datum/keybinding/xeno/rejuvenate
-	name = "rejuvenate"
-	full_name = "Gorger: Rejuvenate"
-	description = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
-	keybind_signal = COMSIG_XENOABILITY_REJUVENATE
-
-/datum/keybinding/xeno/psychic_link
-	name = "psychic link"
-	full_name = "Gorger: Psychic Link"
-	description = "Link to a xenomorph and take some damage in their place. During this time, you can't move. Use rest action to cancel."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_LINK
-
-/datum/keybinding/xeno/carnage
-	name = "carnage"
-	full_name = "Gorger: Carnage"
-	description = "For a while your attacks drain blood and heal you. During Feast you also heal nearby allies."
-	keybind_signal = COMSIG_XENOABILITY_CARNAGE
-
-/datum/keybinding/xeno/feast
-	name = "feast"
-	full_name = "Gorger: Feast"
-	description = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
-	keybind_signal = COMSIG_XENOABILITY_FEAST
 
 /datum/keybinding/xeno/forward_charge
 	name = "forward charge"
@@ -430,6 +436,73 @@
 	keybind_signal = COMSIG_XENOABILITY_TENTACLE
 	hotkey_keys = list("Q")
 
+/datum/keybinding/xeno/acidic_salve
+	name = "acidic_salve"
+	full_name = "Drone: Acidic Salve"
+	description = "Heal a xenomorph with this."
+	keybind_signal = COMSIG_XENOABILITY_ACIDIC_SALVE
+	hotkey_keys = list("F")
+
+/datum/keybinding/xeno/essence_link
+	name = "essence_link"
+	full_name = "Drone: Essence Link"
+	description = "Establish a link of plasma with a sister."
+	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK
+
+/datum/keybinding/xeno/essence_link_remove
+	name = "essence_link_remove"
+	full_name = "Drone: End Essence Link"
+	description = "Forcibly end an Essence Link."
+	keybind_signal = COMSIG_XENOABILITY_ESSENCE_LINK_REMOVE
+
+/datum/keybinding/xeno/enhancement
+	name = "enhancement"
+	full_name = "Drone: Enhancement"
+	description = "Using an Essence Link, increase a sister's capabilities beyond their limits."
+	keybind_signal = COMSIG_XENOABILITY_ENHANCEMENT
+
+/datum/keybinding/xeno/devour
+	name = "devour"
+	full_name = "Gorger: Devour"
+	description = "Devour your victim to be able to carry it faster."
+	keybind_signal = COMSIG_XENOABILITY_DEVOUR
+
+/datum/keybinding/xeno/drain
+	name = "drain"
+	full_name = "Gorger: Drain"
+	description = "Stagger a marine and drain some of their blood. When used on a dead human, you heal gradually and don't gain blood."
+	keybind_signal = COMSIG_XENOABILITY_DRAIN
+
+/datum/keybinding/xeno/transfusion
+	name = "transfusion"
+	full_name = "Gorger: Transfusion"
+	description = "Restores some of the health of another xenomorph, or overheals, at the cost of blood."
+	keybind_signal = COMSIG_XENOABILITY_TRANSFUSION
+
+/datum/keybinding/xeno/rejuvenate
+	name = "rejuvenate"
+	full_name = "Gorger: Rejuvenate"
+	description = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
+	keybind_signal = COMSIG_XENOABILITY_REJUVENATE
+
+/datum/keybinding/xeno/psychic_link
+	name = "psychic link"
+	full_name = "Gorger: Psychic Link"
+	description = "Link to a xenomorph and take some damage in their place. During this time, you can't move. Use rest action to cancel."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_LINK
+
+/datum/keybinding/xeno/carnage
+	name = "carnage"
+	full_name = "Gorger: Carnage"
+	description = "For a while your attacks drain blood and heal you. During Feast you also heal nearby allies."
+	keybind_signal = COMSIG_XENOABILITY_CARNAGE
+
+/datum/keybinding/xeno/feast
+	name = "feast"
+	full_name = "Gorger: Feast"
+	description = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
+	keybind_signal = COMSIG_XENOABILITY_FEAST
+
 /datum/keybinding/xeno/resin_walker
 	name = "resin_walker"
 	full_name = "Hivelord: Toggle Resin Walker"
@@ -462,6 +535,18 @@
 	description = "Imbues a target xeno with healing energy, restoring extra Sunder and Health once every 2 seconds up to 5 times whenever it regenerates normally. 60 second duration."
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
 	hotkey_keys = list("X")
+
+/datum/keybinding/xeno/sow
+	name = "sow"
+	full_name = "Hivelord: Sow"
+	description = "Plant the seeds of an alien plant."
+	keybind_signal = COMSIG_XENOABILITY_DROP_PLANT
+
+/datum/keybinding/xeno/sow_select_plant
+	name = "choose_plant"
+	full_name = "Hivelord: Choose plant"
+	description = "Pick what type of plant to sow."
+	keybind_signal = COMSIG_XENOABILITY_CHOOSE_PLANT
 
 /datum/keybinding/xeno/change_form
 	name = "change_form"
@@ -518,58 +603,46 @@
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_TRACE
 	hotkey_keys = list("G")
 
-/datum/keybinding/xeno/psychic_whisper
-	name = "psychic_whisper"
-	full_name = "Psychic Whisper"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_WHISPER
-
-/datum/keybinding/xeno/lay_egg
-	name = "lay_egg"
-	full_name = "Lay Egg"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_LAY_EGG
-
-/datum/keybinding/xeno/call_of_the_burrowed
-	name = "call_of_the_burrowed"
-	full_name = "Call of the Burrowed"
-	description = "Attempts to summon all currently burrowed larva."
-	keybind_signal = COMSIG_XENOABILITY_CALL_OF_THE_BURROWED
-
-/datum/keybinding/xeno/psychic_fling
-	name = "psychic_fling"
-	full_name = "Shrike: Psychic Fling"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
-	hotkey_keys = list("E")
-
-/datum/keybinding/xeno/unrelenting_force
-	name = "unrelenting_force"
-	full_name = "Shrike: Unrelenting Force"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE
-	hotkey_keys = list("R")
-
-/datum/keybinding/xeno/unrelenting_force_select
-	name = "unrelenting_force_select"
-	full_name = "Shrike: Select Unrelenting Force"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT
-
-/datum/keybinding/xeno/psychic_heal
-	name = "psychic_cure"
-	full_name = "Shrike: Psychic Cure"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
+/datum/keybinding/xeno/nightfall
 	hotkey_keys = list("F")
+	name = "nightfall"
+	full_name = "King: Nightfall"
+	description = "Shut down all nearby electric lights for 10 seconds"
+	keybind_signal = COMSIG_XENOABILITY_NIGHTFALL
 
+/datum/keybinding/xeno/petrify
+	hotkey_keys = list("E")
+	name = "petrify"
+	full_name = "King: Petrify"
+	description = "Petrifies all humans within view. While petrified humans can neither be damaged or take any actions."
+	keybind_signal = COMSIG_XENOABILITY_PETRIFY
 
-/datum/keybinding/xeno/psychic_storm
-	name = "gravnade"
-	full_name = "Shrike: Psychic Vortex"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_VORTEX
-	hotkey_keys = list("X")
+/datum/keybinding/xeno/off_guard
+	hotkey_keys = list("Q")
+	name = "off_guard"
+	full_name = "King: Off-guard"
+	description = "Muddles the mind of an enemy, increasing their scatter for a while."
+	keybind_signal = COMSIG_XENOABILITY_OFFGUARD
+
+/datum/keybinding/xeno/shattering_roar
+	hotkey_keys = list("R")
+	name = "shattering_roar"
+	full_name = "King: Shattering roar"
+	description = "Unleash a mighty psychic roar, knocking down any foes in your path and weakening them."
+	keybind_signal = COMSIG_XENOABILITY_SHATTERING_ROAR
+
+/datum/keybinding/xeno/zero_form_beam
+	hotkey_keys = list("R")
+	name = "zero_form_beam"
+	full_name = "King: Zero-form beam"
+	description = "After a windup, concentrates the hives energy into a forward-facing beam that pierces everything, but only hurts living beings."
+	keybind_signal = COMSIG_XENOABILITY_ZEROFORMBEAM
+
+/datum/keybinding/xeno/psychic_summon
+	name = "psychic_summon"
+	full_name = "King: Psychic Summon"
+	description = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
+	keybind_signal = COMSIG_XENOABILITY_HIVE_SUMMON
 
 /datum/keybinding/xeno/screech
 	name = "screech"
@@ -685,6 +758,67 @@
 	keybind_signal = COMSIG_XENOABILITY_SNATCH
 	hotkey_keys = list("Q")
 
+/datum/keybinding/xeno/toxic_slash
+	name = "toxic_slash"
+	full_name = "Sentinel: Toxic Slash"
+	description = "Imbue your claws with toxins, inflicting the Intoxicated debuff on hit and dealing damage over time."
+	keybind_signal = COMSIG_XENOABILITY_TOXIC_SLASH
+	hotkey_keys = list("R")
+
+/datum/keybinding/xeno/drain_sting
+	name = "drain_sting"
+	full_name = "Sentinel: Drain Sting"
+	description = "Sting a victim, draining any Intoxicated debuffs they may have, restoring you and dealing damage."
+	keybind_signal = COMSIG_XENOABILITY_DRAIN_STING
+	hotkey_keys = list("F")
+
+/datum/keybinding/xeno/toxicgrenade
+	name = "toxic_grenade"
+	full_name = "Sentinel: Toxic Grenade"
+	description = "Throws a ball of resin containing a toxin that inflicts the Intoxicated debuff, dealing damage over time."
+	keybind_signal = COMSIG_XENOABILITY_TOXIC_GRENADE
+	hotkey_keys = list("Q")
+
+/datum/keybinding/xeno/psychic_fling
+	name = "psychic_fling"
+	full_name = "Shrike: Psychic Fling"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
+	hotkey_keys = list("E")
+
+/datum/keybinding/xeno/unrelenting_force
+	name = "unrelenting_force"
+	full_name = "Shrike: Unrelenting Force"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE
+	hotkey_keys = list("R")
+
+/datum/keybinding/xeno/unrelenting_force_select
+	name = "unrelenting_force_select"
+	full_name = "Shrike: Select Unrelenting Force"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT
+
+/datum/keybinding/xeno/psychic_heal
+	name = "psychic_cure"
+	full_name = "Shrike: Psychic Cure"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
+	hotkey_keys = list("F")
+
+/datum/keybinding/xeno/psychic_storm
+	name = "gravnade"
+	full_name = "Shrike: Psychic Vortex"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_VORTEX
+	hotkey_keys = list("X")
+
+/datum/keybinding/xeno/scatter_spit
+	name = "scatter_spit"
+	full_name = "Spitter: Scatter Spit"
+	description = "Fires a scattershot of 6 acid globules which create acid puddles on impact or at the end of their range."
+	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
+
 /datum/keybinding/xeno/toggle_agility
 	name = "toggle_agility"
 	full_name = "Warrior: Toggle Agility"
@@ -726,36 +860,6 @@
 	description = "Precisely strike your target from further away, slowing and confusing them. Resets punch cooldown."
 	keybind_signal = COMSIG_XENOABILITY_JAB
 	hotkey_keys = list("E")
-
-/datum/keybinding/xeno/inject_egg_neurogas
-	name = "inject_egg_neurogas"
-	full_name = "Inject Egg (Neurogas)"
-	description = "Inject an egg with neurogas, killing the little one inside"
-	keybind_signal = COMSIG_XENOABILITY_INJECT_EGG_NEUROGAS
-
-/datum/keybinding/xeno/rally_hive
-	name = "rally_hive"
-	full_name = "Rally Hive"
-	description = "Rallies the hive to a target location."
-	keybind_signal = COMSIG_XENOABILITY_RALLY_HIVE
-
-/datum/keybinding/xeno/rally_minion
-	name = "rally_minion"
-	full_name = "Rally Minions"
-	description = "Rallies the minions to a target location, or yourself."
-	keybind_signal = COMSIG_XENOABILITY_RALLY_MINION
-
-/datum/keybinding/xeno/command_minions
-	name = "command_minion"
-	full_name = "Command Minions"
-	description = "Order the minions escorting you to be either agressive or passive."
-	keybind_signal = COMSIG_XENOABILITY_MINION_BEHAVIOUR
-
-/datum/keybinding/xeno/scatter_spit
-	name = "scatter_spit"
-	full_name = "Spitter: Scatter Spit"
-	description = "Fires a scattershot of 6 acid globules which create acid puddles on impact or at the end of their range."
-	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
 
 /datum/keybinding/xeno/rewind
 	name = "rewind"
@@ -799,66 +903,34 @@
 	description = "Freezes bullets in their course, and they will start to move again only after a certain time"
 	keybind_signal = COMSIG_XENOABILITY_TIMESTOP
 
-/datum/keybinding/xeno/nightfall
-	hotkey_keys = list("F")
-	name = "nightfall"
-	full_name = "King: Nightfall"
-	description = "Shut down all nearby electric lights for 10 seconds"
-	keybind_signal = COMSIG_XENOABILITY_NIGHTFALL
-
-/datum/keybinding/xeno/petrify
+/datum/keybinding/xeno/psychic_shield
+	name = "Psychic Shield"
+	full_name = "Warlock: Psychic Shield"
+	description = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_SHIELD
 	hotkey_keys = list("E")
-	name = "petrify"
-	full_name = "King: Petrify"
-	description = "Petrifies all humans within view. While petrified humans can neither be damaged or take any actions."
-	keybind_signal = COMSIG_XENOABILITY_PETRIFY
 
-/datum/keybinding/xeno/off_guard
+/datum/keybinding/xeno/trigger_psychic_shield
+	name = "Trigger Psychic Shield"
+	full_name = "Warlock: Trigger Psychic Shield"
+	description = "Triggers the Psychic Shield ability without selecting it."
+	keybind_signal = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD
+
+/datum/keybinding/xeno/psychic_blast
+	name = "Psychic Blast"
+	full_name = "Warlock: Psychic Blast"
+	description = "Fire a lightly-damaging AOE psychic beam which knocks back enemies after a short charge-up."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_BLAST
+	hotkey_keys = list("R")
+
+/datum/keybinding/xeno/psychic_crush
+	name = "Psychic Crush"
+	full_name = "Warlock: Psychic Crush"
+	description = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area."
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CRUSH
 	hotkey_keys = list("Q")
-	name = "off_guard"
-	full_name = "King: Off-guard"
-	description = "Muddles the mind of an enemy, increasing their scatter for a while."
-	keybind_signal = COMSIG_XENOABILITY_OFFGUARD
 
-/datum/keybinding/xeno/shattering_roar
-	hotkey_keys = list("R")
-	name = "shattering_roar"
-	full_name = "King: Shattering roar"
-	description = "Unleash a mighty psychic roar, knocking down any foes in your path and weakening them."
-	keybind_signal = COMSIG_XENOABILITY_SHATTERING_ROAR
-
-/datum/keybinding/xeno/zero_form_beam
-	hotkey_keys = list("R")
-	name = "zero_form_beam"
-	full_name = "King: Zero-form beam"
-	description = "After a windup, concentrates the hives energy into a forward-facing beam that pierces everything, but only hurts living beings."
-	keybind_signal = COMSIG_XENOABILITY_ZEROFORMBEAM
-
-/datum/keybinding/xeno/psychic_summon
-	name = "psychic_summon"
-	full_name = "King: Psychic Summon"
-	description = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
-	keybind_signal = COMSIG_XENOABILITY_HIVE_SUMMON
-
-/datum/keybinding/xeno/vent
-	name = "vent"
-	full_name = "Vent crawl"
-	description = "Enter an air vent and crawl through the pipe system."
-	keybind_signal = COMSIG_XENOABILITY_VENTCRAWL
-
-/datum/keybinding/xeno/sow
-	name = "sow"
-	full_name = "Hivelord : Sow"
-	description = "Plant the seeds of an alien plant."
-	keybind_signal = COMSIG_XENOABILITY_DROP_PLANT
-
-/datum/keybinding/xeno/sow_select_plant
-	name = "choose_plant"
-	full_name = "Hivelord : Choose plant"
-	description = "Pick what type of plant to sow."
-	keybind_signal = COMSIG_XENOABILITY_CHOOSE_PLANT
-
-/datum/keybinding/xeno/burrow
+	/datum/keybinding/xeno/burrow
 	name = "burrow"
 	full_name = "Widow: Burrow"
 	description = "Dig to the ground, making you invisible."
@@ -905,61 +977,3 @@
 	full_name = "Widow: Spiderling Mark"
 	description = "Signal your spawn to a target they shall attack."
 	keybind_signal = COMSIG_XENOABILITY_SPIDERLING_MARK
-
-/datum/keybinding/xeno/dash_explosion
-	name = "Dash Explosion"
-	full_name = "Baneling: Dash Explode"
-	description = "Aim in a direction, charge up and dash, knocking down any humans hit and detonate yourself. "
-	keybind_signal = COMSIG_XENOABILITY_BANELING_DASH_EXPLOSION
-
-/datum/keybinding/xeno/spawn_pod
-	name = "Spawn Pod"
-	full_name = "Baneling: Spawn Pod"
-	description = "Spawn a pod on your current position, when you die from any source you will respawn on this pod. Activate again to change its location. "
-	keybind_signal = COMSIG_XENOABILITY_BANELING_SPAWN_POD
-
-/datum/keybinding/xeno/baneling_explode
-	name = "Explode"
-	full_name = "Baneling: Explode"
-	description = "Detonate yourself, spreading your currently selected reagent. Size depends on current stored plasma, more plasma is more reagent."
-	keybind_signal = COMSIG_XENOABILITY_BANELING_EXPLODE
-
-/datum/keybinding/xeno/select_reagent/baneling
-	name = "Select Reagent"
-	full_name = "Baneling: Select Reagent"
-	description = "Choose a reagent that will be spread upon death. Costs plasma to change."
-	keybind_signal = COMSIG_XENOABILITY_BANELING_CHOOSE_REAGENT
-
-/datum/keybinding/xeno/vent/down(client/user)
-	. = ..()
-	if(!isxeno(user.mob))
-		return
-	var/mob/living/carbon/xenomorph/xeno = user.mob
-	xeno.vent_crawl()
-
-/datum/keybinding/xeno/psychic_shield
-	name = "Psychic Shield"
-	full_name = "Warlock: Psychic Shield"
-	description = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_SHIELD
-	hotkey_keys = list("E")
-
-/datum/keybinding/xeno/trigger_psychic_shield
-	name = "Trigger Psychic Shield"
-	full_name = "Warlock: Trigger Psychic Shield"
-	description = "Triggers the Psychic Shield ability without selecting it."
-	keybind_signal = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD
-
-/datum/keybinding/xeno/psychic_blast
-	name = "Psychic Blast"
-	full_name = "Warlock: Psychic Blast"
-	description = "Fire a lightly-damaging AOE psychic beam which knocks back enemies after a short charge-up."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_BLAST
-	hotkey_keys = list("R")
-
-/datum/keybinding/xeno/psychic_crush
-	name = "Psychic Crush"
-	full_name = "Warlock: Psychic Crush"
-	description = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area."
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CRUSH
-	hotkey_keys = list("Q")


### PR DESCRIPTION
## About The Pull Request

Reorganises the xeno keybindings so that multi-caste abilities are at the top, then single caste abilities all in alphabetical order. Also adds some default keybindings for Drone, Queen and multi-caste abilities which didn't have any before. 

## Why It's Good For The Game

The ordering before was pretty arbitrary (mixing in multi-caste abilities in the middle of single caste abilities, not alphabetical or tier order, etc) so this makes it easier for players and coders to edit. And having more default keybinds is helpful for new players, as well as if a veteran has to reset their bindings for whatever reason. 

## Changelog

:cl:
add: Added some default keybinds for Drone, Queen and multi-caste abilities
refactor: Reordered xeno keybindings so it's now in alphabetical caste order
/:cl: