### PR TITLE
Reduces req launch CD to 5 seconds.

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -7,7 +7,7 @@
 	interaction_flags = INTERACT_MACHINE_TGUI
 	circuit = /obj/item/circuitboard/computer/supplydrop
 	///Time between two supply drops
-	var/launch_cooldown = 30 SECONDS
+	var/launch_cooldown = 5 SECONDS
 	///The beacon we will send the supplies
 	var/datum/supply_beacon/supply_beacon = null
 	///The linked supply pad of this console


### PR DESCRIPTION

## About The Pull Request
Reduces the cooldown before req can send down another crate down to 5 seconds.
## Why It's Good For The Game
This just makes req more stressful to play and is not really a balance concern since you can just always load up a crate with a ton of stuff. Reducing the cooldown would alleviate unnecessary stress.
## Changelog
:cl:
balance: Req computer has a 5 second cooldown instead of 30
/:cl:
