### PR TITLE
CAS balance patch: Widowmaker is dead, long live widowmaker

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,5 +1,5 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
+#define DROPSHIP_POINT_RATE 18 * (GLOB.current_orbit/3)
 #define SUPPLY_POINT_RATE 20 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -510,7 +510,7 @@
 	ammo_name = "minirocket"
 	travelling_time = 2 SECONDS
 	transferable_ammo = TRUE
-	point_cost = 150
+	point_cost = 175
 	ammo_type = CAS_MINI_ROCKET
 	devastating_explosion_range = 0
 	heavy_explosion_range = 2

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -206,11 +206,11 @@
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	equipment_type = /obj/structure/dropship_equipment/cas/weapon/heavygun
 	travelling_time = 6 SECONDS
-	ammo_count = 200
-	max_ammo_count = 200
+	ammo_count = 2000
+	max_ammo_count = 2000
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 20
-	point_cost = 75
+	ammo_used_per_firing = 200
+	point_cost = 100
 	///Radius of the square that the bullets will strafe
 	var/bullet_spread_range = 2
 	///Width of the square we are attacking, so you can make rectangular attacks later
@@ -258,7 +258,7 @@
 			if(QDELETED(AM))
 				continue
 			//This may seem a bit wacky as we're exploding the turf's content twice, but doing it another way would be even more wacky because of how hard it is to modify explosion damage without adding a whole other explosion type
-			AM.ex_act(EXPLODE_LIGHT) 
+			AM.ex_act(EXPLODE_LIGHT)
 
 	if(length(strafelist))
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 2)
@@ -269,7 +269,7 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	travelling_time = 3 SECONDS
-	point_cost = 150
+	point_cost = 225
 
 
 //railgun
@@ -321,7 +321,7 @@
 	transferable_ammo = TRUE
 	ammo_used_per_firing = 10
 	warning_sound = 'sound/effects/nightvision.ogg'
-	point_cost = 85
+	point_cost = 150
 	///The length of the beam that will come out of when we fire do both ends xxxoxxx where o is where you click
 	var/laze_radius = 4
 	ammo_type = CAS_LASER_BATTERY
@@ -395,7 +395,7 @@
 	icon_state = "single"
 	travelling_time = 3 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
-	point_cost = 75
+	point_cost = 225
 	devastating_explosion_range = 2
 	heavy_explosion_range = 4
 	light_explosion_range = 7
@@ -412,7 +412,7 @@
 	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas. Moving this will require some sort of lifter."
 	icon_state = "banshee"
 	ammo_id = "b"
-	point_cost = 150
+	point_cost = 225
 	devastating_explosion_range = 2
 	heavy_explosion_range = 4
 	light_explosion_range = 7
@@ -446,7 +446,7 @@
 	desc = "The SM-17 'Fatty' is the most devestating rocket in TGMC arsenal, only second after its big cluster brother in Orbital Cannon. These rocket are also known for highest number of Friendly-on-Friendly incidents due to secondary cluster explosions as well as range of these explosions, TGMC recommends pilots to encourage usage of signal flares or laser for 'Fatty' support. Moving this will require some sort of lifter."
 	icon_state = "fatty"
 	ammo_id = "f"
-	point_cost = 250
+	point_cost = 325
 	devastating_explosion_range = 2
 	heavy_explosion_range = 3
 	light_explosion_range = 4
@@ -479,7 +479,7 @@
 	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time. Moving this will require some sort of lifter."
 	icon_state = "napalm"
 	ammo_id = "n"
-	point_cost = 200
+	point_cost = 250
 	devastating_explosion_range = 2
 	heavy_explosion_range = 3
 	light_explosion_range = 4
@@ -508,13 +508,13 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 4 SECONDS
+	travelling_time = 2 SECONDS
 	transferable_ammo = TRUE
-	point_cost = 100
+	point_cost = 150
 	ammo_type = CAS_MINI_ROCKET
 	devastating_explosion_range = 0
 	heavy_explosion_range = 2
-	light_explosion_range = 4
+	light_explosion_range = 3
 	prediction_type = CAS_AMMO_EXPLOSIVE
 	cas_effect = /obj/effect/overlay/blinking_laser/minirocket
 
@@ -536,7 +536,8 @@
 	name = "incendiary mini rocket stack"
 	desc = "A pack of laser guided incendiary mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_inc"
-	point_cost = 200
+	point_cost = 250
+	travelling_time = 4 SECONDS
 	light_explosion_range = 3 //Slightly weaker than standard minirockets
 	fire_range = 3 //Fire range should be the same as the explosion range. Explosion should leave fire, not vice versa
 	prediction_type = CAS_AMMO_INCENDIARY
@@ -550,7 +551,8 @@
 	name = "smoke mini rocket stack"
 	desc = "A pack of laser guided screening smoke mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_smoke"
-	point_cost = 25
+	point_cost = 75
+	travelling_time = 4 SECONDS
 	cas_effect = /obj/effect/overlay/blinking_laser/smoke
 	devastating_explosion_range = 0
 	heavy_explosion_range = 0
@@ -566,8 +568,9 @@
 	name = "Tanglefoot mini rocket stack"
 	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
-	point_cost = 150
+	point_cost = 200
 	devastating_explosion_range = 0
+	travelling_time = 4 SECONDS
 	heavy_explosion_range = 0
 	light_explosion_range = 2
 	cas_effect = /obj/effect/overlay/blinking_laser/tfoot
@@ -583,7 +586,8 @@
 	name = "illumination rocket flare stack"
 	desc = "A pack of laser guided mini rockets, each loaded with a payload of white-star illuminant and a parachute, while extremely ineffective at damaging the enemy, it is very effective at lighting the battlefield so marines can damage the enemy. Moving this will require some sort of lifter."
 	icon_state = "minirocket_ilm"
-	point_cost = 25 // Not a real rocket, so its cheap
+	point_cost = 50 // Not a real rocket, so its cheap
+	travelling_time = 4 SECONDS
 	cas_effect = /obj/effect/overlay/blinking_laser/flare
 	devastating_explosion_range = 0
 	heavy_explosion_range = 0

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -721,7 +721,7 @@
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
 	firing_sound = 'sound/weapons/gunship_chaingun.ogg'
-	point_cost = 400
+	point_cost = 300
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 
@@ -749,7 +749,7 @@
 	desc = "A rocket pod weapon system capable of launching a single laser-guided rocket. Moving this will require some sort of lifter."
 	firing_sound = 'sound/weapons/gunship_rocket.ogg'
 	firing_delay = 5
-	point_cost = 600
+	point_cost = 450
 	ammo_type_used = CAS_MISSILE
 
 /obj/structure/dropship_equipment/cas/weapon/rocket_pod/deplete_ammo()
@@ -773,7 +773,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_rocketpod.ogg'
 	firing_delay = 10 //1 seconds
-	point_cost = 600
+	point_cost = 450
 	ammo_type_used = CAS_MINI_ROCKET
 
 /obj/structure/dropship_equipment/cas/weapon/minirocket_pod/update_icon()
@@ -797,7 +797,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_laser.ogg'
 	firing_delay = 50 //5 seconds
-	point_cost = 600
+	point_cost = 800
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_LASER_BATTERY
 

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -5,6 +5,7 @@
 		return FALSE
 
 	SSpoints.supply_points[faction_selling] += points
+	SSpoints.dropship_points += points * 0.05
 	return new /datum/export_report(points, name, faction_selling)
 
 /mob/living/carbon/human/supply_export(faction_selling)


### PR DESCRIPTION

## About The Pull Request
Every single change is documented over at https://hackmd.io/@dopamiin0/caschange1

In short: orbit more dramatically affects CAS pointgen. CAS now gets 5% of all exports added to their point total. The vast majority of CAS items have had their prices increased by 33-40%. A select few have had their cost increased more dramatically for balance concerns. A select few have had their cost increased by less, not at all, or reduced due to being previously underpowered/unpurchasable. Minirockets have been mini-reworked to have a base speed of 2s and a smaller explosion radius. 
## Why It's Good For The Game
PLEASE read https://hackmd.io/@dopamiin0/caschange1
I am begging you. If you ask something that is answered in the document you will be laughed at

Summarized: CAS is in a weirdly balanced state. It has some options, such as widowmakers, which are just miles above the rest and way stronger than the other options. It has other options that virtually never see use, whether because they're simply outcompeted by other options or they're just costed so poorly. These cost changes aim to 'normalize' CAS prices to more reasonable levels, instead of just having blatantly overpowered options and noob trap point drain options.

As for the overall point changes, I think tying CAS more closely to the requisitions system is overall healthy for the game. Assuming comparable spending rates, CAS should be poor when requisitions is poor and vice versa, to more strongly encourage marine players to interact with exporting and orbit levels. Most prices for CAS items have been increased to accommodate these changes - high orbit and lots of exports will now allow CAS to get richer than before, but low orbit and little req income will also affect CAS far more harshly than before. 
## Changelog
:cl:
add: The dropship fabricator will now receive points whenever anything is exported, equal to 5% of the exported item's value. 
balance: Low orbit now only generates 6 points a minute for CAS. High orbit now generates 30.
balance: The prices of almost all items in the dropship fabricator have been increased.
balance: Minirockets now only take 2 seconds to impact on medium orbit, but have an even smaller explosion radius.
/:cl:
