### PR TITLE
Restoration of acid wall sprite + layer tweak

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -153,6 +153,9 @@
 	. = ..()
 	acid_melt_multiplier = melting_rate
 	acid_t = target
+	layer = acid_t.layer
+	if(iswallturf(acid_t))
+		icon_state = icon_state += "_wall"
 	START_PROCESSING(SSslowprocess, src)
 
 /obj/effect/xenomorph/acid/Destroy()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -153,7 +153,7 @@
 	. = ..()
 	acid_melt_multiplier = melting_rate
 	acid_t = target
-	if(acid_t == null)
+	if(!acid_t)
 		return INITIALIZE_HINT_QDEL
 	layer = acid_t.layer
 	if(iswallturf(acid_t))

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -153,6 +153,8 @@
 	. = ..()
 	acid_melt_multiplier = melting_rate
 	acid_t = target
+	if(acid_t == null)
+		return INITIALIZE_HINT_QDEL
 	layer = acid_t.layer
 	if(iswallturf(acid_t))
 		icon_state = icon_state += "_wall"


### PR DESCRIPTION
## About The Pull Request

Restores forgotten sprites of acid on walls, also i've made it so acid would have layer of item it is currently melting, so acid would no longer render over literally everything including mobs.

![dreamseeker_4XUDCroRAT](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/bd8a36d8-389c-47ab-9f4d-ec4558934b35)

Without layers tweak:
![dreamseeker_KdL2I7c2K8](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/05a483e5-18ca-4cc5-8929-f764e38decdd)

With layers tweak:
![dreamseeker_VsW9utQjcz](https://github.com/tgstation/TerraGov-Marine-Corps/assets/100090741/94f1e586-ee02-4c83-b04a-73e868bd8372)


## Why It's Good For The Game
## Changelog
:cl:
add: acid on walls now has unique set of sprites
fix: fixed acid rendering over everything
/:cl:
