### PR TITLE
Reduces medivac bed price in corpsmen vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/healthanalyzer/gloves = list(CAT_MEDSUP, "Health scanner gloves", 2, "black"),
 		/obj/item/defibrillator/gloves = list(CAT_MEDSUP, "Advanced medical gloves", 5, "black"),
-		/obj/effect/vendor_bundle/stretcher = list(CAT_MEDSUP, "Medivac Stretcher", 45, "black"),
+		/obj/effect/vendor_bundle/stretcher = list(CAT_MEDSUP, "Medivac Stretcher", 20, "black"),
 	))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(


### PR DESCRIPTION

## About The Pull Request
Price goes from 45 to 20, which is about half of a corpsman budget. Still expensive, but less demanding now.


## Why It's Good For The Game
The medivac beds are way overpriced, actually. It's not worth skimping on gloves, mera, derma, meladerm or the rest. This PR makes it possible to squeeze the extra without sacrificing everything.

## Changelog
:cl:
balance: Made medivac beds ~50% cheaper for corpsmen
/:cl:
