### PR TITLE
Fix xeno spawns not counting towards autobalance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -172,6 +172,8 @@
 				SSmonitor.stats.primo_T2--
 			if(XENO_TIER_THREE)
 				SSmonitor.stats.primo_T3--
+			if(XENO_TIER_FOUR)
+				SSmonitor.stats.primo_T4--
 
 	new_xeno.upgrade_stored = max(upgrade_stored, new_xeno.upgrade_stored)
 	while(new_xeno.upgrade_possible() && new_xeno.upgrade_stored >= new_xeno.xeno_caste.upgrade_threshold)

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -47,8 +47,22 @@
 		current_aura.strength = xeno_caste.aura_strength
 
 	switch(upgrade)
-		//PURCHASED UPGRADE
+		if(XENO_UPGRADE_NORMAL)
+			switch(tier)
+				if(XENO_TIER_TWO)
+					SSmonitor.stats.normal_T2++
+				if(XENO_TIER_THREE)
+					SSmonitor.stats.normal_T3++
+				if(XENO_TIER_FOUR)
+					SSmonitor.stats.normal_T4++
 		if(XENO_UPGRADE_PRIMO)
+			switch(tier)
+				if(XENO_TIER_TWO)
+					SSmonitor.stats.primo_T2++
+				if(XENO_TIER_THREE)
+					SSmonitor.stats.primo_T3++
+				if(XENO_TIER_FOUR)
+					SSmonitor.stats.primo_T4++
 			if(!silent)
 				to_chat(src, span_xenoannounce(xeno_caste.primordial_message))
 


### PR DESCRIPTION
## About The Pull Request

These were being decremented but never incremented so xeno deaths were actually counting *towards* turning autobalance on

## Changelog

:cl:
fix: Fix xeno spawns not counting towards autobalance
/:cl: