### PR TITLE
Blackbox subsystem doesn't fire postgame

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(blackbox)
 	name = "Blackbox"
 	wait = 10 MINUTES
-	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME
+	runlevels = RUNLEVEL_GAME
 
 	var/list/feedback = list()
 	var/sealed = FALSE


### PR DESCRIPTION

## About The Pull Request

This prevents people from farming hours during times where the server has no admin to run it (eternal EORD)

I don't know what label to even put this under CL so guh.
## Why It's Good For The Game

People farming hours when there aren't admins on is very cringe.
## Changelog
:cl:
del: Blackbox subsystem doesn't fire postgame
/:cl:
