### PR TITLE
Hold order nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -974,7 +974,7 @@
 		damage = victim.modify_by_armor(damage, blocked, penetration, def_zone)
 
 	if(victim.protection_aura)
-		damage = round(damage * ((10 - victim.protection_aura) / 10))
+		damage = round(damage * ((20 - victim.protection_aura) / 20))
 
 	if(!damage)
 		return 0


### PR DESCRIPTION

## About The Pull Request
Reduces hold order from 10% damage resist per level to 5%
## Why It's Good For The Game
I decided against removing damage resist after talking to Tivi, decided to do this instead. People have been going SL/FC to exclusively spam hold order due to the insane damage resist it gives, alongside running heavy tyr 2 and premedding with it. Those are honestly fine, this pushes it over the edge.
## Changelog
:cl:
balance: Hold order gives 5% damage resist per leadership level instead of 10%.
/:cl:
