### PR TITLE
Reverts Gun Nomeculture (Mostly) entirely.

### DIFF
--- a/code/__DEFINES/calibers.dm
+++ b/code/__DEFINES/calibers.dm
@@ -9,7 +9,7 @@
 #define CALIBER_45L ".45 Long"
 #define CALIBER_22LR ".22 LR"
 #define CALIBER_380ACP ".380 ACP"
-#define CALIBER_PLASMA "Ionized Plasma Bolt" //PP-7 Plasma Pistol
+#define CALIBER_PLASMA "Ionized Plasma Bolt" //TX-7 Plasma Pistol
 #define CALIBER_50AE ".50 AE"
 #define CALIBER_41RIM ".41 Rimfire" //Derringer
 #define CALIBER_70MANKEY ".70 Mankey" //Don't ask
@@ -72,7 +72,7 @@
 #define CALIBER_FUEL "Fuel"
 #define CALIBER_FUEL_THICK "UT-Napthal Fuel"
 #define CALIBER_WATER "Water"
-#define CALIBER_10X28 "10x28mm" //Sentry, OG Smartgun and SR-26 Sniper?
+#define CALIBER_10X28 "10x28mm" //Sentry, OG Smartgun and T-26 Sniper?
 #define CALIBER_86 "86mm" //MBT Main Cannon
 #define CALIBER_PEPPERBALL "SAN Ball " //Pepperball gun
 #define CALIBER_10G_RAIL "10 gauge rail"

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -137,14 +137,14 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 		/obj/item/storage/pouch/explosive/razorburn = list(CAT_LEDSUP, "Pack of Razorburn grenades", 24, "orange"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_large = list(CAT_LEDSUP, "Razorburn canister", 21, "black"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol = list(CAT_LEDSUP, "Razorburn grenade", 6, "black"),
-		/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_LEDSUP, "FL-84 flamethrower", 12, "black"),
+		/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_LEDSUP, "TL-84 flamethrower", 12, "black"),
 		/obj/item/ammo_magazine/flamer_tank/large = list(CAT_LEDSUP, "Flamethrower tank", 4, "black"),
 		/obj/item/storage/backpack/marine/radiopack = list(CAT_LEDSUP, "Radio Pack", 15, "black"),
-		/obj/item/weapon/gun/revolver/standard_magnum = list(CAT_LEDSUP, "R-76 Magnum", 12, "black"),
-		/obj/item/weapon/gun/rifle/tx55 = list(CAT_LEDSUP, "AR-55 OICW Rifle", 25, "black"),
-		/obj/item/ammo_magazine/rifle/tx54 = list(CAT_LEDSUP, "GL-54 Flak Magazine for AR-55/GL-54", 5, "black"),
-		/obj/item/ammo_magazine/rifle/tx54/smoke = list(CAT_LEDSUP, "GL-54 tactical smoke Magazine for AR-55/GL-54", 3, "black"),
-		/obj/item/ammo_magazine/rifle/tx54/smoke/tangle = list(CAT_LEDSUP, "GL-54 Tanglefoot Magazine for AR-55/GL-54", 12, "black"),
+		/obj/item/weapon/gun/revolver/standard_magnum = list(CAT_LEDSUP, "TL-76 Magnum", 12, "black"),
+		/obj/item/weapon/gun/rifle/tx55 = list(CAT_LEDSUP, "TX-55 OICW Rifle", 25, "black"),
+		/obj/item/ammo_magazine/rifle/tx54 = list(CAT_LEDSUP, "TX-54 Flak Magazine for TX-55/TX-54", 5, "black"),
+		/obj/item/ammo_magazine/rifle/tx54/smoke = list(CAT_LEDSUP, "TX-54 tactical smoke Magazine for TX-55/TX-54", 3, "black"),
+		/obj/item/ammo_magazine/rifle/tx54/smoke/tangle = list(CAT_LEDSUP, "TX-54 Tanglefoot Magazine for TX-55/TX-54", 12, "black"),
 		/obj/item/storage/firstaid/adv = list(CAT_LEDSUP, "Advanced firstaid kit", 10, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_LEDSUP, "Injector (Synaptizine)", 10, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_LEDSUP, "Injector (Advanced)", 15, "orange"),
@@ -165,10 +165,10 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 		/obj/item/storage/pouch/explosive/razorburn = list(CAT_FCSUP, "Pack of Razorburn grenades", 24, "orange"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_large = list(CAT_FCSUP, "Razorburn canister", 21, "black"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol = list(CAT_FCSUP, "Razorburn grenade", 6, "black"),
-		/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_FCSUP, "FL-84 flamethrower", 12, "black"),
+		/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_FCSUP, "TL-84 flamethrower", 12, "black"),
 		/obj/item/ammo_magazine/flamer_tank/large = list(CAT_FCSUP, "Flamethrower tank", 4, "black"),
 		/obj/item/storage/backpack/marine/radiopack = list(CAT_FCSUP, "Radio Pack", 15, "black"),
-		/obj/item/weapon/gun/revolver/standard_magnum = list(CAT_FCSUP, "R-76 Magnum", 12, "black"),
+		/obj/item/weapon/gun/revolver/standard_magnum = list(CAT_FCSUP, "TL-76 Magnum", 12, "black"),
 		/obj/item/storage/firstaid/adv = list(CAT_FCSUP, "Advanced firstaid kit", 10, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_FCSUP, "Injector (Synaptizine)", 10, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_FCSUP, "Injector (Advanced)", 15, "orange"),
@@ -177,22 +177,22 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 //A way to give them everything at once that still works with loadouts would be nice, but barring that make sure that your point calculation is set up so they don't get more than what they're supposed to
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/clothing/glasses/night/m56_goggles = list(CAT_ESS, "KLTD Smart Goggles", 0, "white"),
-	/obj/effect/vendor_bundle/smartgunner_pistol = list(CAT_ESS, "SP-13 smart pistol bundle", 0, "white"),
-	/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = list(CAT_SGSUP, "SP-13 smart pistol ammo", 2, "black"),
-	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Smart Machine Gun", 29, "orange"), //If a smartgunner buys a SG-29, then they will have 16 points to purchase 4 SG-29 drums
-	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Ammo Drum", 4, "black"),
-	/obj/item/weapon/gun/minigun/smart_minigun = list(CAT_SGSUP, "SG-85 Smart Handheld Gatling Gun", 27, "orange"), //If a smartgunner buys a SG-85, then they should be able to buy only 1 powerpack and 2 ammo bins
-	/obj/item/ammo_magazine/minigun_powerpack/smartgun = list(CAT_SGSUP, "SG-85 Powerpack", 10, "black"),
-	/obj/item/ammo_magazine/packet/smart_minigun = list(CAT_SGSUP, "SG-85 Ammo Bin", 4, "black"),
-	/obj/item/weapon/gun/rifle/standard_smarttargetrifle = list(CAT_SGSUP, "SG-62 Target Rifle", 25, "orange"), //If a SG buys a SG-62, they'll have 15 points left, should be enough to buy some mags and or extra SR ammo.
-	/obj/item/ammo_magazine/rifle/standard_smarttargetrifle = list(CAT_SGSUP, "SG-62 Target Rifle Magazine", 3, "orange"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle = list(CAT_SGSUP, "SG-153 Spotting Rifle Magazine", 2, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact = list(CAT_SGSUP, "SG-153 Spotting Rifle High Impact Magazine", 2, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/heavyrubber = list(CAT_SGSUP, "SG-153 Spotting Rifle Heavy Rubber Magazine", 2, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten = list(CAT_SGSUP, "SG-153 Spotting Rifle Tungsten Magazine", 2, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/flak = list(CAT_SGSUP, "SG-153 Spotting Rifle Flak Magazine", 2, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/plasmaloss = list(CAT_SGSUP, "SG-153 Spotting Rifle Tanglefoot Magazine", 3, "black"),
-	/obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary = list(CAT_SGSUP, "SG-153 Spotting Rifle Incendiary Magazine", 3, "black"),
+	/obj/effect/vendor_bundle/smartgunner_pistol = list(CAT_ESS, "TX-13 smart pistol bundle", 0, "white"),
+	/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = list(CAT_SGSUP, "TX-13 smart pistol ammo", 2, "black"),
+	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_SGSUP, "T-29 Smart Machine Gun", 29, "orange"), //If a smartgunner buys a T-29, then they will have 16 points to purchase 4 T-29 drums
+	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_SGSUP, "T-29 Ammo Drum", 4, "black"),
+	/obj/item/weapon/gun/minigun/smart_minigun = list(CAT_SGSUP, "T-85 Smart Handheld Gatling Gun", 27, "orange"), //If a smartgunner buys a T-85, then they should be able to buy only 1 powerpack and 2 ammo bins
+	/obj/item/ammo_magazine/minigun_powerpack/smartgun = list(CAT_SGSUP, "T-85 Powerpack", 10, "black"),
+	/obj/item/ammo_magazine/packet/smart_minigun = list(CAT_SGSUP, "T-85 Ammo Bin", 4, "black"),
+	/obj/item/weapon/gun/rifle/standard_smarttargetrifle = list(CAT_SGSUP, "T-62 Target Rifle", 25, "orange"), //If a SG buys a T-62, they'll have 15 points left, should be enough to buy some mags and or extra TL-153 ammo.
+	/obj/item/ammo_magazine/rifle/standard_smarttargetrifle = list(CAT_SGSUP, "T-62 Target Rifle Magazine", 3, "orange"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle = list(CAT_SGSUP, "TL-153 Spotting Rifle Magazine", 2, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact = list(CAT_SGSUP, "TL-153 Spotting Rifle High Impact Magazine", 2, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/heavyrubber = list(CAT_SGSUP, "TL-153 Spotting Rifle Heavy Rubber Magazine", 2, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten = list(CAT_SGSUP, "TL-153 Spotting Rifle Tungsten Magazine", 2, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/flak = list(CAT_SGSUP, "TL-153 Spotting Rifle Flak Magazine", 2, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/plasmaloss = list(CAT_SGSUP, "TL-153 Spotting Rifle Tanglefoot Magazine", 3, "black"),
+	/obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary = list(CAT_SGSUP, "TL-153 Spotting Rifle Incendiary Magazine", 3, "black"),
 	))
 
 

--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -123,8 +123,8 @@
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/dylovene, SLOT_IN_SUIT)
 
 /datum/outfit/quick/tgmc/marine/standard_assaultrifle
-	name = "AR-12 rifleman"
-	desc = "The classic line rifleman. Equipped with an AR-12 assault rifle with UGL, heavy armor, and plenty of grenades and ammunition. A solid all-rounder."
+	name = "T-12 rifleman"
+	desc = "The classic line rifleman. Equipped with an T-12 assault rifle with UGL, heavy armor, and plenty of grenades and ammunition. A solid all-rounder."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_assaultrifle/rifleman
 	belt = /obj/item/storage/belt/marine/t12
@@ -166,8 +166,8 @@
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher/mini, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/standard_carbine
-	name = "AR-18 Rifleman"
-	desc = "The modern line rifleman. Equipped with an AR-18 carbine with UGL, heavy armor, and plenty of grenades and ammunition. Boasts better mobility and damage output than the AR-12, but suffers with a smaller magazine and worse performance at longer ranges."
+	name = "T-18 Rifleman"
+	desc = "The modern line rifleman. Equipped with an T-18 carbine with UGL, heavy armor, and plenty of grenades and ammunition. Boasts better mobility and damage output than the T-12, but suffers with a smaller magazine and worse performance at longer ranges."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_carbine/standard
 	belt = /obj/item/storage/belt/marine/t18
@@ -188,8 +188,8 @@
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/combat_rifle
-	name = "AR-11 Rifleman"
-	desc = "The old rifleman. Equipped with an AR-11 combat rifle with heavy armor, and plenty of grenades and ammunition. Has a large capacity with deadly damage output at all ranges, but lacks many attachment options of more modern weapons and somewhat more cumbersome to handle."
+	name = "TX-11 Rifleman"
+	desc = "The old rifleman. Equipped with an TX-11 combat rifle with heavy armor, and plenty of grenades and ammunition. Has a large capacity with deadly damage output at all ranges, but lacks many attachment options of more modern weapons and somewhat more cumbersome to handle."
 
 	suit_store = /obj/item/weapon/gun/rifle/tx11/standard
 	belt = /obj/item/storage/belt/marine/combat_rifle
@@ -210,8 +210,8 @@
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher/mini, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/standard_battlerifle
-	name = "BR-64 Rifleman"
-	desc = "Heavier firepower for the discerning rifleman. Equipped with an BR-64 battle rifle with UGL, heavy armor, and plenty of grenades and ammunition. Higher damage and penetration, at the cost of a more bulky weapon."
+	name = "T-64 Rifleman"
+	desc = "Heavier firepower for the discerning rifleman. Equipped with an T-64 battle rifle with UGL, heavy armor, and plenty of grenades and ammunition. Higher damage and penetration, at the cost of a more bulky weapon."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_br/standard
 	belt = /obj/item/storage/belt/marine/standard_battlerifle
@@ -232,8 +232,8 @@
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/standard_skirmishrifle
-	name = "AR-21 Rifleman"
-	desc = "Better stopping power at the cost of lower rate of fire. Equipped with an AR-21 skirmish rifle with UGL, heavy armor, and plenty of grenades and ammunition. Rewards good aim with its heavy rounds."
+	name = "T-21 Rifleman"
+	desc = "Better stopping power at the cost of lower rate of fire. Equipped with an T-21 skirmish rifle with UGL, heavy armor, and plenty of grenades and ammunition. Rewards good aim with its heavy rounds."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_skirmishrifle/standard
 	belt = /obj/item/storage/belt/marine/standard_skirmishrifle
@@ -365,7 +365,7 @@
 
 /datum/outfit/quick/tgmc/marine/pyro
 	name = "FL-84 Flamethrower Operator"
-	desc = "For burning enemies, and sometimes friends. Equipped with an FL-84 flamethrower and wide nozzle, SMG-25 secondary weapon, heavy armor upgraded with a 'Surt' fireproof module, and a backtank of fuel. Can burn down large areas extremely quickly both to flush out the enemy and to cover flanks. Is very slow however, ineffective at long range, and can expend all available fuel quickly if used excessively."
+	desc = "For burning enemies, and sometimes friends. Equipped with an FL-84 flamethrower and wide nozzle, MR-25 secondary weapon, heavy armor upgraded with a 'Surt' fireproof module, and a backtank of fuel. Can burn down large areas extremely quickly both to flush out the enemy and to cover flanks. Is very slow however, ineffective at long range, and can expend all available fuel quickly if used excessively."
 
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/heavy/surt
 	mask = /obj/item/clothing/mask/gas/tactical
@@ -385,8 +385,8 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/packet/p10x20mm, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/standard_shotgun
-	name = "SH-35 Scout"
-	desc = "For getting too close for comfort. Equipped with a SH-35 shotgun with buckshot and flechette rounds, a MP-19 sidearm, a good amount of grenades and light armor with a cutting edge 'svallin' shield module. Provides for excellent mobility and devestating close range firepower, but will falter against sustained firepower."
+	name = "T-35 Scout"
+	desc = "For getting too close for comfort. Equipped with a T-35 shotgun with buckshot and flechette rounds, a TP-19 sidearm, a good amount of grenades and light armor with a cutting edge 'svallin' shield module. Provides for excellent mobility and devestating close range firepower, but will falter against sustained firepower."
 
 	belt = /obj/item/storage/belt/shotgun
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/light/shield
@@ -435,8 +435,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/light_carbine
-	name = "AR-18 Scout"
-	desc = "High damage and high speed. Equipped with an AR-18 carbine with UGL, light armor with a cutting edge 'svallin' shield module, and plenty of grenades and ammunition. Great mobility and damage output, but low magazine capacity and weak armor without the shield active means this loadout is best suited to hit and run tactics."
+	name = "T-18 Scout"
+	desc = "High damage and high speed. Equipped with an T-18 carbine with UGL, light armor with a cutting edge 'svallin' shield module, and plenty of grenades and ammunition. Great mobility and damage output, but low magazine capacity and weak armor without the shield active means this loadout is best suited to hit and run tactics."
 
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/light/shield
 	suit_store = /obj/item/weapon/gun/rifle/standard_carbine/scout
@@ -458,8 +458,8 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/marine/shield_tank
-	name = "SMG-25 Guardian"
-	desc = "Professional bullet catcher. Equipped with an SMG-25 submachine gun, a TL-172 defensive shield and heavy armor reinforced with a 'Tyr' module. Designed to absorb as much incoming damage as possible to protect your squishier comrades, however your mobility and damage output are notably diminished. Also of note: the excellent thermal mass of the TL-172 means it is unusually effective against the SOM's volkite weaponry."
+	name = "MR-25 Guardian"
+	desc = "Professional bullet catcher. Equipped with an MR-25 submachine gun, a TL-172 defensive shield and heavy armor reinforced with a 'Tyr' module. Designed to absorb as much incoming damage as possible to protect your squishier comrades, however your mobility and damage output are notably diminished. Also of note: the excellent thermal mass of the TL-172 means it is unusually effective against the SOM's volkite weaponry."
 
 	head = /obj/item/clothing/head/modular/m10x/tyr
 	glasses = /obj/item/clothing/glasses/welding
@@ -486,7 +486,7 @@
 
 /datum/outfit/quick/tgmc/marine/machete
 	name = "Assault Marine"
-	desc = "This doesn't look standard issue... Equipped with a SMG-25 submachine gun, machete and jetpack, along with light armor upgraded with a 'svallin' shield module. It's not clear why this is here, nevertheless it has excellent mobility, and would likely be devastating against anyone you manage to actually reach."
+	desc = "This doesn't look standard issue... Equipped with a MR-25 submachine gun, machete and jetpack, along with light armor upgraded with a 'svallin' shield module. It's not clear why this is here, nevertheless it has excellent mobility, and would likely be devastating against anyone you manage to actually reach."
 
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/light/shield
 	back = /obj/item/jetpack_marine
@@ -558,7 +558,7 @@
 
 /datum/outfit/quick/tgmc/engineer/rrengineer
 	name = "Rocket Specialist"
-	desc = "Bringing the big guns. Equipped with a AR-18 carbine and RL-160 along with the standard engineer kit. Excellent against groups of enemy infantry or light armor, but only has limited ammunition."
+	desc = "Bringing the big guns. Equipped with a T-18 carbine and T-160 along with the standard engineer kit. Excellent against groups of enemy infantry or light armor, but only has limited ammunition."
 	quantity = 2
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_carbine/engineer
@@ -576,7 +576,7 @@
 
 /datum/outfit/quick/tgmc/engineer/sentry
 	name = "Sentry Technician"
-	desc = "Firing more guns than you have hands. Equipped with a AR-12 assault rifle with miniflamer, and two minisentries along with the standard engineer kit. Allows the user to quickly setup strong points and lock areas down, with some sensible placement."
+	desc = "Firing more guns than you have hands. Equipped with a T-12 assault rifle with miniflamer, and two minisentries along with the standard engineer kit. Allows the user to quickly setup strong points and lock areas down, with some sensible placement."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_assaultrifle/engineer
 	belt = /obj/item/storage/belt/marine/t12
@@ -598,7 +598,7 @@
 
 /datum/outfit/quick/tgmc/engineer/demolition
 	name = "Demolition Specialist"
-	desc = "Boom boom, shake the room. Equipped with a SH-15 auto shotgun and UGL and an impressive array of mines, detpacks and grenades, along with the standard engineer kit. Excellent for blasting through any obstacle, and mining areas to restrict enemy movement."
+	desc = "Boom boom, shake the room. Equipped with a TX-15 auto shotgun and UGL and an impressive array of mines, detpacks and grenades, along with the standard engineer kit. Excellent for blasting through any obstacle, and mining areas to restrict enemy movement."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_autoshotgun/engineer
 	back = /obj/item/storage/backpack/marine/tech
@@ -659,8 +659,8 @@
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/neuraline, SLOT_IN_HEAD)
 
 /datum/outfit/quick/tgmc/corpsman/standard_medic
-	name = "AR-12 Corpsman"
-	desc = "Keeping everone else in the fight. Armed with an AR-12 assault rifle with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
+	name = "T-12 Corpsman"
+	desc = "Keeping everone else in the fight. Armed with an T-12 assault rifle with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_assaultrifle/medic
 
@@ -684,8 +684,8 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_assaultrifle, SLOT_IN_R_POUCH)
 
 /datum/outfit/quick/tgmc/corpsman/standard_smg
-	name = "SMG-90 Corpsman"
-	desc = "Keeping everone else in the fight. Armed with an SMG-90 submachine gun to maintain good mobility, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
+	name = "T-90 Corpsman"
+	desc = "Keeping everone else in the fight. Armed with an T-90 submachine gun to maintain good mobility, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
 
 	suit_store = /obj/item/weapon/gun/smg/standard_smg/tactical
 
@@ -711,8 +711,8 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/standard_smg, SLOT_IN_R_POUCH)
 
 /datum/outfit/quick/tgmc/corpsman/standard_skirmishrifle
-	name = "AR-21 Corpsman"
-	desc = "Keeping everone else in the fight. Armed with an AR-21 skirmish rifle with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
+	name = "T-21 Corpsman"
+	desc = "Keeping everone else in the fight. Armed with an T-21 skirmish rifle with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_skirmishrifle/standard
 
@@ -736,8 +736,8 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_skirmishrifle, SLOT_IN_R_POUCH)
 
 /datum/outfit/quick/tgmc/corpsman/auto_shotgun
-	name = "SH-15 Corpsman"
-	desc = "Keeping everone else in the fight. Armed with a SH-15 auto shotgun with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
+	name = "TX-15 Corpsman"
+	desc = "Keeping everone else in the fight. Armed with a TX-15 auto shotgun with underbarrel grenade launcher, an impressive array of tools for healing your team, and a 'Mimir' biological protection module to allow you to continue operating in hazardous environments. With medivacs out of the question, you are the only thing standing between your buddies and an early grave."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_autoshotgun/engineer
 
@@ -865,7 +865,7 @@
 
 /datum/outfit/quick/tgmc/smartgunner/minigun_sg
 	name = "SG85 Smart Machinegunner"
-	desc = "More bullets than sense. Equipped with an SG-85 smart gatling gun, an MP-19 sidearm, heavy armor upgraded with a 'Tyr' extra armor mdule and a whole lot of bullets. For when you want to unleash a firehose of firepower. Try not to run out of ammo."
+	desc = "More bullets than sense. Equipped with an SG-85 smart gatling gun, an TP-19 sidearm, heavy armor upgraded with a 'Tyr' extra armor mdule and a whole lot of bullets. For when you want to unleash a firehose of firepower. Try not to run out of ammo."
 
 	belt = /obj/item/storage/belt/sparepouch
 	suit_store = /obj/item/weapon/gun/minigun/smart_minigun/motion_detector
@@ -914,8 +914,8 @@
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/dylovene, SLOT_IN_SUIT)
 
 /datum/outfit/quick/tgmc/leader/standard_assaultrifle
-	name = "AR-12 Patrol Leader"
-	desc = "Gives the orders. Equipped with an AR-12 assault rifle with UGL, plenty of grenades, some support kit such as deployable cameras, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents."
+	name = "T-12 Patrol Leader"
+	desc = "Gives the orders. Equipped with an T-12 assault rifle with UGL, plenty of grenades, some support kit such as deployable cameras, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_assaultrifle/rifleman
 	belt = /obj/item/storage/belt/marine/t12
@@ -942,8 +942,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars/tactical/range, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/leader/standard_carbine
-	name = "AR-18 Patrol Leader"
-	desc = "Gives the orders. Equipped with an AR-18 carbine with plasma pistol attachment, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, while unleashing excellent damage at medium range."
+	name = "T-18 Patrol Leader"
+	desc = "Gives the orders. Equipped with an T-18 carbine with plasma pistol attachment, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, while unleashing excellent damage at medium range."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_carbine/plasma_pistol
 	belt = /obj/item/storage/belt/marine/t18
@@ -970,8 +970,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars/tactical/range, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/leader/combat_rifle
-	name = "AR-11 Patrol Leader"
-	desc = "Gives the orders. Equipped with an AR-11 combat rifle, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, with excellent damage at all ranges."
+	name = "TX-11 Patrol Leader"
+	desc = "Gives the orders. Equipped with an TX-11 combat rifle, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, with excellent damage at all ranges."
 
 	suit_store = /obj/item/weapon/gun/rifle/tx11/standard
 	belt = /obj/item/storage/belt/marine/combat_rifle
@@ -998,8 +998,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars/tactical/range, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/leader/standard_battlerifle
-	name = "BR-64 Patrol Leader"
-	desc = "Gives the orders. Equipped with an BR-64 battle rifle with UGL, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. The battle rifle offers improved damage and penetration compared to more common rifles, but still retains a grenade launcher that the AR-11 lacks."
+	name = "T-64 Patrol Leader"
+	desc = "Gives the orders. Equipped with an T-64 battle rifle with UGL, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. The battle rifle offers improved damage and penetration compared to more common rifles, but still retains a grenade launcher that the TX-11 lacks."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_br/standard
 	belt = /obj/item/storage/belt/marine/standard_battlerifle
@@ -1025,8 +1025,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars/tactical/range, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/leader/auto_shotgun
-	name = "SH-15 Patrol Leader"
-	desc = "Gives the orders. Equipped with an SH-15 auto shotgun, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, with strong damage and control."
+	name = "TX-15 Patrol Leader"
+	desc = "Gives the orders. Equipped with an TX-15 auto shotgun, plenty of grenades, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents, with strong damage and control."
 
 	suit_store = /obj/item/weapon/gun/rifle/standard_autoshotgun/plasma_pistol
 	belt = /obj/item/storage/belt/marine/auto_shotgun
@@ -1081,8 +1081,8 @@
 	H.equip_to_slot_or_del(new /obj/item/binoculars/tactical/range, SLOT_IN_ACCESSORY)
 
 /datum/outfit/quick/tgmc/leader/oicw
-	name = "AR-55 Patrol Leader"
-	desc = "Gives the orders. Equipped with an AR-55 OICW with plenty of grenades for its integrated grenade launcher, some support kit such as deployable cameras, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents."
+	name = "TX-55 Patrol Leader"
+	desc = "Gives the orders. Equipped with an TX-55 OICW with plenty of grenades for its integrated grenade launcher, some support kit such as deployable cameras, as well as heavy armor with a 'valkyrie' autodoc module. You can provide excellent support to your squad thanks to your kit and order shouting talents."
 	quantity = 2
 
 	suit_store = /obj/item/weapon/gun/rifle/tx55/combat_patrol

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -249,39 +249,39 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		)), \
 	null, \
 	new/datum/stack_recipe_list("pistol boxes",list( \
-		new/datum/stack_recipe("P-14 mag box", /obj/item/storage/box/visual/magazine/compact/standard_pistol), \
-		new/datum/stack_recipe("P-23 mag box", /obj/item/storage/box/visual/magazine/compact/standard_heavypistol), \
-		new/datum/stack_recipe("R-44 mag box", /obj/item/storage/box/visual/magazine/compact/standard_revolver), \
-		new/datum/stack_recipe("P-17 mag box", /obj/item/storage/box/visual/magazine/compact/standard_pocketpistol), \
+		new/datum/stack_recipe("TP-14 mag box", /obj/item/storage/box/visual/magazine/compact/standard_pistol), \
+		new/datum/stack_recipe("TP-23 mag box", /obj/item/storage/box/visual/magazine/compact/standard_heavypistol), \
+		new/datum/stack_recipe("M-44 mag box", /obj/item/storage/box/visual/magazine/compact/standard_revolver), \
+		new/datum/stack_recipe("TP-17 mag box", /obj/item/storage/box/visual/magazine/compact/standard_pocketpistol), \
 		new/datum/stack_recipe("88M4 mag box", /obj/item/storage/box/visual/magazine/compact/vp70), \
 		new/datum/stack_recipe("Derringer packet box", /obj/item/storage/box/visual/magazine/compact/derringer), \
-		new/datum/stack_recipe("PP-7 plasma cell box", /obj/item/storage/box/visual/magazine/compact/plasma_pistol), \
+		new/datum/stack_recipe("TX-7 plasma cell box", /obj/item/storage/box/visual/magazine/compact/plasma_pistol), \
 		)), \
 	new/datum/stack_recipe_list("smg boxes",list( \
-		new/datum/stack_recipe("SMG-90 mag box", /obj/item/storage/box/visual/magazine/compact/standard_smg), \
-		new/datum/stack_recipe("MP-19 mag box", /obj/item/storage/box/visual/magazine/compact/standard_machinepistol), \
+		new/datum/stack_recipe("T-90 mag box", /obj/item/storage/box/visual/magazine/compact/standard_smg), \
+		new/datum/stack_recipe("T-19 mag box", /obj/item/storage/box/visual/magazine/compact/standard_machinepistol), \
 		new/datum/stack_recipe("Pepperball canister box", /obj/item/storage/box/visual/magazine/compact/pepperball), \
 		)), \
 	new/datum/stack_recipe_list("rifle boxes",list( \
-		new/datum/stack_recipe("AR-12 mag box", /obj/item/storage/box/visual/magazine/compact/standard_assaultrifle), \
-		new/datum/stack_recipe("AR-18 mag box", /obj/item/storage/box/visual/magazine/compact/standard_carbine), \
-		new/datum/stack_recipe("AR-21 mag box", /obj/item/storage/box/visual/magazine/compact/standard_skirmishrifle), \
-		new/datum/stack_recipe("AR-11 mag box", /obj/item/storage/box/visual/magazine/compact/ar11), \
+		new/datum/stack_recipe("T-12 mag box", /obj/item/storage/box/visual/magazine/compact/standard_assaultrifle), \
+		new/datum/stack_recipe("T-18 mag box", /obj/item/storage/box/visual/magazine/compact/standard_carbine), \
+		new/datum/stack_recipe("T-21 mag box", /obj/item/storage/box/visual/magazine/compact/standard_skirmishrifle), \
+		new/datum/stack_recipe("TX-11 mag box", /obj/item/storage/box/visual/magazine/compact/ar11), \
 		new/datum/stack_recipe("Martini Henry packet box", /obj/item/storage/box/visual/magazine/compact/martini), \
 		new/datum/stack_recipe("TE cell box", /obj/item/storage/box/visual/magazine/compact/lasrifle/marine), \
-		new/datum/stack_recipe("SH-15 mag box", /obj/item/storage/box/visual/magazine/compact/sh15), \
+		new/datum/stack_recipe("TX-15 mag box", /obj/item/storage/box/visual/magazine/compact/sh15), \
 		)), \
 	new/datum/stack_recipe_list("marksmen rifle boxes",list( \
-		new/datum/stack_recipe("DMR-37 mag box", /obj/item/storage/box/visual/magazine/compact/standard_dmr), \
-		new/datum/stack_recipe("BR-64 mag box", /obj/item/storage/box/visual/magazine/compact/standard_br), \
-		new/datum/stack_recipe("SR-127 mag box", /obj/item/storage/box/visual/magazine/compact/chamberedrifle), \
+		new/datum/stack_recipe("T-37 mag box", /obj/item/storage/box/visual/magazine/compact/standard_dmr), \
+		new/datum/stack_recipe("T-64 mag box", /obj/item/storage/box/visual/magazine/compact/standard_br), \
+		new/datum/stack_recipe("TL-127 mag box", /obj/item/storage/box/visual/magazine/compact/chamberedrifle), \
 		new/datum/stack_recipe("Mosin packet box", /obj/item/storage/box/visual/magazine/compact/mosin), \
 		)), \
 	new/datum/stack_recipe_list("machinegun boxes",list( \
-		new/datum/stack_recipe("MG-42 drum mag box", /obj/item/storage/box/visual/magazine/compact/standard_lmg), \
-		new/datum/stack_recipe("MG-60 mag box", /obj/item/storage/box/visual/magazine/compact/standard_gpmg), \
-		new/datum/stack_recipe("MG-27 mag box", /obj/item/storage/box/visual/magazine/compact/standard_mmg), \
-		new/datum/stack_recipe("HMG-08 drum box", /obj/item/storage/box/visual/magazine/compact/heavymachinegun), \
+		new/datum/stack_recipe("T-42 drum mag box", /obj/item/storage/box/visual/magazine/compact/standard_lmg), \
+		new/datum/stack_recipe("T-60 mag box", /obj/item/storage/box/visual/magazine/compact/standard_gpmg), \
+		new/datum/stack_recipe("T-27 mag box", /obj/item/storage/box/visual/magazine/compact/standard_mmg), \
+		new/datum/stack_recipe("MG-08/495 drum box", /obj/item/storage/box/visual/magazine/compact/heavymachinegun), \
 		)) \
 	))
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -697,8 +697,8 @@
 // -Pistol-
 
 /obj/item/storage/box/visual/magazine/compact/standard_pistol
-	name = "P-14 magazine box"
-	desc = "A box specifically designed to hold a large amount of P-14 magazines."
+	name = "TP-14 magazine box"
+	desc = "A box specifically designed to hold a large amount of TP-14 magazines."
 	closed_overlay = "mag_box_small_overlay_p14"
 	can_hold = list(
 		/obj/item/ammo_magazine/pistol/standard_pistol,
@@ -784,8 +784,8 @@
 // -SMG-
 
 /obj/item/storage/box/visual/magazine/compact/standard_smg
-	name = "SMG-90 magazine box"
-	desc = "A box specifically designed to hold a large amount of SMG-90 magazines."
+	name = "T-90 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-90 magazines."
 	closed_overlay = "mag_box_small_overlay_smg90"
 	can_hold = list(
 		/obj/item/ammo_magazine/smg/standard_smg,
@@ -796,8 +796,8 @@
 	spawn_type = /obj/item/ammo_magazine/smg/standard_smg
 
 /obj/item/storage/box/visual/magazine/compact/standard_machinepistol
-	name = "MP-19 magazine box"
-	desc = "A box specifically designed to hold a large amount of MP-19 magazines."
+	name = "TP-19 magazine box"
+	desc = "A box specifically designed to hold a large amount of TP-19 magazines."
 	closed_overlay = "mag_box_small_overlay_mp19"
 	can_hold = list(
 		/obj/item/ammo_magazine/smg/standard_machinepistol,
@@ -823,8 +823,8 @@
 // -Rifle-
 
 /obj/item/storage/box/visual/magazine/compact/standard_assaultrifle
-	name = "AR-12 magazine box"
-	desc = "A box specifically designed to hold a large amount of AR-12 magazines."
+	name = "T-12 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-12 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_ar12"
 	can_hold = list(
@@ -836,8 +836,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/standard_assaultrifle
 
 /obj/item/storage/box/visual/magazine/compact/standard_carbine
-	name = "AR-18 magazine box"
-	desc = "A box specifically designed to hold a large amount of AR-18 magazines."
+	name = "T-18 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-18 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_ar18"
 	can_hold = list(
@@ -849,8 +849,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/standard_carbine
 
 /obj/item/storage/box/visual/magazine/compact/standard_skirmishrifle
-	name = "AR-21 magazine box"
-	desc = "A box specifically designed to hold a large amount of AR-21 magazines."
+	name = "T-21 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-21 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_ar21"
 	can_hold = list(
@@ -862,8 +862,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/standard_skirmishrifle
 
 /obj/item/storage/box/visual/magazine/compact/ar11
-	name = "AR-11 magazine box"
-	desc = "A box specifically designed to hold a large amount of AR-11 magazines."
+	name = "TX-11 magazine box"
+	desc = "A box specifically designed to hold a large amount of TX-11 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_ar11"
 	can_hold = list(
@@ -888,8 +888,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/martini
 
 /obj/item/storage/box/visual/magazine/compact/sh15
-	name = "SH-15 magazine box"
-	desc = "A box specifically designed to hold a large amount of SH-15 magazines."
+	name = "TX-15 magazine box"
+	desc = "A box specifically designed to hold a large amount of TX-15 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_sh15"
 	can_hold = list(
@@ -898,7 +898,7 @@
 	)
 
 /obj/item/storage/box/visual/magazine/compact/sh15/flechette
-	name = "SH-15 flechette magazine box"
+	name = "TX-15 flechette magazine box"
 	closed_overlay = "mag_box_small_overlay_sh15_flechette"
 
 /obj/item/storage/box/visual/magazine/compact/sh15/flechette/full
@@ -906,7 +906,7 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/tx15_flechette
 
 /obj/item/storage/box/visual/magazine/compact/sh15/slug
-	name = "SH-15 slug magazine box"
+	name = "TX-15 slug magazine box"
 	closed_overlay = "mag_box_small_overlay_sh15_slug"
 
 /obj/item/storage/box/visual/magazine/compact/sh15/slug/full
@@ -963,8 +963,8 @@
 // -Marksmen-
 
 /obj/item/storage/box/visual/magazine/compact/standard_dmr
-	name = "DMR-37 magazine box"
-	desc = "A box specifically designed to hold a large amount of DMR-37 magazines."
+	name = "T-37 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-37 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_dmr37"
 	can_hold = list(
@@ -976,8 +976,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/standard_dmr
 
 /obj/item/storage/box/visual/magazine/compact/standard_br
-	name = "BR-64 magazine box"
-	desc = "A box specifically designed to hold a large amount of BR-64 magazines."
+	name = "T-64 magazine box"
+	desc = "A box specifically designed to hold a large amount of T-64 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_br64"
 	can_hold = list(
@@ -989,8 +989,8 @@
 	spawn_type = /obj/item/ammo_magazine/rifle/standard_br
 
 /obj/item/storage/box/visual/magazine/compact/chamberedrifle
-	name = "SR-127 magazine box"
-	desc = "A box specifically designed to hold a large amount of SR-127 magazines."
+	name = "TL-127 magazine box"
+	desc = "A box specifically designed to hold a large amount of TL-127 magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_sr127"
 	can_hold = list(
@@ -1022,8 +1022,8 @@
 // -Machinegun-
 
 /obj/item/storage/box/visual/magazine/compact/standard_lmg
-	name = "MG-42 drum magazine box"
-	desc = "A box specifically designed to hold a large amount of MG-42 drum magazines."
+	name = "T-42 drum magazine box"
+	desc = "A box specifically designed to hold a large amount of T-42 drum magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_mg42"
 	can_hold = list(
@@ -1062,8 +1062,8 @@
 
 
 /obj/item/storage/box/visual/magazine/compact/heavymachinegun
-	name = "HMG-08 drum box"
-	desc = "A box specifically designed to hold a large amount of HMG-08 drum."
+	name = "MG-08/495 drum box"
+	desc = "A box specifically designed to hold a large amount of MG-08/495 drum."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_mg08"
 	can_hold = list(

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -421,8 +421,8 @@
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_item)
 
 /obj/item/storage/holster/t35
-	name = "\improper L44 SH-35 scabbard"
-	desc = "A large leather holster allowing the storage of an SH-35 Shotgun. It contains harnesses that allow it to be secured to the back for easy storage."
+	name = "\improper L44 T-35 scabbard"
+	desc = "A large leather holster allowing the storage of an T-35 Shotgun. It contains harnesses that allow it to be secured to the back for easy storage."
 	icon_state = "t35_holster"
 	holsterable_allowed = list(/obj/item/weapon/gun/shotgun/pump/t35)
 	can_hold = list(
@@ -452,8 +452,8 @@
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_item)
 
 /obj/item/storage/holster/t19
-	name = "\improper M276 pattern MP-19 holster rig"
-	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is designed for the MP-19 SMG, and features a larger frame to support the gun. Due to its unorthodox design, it isn't a very common sight, and is only specially issued."
+	name = "\improper M276 pattern TP-19 holster rig"
+	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is designed for the TP-19 SMG, and features a larger frame to support the gun. Due to its unorthodox design, it isn't a very common sight, and is only specially issued."
 	icon_state = "t19_holster"
 	icon = 'icons/obj/clothing/belts.dmi'
 	flags_equip_slot = ITEM_SLOT_BELT
@@ -774,8 +774,8 @@
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_gun)
 
 /obj/item/storage/holster/belt/ts34
-	name = "\improper M276 pattern SH-34 shotgun holster rig"
-	desc = "A purpose built belt-holster assembly that holds a SH-34 shotgun and one shell box or 2 handfuls."
+	name = "\improper M276 pattern TS-34 shotgun holster rig"
+	desc = "A purpose built belt-holster assembly that holds a TS-34 shotgun and one shell box or 2 handfuls."
 	icon_state = "ts34_holster"
 	max_w_class = WEIGHT_CLASS_BULKY //So it can hold the shotgun.
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -102,23 +102,23 @@
 	icon_state = "chest"
 
 /obj/structure/largecrate/supply/weapons/standard_carbine
-	name = "\improper AR-18 Carbine weapons chest (x10)"
-	desc = "A weapons chest containing ten AR-18 Carbines."
+	name = "\improper T-18 Carbine weapons chest (x10)"
+	desc = "A weapons chest containing ten T-18 Carbines."
 	supplies = list(/obj/item/weapon/gun/rifle/standard_carbine = 10)
 
 /obj/structure/largecrate/supply/weapons/shotgun
-	name = "\improper SH-35 pump action shotgun weapons chest (x10)"
-	desc = "A weapons chest containing ten SH-35 pump shotguns."
+	name = "\improper T-35 pump action shotgun weapons chest (x10)"
+	desc = "A weapons chest containing ten T-35 pump shotguns."
 	supplies = list(/obj/item/weapon/gun/shotgun/pump/t35 = 10)
 
 /obj/structure/largecrate/supply/weapons/standard_smg
-	name = "\improper SMG-90 sub machinegun weapons chest (x8)"
-	desc = "A weapons chest containing eight SMG-90 submachine guns."
+	name = "\improper T-90 sub machinegun weapons chest (x8)"
+	desc = "A weapons chest containing eight T-90 submachine guns."
 	supplies = list(/obj/item/weapon/gun/smg/standard_smg = 8)
 
 /obj/structure/largecrate/supply/weapons/pistols
 	name = "sidearm weapons chest (x20)"
-	desc = "A weapons chest containing eight R-44 revolvers, and twelve P-14 service pistols."
+	desc = "A weapons chest containing eight R-44 revolvers, and twelve TP-14 service pistols."
 	supplies = list(/obj/item/weapon/gun/revolver/standard_revolver = 6, /obj/item/weapon/gun/pistol/standard_pistol = 12)
 
 /obj/structure/largecrate/supply/weapons/flamers
@@ -127,8 +127,8 @@
 	supplies = list(/obj/item/weapon/gun/flamer/big_flamer = 4)
 
 /obj/structure/largecrate/supply/weapons/hpr
-	name = "\improper MG-42 LMG weapons chest (x2)"
-	desc = "A weapons chest containing two MG-42 LMG."
+	name = "\improper T-42 LMG weapons chest (x2)"
+	desc = "A weapons chest containing two T-42 LMG."
 	supplies = list(/obj/item/weapon/gun/rifle/standard_lmg = 2)
 
 /obj/structure/largecrate/supply/weapons/sentries
@@ -137,13 +137,13 @@
 	supplies = list(/obj/item/storage/box/crate/sentry = 2)
 
 /obj/structure/largecrate/supply/weapons/standard_hmg
-	name = "\improper HSG-102 mounted heavy smartgun chest (x2)"
-	desc = "A supply crate containing two boxed HSG-102 mounted heavy smartguns."
+	name = "\improper TL-102 mounted heavy smartgun chest (x2)"
+	desc = "A supply crate containing two boxed TL-102 mounted heavy smartguns."
 	supplies = list(/obj/item/storage/box/tl102 = 2)
 
 /obj/structure/largecrate/supply/weapons/standard_atgun
-	name = "\improper AT-36 anti tank gun and ammo chest (x1, x10)"
-	desc = "A supply crate containing a AT-36 and a full set of ammo to load into the sponson."
+	name = "\improper TAT-36 anti tank gun and ammo chest (x1, x10)"
+	desc = "A supply crate containing a TAT-36 and a full set of ammo to load into the sponson."
 	supplies = list(
 		/obj/item/weapon/gun/standard_atgun = 1,
 		/obj/item/ammo_magazine/standard_atgun = 4,
@@ -156,13 +156,13 @@
 	icon_state = "case"
 
 /obj/structure/largecrate/supply/ammo/m41a
-	name = "\improper PR-412 magazine case (x20)"
-	desc = "An ammunition case containing 20 PR-412 magazines."
+	name = "\improper M412 magazine case (x20)"
+	desc = "An ammunition case containing 20 M412 magazines."
 	supplies = list(/obj/item/ammo_magazine/rifle = 20)
 
 /obj/structure/largecrate/supply/ammo/m41a_box
-	name = "\improper PR-412 ammunition box case (x4)"
-	desc = "An ammunition case containing four PR-412 600 round boxes of ammunition."
+	name = "\improper M412 ammunition box case (x4)"
+	desc = "An ammunition case containing four M412 600 round boxes of ammunition."
 	supplies = list(/obj/item/big_ammo_box = 4)
 
 /obj/structure/largecrate/supply/ammo/shotgun
@@ -171,8 +171,8 @@
 	supplies = list(/obj/item/ammo_magazine/shotgun = 8, /obj/item/ammo_magazine/shotgun/buckshot = 8, /obj/item/ammo_magazine/shotgun/flechette = 8)
 
 /obj/structure/largecrate/supply/ammo/standard_smg
-	name = "\improper SMG-90 magazine case (x16)"
-	desc = "An ammunition case containing sixteen SMG-90 magazines."
+	name = "\improper T-90 magazine case (x16)"
+	desc = "An ammunition case containing sixteen T-90 magazines."
 	supplies = list(/obj/item/ammo_magazine/smg/standard_smg = 16)
 
 /obj/structure/largecrate/supply/ammo/pistol
@@ -186,8 +186,8 @@
 	supplies = list(/obj/item/ammo_magazine/sentry = 6)
 
 /obj/structure/largecrate/supply/ammo/standard_hmg
-	name = "\improper HSG-102 ammunition box case (x6)"
-	desc = "An ammunition case containing six HSG-102 ammunition boxes."
+	name = "\improper TL-102 ammunition box case (x6)"
+	desc = "An ammunition case containing six TL-102 ammunition boxes."
 	supplies = list(/obj/item/ammo_magazine/tl102 = 6)
 
 /obj/structure/largecrate/supply/ammo/standard_ammo

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -264,7 +264,7 @@
 
 /obj/structure/prop/mainship/missile_tube
 	name = "\improper Mk 33 ASAT launcher system"
-	desc = "Cold launch tubes that can fire a few varieties of missiles out of them The most common being the ASAAR-21 Rapier IV missile used against satellites and other spacecraft and the BGM-227 Sledgehammer missile which is used for ground attack."
+	desc = "Cold launch tubes that can fire a few varieties of missiles out of them The most common being the ASAT-21 Rapier IV missile used against satellites and other spacecraft and the BGM-227 Sledgehammer missile which is used for ground attack."
 	icon = 'icons/Marine/mainship_props96.dmi'
 	icon_state = "missiletubenorth"
 	bound_width = 32

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -226,7 +226,7 @@
 	lore_text = "The K23 itself was designed at first for military use as 12 gauge pump-action shotguns were starting to pick up steam \
 	again due to advancements in ammunition made them much more effective at breaking doors and simple masterkey shotguns were starting \
 	to fall out of favor due to the preference of grenade launchers or other grips started to phase them out. <br><br>\
-	Eventually trials were made for a new shotgun and the K23 eventually won them out and was adopted as the SH-35. It was \
+	Eventually trials were made for a new shotgun and the K23 eventually won them out and was adopted as the T-35. It was \
 	officially adopted as a door breaching tool but was incredibly effective at close quarters and shipside combat because \
 	advancements in  ammunition allowed shotguns to punch through common ballistic armor, making it a popular option for close quarters situations."
 
@@ -254,9 +254,9 @@
 /datum/codex_entry/standard_assaultrifle
 	associated_paths = list(/obj/item/weapon/gun/rifle/standard_assaultrifle)
 	lore_text = "The Keckler and Hoch M-12 was created out of an order for a robust rifle using a caseless round, after the ergonomic and costly disaster of the 'Rifle of the future' Project. \
-	Ironically, the M-12 submitted by the very group that made the national disaster that the AR-11 (originally designated the M-11) ended up winning out all the tests. \
+	Ironically, the M-12 submitted by the very group that made the national disaster that the TX-11 (originally designated the M-11) ended up winning out all the tests. \
 	It was designed to be simple to use, disassemble and basically survive every condition, however due to reports of barrel melting from the high use of polymers. It ended up being heavier than its ilk to compensate.\
-	After wining all the tests, it was accepted and christened the 'AR-12' in service. Aside from issues with barrel overheating, which later models fixed. It is known for reliability across the Marine Corps and the wider galaxy.\
+	After wining all the tests, it was accepted and christened the 'T-12' in service. Aside from issues with barrel overheating, which later models fixed. It is known for reliability across the Marine Corps and the wider galaxy.\
 	Most would say the simple blend of a good magazine size, ergonomics and adaptablitty elevate this weapon above the rest."
 
 /datum/codex_entry/standard_carbine
@@ -265,7 +265,7 @@
 	The Carbine variant, known as the 'ALF-51' focused on creating a small, compact package that could fire a rifle-sized round while still retaining good accuracy and shot placement.\
 	Originally, it was meant to fire in burst-fire only, future production variants turned to feature full-auto after it showed that in testing, it would improve troop morale and confidence in the versatility in the rifle.\
 	The entire ALF-series ended up being panic bought in mass by specialized troops in the Marine Corps, generally Peacekeeper sections or Air Assault sections, it eventually spread by osmosis in popularity.\
-	Eventually, they ended up becoming standard issue and a formal contract was signed, the Carbine was christened the 'AR-18'.\
+	Eventually, they ended up becoming standard issue and a formal contract was signed, the Carbine was christened the 'T-18'.\
 	Most would say its particularly compact appreance and performance, combined with good burst-fire capablity are its edge in combat. Watch your ammo, though."
 
 /datum/codex_entry/standard_lmg
@@ -274,7 +274,7 @@
 	The Machinegun variant, known as the 'ALF-22' focused on creating a versatile package consisting of a light squad support weapon, with a focus on mobility and accurate fire over pure magazine size.\
 	It ended up with a drum magazine, elongated heavy barrel for sustained firing, its overall shape being of a common rifle generally assists it in being easy to pickup and use, and can mount more underbarrel attachments compared to its peers in its class.\
 	The entire ALF-series ended up being panic bought in mass by specialized troops in the Marine Corps, generally Peacekeeper sections or Air Assault sections, it eventually spread by osmosis in popularity.\
-	Eventually, they ended up becoming standard issue and a formal contract was signed, the Machinegun was christened the 'MG-42'.\
+	Eventually, they ended up becoming standard issue and a formal contract was signed, the Machinegun was christened the 'T-42'.\
 	Most would say the large magazine capacity combined with ease of use and ability to lay down fire with good frontline potential is the main advantage of this weapon. You will still be one the slower people in your group, however."
 
 /datum/codex_entry/standard_skirmishrifle
@@ -283,7 +283,7 @@
 	The 'Skirmish' Rifle variant, known as the 'ALF-6' focused on creating a fullpower rifle, light and with a good blend of mobility, firerate and firepower.\
 	The rifle ended up being the rifle to truly kick off the ALF series, becoming famous for being a great blend of firepower, mobility and ease of use, however the system was known for tearing rounds like it was nothing.\
 	The entire ALF-series ended up being panic bought in mass by specialized troops in the Marine Corps, generally Peacekeeper sections or Air Assault sections, it eventually spread by osmosis in popularity.\
-	Eventually, they ended up becoming standard issue and a formal contract was signed, the Rifle was christened the 'AR-21'.\
+	Eventually, they ended up becoming standard issue and a formal contract was signed, the Rifle was christened the 'T-21'.\
 	Most would say it earned its term of a 'Skirmish' rifle due to use in constant skirmishes by frontline troops, due to a low magazine size, but good overall mobility combined with firepower. Watch your magazine count and put the hurt downrange."
 
 /datum/codex_entry/standard_tx11
@@ -292,7 +292,7 @@
 	The M-11 was created to be the ultimate weapon, being able to lay down fire like an MG with a high capacity, amazing burst fire capability, specialized scope for long range damage, it was tested and destroyed the competition.\
 	It did amazing in field tests, and was effectively the best rifle overall. Most concerns were ergonomical, however it was pushed aside for a need of a new rifle, and money was already spent in making the entire thing, so getting a new competition would be too bothersome.\
 	Eventually however, these ergonomic failures lead to constant troop complaints due to the unergonomic nature of the rifle, troops who swore by it loved it, troops who hated it called it a useless brick.\
-	Eventually pushback got so large that a new bid was quickly placed within less than a decade, and the M-11, by now christened the 'AR-11', was considered a failure and mothballed.\
+	Eventually pushback got so large that a new bid was quickly placed within less than a decade, and the M-11, by now christened the 'TX-11', was considered a failure and mothballed.\
 	However, some have been pulled out of long term storage, and recent spottings have shown modernizations such as removal of the side magazines, an overall more ergonomic shape with less brick-like features, and a larger magazine.\
 	Most would say that the unusually large magazine capacity, amazing burst fire capability allows for an interesting use of a support weapon. But its bulky and unusual shape leading a low amount of attachments can hamper it in combat."
 
@@ -329,4 +329,4 @@
 	It's generally used inside it's belt holster or slung on your back as a secondary firearm for use in situations where you have a \
 	larger gun and would prefer a more CQC able weapon. It also has a rather large magazine capacity due to the small caliber size and caseless ammunition. <br><br>\
 	The MD-65 was adopted as a program to allow specialized units like medics and engineers to carry a smaller firearm to maximize \
-	weight and storage capacity. However it slowly spread in popularity to light infantry and scout units. It was named SMG-90 upon adoption."
+	weight and storage capacity. However it slowly spread in popularity to light infantry and scout units. It was named T-90 upon adoption."

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -716,7 +716,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 /obj/item/attachable/scope/optical
 	name = "T-49 Optical imaging scope"
 	icon_state = "imagerscope"
-	desc = "A rail-mounted scope designed for the AR-55 and GL-54. Features low light optical imaging capabilities and assists with precision aiming. Allows zoom by activating the attachment."
+	desc = "A rail-mounted scope designed for the TX-55 and TX-54. Features low light optical imaging capabilities and assists with precision aiming. Allows zoom by activating the attachment."
 	has_nightvision = TRUE
 	aim_speed_mod = 0.3
 	wield_delay_mod = 0.2 SECONDS
@@ -753,11 +753,11 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	icon_state = "tl127_scope"
 	aim_speed_mod = 0
 	wield_delay_mod = 0
-	desc = "A rail mounted zoom sight scope specialized for the SR-127 sniper rifle. Allows zoom by activating the attachment."
+	desc = "A rail mounted zoom sight scope specialized for the TL-127 sniper rifle. Allows zoom by activating the attachment."
 
 /obj/item/attachable/scope/unremovable/heavymachinegun
-	name = "HMG-08 long range ironsights"
-	desc = "An unremovable set of long range ironsights for an HMG-08 machinegun."
+	name = "MG-08/495 long range ironsights"
+	desc = "An unremovable set of long range ironsights for an MG-08/495 machinegun."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
 	zoom_tile_offset = 5
@@ -774,14 +774,14 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	zoom_viewsize = 0
 
 /obj/item/attachable/scope/unremovable/standard_atgun
-	name = "AT-36 long range scope"
+	name = "TAT-36 long range scope"
 	desc = "An unremovable set of long range scopes, very complex to properly range. Requires time to aim.."
 	icon_state = "sniperscope_invisible"
 	scope_delay = 2 SECONDS
 	zoom_tile_offset = 7
 
 /obj/item/attachable/scope/unremovable/tl102
-	name = "HSG-102 smart sight"
+	name = "TL-102 smart sight"
 	desc = "An unremovable smart sight built for use with the tl102, it does nearly all the aiming work for the gun's integrated IFF systems."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
@@ -890,7 +890,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	variants_by_parent_type = list(/obj/item/weapon/gun/rifle/som = "")
 
 /obj/item/attachable/scope/mini/tx11
-	name = "AR-11 mini rail scope"
+	name = "TX-11 mini rail scope"
 	icon_state = "tx11scope"
 
 /obj/item/attachable/scope/antimaterial
@@ -913,7 +913,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	flags_attach_features = ATTACH_ACTIVATION
 
 /obj/item/attachable/scope/mini/dmr
-	name = "DMR-37 mini rail scope"
+	name = "T-37 mini rail scope"
 	icon_state = "t37"
 
 
@@ -976,8 +976,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/tx15
-	name = "\improper SH-15 stock"
-	desc = "The standard stock for the SH-15. Cannot be removed."
+	name = "\improper TX-15 stock"
+	desc = "The standard stock for the TX-15. Cannot be removed."
 	icon_state = "tx15stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
@@ -1011,8 +1011,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 10
 
 /obj/item/attachable/stock/tl127stock
-	name = "\improper SR-127 stock"
-	desc = "A irremovable SR-127 sniper rifle stock."
+	name = "\improper TL-127 stock"
+	desc = "A irremovable TL-127 sniper rifle stock."
 	icon_state = "tl127stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
@@ -1046,8 +1046,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/t39stock
-	name = "\improper SH-39 stock"
-	desc = "A specialized stock for the SH-39."
+	name = "\improper T-39 stock"
+	desc = "A specialized stock for the T-39."
 	icon_state = "t39stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
@@ -1080,11 +1080,11 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/m41a
-	name = "PR-11 stock"
+	name = "HK-11 stock"
 	icon_state = "m41a"
 
 /obj/item/attachable/stock/tx11
-	name = "AR-11 stock"
+	name = "TX-11 stock"
 	icon_state = "tx11stock"
 
 /obj/item/attachable/stock/som_mg_stock
@@ -1095,29 +1095,29 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 0
 
 /obj/item/attachable/stock/t18stock
-	name = "\improper AR-18 stock"
-	desc = "A specialized stock for the AR-18."
+	name = "\improper T-18 stock"
+	desc = "A specialized stock for the T-18."
 	icon_state = "t18stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/t12stock
-	name = "\improper AR-12 stock"
-	desc = "A specialized stock for the AR-12."
+	name = "\improper T-12 stock"
+	desc = "A specialized stock for the T-12."
 	icon_state = "t12stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/t42stock
-	name = "\improper MG-42 stock"
-	desc = "A specialized stock for the MG-42."
+	name = "\improper T-42 stock"
+	desc = "A specialized stock for the T-42."
 	icon_state = "t42stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
 
 /obj/item/attachable/stock/t64stock
-	name = "\improper BR-64 stock"
-	desc = "A specialized stock for the BR-64."
+	name = "\improper T-64 stock"
+	desc = "A specialized stock for the T-64."
 	icon_state = "t64stock"
 
 //You can remove the stock on the Magnum. So it has stats and is removeable.
@@ -1332,8 +1332,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	accuracy_unwielded_mod = -0.1
 
 /obj/item/attachable/foldable/t19stock
-	name = "\improper MP-19 machinepistol stock"
-	desc = "A submachinegun stock distributed in small numbers to TGMC forces. Compatible with the MP-19, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl."
+	name = "\improper TP-19 machinepistol stock"
+	desc = "A submachinegun stock distributed in small numbers to TGMC forces. Compatible with the TP-19, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl."
 	flags_attach_features = ATTACH_ACTIVATION
 	wield_delay_mod = 0.1 SECONDS
 	melee_mod = 5
@@ -1373,8 +1373,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	scatter_unwielded_mod = 4
 
 /obj/item/attachable/foldable/t35stock
-	name = "\improper SH-35 stock"
-	desc = "A non-standard heavy stock for the SH-35 shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too."
+	name = "\improper T-35 stock"
+	desc = "A non-standard heavy stock for the T-35 shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too."
 	icon = 'icons/Marine/attachments_64.dmi'
 	icon_state = "t35stock"
 	flags_attach_features = ATTACH_ACTIVATION

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -274,8 +274,8 @@
 		to_chat(mob_caught, isxeno(mob_caught) ? span_xenodanger(burn_message) : span_highdanger(burn_message))
 
 /obj/item/weapon/gun/flamer/big_flamer
-	name = "\improper FL-240 incinerator unit"
-	desc = "The FL-240 has proven to be one of the most effective weapons at clearing out soft-targets. This is a weapon to be feared and respected as it is quite deadly."
+	name = "\improper M-240 incinerator unit"
+	desc = "The M-240 has proven to be one of the most effective weapons at clearing out soft-targets. This is a weapon to be feared and respected as it is quite deadly."
 	icon_state = "m240"
 	item_state = "m240"
 
@@ -309,8 +309,8 @@
 
 //dedicated engineer pyro kit flamer
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard/engineer
-	name = "\improper FL-86 incinerator unit"
-	desc = "The FL-86 is a more light weight incinerator unit designed specifically to fit into its accompanying engineers bag. Can only be used with magazine fuel tanks however."
+	name = "\improper TL-86 incinerator unit"
+	desc = "The TL-86 is a more light weight incinerator unit designed specifically to fit into its accompanying engineers bag. Can only be used with magazine fuel tanks however."
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/large
 	allowed_ammo_types = list(
 		/obj/item/ammo_magazine/flamer_tank,
@@ -367,8 +367,8 @@
 
 
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard
-	name = "\improper FL-84 flamethrower"
-	desc = "The FL-84 flamethrower is the current standard issue flamethrower of the TGMC, and is used for area control and urban combat. Use unique action to use hydro cannon"
+	name = "\improper TL-84 flamethrower"
+	desc = "The TL-84 flamethrower is the current standard issue flamethrower of the TGMC, and is used for area control and urban combat. Use unique action to use hydro cannon"
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/large
 	icon_state = "tl84"
 	item_state = "tl84"

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -96,11 +96,11 @@ The Grenade Launchers
 	return list(grenade.hud_state, grenade.hud_state_empty)
 
 //-------------------------------------------------------
-//GL-70 Grenade Launcher.
+//T-70 Grenade Launcher.
 
 /obj/item/weapon/gun/grenade_launcher/multinade_launcher
-	name = "\improper GL-70 grenade launcher"
-	desc = "The GL-70 is the standard grenade launcher used by the TerraGov Marine Corps for area denial and big explosions."
+	name = "\improper T-70 grenade launcher"
+	desc = "The T-70 is the standard grenade launcher used by the TerraGov Marine Corps for area denial and big explosions."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t70"
 	item_state = "t70"
@@ -175,8 +175,8 @@ The Grenade Launchers
 	flags_attach_features = NONE
 
 /obj/item/weapon/gun/grenade_launcher/underslung/battle_rifle
-	name = "\improper BR-64 underslung grenade launcher"
-	desc = "A weapon-mounted, reloadable, two-shot grenade launcher designed to fit the BR-64."
+	name = "\improper T-64 underslung grenade launcher"
+	desc = "A weapon-mounted, reloadable, two-shot grenade launcher designed to fit the T-64."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "t64_grenade"
 	pixel_shift_x = 21
@@ -191,7 +191,7 @@ The Grenade Launchers
 	flags_attach_features = ATTACH_REMOVABLE
 
 /obj/item/weapon/gun/grenade_launcher/single_shot
-	name = "\improper GL-81 grenade launcher"
+	name = "\improper T-81 grenade launcher"
 	desc = "A lightweight, single-shot grenade launcher used by the TerraGov Marine Corps for area denial and big explosions."
 	icon_state = "m81"
 	item_state = "m81"
@@ -208,7 +208,7 @@ The Grenade Launchers
 
 
 /obj/item/weapon/gun/grenade_launcher/single_shot/riot
-	name = "\improper GL-81 riot grenade launcher"
+	name = "\improper M-81 riot grenade launcher"
 	desc = "A lightweight, single-shot grenade launcher to launch tear gas grenades. Used by Nanotrasen security during riots."
 	default_ammo_type = null
 	allowed_ammo_types = list(/obj/item/explosive/grenade/chem_grenade)

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -1,7 +1,7 @@
 ///box for storage of ammo and gun
 /obj/item/storage/box/tl102
 	name = "\improper TL-102 crate"
-	desc = "A large and rusted metal case. It has not seen much use. Written in faded letters on its top, it says, \"This is a HSG-102 heavy smartgun\". There are many other warning labels atop that are too faded to read."
+	desc = "A large and rusted metal case. It has not seen much use. Written in faded letters on its top, it says, \"This is a TL-102 heavy smartgun\". There are many other warning labels atop that are too faded to read."
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "crate"
 	w_class = WEIGHT_CLASS_HUGE
@@ -16,10 +16,10 @@
 	new /obj/item/weapon/gun/tl102(src) //gun itself
 	new /obj/item/ammo_magazine/tl102(src) //ammo for the gun
 
-///HSG-102, now with full auto. It is not a superclass of deployed guns, however there are a few varients.
+///TL-102, now with full auto. It is not a superclass of deployed guns, however there are a few varients.
 /obj/item/weapon/gun/tl102
 	name = "\improper TL-102 mounted heavy smartgun"
-	desc = "The HSG-102 heavy machinegun, it's too heavy to be wielded or operated without the tripod. IFF capable. No extra work required, just deploy it with Ctrl-Click. Can be repaired with a blowtorch once deployed."
+	desc = "The TL-102 heavy machinegun, it's too heavy to be wielded or operated without the tripod. IFF capable. No extra work required, just deploy it with Ctrl-Click. Can be repaired with a blowtorch once deployed."
 
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -68,7 +68,7 @@
 ///Unmovable ship mounted version.
 /obj/item/weapon/gun/tl102/hsg_nest
 	name = "\improper TL-102 heavy smartgun nest"
-	desc = "A HSG-102 heavy smartgun mounted upon a small reinforced post with sandbags to provide a small machinegun nest for all your defense purpose needs.</span>"
+	desc = "A TL-102 heavy smartgun mounted upon a small reinforced post with sandbags to provide a small machinegun nest for all your defense purpose needs.</span>"
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "entrenched"
 
@@ -275,7 +275,7 @@
 	max_integrity = 600
 	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
-///This is my meme version, the first version of the HSG-102 to have auto-fire, revel in its presence.
+///This is my meme version, the first version of the TL-102 to have auto-fire, revel in its presence.
 /obj/item/weapon/gun/tl102/death
 	name = "\improper \"Death incarnate\" heavy machine gun"
 	desc = "It looks like a regular TL-102, however glowing archaeic writing glows faintly on its sides and top. It beckons for blood."
@@ -409,7 +409,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/t27, /obj/item/attachable/scope/unremovable/mmg, /obj/item/attachable/heavy_barrel)
 
 //-------------------------------------------------------
-//AT-36 Anti Tank Gun
+//TAT-36 Anti Tank Gun
 
 /obj/item/weapon/gun/standard_atgun
 	name = "\improper TAT-36 anti tank gun"

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -1,6 +1,6 @@
 ///box for storage of ammo and gun
 /obj/item/storage/box/tl102
-	name = "\improper HSG-102 crate"
+	name = "\improper TL-102 crate"
 	desc = "A large and rusted metal case. It has not seen much use. Written in faded letters on its top, it says, \"This is a HSG-102 heavy smartgun\". There are many other warning labels atop that are too faded to read."
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "crate"
@@ -18,7 +18,7 @@
 
 ///HSG-102, now with full auto. It is not a superclass of deployed guns, however there are a few varients.
 /obj/item/weapon/gun/tl102
-	name = "\improper HSG-102 mounted heavy smartgun"
+	name = "\improper TL-102 mounted heavy smartgun"
 	desc = "The HSG-102 heavy machinegun, it's too heavy to be wielded or operated without the tripod. IFF capable. No extra work required, just deploy it with Ctrl-Click. Can be repaired with a blowtorch once deployed."
 
 	w_class = WEIGHT_CLASS_HUGE
@@ -67,7 +67,7 @@
 
 ///Unmovable ship mounted version.
 /obj/item/weapon/gun/tl102/hsg_nest
-	name = "\improper HSG-102 heavy smartgun nest"
+	name = "\improper TL-102 heavy smartgun nest"
 	desc = "A HSG-102 heavy smartgun mounted upon a small reinforced post with sandbags to provide a small machinegun nest for all your defense purpose needs.</span>"
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "entrenched"
@@ -93,8 +93,8 @@
 //MG-2005 mounted minigun
 
 /obj/item/weapon/gun/standard_minigun
-	name = "\improper MG-2005 mounted minigun"
-	desc = "The MG-2005 mounted minigun is a gun simple in principle, it will shoot a lot of bullets really fast and will rip through xeno hordes."
+	name = "\improper TL-2005 mounted minigun"
+	desc = "The TL-2005 mounted minigun is a gun simple in principle, it will shoot a lot of bullets really fast and will rip through xeno hordes."
 
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -135,7 +135,7 @@
 
 ///Unmovable ship mounted version.
 /obj/item/weapon/gun/standard_minigun/nest
-	name = "\improper MG-2005 mounted minigun nest"
+	name = "\improper TL-2005 mounted minigun nest"
 	desc = "A MG-2005 mounted minigun mounted upon a small reinforced post with sandbags."
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "minigun_nest"
@@ -152,8 +152,8 @@
 //ATR-22 mounted heavy anti-air gun
 
 /obj/item/weapon/gun/standard_auto_cannon
-	name = "\improper ATR-22 mounted flak gun"
-	desc = "The ATR-22 is a recoiling barrel 20mm autocannon, created to be used against low flying targets, it is however able to engage ground targets at medium ranges with extreme efficency even if the recoil makes it near impossible to hit anything close by, its bullets will shred hard targets such as armored foes or walls. Both barrels can be fired at the same time rather than in sequence, but will incur large scatter penalties do so."
+	name = "\improper TL-22 mounted flak gun"
+	desc = "The TL-22 is a recoiling barrel 20mm autocannon, created to be used against low flying targets, it is however able to engage ground targets at medium ranges with extreme efficency even if the recoil makes it near impossible to hit anything close by, its bullets will shred hard targets such as armored foes or walls. Both barrels can be fired at the same time rather than in sequence, but will incur large scatter penalties do so."
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/marine-ac.dmi'
@@ -236,8 +236,8 @@
 //RR-15 mounted heavy recoilless rifle
 
 /obj/item/weapon/gun/launcher/rocket/heavy_rr
-	name = "\improper RR-15 mounted heavy recoilless rifle"
-	desc = "The RR-15 mounted recoilless rifle is a non-IFF, modernized version of the L6 Wombat using 75mm. Reintroduced due to the rather close quarter nature of combat against xenomorphs, this thing will kill mostly anything on its way."
+	name = "\improper TL-15 mounted heavy recoilless rifle"
+	desc = "The TL-15 mounted recoilless rifle is a non-IFF, modernized version of the L6 Wombat using 75mm. Reintroduced due to the rather close quarter nature of combat against xenomorphs, this thing will kill mostly anything on its way."
 
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -278,7 +278,7 @@
 ///This is my meme version, the first version of the HSG-102 to have auto-fire, revel in its presence.
 /obj/item/weapon/gun/tl102/death
 	name = "\improper \"Death incarnate\" heavy machine gun"
-	desc = "It looks like a regular HSG-102, however glowing archaeic writing glows faintly on its sides and top. It beckons for blood."
+	desc = "It looks like a regular TL-102, however glowing archaeic writing glows faintly on its sides and top. It beckons for blood."
 	icon = 'icons/Marine/marine-hmg.dmi'
 
 	aim_slowdown = 3
@@ -297,7 +297,7 @@
 // This is a deployed IFF-less MACHINEGUN, has 500 rounds, drums do not fit anywhere but your belt slot and your back slot. But it has 500 rounds. That's nice.
 
 /obj/item/weapon/gun/heavymachinegun
-	name = "\improper HMG-08 heavy machinegun"
+	name = "\improper MG-08/495 heavy machinegun"
 	desc = "An absolute monster of a weapon, this is a watercooled heavy machinegun modernized by some crazy armorer with a wheeling kit included. Considering the mish mash of parts for the wheeling kit, you think its from another model of the gun. The pinnacle at holding a chokepoint. Holds 500 rounds of 10x28mm caseless in a box case. IS NOT IFF CAPABLE. Aiming carefully recommended. Can be repaired with a blowtorch once deployed. Alt Right click to unanchor and reanchor it."
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -343,8 +343,8 @@
 //MG-27 Medium Machine Gun
 
 /obj/item/weapon/gun/standard_mmg
-	name = "\improper MG-27 medium machinegun"
-	desc = "The MG-27 is the SG-29s aging IFF-less cousin, made for rapid accurate machinegun fire in a short amount of time, you could use it while standing, not a great idea. Use the tripod for actual combat. It uses 10x27mm boxes."
+	name = "\improper T-27 medium machinegun"
+	desc = "The T-27 is the SG-29s aging IFF-less cousin, made for rapid accurate machinegun fire in a short amount of time, you could use it while standing, not a great idea. Use the tripod for actual combat. It uses 10x27mm boxes."
 	flags_equip_slot = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/Marine/marine-mmg.dmi'
@@ -412,8 +412,8 @@
 //AT-36 Anti Tank Gun
 
 /obj/item/weapon/gun/standard_atgun
-	name = "\improper AT-36 anti tank gun"
-	desc = "The AT-36 is a light dual purpose anti tank and anti personnel weapon used by the TGMC. Used for light vehicle or bunker busting on a short notice. Best used by two people. It can move around with wheels, and has an ammo rack intergral to the weapon. CANNOT BE UNDEPLOYED ONCE DEPLOYED! It uses several types of 37mm shells boxes. Alt-right click on it to anchor it so that it cannot be moved by anyone, then alt-right click again to move it."
+	name = "\improper TAT-36 anti tank gun"
+	desc = "The TAT-36 is a light dual purpose anti tank and anti personnel weapon used by the TGMC. Used for light vehicle or bunker busting on a short notice. Best used by two people. It can move around with wheels, and has an ammo rack intergral to the weapon. CANNOT BE UNDEPLOYED ONCE DEPLOYED! It uses several types of 37mm shells boxes. Alt-right click on it to anchor it so that it cannot be moved by anyone, then alt-right click again to move it."
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/Marine/marine-atgun.dmi'
 	icon_state = "tat36"
@@ -505,8 +505,8 @@
 //AGLS-37, or Automatic Grenade Launching System 37, a fully automatic mounted grenade launcher that fires fragmentation and HE shells, can't be turned.
 
 /obj/item/weapon/gun/standard_agls
-	name = "\improper AGLS-37 Kauser automatic grenade launcher"
-	desc = "The AGLS-37 automatic grenade launching IFF capable system, it's too heavy to be wielded or operated without the tripod. On the back, it reads: \"The Explosions and Fragmentation from this weapon ARE NOT friendly fire capable. Kauser is not obligated to buy you new body parts for you or your friends if you lose them.\"\nCan be deployed with Crtl-Click. It CANNOT be turned once deployed, due to a lack of swivels, pick it up to move your cone of fire. Can be repaired with a blowtorch once deployed."
+	name = "\improper TSGLS-37 Kauser automatic grenade launcher"
+	desc = "The TSGLS-37 automatic grenade launching IFF capable system, it's too heavy to be wielded or operated without the tripod. On the back, it reads: \"The Explosions and Fragmentation from this weapon ARE NOT friendly fire capable. Kauser is not obligated to buy you new body parts for you or your friends if you lose them.\"\nCan be deployed with Crtl-Click. It CANNOT be turned once deployed, due to a lack of swivels, pick it up to move your cone of fire. Can be repaired with a blowtorch once deployed."
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
 	caliber = CALIBER_40MM

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -42,11 +42,11 @@
 	placed_overlay_iconstate = "pistol"
 
 //-------------------------------------------------------
-//P-14 PISTOL
+//TP-14 PISTOL
 
 /obj/item/weapon/gun/pistol/standard_pistol
-	name = "\improper P-14 pistol"
-	desc = "The P-14, produced by Terran Armories. A reliable sidearm that loads 9x19mm Parabellum Auto munitions. Capable of mounting a limited amount of attachments, and firing at a respectable rate of fire, often as fast as you can pull the trigger. Takes 21-round 9mm magazines."
+	name = "\improper TP-14 pistol"
+	desc = "The TP-14, produced by Terran Armories. A reliable sidearm that loads 9x19mm Parabellum Auto munitions. Capable of mounting a limited amount of attachments, and firing at a respectable rate of fire, often as fast as you can pull the trigger. Takes 21-round 9mm magazines."
 	icon_state = "tp14"
 	item_state = "tp14"
 	caliber = CALIBER_9X19 //codex
@@ -68,9 +68,9 @@
 	lower_akimbo_accuracy = 4
 
 //-------------------------------------------------------
-//PP-7 Plasma Pistol
+//TX-7 Plasma Pistol
 /obj/item/weapon/gun/pistol/plasma_pistol
-	name = "\improper PP-7 plasma pistol"
+	name = "\improper TX-7 plasma pistol"
 	desc = "An experimental weapon designed to set the terrain and targets on fire. It hums with power as magnetic fields coil round each other."
 	icon_state = "tx7"
 	item_state = "tx7"
@@ -163,11 +163,11 @@
 	accuracy_mult = 1.15
 
 //-------------------------------------------------------
-// P-23 service pistol
+// TP-23 service pistol
 
 /obj/item/weapon/gun/pistol/standard_heavypistol
-	name = "\improper P-23 service pistol"
-	desc = "A standard P-23 chambered in .45 ACP. Has a smaller magazine capacity, but packs a better punch. Has an irremovable laser sight. Uses .45 magazines."
+	name = "\improper TP-23 service pistol"
+	desc = "A standard TP-23 chambered in .45 ACP. Has a smaller magazine capacity, but packs a better punch. Has an irremovable laser sight. Uses .45 magazines."
 	icon_state = "tp23"
 	item_state = "tp23"
 	caliber = CALIBER_45ACP //codex
@@ -212,8 +212,8 @@
 //P-1911
 
 /obj/item/weapon/gun/pistol/m1911
-	name = "\improper P-1911 service pistol"
-	desc = "A P-1911 chambered in .45 ACP. An archaic weapon, yet its popular and extremely reliable mechanism provided a template for many semi-automatic pistols to come."
+	name = "\improper M1911 service pistol"
+	desc = "A M-1911 chambered in .45 ACP. An archaic weapon, yet its popular and extremely reliable mechanism provided a template for many semi-automatic pistols to come."
 	icon_state = "m1911"
 	item_state = "m1911"
 	caliber = CALIBER_45ACP //codex
@@ -234,7 +234,7 @@
 	lower_akimbo_accuracy = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
-	name = "\improper P-1911A1 custom pistol"
+	name = "\improper M1911A1 custom pistol"
 	desc = "A handgun that has received several modifications. It seems to have been lovingly taken care of and passed down for generations. Lacks an auto magazine eject feature."
 	icon_state = "m1911c"
 	attachable_allowed = list(
@@ -255,7 +255,7 @@
 //P-22. Blocc
 
 /obj/item/weapon/gun/pistol/g22
-	name = "\improper P-22 pistol"
+	name = "\improper G22 pistol"
 	desc = "A popular police firearm in the modern day. Chambered in 9x19mm."
 	icon_state = "g22"
 	item_state = "g22"
@@ -276,7 +276,7 @@
 	fire_delay = 0.2 SECONDS
 
 /obj/item/weapon/gun/pistol/g22/tranq
-	name = "\improper P-22 custom pistol"
+	name = "\improper G22 custom pistol"
 	desc = "A 20th century military firearm customized for special forces use, fires tranq darts to take down enemies nonlethally. It does not seem to accept any other attachments."
 	icon_state = "g22"
 	item_state = "g22"
@@ -420,10 +420,10 @@
 	fire_delay = 0.15 SECONDS
 
 //-------------------------------------------------------
-//P-17 Pocket pistol. Based on a PMM.
+//TP-17 Pocket pistol. Based on a PMM.
 
 /obj/item/weapon/gun/pistol/standard_pocketpistol
-	name = "\improper P-17 pocket pistol"
+	name = "\improper TP-17 pocket pistol"
 	desc = "A tiny pistol used by the TGMC as an emergency handgun meant to be stored about anywhere. Fits in boots. Uses .380 ACP stored in an eight round magazine."
 	icon_state = "tp17"
 	item_state = "tp17"
@@ -731,8 +731,8 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 
 // Smart pistol, based on Calico M-950
 /obj/item/weapon/gun/pistol/smart_pistol
-	name = "\improper SP-13 smart pistol"
-	desc = "The SP-13 is a IFF-capable sidearm used by the TerraGov Marine Corps. A cutting-edge miniaturization technology allows mounting of a KTLD IFF system on the pistol, albeit at high manufactoring cost and the usual specialized training required to use such a pistol. Unique design feature high-capacity mag on top of the barrel, with integrated sight."
+	name = "\improper TX-13 smart pistol"
+	desc = "The TX-13 is a IFF-capable sidearm used by the TerraGov Marine Corps. A cutting-edge miniaturization technology allows mounting of a KTLD IFF system on the pistol, albeit at high manufactoring cost and the usual specialized training required to use such a pistol. Unique design feature high-capacity mag on top of the barrel, with integrated sight."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "sp13"
 	item_state = "sp13"

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -55,11 +55,11 @@
 	do_trick(usr)
 
 //-------------------------------------------------------
-//R-44 COMBAT REVOLVER
+//TP-44 COMBAT REVOLVER
 
 /obj/item/weapon/gun/revolver/standard_revolver
-	name = "\improper R-44 combat revolver"
-	desc = "The R-44 standard combat revolver, produced by Terran Armories. A sturdy and hard hitting firearm that loads .44 Magnum rounds. Holds 7 rounds in the cylinder. Due to an error in the cylinder rotation system the fire rate of the gun is much faster than intended, it ended up being billed as a feature of the system."
+	name = "\improper TP-44 combat revolver"
+	desc = "The TP-44 standard combat revolver, produced by Terran Armories. A sturdy and hard hitting firearm that loads .44 Magnum rounds. Holds 7 rounds in the cylinder. Due to an error in the cylinder rotation system the fire rate of the gun is much faster than intended, it ended up being billed as a feature of the system."
 	icon_state = "tp44"
 	item_state = "tp44"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_r44.ogg'
@@ -157,8 +157,8 @@
 //Mateba is pretty well known. The cylinder folds up instead of to the side. This has a non-marine version and a marine version.
 
 /obj/item/weapon/gun/revolver/mateba
-	name = "\improper R-24 'Mateba' autorevolver"
-	desc = "The R-24 is the rather rare autorevolver used by the TGMC issued in rather small numbers to backline personnel and officers it uses recoil to spin the cylinder. Uses heavy .454 rounds."
+	name = "\improper TL-24 'Mateba' autorevolver"
+	desc = "The TL-24 s the rather rare autorevolver used by the TGMC issued in rather small numbers to backline personnel and officers it uses recoil to spin the cylinder. Uses heavy .454 rounds."
 	icon_state = "mateba"
 	item_state = "mateba"
 	fire_animation = "mateba_fire"
@@ -197,7 +197,7 @@
 
 
 /obj/item/weapon/gun/revolver/mateba/custom
-	name = "\improper R-24 autorevolver special"
+	name = "\improper TL-24 autorevolver special"
 	desc = "The Mateba is a powerful, fast-firing revolver that uses its own recoil to rotate the cylinders. This one appears to have had more love and care put into it. Uses .454 rounds."
 	icon_state = "mateba"
 	item_state = "mateba"
@@ -270,11 +270,11 @@
 	damage_falloff_mult = 1.2
 
 //-------------------------------------------------------
-// The R-76 Magnum. Fires a big round, equal to a slug. Has a windup.
+// The TL-76 Magnum. Fires a big round, equal to a slug. Has a windup.
 
 /obj/item/weapon/gun/revolver/standard_magnum
-	name = "\improper R-76 KC magnum"
-	desc = "The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
+	name = "\improper TL-76 KC magnum"
+	desc = "The TL-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t76"
 	item_state = "t76"
@@ -330,19 +330,19 @@
 	)
 
 /obj/item/weapon/gun/revolver/standard_magnum/fancy/gold
-	desc = "A gold plated R-76 magnum, to ensure it's incredibly expensive as well as incredibly impractical. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
+	desc = "A gold plated TL-76 magnum, to ensure it's incredibly expensive as well as incredibly impractical. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
 	icon_state = "g_t76"
 	item_state = "g_t76"
 	fire_animation = "g_t76_fire"
 
 /obj/item/weapon/gun/revolver/standard_magnum/fancy/silver
-	desc = "A silver plated R-76 magnum, to ensure it's incredibly expensive as well as incredibly impractical. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
+	desc = "A silver plated TL-76 magnum, to ensure it's incredibly expensive as well as incredibly impractical. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
 	icon_state = "s_t76"
 	item_state = "s_t76"
 	fire_animation = "s_t76_fire"
 
 /obj/item/weapon/gun/revolver/standard_magnum/fancy/nickle
-	desc = "A nickle plated R-76 magnum, for a more tasteful finish. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
+	desc = "A nickle plated TL-76 magnum, for a more tasteful finish. The R-76 magnum is an absolute beast of a handgun used by the TGMC, rumors say it was created as a money laundering scheme by some general due to the sheer inpracticality of this firearm. Hits hard, recommended to be used with its stock attachment. Chambered in 12.7mm."
 	icon_state = "n_t76"
 	item_state = "n_t76"
 	fire_animation = "n_t76_fire"
@@ -364,10 +364,10 @@
 
 
 //-------------------------------------------------------
-//R-44, based off the SAA.
+//M-44, based off the SAA.
 
 /obj/item/weapon/gun/revolver/single_action/m44
-	name = "\improper R-44 SAA revolver"
+	name = "\improper M-44 SAA revolver"
 	desc = "A uncommon revolver occasionally carried by civilian law enforcement that's very clearly based off a modernized Single Action Army. Has to be manully primed with each shot. Uses .44 Magnum rounds."
 	icon_state = "m44"
 	item_state = "m44"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -183,7 +183,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/t12stock, /obj/item/attachable/magnetic_harness, /obj/item/attachable/extended_barrel, /obj/item/weapon/gun/grenade_launcher/underslung)
 
 //-------------------------------------------------------
-//DMR-37 DMR
+//T-37 DMR
 
 /obj/item/weapon/gun/rifle/standard_dmr
 	name = "\improper T-37 SCA designated marksman rifle"
@@ -265,7 +265,7 @@
 
 /obj/item/weapon/gun/rifle/standard_br
 	name = "\improper T-64 SCA battle rifle"
-	desc = "The San Cristo Arms BR-64 is the TerraGov Marine Corps main battle rifle. It is known for its consistent ability to perform well at most ranges, and medium range stopping power with bursts. It is mostly used by people who prefer a bigger round than the average. Uses 10x26.5smm caseless caliber."
+	desc = "The San Cristo Arms T-64 is the TerraGov Marine Corps main battle rifle. It is known for its consistent ability to perform well at most ranges, and medium range stopping power with bursts. It is mostly used by people who prefer a bigger round than the average. Uses 10x26.5smm caseless caliber."
 	icon_state = "t64"
 	item_state = "t64"
 	icon = 'icons/Marine/gun64.dmi'

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -23,11 +23,11 @@
 	lower_akimbo_accuracy = 3
 
 //-------------------------------------------------------
-//AR-18 Carbine
+//T-18 Carbine
 
 /obj/item/weapon/gun/rifle/standard_carbine
-	name = "\improper AR-18 Kauser carbine"
-	desc = "The Keckler and Hoch AR-18 carbine is one of the standard rifles used by the TerraGov Marine Corps. It's commonly used by people who prefer greater mobility in combat, like scouts and other light infantry. Uses 10x24mm caseless ammunition."
+	name = "\improper T-18 Kauser carbine"
+	desc = "The Keckler and Hoch T-18 carbine is one of the standard rifles used by the TerraGov Marine Corps. It's commonly used by people who prefer greater mobility in combat, like scouts and other light infantry. Uses 10x24mm caseless ammunition."
 	icon_state = "t18"
 	item_state = "t18"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_ar18.ogg'
@@ -105,11 +105,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/t18stock, /obj/item/weapon/gun/pistol/plasma_pistol, /obj/item/attachable/motiondetector, /obj/item/attachable/compensator)
 
 //-------------------------------------------------------
-//AR-12 Assault Rifle
+//T-12 Assault Rifle
 
 /obj/item/weapon/gun/rifle/standard_assaultrifle
-	name = "\improper AR-12 K&H assault rifle"
-	desc = "The Keckler and Hoch AR-12 assault rifle used to be the TerraGov Marine Corps standard issue rifle before the AR-18 carbine replaced it. It is, however, still used widely despite that. The gun itself is very good at being used in most situations however it suffers in engagements at close quarters and is relatively hard to shoulder than some others. It uses 10x24mm caseless ammunition."
+	name = "\improper T-12 K&H assault rifle"
+	desc = "The Keckler and Hoch T12 assault rifle used to be the TerraGov Marine Corps standard issue rifle before the T18 carbine replaced it. It is, however, still used widely despite that. The gun itself is very good at being used in most situations however it suffers in engagements at close quarters and is relatively hard to shoulder than some others. It uses 10x24mm caseless ammunition."
 	icon_state = "t12"
 	item_state = "t12"
 	fire_sound = "gun_ar12"
@@ -186,8 +186,8 @@
 //DMR-37 DMR
 
 /obj/item/weapon/gun/rifle/standard_dmr
-	name = "\improper DMR-37 SCA designated marksman rifle"
-	desc = "The San Cristo Arms DMR-37 is the TerraGov Marine Corps designated marksman rifle. It is rather well-known for it's very consistent target placement at longer than usual range, it however lacks a burst fire mode or an automatic mode. It is mostly used by people who prefer to do more careful shooting than most. Uses 10x27mm caseless caliber."
+	name = "\improper T-37 SCA designated marksman rifle"
+	desc = "The San Cristo Arms T-37 is the TerraGov Marine Corps designated marksman rifle. It is rather well-known for it's very consistent target placement at longer than usual range, it however lacks a burst fire mode or an automatic mode. It is mostly used by people who prefer to do more careful shooting than most. Uses 10x27mm caseless caliber."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t37"
 	item_state = "t37"
@@ -261,10 +261,10 @@
 
 
 //-------------------------------------------------------
-//BR-64 BR
+//T-64 BR
 
 /obj/item/weapon/gun/rifle/standard_br
-	name = "\improper BR-64 SCA battle rifle"
+	name = "\improper T-64 SCA battle rifle"
 	desc = "The San Cristo Arms BR-64 is the TerraGov Marine Corps main battle rifle. It is known for its consistent ability to perform well at most ranges, and medium range stopping power with bursts. It is mostly used by people who prefer a bigger round than the average. Uses 10x26.5smm caseless caliber."
 	icon_state = "t64"
 	item_state = "t64"
@@ -337,11 +337,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/t64stock, /obj/item/weapon/gun/grenade_launcher/underslung/battle_rifle, /obj/item/attachable/reddot, /obj/item/attachable/extended_barrel)
 
 //-------------------------------------------------------
-//PR-412 Pulse Rifle
+//M412 Pulse Rifle
 
 /obj/item/weapon/gun/rifle/m412
-	name = "\improper PR-412 pulse rifle"
-	desc = "The PR-412 rifle is a Pulse Industries rifle, billed as a pulse rifle due to its use of electronic firing for faster velocity. A rather common sight in most systems. Uses 10x24mm caseless ammunition."
+	name = "\improper M412 pulse rifle"
+	desc = "The M412 rifle is a Pulse Industries rifle, billed as a pulse rifle due to its use of electronic firing for faster velocity. A rather common sight in most systems. Uses 10x24mm caseless ammunition."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "m412"
 	item_state = "m412"
@@ -405,11 +405,11 @@
 
 
 //-------------------------------------------------------
-//PR-412 PMC VARIANT
+//M412 PMC VARIANT
 
 /obj/item/weapon/gun/rifle/m412/elite
-	name = "\improper PR-412E battle rifle"
-	desc = "An \"Elite\" modification of the PR-412 pulse rifle series, given to special operation units. It has been given a stock and a longer barrel with an integrated barrel charger, with a red skull stenciled on the body for some reason."
+	name = "\improper M412E battle rifle"
+	desc = "An \"Elite\" modification of the M412 pulse rifle series, given to special operation units. It has been given a stock and a longer barrel with an integrated barrel charger, with a red skull stenciled on the body for some reason."
 	icon_state = "m412e"
 	item_state = "m412e"
 	default_ammo_type = /obj/item/ammo_magazine/rifle/ap
@@ -453,10 +453,10 @@
 
 
 //-------------------------------------------------------
-//PR-11
+//HK-11
 
 /obj/item/weapon/gun/rifle/m41a
-	name = "\improper PR-11 pulse rifle"
+	name = "\improper HK-11 pulse rifle"
 	desc = "A strange failed electronically fired rifle, a rather unknown weapon of its time. It caused a surge in the use of electronic firing in the modern era though. Uses 10x24mm caseless ammunition. Has a irremoveable grenade launcher."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "m41a"
@@ -806,11 +806,11 @@
 
 
 //-------------------------------------------------------
-//MG-42 Light Machine Gun
+//T-42 Light Machine Gun
 
 /obj/item/weapon/gun/rifle/standard_lmg
-	name = "\improper MG-42 Kauser light machine gun"
-	desc = "The Kauser MG-42 is the TGMC's current standard non-IFF-capable LMG. It's known for its ability to lay down heavy fire support very well. It is generally used when someone wants to hold a position or provide fire support. It uses 10x24mm ammunition."
+	name = "\improper T-42 Kauser light machine gun"
+	desc = "The Kauser T-42 is the TGMC's current standard non-IFF-capable LMG. It's known for its ability to lay down heavy fire support very well. It is generally used when someone wants to hold a position or provide fire support. It uses 10x24mm ammunition."
 
 	icon_state = "t42"
 	item_state = "t42"
@@ -880,11 +880,11 @@
 	movement_acc_penalty_mult = 6
 
 //-------------------------------------------------------
-//MG-60 General Purpose Machine Gun
+//T-60 General Purpose Machine Gun
 
 /obj/item/weapon/gun/rifle/standard_gpmg
-	name = "\improper MG-60 Raummetall general purpose machine gun"
-	desc = "The Raummetall MG-60 general purpose machinegun is the TGMC's current standard GPMG. Though usually seen mounted on vehicles, it is sometimes used by infantry to hold chokepoints or suppress enemies, or in rare cases for marching fire. It uses 10x26mm boxes."
+	name = "\improper T-60 Raummetall general purpose machine gun"
+	desc = "The Raummetall T-60 general purpose machinegun is the TGMC's current standard GPMG. Though usually seen mounted on vehicles, it is sometimes used by infantry to hold chokepoints or suppress enemies, or in rare cases for marching fire. It uses 10x26mm boxes."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t60"
 	item_state = "t60"
@@ -957,8 +957,8 @@
 //M41AE2 Heavy Pulse Rifle
 
 /obj/item/weapon/gun/rifle/m412l1_hpr
-	name = "\improper PR-412L1 heavy pulse rifle"
-	desc = "A large weapon capable of laying down supressing fire, based on the PR-412 pulse rifle platform. Effective in burst fire. Uses 10x24mm caseless ammunition."
+	name = "\improper M412L1 heavy pulse rifle"
+	desc = "A large weapon capable of laying down supressing fire, based on the M412 pulse rifle platform. Effective in burst fire. Uses 10x24mm caseless ammunition."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "m412l1"
 	item_state = "m412l1"
@@ -1132,11 +1132,11 @@
 	desc = "The primary rifle of many space pirates and militias, the Type 71 is a reliable rifle chambered in 7.62x39mm, firing in three round bursts to conserve ammunition."
 
 //-------------------------------------------------------
-//SH-15 AUTOMATIC SHOTGUN
+//TX-15 AUTOMATIC SHOTGUN
 
 /obj/item/weapon/gun/rifle/standard_autoshotgun
-	name = "\improper Zauer SH-15 automatic shotgun"
-	desc = "The Zauer SH-15 Automatic Assault Shotgun, this is a Terran Armories variant. Another iteration of the ZX series of firearms though it has been since regulated as part of the TGMC arsenal, hence the SH designation. It took over the various shotgun models as the semi-automatic shotgun provided to the TGMC. It is rifled, and loads primarily longer ranged munitions, being incompatible with buckshot shells. Takes 12-round 16 gauge magazines."
+	name = "\improper Zauer TX-15 automatic shotgun"
+	desc = "The Zauer TX-15 Automatic Assault Shotgun, this is a Terran Armories variant. Another iteration of the ZX series of firearms though it has been since regulated as part of the TGMC arsenal, hence the SH designation. It took over the various shotgun models as the semi-automatic shotgun provided to the TGMC. It is rifled, and loads primarily longer ranged munitions, being incompatible with buckshot shells. Takes 12-round 16 gauge magazines."
 	icon_state = "tx15"
 	item_state = "tx15"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_sh15.ogg'
@@ -1193,11 +1193,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/tx15, /obj/item/attachable/motiondetector, /obj/item/attachable/extended_barrel, /obj/item/weapon/gun/pistol/plasma_pistol)
 
 //-------------------------------------------------------
-//SG-29 Smart Machine Gun (It's more of a rifle than the SG.)
+//T-29 Smart Machine Gun (It's more of a rifle than the SG.)
 
 /obj/item/weapon/gun/rifle/standard_smartmachinegun
-	name = "\improper SG-29 Raummetall-KT smart machine gun"
-	desc = "The Raummetall-KT SG-29 is the TGMC's current standard IFF-capable medium machine gun. It's known for its ability to lay down heavy fire support very well. It is generally used when someone wants to hold a position or provide fire support. Requires special training and it cannot turn off IFF. It uses 10x26mm ammunition."
+	name = "\improper T-29 Raummetall-KT smart machine gun"
+	desc = "The Raummetall-KT T-29 is the TGMC's current standard IFF-capable medium machine gun. It's known for its ability to lay down heavy fire support very well. It is generally used when someone wants to hold a position or provide fire support. Requires special training and it cannot turn off IFF. It uses 10x26mm ammunition."
 	icon_state = "sg29"
 	item_state = "sg29"
 	caliber = CALIBER_10x26_CASELESS //codex
@@ -1255,8 +1255,8 @@
 //SG Target Rifle, has underbarreled spotting rifle that applies effects.
 
 /obj/item/weapon/gun/rifle/standard_smarttargetrifle
-	name = "\improper SG-62 Kauser-KT smart target rifle"
-	desc = "The Kauser-KT SG-62 is a IFF-capable rifle used by the TerraGov Marine Corps, coupled with a spotting rifle that is also IFF capable of applying various bullets with specialized ordnance, this is a gun with many answers to many situations... if you have the right ammo loaded. Requires special training and it cannot turn off IFF. It uses high velocity 10x27mm for the rifle and 12x66mm ammunition for the underslung rifle."
+	name = "\improper T-62 Kauser-KT smart target rifle"
+	desc = "The Kauser-KT T-62 is a IFF-capable rifle used by the TerraGov Marine Corps, coupled with a spotting rifle that is also IFF capable of applying various bullets with specialized ordnance, this is a gun with many answers to many situations... if you have the right ammo loaded. Requires special training and it cannot turn off IFF. It uses high velocity 10x27mm for the rifle and 12x66mm ammunition for the underslung rifle."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "sg62"
 	item_state = "sg62"
@@ -1300,7 +1300,7 @@
 	placed_overlay_iconstate = "smartgun"
 
 /obj/item/weapon/gun/rifle/standard_spottingrifle
-	name = "SG-153 spotting rifle"
+	name = "TL-153 spotting rifle"
 	desc = "An underslung spotting rifle, generally found ontop of another gun."
 	icon_state = "sg153"
 	icon = 'icons/Marine/gun64.dmi'
@@ -1379,11 +1379,11 @@
 
 
 //-------------------------------------------------------
-//SR-127 bolt action sniper rifle
+//TL-127 bolt action sniper rifle
 
 /obj/item/weapon/gun/rifle/chambered
-	name = "\improper SR-127 Bauer bolt action rifle"
-	desc = "The Bauer SR-127 is the standard issue bolt action rifle used by the TGMC. Known for its long range accuracy and use by marksmen despite its age and lack of IFF, though careful aim allows fire support from behind. It has an irremoveable scope. Uses 8.6×70mm box magazines."
+	name = "\improper TL-127 Bauer bolt action rifle"
+	desc = "The Bauer TL-127 is the standard issue bolt action rifle used by the TGMC. Known for its long range accuracy and use by marksmen despite its age and lack of IFF, though careful aim allows fire support from behind. It has an irremoveable scope. Uses 8.6×70mm box magazines."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "tl127"
 	item_state = "tl127"
@@ -1453,11 +1453,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/tl127stock)
 
 //-------------------------------------------------------
-//SR-81 Auto-Sniper
+//T-81 Auto-Sniper
 
 /obj/item/weapon/gun/rifle/standard_autosniper
-	name = "\improper SR-81 Kauser-KT automatic sniper rifle"
-	desc = "The Kauser-KT SR-81 is the TerraGov Marine Corps's automatic sniper rifle usually married to it's iconic NVG/KTLD scope combo. It is notable for its high rate of fire for its class, and has decent performance in any range. Uses 8.6x70mm caseless with specialized pressures for IFF fire."
+	name = "\improper T-81 Kauser-KT automatic sniper rifle"
+	desc = "The Kauser-KT T-81 is the TerraGov Marine Corps's automatic sniper rifle usually married to it's iconic NVG/KTLD scope combo. It is notable for its high rate of fire for its class, and has decent performance in any range. Uses 8.6x70mm caseless with specialized pressures for IFF fire."
 	icon_state = "t81"
 	item_state = "t81"
 	fire_sound = 'sound/weapons/guns/fire/sniper.ogg'
@@ -1500,11 +1500,11 @@
 	movement_acc_penalty_mult = 6
 
 //-------------------------------------------------------
-//AR-11 Rifle, based on the gamer-11
+//TX-11 Rifle, based on the gamer-11
 
 /obj/item/weapon/gun/rifle/tx11
-	name = "\improper AR-11 K&H combat rifle"
-	desc = "The Keckler and Hoch AR-11 is the former standard issue rifle of the TGMC. Most of them have been mothballed into storage long ago, but some still pop up in marine or mercenary hands. It is known for its large magazine size and great burst fire, but rather awkward to use, especially during combat. It uses 4.92×34mm caseless HV ammunition."
+	name = "\improper TX-11 K&H combat rifle"
+	desc = "The Keckler and Hoch TX-11 is the former standard issue rifle of the TGMC. Most of them have been mothballed into storage long ago, but some still pop up in marine or mercenary hands. It is known for its large magazine size and great burst fire, but rather awkward to use, especially during combat. It uses 4.92×34mm caseless HV ammunition."
 	icon_state = "tx11"
 	item_state = "tx11"
 	caliber = CALIBER_492X34_CASELESS //codex
@@ -1562,11 +1562,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/tx11, /obj/item/attachable/reddot, /obj/item/attachable/lasersight)
 
 //-------------------------------------------------------
-//AR-21 Assault Rifle
+//T-21 Assault Rifle
 
 /obj/item/weapon/gun/rifle/standard_skirmishrifle
-	name = "\improper AR-21 Kauser skirmish rifle"
-	desc = "The Kauser AR-21 is a versatile rifle is developed to bridge a gap between higher caliber weaponry and a normal rifle. It fires a strong 10x25mm round, which has decent stopping power. It however suffers in magazine size and movement capablity compared to smaller peers."
+	name = "\improper T-21 Kauser skirmish rifle"
+	desc = "The Kauser T-21 is a versatile rifle is developed to bridge a gap between higher caliber weaponry and a normal rifle. It fires a strong 10x25mm round, which has decent stopping power. It however suffers in magazine size and movement capablity compared to smaller peers."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t21"
 	item_state = "t21"
@@ -1642,7 +1642,7 @@
 
 /obj/item/weapon/gun/rifle/alf_machinecarbine
 	name = "\improper ALF-51B Kauser machinecarbine"
-	desc = "The Kauser ALF-51B is an unoffical modification of a ALF-51, or better known as the AR-18 carbine, modified to SMG length of barrel, rechambered for a stronger round, and belt based. Truly the peak of CQC. Useless past that. Aiming is impossible. Uses 10x25mm caseless ammunition."
+	desc = "The Kauser ALF-51B is an unoffical modification of a ALF-51, or better known as the T18 carbine, modified to SMG length of barrel, rechambered for a stronger round, and belt based. Truly the peak of CQC. Useless past that. Aiming is impossible. Uses 10x25mm caseless ammunition."
 	icon_state = "alf51b"
 	item_state = "alf51b"
 	fire_animation = "alf51b_fire"
@@ -1739,9 +1739,9 @@
 	movement_acc_penalty_mult = 4
 
 //-------------------------------------------------------
-// GL-54 grenade launcher
+// TX-54 grenade launcher
 /obj/item/weapon/gun/rifle/tx54
-	name = "\improper GL-54 grenade launcher"
+	name = "\improper TX-54 grenade launcher"
 	desc = "A magazine fed, semi-automatic grenade launcher designed to shoot airbursting smart grenades. Requires a T49 scope for precision aiming."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "tx54"
@@ -1791,10 +1791,10 @@
 	aim_speed_modifier = 2
 
 //-------------------------------------------------------
-// AR-55 built in grenade launcher
+// TX-55 built in grenade launcher
 
 /obj/item/weapon/gun/rifle/tx54/mini
-	name = "\improper GL-55 20mm grenade launcher"
+	name = "\improper TX-55 20mm grenade launcher"
 	desc = "A weapon-mounted, reloadable, five-shot grenade launcher."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "tx55gl"
@@ -1810,11 +1810,11 @@
 	starting_attachment_types = list()
 
 //-------------------------------------------------------
-// AR-55 rifle
+// TX-55 rifle
 
 /obj/item/weapon/gun/rifle/tx55
-	name = "\improper AR-55 assault rifle"
-	desc = "Officially designated an Objective Individual Combat Weapon, the AR-55 features an upper bullpup 20mm grenade launcher designed to fire a variety of specialised rounds, and an underslung assault rifle using 10x24mm caseless ammunition. Somewhat cumbersome to use due to its size and weight. Requires a T49 scope for precision aiming."
+	name = "\improper TX-55 assault rifle"
+	desc = "Officially designated an Objective Individual Combat Weapon, the TX-55 features an upper bullpup 20mm grenade launcher designed to fire a variety of specialised rounds, and an underslung assault rifle using 10x24mm caseless ammunition. Somewhat cumbersome to use due to its size and weight. Requires a T49 scope for precision aiming."
 	icon_state = "tx55"
 	item_state = "tx55"
 	fire_sound = "gun_ar12"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -37,7 +37,7 @@
 //TACTICAL SHOTGUN
 
 /obj/item/weapon/gun/shotgun/combat
-	name = "\improper SH-221 tactical shotgun"
+	name = "\improper MK-221 tactical shotgun"
 	desc = "The Nanotrasen SH-221 Shotgun, a quick-firing semi-automatic shotgun based on the centuries old Benelli M4 shotgun. Only issued to the TGMC in small numbers."
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon_state = "mk221"
@@ -68,10 +68,10 @@
 
 
 //-------------------------------------------------------
-//SH-39 semi automatic shotgun. Used by marines.
+//T-39 semi automatic shotgun. Used by marines.
 
 /obj/item/weapon/gun/shotgun/combat/standardmarine
-	name = "\improper SH-39 combat shotgun"
+	name = "\improper T-39 combat shotgun"
 	desc = "The Terran Armories SH-39 combat shotgun is a semi automatic shotgun used by breachers and pointmen within the TGMC squads. Uses 12 gauge shells."
 	force = 20 //Has a stock already
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -188,7 +188,7 @@
 //MARINE DOUBLE SHOTTY
 
 /obj/item/weapon/gun/shotgun/double/marine
-	name = "\improper SH-34 double barrel shotgun"
+	name = "\improper TS-34 double barrel shotgun"
 	desc = "A double barreled shotgun of archaic, but sturdy design used by the TGMC. Due to reports of barrel bursting, the abiility to fire both barrels has been disabled. Uses 12 gauge shells, but can only hold 2 at a time."
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon_state = "ts34"
@@ -274,7 +274,7 @@
 //-------------------------------------------------------
 //A shotgun, how quaint.
 /obj/item/weapon/gun/shotgun/pump/cmb
-	name = "\improper SH-12 Paladin pump shotgun"
+	name = "\improper Paladin-12 pump shotgun"
 	desc = "A nine-round pump action shotgun. A shotgun used for hunting, home defence and police work, many versions of it exist and are used by just about anyone."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "pal12"
@@ -654,9 +654,9 @@
 	cock_delay = 0.2 SECONDS
 
 //------------------------------------------------------
-//SH-35 Pump shotgun
+//T-35 Pump shotgun
 /obj/item/weapon/gun/shotgun/pump/t35
-	name = "\improper SH-35 pump shotgun"
+	name = "\improper T-35 pump shotgun"
 	desc = "The Terran Armories SH-35 is the shotgun used by the TerraGov Marine Corps. It's used as a close quarters tool when someone wants something more suited for close range than most people, or as an odd sidearm on your back for emergencies. Uses 12 gauge shells.\n<b>Requires a pump, which is the Unique Action key.</b>"
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/gun64.dmi'

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -72,7 +72,7 @@
 
 /obj/item/weapon/gun/shotgun/combat/standardmarine
 	name = "\improper T-39 combat shotgun"
-	desc = "The Terran Armories SH-39 combat shotgun is a semi automatic shotgun used by breachers and pointmen within the TGMC squads. Uses 12 gauge shells."
+	desc = "The Terran Armories T-39 combat shotgun is a semi automatic shotgun used by breachers and pointmen within the TGMC squads. Uses 12 gauge shells."
 	force = 20 //Has a stock already
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/gun64.dmi'
@@ -657,7 +657,7 @@
 //T-35 Pump shotgun
 /obj/item/weapon/gun/shotgun/pump/t35
 	name = "\improper T-35 pump shotgun"
-	desc = "The Terran Armories SH-35 is the shotgun used by the TerraGov Marine Corps. It's used as a close quarters tool when someone wants something more suited for close range than most people, or as an odd sidearm on your back for emergencies. Uses 12 gauge shells.\n<b>Requires a pump, which is the Unique Action key.</b>"
+	desc = "The Terran Armories T-35 is the shotgun used by the TerraGov Marine Corps. It's used as a close quarters tool when someone wants something more suited for close range than most people, or as an odd sidearm on your back for emergencies. Uses 12 gauge shells.\n<b>Requires a pump, which is the Unique Action key.</b>"
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t35"

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -27,7 +27,7 @@
 	movement_acc_penalty_mult = 3
 
 //-------------------------------------------------------
-// MP-19 Machinepistol. It fits here more.
+// TP-19 Machinepistol. It fits here more.
 
 /obj/item/weapon/gun/smg/standard_machinepistol
 	name = "\improper T-19 machinepistol"
@@ -257,7 +257,7 @@
 	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/magnetic_harness, /obj/item/attachable/gyro)
 
 //-------------------------------------------------------
-//SMG-27, based on the grease gun
+//MP-27, based on the grease gun
 
 /obj/item/weapon/gun/smg/mp7
 	name = "\improper MP-27 submachinegun"
@@ -395,7 +395,7 @@
 //GENERIC UZI //Based on the uzi submachinegun, of course.
 
 /obj/item/weapon/gun/smg/uzi
-	name = "\improper SMG-2 submachinegun"
+	name = "\improper MP-2 submachinegun"
 	desc = "A cheap, reliable design and manufacture make this ubiquitous submachinegun useful despite the age. Put the fire selector to full auto for maximum firepower. Use two if you really want to go ham."
 	icon_state = "uzi"
 	item_state = "uzi"

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -30,8 +30,8 @@
 // MP-19 Machinepistol. It fits here more.
 
 /obj/item/weapon/gun/smg/standard_machinepistol
-	name = "\improper MP-19 machinepistol"
-	desc = "The MP-19 is the TerraGov Marine Corps standard-issue machine pistol. It's known for it's low recoil and scatter when used one handed. It's usually carried by specialized troops who do not have the space to carry a much larger gun like medics and engineers. It uses 10x20mm caseless rounds."
+	name = "\improper T-19 machinepistol"
+	desc = "The T-19 is the TerraGov Marine Corps standard-issue machine pistol. It's known for it's low recoil and scatter when used one handed. It's usually carried by specialized troops who do not have the space to carry a much larger gun like medics and engineers. It uses 10x20mm caseless rounds."
 	icon_state = "t19"
 	item_state = "t19"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_mp19.ogg'
@@ -97,8 +97,8 @@
 // War is hell. Not glorious.
 
 /obj/item/weapon/gun/smg/standard_smg
-	name = "\improper SMG-90 submachinegun"
-	desc = "The SMG-90 is the TerraGov Marine Corps standard issue SMG. Its known for it's compact size and ease of use inside the field. It's usually carried by troops who want a lightweight firearm to rush with. It uses 10x20mm caseless rounds."
+	name = "\improper T-90 submachinegun"
+	desc = "The T-90 is the TerraGov Marine Corps standard issue SMG. Its known for it's compact size and ease of use inside the field. It's usually carried by troops who want a lightweight firearm to rush with. It uses 10x20mm caseless rounds."
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_smg90.ogg'
 	icon_state = "t90"
 	item_state = "t90"
@@ -157,8 +157,8 @@
 //M-25 SMG
 
 /obj/item/weapon/gun/smg/m25
-	name = "\improper SMG-25 submachinegun"
-	desc = "The RivArms SMG-25 submachinegun, an update to a classic design. A light firearm capable of effective one-handed use that is ideal for close to medium range engagements. Uses 10x20mm rounds in a high capacity magazine."
+	name = "\improper MR-25 submachinegun"
+	desc = "The RivArms MR-25 submachinegun, an update to a classic design. A light firearm capable of effective one-handed use that is ideal for close to medium range engagements. Uses 10x20mm rounds in a high capacity magazine."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "m25"
 	item_state = "m25"
@@ -216,8 +216,8 @@
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/attachable/gyro)
 
 /obj/item/weapon/gun/smg/m25/elite
-	name = "\improper SMG-25B2 submachinegun"
-	desc = "The RivArms SMG-25 submachinegun, B2 variant. Has an integrated barrel charger. This reliable weapon fires armor piercing 10x20mm rounds and is used by elite troops."
+	name = "\improper MR-25B2 submachinegun"
+	desc = "The RivArms MR-25 submachinegun, B2 variant. Has an integrated barrel charger. This reliable weapon fires armor piercing 10x20mm rounds and is used by elite troops."
 	icon_state = "m25b2"
 	item_state = "m25b2"
 	fire_sound = 'sound/weapons/guns/fire/smg_heavy.ogg'
@@ -260,8 +260,8 @@
 //SMG-27, based on the grease gun
 
 /obj/item/weapon/gun/smg/mp7
-	name = "\improper SMG-27 submachinegun"
-	desc = "An archaic design going back hundreds of years, the SMG-27 was common in its day. Today it sees limited use as cheap computer-printed replicas or family heirlooms, though it somehow got into the hands of colonial rebels."
+	name = "\improper MP-27 submachinegun"
+	desc = "An archaic design going back hundreds of years, the MP-27 was common in its day. Today it sees limited use as cheap computer-printed replicas or family heirlooms, though it somehow got into the hands of colonial rebels."
 	icon_state = "mp7"
 	item_state = "mp7"
 	caliber = CALIBER_46X30 //codex

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -24,8 +24,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //Pow! Headshot
 
 /obj/item/weapon/gun/rifle/sniper/antimaterial
-	name = "\improper SR-26 scoped rifle"
-	desc = "The SR-26 is an IFF capable sniper rifle which is mostly used by long range marksmen. It excels in long-range combat situations and support sniping. It has a laser designator installed, and the scope itself has IFF integrated into it. Uses specialized 10x28 caseless rounds made to work with the guns odd IFF-scope system.  \nIt has an integrated Target Marker and a Laser Targeting system.\n\"Peace Through Superior Firepower\"."
+	name = "\improper T-26 scoped rifle"
+	desc = "The T-26 is an IFF capable sniper rifle which is mostly used by long range marksmen. It excels in long-range combat situations and support sniping. It has a laser designator installed, and the scope itself has IFF integrated into it. Uses specialized 10x28 caseless rounds made to work with the guns odd IFF-scope system.  \nIt has an integrated Target Marker and a Laser Targeting system.\n\"Peace Through Superior Firepower\"."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t26"
 	item_state = "t26"
@@ -229,7 +229,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 
 /obj/item/weapon/gun/rifle/sniper/elite
-	name = "\improper SR-42 anti-tank sniper rifle"
+	name = "\improper M-42C anti-tank sniper rifle"
 	desc = "A high end mag-rail heavy sniper rifle from Nanotrasen chambered in the heaviest ammo available, 10x99mm Caseless."
 	icon_state = "m42c"
 	item_state = "m42c"
@@ -266,7 +266,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //SVD //Based on the Dragunov sniper rifle.
 
 /obj/item/weapon/gun/rifle/sniper/svd
-	name = "\improper SR-33 Dragunov sniper rifle"
+	name = "\improper SVD-33 Dragunov sniper rifle"
 	desc = "A semiautomatic sniper rifle, famed for it's marksmanship, and is built from the ground up for it. Fires 7.62x54mmR rounds."
 	icon = 'icons/Marine/gun64.dmi'
 	item_icons = list(
@@ -317,8 +317,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //Based off the XM-8. BR-8 rifle
 
 /obj/item/weapon/gun/rifle/tx8
-	name = "\improper BR-8 scout rifle"
-	desc ="The BR-8 is a light specialized scout rifle, mostly used by light infantry and scouts. It's designed to be useable at all ranges by being very adaptable to different situations due to the ability to use different ammo types. Has IFF.  Takes specialized overpressured 10x28mm rounds."
+	name = "\improper TX-8 scout rifle"
+	desc ="The TX-8 is a light specialized scout rifle, mostly used by light infantry and scouts. It's designed to be useable at all ranges by being very adaptable to different situations due to the ability to use different ammo types. Has IFF.  Takes specialized overpressured 10x28mm rounds."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "tx8"
 	item_state = "tx8"
@@ -385,7 +385,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 // MINIGUN
 
 /obj/item/weapon/gun/minigun
-	name = "\improper MG-100 Vindicator Minigun"
+	name = "\improper T-100 Vindicator Minigun"
 	desc = "A six barreled rotary machine gun, The ultimate in man-portable firepower, capable of laying down high velocity armor piercing rounds this thing will no doubt pack a punch.. If you don't kill all your friends with it, you can use the stablizing system of the Powerpack to fire aimed fire, but you'll move incredibly slowly."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "minigun"
@@ -443,8 +443,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 // SG minigun
 
 /obj/item/weapon/gun/minigun/smart_minigun
-	name = "\improper SG-85 smart handheld gatling gun"
-	desc = "A true monster of providing supportive suppresing fire, the SG-85 is the TGMC's IFF-capable minigun for heavy fire support duty. Boasting a higher firerate than any other handheld weapon. It is chambered in 10x26 caseless."
+	name = "\improper T-85 smart handheld gatling gun"
+	desc = "A true monster of providing supportive suppresing fire, the T-85 is the TGMC's IFF-capable minigun for heavy fire support duty. Boasting a higher firerate than any other handheld weapon. It is chambered in 10x26 caseless."
 	icon_state = "minigun_sg"
 	item_state = "minigun_sg"
 	fire_animation = "minigun_sg_fire"
@@ -472,10 +472,10 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 // PEPPERBALL GUN
 
 //-------------------------------------------------------
-//PB-12
+//TLLL-12
 
 /obj/item/weapon/gun/rifle/pepperball
-	name = "\improper PB-12 pepperball gun"
+	name = "\improper TLLL-12 pepperball gun"
 	desc = "The PB-12 is ostensibly riot control device used by the TGMC in spiffy colors, working through a SAN ball that sends a short acting neutralizing chemical to knock out it's target, or weaken them. Guranteed to work on just about everything. Uses SAN Ball Holders as magazines."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "pepperball"
@@ -525,7 +525,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 /obj/item/weapon/gun/rifle/pepperball/pepperball_mini
 	name = "mini pepperball gun"
-	desc = "An attachable version of the PB-12 pepperball gun. It has a smaller magazine size and has a slower rate of fire."
+	desc = "An attachable version of the TLLL-12 pepperball gun. It has a smaller magazine size and has a slower rate of fire."
 	icon_state = "pepperball_mini"
 	slot = ATTACHMENT_SLOT_UNDER
 	max_shells = 20
@@ -633,8 +633,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //RL-152 RPG
 
 /obj/item/weapon/gun/launcher/rocket/sadar
-	name = "\improper RL-152 sadar rocket launcher"
-	desc = "The RL-152 is the primary anti-armor weapon of the TGMC. Used to take out light-tanks and enemy structures, the RL-152 rocket launcher is a dangerous weapon with a variety of combat uses. Uses a variety of 84mm rockets."
+	name = "\improper T-152 sadar rocket launcher"
+	desc = "The T-152 is the primary anti-armor weapon of the TGMC. Used to take out light-tanks and enemy structures, the RL-152 rocket launcher is a dangerous weapon with a variety of combat uses. Uses a variety of 84mm rockets."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "sadar"
 	item_state = "sadar"
@@ -700,8 +700,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //M5 RPG'S MEAN FUCKING COUSIN
 
 /obj/item/weapon/gun/launcher/rocket/m57a4
-	name = "\improper RL-57A quad thermobaric launcher"
-	desc = "The RL-57A is posssibly the most destructive man-portable weapon ever made. It is a 4-barreled missile launcher capable of burst-firing 4 thermobaric missiles. Enough said."
+	name = "\improper M-57E quad thermobaric launcher"
+	desc = "The M-57E is posssibly the most destructive man-portable weapon ever made. It is a 4-barreled missile launcher capable of burst-firing 4 thermobaric missiles. Enough said."
 	icon_state = "m57a4"
 	item_state = "m57a4"
 	max_shells = 4 //codex
@@ -732,8 +732,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness)
 
 /obj/item/weapon/gun/launcher/rocket/m57a4/t57
-	name = "\improper RL-57 quad thermobaric launcher"
-	desc = "The RL-57 is posssibly the most awful man portable weapon. It is a 4-barreled missile launcher capable of burst-firing 4 thermobaric missiles with nearly no force to the rocket. Enough said."
+	name = "\improper T-57 quad thermobaric launcher"
+	desc = "The T-57 is posssibly the most awful man portable weapon. It is a 4-barreled missile launcher capable of burst-firing 4 thermobaric missiles with nearly no force to the rocket. Enough said."
 	icon_state = "t57"
 	item_state = "t57"
 	default_ammo_type = /obj/item/ammo_magazine/rocket/m57a4
@@ -744,8 +744,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //RL-160 Recoilless Rifle. Its effectively an RPG codewise.
 
 /obj/item/weapon/gun/launcher/rocket/recoillessrifle
-	name = "\improper RL-160 recoilless rifle"
-	desc = "The RL-160 recoilless rifle is a long range explosive ordanance device used by the TGMC used to fire explosive shells at far distances. Uses a variety of 67mm shells designed for various purposes."
+	name = "\improper T-160 recoilless rifle"
+	desc = "The T-160 recoilless rifle is a long range explosive ordanance device used by the TGMC used to fire explosive shells at far distances. Uses a variety of 67mm shells designed for various purposes."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t160"
 	item_state = "t160"
@@ -791,7 +791,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //Disposable RPG
 
 /obj/item/weapon/gun/launcher/rocket/oneuse
-	name = "\improper RL-72 disposable rocket launcher"
+	name = "\improper T-72 disposable rocket launcher"
 	desc = "This is the premier disposable rocket launcher used throughout the galaxy, it cannot be reloaded or unloaded on the field. This one fires an 84mm explosive rocket. Spacebar to shorten or extend it to make it storeable or fireable, respectively."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t72"
@@ -920,11 +920,11 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	movement_acc_penalty_mult = 5 //You shouldn't fire this on the move
 
 //-------------------------------------------------------
-//RG-220 Railgun
+//TX-220 Railgun
 
 /obj/item/weapon/gun/rifle/railgun
-	name = "\improper RG-220 railgun"
-	desc = "The RG-220 is a specialized heavy duty railgun made to shred through hard armor to allow for follow up attacks. Uses specialized canisters to reload."
+	name = "\improper TX-220 railgun"
+	desc = "The TX-220 is a specialized heavy duty railgun made to shred through hard armor to allow for follow up attacks. Uses specialized canisters to reload."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "railgun"
 	item_state = "railgun"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -741,7 +741,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 
 //-------------------------------------------------------
-//RL-160 Recoilless Rifle. Its effectively an RPG codewise.
+//T-160 Recoilless Rifle. Its effectively an RPG codewise.
 
 /obj/item/weapon/gun/launcher/rocket/recoillessrifle
 	name = "\improper T-160 recoilless rifle"

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -59,7 +59,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/large	// Extra thicc tank
 	name = "large flamerthrower tank"
-	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the FL-84 flamethrower."
+	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the TL-84 flamethrower."
 	icon_state = "flametank_large"
 	max_rounds = 75
 	current_rounds = 75
@@ -77,7 +77,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/large/X
 	name = "large flamethrower tank (X)"
-	desc = "A large fuel tank of ultra thick napthal Fuel type X, a sticky combustable liquid chemical that burns extremely hot, for use in the FL-84 flamethrower. Handle with care."
+	desc = "A large fuel tank of ultra thick napthal Fuel type X, a sticky combustable liquid chemical that burns extremely hot, for use in the TL-84 flamethrower. Handle with care."
 	icon_state = "flametank_large_blue"
 	default_ammo = /datum/ammo/flamethrower/blue
 	icon_state_mini = "tank_blue"
@@ -92,7 +92,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/backtank
 	name = "back fuel tank"
-	desc = "A specialized fuel tank for use with the FL-84 flamethrower and FL-240 incinerator unit."
+	desc = "A specialized fuel tank for use with the TL-84 flamethrower and M-240 incinerator unit."
 	icon_state = "flamethrower_tank"
 	flags_equip_slot = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
@@ -107,14 +107,14 @@
 
 /obj/item/ammo_magazine/flamer_tank/backtank/X
 	name = "back fuel tank (X)"
-	desc = "A specialized fuel tank of ultra thick napthal type X for use with the FL-84 flamethrower and FL-240 incinerator unit."
+	desc = "A specialized fuel tank of ultra thick napthal type X for use with the TL-84 flamethrower and M-240 incinerator unit."
 	icon_state = "x_flamethrower_tank"
 	default_ammo = /datum/ammo/flamethrower/blue
 	dispenser_type = /obj/structure/reagent_dispensers/fueltank/xfuel
 
 /obj/item/ammo_magazine/flamer_tank/water
 	name = "pressurized water tank"
-	desc = "A cannister of water for use with the FL-84's underslung extinguisher. Can be refilled by hand."
+	desc = "A cannister of water for use with the TL-84's underslung extinguisher. Can be refilled by hand."
 	icon_state = "watertank"
 	max_rounds = 200
 	current_rounds = 200

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -108,7 +108,7 @@
 
 /obj/item/ammo_magazine/packet/standardautoshotgun
 	name = "box of 16 Gauge shotgun slugs"
-	desc = "A box containing 16 Gauge slugs, they look like they'd fit in the SH-15."
+	desc = "A box containing 16 Gauge slugs, they look like they'd fit in the TX-15."
 	icon_state = "box_16gslug"
 	default_ammo = /datum/ammo/bullet/shotgun/tx15_slug
 	caliber = CALIBER_16G
@@ -117,7 +117,7 @@
 
 /obj/item/ammo_magazine/packet/standardautoshotgun/flechette
 	name = "box of 16 Gauge shotgun flechette shells"
-	desc = "A box containing 16 Gauge flechette shells, they look like they'd fit in the SH-15."
+	desc = "A box containing 16 Gauge flechette shells, they look like they'd fit in the TX-15."
 	icon_state = "box_16gflech"
 	default_ammo = /datum/ammo/bullet/shotgun/tx15_flechette
 

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -1,6 +1,6 @@
 ///Default ammo for the HSG-102.
 /obj/item/ammo_magazine/tl102
-	name = "HSG-102 drum magazine (10x30mm Caseless)"
+	name = "TL-102 drum magazine (10x30mm Caseless)"
 	desc = "A box of 300, 10x30mm caseless tungsten rounds for the HSG-102 mounted heavy smartgun."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-hmg.dmi'
@@ -17,8 +17,8 @@
 	max_rounds = 500
 
 /obj/item/ammo_magazine/heavymachinegun
-	name = "HMG-08 drum magazine (10x30mm Caseless)"
-	desc = "A box of 500, 10x28mm caseless tungsten rounds for the HMG-08 mounted heavy machinegun. Is probably not going to fit in your backpack. Put it on your belt or back."
+	name = "MG-08/495 drum magazine (10x30mm Caseless)"
+	desc = "A box of 500, 10x28mm caseless tungsten rounds for the MG-08/495 mounted heavy machinegun. Is probably not going to fit in your backpack. Put it on your belt or back."
 	w_class = WEIGHT_CLASS_BULKY
 	flags_equip_slot = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	icon = 'icons/Marine/marine-hmg.dmi'
@@ -31,8 +31,8 @@
 	reload_delay = 10 SECONDS
 
 /obj/item/ammo_magazine/heavymachinegun/small
-	name = "HMG-08 box magazine (10x30mm Caseless)"
-	desc = "A box of 250 10x28mm caseless tungsten rounds for the HMG-08 mounted heavy machinegun."
+	name = "MG-08/495 box magazine (10x30mm Caseless)"
+	desc = "A box of 250 10x28mm caseless tungsten rounds for the MG-08/495 mounted heavy machinegun."
 	w_class = WEIGHT_CLASS_NORMAL
 	flags_equip_slot = ITEM_SLOT_BELT
 	icon_state = "mg08_mag_small"
@@ -41,8 +41,8 @@
 	reload_delay = 5 SECONDS
 
 /obj/item/ammo_magazine/standard_mmg
-	name = "MG-27 box magazine (10x27m Caseless)"
-	desc = "A box of 100 10x27mm caseless rounds for the MG-27 medium machinegun."
+	name = "T-27 box magazine (10x27m Caseless)"
+	desc = "A box of 100 10x27mm caseless rounds for the T-27 medium machinegun."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-mmg.dmi'
 	icon_state = "mag"
@@ -54,8 +54,8 @@
 	reload_delay = 1 SECONDS
 
 /obj/item/ammo_magazine/standard_agls
-	name = "AGLS-37 HE magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless HE grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 HE magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless HE grenades for the TSGLS-37 automatic grenade launcher."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "ags_mag"
@@ -66,38 +66,38 @@
 	reload_delay = 4 SECONDS
 
 /obj/item/ammo_magazine/standard_agls/fragmentation
-	name = "AGLS-37 Frag magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless Fragmentation grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 Frag magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless Fragmentation grenades for the TSGLS-37 automatic grenade launcher."
 	icon_state = "ags_mag_frag"
 	default_ammo = /datum/ammo/ags_shrapnel
 
 /obj/item/ammo_magazine/standard_agls/incendiary
-	name = "AGLS-37 WP magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless White Phosphorous grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 WP magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless White Phosphorous grenades for the TSGLS-37 automatic grenade launcher."
 	icon_state = "ags_mag_incend"
 	default_ammo = /datum/ammo/ags_shrapnel/incendiary
 
 /obj/item/ammo_magazine/standard_agls/flare
-	name = "AGLS-37 Flare magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless Flare grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 Flare magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless Flare grenades for the TSGLS-37 automatic grenade launcher."
 	icon_state = "ags_mag_flare"
 	default_ammo = /datum/ammo/grenade_container/ags_grenade/flare
 
 /obj/item/ammo_magazine/standard_agls/cloak
-	name = "AGLS-37 Cloak magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless Cloak grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 Cloak magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless Cloak grenades for the TSGLS-37 automatic grenade launcher."
 	icon_state = "ags_mag_cloak"
 	default_ammo = /datum/ammo/grenade_container/ags_grenade/cloak
 
 /obj/item/ammo_magazine/standard_agls/tanglefoot
-	name = "AGLS-37 Tanglefoot magazine (40mm Caseless)"
-	desc = "A box holding 30 40mm caseless Tanglefoot grenades for the AGLS-37 automatic grenade launcher."
+	name = "TSGLS-37 Tanglefoot magazine (40mm Caseless)"
+	desc = "A box holding 30 40mm caseless Tanglefoot grenades for the TSGLS-37 automatic grenade launcher."
 	icon_state = "ags_mag_pgas"
 	default_ammo = /datum/ammo/grenade_container/ags_grenade/tanglefoot
 
 
 /obj/item/ammo_magazine/standard_atgun
-	name = "AT-36 AP-HE shell (37mm Shell)"
+	name = "TAT-36 AP-HE shell (37mm Shell)"
 	desc = "A 37mm shell for light anti tank guns. Will penetrate walls and fortifications, before hitting a target and exploding, has less payload and punch than usual rounds."
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/Marine/marine-atgun.dmi'
@@ -110,36 +110,36 @@
 	reload_delay = 2 SECONDS
 
 /obj/item/ammo_magazine/standard_atgun/apcr
-	name = "AT-36 APCR shell (37mm Shell)"
+	name = "TAT-36 APCR shell (37mm Shell)"
 	desc = "A 37mm tungsten shell for light anti tank guns made to penetrate through just about everything, but it won't leave a big hole."
 	icon_state = "tat36_shell_apcr"
 	item_state = "tat36_apcr"
 	default_ammo = /datum/ammo/rocket/atgun_shell/apcr
 
 /obj/item/ammo_magazine/standard_atgun/he
-	name = "AT-36 HE (37mm Shell)"
+	name = "TAT-36 HE (37mm Shell)"
 	desc = "A 37mm shell for light anti tank guns made to destroy fortifications, the high amount of payload gives it a slow speed. But it leaves quite a hole."
 	icon_state = "tat36_shell_he"
 	item_state = "tat36_he"
 	default_ammo = /datum/ammo/rocket/atgun_shell/he
 
 /obj/item/ammo_magazine/standard_atgun/beehive
-	name = "AT-36 Beehive (37mm Shell)"
+	name = "TAT-36 Beehive (37mm Shell)"
 	desc = "A 37mm shell for light anti tank guns made to mince infantry, the light payload gives it moderate speed. Turns anyone into swiss cheese."
 	icon_state = "tat36_shell_beehive"
 	item_state = "tat36_beehive"
 	default_ammo = /datum/ammo/rocket/atgun_shell/beehive
 
 /obj/item/ammo_magazine/standard_atgun/incend
-	name = "AT-36 Napalm (37mm Shell)"
+	name = "TAT-36 Napalm (37mm Shell)"
 	desc = "A 37mm shell for light anti tank guns made to set the battlefield ablaze, the light payload gives it a moderate speed. Will cook any target flambé."
 	icon_state = "tat36_shell_incend"
 	item_state = "tat36_incend"
 	default_ammo = /datum/ammo/rocket/atgun_shell/beehive/incend
 
 /obj/item/ammo_magazine/heavy_minigun
-	name = "MG-2005 box magazine (7.62x51mm)"
-	desc = "A box of 1000 rounds for the MG-2005 mounted minigun."
+	name = "TL-2005 box magazine (7.62x51mm)"
+	desc = "A box of 1000 rounds for the T-2005 mounted minigun."
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "minigun"
@@ -151,7 +151,7 @@
 
 /obj/item/ammo_magazine/auto_cannon
 	name = "autocannon high-velocity magazine(20mm)"
-	desc = "A box of 100 high-velocity 20mm rounds for the ATR-22 mounted autocannon. Will pierce people and cover."
+	desc = "A box of 100 high-velocity 20mm rounds for the TL-22 mounted autocannon. Will pierce people and cover."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-ac.dmi'
 	icon_state = "ac_mag"
@@ -164,7 +164,7 @@
 
 /obj/item/ammo_magazine/auto_cannon/flak
 	name = "autocannon smart-detonating magazine(20mm)"
-	desc = "A box of 80 smart-detonating 20mm rounds for the ATR-22 mounted autocannon. Will detonate upon hitting a target."
+	desc = "A box of 80 smart-detonating 20mm rounds for the TL-22 mounted autocannon. Will detonate upon hitting a target."
 	icon_state = "ac_mag_flak"
 	item_state = "ac_flak"
 	default_ammo = /datum/ammo/bullet/auto_cannon/flak
@@ -181,8 +181,8 @@
 	icon_state = "hl_mag"
 
 /obj/item/ammo_magazine/heavy_rr
-	name = "RR-15 HE shell (75mm Shell)"
-	desc = "A 75mm HE shell for the RR-15 mounted heavy recoilless rifle."
+	name = "TL-15 HE shell (75mm Shell)"
+	desc = "A 75mm HE shell for the TL-15 mounted heavy recoilless rifle."
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "75shell"

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -1,7 +1,7 @@
-///Default ammo for the HSG-102.
+///Default ammo for the TL-102.
 /obj/item/ammo_magazine/tl102
 	name = "TL-102 drum magazine (10x30mm Caseless)"
-	desc = "A box of 300, 10x30mm caseless tungsten rounds for the HSG-102 mounted heavy smartgun."
+	desc = "A box of 300, 10x30mm caseless tungsten rounds for the TL-102 mounted heavy smartgun."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "mag"
@@ -12,7 +12,7 @@
 	reload_delay = 5 SECONDS
 	icon_state_mini = "mag_hmg"
 
-///This is the one that comes in the mapbound and dropship mounted version of the HSG-102, it has a stupid amount of ammo. Even more than the ammo counter can display.
+///This is the one that comes in the mapbound and dropship mounted version of the TL-102, it has a stupid amount of ammo. Even more than the ammo counter can display.
 /obj/item/ammo_magazine/tl102/hsg_nest
 	max_rounds = 500
 
@@ -139,7 +139,7 @@
 
 /obj/item/ammo_magazine/heavy_minigun
 	name = "TL-2005 box magazine (7.62x51mm)"
-	desc = "A box of 1000 rounds for the T-2005 mounted minigun."
+	desc = "A box of 1000 rounds for the TL-2005 mounted minigun."
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "minigun"

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -3,7 +3,7 @@
 //M4A3 PISTOL
 
 /obj/item/ammo_magazine/pistol/standard_pistol
-	name = "\improper P-14 magazine (9mm)"
+	name = "\improper TP-14 magazine (9mm)"
 	desc = "A pistol magazine."
 	caliber = CALIBER_9X19
 	icon_state = "tp14"
@@ -15,8 +15,8 @@
 //-------------------------------------------------------
 //PP-7 Plasma Pistol
 /obj/item/ammo_magazine/pistol/plasma_pistol
-	name = "\improper PP-7 plasma cell"
-	desc = "An energy cell for the PP-7 plasma pistol."
+	name = "\improper TX-7 plasma cell"
+	desc = "An energy cell for the TX-7 plasma pistol."
 	caliber = CALIBER_PLASMA
 	icon_state = "tx7"
 	max_rounds = 10
@@ -66,7 +66,7 @@
 //P-1911
 
 /obj/item/ammo_magazine/pistol/m1911
-	name = "\improper P-1911 magazine (.45)"
+	name = "\improper M1911 magazine (.45)"
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = CALIBER_45ACP
 	icon_state = "1911"
@@ -79,7 +79,7 @@
 //P-23
 
 /obj/item/ammo_magazine/pistol/standard_heavypistol
-	name = "\improper P-23 magazine (.45)"
+	name = "\improper TP-23 magazine (.45)"
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = CALIBER_45ACP
 	icon_state = ".45"
@@ -91,7 +91,7 @@
 //Beretta 92FS, the gun McClane carries around in Die Hard. Very similar to the service pistol, all around.
 
 /obj/item/ammo_magazine/pistol/g22
-	name = "\improper P-22 magazine (9mm)"
+	name = "\improper G22 magazine (9mm)"
 	caliber = CALIBER_9X19
 	icon_state = "g22"
 	icon_state_mini = "mag_pistol_normal"
@@ -155,8 +155,8 @@
 //P-17.
 
 /obj/item/ammo_magazine/pistol/standard_pocketpistol
-	name = "\improper P-17 pocket pistol AP magazine (.380)"
-	desc = "A surprisingly small magazine used by the P-17 pistol holding .380 ACP bullets."
+	name = "\improper TP-17 pocket pistol AP magazine (.380)"
+	desc = "A surprisingly small magazine used by the TP-17 pistol holding .380 ACP bullets."
 	default_ammo = /datum/ammo/bullet/pistol/tiny/ap
 	caliber = CALIBER_380ACP
 	icon_state = "tp17"
@@ -256,7 +256,7 @@
 
 //SP-13 (Calico)
 /obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol
-	name = "\improper SP-13 magazine (9mm AP)"
+	name = "\improper TX-13 magazine (9mm AP)"
 	caliber = CALIBER_9X19
 	icon_state = "tx13"
 	icon_state_mini = "mag_pistol_tube"

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -2,7 +2,7 @@
 //external magazines
 
 /obj/item/ammo_magazine/revolver
-	name = "\improper R-44 magnum speed loader (.44)"
+	name = "\improper M-44 magnum speed loader (.44)"
 	desc = "A revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver
 	flags_equip_slot = NONE
@@ -13,21 +13,21 @@
 	max_rounds = 6
 
 /obj/item/ammo_magazine/revolver/marksman
-	name = "\improper R-44 marksman speed loader (.44)"
+	name = "\improper M-44 marksman speed loader (.44)"
 	default_ammo = /datum/ammo/bullet/revolver/marksman
 	caliber = CALIBER_44
 	icon_state = "m_m44"
 	icon_state_mini = "mag_revolver_bronze_red"
 
 /obj/item/ammo_magazine/revolver/heavy
-	name = "\improper R-44 PW-MX speed loader (.44)"
+	name = "\improper M-44 PW-MX speed loader (.44)"
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = CALIBER_44
 	icon_state = "h_m44"
 	icon_state_mini = "mag_revolver_bronze_purple"
 
 /obj/item/ammo_magazine/revolver/standard_revolver
-	name = "\improper R-44 magnum speed loader (.44)"
+	name = "\improper TP-44 magnum speed loader (.44)"
 	desc = "A revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver/tp44
 	flags_equip_slot = NONE

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -5,7 +5,7 @@
 //M41A PULSE RIFLE AMMUNITION
 
 /obj/item/ammo_magazine/rifle/
-	name = "\improper PR-412 magazine (10x24mm)"
+	name = "\improper M412 magazine (10x24mm)"
 	desc = "A 10mm assault rifle magazine."
 	caliber = CALIBER_10X24_CASELESS
 	icon_state = "m412"
@@ -15,7 +15,7 @@
 	max_rounds = 40
 
 /obj/item/ammo_magazine/rifle/extended
-	name = "\improper PR-412 extended magazine (10x24mm)"
+	name = "\improper M412 extended magazine (10x24mm)"
 	desc = "A 10mm assault extended rifle magazine."
 	icon_state = "m412_ext"
 	icon_state_mini = "mag_rifle_big_yellow"
@@ -23,7 +23,7 @@
 	bonus_overlay = "m412_ex"
 
 /obj/item/ammo_magazine/rifle/incendiary
-	name = "\improper PR-412 incendiary magazine (10x24mm)"
+	name = "\improper M412 incendiary magazine (10x24mm)"
 	desc = "A 10mm assault rifle magazine."
 	icon_state = "m412_incendiary"
 	icon_state_mini = "mag_rifle_big_red"
@@ -31,7 +31,7 @@
 	bonus_overlay = "m412_incend"
 
 /obj/item/ammo_magazine/rifle/ap
-	name = "\improper PR-412 AP magazine (10x24mm)"
+	name = "\improper M412 AP magazine (10x24mm)"
 	desc = "A 10mm armor piercing magazine."
 	icon_state = "m412_ap"
 	icon_state_mini = "mag_rifle_big_green"
@@ -42,7 +42,7 @@
 //T18 Carbine
 
 /obj/item/ammo_magazine/rifle/standard_carbine
-	name = "\improper AR-18 magazine (10x24mm)"
+	name = "\improper T-18 magazine (10x24mm)"
 	desc = "A 10mm carbine magazine."
 	caliber = CALIBER_10X24_CASELESS
 	icon_state = "t18"
@@ -55,7 +55,7 @@
 //T12 Assault Rifle
 
 /obj/item/ammo_magazine/rifle/standard_assaultrifle
-	name = "\improper AR-12 magazine (10x24mm)"
+	name = "\improper T-12 magazine (10x24mm)"
 	desc = "A 10mm assault rifle magazine."
 	caliber = CALIBER_10X24_CASELESS
 	icon_state = "t12"
@@ -68,7 +68,7 @@
 //T37 DMR
 
 /obj/item/ammo_magazine/rifle/standard_dmr
-	name = "\improper DMR-37 magazine (10x27mm)"
+	name = "\improper T-37 magazine (10x27mm)"
 	desc = "A 10mm DMR magazine."
 	caliber = CALIBER_10x27_CASELESS
 	icon_state = "t37"
@@ -81,7 +81,7 @@
 //T64 BR
 
 /obj/item/ammo_magazine/rifle/standard_br
-	name = "\improper BR-64 magazine (10x26.5mm)"
+	name = "\improper T-64 magazine (10x26.5mm)"
 	desc = "A 10mm battle rifle magazine."
 	caliber = CALIBER_10x265_CASELESS
 	icon_state = "t64"
@@ -94,8 +94,8 @@
 //M41A TRUE AND ORIGINAL
 
 /obj/item/ammo_magazine/rifle/m41a
-	name = "\improper PR-11 magazine (10x24mm)"
-	desc = "A semi-rectangular box of rounds for the PR-11 Pulse Rifle."
+	name = "\improper HK-11 magazine (10x24mm)"
+	desc = "A semi-rectangular box of rounds for the HK-11 Pulse Rifle."
 	icon_state = "m41a"
 	icon_state_mini = "mag_rifle_big_light"
 	max_rounds = 95
@@ -202,8 +202,8 @@
 //MG-42 Light Machine Gun
 
 /obj/item/ammo_magazine/standard_lmg
-	name = "\improper MG-42 drum magazine (10x24mm)"
-	desc = "A drum magazine for the MG-42 light machine gun."
+	name = "\improper T-42 drum magazine (10x24mm)"
+	desc = "A drum magazine for the T-42 light machine gun."
 	icon_state = "t42"
 	icon_state_mini = "mag_drum"
 	caliber = CALIBER_10X24_CASELESS
@@ -215,8 +215,8 @@
 //MG-60 General Purpose Machine Gun
 
 /obj/item/ammo_magazine/standard_gpmg
-	name = "\improper MG-60 GPMG box magazine (10x26mm)"
-	desc = "A belt box for the MG-60 general purpose machinegun."
+	name = "\improper T-60 GPMG box magazine (10x26mm)"
+	desc = "A belt box for the T-60 general purpose machinegun."
 	icon_state = "t60"
 	icon_state_mini = "mag_gpmg"
 	caliber = CALIBER_10x26_CASELESS
@@ -229,8 +229,8 @@
 //PR-412L1 HEAVY PULSE RIFLE
 
 /obj/item/ammo_magazine/m412l1_hpr
-	name = "\improper PR-412L1 box magazine (10x24mm)"
-	desc = "A semi-rectangular box of rounds for the PR-412L1 heavy pulse rifle."
+	name = "\improper M412L1 box magazine (10x24mm)"
+	desc = "A semi-rectangular box of rounds for the M412L1 heavy pulse rifle."
 	icon_state = "m412l1"
 	icon_state_mini = "mag_box"
 	caliber = CALIBER_10X24_CASELESS
@@ -253,8 +253,8 @@
 //TX-16 AUTOMATIC SHOTGUN
 
 /obj/item/ammo_magazine/rifle/tx15_flechette
-	name = "\improper SH-15 flechette magazine (16 gauge)"
-	desc = "A magazine of 16 gauge flechette rounds, for the SH-15."
+	name = "\improper TX-15 flechette magazine (16 gauge)"
+	desc = "A magazine of 16 gauge flechette rounds, for the TX-15."
 	caliber = CALIBER_16G
 	icon_state = "tx15_flechette"
 	icon_state_mini = "mag_tx15_flechette"
@@ -263,8 +263,8 @@
 	bonus_overlay = "tx15_flech"
 
 /obj/item/ammo_magazine/rifle/tx15_slug
-	name = "\improper SH-15 slug magazine (16 gauge)"
-	desc = "A magazine of 16 gauge slugs, for the SH-15."
+	name = "\improper TX-15 slug magazine (16 gauge)"
+	desc = "A magazine of 16 gauge slugs, for the TX-15."
 	caliber = CALIBER_16G
 	icon_state = "tx15_slug"
 	icon_state_mini = "mag_tx15_slug"
@@ -276,7 +276,7 @@
 //SMARTMACHINEGUN AMMUNITION
 
 /obj/item/ammo_magazine/standard_smartmachinegun
-	name = "\improper SG-29 drum magazine"
+	name = "\improper T-29 drum magazine"
 	desc = "A wide drum magazine carefully filled to capacity with 10x26mm specialized smart rounds."
 	caliber = CALIBER_10x26_CASELESS
 	icon_state = "sg29"
@@ -290,7 +290,7 @@
 //SMART TARGET RIFLE AMMUNITION
 
 /obj/item/ammo_magazine/rifle/standard_smarttargetrifle
-	name = "\improper SG-62 magazine (10x27mm HV)"
+	name = "\improper T-62 magazine (10x27mm HV)"
 	desc = "A magazine filled with 10x27mm specialized smart rounds."
 	caliber = CALIBER_10x27_CASELESS
 	icon_state = "sg62"
@@ -303,7 +303,7 @@
 //SPOTTING RIFLE AMMUNITION
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle
-	name = "\improper SG-153 magazine (12x7mm)"
+	name = "\improper TL-153 magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm lethal smart rounds, these will do nothing other than pack a big punch."
 	caliber = CALIBER_12x7
 	icon_state = "sg153"
@@ -313,37 +313,37 @@
 	icon_state_mini = "mag_sg29"
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact
-	name = "\improper SG-153 high impact magazine (12x7mm)"
+	name = "\improper TL-153 high impact magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm high impact smart rounds, these will likely stagger and slow anything they hit."
 	icon_state = "sg153_hi"
 	default_ammo = /datum/ammo/bullet/spottingrifle/highimpact
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/heavyrubber
-	name = "\improper SG-153 heavy rubber magazine (12x7mm)"
+	name = "\improper TL-153 heavy rubber magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm heavy rubber smart rounds, these will likely stun and displace anything they hit."
 	icon_state = "sg153_hr"
 	default_ammo = /datum/ammo/bullet/spottingrifle/heavyrubber
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/plasmaloss
-	name = "\improper SG-153 tanglefoot magazine (12x7mm)"
+	name = "\improper TL-153 tanglefoot magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm smart rounds tipped with 'Tanglefoot' poison, these rounds will drain the energy out of targets they hit."
 	icon_state = "sg153_hr"
 	default_ammo = /datum/ammo/bullet/spottingrifle/plasmaloss
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten
-	name = "\improper SG-153 tungsten magazine (12x7mm)"
+	name = "\improper TL-153 tungsten magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm tungsten smart rounds, these rounds will massively knock back any target it hits."
 	icon_state = "sg153_tg"
 	default_ammo = /datum/ammo/bullet/spottingrifle/tungsten
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary
-	name = "\improper SG-153 incendiary magazine (12x7mm)"
+	name = "\improper TL-153 incendiary magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm incendiary smart rounds, these rounds will set alight anything they hit."
 	icon_state = "sg153_ic"
 	default_ammo = /datum/ammo/bullet/spottingrifle/incendiary
 
 /obj/item/ammo_magazine/rifle/standard_spottingrifle/flak
-	name = "\improper SG-153 flak magazine (12x7mm)"
+	name = "\improper TL-153 flak magazine (12x7mm)"
 	desc = "A magazine filled with 12x7mm flak smart rounds, these rounds will airburst on contact with an organic target, causing damage in a small area near the target."
 	icon_state = "sg153_fl"
 	default_ammo = /datum/ammo/bullet/spottingrifle/flak
@@ -364,8 +364,8 @@
 //-------------------------------------------------------
 //Marine magazine sniper, or the SR-127.
 /obj/item/ammo_magazine/rifle/chamberedrifle
-	name = "SR-127 bolt action rifle magazine"
-	desc = "A box magazine filled with 8.6x70mm rifle rounds for the SR-127."
+	name = "TL-127 bolt action rifle magazine"
+	desc = "A box magazine filled with 8.6x70mm rifle rounds for the TL-127."
 	caliber = CALIBER_86X70
 	icon_state = "tl127"
 	icon_state_mini = "mag_rifle_big"
@@ -374,8 +374,8 @@
 	bonus_overlay = "tl127_mag"
 
 /obj/item/ammo_magazine/rifle/chamberedrifle/flak
-	name = "SR-127 bolt action rifle flak magazine"
-	desc = "A box magazine filled with 8.6x70mm rifle flak rounds for the SR-127."
+	name = "TL-127 bolt action rifle flak magazine"
+	desc = "A box magazine filled with 8.6x70mm rifle flak rounds for the TL-127."
 	icon_state = "tl127_flak"
 	icon_state_mini = "mag_sniper_blue"
 	default_ammo = /datum/ammo/bullet/sniper/pfc/flak
@@ -384,8 +384,8 @@
 //-------------------------------------------------------
 //Marine magazine automatic sniper, or the SR-81.
 /obj/item/ammo_magazine/rifle/autosniper
-	name = "\improper SR-81 automatic sniper rifle magazine"
-	desc = "A box magazine filled with low pressure 8.6x70mm rifle rounds for the SR-81."
+	name = "\improper T-81 automatic sniper rifle magazine"
+	desc = "A box magazine filled with low pressure 8.6x70mm rifle rounds for the T-81."
 	caliber = CALIBER_86X70
 	icon_state = "t81"
 	icon_state_mini = "mag_rifle_greyblue"
@@ -395,8 +395,8 @@
 //-------------------------------------------------------
 //G-11, AR-11
 /obj/item/ammo_magazine/rifle/tx11
-	name = "\improper AR-11 combat rifle magazine"
-	desc = "A magazine filled with 4.92×34mm rifle rounds for the AR-11."
+	name = "\improper TX-11 combat rifle magazine"
+	desc = "A magazine filled with 4.92×34mm rifle rounds for the TX-11."
 	caliber = CALIBER_492X34_CASELESS
 	icon_state = "tx11"
 	icon_state_mini = "mag_tx11"
@@ -406,8 +406,8 @@
 //-------------------------------------------------------
 //AR-21
 /obj/item/ammo_magazine/rifle/standard_skirmishrifle
-	name = "\improper AR-21 skirmish rifle magazine"
-	desc = "A magazine filled with 10x25mm rifle rounds for the AR-21."
+	name = "\improper T-21 skirmish rifle magazine"
+	desc = "A magazine filled with 10x25mm rifle rounds for the T-21."
 	caliber = CALIBER_10X25_CASELESS
 	icon_state = "t21"
 	icon_state_mini = "mag_rifle"
@@ -443,7 +443,7 @@
 //GL-54
 /obj/item/ammo_magazine/rifle/tx54
 	name = "\improper 20mm airburst grenade magazine"
-	desc = "A 20mm magazine loaded with airburst grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with airburst grenades. For use with the TX-54 or TX-55."
 	caliber = CALIBER_20MM
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_blue"
@@ -455,7 +455,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/he
 	name = "\improper 20mm HE grenade magazine"
-	desc = "A 20mm magazine loaded with HE grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with HE grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/he
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_red"
@@ -463,7 +463,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/incendiary
 	name = "\improper 20mm incendiary grenade magazine"
-	desc = "A 20mm magazine loaded with incendiary grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with incendiary grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/incendiary
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_orange"
@@ -471,7 +471,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/smoke
 	name = "\improper 20mm tactical smoke grenade magazine"
-	desc = "A 20mm magazine loaded with tactical smoke grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with tactical smoke grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/smoke
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_green"
@@ -479,7 +479,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/smoke/dense
 	name = "\improper 20mm smoke grenade magazine"
-	desc = "A 20mm magazine loaded with smoke grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with smoke grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/smoke/dense
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_cyan"
@@ -487,7 +487,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/smoke/tangle
 	name = "\improper 20mm tanglefoot grenade magazine"
-	desc = "A 20mm magazine loaded with tanglefoot grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with tanglefoot grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/smoke/tangle
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_purple"
@@ -495,7 +495,7 @@
 
 /obj/item/ammo_magazine/rifle/tx54/razor
 	name = "\improper 20mm razorburn grenade magazine"
-	desc = "A 20mm magazine loaded with razorburn grenades. For use with the GL-54 or AR-55."
+	desc = "A 20mm magazine loaded with razorburn grenades. For use with the TX-54 or TX-55."
 	default_ammo = /datum/ammo/tx54/razor
 	icon_state = "tx54_airburst"
 	icon_state_mini = "mag_sniper_yellow"

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -199,7 +199,7 @@
 	max_rounds = 24
 
 //-------------------------------------------------------
-//MG-42 Light Machine Gun
+//T-42 Light Machine Gun
 
 /obj/item/ammo_magazine/standard_lmg
 	name = "\improper T-42 drum magazine (10x24mm)"
@@ -226,7 +226,7 @@
 	reload_delay = 3 SECONDS
 
 //-------------------------------------------------------
-//PR-412L1 HEAVY PULSE RIFLE
+//M412L1 HEAVY PULSE RIFLE
 
 /obj/item/ammo_magazine/m412l1_hpr
 	name = "\improper M412L1 box magazine (10x24mm)"
@@ -362,7 +362,7 @@
 	max_rounds = 20
 
 //-------------------------------------------------------
-//Marine magazine sniper, or the SR-127.
+//Marine magazine sniper, or the TL-127.
 /obj/item/ammo_magazine/rifle/chamberedrifle
 	name = "TL-127 bolt action rifle magazine"
 	desc = "A box magazine filled with 8.6x70mm rifle rounds for the TL-127."
@@ -382,7 +382,7 @@
 	bonus_overlay = "tl127_flak"
 
 //-------------------------------------------------------
-//Marine magazine automatic sniper, or the SR-81.
+//Marine magazine automatic sniper, or the T-81.
 /obj/item/ammo_magazine/rifle/autosniper
 	name = "\improper T-81 automatic sniper rifle magazine"
 	desc = "A box magazine filled with low pressure 8.6x70mm rifle rounds for the T-81."
@@ -393,7 +393,7 @@
 	max_rounds = 20
 
 //-------------------------------------------------------
-//G-11, AR-11
+//G-11, TX-11
 /obj/item/ammo_magazine/rifle/tx11
 	name = "\improper TX-11 combat rifle magazine"
 	desc = "A magazine filled with 4.92×34mm rifle rounds for the TX-11."
@@ -404,7 +404,7 @@
 	max_rounds = 70
 
 //-------------------------------------------------------
-//AR-21
+//T-21
 /obj/item/ammo_magazine/rifle/standard_skirmishrifle
 	name = "\improper T-21 skirmish rifle magazine"
 	desc = "A magazine filled with 10x25mm rifle rounds for the T-21."
@@ -440,7 +440,7 @@
 	max_rounds = 30
 
 //-------------------------------------------------------
-//GL-54
+//TX-54
 /obj/item/ammo_magazine/rifle/tx54
 	name = "\improper 20mm airburst grenade magazine"
 	desc = "A 20mm magazine loaded with airburst grenades. For use with the TX-54 or TX-55."

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -9,7 +9,7 @@
 //M25 SMG ammo
 
 /obj/item/ammo_magazine/smg/m25
-	name = "\improper SMG-25 magazine (10x20mm)"
+	name = "\improper MR-25 magazine (10x20mm)"
 	desc = "A 10x20mm caseless submachinegun magazine."
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "m25"
@@ -17,24 +17,24 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_magazine/smg/m25/ap
-	name = "\improper SMG-25 AP magazine (10x20mm)"
+	name = "\improper MR-25 AP magazine (10x20mm)"
 	icon_state = "m25_ap"
 	default_ammo = /datum/ammo/bullet/smg/ap
 	icon_state_mini = "mag_smg_green"
 	bonus_overlay = "m25_ap"
 
 /obj/item/ammo_magazine/smg/m25/extended
-	name = "\improper SMG-25 extended magazine (10x20mm)"
+	name = "\improper MR-25 extended magazine (10x20mm)"
 	icon_state = "m25_ext"
 	max_rounds = 90
 	icon_state_mini = "mag_smg_yellow"
 	bonus_overlay = "m25_ex"
 
 //-------------------------------------------------------
-//MP-19 Machinepistol ammo
+//TP-19 Machinepistol ammo
 
 /obj/item/ammo_magazine/smg/standard_machinepistol
-	name = "\improper MP-19 machinepistol magazine (10x20mm)"
+	name = "\improper TP-19 machinepistol magazine (10x20mm)"
 	desc = "A 10x20mm caseless machine pistol magazine."
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t19"
@@ -43,10 +43,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 //-------------------------------------------------------
-//SMG-90 SMG ammo
+//T-90 SMG ammo
 
 /obj/item/ammo_magazine/smg/standard_smg
-	name = "\improper SMG-90 submachine gun magazine (10x20mm)"
+	name = "\improper T-90 submachine gun magazine (10x20mm)"
 	desc = "A 10x20mm caseless submachine gun magazine."
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t90"
@@ -55,11 +55,11 @@
 	icon_state_mini = "mag_t90"
 
 //-------------------------------------------------------
-//SMG-27, based on the SMG-27, based on the M7.
+//MP-27, based on the MP-27, based on the M7.
 
 /obj/item/ammo_magazine/smg/mp7
-	name = "\improper SMG-27 magazine (4.6x30mm)"
-	desc = "A 4.6mm magazine for the SMG-27."
+	name = "\improper MP-27 magazine (4.6x30mm)"
+	desc = "A 4.6mm magazine for the MP-27."
 	default_ammo = /datum/ammo/bullet/smg/ap
 	caliber = CALIBER_46X30
 	icon_state = "mp7"
@@ -107,8 +107,8 @@
 //GENERIC UZI //Based on the uzi submachinegun, of course.
 
 /obj/item/ammo_magazine/smg/uzi
-	name = "\improper SMG-2 magazine (9mm)"
-	desc = "A magazine for the SMG-2."
+	name = "\improper MP-2 magazine (9mm)"
+	desc = "A magazine for the MP-2."
 	caliber = CALIBER_9X21
 	icon_state = "uzi"
 	icon_state_mini = "mag_smg_dark"

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -3,7 +3,7 @@
 //Keyword rifles. They are subtype of rifles, but still contained here as a specialist weapon.
 
 /obj/item/ammo_magazine/sniper
-	name = "\improper SR-26 magazine (10x28mm)"
+	name = "\improper T-26 magazine (10x28mm)"
 	desc = "A magazine of antimaterial rifle ammo."
 	caliber = CALIBER_10X28
 	icon_state = "t26"
@@ -15,14 +15,14 @@
 
 
 /obj/item/ammo_magazine/sniper/incendiary
-	name = "\improper SR-26 incendiary magazine (10x28mm)"
+	name = "\improper T-26 incendiary magazine (10x28mm)"
 	default_ammo = /datum/ammo/bullet/sniper/incendiary
 	icon_state = "t26_inc"
 	icon_state_mini = "mag_sniper_red"
 	bonus_overlay = "t26_incend"
 
 /obj/item/ammo_magazine/sniper/flak
-	name = "\improper SR-26 flak magazine (10x28mm)"
+	name = "\improper T-26 flak magazine (10x28mm)"
 	default_ammo = /datum/ammo/bullet/sniper/flak
 	icon_state = "t26_flak"
 	icon_state_mini = "mag_sniper_blue"
@@ -31,7 +31,7 @@
 //SR-42 magazine
 
 /obj/item/ammo_magazine/sniper/elite
-	name = "\improper SR-42 marksman magazine (10x99mm)"
+	name = "\improper M42C marksman magazine (10x99mm)"
 	default_ammo = /datum/ammo/bullet/sniper/elite
 	caliber = CALIBER_10X99
 	icon_state = "m42c"
@@ -56,7 +56,7 @@
 
 /obj/item/ammo_magazine/rifle/tx8
 	name = "\improper high velocity magazine (10x28mm)"
-	desc = "A magazine of overpressuered high velocity rounds for use in the BR-8 battle rifle. The BR-8 battle rifle is the only gun that can chamber these rounds."
+	desc = "A magazine of overpressuered high velocity rounds for use in the TX-8 battle rifle. The TX-8 battle rifle is the only gun that can chamber these rounds."
 	icon_state = "tx8"
 	caliber = CALIBER_10X28_CASELESS
 	default_ammo = /datum/ammo/bullet/rifle/tx8
@@ -65,7 +65,7 @@
 
 /obj/item/ammo_magazine/rifle/tx8/incendiary
 	name = "\improper high velocity incendiary magazine (10x28mm)"
-	desc = "A magazine of overpressuered high velocity incendiary rounds for use in the BR-8 battle rifle. The BR-8 battle rifle is the only gun that can chamber these rounds."
+	desc = "A magazine of overpressuered high velocity incendiary rounds for use in the TX-8 battle rifle. The TX-8 battle rifle is the only gun that can chamber these rounds."
 	caliber = CALIBER_10X28_CASELESS
 	icon_state = "tx8_incend"
 	default_ammo = /datum/ammo/bullet/rifle/tx8/incendiary
@@ -74,7 +74,7 @@
 
 /obj/item/ammo_magazine/rifle/tx8/impact
 	name = "\improper high velocity impact magazine (10x28mm)"
-	desc = "A magazine of overpressuered high velocity impact rounds for use in the BR-8 battle rifle. The BR-8 battle rifle is the only gun that can chamber these rounds."
+	desc = "A magazine of overpressuered high velocity impact rounds for use in the TX-8 battle rifle. The TX-8 battle rifle is the only gun that can chamber these rounds."
 	icon_state = "tx8_impact"
 	default_ammo = /datum/ammo/bullet/rifle/tx8/impact
 	icon_state_mini = "mag_rifle_big_blue"
@@ -121,7 +121,7 @@
 
 /obj/item/ammo_magazine/rocket/sadar
 	name = "\improper 84mm 'L-G' high-explosive rocket"
-	desc = "A warhead for the RL-152 rocket launcher. Carries a bogstandard HE warhead that explodes. Due to being laser-guided, it will hit exactly where you aim, however the payload is smaller due to the internal space required for this.  When empty, use this frame to deconstruct it."
+	desc = "A warhead for the T-152 rocket launcher. Carries a bogstandard HE warhead that explodes. Due to being laser-guided, it will hit exactly where you aim, however the payload is smaller due to the internal space required for this.  When empty, use this frame to deconstruct it."
 	caliber = CALIBER_84MM
 	icon_state = "rocket_he"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -132,7 +132,7 @@
 
 /obj/item/ammo_magazine/rocket/sadar/unguided
 	name = "\improper 84mm 'Unguided' high-explosive rocket"
-	desc = "A warhead for the RL-152 rocket launcher. Carries a bogstandard HE warhead that explodes. It is entirely unguided, and thus 'Dumb', this allows for a larger payload, and a skilled operator can hit longer ranged hits that a laser-guided rocket could not reach at all.  When empty, use this frame to deconstruct it."
+	desc = "A warhead for the T-152 rocket launcher. Carries a bogstandard HE warhead that explodes. It is entirely unguided, and thus 'Dumb', this allows for a larger payload, and a skilled operator can hit longer ranged hits that a laser-guided rocket could not reach at all.  When empty, use this frame to deconstruct it."
 	icon_state = "rocket_he_unguided"
 	default_ammo = /datum/ammo/rocket/he/unguided
 
@@ -161,7 +161,7 @@
 
 /obj/item/ammo_magazine/rocket/recoilless
 	name = "\improper 67mm high-explosive shell"
-	desc = "A high explosive shell for the RL-160 recoilless rifle. Causes a heavy explosion over a small area. Requires specialized storage to carry."
+	desc = "A high explosive shell for the T-160 recoilless rifle. Causes a heavy explosion over a small area. Requires specialized storage to carry."
 	caliber = CALIBER_67MM
 	icon_state = "shell"
 	w_class = WEIGHT_CLASS_BULKY
@@ -171,39 +171,39 @@
 
 /obj/item/ammo_magazine/rocket/recoilless/light
 	name = "\improper 67mm light-explosive shell"
-	desc = "A light explosive shell for the RL-160 recoilless rifle. Causes a light explosion over a large area. Can go farther than other shells of its type due to the light payload. Requires specialized storage to carry."
+	desc = "A light explosive shell for the T-160 recoilless rifle. Causes a light explosion over a large area. Can go farther than other shells of its type due to the light payload. Requires specialized storage to carry."
 	icon_state = "shell_le"
 	default_ammo = /datum/ammo/rocket/recoilless/light
 	reload_delay = 10
 
 /obj/item/ammo_magazine/rocket/recoilless/low_impact
 	name = "\improper 67mm light-explosive shell"
-	desc = "A light explosive shell for the RL-160 recoilless rifle. Causes a light explosion over a large area but low impact damage. Can go farther than other shells of its type due to the light payload. Requires specialized storage to carry."
+	desc = "A light explosive shell for the T-160 recoilless rifle. Causes a light explosion over a large area but low impact damage. Can go farther than other shells of its type due to the light payload. Requires specialized storage to carry."
 	icon_state = "shell_le"
 	default_ammo = /datum/ammo/rocket/recoilless/low_impact
 	reload_delay = 10
 
 /obj/item/ammo_magazine/rocket/recoilless/heat
 	name = "\improper 67mm HEAT shell"
-	desc = "A high explosive-anti tank shell for the RL-160 recoilless rifle. Fires a penetrating shot with no explosion. It will do moderate damage to all types of enemies, but does not sunder their armor. Requires specialized storage to carry."
+	desc = "A high explosive-anti tank shell for the T-160 recoilless rifle. Fires a penetrating shot with no explosion. It will do moderate damage to all types of enemies, but does not sunder their armor. Requires specialized storage to carry."
 	icon_state = "shell_heat"
 	default_ammo = /datum/ammo/rocket/recoilless/heat
 
 /obj/item/ammo_magazine/rocket/recoilless/smoke
 	name = "\improper 67mm Chemical (Smoke) shell"
-	desc = "A chemical shell for the RL-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains thick concealing smoke. Requires specialized storage to carry."
+	desc = "A chemical shell for the T-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains thick concealing smoke. Requires specialized storage to carry."
 	icon_state = "shell_smoke"
 	default_ammo = /datum/ammo/rocket/recoilless/chemical
 
 /obj/item/ammo_magazine/rocket/recoilless/cloak
 	name = "\improper 67mm Chemical (Cloak) shell"
-	desc = "A chemical shell for the RL-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains advanced cloaking smoke. Requires specialized storage to carry."
+	desc = "A chemical shell for the T-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains advanced cloaking smoke. Requires specialized storage to carry."
 	icon_state = "shell_cloak"
 	default_ammo = /datum/ammo/rocket/recoilless/chemical/cloak
 
 /obj/item/ammo_magazine/rocket/recoilless/plasmaloss
 	name = "\improper 67mm Chemical (Tanglefoot) shell"
-	desc = "A chemical shell for the RL-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains plasma-draining Tanglefoot smoke. Requires specialized storage to carry."
+	desc = "A chemical shell for the T-160 recoilless rifle. Fires a low velocity shell for close quarters application of chemical gas, friendlies will be able to easily dodge it due to low velocity. This warhead contains plasma-draining Tanglefoot smoke. Requires specialized storage to carry."
 	icon_state = "shell_tanglefoot"
 	default_ammo = /datum/ammo/rocket/recoilless/chemical/plasmaloss
 
@@ -235,7 +235,7 @@
 
 /obj/item/ammo_magazine/rocket/m57a4
 	name = "\improper 84mm thermobaric rocket array"
-	desc = "A thermobaric rocket tube for a RL-57 quad launcher. Activate in hand to receive some metal when it's used up. The Rockets don't do much damage on a direct hit, but the fire effect is strong.."
+	desc = "A thermobaric rocket tube for a T-57 quad launcher. Activate in hand to receive some metal when it's used up. The Rockets don't do much damage on a direct hit, but the fire effect is strong.."
 	caliber = CALIBER_ROCKETARRAY
 	icon_state = "quad_rocket"
 	max_rounds = 4
@@ -244,7 +244,7 @@
 
 /obj/item/ammo_magazine/rocket/m57a4/ds
 	name = "\improper 84mm thermobaric rocket array"
-	desc = "A thermobaric rocket tube for a RL-57 quad launcher. Activate in hand to receive some metal when it's used up. Has huge red markings..."
+	desc = "A thermobaric rocket tube for a M-57E quad launcher. Activate in hand to receive some metal when it's used up. Has huge red markings..."
 	caliber = CALIBER_ROCKETARRAY
 	icon_state = "quad_rocket"
 	max_rounds = 4
@@ -252,7 +252,7 @@
 	reload_delay = 2 SECONDS
 
 /obj/item/ammo_magazine/internal/launcher/rocket/m57a4
-	desc = "The internal tube of an RL-57 thermobaric launcher."
+	desc = "The internal tube of an M-57E thermobaric launcher."
 	caliber = CALIBER_ROCKETARRAY
 	default_ammo = /datum/ammo/rocket/wp/quad
 	max_rounds = 4
@@ -384,8 +384,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_magazine/minigun_powerpack
-	name = "\improper MG-100 Vindicator powerpack"
-	desc = "A heavy reinforced backpack with support equipment, power cells, and spare rounds for the MG-100 Minigun System.\nClick the icon in the top left to reload your M56."
+	name = "\improper T-100 Vindicator powerpack"
+	desc = "A heavy reinforced backpack with support equipment, power cells, and spare rounds for the T-100 Minigun System.\nClick the icon in the top left to reload your M56."
 	icon = 'icons/obj/items/storage/storage.dmi'
 	icon_state = "powerpack"
 	flags_atom = CONDUCT
@@ -410,7 +410,7 @@
 	flags_item_map_variant = null
 
 /obj/item/ammo_magazine/minigun_powerpack/smartgun
-	name = "\improper SG-85 powerpack"
+	name = "\improper T-85 powerpack"
 	desc = "A reinforced backpack heavy with the IFF altered ammunition, onboard micro generator, and extensive cooling system which enables the SG-85 gatling gun to operate. \nUse the SG-85 on the backpack itself to connect them."
 	icon_state = "powerpacksg"
 	flags_magazine = MAGAZINE_WORN|MAGAZINE_REFILLABLE

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -157,7 +157,7 @@
 	default_ammo = /datum/ammo/rocket/wp/unguided
 
 //-------------------------------------------------------
-//RL-160 recoilless rifle
+//T-160 recoilless rifle
 
 /obj/item/ammo_magazine/rocket/recoilless
 	name = "\improper 67mm high-explosive shell"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -318,187 +318,187 @@ WEAPONS
 	cost = 600
 
 /datum/supply_packs/weapons/tx54
-	name = "GL-54 airburst grenade launcher"
+	name = "TX-54 airburst grenade launcher"
 	contains = list(/obj/item/weapon/gun/rifle/tx54)
 	cost = 300
 
 /datum/supply_packs/weapons/tx54_airburst
-	name = "GL-54 airburst grenade magazine"
+	name = "TX-54 airburst grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54)
 	cost = 20
 
 /datum/supply_packs/weapons/tx54_incendiary
-	name = "GL-54 incendiary grenade magazine"
+	name = "TX-54 incendiary grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/incendiary)
 	cost = 60
 
 /datum/supply_packs/weapons/tx54_smoke
-	name = "GL-54 tactical smoke grenade magazine"
+	name = "TX-54 tactical smoke grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/smoke)
 	cost = 12
 
 /datum/supply_packs/weapons/tx54_smoke/dense
-	name = "GL-54 dense smoke grenade magazine"
+	name = "TX-54 dense smoke grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/smoke/dense)
 	cost = 8
 
 /datum/supply_packs/weapons/tx54_smoke/tangle
-	name = "GL-54 tanglefoot grenade magazine"
+	name = "TX-54 tanglefoot grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/smoke/tangle)
 	cost = 48
 
 /datum/supply_packs/weapons/tx54_he
-	name = "GL-54 HE grenade magazine"
+	name = "TX-54 HE grenade magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/he)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/tx55
-	name = "AR-55 OICW Rifle"
+	name = "TX-55 OICW Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/tx55)
 	cost = 525
 
 /datum/supply_packs/weapons/recoillesskit
-	name = "RL-160 Recoilless rifle kit"
+	name = "T-160 Recoilless rifle kit"
 	contains = list(/obj/item/storage/holster/backholster/rpg/full)
 	cost = 400
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_regular
-	name = "RL-160 RR HE shell"
+	name = "T-160 RR HE shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_le
-	name = "RL-160 RR LE shell"
+	name = "T-160 RR LE shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless/light)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_heat
-	name = "RL-160 HEAT shell"
+	name = "T-160 HEAT shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless/heat)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_smoke
-	name = "RL-160 RR Smoke shell"
+	name = "T-160 RR Smoke shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless/smoke)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_smoke
-	name = "RL-160 RR Cloak shell"
+	name = "T-160 RR Cloak shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless/cloak)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/shell_smoke
-	name = "RL-160 RR Tanglefoot shell"
+	name = "T-160 RR Tanglefoot shell"
 	contains = list(/obj/item/ammo_magazine/rocket/recoilless/plasmaloss)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/pepperball
-	name = "PB-12 pepperball gun"
+	name = "TLLL-12 pepperball gun"
 	contains = list(/obj/item/weapon/gun/rifle/pepperball)
 	cost = 100
 
 /datum/supply_packs/weapons/railgun
-	name = "SR-220 Railgun"
+	name = "TX-220 Railgun"
 	contains = list(/obj/item/weapon/gun/rifle/railgun)
 	cost = 400
 
 /datum/supply_packs/weapons/railgun_ammo
-	name = "SR-220 Railgun armor piercing discarding sabot round"
+	name = "TX-220 Railgun armor piercing discarding sabot round"
 	contains = list(/obj/item/ammo_magazine/railgun)
 	cost = 50
 
 /datum/supply_packs/weapons/railgun_ammo/hvap
-	name = "SR-220 Railgun high velocity armor piercing round"
+	name = "TX-220 Railgun high velocity armor piercing round"
 	contains = list(/obj/item/ammo_magazine/railgun/hvap)
 	cost = 50
 
 /datum/supply_packs/weapons/railgun_ammo/smart
-	name = "SR-220 Railgun smart armor piercing round"
+	name = "TX-220 Railgun smart armor piercing round"
 	contains = list(/obj/item/ammo_magazine/railgun/smart)
 	cost = 50
 
 /datum/supply_packs/weapons/tx8
-	name = "BR-8 Scout Rifle"
+	name = "TX-8 Scout Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/tx8)
 	cost = 400
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/scout_regular
-	name = "BR-8 scout rifle magazine"
+	name = "TX-8 scout rifle magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8)
 	cost = 20
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/scout_regular_box
-	name = "BR-8 scout rifle ammo box"
+	name = "TX-8 scout rifle ammo box"
 	contains = list(/obj/item/ammo_magazine/packet/scout_rifle)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/scout_impact
-	name = "BR-8 scout rifle impact magazine"
+	name = "TX-8 scout rifle impact magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8/impact)
 	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/scout_incendiary
-	name = "Br-8 scout rifle incendiary magazine"
+	name = "TX-8 scout rifle incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8/incendiary)
 	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/thermobaric
-	name = "RL-57 Thermobaric Launcher"
+	name = "T-57 Thermobaric Launcher"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4/t57)
 	cost = 500
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/thermobaric_wp
-	name = "RL-57 Thermobaric WP rocket array"
+	name = "T-57 Thermobaric WP rocket array"
 	contains = list(/obj/item/ammo_magazine/rocket/m57a4)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specdemo
-	name = "RL-152 SADAR Rocket Launcher"
+	name = "T-152 SADAR Rocket Launcher"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/sadar)
 	cost = SADAR_PRICE
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_regular
-	name = "RL-152 SADAR HE rocket"
+	name = "T-152 SADAR HE rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_regular_unguided
-	name = "RL-152 SADAR HE rocket (Unguided)"
+	name = "T-152 SADAR HE rocket (Unguided)"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/unguided)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_ap
-	name = "RL-152 SADAR AP rocket"
+	name = "T-152 SADAR AP rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/ap)
 	cost = 60
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_wp
-	name = "RL-152 SADAR WP rocket"
+	name = "T-152 SADAR WP rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp)
 	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/rpg_wp_unguided
-	name = "RL-152 SADAR WP rocket (Unguided)"
+	name = "T-152 SADAR WP rocket (Unguided)"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp/unguided)
 	cost = 40
 	available_against_xeno_only = TRUE
@@ -521,59 +521,59 @@ WEAPONS
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/autosniper
-	name = "SR-81 IFF Auto Sniper kit"
+	name = "T-81 IFF Auto Sniper kit"
 	contains = list(/obj/item/weapon/gun/rifle/standard_autosniper)
 	cost = 500
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/autosniper_regular
-	name = "SR-81 IFF sniper magazine"
+	name = "T-81 IFF sniper magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/autosniper)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/autosniper_packet
-	name = "SR-81 IFF sniper ammo box"
+	name = "T-81 IFF sniper ammo box"
 	contains = list(/obj/item/ammo_magazine/packet/autosniper)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial
-	name = "SR-26 Antimaterial rifle (AMR) kit"
+	name = "T-26 Antimaterial rifle (AMR) kit"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
 	cost = 775
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial_ammo
-	name = "SR-26 AMR magazine"
+	name = "T-26 AMR magazine"
 	contains = list(/obj/item/ammo_magazine/sniper)
 	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial_incend_ammo
-	name = "SR-26 AMR incendiary magazine"
+	name = "T-26 AMR incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/sniper/incendiary)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial_flak_ammo
-	name = "SR-26 AMR flak magazine"
+	name = "T-26 AMR flak magazine"
 	contains = list(/obj/item/ammo_magazine/sniper/flak)
 	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specminigun
-	name = "MG-100 Vindicator Minigun"
+	name = "T-100 Vindicator Minigun"
 	contains = list(/obj/item/weapon/gun/minigun)
 	cost = MINIGUN_PRICE
 
 /datum/supply_packs/weapons/minigun
-	name = "MG-100 Vindicator Minigun Powerpack"
+	name = "T-100 Vindicator Minigun Powerpack"
 	contains = list(/obj/item/ammo_magazine/minigun_powerpack)
 	cost = 50
 
 /datum/supply_packs/weapons/mmg
-	name = "MG-27 Medium Machinegun"
+	name = "T-27 Medium Machinegun"
 	contains = list(/obj/item/weapon/gun/standard_mmg)
 	cost = 100
 
@@ -593,76 +593,76 @@ WEAPONS
 	cost = 40
 
 /datum/supply_packs/weapons/smartgun
-	name = "SG-29 smart machine gun"
+	name = "T-29 smart machine gun"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smartmachinegun)
 	cost = 400
 
 /datum/supply_packs/weapons/smartgun_ammo
-	name = "SG-29 ammo drum"
+	name = "T-29 ammo drum"
 	contains = list(/obj/item/ammo_magazine/standard_smartmachinegun)
 	cost = 50
 
 /datum/supply_packs/weapons/smart_minigun
-	name = "SG-85 smart gatling gun"
+	name = "T-85 smart gatling gun"
 	contains = list(/obj/item/weapon/gun/minigun/smart_minigun)
 	cost = 400
 
 /datum/supply_packs/weapons/smart_minigun_ammo
-	name = "SG-85 ammo bin"
+	name = "T-85 ammo bin"
 	contains = list(/obj/item/ammo_magazine/packet/smart_minigun)
 	cost = 50
 
 /datum/supply_packs/weapons/smarttarget_rifle
-	name = "SG-62 Smart Target Rifle"
+	name = "T-62 Smart Target Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smarttargetrifle)
 	cost = 400
 
 /datum/supply_packs/weapons/smarttarget_rifle_ammo
-	name = "SG-62 smart target rifle ammo"
+	name = "T-62 smart target rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_smarttargetrifle)
 	cost = 35
 
 /datum/supply_packs/weapons/spotting_rifle_ammo
-	name = "SG-153 spotting rifle ammo"
+	name = "TL-153 spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle)
 	cost = 15
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/highimpact
-	name = "SG-153 high impact spotting rifle ammo"
+	name = "TL-153 high impact spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact)
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/heavyrubber
-	name = "SG-153 heavy rubber spotting rifle ammo"
+	name = "TL-153 heavy rubber spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/heavyrubber)
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/plasmaloss
-	name = "SG-153 tanglefoot spotting rifle ammo"
+	name = "TL-153 tanglefoot spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/plasmaloss)
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/tungsten
-	name = "SG-153 tungsten spotting rifle ammo"
+	name = "TL-153 tungsten spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten)
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/flak
-	name = "SG-153 flak spotting rifle ammo"
+	name = "TL-153 flak spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/flak)
 
 /datum/supply_packs/weapons/spotting_rifle_ammo/incendiary
-	name = "SG-153 incendiary spotting rifle ammo"
+	name = "TL-153 incendiary spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary)
 
 /datum/supply_packs/weapons/flamethrower
-	name = "FL-84 Flamethrower"
+	name = "TL-84 Flamethrower"
 	contains = list(/obj/item/weapon/gun/flamer/big_flamer/marinestandard)
 	cost = 150
 
 /datum/supply_packs/weapons/napalm
-	name = "FL-84 normal fuel tank"
+	name = "TL-84 normal fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large)
 	cost = 60
 
 /datum/supply_packs/weapons/napalm_X
-	name = "FL-84 X fuel tank"
+	name = "TL-84 X fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large/X)
 	cost = 300
 
@@ -683,7 +683,7 @@ WEAPONS
 	containertype = null
 
 /datum/supply_packs/weapons/rpgoneuse
-	name = "RL-72 Disposable RPG"
+	name = "T-72 Disposable RPG"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/oneuse)
 	cost = 100
 	available_against_xeno_only = TRUE
@@ -708,7 +708,7 @@ WEAPONS
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/magnum
-	name = "R-76 Magnum"
+	name = "TL-76 Magnum"
 	contains = list(/obj/item/weapon/gun/revolver/standard_magnum)
 	notes = "Ammo is contained within normal marine vendors."
 	cost = 75
@@ -722,7 +722,7 @@ WEAPONS
 	cost = 200
 
 /datum/supply_packs/weapons/pfcflak
-	name = "SR-127 Flak Magazine"
+	name = "TL-127 Flak Magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/chamberedrifle/flak)
 	cost = 50
 	available_against_xeno_only = TRUE

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -193,12 +193,12 @@ WEAPONS
 
 
 /datum/supply_packs/weapons/m56d_emplacement
-	name = "HSG-102 Mounted Heavy Smartgun"
+	name = "TL-102 Mounted Heavy Smartgun"
 	contains = list(/obj/item/storage/box/tl102)
 	cost = 600
 
 /datum/supply_packs/weapons/m56d
-	name = "HSG-102 mounted heavy smartgun ammo"
+	name = "TL-102 mounted heavy smartgun ammo"
 	contains = list(/obj/item/ammo_magazine/tl102)
 	cost = 30
 
@@ -263,12 +263,12 @@ WEAPONS
 	cost = 55
 
 /datum/supply_packs/weapons/antitankgun
-	name = "AT-36 Anti Tank Gun"
+	name = "TAT-36 Anti Tank Gun"
 	contains = list(/obj/item/weapon/gun/standard_atgun)
 	cost = 800
 
 /datum/supply_packs/weapons/antitankgunammo
-	name = "AT-36 AP-HE Shell (x3)"
+	name = "TAT-36 AP-HE Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun,
 		/obj/item/ammo_magazine/standard_atgun,
@@ -277,7 +277,7 @@ WEAPONS
 	cost = 20
 
 /datum/supply_packs/weapons/antitankgunammo/apcr
-	name = "AT-36 APCR Shell (x3)"
+	name = "TAT-36 APCR Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun/apcr,
 		/obj/item/ammo_magazine/standard_atgun/apcr,
@@ -286,7 +286,7 @@ WEAPONS
 	cost = 20
 
 /datum/supply_packs/weapons/antitankgunammo/he
-	name = "AT-36 HE Shell (x3)"
+	name = "TAT-36 HE Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun/he,
 		/obj/item/ammo_magazine/standard_atgun/he,
@@ -295,7 +295,7 @@ WEAPONS
 	cost = 20
 
 /datum/supply_packs/weapons/antitankgunammo/beehive
-	name = "AT-36 Beehive Shell (x3)"
+	name = "TAT-36 Beehive Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun/beehive,
 		/obj/item/ammo_magazine/standard_atgun/beehive,
@@ -304,7 +304,7 @@ WEAPONS
 	cost = 20
 
 /datum/supply_packs/weapons/antitankgunammo/incendiary
-	name = "AT-36 Napalm Shell (x3)"
+	name = "TAT-36 Napalm Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun/incend,
 		/obj/item/ammo_magazine/standard_atgun/incend,
@@ -578,17 +578,17 @@ WEAPONS
 	cost = 100
 
 /datum/supply_packs/weapons/hmg
-	name = "HMG-08 heavy machinegun"
+	name = "MG-08/495 heavy machinegun"
 	contains = list(/obj/item/weapon/gun/heavymachinegun)
 	cost = 400
 
 /datum/supply_packs/weapons/hmg_ammo
-	name = "HMG-08 heavy machinegun ammo (500 rounds)"
+	name = "MG-08/495 heavy machinegun ammo (500 rounds)"
 	contains = list(/obj/item/ammo_magazine/heavymachinegun)
 	cost = 70
 
 /datum/supply_packs/weapons/hmg_ammo_small
-	name = "HMG-08 heavy machinegun ammo (250 rounds)"
+	name = "MG-08/495 heavy machinegun ammo (250 rounds)"
 	contains = list(/obj/item/ammo_magazine/heavymachinegun/small)
 	cost = 40
 
@@ -1526,32 +1526,32 @@ Imports
 	containertype = /obj/structure/closet/crate/weapon
 
 /datum/supply_packs/imports/m41a
-	name = "PR-11 Pulse Rifle"
+	name = "HK-11 Pulse Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/m41a)
 	cost = 50
 
 /datum/supply_packs/imports/m41a/ammo
-	name = "PR-11 Pulse Rifle Ammo"
+	name = "HK-11 Pulse Rifle Ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/m41a)
 	cost = 3
 
 /datum/supply_packs/imports/m412
-	name = "PR-412 Pulse Rifle"
+	name = "M412 Pulse Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/m412)
 	cost = 50
 
 /datum/supply_packs/imports/m41a2/ammo
-	name = "PR-412 Pulse Rifle Ammo"
+	name = "M412 Pulse Rifle Ammo"
 	contains = list(/obj/item/ammo_magazine/rifle)
 	cost = 3
 
 /datum/supply_packs/imports/m412l1
-	name = "PR-412L1 Heavy Pulse Rifle"
+	name = "M412L1 Heavy Pulse Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/m412l1_hpr)
 	cost = 150
 
 /datum/supply_packs/imports/m412l1/ammo
-	name = "PR-412L1 Heavy Pulse Rifle Ammo"
+	name = "M412L1 Heavy Pulse Rifle Ammo"
 	contains = list(/obj/item/ammo_magazine/m412l1_hpr)
 	cost = 25
 
@@ -1566,22 +1566,22 @@ Imports
 	cost = 3
 
 /datum/supply_packs/imports/mp7
-	name = "SMG-27 SMG"
+	name = "MP-27 SMG"
 	contains = list(/obj/item/weapon/gun/smg/mp7)
 	cost = 50
 
 /datum/supply_packs/imports/mp7/ammo
-	name = "SMG-27 SMG Ammo"
+	name = "MP-27 SMG Ammo"
 	contains = list(/obj/item/ammo_magazine/smg/mp7)
 	cost = 3
 
 /datum/supply_packs/imports/m25
-	name = "SMG-25 SMG"
+	name = "MR-25 SMG"
 	contains = list(/obj/item/weapon/gun/smg/m25)
 	cost = 50
 
 /datum/supply_packs/imports/m25/ammo
-	name = "SMG-25 SMG Ammo"
+	name = "MR-25 SMG Ammo"
 	contains = list(/obj/item/ammo_magazine/smg/m25)
 	cost = 3
 
@@ -1606,12 +1606,12 @@ Imports
 	cost = 3
 
 /datum/supply_packs/imports/uzi
-	name = "SMG-2 Uzi SMG"
+	name = "MP-2 Uzi SMG"
 	contains = list(/obj/item/weapon/gun/smg/uzi)
 	cost = 50
 
 /datum/supply_packs/imports/uzi/ammo
-	name = "SMG-2 Uzi SMG Ammo"
+	name = "MP-2 Uzi SMG Ammo"
 	contains = list(/obj/item/ammo_magazine/smg/uzi)
 	cost = 3
 
@@ -2072,7 +2072,7 @@ FACTORY
 	cost = 250
 
 /datum/supply_packs/factory/autosniper_magazine_refill
-	name = "SR-81 IFF Auto Sniper magazine assembly refill"
+	name = "T-81 IFF Auto Sniper magazine assembly refill"
 	contains = list(/obj/item/factory_refill/auto_sniper_magazine_refill)
 	cost = 400
 

--- a/html/changelogs/archive/2020-10.yml
+++ b/html/changelogs/archive/2020-10.yml
@@ -147,10 +147,10 @@
   - bugfix: PoS pipenet now provides air to more rooms, and had missing pipes fixed
   - imageadd: OB/Railgun sprite empty space removed
   Pariah919:
-  - rscadd: Added new PR-412 series of rifles.
+  - rscadd: Added new M412 series of rifles.
   - rscdel: Removed old Pulse rifles fix:Some indentation issues that the HPR had
-  - balance: PR-412 has 5% more damage than the AR, PR-412L1 (the HPR) has slightly better
-      fire delay. PR-412 families stat is in general consistent with the normal AR family.
+  - balance: M412 has 5% more damage than the AR, M412L1 (the HPR) has slightly better
+      fire delay. M412 families stat is in general consistent with the normal AR family.
   XSlayer300:
   - spellcheck: Fixed a few typos relating to pain and xeno acid.
 2020-10-18:

--- a/html/changelogs/archive/2020-11.yml
+++ b/html/changelogs/archive/2020-11.yml
@@ -26,8 +26,8 @@
   - rscadd: Added a new UI for the mortar
   Pariah919:
   - balance: survivor has survival knife and hard hat on non cold maps
-  - balance: Added PR-412s to LV security armory, added flechette to big red and LV,
-      gave PR-412/MR25 to big red armory, they've been spending money on modernization
+  - balance: Added M412s to LV security armory, added flechette to big red and LV,
+      gave M412/MR25 to big red armory, they've been spending money on modernization
   - balance: shields now protect 50% soft armor from anything attacking you, but no
       longer have 5 melee hard armor.
   Wayland-Smithy:

--- a/html/changelogs/archive/2021-01.yml
+++ b/html/changelogs/archive/2021-01.yml
@@ -275,8 +275,8 @@
   SpaceLove:
   - rscadd: Synthetic ranks added
   Sulaboy:
-  - bugfix: PR-412L1 and PR-412 Elite now show correct stock
-  - bugfix: PR-412L1 can now attach rail-scope, and mini-scope
+  - bugfix: M412L1 and M412 Elite now show correct stock
+  - bugfix: M412L1 can now attach rail-scope, and mini-scope
   Surrealaser:
   - bugfix: Fixes damage delays for most relevant damage events.
   TiviPlus:

--- a/html/changelogs/archive/2021-07.yml
+++ b/html/changelogs/archive/2021-07.yml
@@ -597,7 +597,7 @@
   - rscadd: In a situation of stalemate, marine and xeno respawn will be buffed
   - balance: All shuttles are immune to direct cas and ob hit
   Pariah919:
-  - expansion: seasonal gun bucket expanded-rifle bucket 2 has a PR-412 and HK-11 rather
+  - expansion: seasonal gun bucket expanded-rifle bucket 2 has a M412 and HK-11 rather
       than just an Uzi. And added a new bucket with an MR-25 and the MP-27
   - balance: minigun has been improved a bit, has 0.15 fire delay from 0.2, and has
       aim mode with a aim mode fire delay of 0.25, but you move VERY, VERY slowly

--- a/html/changelogs/archive/2022-03.yml
+++ b/html/changelogs/archive/2022-03.yml
@@ -287,7 +287,7 @@
       defib warble.'
   Lumipharon:
   - bugfix: Boiler gas cloud no longer scales in size past Ancient
-  - rscadd: 'Adds the GL-54, a magazine fed grenade launcher utilising 20mm airbursting
+  - rscadd: 'Adds the TX-54, a magazine fed grenade launcher utilising 20mm airbursting
       grenades remove: Impact grenades are no longer available roundstart'
   - bugfix: grenades fired from weapons no longer always point north mid flight
   RipGrayson:

--- a/html/changelogs/archive/2022-04.yml
+++ b/html/changelogs/archive/2022-04.yml
@@ -7,7 +7,7 @@
       beret
   Lumipharon:
   - bugfix: fixes a 100% intentional April fool's prank
-  - rscadd: GL-54 ammo now uses greyscaling
+  - rscadd: TX-54 ammo now uses greyscaling
   - code_imp: Add support for greyscale projectiles and bullets
   Mrrpip:
   - rscadd: Added the marine riot helmet, with a poorly made orange paintjob.

--- a/html/changelogs/archive/2022-05.yml
+++ b/html/changelogs/archive/2022-05.yml
@@ -178,7 +178,7 @@
   - bugfix: Turrets can no longer be removed from dropship turret modules
   MrHorizons:
   - spellcheck: The "SR-8" scout rifle is now the BR-8, as its description says.
-  - spellcheck: The SR-81 automatic sniper rifle has been designated as such, after
+  - spellcheck: The T-81 automatic sniper rifle has been designated as such, after
   Pariah919:
   - balance: vertical grips reduce your wield slowdown.
   QualityVan:

--- a/html/changelogs/archive/2022-06.yml
+++ b/html/changelogs/archive/2022-06.yml
@@ -301,7 +301,7 @@
   BraveMole:
   - rscadd: New wraith ability, rewind
   Hatterhat:
-  - balance: the BR-64 battle rifle now has one extra round per magazine, raising
+  - balance: the T-64 battle rifle now has one extra round per magazine, raising
       it to 36 rounds instead of 35, with a new theoretical max of 36+1 rounds in
       the gun
   QualityVan:

--- a/html/changelogs/archive/2022-08.yml
+++ b/html/changelogs/archive/2022-08.yml
@@ -104,9 +104,9 @@
   - rscdel: removed redundant check for volume amount
   - spellcheck: changed the exact wording on some of the vali balloon messages
   Xsdew:
-  - imageadd: 'Re sprites for the following: AR-18, AR-12, SMG-90, P-14, SH-35, MG-42.'
+  - imageadd: 'Re sprites for the following: T-18, T-12, T-90, P-14, T-35, T-42.'
   - imagedel: Unused sprites of those weapons were removed.
-  - code_imp: added code to allow for the new sprites to be used, with the MG-42 getting
+  - code_imp: added code to allow for the new sprites to be used, with the T-42 getting
       the first big mob icon sprite.
   mc-oofert:
   - bugfix: You can no longer get out of the condor while it is flying so you dont
@@ -146,13 +146,13 @@
   - bugfix: Fix some Combat Patrol end of round stats
 2022-08-16:
   Lumipharon:
-  - rscadd: 'Combat Patrol: Added laser rifle and AR-55 loadouts to TGMC SL''s'
-  - rscadd: 'Combat Patrol: Added SMG-90, laser carbine and AR-21 loadouts to TGMC
+  - rscadd: 'Combat Patrol: Added laser rifle and TX-55 loadouts to TGMC SL''s'
+  - rscadd: 'Combat Patrol: Added T-90, laser carbine and T-21 loadouts to TGMC
       medics'
-  - rscadd: 'Combat Patrol: Added AR-21 loadout to TGMC marines'
+  - rscadd: 'Combat Patrol: Added T-21 loadout to TGMC marines'
   - balance: 'Combat Patrol: Removed the two AP mags from the V-21 scout loadout,
       removed quantity limit on SG-85 loadout, added more C4 to TGMC demo engi loadout'
-  - bugfix: 'Combat Patrol: Added missing ammo for SH-15 medic loadout'
+  - bugfix: 'Combat Patrol: Added missing ammo for TX-15 medic loadout'
 2022-08-17:
   QualityVan:
   - bugfix: Dead xenos stop emitting pheromones
@@ -287,7 +287,7 @@
   - imageadd: defend and rally arrow pointer and minimap icons for orders
 2022-08-31:
   Lumipharon:
-  - rscadd: 'Combat Patrol: Added a new AR-18 scout loadout for TGMC marines, and
+  - rscadd: 'Combat Patrol: Added a new T-18 scout loadout for TGMC marines, and
       MPI_KM loadouts for SOM veterans and SL''s'
   - balance: 'Combat Patrol: Several  tweaks and changes to various loadouts'
   Xsdew:

--- a/html/changelogs/archive/2022-09.yml
+++ b/html/changelogs/archive/2022-09.yml
@@ -64,7 +64,7 @@
   - bugfix: fixed flamers not igniting tiles with border objects like barricades or
       windoors in suitable cases
   - refactor: refactored some flamer and cone code
-  - balance: Improved GL-54 airburst stagger and slow slightly, removed it entirely
+  - balance: Improved TX-54 airburst stagger and slow slightly, removed it entirely
       from incendiary
   Pariah919:
   - rscadd: Added 3 new chemical shells to RR (Smoke/HEAT/CloakSmoke/Tanglefoot).
@@ -296,7 +296,7 @@
   Lumipharon:
   - bugfix: medical item description text will no longer spill into the next storage
       slot
-  - balance: Increased MP-19 akimbo penalties
+  - balance: Increased TP-19 akimbo penalties
   tyeagg:
   - qol: bigger minimap icons for disks and orders
   - imageadd: big minimap icons
@@ -315,7 +315,7 @@
   hyper2snyper:
   - rscadd: 'The newly sprited primaries are now colorable with facepaint. Included:
       AR12, AR18, SMG90, P14, SH35, LMG42'
-  - rscadd: Support for colorable attachments, SH-35 stock now colorable like the
+  - rscadd: Support for colorable attachments, T-35 stock now colorable like the
       gun itself.
 2022-09-28:
   Jalopkomit18:
@@ -343,7 +343,7 @@
   - qol: added seperate keybinds for disguise and stealth
 2022-09-29:
   hyper2snyper:
-  - rscadd: Hyperscales the SG-29 and AR-21
+  - rscadd: Hyperscales the SG-29 and T-21
   - rscadd: Hyperscales both the Vertical and Angled grip attachments.
 2022-09-30:
   DeltaFire15:
@@ -356,5 +356,5 @@
   - spellcheck: 'MPs have a unique spawn in blurb. tweak: MPs have Squad Engineer/Medic
       rank scaling. (E3->E4->E5)'
   maikilangiolo:
-  - rscadd: added holsters for the mp19 and smg-25
+  - rscadd: added holsters for the mp19 and MR-25
   - balance: engineering storage module can fit filled sandbags

--- a/html/changelogs/archive/2022-10.yml
+++ b/html/changelogs/archive/2022-10.yml
@@ -51,7 +51,7 @@
   - rscadd: Seasonal round tips
   - rscadd: Isotonic pills
   Aquilar:
-  - bugfix: adjusts the positioning of the attachments on the BR-64, AR-18 and PR-11
+  - bugfix: adjusts the positioning of the attachments on the T-64, T-18 and HK-11
   Lewdcifer:
   - imageadd: Added particle visuals to Defiler's Reagent Slash and Emit Neurogas
       abilities.
@@ -65,7 +65,7 @@
   - code_imp: cleaned up a bit of flashbang code
   - rscadd: The SOM have begun domestic food production to replace imported UPP rations
   hyper2snyper:
-  - bugfix: Fixes the right hand mob state for the AR-21 and SG-29
+  - bugfix: Fixes the right hand mob state for the T-21 and SG-29
   lbnesquik:
   - rscadd: Expanded Prison West LZ2 by 1 tile west
 2022-10-08:
@@ -87,7 +87,7 @@
   - rscadd: Added Radiation effects for use by the SOM. War crimes have never been
       so easy!
   - bugfix: Fixed a couple of minor gun ammo bugs
-  - balance: Very slightly increased burst extra delay on the AR-11
+  - balance: Very slightly increased burst extra delay on the TX-11
   TiviPlus:
   - bugfix: Ammo HUDs will now always blink when you are out of ammo instead of only
       the bottommost one
@@ -157,7 +157,7 @@
   - bugfix: Mechs are no longer immortal
   - balance: Some mech guns nerfed
   Losenis:
-  - balance: SR-127 can now fit barrel charger
+  - balance: TL-127 can now fit barrel charger
   tyeagg:
   - imageadd: minimap icons for st, cl ,mo ,cmo, uavs, supply beacons, asrs pads,
       teleporter pads, sentries, spawners, phero tower and xeno turrets
@@ -345,7 +345,7 @@
   - bugfix: fixed C4 being hearable way too far.
 2022-10-27:
   Lumipharon:
-  - bugfix: fixed the MG-42 mob sprites and various other minor gun mob sprite issues
+  - bugfix: fixed the T-42 mob sprites and various other minor gun mob sprite issues
   - bugfix: fixed another minor vote bug
   Zar000:
   - balance: xenos dont pay back for roundstart slots

--- a/html/changelogs/archive/2023-01.yml
+++ b/html/changelogs/archive/2023-01.yml
@@ -125,9 +125,9 @@
   - bugfix: fixes incorrect morgue sprite when something is inside of it
   - bugfix: fixed db holster using error placeholder sprite in some situations
   'Code: Lumi, Sprites: Ocelot & Lumi':
-  - rscadd: Added folding stocks for the MP-19, SH_35 and Skorpion
-  - rscadd: BR-64 comes with a custom UGL. No actual balance change
-  - balance: MP-19 now has fuller auto instead of burst fire, improving the performance
+  - rscadd: Added folding stocks for the TP-19, SH_35 and Skorpion
+  - rscadd: T-64 comes with a custom UGL. No actual balance change
+  - balance: TP-19 now has fuller auto instead of burst fire, improving the performance
       of a single gun but nerfing akimbo
   - bugfix: fixed a couple of minor gun bugs
   - imageadd: Resprited a variety of guns and attachments
@@ -281,7 +281,7 @@
       into a single item and merged into the Style line. Its webbing variant can be
       accessed by using green facepaint.
   Lumipharon:
-  - rscadd: Added BR-64 loadouts to HvH
+  - rscadd: Added T-64 loadouts to HvH
   - balance: 'HvH: All loadouts now have advanced combat injectors instead of combat
       injectors'
   - balance: 'HvH: Buffed the V-41 damage and added slowdown on hit'
@@ -301,7 +301,7 @@
   - bugfix: fixed a timer bug with sensor towers.
   - bugfix: eswords no longer block almost all incoming damage
   - bugfix: fixed a bug with King's summon
-  - bugfix: fixed a minor MG-42 sprite issue
+  - bugfix: fixed a minor T-42 sprite issue
   RipGrayson:
   - bugfix: Removed some misplaced hull windows on Big Red.
   - bugfix: Fixed an oversight with podding on Chigusa.

--- a/html/changelogs/archive/2023-02.yml
+++ b/html/changelogs/archive/2023-02.yml
@@ -84,7 +84,7 @@
   - rscadd: Marine combat boots is now actually black
   - rscadd: adds brown marine combat boots
   Lumipharon:
-  - balance: 'HvH: SH-35 and V-51 loadouts no longer have tac sensors'
+  - balance: 'HvH: T-35 and V-51 loadouts no longer have tac sensors'
   - balance: 'HvH: Removed the damage malus from the V-51B burst shotgun'
   - balance: 'HvH: Improved damage falloff for volkite weapons slightly'
   - balance: 'HvH: MG-27 scope cannot be removed'
@@ -101,8 +101,8 @@
   - balance: Reduced MG-60 damage to 25 from 27.5, and reduced magazine capacity to
       200 from 250
   Pariah919:
-  - balance: MG-42 now has AR-12 burst fire. As in completely the same.
-  - balance: MG-42 now has BFA and tactical sensor.
+  - balance: T-42 now has T-12 burst fire. As in completely the same.
+  - balance: T-42 now has BFA and tactical sensor.
   - balance: Both Marine and DS Thermobarics have a 10 second reload time.
   Xander3359:
   - qol: You can hold click to throw knives at a constant rate.
@@ -312,7 +312,7 @@
   - balance: PMC ERT updates slightly with better loadouts, mainly for more ammunition
       and grenades
   - balance: VP78 burst fire is no longer just a worse version of semi auto
-  - balance: ' PR-412E no longer has a pointless burstfire mode'
+  - balance: ' M412E no longer has a pointless burstfire mode'
   - bugfix: fixed quick equip not working for some items obtained from loadout vendors
   - qol: SADAR and RPG rounds now have ammo specific projectile sprites
   - imageadd: Updated SADAR sprites

--- a/html/changelogs/archive/2023-03.yml
+++ b/html/changelogs/archive/2023-03.yml
@@ -44,7 +44,7 @@
   - rscdel: You can no longer fire underbarrel attachments with middle click.
   - rscadd: Primed grenades throw on click regardless of intent.
   novaepee:
-  - rscadd: SR-127 now spawn scopeless in planetside due to HvH balance
+  - rscadd: TL-127 now spawn scopeless in planetside due to HvH balance
 2023-03-03:
   Lumipharon:
   - imageadd: Human mob sprites have been brought into the future

--- a/html/changelogs/archive/2023-04.yml
+++ b/html/changelogs/archive/2023-04.yml
@@ -238,11 +238,11 @@
   - refactor: Flare pouch is a holster now
   - imageadd: New flare pouch sprites
   Pariah919:
-  - rscadd: AR-55 is now avaliable to be bought from req for 525 points, magazines
+  - rscadd: TX-55 is now avaliable to be bought from req for 525 points, magazines
       are 25 points.
-  - rscadd: SLs can now buy AR-55s from their vendors, and as such can also buy basic
-      GL-54 magazines.
-  - balance: GL-54 Airburst magazines have been halved in price in req from 40 to
+  - rscadd: SLs can now buy TX-55s from their vendors, and as such can also buy basic
+      TX-54 magazines.
+  - balance: TX-54 Airburst magazines have been halved in price in req from 40 to
       20.
   RipGrayson:
   - bugfix: Random spawners should no longer malfunction

--- a/html/changelogs/archive/2023-07.yml
+++ b/html/changelogs/archive/2023-07.yml
@@ -1,7 +1,7 @@
 2023-07-01:
   Pariah919:
-  - balance: SMG-25 can now fit underbarreled guns.
-  - balance: SMG-25 and its elite version now have higher akimbo maluses, and have
+  - balance: MR-25 can now fit underbarreled guns.
+  - balance: MR-25 and its elite version now have higher akimbo maluses, and have
       less damage falloff over distance.
   ivanmixo:
   - bugfix: Fixes various ghostize runtimes
@@ -327,7 +327,7 @@
   Mrrpip:
   - rscadd: 16G ammo boxes have arrived, now you'll get to use more shotgun in your
       autoshotgun!
-  - imageadd: The SH-15 slug mag is now green.
+  - imageadd: The TX-15 slug mag is now green.
   TiviPlus:
   - rscadd: Added Bulwark ability to queen
   - rscadd: Xenos have tts now


### PR DESCRIPTION

## About The Pull Request
This reverts gun nomeculture changes from #10055 for marine and non-marine guns, outside of Sentries which stay ST.
## Why It's Good For The Game
This change has not worked for the last year, if anything it has made everything more confusing because it changed *non marine weapons for no discernable reason beyond "I think its less confusing" and at absolute random.* 
Which causes you be to be unable to tell which gun is which on a per faction basis because the gun class was assigned at seemingly random, now that we have gun manufacturers on most gun names now which should make most guns easier to identify even with the T-## for marines so this confusing and utterly worthless gun class system is even more irrelevant than ever, it changed nothing but cause confusion for veteran and newer players who use different naming schemes (or for the vast of them I talk to, get consolidated into the former.)

I kept the changes on a few things like sentry guns since I think those are better with gun class than with T-###, outside of that the only other thing I kept was the SVD rename from the top of my head.
## Changelog
:cl:
spellcheck: Reverted gun nomeculture for marine guns to T-###, reverted gun names for non-marine guns to pre gun class change names.
/:cl:
