### PR TITLE
Reduces number of widow's spiderlings to 4 from 5

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -39,7 +39,7 @@
 	minimap_icon = "widow"
 
 	// *** Widow Abilities *** //
-	max_spiderlings = 5
+	max_spiderlings = 4
 
 	// *** Abilities *** ///
 	actions = list(


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
Widow's damage is a bit silly, especially considering the maturity rework making her always have the ancient amount of spiderlings. This caste's design is already very questionable, having even more insane burst damage on average is not great.
## Changelog
:cl:
balance: Widow's max spiderlings is now 4 instead of 5.
/:cl:
