### PR TITLE
Added many defaults for xeno keybinds, and three new ones available

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -843,6 +843,7 @@
 #define COMSIG_XENOABILITY_BURROW "xenoability_burrow"
 #define COMSIG_XENOABILITY_LEASH_BALL "xenoability_leash_ball"
 #define COMSIG_XENOABILITY_CREATE_SPIDERLING "xenoability_create_spiderling"
+#define COMSIG_XENOABILITY_CREATE_SPIDERLING_USING_CC "xenoability_create_spiderling_using_cc"
 #define COMSIG_XENOABILITY_ATTACH_SPIDERLINGS "xenoability_attach_spiderlings"
 #define COMSIG_XENOABILITY_CANNIBALISE_SPIDERLING "xenoability_cannibalise_spiderling"
 #define COMSIG_XENOABILITY_WEB_HOOK "xenoability_web_hook"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -737,6 +737,7 @@
 #define COMSIG_XENOABILITY_SWITCH_HUGGER "xenoability_switch_hugger"
 #define COMSIG_XENOABILITY_CHOOSE_HUGGER "xenoability_choose_hugger"
 #define COMSIG_XENOABILITY_DROP_ALL_HUGGER "xenoability_drop_all_hugger"
+#define COMSIG_XENOABILITY_BUILD_HUGGER_TURRET "xenoability_build_hugger_turret"
 
 #define COMSIG_XENOABILITY_STOMP "xenoability_stomp"
 #define COMSIG_XENOABILITY_TOGGLE_CHARGE "xenoability_toggle_charge"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -52,7 +52,7 @@
 	full_name = "Recycle xenomorph"
 	description = "Recycles a fellow dead xenomorph"
 	keybind_signal = COMSIG_XENOABILITY_RECYCLE
-	hotkey_keys = list("`")
+	hotkey_keys = list("ShiftE")
 
 /datum/keybinding/xeno/place_acid_well
 	name = "place_acid_well"
@@ -121,7 +121,7 @@
 	full_name = "Ozelomelyn Sting"
 	description = "A channeled melee attack that injects the target with Ozelomelyn over a few seconds, purging chemicals and dealing minor toxin damage to a moderate cap while inside them."
 	keybind_signal = COMSIG_XENOABILITY_OZELOMELYN_STING
-	hotkey_keys = list("`")
+	hotkey_keys = list("ShiftE")
 
 /datum/keybinding/xeno/transfer_plasma
 	name = "transfer_plasma"
@@ -175,7 +175,7 @@
 	full_name = "Lay Egg"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_LAY_EGG
-	hotkey_keys = list("\\")
+	hotkey_keys = list("ShiftQ")
 
 /datum/keybinding/xeno/call_of_the_burrowed
 	name = "call_of_the_burrowed"
@@ -550,7 +550,7 @@
 	full_name = "Hivelord: Build Tunnel"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_BUILD_TUNNEL
-	hotkey_keys = list("\\")
+	hotkey_keys = list("ShiftQ")
 
 /datum/keybinding/xeno/place_jelly_pod
 	name = "place_jelly_pod"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -18,6 +18,7 @@
 	full_name = "Regurgitate / Cocoon"
 	description = "Vomit whatever you have devoured. / Cocoon the targeted body, which will produce psy and larva points over time."
 	keybind_signal = COMSIG_XENOABILITY_REGURGITATE
+	hotkey_keys = list("K")
 
 /datum/keybinding/xeno/blessingmenu
 	name = "blessings menu"
@@ -34,7 +35,6 @@
 	hotkey_keys = list("V")
 
 /datum/keybinding/xeno/choose_weeds
-	hotkey_keys = list("Space")
 	name = "choose_weeds"
 	full_name = "Choose Weed"
 	description = "Choose what weed you will drop."
@@ -52,7 +52,7 @@
 	full_name = "Recycle xenomorph"
 	description = "Recycles a fellow dead xenomorph"
 	keybind_signal = COMSIG_XENOABILITY_RECYCLE
-	hotkey_keys = list("G")
+	hotkey_keys = list("`")
 
 /datum/keybinding/xeno/place_acid_well
 	name = "place_acid_well"
@@ -61,11 +61,11 @@
 	keybind_signal = COMSIG_XENOABILITY_PLACE_ACID_WELL
 	hotkey_keys = list("G")
 
-/datum/keybinding/xeno/emit_recovery
-	name = "emit_recovery"
-	full_name = "Emit Recovery Pheromones"
-	description = "Increases healing for yourself and nearby teammates."
-	keybind_signal = COMSIG_XENOABILITY_EMIT_RECOVERY
+/datum/keybinding/xeno/emit_frenzy
+	name = "emit_frenzy"
+	full_name = "Emit Frenzy Pheromones"
+	description = "Increases damage for yourself and nearby teammates."
+	keybind_signal = COMSIG_XENOABILITY_EMIT_FRENZY
 	hotkey_keys = list("7")
 
 /datum/keybinding/xeno/emit_warding
@@ -75,11 +75,11 @@
 	keybind_signal = COMSIG_XENOABILITY_EMIT_WARDING
 	hotkey_keys = list("8")
 
-/datum/keybinding/xeno/emit_frenzy
-	name = "emit_frenzy"
-	full_name = "Emit Frenzy Pheromones"
-	description = "Increases damage for yourself and nearby teammates."
-	keybind_signal = COMSIG_XENOABILITY_EMIT_FRENZY
+/datum/keybinding/xeno/emit_recovery
+	name = "emit_recovery"
+	full_name = "Emit Recovery Pheromones"
+	description = "Increases healing for yourself and nearby teammates."
+	keybind_signal = COMSIG_XENOABILITY_EMIT_RECOVERY
 	hotkey_keys = list("9")
 
 /datum/keybinding/xeno/corrosive_acid
@@ -87,12 +87,14 @@
 	full_name = "Corrosive Acid"
 	description = "Cover an object with acid to slowly melt it. Takes a few seconds."
 	keybind_signal = COMSIG_XENOABILITY_CORROSIVE_ACID
+	hotkey_keys = list("X")
 
 /datum/keybinding/xeno/spray_acid
 	name = "spray_acid"
 	full_name = "Acid Spray"
 	description = "Sprays some acid"
 	keybind_signal = COMSIG_XENOABILITY_SPRAY_ACID
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/xeno_spit
 	name = "xeno_spit"
@@ -119,6 +121,7 @@
 	full_name = "Ozelomelyn Sting"
 	description = "A channeled melee attack that injects the target with Ozelomelyn over a few seconds, purging chemicals and dealing minor toxin damage to a moderate cap while inside them."
 	keybind_signal = COMSIG_XENOABILITY_OZELOMELYN_STING
+	hotkey_keys = list("`")
 
 /datum/keybinding/xeno/transfer_plasma
 	name = "transfer_plasma"
@@ -132,12 +135,15 @@
 	full_name = "Pounce"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_POUNCE
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/toggle_charge
 	name = "toggle_charge"
 	full_name = "Toggle Charge"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_CHARGE
+	hotkey_keys = list("Space")
+
 /datum/keybinding/xeno/toxic_spit
 	name = "toxic_spit"
 	full_name = "Sentinel: Toxic Spit"
@@ -169,18 +175,13 @@
 	full_name = "Lay Egg"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_LAY_EGG
+	hotkey_keys = list("\\")
 
 /datum/keybinding/xeno/call_of_the_burrowed
 	name = "call_of_the_burrowed"
 	full_name = "Call of the Burrowed"
 	description = "Attempts to summon all currently burrowed larva."
 	keybind_signal = COMSIG_XENOABILITY_CALL_OF_THE_BURROWED
-
-/datum/keybinding/xeno/inject_egg_neurogas
-	name = "inject_egg_neurogas"
-	full_name = "Inject Egg (Neurogas)"
-	description = "Inject an egg with neurogas, killing the little one inside"
-	keybind_signal = COMSIG_XENOABILITY_INJECT_EGG_NEUROGAS
 
 /datum/keybinding/xeno/rally_hive
 	name = "rally_hive"
@@ -209,24 +210,28 @@
 	full_name = "Baneling: Dash Explode"
 	description = "Aim in a direction, charge up and dash, knocking down any humans hit and detonate yourself. "
 	keybind_signal = COMSIG_XENOABILITY_BANELING_DASH_EXPLOSION
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/spawn_pod
 	name = "Spawn Pod"
 	full_name = "Baneling: Spawn Pod"
 	description = "Spawn a pod on your current position, when you die from any source you will respawn on this pod. Activate again to change its location. "
 	keybind_signal = COMSIG_XENOABILITY_BANELING_SPAWN_POD
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/baneling_explode
 	name = "Explode"
 	full_name = "Baneling: Explode"
 	description = "Detonate yourself, spreading your currently selected reagent. Size depends on current stored plasma, more plasma is more reagent."
 	keybind_signal = COMSIG_XENOABILITY_BANELING_EXPLODE
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/select_reagent/baneling
 	name = "Select Reagent"
 	full_name = "Baneling: Select Reagent"
 	description = "Choose a reagent that will be spread upon death. Costs plasma to change."
 	keybind_signal = COMSIG_XENOABILITY_BANELING_CHOOSE_REAGENT
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/long_range_sight
 	name = "long_range_sight"
@@ -274,18 +279,21 @@
 	full_name = "Bull: Plow Charge"
 	description = "A charge that plows through the victims."
 	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/headbutt_charge
 	name = "headbutt_charge"
 	full_name = "Bull: Headbutt Charge"
 	description = "A charge that tosses the victim forward or backwards, depending on intent."
 	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/gore_charge
 	name = "gore_charge"
 	full_name = "Bull: Gore Charge"
 	description = "A charge that gores the victim."
 	keybind_signal = COMSIG_XENOABILITY_BULLGORE
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/throw_hugger
 	name = "throw_hugger"
@@ -306,6 +314,7 @@
 	full_name = "Carrier: Place Trap"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_PLACE_TRAP
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/spawn_hugger
 	name = "spawn_hugger"
@@ -334,12 +343,19 @@
 	keybind_signal = COMSIG_XENOABILITY_DROP_ALL_HUGGER
 	hotkey_keys = list("Space")
 
+/datum/keybinding/xeno/build_hugger_turret
+	name = "build_hugger_turret"
+	full_name = "Carrier: Build Hugger Turret"
+	description = "Build a hugger turret."
+	keybind_signal = COMSIG_XENOABILITY_BUILD_HUGGER_TURRET
+	hotkey_keys = list("R")
+
 /datum/keybinding/xeno/stomp
 	name = "stomp"
 	full_name = "Crusher: Stomp"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_STOMP
-	hotkey_keys = list("Space")
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/cresttoss
 	name = "cresttoss"
@@ -409,6 +425,7 @@
 	full_name = "Defiler: Select Reagent"
 	description = "Cycles through reagents to choose one for Defiler abilities."
 	keybind_signal = COMSIG_XENOABILITY_SELECT_REAGENT
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/radial_select_reagent
 	name = "radial_select_reagent"
@@ -422,6 +439,7 @@
 	full_name = "Defiler: Reagent Slash"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_REAGENT_SLASH
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/defile
 	name = "defile"
@@ -436,6 +454,12 @@
 	description = "Allows the defiler to grab a tallhost or item from range and bring it towards the defiler."
 	keybind_signal = COMSIG_XENOABILITY_TENTACLE
 	hotkey_keys = list("Q")
+
+/datum/keybinding/xeno/inject_egg_neurogas
+	name = "inject_egg_neurogas"
+	full_name = "Defiler: Inject Egg (Neurogas)"
+	description = "Inject an egg with neurogas, killing the little one inside"
+	keybind_signal = COMSIG_XENOABILITY_INJECT_EGG_NEUROGAS
 
 /datum/keybinding/xeno/acidic_salve
 	name = "acidic_salve"
@@ -470,42 +494,49 @@
 	full_name = "Gorger: Devour"
 	description = "Devour your victim to be able to carry it faster."
 	keybind_signal = COMSIG_XENOABILITY_DEVOUR
+	hotkey_keys = list("X")
 
 /datum/keybinding/xeno/drain
 	name = "drain"
 	full_name = "Gorger: Drain"
 	description = "Stagger a marine and drain some of their blood. When used on a dead human, you heal gradually and don't gain blood."
 	keybind_signal = COMSIG_XENOABILITY_DRAIN
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/transfusion
 	name = "transfusion"
 	full_name = "Gorger: Transfusion"
 	description = "Restores some of the health of another xenomorph, or overheals, at the cost of blood."
 	keybind_signal = COMSIG_XENOABILITY_TRANSFUSION
+	hotkey_keys = list("H")
 
 /datum/keybinding/xeno/rejuvenate
 	name = "rejuvenate"
 	full_name = "Gorger: Rejuvenate"
 	description = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
 	keybind_signal = COMSIG_XENOABILITY_REJUVENATE
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/psychic_link
 	name = "psychic link"
 	full_name = "Gorger: Psychic Link"
 	description = "Link to a xenomorph and take some damage in their place. During this time, you can't move. Use rest action to cancel."
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_LINK
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/carnage
 	name = "carnage"
 	full_name = "Gorger: Carnage"
 	description = "For a while your attacks drain blood and heal you. During Feast you also heal nearby allies."
 	keybind_signal = COMSIG_XENOABILITY_CARNAGE
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/feast
 	name = "feast"
 	full_name = "Gorger: Feast"
 	description = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
 	keybind_signal = COMSIG_XENOABILITY_FEAST
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/resin_walker
 	name = "resin_walker"
@@ -519,6 +550,7 @@
 	full_name = "Hivelord: Build Tunnel"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_BUILD_TUNNEL
+	hotkey_keys = list("\\")
 
 /datum/keybinding/xeno/place_jelly_pod
 	name = "place_jelly_pod"
@@ -538,13 +570,14 @@
 	full_name = "Hivelord: Healing Infusion"
 	description = "Imbues a target xeno with healing energy, restoring extra Sunder and Health once every 2 seconds up to 5 times whenever it regenerates normally. 60 second duration."
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
-	hotkey_keys = list("X")
+	hotkey_keys = list("H")
 
 /datum/keybinding/xeno/sow
 	name = "sow"
 	full_name = "Hivelord: Sow"
 	description = "Plant the seeds of an alien plant."
 	keybind_signal = COMSIG_XENOABILITY_DROP_PLANT
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/sow_select_plant
 	name = "choose_plant"
@@ -559,8 +592,8 @@
 	keybind_signal = COMSIG_XENOMORPH_HIVEMIND_CHANGE_FORM
 	hotkey_keys = list("F")
 
-/datum/keybinding/xeno/change_form
-	name = "change_form"
+/datum/keybinding/xeno/teleport_minimap
+	name = "teleport_minimap"
 	full_name = "Hivemind: Open teleportation minimap"
 	description = "Opens up the minimap which, when you click somewhere, tries to teleport you to the selected location"
 	keybind_signal = COMISG_XENOMORPH_HIVEMIND_TELEPORT
@@ -585,20 +618,21 @@
 	full_name = "Hunter: Mirage"
 	description = "Creates multiple mirror images of the xeno."
 	keybind_signal = COMSIG_XENOABILITY_MIRAGE
-	hotkey_keys = list("E")
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/silence
 	name = "impair senses"
 	full_name = "Hunter: Silence"
 	description = "Impairs the ability of hostile living creatures we can see in a 5x5 area. Targets will be unable to speak and hear for 10 seconds."
 	keybind_signal = COMSIG_XENOABILITY_SILENCE
+	hotkey_keys = list("X")
 
 /datum/keybinding/xeno/mark
 	name = "mark"
 	full_name = "Hunter: Mark"
 	description = "Mark that lonely marine so that you can track with Psychic Trace."
 	keybind_signal = COMSIG_XENOABILITY_HUNTER_MARK
-	hotkey_keys = list("F")
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/psychic_trace
 	name = "psychic_trace"
@@ -650,9 +684,10 @@
 
 /datum/keybinding/xeno/acid_dash
 	name = "acid_dash"
-	full_name = "Praetorian : Acid Dash"
+	full_name = "Praetorian: Acid Dash"
 	description = "Quickly dash, leaving acid in your path and knocking down the first marine hit. Has reset potential."
 	keybind_signal = COMSIG_XENOABILITY_ACID_DASH
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/screech
 	name = "screech"
@@ -752,6 +787,7 @@
 	full_name = "Runner: Toggle Savage"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_SAVAGE
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/evasion
 	name = "evasion"
@@ -827,6 +863,7 @@
 	full_name = "Spitter: Scatter Spit"
 	description = "Fires a scattershot of 6 acid globules which create acid puddles on impact or at the end of their range."
 	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/psychic_shield
 	name = "Psychic Shield"
@@ -902,87 +939,102 @@
 	full_name = "Widow: Burrow"
 	description = "Dig to the ground, making you invisible."
 	keybind_signal = COMSIG_XENOABILITY_BURROW
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/web_spit
 	name = "Web Spit"
 	full_name = "Widow: Web Spit"
 	description = "Spit web at your target. Hitting the target will impede their functions depending on their hit location."
 	keybind_signal = COMSIG_XENOABILITY_WEB_SPIT
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/leash_ball
 	name = "Leash Ball"
 	full_name = "Widow: Leash Ball"
 	description = "Spit a huge web ball of web that snares groups of targets for a brief while."
 	keybind_signal = COMSIG_XENOABILITY_LEASH_BALL
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/create_spiderling
 	name = "Birth Spiderling"
 	full_name = "Widow: Birth Spiderling"
 	description = "Give birth to a spiderling after a short charge-up."
 	keybind_signal = COMSIG_XENOABILITY_CREATE_SPIDERLING
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/attach_spiderlings
 	name = "Attach Spiderlings"
 	full_name = "Widow: Attach Spiderlings"
 	description = "Scoop up and carry your spawn with you."
 	keybind_signal = COMSIG_XENOABILITY_ATTACH_SPIDERLINGS
+	hotkey_keys = list("X")
 
 /datum/keybinding/xeno/cannibalise
 	name = "Cannibalise Spiderling"
 	full_name = "Widow: Cannibalise Spiderling"
 	description = "Eat your own young and store their biomass for later."
 	keybind_signal = COMSIG_XENOABILITY_CANNIBALISE_SPIDERLING
+	hotkey_keys = list("G")
 
 /datum/keybinding/xeno/web_hook
 	name = "Web Hook"
 	full_name = "Widow: Web Hook"
 	description = "Shoot a strong web and pull yourself towards whatever it hits."
 	keybind_signal = COMSIG_XENOABILITY_WEB_HOOK
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/spiderling_mark
 	name = "Spiderling Mark"
 	full_name = "Widow: Spiderling Mark"
 	description = "Signal your spawn to a target they shall attack."
 	keybind_signal = COMSIG_XENOABILITY_SPIDERLING_MARK
+	hotkey_keys = list("V")
 
 /datum/keybinding/xeno/rewind
 	name = "rewind"
 	full_name = "Wraith: Time Shift"
 	description = "Save the location and status of the target. When the time is up, the target location and status are restored"
 	keybind_signal = COMSIG_XENOABILITY_REWIND
+	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/portal
 	name = "portal"
 	full_name = "Wraith: Portal"
 	description = "Place the first portal on your location. You can travel from portal one to portal two and vice versa."
 	keybind_signal =COMSIG_XENOABILITY_PORTAL
+	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/portal_two
 	name = "portal_two"
 	full_name = "Wraith: Portal two"
 	description = "Place the second portal on your location. You can travel from portal one to portal two and vice versa."
 	keybind_signal =COMSIG_XENOABILITY_PORTAL_ALTERNATE
+	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/blink
 	name = "wraith_blink"
 	full_name = "Wraith: Blink"
 	description = "Teleport to a space a short distance away within line of sight. Can teleport mobs you're dragging with you at the cost of higher cooldown."
 	keybind_signal = COMSIG_XENOABILITY_BLINK
+	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/banish
 	name = "banish"
 	full_name = "Wraith: Banish"
 	description = "Banish a creature or object a short distance away within line of sight to null space. Can target oneself and allies. Can be manually cancelled with Recall."
 	keybind_signal = COMSIG_XENOABILITY_BANISH
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/recall
 	name = "recall"
 	full_name = "Wraith: Recall"
 	description = "Recall a target from netherspace, ending Banish's effect."
 	keybind_signal = COMSIG_XENOABILITY_RECALL
+	hotkey_keys = list("G")
 
 /datum/keybinding/xeno/timestop
 	name = "timestop"
 	full_name = "Wraith: Time stop"
 	description = "Freezes bullets in their course, and they will start to move again only after a certain time"
 	keybind_signal = COMSIG_XENOABILITY_TIMESTOP
+	hotkey_keys = list("V")

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -962,6 +962,13 @@
 	keybind_signal = COMSIG_XENOABILITY_CREATE_SPIDERLING
 	hotkey_keys = list("F")
 
+/datum/keybinding/xeno/create_spiderling_using_cc
+	name = "Birth Spiderling using Cannibalise charges"
+	full_name = "Widow: Birth Spiderling using Cannibalise charges"
+	description = "Give birth to a spiderling after a short charge-up if you have any Cannibalise charges available."
+	keybind_signal = COMSIG_XENOABILITY_CREATE_SPIDERLING_USING_CC
+	hotkey_keys = list("H")
+
 /datum/keybinding/xeno/attach_spiderlings
 	name = "Attach Spiderlings"
 	full_name = "Widow: Attach Spiderlings"

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -300,6 +300,9 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	desc = "Build a hugger turret"
 	plasma_cost = 800
 	cooldown_timer = 5 MINUTES
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BUILD_HUGGER_TURRET,
+	)
 
 /datum/action/xeno_action/build_hugger_turret/can_use_action(silent, override_flags)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -135,7 +135,9 @@
 	cooldown_timer = 15 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_SPIDERLING,
+		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_CREATE_SPIDERLING_USING_CC,
 	)
+
 	/// List of all our spiderlings
 	var/list/mob/living/carbon/xenomorph/spiderling/spiderlings = list()
 	/// Current amount of cannibalise charges


### PR DESCRIPTION
## About The Pull Request
- Fixed "Hivemind: Change Form" keybinding not being available.
- Added "Carrier: Build Hugger Turret" and "Widow: Birth Spiderling using Cannibalise charges" keybinds.
- A lot of default hotkeys were added for ones which didn't already have them, so now almost all abilities have one if they're frequently used. Some existing hotkeys were changed also to eliminate conflicts across all castes, and so that similar abilities from different castes use the same hotkey. Focus was on minimising unassigned hotkeys, eliminating hotkey conflicts, and having similar abilities from different castes use the same keys (e.g. Healing Infusion and Psychic Cure, Essence Link and Psychic Link, etc)
- Swapped the newly added default hotkeys for Frenzy and Recovery pheromones so that it matches the sequential order based on the sprite overlay.
- Relabelled "Inject Egg" as a Defiler ability.

## Why It's Good For The Game

Personally speaking as someone who hadn't played in over a year and had to reset my hotkeys when I came back, it's been a pain to figure out what hotkeys to use when you want to play a variety of different castes and not have any conflicts. This is to save others that headache, as well as make it easier for newbies to play any xeno without having to spend this time either. 

## Changelog

:cl:
fix: "Hivemind: Change Form" keybinding now available.
add: "Carrier: Build Hugger Turret" and "Widow: Birth Spiderling using Cannibalise charges" keybindings now available.
add: Almost all xeno abilities now have default keybinds.
refactor: A few existing xeno default keybinds were changed to prevent conflicts.
/:cl: