### PR TITLE
Fixes some issues with weed walls

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -183,18 +183,17 @@
 	plane = GAME_PLANE
 	icon = 'icons/obj/smooth_objects/weedwall.dmi'
 	icon_state = "weedwall"
-	base_icon_state = "weedwall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_ALIEN_WEEDS)
-	canSmoothWith = list(SMOOTH_GROUP_ALIEN_WEEDS)
 
 /obj/alien/weeds/weedwall/update_icon_state()
 	var/turf/closed/wall/W = loc
 	if(!istype(W))
 		icon_state = initial(icon_state)
 	else
-		icon_state = W.junctiontype ? "weedwall[W.junctiontype]" : initial(icon_state)
-	icon_state += color_variant
+		icon_state = W.smoothing_junction ? "weedwall-[W.smoothing_junction]" : initial(icon_state)
+	if(color_variant == STICKY_COLOR)
+		icon = 'icons/obj/smooth_objects/weedwallsticky.dmi'
+	if(color_variant == RESTING_COLOR)
+		icon = 'icons/obj/smooth_objects/weedwallrest.dmi'
 
 // =================
 // windowed weed wall
@@ -204,6 +203,8 @@
 	var/window_type = /obj/structure/window/framed
 
 /obj/alien/weeds/weedwall/window/update_icon_state()
+	var/obj/structure/window/framed/F = locate() in loc
+	icon_state = F?.smoothing_junction ? "weedwall-[F.smoothing_junction]" : initial(icon_state)
 	if(color_variant == STICKY_COLOR)
 		icon = 'icons/obj/smooth_objects/weedwallsticky.dmi'
 	if(color_variant == RESTING_COLOR)

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -192,7 +192,7 @@
 		icon_state = W.smoothing_junction ? "weedwall-[W.smoothing_junction]" : initial(icon_state)
 	if(color_variant == STICKY_COLOR)
 		icon = 'icons/obj/smooth_objects/weedwallsticky.dmi'
-	if(color_variant == RESTING_COLOR)
+	else if(color_variant == RESTING_COLOR)
 		icon = 'icons/obj/smooth_objects/weedwallrest.dmi'
 
 // =================


### PR DESCRIPTION

## About The Pull Request

Title.
This PR fixes weed walls being weird when smoothing on walls and also a rare instance where they could become invisible due to resetting to its initial (invalid) icon_state.

## Why It's Good For The Game

Bugs bad, fixes good.

## Changelog
:cl:
fix: Fixes weeds on walls sometimes going invisible.
/:cl:
