### PR TITLE
Adds roundstart heavy weapon rotation.

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(persistence)
 	///Stores how long each season should last
 	var/list/seasons_durations = list(
 		SEASONAL_GUNS = 24 HOURS,
-		SEASONAL_HEAVY = 24 HOURS,
+		SEASONAL_HEAVY = 8 HOURS,
 	)
 	///Stores the current season for each season group
 	var/list/season_progress = list()
@@ -40,6 +40,7 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/heavy_defualt,
 		/datum/season_datum/weapons/guns/heavy_ff,
 		/datum/season_datum/weapons/guns/heavy_autorail,
+		/datum/season_datum/weapons/guns/heavy_shock,
 		),
 	)
 	///The saved list of custom outfits names
@@ -323,7 +324,7 @@ SUBSYSTEM_DEF(persistence)
 
 /datum/season_datum/weapons/guns/heavy_ff
 	name = "Fire and Forget Heavy Weapons"
-	description = "TAT, Thermobarics and Disposables for roundstart loadouts."
+	description = "TAT, Thermobarics and Disposables for roundstart vendors."
 	item_list = list(
 			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
 			/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
@@ -333,7 +334,7 @@ SUBSYSTEM_DEF(persistence)
 
 /datum/season_datum/weapons/guns/heavy_autorail
 	name = "Wall and Armor Shredder Weapons"
-	description = "Flak gun and Railgun for roundstart loadouts."
+	description = "Flak gun and Railgun for roundstart vendors."
 	item_list = list(
 			/obj/item/weapon/gun/standard_auto_cannon = 1,
 			/obj/item/ammo_magazine/auto_cannon = 3,
@@ -342,4 +343,21 @@ SUBSYSTEM_DEF(persistence)
 			/obj/item/ammo_magazine/railgun = 10,
 			/obj/item/ammo_magazine/railgun/smart = 6,
 		)
+
+/datum/season_datum/weapons/guns/heavy_shock
+	name = "Shock Weapons"
+	description = "RR and MLRS for roundstart vendors."
+	item_list = list(
+			/obj/item/storage/holster/backholster/rpg/full = 2,
+			/obj/item/ammo_magazine/rocket/recoilless = 4,
+			/obj/item/ammo_magazine/rocket/recoilless/light = 4,
+			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
+			/obj/item/mortar_kit/mlrs = 2,
+			/obj/item/storage/box/mlrs_rockets = 8,
+			/obj/item/storage/box/mlrs_rockets_gas = 4,
+		)
+
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(persistence)
 	///Stores how long each season should last
 	var/list/seasons_durations = list(
 		SEASONAL_GUNS = 24 HOURS,
-		SEASONAL_HEAVY = 8 HOURS,
+		SEASONAL_HEAVY = 24 HOURS,
 	)
 	///Stores the current season for each season group
 	var/list/season_progress = list()

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -310,7 +310,7 @@ SUBSYSTEM_DEF(persistence)
 // Heavy Weapons Seasonals //
 
 /datum/season_datum/weapons/guns/heavy_defualt
-	name = "Deafault Heavy Weapons"
+	name = "Default Heavy Weapons"
 	description = "The generic set of roundstart TGMC heavy weapons, TAT and RR."
 	item_list = list(
 		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
@@ -321,7 +321,7 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
 		/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
 		/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
-		)
+	)
 
 /datum/season_datum/weapons/guns/heavy_ff
 	name = "Fire and Forget Heavy Weapons"
@@ -331,7 +331,7 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
 		/obj/item/ammo_magazine/rocket/m57a4 = 6,
 		/obj/item/weapon/gun/launcher/rocket/oneuse = 8,
-		)
+	)
 
 /datum/season_datum/weapons/guns/heavy_autorail
 	name = "Wall and Armor Shredder Weapons"
@@ -343,7 +343,7 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/rifle/railgun = 2,
 		/obj/item/ammo_magazine/railgun = 10,
 		/obj/item/ammo_magazine/railgun/smart = 6,
-		)
+	)
 
 /datum/season_datum/weapons/guns/heavy_shock
 	name = "Shock Weapons"
@@ -359,6 +359,4 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/mortar_kit/mlrs = 2,
 		/obj/item/storage/box/mlrs_rockets = 8,
 		/obj/item/storage/box/mlrs_rockets_gas = 4,
-		)
-
-
+	)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -328,9 +328,9 @@ SUBSYSTEM_DEF(persistence)
 	description = "TAT, Thermobarics and Disposables for roundstart vendors."
 	item_list = list(
 		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
-		/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
-		/obj/item/ammo_magazine/rocket/m57a4 = 6,
-		/obj/item/weapon/gun/launcher/rocket/oneuse = 8,
+		/obj/item/weapon/gun/launcher/rocket/m57a4/t57/unloaded = 2,
+		/obj/item/ammo_magazine/rocket/m57a4 = 8,
+		/obj/structure/largecrate/supply/explosives/disposable = 1,
 	)
 
 /datum/season_datum/weapons/guns/heavy_autorail
@@ -340,8 +340,8 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/standard_auto_cannon = 1,
 		/obj/item/ammo_magazine/auto_cannon = 3,
 		/obj/item/ammo_magazine/auto_cannon/flak = 3,
-		/obj/item/weapon/gun/rifle/railgun = 2,
-		/obj/item/ammo_magazine/railgun = 10,
+		/obj/item/weapon/gun/rifle/railgun/unloaded = 2,
+		/obj/item/ammo_magazine/railgun = 12,
 		/obj/item/ammo_magazine/railgun/smart = 6,
 	)
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -38,6 +38,9 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/lever_seasonal,
 		),
 		SEASONAL_HEAVY = list(
+		/datum/season_datum/weapons/guns/heavy_defualt,
+		/datum/season_datum/weapons/guns/heavy_ff,
+		/datum/season_datum/weapons/guns/heavy_autorail,
 		/datum/season_datum/weapons/guns/heavy_shock,
 		),
 	)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -18,6 +18,7 @@ SUBSYSTEM_DEF(persistence)
 	///Stores how long each season should last
 	var/list/seasons_durations = list(
 		SEASONAL_GUNS = 24 HOURS,
+		SEASONAL_HEAVY = 24 HOURS,
 	)
 	///Stores the current season for each season group
 	var/list/season_progress = list()
@@ -34,7 +35,12 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
 		/datum/season_datum/weapons/guns/shotgun_seasonal,
 		/datum/season_datum/weapons/guns/lever_seasonal,
-		)
+		),
+		SEASONAL_HEAVY = list(
+		/datum/season_datum/weapons/guns/heavy_defualt,
+		/datum/season_datum/weapons/guns/heavy_ff,
+		/datum/season_datum/weapons/guns/heavy_autorail,
+		),
 	)
 	///The saved list of custom outfits names
 	var/list/custom_loadouts = list()
@@ -298,3 +304,42 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
 		/obj/item/ammo_magazine/shotgun/mbx900/tracking = -1,
 		)
+
+// Heavy Weapons Seasonals //
+
+/datum/season_datum/weapons/guns/heavy_defualt
+	name = "Deafault Heavy Weapons"
+	description = "The generic set of roundstart TGMC heavy weapons, TAT and RR."
+	item_list = list(
+			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+			/obj/item/storage/holster/backholster/rpg/full = 2,
+			/obj/item/ammo_magazine/rocket/recoilless = 4,
+			/obj/item/ammo_magazine/rocket/recoilless/light = 4,
+			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
+		)
+
+/datum/season_datum/weapons/guns/heavy_ff
+	name = "Fire and Forget Heavy Weapons"
+	description = "TAT, Thermobarics and Disposables for roundstart loadouts."
+	item_list = list(
+			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+			/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
+			/obj/item/ammo_magazine/rocket/m57a4 = 6,
+			/obj/item/weapon/gun/launcher/rocket/oneuse = 8,
+		)
+
+/datum/season_datum/weapons/guns/heavy_autorail
+	name = "Wall and Armor Shredder Weapons"
+	description = "Flak gun and Railgun for roundstart loadouts."
+	item_list = list(
+			/obj/item/weapon/gun/standard_auto_cannon = 1,
+			/obj/item/ammo_magazine/auto_cannon = 3,
+			/obj/item/ammo_magazine/auto_cannon/flak = 3,
+			/obj/item/weapon/gun/rifle/railgun = 2,
+			/obj/item/ammo_magazine/railgun = 10,
+			/obj/item/ammo_magazine/railgun/smart = 6,
+		)
+

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -38,9 +38,6 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/lever_seasonal,
 		),
 		SEASONAL_HEAVY = list(
-		/datum/season_datum/weapons/guns/heavy_defualt,
-		/datum/season_datum/weapons/guns/heavy_ff,
-		/datum/season_datum/weapons/guns/heavy_autorail,
 		/datum/season_datum/weapons/guns/heavy_shock,
 		),
 	)
@@ -356,7 +353,6 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
 		/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
 		/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
-		/obj/item/mortar_kit/mlrs = 2,
-		/obj/item/storage/box/mlrs_rockets = 8,
+		/obj/structure/closet/crate/mortar_ammo/mlrs_kit = 2,
 		/obj/item/storage/box/mlrs_rockets_gas = 4,
 	)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -9,6 +9,7 @@
 
 //Season names
 #define SEASONAL_GUNS "seasonal_guns"
+#define SEASONAL_HEAVY "seasonal_heavy"
 
 SUBSYSTEM_DEF(persistence)
 	name = "Persistence"

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -313,52 +313,52 @@ SUBSYSTEM_DEF(persistence)
 	name = "Deafault Heavy Weapons"
 	description = "The generic set of roundstart TGMC heavy weapons, TAT and RR."
 	item_list = list(
-			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
-			/obj/item/storage/holster/backholster/rpg/full = 2,
-			/obj/item/ammo_magazine/rocket/recoilless = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/light = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
+		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+		/obj/item/storage/holster/backholster/rpg/full = 2,
+		/obj/item/ammo_magazine/rocket/recoilless = 4,
+		/obj/item/ammo_magazine/rocket/recoilless/light = 4,
+		/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
 		)
 
 /datum/season_datum/weapons/guns/heavy_ff
 	name = "Fire and Forget Heavy Weapons"
 	description = "TAT, Thermobarics and Disposables for roundstart vendors."
 	item_list = list(
-			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
-			/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
-			/obj/item/ammo_magazine/rocket/m57a4 = 6,
-			/obj/item/weapon/gun/launcher/rocket/oneuse = 8,
+		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+		/obj/item/weapon/gun/launcher/rocket/m57a4/t57 = 2,
+		/obj/item/ammo_magazine/rocket/m57a4 = 6,
+		/obj/item/weapon/gun/launcher/rocket/oneuse = 8,
 		)
 
 /datum/season_datum/weapons/guns/heavy_autorail
 	name = "Wall and Armor Shredder Weapons"
 	description = "Flak gun and Railgun for roundstart vendors."
 	item_list = list(
-			/obj/item/weapon/gun/standard_auto_cannon = 1,
-			/obj/item/ammo_magazine/auto_cannon = 3,
-			/obj/item/ammo_magazine/auto_cannon/flak = 3,
-			/obj/item/weapon/gun/rifle/railgun = 2,
-			/obj/item/ammo_magazine/railgun = 10,
-			/obj/item/ammo_magazine/railgun/smart = 6,
+		/obj/item/weapon/gun/standard_auto_cannon = 1,
+		/obj/item/ammo_magazine/auto_cannon = 3,
+		/obj/item/ammo_magazine/auto_cannon/flak = 3,
+		/obj/item/weapon/gun/rifle/railgun = 2,
+		/obj/item/ammo_magazine/railgun = 10,
+		/obj/item/ammo_magazine/railgun/smart = 6,
 		)
 
 /datum/season_datum/weapons/guns/heavy_shock
 	name = "Shock Weapons"
 	description = "RR and MLRS for roundstart vendors."
 	item_list = list(
-			/obj/item/storage/holster/backholster/rpg/full = 2,
-			/obj/item/ammo_magazine/rocket/recoilless = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/light = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
-			/obj/item/mortar_kit/mlrs = 2,
-			/obj/item/storage/box/mlrs_rockets = 8,
-			/obj/item/storage/box/mlrs_rockets_gas = 4,
+		/obj/item/storage/holster/backholster/rpg/full = 2,
+		/obj/item/ammo_magazine/rocket/recoilless = 4,
+		/obj/item/ammo_magazine/rocket/recoilless/light = 4,
+		/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
+		/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
+		/obj/item/mortar_kit/mlrs = 2,
+		/obj/item/storage/box/mlrs_rockets = 8,
+		/obj/item/storage/box/mlrs_rockets_gas = 4,
 		)
 
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -842,7 +842,7 @@
 
 
 /obj/structure/closet/crate/mortar_ammo/mlrs_kit
-	name = "\improper TA-40L howitzer kit"
+	name = "\improper TA-40L MLRS kit"
 	desc = "A crate containing a basic, somehow compressed kit consisting of an entire multiple launch rocket system and some rockets, to get a artilleryman started."
 
 /obj/structure/closet/crate/mortar_ammo/mlrs_kit/PopulateContents()

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -221,7 +221,7 @@
 
 	seasonal_items = list(
 		SEASONAL_GUNS = "Seasonal",
-		SEASONAL_HEAVY = "Rotational Heavy Weapons",
+		SEASONAL_HEAVY = "Operational Weapons",
 	)
 
 /obj/machinery/vending/weapon/crash

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -136,19 +136,11 @@
 		"Heavy Weapons" = list(
 			/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
 			/obj/structure/closet/crate/mortar_ammo/howitzer_kit = 1,
-			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
 			/obj/item/storage/box/crate/sentry = 4,
 			/obj/item/storage/box/tl102 = 1,
 			/obj/item/weapon/gun/heavymachinegun = 1,
 			/obj/item/ammo_magazine/heavymachinegun = 5,
 			/obj/item/ammo_magazine/heavymachinegun/small = 10,
-			/obj/item/storage/holster/backholster/rpg/full = 2,
-			/obj/item/ammo_magazine/rocket/recoilless = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/light = 4,
-			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
-			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,
@@ -229,6 +221,7 @@
 
 	seasonal_items = list(
 		SEASONAL_GUNS = "Seasonal",
+		SEASONAL_HEAVY = "Rotational Heavy Weapons",
 	)
 
 /obj/machinery/vending/weapon/crash

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -254,6 +254,10 @@
 	desc = "A case containing twenty five 80mm flare mortar shells."
 	supplies = list(/obj/item/mortal_shell/flare = 25)
 
+/obj/structure/largecrate/supply/explosives/disposable
+	name = "RL-72 disposable rocket launchers (x8)"
+	desc = "A case contaning eight RL-72 disposables."
+	supplies = list(/obj/item/weapon/gun/launcher/rocket/oneuse = 1)
 
 /obj/structure/largecrate/supply/supplies
 	name = "supplies crate"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -739,6 +739,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	default_ammo_type = /obj/item/ammo_magazine/rocket/m57a4
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rocket/m57a4)
 
+/obj/item/weapon/gun/launcher/rocket/m57a4/t57/unloaded
+	default_ammo_type = null
 
 //-------------------------------------------------------
 //RL-160 Recoilless Rifle. Its effectively an RPG codewise.
@@ -958,6 +960,9 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	recoil = 3
 	scatter = 0
 	movement_acc_penalty_mult = 6
+
+/obj/item/weapon/gun/rifle/railgun/unloaded
+	default_ammo_type = null
 
 //-------------------------------------------------------
 //ML-120 Coilgun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds heavy weapon rotation to roundstart kit.
Effectively, the TAT and RR can get replaced by other stuff, everything totals up to an imaginary power level of like 12, with the TAT being 6 and an RR being 3.

Current buckets are listed down below, name of the tab is "Operational Weapons". Rerolls every 24.

<details>

- Default - Which is the current one of just TAT and 2 RRs.
- Fire and Forget - TAT, 8 disposables, and 2 Thermobarics.
- Autorail - Flak gun and Railgun (With no HVAP!)
- Shock - 2 RRs and an MLRS

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more variety to roundstart marine rollouts and thoughts, gives 40-60 point range weapons that are underused some more time in the spotlight and lets us test new roundstart marine powerkit rollouts to see how it affects the game, which is the main thing I'm interested in with this PR.

Boring design process/thoughts blarb if you care at all below.

<details>
I also briefly considered rolling other stuff like flamers, HMG/HSG into this "Operational rotation" but I eventually realized that marines with 0 flamers roundstart would probably not be a very good idea, and there's not enough variety in possible artillery pieces to have any more interesting loadouts beyond the mortar+howi we already have, so this mainly aims at TAT and RR, maybe in the future other stuff could be rolled into this.


Another train of thought I maybe thought of was making things be "Equivalent" I.E Railgun and RR replace eachother in loadouts, and generally structuring everything but I eventually realized that would be probably a bad idea, I also considered adding a BR8/Autosniper bin but I don't have enough political power to convince the playerbase that those are fine roundstart inexchange for no TAT or RR. (Even though I think it would!)

~~I also meant for this to be my birthday joke PR but it became serious so uhhhhhhh.~~

Funny chart of power below, power in general is entirely subjective. Ideally most bins should equal 12 or so. Everyone will disagree here.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/46353991/cda73770-1677-4f04-a769-2cd191f510ce)

</details>

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Rotational heavy weapons system, the tab itself ingame is called 'Operational Weapons' which rotates every 24 hours between bins like seasonals, TAT and RR have been moved to here and the 3 other bins contain objects like Flak, Thermo, and DRPGs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
