### PR TITLE
Fix TTS preview voice being always robotic

### DIFF
--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -527,14 +527,14 @@
 			if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_TRY_TTS))
 				return
 			TIMER_COOLDOWN_START(ui.user, COOLDOWN_TRY_TTS, 0.5 SECONDS)
-			INVOKE_ASYNC(SStts, TYPE_PROC_REF(/datum/controller/subsystem/tts, queue_tts_message), ui.user.client, "Hello, this is my voice.", speaker = choice, local = TRUE, silicon = isrobot(GLOB.all_species[species]), pitch = tts_pitch)
+			INVOKE_ASYNC(SStts, TYPE_PROC_REF(/datum/controller/subsystem/tts, queue_tts_message), ui.user.client, "Hello, this is my voice.", speaker = choice, local = TRUE, silicon = isrobot(GLOB.all_species[species]) ? TRUE : "", pitch = tts_pitch)
 
 		if("tts_pitch")
 			tts_pitch = clamp(text2num(params["newValue"]), -12, 12)
 			if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_TRY_TTS))
 				return
 			TIMER_COOLDOWN_START(ui.user, COOLDOWN_TRY_TTS, 0.5 SECONDS)
-			INVOKE_ASYNC(SStts, TYPE_PROC_REF(/datum/controller/subsystem/tts, queue_tts_message), ui.user.client, "Hello, this is my voice.", speaker = tts_voice, local = TRUE, silicon = isrobot(GLOB.all_species[species]), pitch = tts_pitch)
+			INVOKE_ASYNC(SStts, TYPE_PROC_REF(/datum/controller/subsystem/tts, queue_tts_message), ui.user.client, "Hello, this is my voice.", speaker = tts_voice, local = TRUE, silicon = isrobot(GLOB.all_species[species]) ? TRUE : "", pitch = tts_pitch)
 
 		if("squad")
 			var/new_squad = params["newValue"]


### PR DESCRIPTION
## About The Pull Request

The "This is my voice" preview in prefs was always robotic because in python `bool('0') == True`. This could be fixed on the tts-api.py side too but I'm not sure anyone will update that in a meaningful amount of time

## Changelog

:cl:
fix: Fix TTS preview voice being always robotic
/:cl:
