### PR TITLE
Redone flames light colors

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -176,6 +176,10 @@ Important note: colors can end up significantly different from the basic html pi
 #define LIGHT_COLOR_TUNGSTEN "#FAE1AF"
 /// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 #define LIGHT_COLOR_HALOGEN "#F0FAFA"
+/// More bright and rich in color compared to lava. rgb(248, 136, 24)
+#define LIGHT_COLOR_FLAME "#F88818"
+/// Rich and bright blue. rgb(0, 183, 255)
+#define LIGHT_COLOR_BLUE_FLAME "#00b8ff"
 
 //Ammo and grenade colors
 #define COLOR_AMMO_AIRBURST "#2272eb"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3292,7 +3292,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration = 5
 	shell_speed = 1.5
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_EXPLOSIVE
-	bullet_color = COLOR_VIBRANT_LIME
+	bullet_color = LIGHT_COLOR_ELECTRIC_GREEN
 
 	///Fire burn time
 	var/heat = 12

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -486,7 +486,6 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	light_on = TRUE
 	light_range = 3
 	light_power = 3
-	light_color = LIGHT_COLOR_LAVA
 	///Tracks how much "fire" there is. Basically the timer of how long the fire burns
 	var/firelevel = 12
 	///Tracks how HOT the fire is. This is basically the heat level of the fire and determines the temperature
@@ -497,6 +496,7 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 /obj/flamer_fire/Initialize(mapload, fire_lvl, burn_lvl, f_color, fire_stacks = 0, fire_damage = 0)
 	. = ..()
 	set_fire(fire_lvl, burn_lvl, f_color, fire_stacks, fire_damage)
+	updateicon()
 
 	START_PROCESSING(SSobj, src)
 
@@ -550,15 +550,15 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 		C.take_overall_damage(fire_damage, BURN, FIRE, updating_health = TRUE)
 
 /obj/flamer_fire/proc/updateicon()
-	var/light_color = "LIGHT_COLOR_LAVA"
+	var/light_color = "LIGHT_COLOR_FLAME"
 	var/light_intensity = 3
 	switch(flame_color)
 		if("red")
-			light_color = LIGHT_COLOR_LAVA
+			light_color = LIGHT_COLOR_FLAME
 		if("blue")
-			light_color = LIGHT_COLOR_CYAN
+			light_color = LIGHT_COLOR_BLUE_FLAME
 		if("green")
-			light_color = LIGHT_COLOR_GREEN
+			light_color = LIGHT_COLOR_ELECTRIC_GREEN
 	switch(firelevel)
 		if(1 to 9)
 			icon_state = "[flame_color]_1"


### PR DESCRIPTION
## About The Pull Request

Ports CM flame light colors instead of the existing one, new ones are a lot more rich in color and more epic looking in general, also i fixed a visual bug where the actual flame color is applied with a noticeable delay.

Color comparison:

**Normal -**

Before
![dreamseeker_8dadKX62Z7](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/fb487440-a609-4bf2-8a7c-f12d6e4c091f)

After
![dreamseeker_tK7RL52JlS](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/039dd033-ac21-4e22-b62f-a806d9b43522)

**Plasma-**

Before
![dreamseeker_gAbdrkhqPS](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/049e7fbd-c960-4005-92a3-a37e9dd13b1b)

After
![dreamseeker_CGh6bFIaW1](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/a7659dc2-fe47-4a27-a9eb-b4d8db3d19a6)

**Napalm-**

Before
![dreamseeker_jbO65hsiH9](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/22114dcb-0ef8-490c-8f10-942b41bb3246)

After
![dreamseeker_LubTUw9m8h](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/cca9896d-bd13-471f-aaba-430b9f93933c)

Also demonstration of fixed flame light update: (look at how plasma flame uses orange light color before switching to the correct one)

Before
![dreamseeker_HK0ZVmSgp8](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/2d090b76-f346-4e64-9384-9b2d47f7d3c8)

After
![dreamseeker_pbwzcOCCPZ](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/0f906990-a917-4fe8-8398-c43455073443)


## Why It's Good For The Game

Better visuals - good, bugs - bad.

## Changelog
:cl:
fix: flames now spawn with correct flame light color
code: changed hex color codes of flame light color
/:cl:
