### PR TITLE
Fix backpack prefs overriding job backpacks

### DIFF
--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -310,6 +310,8 @@ GLOBAL_PROTECT(exp_specialmap)
 
 		equip_role_outfit(job)
 
+		regenerate_icons() //some items lack icons unless updated
+
 	if((job.job_flags & JOB_FLAG_ALLOWS_PREFS_GEAR) && player)
 		equip_preference_gear(player)
 

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -289,14 +289,24 @@ GLOBAL_PROTECT(exp_specialmap)
 	LAZYADD(GLOB.alive_human_list_faction[faction], src)
 	comm_title = job.comm_title
 	if(job.outfit)
-		var/id_type = job.outfit.id ? job.outfit.id : /obj/item/card/id
-		var/obj/item/card/id/id_card = new id_type(src)
-		if(wear_id)
-			if(!admin_action)
-				stack_trace("[src] had an ID when apply_outfit_to_spawn() ran")
-			QDEL_NULL(wear_id)
-		equip_to_slot_or_del(id_card, SLOT_WEAR_ID)
-		job.outfit.handle_id(src)
+		if(job.outfit.id)
+			var/obj/item/card/id/id_card = new job.outfit.id
+			if(wear_id)
+				if(!admin_action)
+					stack_trace("[src] had an ID when apply_outfit_to_spawn() ran")
+				QDEL_NULL(wear_id)
+			equip_to_slot_or_del(id_card, SLOT_WEAR_ID)
+
+		if(player && isnull(job.outfit.back) && player.prefs.backpack > BACK_NOTHING)
+			var/obj/item/storage/backpack/new_backpack
+			switch(player.prefs.backpack)
+				if(BACK_BACKPACK)
+					new_backpack = new /obj/item/storage/backpack/marine(src)
+				if(BACK_SATCHEL)
+					new_backpack = new /obj/item/storage/backpack/marine/satchel(src)
+			equip_to_slot_or_del(new_backpack, SLOT_BACK)
+
+		job.outfit.handle_id(src, player)
 
 		equip_role_outfit(job)
 

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -310,8 +310,6 @@ GLOBAL_PROTECT(exp_specialmap)
 
 		equip_role_outfit(job)
 
-		regenerate_icons() //some items lack icons unless updated
-
 	if((job.job_flags & JOB_FLAG_ALLOWS_PREFS_GEAR) && player)
 		equip_preference_gear(player)
 

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -4,7 +4,7 @@
 	var/w_uniform = null
 	var/wear_suit = null
 	var/toggle_helmet = TRUE
-	var/back = null
+	var/back = null // Set to FALSE if your outfit needs nothing in back slot at all
 	var/belt = null
 	var/gloves = null
 	var/shoes = null

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -213,15 +213,6 @@
 	character.underwear = underwear
 	character.undershirt = undershirt
 
-	if(backpack > BACK_NOTHING)
-		var/obj/item/storage/backpack/new_backpack
-		switch(backpack)
-			if(BACK_BACKPACK)
-				new_backpack = new /obj/item/storage/backpack/marine(character)
-			if(BACK_SATCHEL)
-				new_backpack = new /obj/item/storage/backpack/marine/satchel(character)
-		character.equip_to_slot_or_del(new_backpack, SLOT_BACK)
-
 	character.update_body()
 	character.update_hair()
 


### PR DESCRIPTION
## About The Pull Request

Fixes backpack prefs overriding the actual specified backpacks in job datums, because of which ST and CE never spawn with a their back fuel tanks for example. Also made it possible to specify having no ID slot item and no backpack slot item at all, right now it's impossible, if you set ID to null it'd still spawn, if you set backpack to null it'd just spawn the one from prefs anyway.

## Why It's Good For The Game

Bugs - bad, fix - good, flexible datums - even better.

## Changelog
:cl:
fix: id card having no mob icon when spawning on mob
fix: fixed backpack prefs overriding spawn of job assigned backpacks
code: made it possible to specify to spawn without backpack or id in job datums
/:cl:
