### PR TITLE
Martini Henry Attachie Compatibility Changes

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -465,10 +465,13 @@
 		/obj/item/attachable/motiondetector,
 		/obj/item/attachable/buildasentry,
 		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/verticalgrip,
+		/obj/item/attachable/flashlight/under,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 19, "under_y" = 14, "stock_x" = 15, "stock_y" = 12)
+	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 32, "under_y" = 18, "stock_x" = 15, "stock_y" = 12)
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_slowdown = 0.35
 	aim_time = 0.5 SECONDS


### PR DESCRIPTION
## About The Pull Request

Adds angled grip, vertical grip, and underbarrel flashlight to compatible attachment list for the Martini Henry, and adjusts the underbarrel attachment offsets to make it not fugly.
 
## Why It's Good For The Game

Martini henry is a meme gun, and should be able to use the attachments listed above because it will have better ease of use for the user, without affecting its combat strength too much. I intentionally didn't add underbarrel guns to it, so it retains its meme/gimmick status.

## Changelog

:cl:
balance: Added under barrel flashlight to martini attachment list
balance: Added angled grip to martini attachment list
balance: Added vertical grip to martini attachment list
fix: fixed a few things
/:cl: