### PR TITLE
Superheavy pistol balanc pass

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -426,7 +426,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = 0.75
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, stagger = 0.5 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -331,7 +331,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.35 SECONDS
+	fire_delay = 0.45 SECONDS
 	scatter_unwielded = 25
 	recoil = 1
 	recoil_unwielded = 2
@@ -473,7 +473,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
-	fire_delay = 0.4 SECONDS
+	fire_delay = 0.45 SECONDS
 	burst_delay = 0.5 SECONDS
 	damage_mult = 1.1
 	recoil = 1

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -475,7 +475,7 @@
 
 	fire_delay = 0.4 SECONDS
 	burst_delay = 0.5 SECONDS
-	damage_mult = 1.15
+	damage_mult = 1.1
 	recoil = 1
 	recoil_unwielded = 2
 	accuracy_mult_unwielded = 0.6

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -331,7 +331,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.35 SECONDS
 	scatter_unwielded = 25
 	recoil = 1
 	recoil_unwielded = 2
@@ -473,14 +473,14 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
-	fire_delay = 0.35 SECONDS
+	fire_delay = 0.4 SECONDS
 	burst_delay = 0.5 SECONDS
-	damage_mult = 1.2
-	recoil = 0
+	damage_mult = 1.15
+	recoil = 1
 	recoil_unwielded = 2
 	accuracy_mult_unwielded = 0.6
-	scatter = 2
-	scatter_unwielded = 6
+	scatter = 3
+	scatter_unwielded = 7
 
 //-------------------------------------------------------
 //VP70


### PR DESCRIPTION
## About The Pull Request
Nerfs stagger from 2 to 0.5. Also nerfs the firedelay by 0.1 on all of them.
Hipower does 1.1 rather than 1.2, scatters a bit more and has natural recoil.
## Why It's Good For The Game
Makes super heavy pistols more in line with stagger on hit and general damage.
## Changelog
:cl:
balance: Another balance pass on superheavy pistols, their stagger has been significantly reduced, alongside their fire rate being minorly made worse (0.05 more seconds, so .35 for Deagle and .4 for automag.) Automag does a bit less damage and has a bit more scatter.
/:cl:
