### PR TITLE
Closets no longer use signals for no reason + fixes weird behaviour with forceMove and closets

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -249,7 +249,6 @@
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 #define COMSIG_MOVABLE_Z_CHANGED "movable_ztransit" 			//from base of atom/movable/onTransitZ(): (old_z, new_z)
-#define COMSIG_MOVABLE_CLOSET_DUMPED "movable_closet_dumped"
 #define COMSIG_MOVABLE_PREBUMP_TURF "movable_prebump_turf"
 #define COMSIG_MOVABLE_PREBUMP_MOVABLE "movable_prebump_movable"
 	#define COMPONENT_MOVABLE_PREBUMP_STOPPED (1<<0)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -34,7 +34,7 @@
 		return
 
 	if(climbable)
-		structure_shaken()
+		INVOKE_ASYNC(src, PROC_REF(structure_shaken))
 		climbable = FALSE //Open crate is not a surface that works when climbing around
 
 /obj/structure/closet/crate/close()


### PR DESCRIPTION

## About The Pull Request

Deletes comsig closet dumped because why does it exist? It just causes issues with unregistration. Instead an exited signal gets registered to whatever mob enters the closet so we can do something when the mob gets forceMoved or such and call the open proc, which helps with tarps making people perma invis if teleported out a tarp for example. This gets unregistered on open.

Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/13833
## Why It's Good For The Game

Closets are a bit weird code wise and exploits aren't cool. This addresses both.
## Changelog
:cl:
fix: Fixed tarping before eord making you invisible
refactor: Made lockers not use signals where they aren't necessary. Should help with signals not unregistering properly in some cases
/:cl:
