### PR TITLE
Adds An Eyewear Category to Clothing Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1232,8 +1232,6 @@
 			/obj/item/clothing/head/modular/style/beanie = -1,
 			/obj/item/clothing/head/modular/style/headband = -1,
 			/obj/item/clothing/head/modular/style/bandana = -1,
-			/obj/item/clothing/glasses/mgoggles = -1,
-			/obj/item/clothing/glasses/mgoggles/prescription = -1,
 		),
 		"Masks" = list(
 			/obj/item/clothing/mask/rebreather/scarf = -1,
@@ -1316,6 +1314,16 @@
 			/obj/item/clothing/mask/surgical = -1,
 			/obj/item/clothing/gloves/latex = -1,
 			/obj/item/clothing/shoes/white = -1,
+		),
+		"Eyewear" = list(
+			/obj/item/clothing/glasses/regular = -1,
+			/obj/item/clothing/glasses/eyepatch = -1,
+			/obj/item/clothing/glasses/sunglasses/fake/big = -1,
+			/obj/item/clothing/glasses/sunglasses/fake/big/prescription = -1,
+			/obj/item/clothing/glasses/sunglasses/fake = -1,
+			/obj/item/clothing/glasses/sunglasses/fake/prescription = -1,
+			/obj/item/clothing/glasses/mgoggles = -1,
+			/obj/item/clothing/glasses/mgoggles/prescription = -1,
 		),
 	)
 


### PR DESCRIPTION

## About The Pull Request
Adds an eyewear category to the clothing vendor, with various cosmetic and prescription sunglasses from the loadout prefs. Also moves the ballistic goggles from headwear to this new category.
![Change Me - Pillar of Spring 9_21_2023 9_48_22 PM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/4f982c0c-71a2-4ca4-b0a4-e8518967a9e0)

(Note: The duplicate sunglasses are due to the shades and sunglasses sharing the same name. Each of the sunglasses are the fake kind, so they do not provide flash protection.)
## Why It's Good For The Game
Having the cosmetic eyewear all in the same place will make customizing your character less tedious and difficult. Also the ballistic goggles being in headwear didn't really make much sense.
## Changelog
:cl:
add: Added an eyewear category to the surplus clothing vendor, containing various cosmetic and prescription eyewear.
del: Moved the ballistic goggles from the headwear category to the new eyewear category.
/:cl:
