### PR TITLE
You can now right click webbings and helmets to draw from them, and you can ctrlclick to draw leftmost item from storage

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -86,7 +86,7 @@
 	//If there is an item in the slot you are clicking on, this will relay the click to the item within the slot
 	var/atom/item_in_slot = usr.get_item_by_slot(slot_id)
 	if(item_in_slot)
-		return item_in_slot.Click()
+		return item_in_slot.Click(location, control, params)
 
 	if(!istype(src, /atom/movable/screen/inventory/hand) && usr.attack_ui(slot_id)) // until we get a proper hands refactor
 		usr.update_inv_l_hand()

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -858,7 +858,7 @@
  * 
  * Arguments:
  * * mob/living/user - The mob attempting to draw from this container
- * * start_from_left - Determines if we should draw the leftmost or rightmost object out of the contents. FALSE by default.
+ * * start_from_left - If true we draw the leftmost object instead of the rightmost. FALSE by default.
  */
 /obj/item/storage/proc/attempt_draw_object(mob/living/user, start_from_left = FALSE)
 	if(!ishuman(user) || user.incapacitated() || isturf(loc))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -836,6 +836,7 @@
 
 
 /obj/item/storage/AltClick(mob/user)
+	. = ..()
 	attempt_draw_object(user)
 
 /obj/item/storage/AltRightClick(mob/user)
@@ -843,6 +844,9 @@
 		open(user)
 
 /obj/item/storage/attack_hand_alternate(mob/living/user)
+	. = ..()
+	if(.)
+		return
 	attempt_draw_object(user)
 
 ///attempts to get the first possible object from this container
@@ -857,6 +861,7 @@
 	drawn_item.attack_hand(user)
 
 /obj/item/storage/proc/PopulateContents()
+	return
 
 /obj/item/storage/update_icon_state()
 	if(!sprite_slots)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -849,15 +849,25 @@
 		return
 	attempt_draw_object(user)
 
-///attempts to get the first possible object from this container
-/obj/item/storage/proc/attempt_draw_object(mob/living/user)
+/obj/item/storage/CtrlClick(mob/living/user)
+	. = ..()
+	attempt_draw_object(user, TRUE)
+
+/**
+ * Attempts to get the first possible object from this container
+ * 
+ * Arguments:
+ * * mob/living/user - The mob attempting to draw from this container
+ * * start_from_left - Determines if we should draw the leftmost or rightmost object out of the contents. FALSE by default.
+ */
+/obj/item/storage/proc/attempt_draw_object(mob/living/user, start_from_left = FALSE)
 	if(!ishuman(user) || user.incapacitated() || isturf(loc))
 		return
 	if(!length(contents))
 		return balloon_alert(user, "Empty")
 	if(user.get_active_held_item())
 		return //User is already holding something.
-	var/obj/item/drawn_item = contents[length(contents)]
+	var/obj/item/drawn_item = start_from_left ? contents[1] : contents[length(contents)]
 	drawn_item.attack_hand(user)
 
 /obj/item/storage/proc/PopulateContents()

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -72,6 +72,7 @@
 	INVOKE_ASYNC(storage, TYPE_PROC_REF(/atom, attackby), I, user)
 	return COMPONENT_NO_AFTERATTACK
 
+///We draw from the item's storage
 /obj/item/armor_module/storage/proc/draw_from_storage(datum/source, mob/user)
 	SIGNAL_HANDLER
 	if(parent.loc != user)
@@ -79,6 +80,8 @@
 	INVOKE_ASYNC(storage, TYPE_PROC_REF(/obj/item/storage/internal, attempt_draw_object), user)
 	return COMPONENT_NO_ATTACK_HAND
 
+
+///We draw the leftmost item from the item's storage
 /obj/item/armor_module/storage/proc/left_draw_from_storage(datum/source, mob/user)
 	SIGNAL_HANDLER
 	if(parent.loc != user)

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -35,12 +35,13 @@
 	RegisterSignal(parent, COMSIG_CLICK_ALT_RIGHT, PROC_REF(open_storage))	//Open storage if the armor is alt right clicked
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(insert_item))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, PROC_REF(open_storage))
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_ALTERNATE, PROC_REF(draw_from_storage))
 	storage.master_item = parent
 
 /obj/item/armor_module/storage/on_detach(obj/item/detaching_from, mob/user)
 	equip_delay_self = initial(equip_delay_self)
 	strip_delay = initial(strip_delay)
-	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_CLICK_ALT_RIGHT, COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_ATTACK_GHOST))
+	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_CLICK_ALT_RIGHT, COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_ALTERNATE))
 	storage.master_item = src
 	return ..()
 
@@ -69,6 +70,13 @@
 		return
 	INVOKE_ASYNC(storage, TYPE_PROC_REF(/atom, attackby), I, user)
 	return COMPONENT_NO_AFTERATTACK
+
+/obj/item/armor_module/storage/proc/draw_from_storage(datum/source, mob/user)
+	SIGNAL_HANDLER
+	if(parent.loc != user)
+		return
+	INVOKE_ASYNC(storage, TYPE_PROC_REF(/obj/item/storage/internal, attempt_draw_object), user)
+	return COMPONENT_NO_ATTACK_HAND
 
 /obj/item/armor_module/storage/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -36,12 +36,13 @@
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(insert_item))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, PROC_REF(open_storage))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_ALTERNATE, PROC_REF(draw_from_storage))
+	RegisterSignal(parent, COMSIG_CLICK_CTRL, PROC_REF(left_draw_from_storage))
 	storage.master_item = parent
 
 /obj/item/armor_module/storage/on_detach(obj/item/detaching_from, mob/user)
 	equip_delay_self = initial(equip_delay_self)
 	strip_delay = initial(strip_delay)
-	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_CLICK_ALT_RIGHT, COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_ALTERNATE))
+	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_CLICK_ALT_RIGHT, COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_ALTERNATE, COMSIG_CLICK_CTRL))
 	storage.master_item = src
 	return ..()
 
@@ -76,6 +77,13 @@
 	if(parent.loc != user)
 		return
 	INVOKE_ASYNC(storage, TYPE_PROC_REF(/obj/item/storage/internal, attempt_draw_object), user)
+	return COMPONENT_NO_ATTACK_HAND
+
+/obj/item/armor_module/storage/proc/left_draw_from_storage(datum/source, mob/user)
+	SIGNAL_HANDLER
+	if(parent.loc != user)
+		return
+	INVOKE_ASYNC(storage, TYPE_PROC_REF(/obj/item/storage/internal, attempt_draw_object), user, TRUE)
 	return COMPONENT_NO_ATTACK_HAND
 
 /obj/item/armor_module/storage/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION

## About The Pull Request

You can now right click webbings and helmets to draw from them, and you can ctrlclick to draw leftmost item from storage.

Drawing with right click from helmet, webbing, armor. Drawing leftmost from toolbelt.

https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/17ee28a4-7cc6-4783-9494-47b2fda02a26


Also fixes a bug where clicking an inventory UI element didn't properly pass down it's click arguments to the item in the slot. This means that you can actually right and ctrl click inventory slots to right click and ctrl click the item in the slot.

I couldn't do the 3rd additional (inserting into leftmost in belt) from https://github.com/tgstation/TerraGov-Marine-Corps/issues/13980 due to BYOND's contents list being a special snowflake and I don't want to anger it by trying to manually edit `contents`

![chrome_8rCtU2df5C](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/af153324-c8d3-416b-bbe8-1c757365fb38)
## Why It's Good For The Game

More inventory controls is neat.
## Changelog
:cl:
add: You can now draw from webbings, armor and helmet with right click
add: You can now draw the leftmost item from storage
fix: Fixed clicking the inventory hud element not transferring clicks to the item in the slot correctly (right clicking the slots now right clicks the item in the slot)
/:cl:
