### PR TITLE
Re-adds the Magmoor LZ 2 SE flank

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -8864,12 +8864,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
-"glQ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/southeast)
 "gmb" = (
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/magmoor/civilian/clean)
@@ -74588,13 +74582,13 @@ iLH
 iLH
 iLH
 iLH
-iLH
-iLH
-iLH
-iLH
-iLH
-iLH
-glQ
+lbz
+kae
+kae
+kae
+ngh
+ngh
+lbz
 oGr
 oGr
 oGr
@@ -74822,12 +74816,12 @@ ngh
 ngh
 ngh
 ngh
-ngh
-ngh
-ngh
-kae
-kae
-glQ
+oGr
+oGr
+oGr
+oGr
+oGr
+oGr
 oGr
 oGr
 oGr


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/e0fcd960-6a9f-4a36-9951-95f8f1a4d3f6)
## Why It's Good For The Game
I thought we have learned from Gelida at this point why two entrance FOB's are very bad. It extends FOB sieges to an unnecessary degree, multiplied by competent engineers. This flank is one tile larger than the last one, two tile entrances are yucky.
## Changelog
:cl:

balance: Re-added Magmoor LZ 2's SE flank.
/:cl:
