### PR TITLE
Chemerette tweaks

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -379,10 +379,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "anticigoff"
 	item_state = "anticigoff"
 	icon_on = "anticigon"
-	smoketime = 30
-	chem_volume = 60
-	transquantity = 2 // one of each for the whole duration
-	list_reagents = list(/datum/reagent/medicine/ryetalyn = 30, /datum/reagent/water = 30)  //some water so it purges the rye too
+	smoketime = 31
+	chem_volume = 6
+	transquantity = 0.2
+	list_reagents = list(/datum/reagent/medicine/ryetalyn = 3, /datum/reagent/serotrotium = 3)
 
 /obj/item/clothing/mask/cigarette/emergency
 	name = "Red Comrade"
@@ -390,7 +390,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "rrcigoff"
 	item_state = "rrcigoff"
 	icon_on = "rrcigon"
-	smoketime = 10
+	smoketime = 11
 	transquantity = 1
 	list_reagents = list(/datum/reagent/medicine/russian_red = 10)  //same ammount as a pill
 
@@ -400,9 +400,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "bicacigoff"
 	item_state = "bicacigoff"
 	icon_on = "bicacigon"
-	smoketime = 30
-	transquantity = 5 // one of each for the whole duration
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 15)
+	smoketime = 31
+	transquantity = 0.3
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 9)
 
 /obj/item/clothing/mask/cigarette/kelo
 	name = "lemon flavored cigarette"
@@ -410,9 +410,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "kelocigoff"
 	item_state = "kelocigoff"
 	icon_on = "kelocigon"
-	smoketime = 30
-	transquantity = 5 // one of each for the whole duration
-	list_reagents = list(/datum/reagent/medicine/kelotane = 15)
+	smoketime = 31
+	transquantity = 0.3
+	list_reagents = list(/datum/reagent/medicine/kelotane = 9)
 
 /obj/item/clothing/mask/cigarette/tram
 	name = "poppy flavored cigarette"
@@ -420,7 +420,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "tramcigoff"
 	item_state = "tramcigoff"
 	icon_on = "tramcigon"
-	smoketime = 15  //so half a minute
+	smoketime = 16  //so half a minute
 	chem_volume = 60
 	transquantity = 2 // one of each for the whole duration
 	list_reagents = list(/datum/reagent/medicine/tramadol = 30, /datum/reagent/water = 30)


### PR DESCRIPTION
## About The Pull Request

Tweaks Chemerettes, Neurokiller now has Serotrotium to better fit the description that it may tire the smoker, lowered its chem volume and transfer rate so the chems are only in the smokers system while they're being smoked. Bicaridine and Kelotane now do the same instead of dumping 5u into the smoker for 6 ticks. Smoke time has been bumped up one for each as they were not using all the chems beforehand. (use the RR cig and see only 9 cloneloss)
## Why It's Good For The Game

Good because it makes existing thing work more like what the descriptions say they do.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Chemerette tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
