### PR TITLE
Adds barbed wire to standard, bar and umbilical tadpole

### DIFF
--- a/_maps/shuttles/minidropship_mobile_bar.dmm
+++ b/_maps/shuttles/minidropship_mobile_bar.dmm
@@ -192,6 +192,7 @@
 	pixel_x = 25;
 	pixel_y = 8
 	},
+/obj/item/stack/barbed_wire/full,
 /turf/open/floor/carpet/side{
 	dir = 4
 	},

--- a/_maps/shuttles/minidropship_standard.dmm
+++ b/_maps/shuttles/minidropship_standard.dmm
@@ -51,6 +51,7 @@
 	id = "minidropship_podlock";
 	name = "inner door-control"
 	},
+/obj/item/stack/barbed_wire/half_stack,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "n" = (

--- a/_maps/shuttles/minidropship_umbilical.dmm
+++ b/_maps/shuttles/minidropship_umbilical.dmm
@@ -174,6 +174,7 @@
 "Q" = (
 /obj/structure/table/mainship,
 /obj/effect/turf_decal/tile/transparent/dark_blue/full,
+/obj/item/stack/barbed_wire/small_stack,
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
 "R" = (


### PR DESCRIPTION

## About The Pull Request
Adds barbed wire on the ground to the tadpoles on the title.
## Why It's Good For The Game
With the metal from floortile removal, good to allow the PO to barb their cades easily. 3 hardpoint tad gets none because it is unbalanced as is, and the big tadpole already has metal in it.
## Changelog
:cl:
add: Adds barbed wire to the Standard, Bar and Umbilical tadpole.
/:cl:
