### PR TITLE
Adds a xeno respawn timer, nerfs silo scaling

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -106,7 +106,10 @@
 #define TIME_BEFORE_TAKING_BODY 1 MINUTES
 
 #define DEATHTIME_CHECK(M) ((world.time - GLOB.key_to_time_of_role_death[M.key]) < SSticker.mode?.respawn_time)
-#define DEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_role_death[M.key]) * 0.1] second\s.</span><br><span class='warning'>You must wait [SSticker.mode?.respawn_time * 0.1] seconds before rejoining the game!"))
+#define DEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class='warning'>You must wait [SSticker.mode?.respawn_time * 0.1] seconds before rejoining the game!"))
+
+#define XENODEATHTIME_CHECK(M) ((world.time - (GLOB.key_to_time_of_xeno_death[M.key] ? GLOB.key_to_time_of_xeno_death[M.key] : -INFINITY) < SSticker.mode?.xenorespawn_time))
+#define XENODEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class ='warning'>You must wait [SSticker.mode?.xenorespawn_time * 0.1] seconds before rejoining the game as a Xenomorph!"))
 
 #define COUNT_IGNORE_HUMAN_SSD (1<<0)
 #define COUNT_IGNORE_XENO_SSD (1<<1)

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -106,7 +106,7 @@
 #define TIME_BEFORE_TAKING_BODY 1 MINUTES
 
 #define DEATHTIME_CHECK(M) ((world.time - GLOB.key_to_time_of_role_death[M.key]) < SSticker.mode?.respawn_time)
-#define DEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class='warning'>You must wait [SSticker.mode?.respawn_time * 0.1] seconds before rejoining the game!"))
+#define DEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_role_death[M.key]) * 0.1] second\s.</span><br><span class='warning'>You must wait [SSticker.mode?.respawn_time * 0.1] seconds before rejoining the game!"))
 
 #define XENODEATHTIME_CHECK(M) ((world.time - (GLOB.key_to_time_of_xeno_death[M.key] ? GLOB.key_to_time_of_xeno_death[M.key] : -INFINITY) < SSticker.mode?.xenorespawn_time))
 #define XENODEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class ='warning'>You must wait [SSticker.mode?.xenorespawn_time * 0.1] seconds before rejoining the game as a Xenomorph!"))

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -109,7 +109,7 @@
 #define DEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_role_death[M.key]) * 0.1] second\s.</span><br><span class='warning'>You must wait [SSticker.mode?.respawn_time * 0.1] seconds before rejoining the game!"))
 
 #define XENODEATHTIME_CHECK(M) ((world.time - (GLOB.key_to_time_of_xeno_death[M.key] ? GLOB.key_to_time_of_xeno_death[M.key] : -INFINITY) < SSticker.mode?.xenorespawn_time))
-#define XENODEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class ='warning'>You must wait [SSticker.mode?.xenorespawn_time * 0.1] seconds before rejoining the game as a Xenomorph!"))
+#define XENODEATHTIME_MESSAGE(M) to_chat(M, span_warning("You have been dead for [(world.time - GLOB.key_to_time_of_xeno_death[M.key]) * 0.1] second\s.</span><br><span class ='warning'>You must wait [SSticker.mode?.xenorespawn_time * 0.1] seconds before rejoining the game as a Xenomorph! You can take a SSD minion without resetting your timer."))
 
 #define COUNT_IGNORE_HUMAN_SSD (1<<0)
 #define COUNT_IGNORE_XENO_SSD (1<<1)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -39,5 +39,8 @@ GLOBAL_PROTECT(key_to_time_of_role_death)
 GLOBAL_LIST_EMPTY(key_to_time_of_death)
 GLOBAL_PROTECT(key_to_time_of_death)
 
+GLOBAL_LIST_EMPTY(key_to_time_of_xeno_death)
+GLOBAL_PROTECT(key_to_time_of_xeno_death)
+
 ///List of ssd living mobs
 GLOBAL_LIST_EMPTY(ssd_living_mobs)

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -76,6 +76,12 @@
 		to_chat(owner, span_warning("You cannot join if the mob is dead."))
 		return FALSE
 
+	if(isxeno(new_mob))
+		var/mob/living/carbon/xenomorph/ssd_xeno = new_mob
+		if(ssd_xeno.tier != XENO_TIER_MINION && XENODEATHTIME_CHECK(owner))
+			XENODEATHTIME_MESSAGE(owner)
+			return
+
 	if(HAS_TRAIT(new_mob, TRAIT_POSSESSING))
 		to_chat(owner, span_warning("That mob is currently possessing a different mob."))
 		return FALSE

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -28,6 +28,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/deploy_time_lock = 15 MINUTES
 	///The respawn time for marines
 	var/respawn_time = 30 MINUTES
+	//The respawn time for Xenomorphs
+	var/xenorespawn_time = 5 MINUTES
 	///How many points do you need to win in a point gamemode
 	var/win_points_needed = 0
 	///The points per faction, assoc list

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -20,6 +20,7 @@
 		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
+	xenorespawn_time = 3 MINUTES
 
 	// Round end conditions
 	var/shuttle_landed = FALSE

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -24,6 +24,7 @@
 		/datum/job/terragov/squad/standard = -1
 	)
 	enable_fun_tads = TRUE
+	xenorespawn_time = 1 MINUTES
 
 /datum/game_mode/extended/announce()
 	to_chat(world, "<b>The current game mode is - Extended Role-Playing!</b>")

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/nuclear_war
 	name = "Nuclear War"
 	config_tag = "Nuclear War"
-	silo_scaling = 2
+	silo_scaling = 1.5
 	flags_round_type = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD
 	flags_xeno_abilities = ABILITY_NUCLEARWAR
 	valid_job_types = list(

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -347,7 +347,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 			. += "Respawn timer: READY"
 		else
 			. += "Respawn timer: [(status_value / 60) % 60]:[add_leading(num2text(status_value % 60), 2, "0")]"
-	if(GLOB.respawn_allowed && MODE_INFESTATION)
+	if(GLOB.respawn_allowed)
 		status_value = ((GLOB.key_to_time_of_xeno_death[key] ? GLOB.key_to_time_of_xeno_death[key] : -INFINITY)  + SSticker.mode?.xenorespawn_time - world.time) * 0.1 //If xeno_death is null, use -INFINITY
 		if(status_value <= 0)
 			. += "Xeno respawn timer: READY"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -291,6 +291,15 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	if(!aghosting && job?.job_flags & (JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE))//Only some jobs cost you your respawn timer.
 		GLOB.key_to_time_of_role_death[ghost.key] = world.time
 
+/mob/living/carbon/xenomorph/ghostize(can_reenter_corpse = TRUE, aghosting = FALSE)
+	. = ..()
+	if(!. || can_reenter_corpse || aghosting)
+		return
+	var/mob/ghost = .
+	if(tier != XENO_TIER_MINION)
+		GLOB.key_to_time_of_xeno_death[ghost.key] = world.time //If you ghost as a xeno that is not a minion, sets respawn timer
+
+
 /mob/dead/observer/Move(atom/newloc, direct)
 	if(updatedir)
 		setDir(direct)//only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
@@ -338,6 +347,12 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 			. += "Respawn timer: READY"
 		else
 			. += "Respawn timer: [(status_value / 60) % 60]:[add_leading(num2text(status_value % 60), 2, "0")]"
+	if(GLOB.respawn_allowed && MODE_INFESTATION)
+		status_value = ((GLOB.key_to_time_of_xeno_death[key] ? GLOB.key_to_time_of_xeno_death[key] : -INFINITY)  + SSticker.mode?.xenorespawn_time - world.time) * 0.1 //If xeno_death is null, use -INFINITY
+		if(status_value <= 0)
+			. += "Xeno respawn timer: READY"
+		else
+			. += "Xeno respawn timer: [(status_value / 60) % 60]:[add_leading(num2text(status_value % 60), 2, "0")]"
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"
@@ -627,6 +642,12 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	if(!istype(L))
 		to_chat(src, span_warning("Mob already taken."))
 		return
+
+	if(isxeno(L))
+		var/mob/living/carbon/xenomorph/offered_xenomorph = L
+		if(offered_xenomorph.tier != XENO_TIER_MINION && XENODEATHTIME_CHECK(src))
+			XENODEATHTIME_MESSAGE(src)
+			return
 
 	switch(tgui_alert(usr, "Take over mob named: [L.real_name][L.job ? " | Job: [L.job]" : ""]", "Offered Mob", list("Yes", "No", "Follow")))
 		if("Yes")

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -23,6 +23,9 @@
 	if(is_zoomed)
 		zoom_out()
 
+	if(tier != XENO_TIER_MINION)
+		GLOB.key_to_time_of_xeno_death[key] = world.time
+
 	SSminimaps.remove_marker(src)
 	set_light_on(FALSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -939,6 +939,15 @@ to_chat will check for valid clients itself already so no need to double check f
 		if(length(possible_silos))
 			return attempt_to_spawn_larva_in_silo(xeno_candidate, possible_silos, larva_already_reserved)
 		if(SSticker.mode?.flags_round_type & MODE_SILO_RESPAWN && !SSsilo.can_fire) // Distress mode & prior to shutters opening, so let the queue bypass silos if needed
+			if(XENODEATHTIME_CHECK(xeno_candidate))
+				if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
+					if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
+						log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
+						XENODEATHTIME_MESSAGE(xeno_candidate)
+						return FALSE
+				else
+					XENODEATHTIME_MESSAGE(xeno_candidate)
+					return FALSE
 			return do_spawn_larva(xeno_candidate, pick(GLOB.spawns_by_job[/datum/job/xenomorph]), larva_already_reserved)
 		to_chat(xeno_candidate, span_warning("There are no places currently available to receive new larvas."))
 		return FALSE
@@ -951,6 +960,16 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	if(QDELETED(chosen_mother) || !xeno_candidate?.client)
 		return FALSE
+
+	if(!isnewplayer(xeno_candidate) && XENODEATHTIME_CHECK(xeno_candidate))
+		if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
+			if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
+				log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
+				XENODEATHTIME_MESSAGE(xeno_candidate)
+				return FALSE
+		else
+			XENODEATHTIME_MESSAGE(xeno_candidate)
+			return FALSE
 
 	return spawn_larva(xeno_candidate, chosen_mother, larva_already_reserved)
 
@@ -980,6 +999,16 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	if(QDELETED(chosen_silo) || !xeno_candidate?.client)
 		return FALSE
+
+	if(!isnewplayer(xeno_candidate) && XENODEATHTIME_CHECK(xeno_candidate))
+		if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
+			if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
+				log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
+				XENODEATHTIME_MESSAGE(xeno_candidate)
+				return FALSE
+		else
+			XENODEATHTIME_MESSAGE(xeno_candidate)
+			return FALSE
 
 	return do_spawn_larva(xeno_candidate, chosen_silo.loc, larva_already_reserved)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -932,6 +932,16 @@ to_chat will check for valid clients itself already so no need to double check f
 	if((xeno_job.total_positions - xeno_job.current_positions) < 0)
 		return FALSE
 
+	if(XENODEATHTIME_CHECK(xeno_candidate))
+		if(!check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
+			XENODEATHTIME_MESSAGE(xeno_candidate)
+			return FALSE
+		if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
+			XENODEATHTIME_MESSAGE(xeno_candidate)
+			return FALSE
+		log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
+		message_admins("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
+
 	var/list/possible_mothers = list()
 	var/list/possible_silos = list()
 	SEND_SIGNAL(src, COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, possible_mothers, possible_silos) //List variable passed by reference, and hopefully populated.
@@ -939,15 +949,6 @@ to_chat will check for valid clients itself already so no need to double check f
 		if(length(possible_silos))
 			return attempt_to_spawn_larva_in_silo(xeno_candidate, possible_silos, larva_already_reserved)
 		if(SSticker.mode?.flags_round_type & MODE_SILO_RESPAWN && !SSsilo.can_fire) // Distress mode & prior to shutters opening, so let the queue bypass silos if needed
-			if(XENODEATHTIME_CHECK(xeno_candidate))
-				if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
-					if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
-						log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
-						XENODEATHTIME_MESSAGE(xeno_candidate)
-						return FALSE
-				else
-					XENODEATHTIME_MESSAGE(xeno_candidate)
-					return FALSE
 			return do_spawn_larva(xeno_candidate, pick(GLOB.spawns_by_job[/datum/job/xenomorph]), larva_already_reserved)
 		to_chat(xeno_candidate, span_warning("There are no places currently available to receive new larvas."))
 		return FALSE
@@ -960,16 +961,6 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	if(QDELETED(chosen_mother) || !xeno_candidate?.client)
 		return FALSE
-
-	if(!isnewplayer(xeno_candidate) && XENODEATHTIME_CHECK(xeno_candidate))
-		if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
-			if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
-				log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
-				XENODEATHTIME_MESSAGE(xeno_candidate)
-				return FALSE
-		else
-			XENODEATHTIME_MESSAGE(xeno_candidate)
-			return FALSE
 
 	return spawn_larva(xeno_candidate, chosen_mother, larva_already_reserved)
 
@@ -999,16 +990,6 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	if(QDELETED(chosen_silo) || !xeno_candidate?.client)
 		return FALSE
-
-	if(!isnewplayer(xeno_candidate) && XENODEATHTIME_CHECK(xeno_candidate))
-		if(check_other_rights(xeno_candidate.client, R_ADMIN, FALSE))
-			if(tgui_alert(xeno_candidate, "You wouldn't normally qualify for this respawn. Are you sure you want to bypass it with your admin powers?", "Bypass Respawn", list("Yes", "No")) != "Yes")
-				log_admin("[key_name(xeno_candidate)] used his admin power to bypass respawn before his timer was over")
-				XENODEATHTIME_MESSAGE(xeno_candidate)
-				return FALSE
-		else
-			XENODEATHTIME_MESSAGE(xeno_candidate)
-			return FALSE
 
 	return do_spawn_larva(xeno_candidate, chosen_silo.loc, larva_already_reserved)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1137,12 +1137,21 @@ to_chat will check for valid clients itself already so no need to double check f
 		return
 	var/mob/dead/observer/observer_in_queue
 	while(stored_larva > 0 && LAZYLEN(candidate))
-		observer_in_queue = LAZYACCESS(candidate, 1)
+		for(var/i in 1 to LAZYLEN(candidate))
+			observer_in_queue = LAZYACCESS(candidate, i)
+			if(!XENODEATHTIME_CHECK(observer_in_queue))
+				break
+			observer_in_queue = null //Deathtimer still running
+
+		if(!observer_in_queue) //No valid candidates in the queue
+			break
+
 		LAZYREMOVE(candidate, observer_in_queue)
 		UnregisterSignal(observer_in_queue, COMSIG_QDELETING)
 		if(try_to_give_larva(observer_in_queue))
 			stored_larva--
 			slot_really_taken++
+
 	if(slot_occupied - slot_really_taken > 0)
 		xeno_job.free_job_positions(slot_occupied - slot_really_taken)
 	for(var/i in 1 to LAZYLEN(candidate))


### PR DESCRIPTION
## About The Pull Request
ONLY supposed to be paired up with https://github.com/tgstation/TerraGov-Marine-Corps/pull/13615
Adds a xeno respawn timer as an alternative to the silo rework and nerfs Nuclear War larva generation, to keep a punishment for dying with the maturity rework.
Current time is 5 minutes, 3 for crash. Silo scaling down from 2x to 1.5x.
It applies if you die as a xeno or ghost as a xeno, but not if you are a minion to not punish players for taking minions while waiting
## Why It's Good For The Game
Keeps a punishment for dying as Xeno while keeping it user friendly (i.e larva generation being x number per minute)
## Changelog
:cl:
balance: Added a xeno respawn timer on xeno death and ghosting, does not apply if you took a minion
/:cl:
