### PR TITLE
Reenables taking info tags from corpses

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -136,7 +136,6 @@
 	if(ismob(source))
 		var/mob/mob_source = source
 		if(!item.canStrip(user, mob_source))
-			user.balloon_alert(user, "[item] is stuck!")
 			return FALSE
 
 	return TRUE
@@ -278,6 +277,8 @@
 
 /// A utility function for `/datum/strippable_item`s to finish unequipping an item from a mob.
 /datum/strippable_item/proc/finish_unequip_mob(obj/item/item, mob/source, mob/user)
+	if(item.special_stripped_behavior(user, source))
+		return FALSE
 	if(!source.dropItemToGround(item))
 		return FALSE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -685,7 +685,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 
 /// Used by any item which wants to react to or prevent its own stripping, called after checks/delays. Return TRUE to block normal stripping behavior.
 /obj/item/proc/special_stripped_behavior(mob/stripper, mob/owner)
-
+	return
 
 /obj/item/proc/update_item_sprites()
 	switch(SSmapping.configs[GROUND_MAP].armor_style)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -676,8 +676,16 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 
 	return storage_item.can_be_inserted(src, warning)
 
+/// Checks whether the item can be unequipped from owner by stripper. Generates a message on failure and returns TRUE/FALSE
 /obj/item/proc/canStrip(mob/stripper, mob/owner)
-	return !(flags_item & NODROP)
+	if(flags_item & NODROP)
+		stripper.balloon_alert(stripper, "[src] is stuck!")
+		return FALSE
+	return TRUE
+
+/// Used by any item which wants to react to or prevent its own stripping, called after checks/delays. Return TRUE to block normal stripping behavior.
+/obj/item/proc/special_stripped_behavior(mob/stripper, mob/owner)
+
 
 /obj/item/proc/update_item_sprites()
 	switch(SSmapping.configs[GROUND_MAP].armor_style)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -250,6 +250,12 @@
 	iff_signal = TGMC_LOYALIST_IFF
 	var/dogtag_taken = FALSE
 
+/obj/item/card/id/dogtag/update_icon_state()
+	if(dogtag_taken)
+		icon_state = initial(icon_state) + "_taken"
+		return
+	icon = initial(icon_state)
+
 /obj/item/card/id/dogtag/canStrip(mob/stripper, mob/owner)
 	. = ..()
 	if(!.)
@@ -264,9 +270,10 @@
 /obj/item/card/id/dogtag/special_stripped_behavior(mob/stripper, mob/owner)
 	if(dogtag_taken)
 		return
-	to_chat(stripper, span_notice("You take [owner]'s information tag, leaving the ID tag"))
+	stripper.balloon_alert(stripper, "Took info tag")
+	to_chat(stripper, span_notice("You take [owner]'s information tag, leaving the ID tag."))
 	dogtag_taken = TRUE
-	icon_state = "dogtag_taken"
+	update_icon()
 	var/obj/item/dogtag/info_tag = new()
 	info_tag.fallen_names = list(registered_name)
 	info_tag.fallen_assignments = list(assignment)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -250,6 +250,29 @@
 	iff_signal = TGMC_LOYALIST_IFF
 	var/dogtag_taken = FALSE
 
+/obj/item/card/id/dogtag/canStrip(mob/stripper, mob/owner)
+	. = ..()
+	if(!.)
+		return
+	if(dogtag_taken)
+		stripper.balloon_alert(stripper, "Info tag already taken")
+		return FALSE
+	if(owner.stat != DEAD)
+		stripper.balloon_alert(stripper, "[owner] isn't dead yet")
+		return FALSE
+
+/obj/item/card/id/dogtag/special_stripped_behavior(mob/stripper, mob/owner)
+	if(dogtag_taken)
+		return
+	to_chat(stripper, span_notice("You take [owner]'s information tag, leaving the ID tag"))
+	dogtag_taken = TRUE
+	icon_state = "dogtag_taken"
+	var/obj/item/dogtag/info_tag = new()
+	info_tag.fallen_names = list(registered_name)
+	info_tag.fallen_assignments = list(assignment)
+	stripper.put_in_hands(info_tag)
+	return TRUE
+
 // Vendor points for job override
 /obj/item/card/id/dogtag/smartgun
 	marine_points = list(
@@ -306,7 +329,7 @@
 	icon = 'icons/obj/items/card.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	var/fallen_names[0]
-	var/fallen_assignements[0]
+	var/fallen_assignments[0]
 
 /obj/item/dogtag/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -317,8 +340,8 @@
 		name = "information dog tags"
 		if(D.fallen_names)
 			fallen_names += D.fallen_names
-		if(D.fallen_assignements)
-			fallen_assignements += D.fallen_assignements
+		if(D.fallen_assignments)
+			fallen_assignments += D.fallen_assignments
 		qdel(D)
 		return TRUE
 
@@ -326,14 +349,14 @@
 	. = ..()
 	if(ishuman(user) && fallen_names && length(fallen_names))
 		if(length(fallen_names) == 1)
-			to_chat(user, span_notice("It reads: \"[fallen_names[1]] - [fallen_assignements[1]]\"."))
+			to_chat(user, span_notice("It reads: \"[fallen_names[1]] - [fallen_assignments[1]]\"."))
 		else
 			var/msg = "<span class='notice'> It reads: "
 			for(var/x = 1 to length(fallen_names))
 				if (x == length(fallen_names))
-					msg += "\"[fallen_names[x]] - [fallen_assignements[x]]\""
+					msg += "\"[fallen_names[x]] - [fallen_assignments[x]]\""
 				else
-					msg += "\"[fallen_names[x]] - [fallen_assignements[x]]\", "
+					msg += "\"[fallen_names[x]] - [fallen_assignments[x]]\", "
 
 			msg += ".</span>"
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -254,7 +254,7 @@
 	if(dogtag_taken)
 		icon_state = initial(icon_state) + "_taken"
 		return
-	icon = initial(icon_state)
+	icon_state = initial(icon_state)
 
 /obj/item/card/id/dogtag/canStrip(mob/stripper, mob/owner)
 	. = ..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -129,7 +129,7 @@
 	* obj/item/W is the item you are trying to equip
 	* del_on_fail if true will delete the item instead of dropping it to the floor
 
-	Returns TURE if it was able to put the thing into one of our hands.
+	Returns TRUE if it was able to put the thing into one of our hands.
 */
 /mob/proc/put_in_hands(obj/item/W, del_on_fail = FALSE)
 	W.do_pickup_animation(src)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -533,7 +533,6 @@
 
 /mob/living/carbon/human/stripPanelUnequip(obj/item/I, mob/M, slot_to_process)
 	if(!I.canStrip(M))
-		to_chat(src, span_warning("You can't remove [I.name], it appears to be stuck!</span>"))
 		return
 	log_combat(src, M, "attempted to remove [key_name(I)] ([slot_to_process])")
 


### PR DESCRIPTION

## About The Pull Request
Previously when you attempted to take a dogtag ID, you instead generated a separate item, the info tag, which only held name and job and could stack with multiple other info tags and be put in the ship memorial. All that got removed by the strip UI overhaul, and so this PR puts it back in.

Adds routing to enable items to react to being stripped, like a gun exploding if someone hostile takes it or vital intelligence sending out a warning signal when it's stolen, plus more variable feedback options for why you can't strip something.
## Why It's Good For The Game
Fixes #13806 
Also a couple minor codeside spelling things.
## Changelog
:cl:
fix: Taking info tags from corpses works again
/:cl:
