### PR TITLE
Turn off auto balance being on by default

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -412,7 +412,7 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 	config_entry_value = 30 SECONDS
 
 /datum/config_entry/flag/is_automatic_balance_on
-	config_entry_value = TRUE
+	config_entry_value = FALSE
 
 /datum/config_entry/number/hard_deletes_overrun_threshold
 	integer = FALSE


### PR DESCRIPTION


## About The Pull Request

Modifies the is_automatic_balance_on config entry from starting TRUE to FALSE.

## Why It's Good For The Game

The game will no longer gaslight you into thinking it's fair.

## Changelog

:cl:
config: Modified config entry for auto balance from TRUE to FALSE.
/:cl:
