### PR TITLE
Fix vendor having no icon while vending

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -76,7 +76,7 @@
 	///If the vendor is ready to vend.
 	var/vend_ready = TRUE
 	///How long it takes to vend an item, vend_ready is false during that.
-	var/vend_delay = 0
+	var/vend_delay = 0.1
 	///Vending flags to determine the behaviour of the machine
 	var/vending_flags = NONE
 	/// A /datum/vending_product instance of what we're paying for right now.


### PR DESCRIPTION
## About The Pull Request

When pr about removing vendor delay was created, author didn't take into account that vendors needs at least some delay for the icon code to trigger. I added 0.1 delay which is basically nothing.

## Why It's Good For The Game

Bug - bad, fix - good.

## Changelog
:cl:
fix: fixed vendor not using special icon while vending an item
/:cl:
