### PR TITLE
Fixes doors being weird with line of sight

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -19,9 +19,15 @@
 	var/material_type
 
 /obj/structure/mineral_door/Initialize(mapload)
-	. = ..()
 	if((locate(/mob/living) in loc) && !open)	//If we build a door below ourselves, it starts open.
 		toggle_state()
+	/*
+	We are calling parent later because if we toggle state, the opacity changes only to change to
+	non opaque after the parent procs do their thing, this is an issue because this changes the
+	directional opacity of the turf below to be opaque from all sides, which screws with
+	line of sight because the turf below the door is considered opaque, when it shouldn't be.
+	*/
+	return ..()
 
 /obj/structure/mineral_door/Bumped(atom/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This fixes sentries not being able to target through open doors and open doors blocking line of sight based abilities like fling and heal.
## Why It's Good For The Game

Bugfix good.
## Changelog
:cl:
fix: Fixes doors blocking line of sight when they shouldn't
/:cl:
