### PR TITLE
Revert "Add a category for spare civilian clothing (#13881)"

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1317,9 +1317,6 @@
 			/obj/item/clothing/gloves/latex = -1,
 			/obj/item/clothing/shoes/white = -1,
 		),
-		"Civilian Surplus Wear" = list(
-			/obj/item/clothing/under/rank/chaplain = -1
-		)
 	)
 
 	prices = list()


### PR DESCRIPTION
This reverts commit 405b1ad475d06d4ea7542e410681c10c4b5d95a2.
## About The Pull Request
we added an entire other tab with ONE item
## Why It's Good For The Game
why do we need an entire tab for 1 item, just merge surplus headgear into surplus clothing or something
## Changelog
:cl:
del: surplus clothing
/:cl:
