### PR TITLE
Fixes soundplayer density

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -43,7 +43,6 @@
 /obj/effect/soundplayer
 	anchored = TRUE
 	opacity = FALSE
-	density = TRUE
 	icon_state = "speaker"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/datum/looping_sound/alarm_loop/deltalarm


### PR DESCRIPTION
## About The Pull Request

Title.
They were dense and shouldn't be.
Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/13579

## Why It's Good For The Game

Despite the fact that all the soundplayers are inside walls, apparently people were knocking walls down with plasma cutters and getting obstructed, especially during hijack.

## Changelog
:cl:
fix: Made soundplayers no longer dense.
/:cl:
