### PR TITLE
Standardizes Dropship Hazard Stripe Outlines

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -1230,13 +1230,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"blA" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "blI" = (
 /obj/machinery/door/poddoor/shutters/mainship/cic/armory{
 	dir = 2
@@ -4640,15 +4633,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/starboard_ert)
-"ean" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "eaQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -6496,20 +6480,6 @@
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
-"fCa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/machinery/floodlight/landing,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/squads/req)
 "fCj" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -14180,15 +14150,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
-"lLY" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "lML" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -36289,11 +36250,11 @@ mGC
 aLj
 mGC
 xFW
-fCa
+nqZ
 cVO
-iRc
-noh
 dil
+noh
+iRc
 noh
 iRc
 uXd
@@ -36490,7 +36451,7 @@ mGC
 mGC
 mGC
 mGC
-ean
+jDS
 uST
 aHj
 jtb
@@ -36694,7 +36655,7 @@ mGC
 mGC
 mGC
 mGC
-lLY
+xYf
 rik
 aHj
 jtb
@@ -36881,7 +36842,7 @@ etU
 vAL
 uST
 uST
-blA
+uhS
 xkA
 mGC
 mGC
@@ -36901,11 +36862,11 @@ mGC
 axY
 mGC
 xFW
-fCa
+nqZ
 qQu
-eDA
-mQy
 hHi
+mQy
+eDA
 mQy
 eDA
 fkN
@@ -37087,7 +37048,7 @@ mGC
 mGC
 mtP
 uST
-blA
+uhS
 mGC
 mGC
 mGC

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -130,12 +130,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"ajm" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
 "akW" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -223,9 +217,10 @@
 /area/mainship/shipboard/weapon_room)
 "aql" = (
 /obj/machinery/floodlight/landing,
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "aqp" = (
 /obj/machinery/light/mainship,
@@ -233,9 +228,10 @@
 /area/crew_quarters/toilet)
 "aqx" = (
 /obj/machinery/floodlight/landing,
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "are" = (
 /obj/machinery/door/firedoor/mainship,
@@ -483,14 +479,6 @@
 /obj/effect/landmark/start/job/synthetic,
 /turf/open/floor/mainship/cargo,
 /area/mainship/command/cic)
-"aGh" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "aGk" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -1774,7 +1762,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cfw" = (
-/turf/open/floor/plating/icefloor/warnplate,
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "cfM" = (
 /obj/structure/window/framed/mainship,
@@ -1922,9 +1911,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "csW" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "cth" = (
 /obj/structure/cable,
@@ -1982,6 +1972,12 @@
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"cxw" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cyM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3253,11 +3249,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
-"dXV" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "dYs" = (
 /obj/effect/ai_node,
 /turf/open/floor/carpet/side,
@@ -3398,12 +3389,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"egy" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
 "egI" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -4049,6 +4034,10 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"fbT" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "fcu" = (
 /obj/effect/landmark/corpsespawner/chef/regular,
 /turf/open/floor/mainship/mono,
@@ -5454,6 +5443,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"gVZ" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "gWI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -7394,6 +7390,13 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/stern_hallway)
+"jCW" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "jCY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -9352,10 +9355,6 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
-"lQe" = (
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/light/plating,
-/area/mainship/hallways/hangar)
 "lQN" = (
 /obj/machinery/sleeper,
 /obj/machinery/light/mainship,
@@ -9472,10 +9471,8 @@
 	},
 /area/mainship/command/airoom)
 "lVM" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4
-	},
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "lVR" = (
 /obj/machinery/light/mainship{
@@ -10286,9 +10283,10 @@
 	},
 /area/mainship/shipboard/firing_range)
 "nbW" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ncj" = (
 /obj/structure/cable,
@@ -10707,9 +10705,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "nzB" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "nzV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11978,6 +11977,12 @@
 	dir = 4
 	},
 /area/mainship/medical/chemistry)
+"pgp" = (
+/obj/effect/attach_point/weapon/dropship2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "pgq" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -12050,9 +12055,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "plN" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "plR" = (
 /obj/machinery/robotic_cradle,
@@ -12143,6 +12152,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"pqC" = (
+/obj/effect/attach_point/weapon/dropship2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "prY" = (
 /obj/machinery/computer/camera_advanced/overwatch/req,
 /obj/machinery/light/mainship{
@@ -12979,6 +12994,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"qsh" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "qss" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/closet/bodybag,
@@ -13378,14 +13400,22 @@
 	},
 /area/mainship/medical/operating_room_two)
 "qPc" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "qPq" = (
 /obj/structure/sign/chemistry,
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
+"qPD" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "qQk" = (
 /obj/machinery/light/mainship/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -13531,9 +13561,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qWy" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "qXC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13851,9 +13882,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "rxx" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ryp" = (
 /obj/structure/table/mainship/nometal,
@@ -14029,9 +14061,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "rHw" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 9
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "rHK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15569,7 +15602,10 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "tHk" = (
-/turf/open/floor/plating/icefloor/warnplate/corner,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "tHw" = (
 /obj/machinery/light/mainship{
@@ -16657,6 +16693,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
+"uTE" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "uTG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17089,6 +17132,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"vwd" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "vwh" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Bathroom"
@@ -18769,9 +18819,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "xDq" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "xDy" = (
 /obj/effect/decal/cleanable/blood,
@@ -18939,6 +18990,15 @@
 	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
+"xRJ" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "xRP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46665,20 +46725,20 @@ kDx
 tHk
 csW
 nzB
-xDq
-xDq
-aGh
+kDx
+kDx
+kDx
 rxx
 csW
 csW
 csW
 csW
 nzB
-xDq
-xDq
-xDq
-xDq
-xDq
+kDx
+kDx
+kDx
+kDx
+kDx
 plN
 aql
 wyz
@@ -46920,6 +46980,7 @@ oIb
 kDx
 kDx
 cfw
+fbT
 kDx
 kDx
 kDx
@@ -46935,9 +46996,8 @@ kDx
 kDx
 kDx
 kDx
+gVZ
 kDx
-plN
-plN
 brN
 xBT
 cYZ
@@ -47177,9 +47237,6 @@ xyA
 csW
 csW
 nzB
-kDx
-kDx
-kDx
 iMu
 kDx
 kDx
@@ -47193,8 +47250,11 @@ kDx
 kDx
 kDx
 kDx
-plN
-plN
+kDx
+kDx
+kDx
+jCW
+kDx
 brN
 uqj
 aCM
@@ -47431,7 +47491,6 @@ imJ
 dpY
 nWE
 cPE
-plN
 kDx
 kDx
 kDx
@@ -47450,8 +47509,9 @@ kDx
 kDx
 kDx
 kDx
-xDq
-dXV
+kDx
+kDx
+kDx
 fGZ
 tAu
 sdK
@@ -47688,7 +47748,7 @@ vTt
 dpY
 nWE
 xyA
-plN
+kDx
 kDx
 kDx
 kDx
@@ -47945,7 +48005,7 @@ tyN
 ncO
 nWE
 xyA
-plN
+kDx
 kDx
 kDx
 kDx
@@ -47964,7 +48024,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 kDx
 rCn
 bOz
@@ -48202,7 +48262,7 @@ jLS
 nkm
 nWE
 cPE
-plN
+kDx
 kDx
 kDx
 kDx
@@ -48459,7 +48519,6 @@ tyN
 dpY
 nWE
 cPE
-plN
 kDx
 kDx
 kDx
@@ -48478,8 +48537,9 @@ kDx
 kDx
 kDx
 kDx
-csW
-qPc
+kDx
+kDx
+kDx
 hMB
 lCh
 foU
@@ -48718,8 +48778,8 @@ nWE
 cPE
 xDq
 xDq
-xDq
-ajm
+qWy
+iMu
 kDx
 kDx
 kDx
@@ -48735,8 +48795,8 @@ kDx
 kDx
 kDx
 kDx
-plN
-plN
+uTE
+kDx
 brN
 aWk
 aQX
@@ -48975,10 +49035,8 @@ nWE
 cPE
 kDx
 kDx
-kDx
-egy
-kDx
-kDx
+cfw
+fbT
 kDx
 kDx
 kDx
@@ -48992,8 +49050,10 @@ kDx
 kDx
 kDx
 kDx
-plN
-plN
+kDx
+kDx
+qsh
+kDx
 brN
 aWk
 cYZ
@@ -49232,24 +49292,24 @@ nWE
 cPE
 hFZ
 kDx
-kDx
+nbW
 xDq
 qWy
-csW
-csW
-csW
+kDx
+kDx
+kDx
 rHw
 xDq
 xDq
 xDq
 xDq
 qWy
-csW
-csW
-csW
-csW
-csW
-plN
+kDx
+kDx
+kDx
+kDx
+kDx
+xRJ
 aqx
 brN
 aWk
@@ -49996,7 +50056,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 mjl
 wEZ
 uNz
@@ -50253,7 +50313,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 mjl
 wEZ
 lrW
@@ -50510,7 +50570,7 @@ thg
 kDx
 kDx
 kDx
-plN
+cxw
 oIu
 irz
 lrW
@@ -50767,7 +50827,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 mjl
 wEZ
 lrW
@@ -51024,7 +51084,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 mjl
 wEZ
 dLM
@@ -51281,7 +51341,7 @@ xDq
 xDq
 xDq
 xDq
-dXV
+lVM
 mjl
 wEZ
 lrW
@@ -51806,9 +51866,9 @@ kDx
 kDx
 tHk
 nzB
-xDq
-plN
 kDx
+cxw
+pqC
 kDx
 kDx
 kDx
@@ -52064,8 +52124,8 @@ kDx
 cfw
 kDx
 kDx
-plN
-lQe
+cxw
+kDx
 tHk
 csW
 csW
@@ -52322,12 +52382,12 @@ cfw
 kDx
 kDx
 rxx
-csW
+qPD
 nzB
 kDx
 kDx
 kDx
-plN
+cxw
 duy
 lun
 rzG
@@ -52574,7 +52634,7 @@ ybP
 kDx
 kDx
 kDx
-lQe
+kDx
 cfw
 kDx
 kDx
@@ -52584,7 +52644,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 opn
 qxp
 snV
@@ -52831,7 +52891,7 @@ ybP
 tHk
 csW
 csW
-csW
+qPD
 nzB
 kDx
 kDx
@@ -52841,7 +52901,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 opn
 tqC
 sEl
@@ -53098,7 +53158,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 opn
 isR
 kwS
@@ -53345,7 +53405,7 @@ ybP
 nbW
 xDq
 xDq
-xDq
+vwd
 qWy
 kDx
 kDx
@@ -53355,7 +53415,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 aFJ
 orC
 gnS
@@ -53602,7 +53662,7 @@ ybP
 kDx
 kDx
 kDx
-lQe
+kDx
 cfw
 kDx
 kDx
@@ -53612,7 +53672,7 @@ kDx
 kDx
 kDx
 kDx
-plN
+cxw
 aFJ
 mMx
 gnS
@@ -53864,12 +53924,12 @@ cfw
 kDx
 kDx
 rHw
-xDq
+vwd
 qWy
 kDx
 kDx
 kDx
-plN
+cxw
 opn
 avq
 dpY
@@ -54120,8 +54180,8 @@ kDx
 cfw
 kDx
 kDx
-plN
-lQe
+cxw
+kDx
 nbW
 xDq
 xDq
@@ -54376,9 +54436,9 @@ kDx
 kDx
 nbW
 qWy
-csW
-plN
 kDx
+cxw
+pgp
 kDx
 kDx
 kDx

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -7789,6 +7789,12 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
+"aQN" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "aQP" = (
 /obj/machinery/crema_switch{
 	id = "crema";
@@ -9665,14 +9671,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo/prep)
-"bwn" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/sulaco/hangar)
 "bxJ" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
@@ -11067,6 +11065,15 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"dpk" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar/cas)
 "dpL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -11140,9 +11147,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/evac)
 "dtI" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "duZ" = (
 /obj/structure/bed/chair/sofa/left{
@@ -11297,7 +11305,7 @@
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
 "dKl" = (
-/obj/machinery/landinglight/cas{
+/obj/effect/attach_point/weapon/dropship2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12257,7 +12265,8 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/hallway/lower_foreship)
 "eQF" = (
-/turf/open/floor/plating/icefloor/warnplate,
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "eRD" = (
 /obj/machinery/light/mainship/small{
@@ -12603,6 +12612,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"fsb" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "fsL" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
@@ -13069,9 +13084,10 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "ger" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "geL" = (
 /obj/structure/closet/walllocker/emerglocker{
@@ -13344,13 +13360,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
-"gwb" = (
-/obj/machinery/landinglight/cas{
-	dir = 8
-	},
-/obj/machinery/landinglight/cas,
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "gwm" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
@@ -14026,15 +14035,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/cargo)
-"hoD" = (
-/obj/machinery/landinglight/cas{
-	dir = 8
-	},
-/obj/machinery/landinglight/cas{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "hoF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -15431,12 +15431,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine_monitoring)
-"iVw" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/sulaco/hangar)
 "iVT" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/shutters/opened{
@@ -15689,15 +15683,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"jjp" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/obj/machinery/landinglight/cas{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "jlB" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -15898,11 +15883,6 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
-"jBs" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4
-	},
-/area/sulaco/hangar)
 "jBX" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
@@ -16037,6 +16017,12 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
+"jIo" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "jIv" = (
 /obj/machinery/air_alarm{
 	dir = 4
@@ -16331,6 +16317,13 @@
 	dir = 4
 	},
 /area/sulaco/hangar/droppod)
+"jYG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "jYO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -16559,6 +16552,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/bridge/office)
+"kpD" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "kqp" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -17398,7 +17398,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "lxI" = (
-/obj/machinery/landinglight/cas{
+/obj/effect/attach_point/weapon/dropship2{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -17627,6 +17627,12 @@
 /obj/effect/spawner/random/misc/table_lighting,
 /turf/open/floor/mainship/black,
 /area/sulaco/mechpilotquarters)
+"lJm" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "lJv" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
@@ -17647,6 +17653,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"lMr" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "lMO" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -18253,15 +18263,6 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/prison,
 /area/sulaco/security)
-"mCu" = (
-/obj/machinery/landinglight/cas{
-	dir = 4
-	},
-/obj/machinery/landinglight/cas{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "mCx" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -18801,9 +18802,10 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/sulaco/mechpilotquarters)
 "npe" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "npi" = (
 /obj/structure/dropship_equipment/cas/weapon/heavygun,
@@ -19222,12 +19224,6 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine_monitoring)
-"nPp" = (
-/obj/machinery/landinglight/cas{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "nPU" = (
 /obj/machinery/cic_maptable,
 /turf/open/floor/prison,
@@ -19833,6 +19829,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/bridge)
+"oFM" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "oFW" = (
 /obj/machinery/light/mainship/small,
 /turf/open/floor/prison/arrow/clean{
@@ -20976,6 +20978,10 @@
 	dir = 8
 	},
 /area/mainship/shipboard/weapon_room)
+"qct" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "qcT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -21295,6 +21301,12 @@
 "qDO" = (
 /turf/open/floor/mainship_hull/gray/dir,
 /area/space)
+"qES" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "qFe" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -21395,6 +21407,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"qLw" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "qMu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -21709,6 +21727,12 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
+"rhc" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "rhM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -22351,6 +22375,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"rTR" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "rVm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/prison,
@@ -22796,7 +22824,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "suj" = (
-/obj/machinery/landinglight/cas,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
 "svj" = (
@@ -22987,12 +23017,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/security)
-"sIv" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/sulaco/hangar)
 "sIy" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/supplydrop_console,
@@ -23083,9 +23107,10 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "sMl" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "sMv" = (
 /obj/machinery/vending/nanomed{
@@ -23562,6 +23587,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"trP" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "tsP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -23954,13 +23986,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
-"tPR" = (
-/obj/machinery/landinglight/cas,
-/obj/machinery/landinglight/cas{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "tRg" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
@@ -24228,7 +24253,10 @@
 /turf/open/floor/prison,
 /area/sulaco/firingrange)
 "uiW" = (
-/turf/open/floor/plating/icefloor/warnplate/corner,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "ujq" = (
 /obj/machinery/light/mainship{
@@ -24269,6 +24297,12 @@
 "ukL" = (
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
+"ulM" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "ulO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -24311,9 +24345,10 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/lower_engineering)
 "uoG" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "uoT" = (
 /obj/structure/cable,
@@ -24473,6 +24508,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"uBl" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "uBn" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/mainship/gray,
@@ -24547,6 +24591,13 @@
 	},
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
+"uGa" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "uHR" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -25118,6 +25169,12 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
+"vuZ" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "vvG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -25266,9 +25323,10 @@
 	},
 /area/sulaco/medbay)
 "vCF" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 9
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "vCN" = (
 /turf/closed/wall/mainship/gray,
@@ -25730,6 +25788,12 @@
 	},
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
+"whN" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "whS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/roomba,
@@ -26062,11 +26126,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
-"wKu" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8
-	},
-/area/sulaco/hangar)
 "wKB" = (
 /obj/structure/sign/hydro/three,
 /turf/closed/wall/mainship/gray,
@@ -26424,15 +26483,6 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/sulaco/research)
-"xjm" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/obj/machinery/landinglight/cas{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "xjC" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -26571,9 +26621,13 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
 "xxv" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
+/turf/open/floor/plating,
 /area/sulaco/hangar)
 "xxx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -27189,6 +27243,12 @@
 /obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"ylS" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "ylT" = (
 /obj/machinery/door/poddoor/shutters/opened/wy{
 	dir = 2
@@ -56690,7 +56750,7 @@ wpf
 wpf
 wpf
 imB
-tCl
+dpk
 wpf
 wpf
 wpf
@@ -56938,19 +56998,19 @@ dCC
 bFu
 nCl
 ddK
-hoD
+pwv
+pwv
+pwv
+lJm
+fsb
+pwv
+jIo
 dKl
-dKl
-dKl
-dKl
-dKl
-xjm
-dKl
-dKl
-dKl
-dKl
-dKl
-gwb
+pwv
+pwv
+pwv
+pwv
+pwv
 wSg
 jtC
 jtC
@@ -57195,18 +57255,18 @@ dCC
 cdy
 rpN
 ddK
-nPp
 pwv
 pwv
 pwv
+qct
 pwv
 pwv
+jIo
 pwv
-pwv
-pwv
-pwv
-pwv
-pwv
+lJm
+qLw
+qLw
+qLw
 suj
 ecG
 jtC
@@ -57452,19 +57512,19 @@ dCC
 dZG
 qAV
 ddK
-nPp
 pwv
 pwv
 pwv
+qct
+pwv
+pwv
+oFM
+qLw
+fsb
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-pwv
-pwv
-suj
+jIo
 ecG
 jtC
 jtC
@@ -57709,7 +57769,10 @@ mju
 ahT
 rpN
 ddK
-nPp
+pwv
+pwv
+pwv
+qct
 pwv
 pwv
 pwv
@@ -57718,10 +57781,7 @@ pwv
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-suj
+jIo
 wnj
 jtC
 jtC
@@ -57966,7 +58026,10 @@ dCC
 iNC
 sCO
 ddK
-nPp
+qLw
+qLw
+qLw
+fsb
 pwv
 pwv
 pwv
@@ -57975,10 +58038,7 @@ pwv
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-suj
+jIo
 ecG
 jtC
 jtC
@@ -58223,7 +58283,7 @@ dCC
 uXj
 rpN
 ddK
-nPp
+pwv
 pwv
 pwv
 pwv
@@ -58235,7 +58295,7 @@ pwv
 pwv
 pwv
 pwv
-suj
+jIo
 ecG
 jtC
 jtC
@@ -58480,7 +58540,10 @@ dCC
 ilD
 bew
 ddK
-nPp
+aQN
+aQN
+aQN
+ylS
 pwv
 pwv
 pwv
@@ -58489,10 +58552,7 @@ pwv
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-suj
+jIo
 ecG
 jtC
 bhG
@@ -58737,7 +58797,10 @@ mju
 vfc
 bew
 ddK
-nPp
+pwv
+pwv
+pwv
+qct
 pwv
 pwv
 pwv
@@ -58746,10 +58809,7 @@ pwv
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-suj
+jIo
 ecG
 htz
 omu
@@ -58994,19 +59054,19 @@ dCC
 kwh
 bhA
 ddK
-nPp
 pwv
 pwv
 pwv
+qct
+pwv
+pwv
+ulM
+aQN
+ylS
 pwv
 pwv
 pwv
-pwv
-pwv
-pwv
-pwv
-pwv
-suj
+jIo
 ecG
 jtC
 hOC
@@ -59251,19 +59311,19 @@ dCC
 kwh
 bhA
 ddK
-nPp
 pwv
 pwv
 pwv
+qct
 pwv
 pwv
+jIo
 pwv
-pwv
-pwv
-pwv
-pwv
-pwv
-suj
+qES
+aQN
+aQN
+aQN
+rTR
 ecG
 jtC
 hOC
@@ -59508,19 +59568,19 @@ dCC
 ntA
 qku
 ddK
-mCu
+pwv
+pwv
+pwv
+qES
+ylS
+pwv
+jIo
 lxI
-lxI
-lxI
-lxI
-lxI
-jjp
-lxI
-lxI
-lxI
-lxI
-lxI
-tPR
+pwv
+pwv
+pwv
+pwv
+pwv
 ecG
 jtC
 tNu
@@ -61577,20 +61637,20 @@ aPZ
 uiW
 dtI
 npe
-sMl
-sMl
-bwn
+aPZ
+aPZ
+aPZ
 uoG
 dtI
 dtI
 dtI
 dtI
 npe
-sMl
-sMl
-sMl
-sMl
-sMl
+aPZ
+aPZ
+aPZ
+aPZ
+aPZ
 xxv
 dtI
 svV
@@ -61848,8 +61908,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-xxv
-xxv
+uGa
+aPZ
 svV
 aPF
 uYv
@@ -62105,8 +62165,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-xxv
-xxv
+kpD
+aPZ
 svV
 gHU
 gQS
@@ -62343,7 +62403,6 @@ wjr
 jQS
 aPF
 igo
-xxv
 aPZ
 aPZ
 aPZ
@@ -62362,8 +62421,9 @@ aPZ
 aPZ
 aPZ
 aPZ
-sMl
-jBs
+aPZ
+aPZ
+aPZ
 svV
 aPF
 gHU
@@ -62600,7 +62660,7 @@ wjr
 aSl
 gHU
 igo
-xxv
+aPZ
 aPZ
 aPZ
 aPZ
@@ -62857,7 +62917,7 @@ qHe
 cTC
 jik
 aji
-xxv
+aPZ
 aPZ
 aPZ
 aPZ
@@ -62876,7 +62936,7 @@ aPZ
 aPZ
 aPZ
 aPZ
-xxv
+rhc
 aPZ
 mmv
 aPF
@@ -63114,7 +63174,7 @@ wjr
 aSl
 aPF
 igo
-xxv
+aPZ
 aPZ
 aPZ
 aPZ
@@ -63371,7 +63431,6 @@ wjr
 aSl
 aPF
 jGF
-xxv
 aPZ
 aPZ
 aPZ
@@ -63390,8 +63449,9 @@ aPZ
 aPZ
 aPZ
 aPZ
-dtI
-wKu
+aPZ
+aPZ
+aPZ
 svV
 aPF
 gHU
@@ -63630,8 +63690,8 @@ aPF
 bYh
 sMl
 sMl
-sMl
-sIv
+ger
+uvn
 aPZ
 aPZ
 aPZ
@@ -63647,8 +63707,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-xxv
-xxv
+jYG
+aPZ
 svV
 aPF
 gQS
@@ -63887,10 +63947,8 @@ aPF
 igo
 aPZ
 aPZ
-aPZ
-iVw
-aPZ
-aPZ
+eQF
+rFe
 aPZ
 aPZ
 aPZ
@@ -63904,8 +63962,10 @@ aPZ
 aPZ
 aPZ
 aPZ
-xxv
-xxv
+aPZ
+aPZ
+trP
+aPZ
 svV
 aPF
 aPF
@@ -64144,24 +64204,24 @@ aPF
 igo
 aPZ
 aPZ
-aPZ
+whN
 sMl
 ger
-dtI
-dtI
-dtI
+aPZ
+aPZ
+aPZ
 vCF
 sMl
 sMl
 sMl
 sMl
 ger
-dtI
-dtI
-dtI
-dtI
-dtI
-xxv
+aPZ
+aPZ
+aPZ
+aPZ
+aPZ
+uBl
 sMl
 svV
 gHU
@@ -65419,13 +65479,13 @@ bFa
 ewe
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+uiW
+dtI
+dtI
+dtI
+dtI
+dtI
+vuZ
 qqt
 aPF
 aPF
@@ -65675,14 +65735,14 @@ mDu
 bFa
 ewe
 aPZ
+uiW
+npe
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+rhc
 qqt
 aPF
 aPF
@@ -65932,14 +65992,14 @@ mDu
 bFa
 ewe
 aPZ
+eQF
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
+rhc
 qqt
 aPF
 aPF
@@ -66189,14 +66249,14 @@ mDu
 bFa
 ngp
 aPZ
-aPZ
+eQF
 aPZ
 aPZ
 vzl
 aPZ
 aPZ
 aPZ
-aPZ
+rhc
 vtx
 xNa
 aPF
@@ -66446,14 +66506,14 @@ mDu
 bFa
 ewe
 aPZ
+eQF
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
+rhc
 qqt
 aPF
 aPF
@@ -66703,14 +66763,14 @@ mDu
 bFa
 ewe
 aPZ
+whN
+ger
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+rhc
 qqt
 aPF
 aPF
@@ -66961,13 +67021,13 @@ bFa
 ewe
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+whN
+sMl
+sMl
+sMl
+sMl
+sMl
+lMr
 qqt
 aPF
 aPF

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2183,6 +2183,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/lower_engineering)
+"aPL" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "aQY" = (
 /obj/machinery/conveyor{
 	id = "lower_garbage"
@@ -3073,12 +3079,6 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/engine_core)
-"bgX" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
 "bhd" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -3999,9 +3999,6 @@
 /obj/structure/mirror,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/commandbunks)
-"bou" = (
-/turf/open/floor/plating/icefloor/warnplate/corner,
-/area/mainship/hallways/hangar)
 "boB" = (
 /obj/effect/ai_node,
 /obj/machinery/landinglight/tadpole{
@@ -5146,11 +5143,6 @@
 	dir = 8
 	},
 /area/mainship/engineering/lower_engineering)
-"bBa" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/mainship/hallways/hangar)
 "bBe" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 25
@@ -6953,18 +6945,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"bVL" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
-"bVN" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "bVU" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -7251,8 +7231,8 @@
 /turf/open/floor/mainship/blue/corner,
 /area/mainship/living/port_emb)
 "car" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -7270,8 +7250,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "caJ" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -7514,6 +7494,13 @@
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/delta)
+"ceA" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cfd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7912,6 +7899,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
+"cIT" = (
+/obj/effect/attach_point/weapon/dropship2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cKb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -8045,6 +8038,12 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
+"cTc" = (
+/obj/effect/attach_point/weapon/dropship2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cTo" = (
 /obj/structure/closet,
 /obj/item/toy/plush/lizard,
@@ -8148,12 +8147,6 @@
 	pixel_y = -4
 	},
 /turf/open/floor/plating,
-/area/mainship/hallways/hangar)
-"dbD" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
 /area/mainship/hallways/hangar)
 "dbN" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom,
@@ -8262,9 +8255,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "dmw" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "doe" = (
 /obj/machinery/holopad,
@@ -8672,11 +8669,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
-"dTN" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/mainship/hallways/hangar)
 "dUe" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -9210,13 +9202,6 @@
 /obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
-"eUO" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "eVB" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -9224,13 +9209,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
-"eWx" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "eWQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9298,9 +9276,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fgc" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "fgi" = (
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -9589,13 +9568,15 @@
 /turf/open/floor/carpet/side,
 /area/mainship/command/corporateliaison)
 "fAi" = (
-/obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/landinglight/cas{
 	dir = 1
 	},
 /obj/machinery/landinglight/tadpole{
 	dir = 1;
 	pixel_y = -4
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -10812,7 +10793,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/bow_hallway)
 "htp" = (
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -10962,6 +10943,12 @@
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
+/area/mainship/hallways/hangar)
+"hHM" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "hIv" = (
 /obj/structure/cable,
@@ -11562,6 +11549,17 @@
 	dir = 10
 	},
 /area/mainship/medical/lower_medical)
+"iPG" = (
+/obj/machinery/landinglight/cas{
+	dir = 1
+	},
+/obj/machinery/landinglight/tadpole{
+	dir = 1;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "iRr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -11807,14 +11805,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/bow_hallway)
-"jjN" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "jkn" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -11863,19 +11853,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
-"jse" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/machinery/landinglight/cas{
-	dir = 1
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 1;
-	pixel_y = -4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "jsp" = (
 /obj/structure/bed/chair/nometal{
 	dir = 8
@@ -11901,6 +11878,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/delta)
+"jtW" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "juB" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/cargo/arrow{
@@ -12207,6 +12191,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/alpha)
+"jZL" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "jZN" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -12600,30 +12593,12 @@
 	dir = 4
 	},
 /area/mainship/living/basketball)
-"kHG" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "kHU" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
-"kIj" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "kIm" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Quarters"
@@ -12654,9 +12629,6 @@
 	dir = 1
 	},
 /area/mainship/medical/surgery_hallway)
-"kLN" = (
-/turf/open/floor/plating/icefloor/warnplate,
-/area/mainship/hallways/hangar)
 "kLV" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -12910,9 +12882,10 @@
 	},
 /area/mainship/engineering/lower_engineering)
 "lhc" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 9
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "liL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -13648,6 +13621,12 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engine_core)
+"mnu" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "moi" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 30
@@ -14060,15 +14039,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "mTg" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
-	},
 /obj/machinery/landinglight/cas{
 	dir = 1
 	},
 /obj/machinery/landinglight/tadpole{
 	dir = 1;
 	pixel_y = -4
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -14287,6 +14266,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
+"nja" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "njN" = (
 /obj/structure/sink{
 	dir = 4
@@ -15512,12 +15498,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"pnP" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "poF" = (
 /obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/cargo,
@@ -15536,9 +15516,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
 "ppE" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 9
-	},
+/obj/effect/turf_decal/warning_stripes/thick/corner,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ppQ" = (
@@ -16500,7 +16478,7 @@
 	},
 /area/mainship/squads/req)
 "qNu" = (
-/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "qNK" = (
@@ -17324,6 +17302,13 @@
 	dir = 8
 	},
 /area/mainship/living/tankerbunks)
+"slq" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "smq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17447,9 +17432,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/bridge)
 "srb" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "srL" = (
 /obj/machinery/vending/weapon,
@@ -19892,11 +19878,6 @@
 "wPV" = (
 /turf/open/floor/mainship_hull,
 /area/space)
-"wQl" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "wQK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19939,11 +19920,6 @@
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
 /area/space)
-"wVm" = (
-/turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "wVv" = (
 /obj/machinery/computer/security/marinemainship{
 	dir = 8;
@@ -20507,9 +20483,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/tankerbunks)
 "xUV" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "xUW" = (
 /obj/structure/cable,
@@ -41516,11 +41493,11 @@ blA
 blA
 blA
 blA
-qNu
+car
+aPL
 blA
-blA
-blA
-htp
+hHM
+cTc
 blA
 blA
 blA
@@ -41776,20 +41753,20 @@ blA
 qNu
 blA
 blA
+hHM
 blA
-kHG
 car
-car
-car
-car
-pnP
-jse
-car
-car
-car
-car
-car
-pnP
+srb
+srb
+srb
+htp
+dbC
+blA
+srb
+srb
+srb
+blA
+blA
 vDT
 lOP
 uJT
@@ -42033,19 +42010,19 @@ blA
 qNu
 blA
 blA
+mnu
+srb
+aPL
 blA
 blA
 blA
-blA
-blA
-blA
-htp
+hHM
 fAi
+aPL
 blA
 blA
 blA
-blA
-blA
+mnu
 htp
 vDT
 lOP
@@ -42283,11 +42260,11 @@ bgb
 lvI
 bbR
 dXn
-bVL
-car
-car
-car
-eUO
+blA
+blA
+blA
+blA
+qNu
 blA
 blA
 blA
@@ -42296,14 +42273,14 @@ blA
 blA
 blA
 blA
-htp
-fAi
+hHM
+iPG
 blA
 blA
 blA
 blA
 blA
-htp
+hHM
 vDT
 tgH
 qPs
@@ -42540,7 +42517,11 @@ aTs
 lvI
 bbR
 dXn
-qNu
+car
+srb
+srb
+srb
+aPL
 blA
 blA
 blA
@@ -42549,18 +42530,14 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
-blA
-htp
-fAi
+hHM
+iPG
 blA
 blA
 tqC
 blA
 blA
-htp
+hHM
 kST
 wxQ
 lvI
@@ -42810,14 +42787,14 @@ blA
 blA
 blA
 blA
-htp
-fAi
+hHM
+iPG
 blA
 blA
 blA
 blA
 blA
-htp
+hHM
 vDT
 ikx
 paD
@@ -43054,7 +43031,11 @@ bxM
 lvI
 bbR
 dXn
-qNu
+caJ
+xUV
+xUV
+xUV
+fgc
 blA
 blA
 blA
@@ -43063,18 +43044,14 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
-blA
-htp
-fAi
+hHM
+iPG
 blA
 blA
 blA
 blA
 blA
-htp
+hHM
 sim
 lOP
 uJT
@@ -43311,11 +43288,11 @@ bgb
 bGr
 bbR
 dXn
-bVN
-caJ
-caJ
-caJ
-eWx
+blA
+blA
+blA
+blA
+qNu
 blA
 blA
 blA
@@ -43324,14 +43301,14 @@ blA
 blA
 blA
 blA
-htp
-fAi
+hHM
+iPG
 blA
 blA
 blA
 blA
 blA
-htp
+hHM
 vDT
 lOP
 lvI
@@ -43575,19 +43552,19 @@ blA
 qNu
 blA
 blA
+lhc
+xUV
+fgc
 blA
 blA
 blA
-blA
-blA
-blA
-htp
+hHM
 mTg
-caJ
-caJ
-caJ
-caJ
-caJ
+xUV
+xUV
+xUV
+xUV
+xUV
 ppE
 vDT
 lOP
@@ -43832,12 +43809,12 @@ blA
 qNu
 blA
 blA
+hHM
 blA
-kIj
 caJ
-caJ
-caJ
-caJ
+xUV
+xUV
+xUV
 ppE
 dbC
 blA
@@ -44086,11 +44063,11 @@ blA
 blA
 blA
 blA
-qNu
+caJ
+fgc
 blA
-blA
-blA
-htp
+hHM
+cIT
 blA
 blA
 blA
@@ -46654,23 +46631,23 @@ wxQ
 uGB
 blA
 blA
-bou
+car
 srb
-bBa
-xUV
-xUV
-jjN
-dTN
-srb
-srb
+aPL
+blA
+blA
+blA
+mnu
 srb
 srb
-bBa
-xUV
-xUV
-xUV
-xUV
-xUV
+srb
+srb
+aPL
+blA
+blA
+blA
+blA
+blA
 dmw
 srb
 esw
@@ -46911,7 +46888,7 @@ wxQ
 uGB
 blA
 blA
-kLN
+qNu
 ehi
 blA
 blA
@@ -46928,8 +46905,8 @@ blA
 blA
 blA
 blA
-dmw
-dmw
+jtW
+blA
 esw
 lOP
 oer
@@ -47168,7 +47145,7 @@ wxQ
 uGB
 srb
 srb
-bBa
+aPL
 lBc
 blA
 blA
@@ -47185,8 +47162,8 @@ blA
 blA
 blA
 blA
-dmw
-dmw
+ceA
+blA
 esw
 lOP
 lvI
@@ -47423,7 +47400,6 @@ iZq
 bja
 wxQ
 uGB
-dmw
 blA
 blA
 blA
@@ -47442,8 +47418,9 @@ blA
 blA
 blA
 blA
-xUV
-wQl
+blA
+blA
+blA
 ujl
 lOP
 lvI
@@ -47680,7 +47657,7 @@ iZq
 bja
 wxQ
 uGB
-dmw
+blA
 blA
 blA
 blA
@@ -47937,7 +47914,7 @@ byf
 bHp
 bPH
 uGB
-dmw
+blA
 blA
 blA
 blA
@@ -47956,7 +47933,7 @@ blA
 blA
 blA
 blA
-dmw
+hHM
 blA
 mlZ
 tnj
@@ -48194,7 +48171,6 @@ iZq
 bja
 wxQ
 uGB
-dmw
 blA
 blA
 blA
@@ -48213,7 +48189,8 @@ blA
 blA
 blA
 blA
-dTN
+blA
+mnu
 srb
 mlZ
 wXB
@@ -48451,7 +48428,6 @@ iZq
 bja
 wxQ
 uGB
-dmw
 blA
 blA
 blA
@@ -48470,8 +48446,9 @@ blA
 blA
 blA
 blA
-srb
-wVm
+blA
+blA
+blA
 esw
 lOP
 lvI
@@ -48710,8 +48687,8 @@ wxQ
 uGB
 xUV
 xUV
-xUV
-dbD
+fgc
+lBc
 blA
 blA
 blA
@@ -48727,8 +48704,8 @@ blA
 blA
 blA
 blA
-dmw
-dmw
+nja
+blA
 esw
 lOP
 lvI
@@ -48967,10 +48944,8 @@ wxQ
 uGB
 blA
 blA
-blA
-bgX
-blA
-blA
+qNu
+ehi
 blA
 blA
 blA
@@ -48984,8 +48959,10 @@ blA
 blA
 blA
 blA
-dmw
-dmw
+blA
+blA
+slq
+blA
 esw
 lOP
 oer
@@ -49224,24 +49201,24 @@ wxQ
 uGB
 blA
 blA
-blA
+caJ
 xUV
 fgc
-srb
-srb
-srb
+blA
+blA
+blA
 lhc
 xUV
 xUV
 xUV
 xUV
 fgc
-srb
-srb
-srb
-srb
-srb
-dmw
+blA
+blA
+blA
+blA
+blA
+jZL
 xUV
 esw
 lOP


### PR DESCRIPTION
## About The Pull Request

Standardizes all Dropship, CAS, and Tadpole shipside pads to use the same hazard stripe object outline.

![2023-09-24 22 23 38](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/75237610-9449-4a86-954f-ef1c8aa8285b)
![2023-09-24 22 23 41](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/5aefffaa-a179-4586-95a4-1544ec902a4c)
![2023-09-24 22 23 45](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/37cf8b2f-71a8-45de-87e0-3757fda5befd)

## Why It's Good For The Game

Currently, the ships that use hazard stripes for dropship outlines use the turf version, not the object version. While this initially has no visual impact, once a dropship leaves the occupied tile, these tiles reset to the default downward-facing orientation, which looks bad. This PR changes this so that the hazard stripes never occupy an area underneath the dropship spawn zone, preventing this issue. 

![Screenshot 2023-09-24 224018](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/5b002cdd-8037-47a4-a48f-dbda65fb886b)

For the case of the Tadpole, since there are variable configurations, the hazard stripes being swapped for the object version instead of the turf version means that even in the case of overlapping with the longer Tadpoles, it will simply delete the stripes instead of causing the direction reset you'd see with the turf variant.

## Changelog

:cl:
qol: Standardized hazard stripes for dropship outlines across all ships.
/:cl: