### PR TITLE
Superheavy pistol changes

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -422,10 +422,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "pistol_superheavy"
 	damage = 45
 	penetration = 15
-	sundering = 3.5
+	sundering = 3
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 1)
+	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -423,6 +423,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 45
 	penetration = 15
 	sundering = 3
+	damage_falloff = 0.75
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -331,7 +331,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.3 SECONDS
 	scatter_unwielded = 25
 	recoil = 1
 	recoil_unwielded = 2
@@ -473,7 +473,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.35 SECONDS
 	burst_delay = 0.5 SECONDS
 	damage_mult = 1.2
 	recoil = 0

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -331,11 +331,11 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.7 SECONDS
+	fire_delay = 0.25 SECONDS
 	scatter_unwielded = 25
 	recoil = 1
 	recoil_unwielded = 2
-	scatter = 4
+	scatter = 2
 	scatter_unwielded = 7
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.7
@@ -453,7 +453,7 @@
 
 
 //-------------------------------------------------------
-//.45 MARSHALS PISTOL //Inspired by the Browning Hipower
+// Browning Hipower
 
 /obj/item/weapon/gun/pistol/highpower
 	name = "\improper Highpower automag"
@@ -473,13 +473,13 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
-	fire_delay = 1 SECONDS
+	fire_delay = 0.3 SECONDS
 	burst_delay = 0.5 SECONDS
 	damage_mult = 1.2
-	recoil = 1
+	recoil = 0
 	recoil_unwielded = 2
-	accuracy_mult_unwielded = 0.7
-	scatter = 3
+	accuracy_mult_unwielded = 0.6
+	scatter = 2
 	scatter_unwielded = 6
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request
Super heavy pistol ammo now deals knockback and has slightly less sunder/slowdown. It's effectively nearly the same as non TP-44 revolver ammo, also reduced falloff slightly.

Deagle
Fire delay 0.7->0.3
Better base handling overall.

Hipower
Fire delay 1->0.35
## Why It's Good For The Game
These guns suck complete doodoo, they don't work as pocket stunners because their damage and handling is trash, M-44s generally just handle better despite being stuck as single action, and their ammo economy is equally as bad. If the fire delay is too low I'd probably just make it .35 and .4 respectively and they'd be fine forever, since getting rid of the stagger would just make them worse heavy pistols.
## Changelog
:cl:
balance: Superheavy pistols like the Deagle and Hipower have significantly less fire delay, deal a bit less sunder, deal halved slowdown and have better handling.
/:cl:
