### PR TITLE
Fixes admin wall deletions

### DIFF
--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -182,6 +182,11 @@
 	log_admin("[key_name(usr)] deleted [A]([A.type]) at [AREACOORD(T)].")
 	message_admins("[ADMIN_TPMONTY(usr)] deleted [A]([A.type]) at [ADMIN_VERBOSEJMP(T)].")
 
+	if(isturf(A))
+		var/turf/deleting_turf = A
+		deleting_turf.ScrapeAway()
+		return
+
 	qdel(A)
 
 


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin. You aren't supposed to flat out qdel walls apparently.
## Why It's Good For The Game

Runtime and deletionproof walls are bad.
## Changelog
:cl:
fix: Fixed admin wall deletions
/:cl:
