### PR TITLE
Fix stray zeroes in prefs

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
@@ -296,7 +296,7 @@ export const GameSettings = (props, context) => {
           </Section>
         </Grid.Column>
       </Grid>
-      {is_admin && (
+      {!!is_admin && (
         <Grid>
           <Grid.Column>
             <Section title="Administration (admin only)">

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/KeybindSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/KeybindSettings.tsx
@@ -104,7 +104,7 @@ export const KeybindSettings = (props, context) => {
               />
             ))}
           </Section>
-          {is_admin && (
+          {!!is_admin && (
             <Section title="Administration (admin only)">
               {all_keybindings['ADMIN']?.filter(filterSearch).map((kb) => (
                 <KeybindingPreference key={kb.name} keybind={kb} />


### PR DESCRIPTION
## About The Pull Request

`false && ""` won't render but `0 && ""` will render 0

## Changelog

:cl:
fix: Fix stray zeroes in prefs
/:cl: