### PR TITLE
Revert "Superheavy pistol changes"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -422,11 +422,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "pistol_superheavy"
 	damage = 45
 	penetration = 15
-	sundering = 3
-	damage_falloff = 0.75
+	sundering = 3.5
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -331,11 +331,11 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.7 SECONDS
 	scatter_unwielded = 25
 	recoil = 1
 	recoil_unwielded = 2
-	scatter = 2
+	scatter = 4
 	scatter_unwielded = 7
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.7
@@ -453,7 +453,7 @@
 
 
 //-------------------------------------------------------
-// Browning Hipower
+//.45 MARSHALS PISTOL //Inspired by the Browning Hipower
 
 /obj/item/weapon/gun/pistol/highpower
 	name = "\improper Highpower automag"
@@ -473,13 +473,13 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
-	fire_delay = 0.35 SECONDS
+	fire_delay = 1 SECONDS
 	burst_delay = 0.5 SECONDS
 	damage_mult = 1.2
-	recoil = 0
+	recoil = 1
 	recoil_unwielded = 2
-	accuracy_mult_unwielded = 0.6
-	scatter = 2
+	accuracy_mult_unwielded = 0.7
+	scatter = 3
 	scatter_unwielded = 6
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request
Reverts tgstation/TerraGov-Marine-Corps#13957

## Why It's Good For The Game
As the maintainer who merged this noted this had the potential to be cancer, it has indeed proven true. 

Fast-firing, high-damage, sundering, staggering, slowdown AND knockback. Witnessed many xenos being killed by a single dude with this weapon, being unable to do anything back for 5-10 seconds because they were permanently staggered. 

## Changelog

🆑 balance: Reverts "Superheavy pistols like the Deagle and Hipower have significantly less fire delay, deal a bit less sunder, deal halved slowdown and have better handling." 🆑

