### PR TITLE
Vali claymore bumpslash on wield

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -420,12 +420,16 @@
 	. = ..()
 	AddComponent(/datum/component/harvester, 60, TRUE)
 
-/obj/item/weapon/twohanded/glaive/harvester/equipped(mob/user, slot)
+/obj/item/weapon/twohanded/glaive/harvester/wield(mob/user)
 	. = ..()
+	if(!.)
+		return
 	toggle_item_bump_attack(user, TRUE)
 
-/obj/item/weapon/twohanded/glaive/harvester/dropped(mob/user)
+/obj/item/weapon/twohanded/glaive/harvester/unwield(mob/user)
 	. = ..()
+	if(!.)
+		return
 	toggle_item_bump_attack(user, FALSE)
 
 /obj/item/weapon/twohanded/glaive/harvester/get_mechanics_info()


### PR DESCRIPTION

## About The Pull Request

Copypastas SOMs fire axes bump slash on wield to Vali Claymore.
## Why It's Good For The Game

Good because hitting a xeno for about a third of the total damage on accident really sucks.<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
qol: Vali Claymore only bump slashes when wielded.
/:cl:
