### PR TITLE
Slightly nerfs king pheros

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -36,7 +36,7 @@
 	soft_armor = list(MELEE = 65, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 60, FIRE = 100, ACID = 60)
 
 	// *** Pheromones *** //
-	aura_strength = 6
+	aura_strength = 5.5
 
 	minimap_icon = "xenoking"
 


### PR DESCRIPTION

## About The Pull Request
Takes king phero strength from 6 down to 5.5
## Why It's Good For The Game
Another issue with the maturity rework was perma ancient king pheros, which were fine with maturity on the board, but now are a bit overwhelming considering that they are always on warding, giving a good amount of armor to benos.
## Changelog
:cl:
balance: King pheros strength reduced to 5.5 from 6
/:cl:
