### PR TITLE
Fix boiler making neuro traps with acid

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3783,7 +3783,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(!do_after(user_xeno, 3 SECONDS, TRUE, trap))
 		return FALSE
 	trap.set_trap_type(TRAP_SMOKE_ACID)
-	trap.smoke = new /datum/effect_system/smoke_spread/xeno/neuro/medium
+	trap.smoke = new /datum/effect_system/smoke_spread/xeno/acid
 	trap.smoke.set_up(1, get_turf(trap))
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

If boiler fills carrier's trap with acid mode, it would explode with neurotoxin smoke, this pr fixes it.

## Why It's Good For The Game

Fix - good.

## Changelog
:cl:
fix: fixed boiler making neuro traps with acid
/:cl:
