### PR TITLE
Various QoL changes to end round panel

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for e
 GLOBAL_LIST_EMPTY(living_cameras)
 GLOBAL_LIST_EMPTY(aiEyes)
 GLOBAL_LIST_EMPTY(humans_by_zlevel)			//z level /list/list of alive humans
+GLOBAL_LIST_EMPTY(fallen_marines)			//z level /list/list of alive humans
 
 GLOBAL_LIST_EMPTY(mob_config_movespeed_type_lookup)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -250,6 +250,37 @@
 	iff_signal = TGMC_LOYALIST_IFF
 	var/dogtag_taken = FALSE
 
+/obj/item/card/id/dogtag/update_icon_state()
+	if(dogtag_taken)
+		icon_state = initial(icon_state) + "_taken"
+		return
+	icon = initial(icon_state)
+
+/obj/item/card/id/dogtag/canStrip(mob/stripper, mob/owner)
+	. = ..()
+	if(!.)
+		return
+	if(dogtag_taken)
+		stripper.balloon_alert(stripper, "Info tag already taken")
+		return FALSE
+	//if(owner.stat != DEAD)
+		//stripper.balloon_alert(stripper, "[owner] isn't dead yet")
+		//return FALSE
+
+/obj/item/card/id/dogtag/special_stripped_behavior(mob/stripper, mob/owner)
+	if(dogtag_taken)
+		return
+	stripper.balloon_alert(stripper, "Took info tag")
+	to_chat(stripper, span_notice("You take [owner]'s information tag, leaving the ID tag."))
+	dogtag_taken = TRUE
+	update_icon()
+	var/obj/item/dogtag/info_tag = new()
+	info_tag.fallen_names = list(registered_name)
+	info_tag.owning_marine = list(owner)
+	info_tag.fallen_assignments = list(assignment)
+	stripper.put_in_hands(info_tag)
+	return TRUE
+
 // Vendor points for job override
 /obj/item/card/id/dogtag/smartgun
 	marine_points = list(
@@ -306,7 +337,9 @@
 	icon = 'icons/obj/items/card.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	var/fallen_names[0]
-	var/fallen_assignements[0]
+	var/fallen_assignments[0]
+	///ref to the marine that owns this tag
+	var/mob/living/carbon/human/owning_marine[0]
 
 /obj/item/dogtag/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -315,10 +348,12 @@
 		var/obj/item/dogtag/D = I
 		to_chat(user, span_notice("You join the two tags together."))
 		name = "information dog tags"
+		if(D.owning_marine)
+			owning_marine += D.owning_marine
 		if(D.fallen_names)
 			fallen_names += D.fallen_names
-		if(D.fallen_assignements)
-			fallen_assignements += D.fallen_assignements
+		if(D.fallen_assignments)
+			fallen_assignments += D.fallen_assignments
 		qdel(D)
 		return TRUE
 
@@ -326,14 +361,14 @@
 	. = ..()
 	if(ishuman(user) && fallen_names && length(fallen_names))
 		if(length(fallen_names) == 1)
-			to_chat(user, span_notice("It reads: \"[fallen_names[1]] - [fallen_assignements[1]]\"."))
+			to_chat(user, span_notice("It reads: \"[fallen_names[1]] - [fallen_assignments[1]]\"."))
 		else
 			var/msg = "<span class='notice'> It reads: "
 			for(var/x = 1 to length(fallen_names))
 				if (x == length(fallen_names))
-					msg += "\"[fallen_names[x]] - [fallen_assignements[x]]\""
+					msg += "\"[fallen_names[x]] - [fallen_assignments[x]]\""
 				else
-					msg += "\"[fallen_names[x]] - [fallen_assignements[x]]\", "
+					msg += "\"[fallen_names[x]] - [fallen_assignments[x]]\", "
 
 			msg += ".</span>"
 

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -288,6 +288,8 @@
 /obj/structure/prop/mainship/ship_memorial/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/dogtag))
 		var/obj/item/dogtag/D = I
+		if(D.owning_marine)
+			GLOB.fallen_marines += D.owning_marine
 		if(D.fallen_names)
 			to_chat(user, span_notice("You add [D] to [src]."))
 			if(!fallen_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
Here's a short list of what's been changed,

The status at the end now cares more about if your side achieved victory, not if you're personally alive.
Marines memorialized are given a brief section on the end round panel.
Medals are no longer buried under the misc round stats.
The end round panel now shows off both the xeno hive leader, and the marine captain (if they have one).
Valhalla players now have a unique message for being in Valhalla instead of the generic "you survived" message they currently get.

**Note:** this PR is somewhat dependent on QV's dogtag fixes here https://github.com/tgstation/TerraGov-Marine-Corps/pull/13987, you should probably merge that first.

## Why It's Good For The Game

Qol should be fine, I've needed to do most of these things for quite a while now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The round medals section of the end round panel is no longer hidden under misc stats.
qol: Marine captains are now shown on the end round screen, along with the xeno leader.
qol: Memorialized marines now show up on the end round panel.
qol: The end round panel now cares about what side a player was on during round end.
fix: Valhalla players are no longer treated as alive by the end round panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
