### PR TITLE
Adjustments to Theseus Requisitions

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1097,12 +1097,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
-"adS" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "adT" = (
 /obj/structure/closet/crate/weapon,
 /turf/open/floor/mainship/cargo,
@@ -2282,6 +2276,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/officer_rnr)
+"aVh" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
+/area/mainship/squads/req)
 "aVi" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/aft_umbilical)
@@ -3920,10 +3920,6 @@
 "bnF" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
-"bnG" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "bnH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4137,8 +4133,8 @@
 /area/mainship/squads/req)
 "bpw" = (
 /obj/machinery/air_alarm,
-/obj/structure/largecrate/guns/merc,
-/turf/open/floor/mainship/cargo,
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/squads/req)
 "bpx" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -4148,8 +4144,10 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/machinery/vending/lasgun,
-/turf/open/floor/mainship/cargo,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bpB" = (
 /obj/structure/largecrate/guns/russian,
@@ -4310,20 +4308,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
-"brm" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/mainship/squads/req)
 "brn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
@@ -5476,13 +5467,6 @@
 	dir = 1
 	},
 /area/mainship/engineering/lower_engineering)
-"bGh" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "bGj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/floor,
@@ -8260,6 +8244,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
+"dls" = (
+/turf/open/floor/mainship/green{
+	dir = 9
+	},
+/area/mainship/squads/req)
 "dlC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8281,6 +8270,16 @@
 "dom" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
+"dop" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "dpd" = (
@@ -9458,12 +9457,6 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"fpW" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "fqo" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/misc/gnome,
@@ -12091,9 +12084,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "jNc" = (
 /turf/closed/wall/mainship,
@@ -12461,6 +12452,11 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"kxd" = (
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/squads/req)
 "kxg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -14908,6 +14904,12 @@
 	},
 /turf/open/floor/mainship/silver,
 /area/mainship/hallways/bow_hallway)
+"oiS" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "ojx" = (
 /obj/structure/prop/mainship/cannon_cables,
 /turf/open/floor/plating/mainship,
@@ -15513,6 +15515,10 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"poF" = (
+/obj/structure/largecrate/guns/merc,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "poH" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -16779,9 +16785,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "rkC" = (
 /obj/structure/cable,
@@ -17194,9 +17198,6 @@
 /area/mainship/command/airoom)
 "rZT" = (
 /obj/vehicle/unmanned/droid/ripley,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/squads/req)
 "sao" = (
@@ -17571,6 +17572,11 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"sEZ" = (
+/turf/open/floor/mainship/green{
+	dir = 10
+	},
+/area/mainship/squads/req)
 "sGK" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/mainship/tcomms,
@@ -17664,6 +17670,10 @@
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
+/area/mainship/squads/req)
+"sQs" = (
+/obj/machinery/vending/lasgun,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "sSi" = (
 /obj/machinery/door/poddoor/shutters/mainship/open/indestructible{
@@ -18437,12 +18447,6 @@
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
-"uig" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "uij" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -19446,12 +19450,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
-"vYr" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "vYx" = (
 /obj/machinery/door/window/secure/req,
 /obj/machinery/door/window{
@@ -19484,12 +19482,6 @@
 	dir = 5
 	},
 /area/mainship/command/bridge)
-"wbf" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "wca" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -20538,6 +20530,12 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/bow_hallway)
+"xZq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "xZF" = (
 /obj/effect/landmark/start/latejoin_cryo,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59502,15 +59500,15 @@ cxA
 erX
 eby
 hfD
-pbV
+iWe
 jMY
-bnD
-bnD
+sQs
+bpB
 rkB
-bnD
-bnD
+poF
+rjC
 jMY
-jFn
+iWe
 hfD
 eby
 erX
@@ -59759,15 +59757,15 @@ wvf
 eRq
 vnI
 seG
-bAG
-dIe
-bDM
-bAG
-aat
-bDM
-bAG
-dIe
-bDM
+pbV
+bnD
+bnD
+bnD
+bnD
+bnD
+bnD
+bnD
+jFn
 seG
 eRq
 vnI
@@ -60017,13 +60015,13 @@ vEt
 fCR
 seG
 bAG
-acj
-acj
-acj
-acj
-acj
-acj
-acj
+dIe
+bpq
+kxd
+aat
+bpq
+kxd
+dIe
 bDM
 seG
 vEt
@@ -60274,13 +60272,13 @@ acm
 fLQ
 seG
 bAG
-bnD
-bnD
-adS
-fpW
-bnD
-bnD
-bnD
+iWe
+bDM
+bAG
+iWe
+bDM
+bAG
+iWe
 bDM
 seG
 sZv
@@ -60532,11 +60530,11 @@ lNr
 lNr
 abX
 otD
-bDM
-bAG
+dls
+sEZ
 bzq
-bDM
-bAG
+dls
+sEZ
 otD
 bDM
 seG
@@ -61049,7 +61047,7 @@ seG
 seG
 bAG
 nGK
-bDM
+aVh
 seG
 seG
 seG
@@ -63869,10 +63867,10 @@ blj
 bnF
 bpx
 pqU
-bnG
-bpx
-brm
-bGh
+iWe
+iWe
+jMY
+iWe
 gzg
 vby
 vby
@@ -64125,11 +64123,11 @@ bke
 acw
 bnF
 rZT
-pqU
-uig
-vYr
-vYr
-wbf
+dop
+iWe
+iiq
+fTB
+iWe
 eRq
 eBv
 eBv
@@ -64383,7 +64381,7 @@ biu
 bnF
 bpz
 brn
-fTB
+iWe
 adT
 adU
 iWe
@@ -64638,9 +64636,9 @@ mRy
 bjV
 biu
 bnF
-bpB
-qxm
-iiq
+oiS
+xZq
+iWe
 bsY
 bsY
 iWe
@@ -65152,7 +65150,7 @@ aLX
 bjV
 biu
 bnF
-rjC
+bpx
 bro
 sic
 bGk

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -4909,7 +4909,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "byi" = (
@@ -5482,6 +5482,9 @@
 /obj/item/tool/hand_labeler,
 /obj/effect/spawner/random/engineering/wood,
 /obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/firealarm{
 	dir = 8
 	},
 /turf/open/floor/mainship/floor,
@@ -13770,10 +13773,10 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/vending/cargo_supply,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "mzG" = (
@@ -17263,9 +17266,14 @@
 	},
 /area/mainship/living/tankerbunks)
 "sic" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "sim" = (
@@ -64125,8 +64133,8 @@ bnF
 rZT
 dop
 iWe
-iiq
-fTB
+iWe
+iWe
 iWe
 eRq
 eBv
@@ -64381,9 +64389,9 @@ biu
 bnF
 bpz
 brn
-iWe
-adT
-adU
+fTB
+bsY
+bsY
 iWe
 gzg
 vby
@@ -64638,9 +64646,9 @@ biu
 bnF
 oiS
 xZq
-iWe
-bsY
-bsY
+iiq
+adT
+adU
 iWe
 gzg
 vby
@@ -65157,9 +65165,9 @@ bGk
 avZ
 gaR
 byh
-bzq
-bKU
 otD
+bKU
+aat
 mzi
 may
 jnG

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -387,7 +387,7 @@
 /area/mainship/living/commandbunks)
 "abz" = (
 /obj/vehicle/ridden/motorbike{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
@@ -1032,10 +1032,6 @@
 /obj/machinery/telecomms/server/presets/delta,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"adF" = (
-/obj/vehicle/unmanned/droid/ripley,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/mainship/squads/req)
 "adG" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/bed/chair/nometal,
@@ -1835,6 +1831,7 @@
 /obj/machinery/door/airlock/mainship/marine/requisitions{
 	name = "\improper Requisitions Storage"
 	},
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "aAV" = (
@@ -2004,6 +2001,11 @@
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/medical_science)
+"aGL" = (
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "aHi" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 1
@@ -3572,19 +3574,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
-"bkB" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/mainship/squads/req)
 "bkC" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -3602,12 +3591,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/green{
-	dir = 10
-	},
+/turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "bkE" = (
 /obj/structure/bed/chair/sofa/left{
@@ -3937,9 +3921,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "bnG" = (
-/obj/structure/sink{
-	dir = 8
-	},
+/obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bnH" = (
@@ -4134,23 +4116,8 @@
 	},
 /area/mainship/squads/req)
 "bpq" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/sheet/cardboard{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/item/tool/hand_labeler,
-/obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/mainship/green{
-	dir = 1
-	},
-/area/mainship/squads/req)
-"bpr" = (
-/obj/effect/spawner/random/machinery/machine_frame,
-/turf/open/floor/mainship/green{
-	dir = 1
+	dir = 5
 	},
 /area/mainship/squads/req)
 "bps" = (
@@ -4169,8 +4136,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bpw" = (
-/obj/structure/closet/crate,
 /obj/machinery/air_alarm,
+/obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "bpx" = (
@@ -4181,18 +4148,11 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/o2,
+/obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "bpB" = (
-/obj/vehicle/ridden/powerloader,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
+/obj/structure/largecrate/guns/russian,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "bpD" = (
@@ -4201,12 +4161,6 @@
 	dir = 1
 	},
 /area/mainship/squads/alpha)
-"bpF" = (
-/obj/structure/largecrate/guns,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
 "bpG" = (
 /obj/effect/landmark/start/latejoin_gateway,
 /turf/open/floor/plating/plating_catwalk,
@@ -4353,18 +4307,23 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flipped,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brm" = (
-/obj/machinery/firealarm{
-	dir = 4
+/obj/machinery/light/mainship{
+	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/squads/req)
 "brn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
@@ -4372,7 +4331,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brp" = (
@@ -4530,10 +4491,10 @@
 	},
 /area/mainship/squads/alpha)
 "bsU" = (
-/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bsV" = (
@@ -4948,6 +4909,7 @@
 /area/mainship/hallways/hangar/droppod)
 "byg" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -5515,18 +5477,26 @@
 	},
 /area/mainship/engineering/lower_engineering)
 "bGh" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGj" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGk" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
+/obj/structure/table/mainship/nometal,
+/obj/item/stack/sheet/cardboard{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/item/tool/hand_labeler,
+/obj/effect/spawner/random/engineering/wood,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
@@ -5534,18 +5504,14 @@
 /area/mainship/squads/req)
 "bGm" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
-/obj/machinery/vending/nanomed{
-	dir = 8;
-	pixel_x = -1;
-	pixel_y = -1
-	},
 /obj/machinery/door_control/mainship/req{
 	dir = 1;
 	name = "ASRS conveyor belt public shutter"
 	},
-/turf/open/floor/mainship/green{
-	dir = 6
+/obj/structure/sink{
+	dir = 4
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGq" = (
 /obj/structure/cable,
@@ -5707,6 +5673,9 @@
 	name = "\improper Requisitions Break Room"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "bIK" = (
@@ -6079,12 +6048,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
-"bMy" = (
-/obj/machinery/vending/lasgun,
-/turf/open/floor/mainship/green{
-	dir = 1
-	},
-/area/mainship/squads/req)
 "bMz" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/squad_changer,
@@ -6093,27 +6056,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
-"bMA" = (
-/obj/structure/largecrate/guns/russian,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/green{
-	dir = 1
-	},
-/area/mainship/squads/req)
 "bMB" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/mainship/green{
 	dir = 6
-	},
-/area/mainship/squads/req)
-"bMF" = (
-/obj/structure/largecrate/guns/merc,
-/turf/open/floor/mainship/green/corner{
-	dir = 1
 	},
 /area/mainship/squads/req)
 "bMH" = (
@@ -7727,17 +7675,6 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
-"cni" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "cnU" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/radio/intercom/general,
@@ -8564,6 +8501,10 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
+"dIe" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "dIf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -8810,6 +8751,12 @@
 /obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"dZM" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/green/corner{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "ead" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_emb)
@@ -9087,6 +9034,11 @@
 /obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship_hull,
 /area/space)
+"eBv" = (
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "eCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9899,6 +9851,10 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"fTB" = (
+/obj/structure/closet/crate/construction,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "fUZ" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
@@ -10279,6 +10235,11 @@
 	dir = 8
 	},
 /area/mainship/living/pilotbunks)
+"gzg" = (
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/squads/req)
 "gzh" = (
 /turf/open/floor/mainship/purple/corner{
 	dir = 4
@@ -11208,6 +11169,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"iiq" = (
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "iiA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -11425,6 +11394,7 @@
 	id = "supply_elevator_railing"
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
@@ -11682,6 +11652,9 @@
 	name = "\improper Requisition's Office"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "iYA" = (
@@ -11815,6 +11788,7 @@
 	id = "qm_warehouse";
 	name = "\improper Warehouse Shutters"
 	},
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "jjk" = (
@@ -12287,6 +12261,7 @@
 "kfp" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "khr" = (
@@ -12473,6 +12448,11 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"kvt" = (
+/obj/machinery/vending/nanomed,
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "kwO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -12824,6 +12804,7 @@
 /area/mainship/hallways/hangar)
 "kWq" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "kWU" = (
@@ -13812,6 +13793,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
+"mBt" = (
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/green,
+/area/mainship/squads/req)
 "mBx" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -14777,6 +14762,15 @@
 	dir = 8
 	},
 /area/mainship/medical/surgery_hallway)
+"nYL" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
+/area/mainship/squads/req)
 "nZu" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -14937,6 +14931,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"okW" = (
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "olA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -15287,6 +15286,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
+"oXg" = (
+/turf/open/floor/mainship/orange,
+/area/mainship/squads/req)
 "oXD" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -15560,6 +15562,15 @@
 	dir = 8
 	},
 /area/mainship/living/starboard_emb)
+"pqU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "prM" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -16242,6 +16253,12 @@
 /obj/machinery/microwave,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/officer_study)
+"qxm" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "qxD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16724,6 +16741,10 @@
 	dir = 4
 	},
 /area/mainship/medical/surgery_hallway)
+"rjC" = (
+/obj/structure/largecrate/guns,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "rjQ" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/machinery/light/mainship,
@@ -16835,6 +16856,14 @@
 "rsG" = (
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
+"rth" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "rtD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -17163,6 +17192,13 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"rZT" = (
+/obj/vehicle/unmanned/droid/ripley,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/mainship/squads/req)
 "sao" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small,
@@ -17225,6 +17261,12 @@
 	dir = 8
 	},
 /area/mainship/living/tankerbunks)
+"sic" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "sim" = (
 /obj/effect/ai_node,
 /obj/machinery/landinglight/tadpole{
@@ -17994,6 +18036,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "txr" = (
@@ -18146,6 +18189,14 @@
 /obj/item/book/manual/atmospipes,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engine_monitoring)
+"tJP" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "tKz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18386,6 +18437,12 @@
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"uig" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "uij" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -18918,6 +18975,9 @@
 	dir = 10
 	},
 /area/mainship/shipboard/port_point_defense)
+"vby" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "vcD" = (
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/machinery/door/window{
@@ -19386,6 +19446,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"vYr" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "vYx" = (
 /obj/machinery/door/window/secure/req,
 /obj/machinery/door/window{
@@ -19418,6 +19484,12 @@
 	dir = 5
 	},
 /area/mainship/command/bridge)
+"wbf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "wca" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -19942,10 +20014,6 @@
 /obj/structure/bed/bunkbed,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_emb)
-"xas" = (
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "xaS" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -20264,6 +20332,12 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/repair_bay)
+"xIv" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "xJO" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -59686,13 +59760,13 @@ eRq
 vnI
 seG
 bAG
+dIe
+bDM
+bAG
 aat
 bDM
 bAG
-bzq
-bDM
-bAG
-otD
+dIe
 bDM
 seG
 eRq
@@ -60457,7 +60531,7 @@ lNr
 lNr
 lNr
 abX
-aat
+otD
 bDM
 bAG
 bzq
@@ -60709,7 +60783,7 @@ aLX
 krL
 biu
 fCa
-jFn
+dZM
 pbV
 fOx
 ace
@@ -60978,7 +61052,7 @@ nGK
 bDM
 seG
 seG
-xas
+seG
 mxf
 wgD
 wgD
@@ -61227,7 +61301,7 @@ vaF
 bAG
 bGj
 bnF
-abz
+kvt
 seG
 seG
 kzX
@@ -61235,7 +61309,7 @@ acj
 vaF
 seG
 seG
-bnF
+mBt
 bnF
 kfp
 kfp
@@ -61737,23 +61811,23 @@ biu
 bjV
 biu
 bnF
-bpn
+nYL
 kzX
 acj
 byg
 vaF
-jiv
+rth
 xhL
 xhL
 xhL
 xhL
 xhL
-bAK
+tJP
 jER
 iYu
 muC
 iWe
-iWe
+bta
 irZ
 ruj
 bQw
@@ -61995,8 +62069,8 @@ bjV
 biu
 wcO
 bpq
-iWe
-iWe
+bnD
+bnD
 seG
 bKU
 jiv
@@ -62251,11 +62325,11 @@ biu
 bjV
 biu
 wcO
-bpr
-bnD
+adg
+aGL
 bGm
-bkB
-bMy
+wcO
+bDM
 buI
 xhL
 xhL
@@ -62512,7 +62586,7 @@ bnF
 wcO
 bnF
 bnF
-bMA
+bpn
 jiv
 xhL
 xhL
@@ -62768,8 +62842,8 @@ acj
 acj
 acj
 sPW
-bpF
-bMF
+acj
+vaF
 jiv
 xhL
 xhL
@@ -63545,7 +63619,7 @@ bnF
 jiQ
 jiQ
 jiQ
-cni
+jiQ
 jiQ
 bnF
 bnF
@@ -63793,17 +63867,17 @@ biu
 bjV
 blj
 bnF
-adF
-bBX
+bpx
+pqU
 bnG
-iWe
+bpx
 brm
 bGh
-iWe
-iWe
-iWe
-iWe
-iWe
+gzg
+vby
+vby
+vby
+oXg
 vfW
 rws
 bnF
@@ -64050,17 +64124,17 @@ ayo
 bke
 acw
 bnF
-bpx
-bBX
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
+rZT
+pqU
+uig
+vYr
+vYr
+wbf
+eRq
+eBv
+eBv
+eBv
+vnI
 iWe
 adV
 bnF
@@ -64309,15 +64383,15 @@ biu
 bnF
 bpz
 brn
+fTB
+adT
+adU
 iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
+gzg
+vby
+vby
+vby
+oXg
 iWe
 lDM
 bnF
@@ -64565,16 +64639,16 @@ bjV
 biu
 bnF
 bpB
+qxm
+iiq
+bsY
+bsY
 iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
+gzg
+vby
+vby
+vby
+oXg
 iWe
 abz
 bnF
@@ -64822,17 +64896,17 @@ bjV
 blj
 bnF
 bpw
-bta
+qxm
 iWe
 iWe
 iWe
 iWe
+vEt
+okW
+xIv
+okW
+fCR
 iWe
-iWe
-bta
-iWe
-adT
-adU
 bJI
 bIH
 kWq
@@ -65078,15 +65152,15 @@ aLX
 bjV
 biu
 bnF
-bsY
+rjC
 bro
-adg
+sic
 bGk
 avZ
 gaR
 byh
 bzq
-iWe
+bKU
 otD
 mzi
 may


### PR DESCRIPTION
## About The Pull Request

The Theseus Requisitions department is a little weird. This should help.

![theseus_req](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/4a521100-9515-40a6-9f77-083275230738)

## Why It's Good For The Game

Theseus' requisitions department currently has a lot of clutter in the central zone, with outdated components, mismatched tiles, and other items that generally feel out of place, or in some cases block movement paths to doorways. This moves things around, should look a little nicer while doing so.

## Changelog

:cl:
qol: Adjusted Theseus requisitions to be more ergonomic.
/:cl:
