### PR TITLE
King no longer has additional special autobalance weight

### DIFF
--- a/code/__DEFINES/monitor.dm
+++ b/code/__DEFINES/monitor.dm
@@ -35,7 +35,6 @@
 #define PRIMO_T3_WEIGHT -100
 #define NORMAL_T4_WEIGHT -80
 #define PRIMO_T4_WEIGHT -120
-#define KING_WEIGHT -200 //king is also counted as a T4
 #define SPAWNING_POOL_WEIGHT -100
 
 //The weight of each statistics in the state calculator before shutters drop

--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -111,7 +111,6 @@ SUBSYSTEM_DEF(monitor)
 			. += stats.normal_T3 * NORMAL_T3_WEIGHT
 			. += stats.primo_T4 * PRIMO_T4_WEIGHT
 			. += stats.normal_T4 * NORMAL_T4_WEIGHT
-			. += stats.king * KING_WEIGHT
 			. += human_on_ground * HUMAN_LIFE_ON_GROUND_WEIGHT
 			. += (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) - human_on_ground) * HUMAN_LIFE_ON_SHIP_WEIGHT
 			. += length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) * XENOS_LIFE_WEIGHT


### PR DESCRIPTION
## About The Pull Request

King had special autobalance weight since the caste used to work mechanically as a "game ender" that cost a lot of psy points, now instead it's just another T4 that is pop-locked so it has the same weight as other T4s.

## Why It's Good For The Game

King used to weigh up to 350% of a Queen for autobalance calculations, this hasn't been updated since King got reworked into a much weaker pop-locked T4 caste.

## Changelog

:cl:
del: King no longer has additional special autobalance weight.
/:cl:
