### PR TITLE
Queen and King rank fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -1,6 +1,7 @@
 /datum/xeno_caste/king
 	caste_name = "King"
 	display_name = "King"
+	upgrade_name = ""
 	caste_type_path = /mob/living/carbon/xenomorph/king
 	caste_desc = "A primordial creature, evolved to smash the hardiest of defences and hunt the hardiest of prey."
 
@@ -68,6 +69,7 @@
 	upgrade = XENO_UPGRADE_NORMAL
 
 /datum/xeno_caste/king/primordial
+	upgrade_name = "Primordial"
 	caste_desc = "An avatar of death. Running won't help you now."
 	primordial_message = "Death cannot create, but you definitely know how to destroy."
 	upgrade = XENO_UPGRADE_PRIMO

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -26,11 +26,21 @@
 	playsound(loc, 'sound/voice/xenos_roaring.ogg', 75, 0)
 
 /mob/living/carbon/xenomorph/king/generate_name()
-	switch(upgrade)
-		if(XENO_UPGRADE_NORMAL)
-			name = "[hive.prefix]Emperor ([nicknumber])"	 //Normal
-		if(XENO_UPGRADE_PRIMO)
-			name = "[hive.prefix]Primordial Emperor ([nicknumber])"
+	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
+	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	switch(playtime_mins)
+		if(0 to 600)
+			name = prefix + "Broodling King ([nicknumber])"
+		if(601 to 3000)
+			name = prefix + "Mature King ([nicknumber])"
+		if(3001 to 9000)
+			name = prefix + "Noble Emperor ([nicknumber])"
+		if(9001 to 18000)
+			name = prefix + "Royal Emperor ([nicknumber])"
+		if(18001 to INFINITY)
+			name = prefix + "Archon Emperor ([nicknumber])"
+		else
+			name = prefix + "Broodling King ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -1,6 +1,7 @@
 /datum/xeno_caste/queen
 	caste_name = "Queen"
 	display_name = "Queen"
+	upgrade_name = ""
 	caste_type_path = /mob/living/carbon/xenomorph/queen
 	caste_desc = "The biggest and baddest xeno. The Queen controls the hive."
 	job_type = /datum/job/xenomorph/queen
@@ -82,6 +83,7 @@
 	upgrade = XENO_UPGRADE_NORMAL
 
 /datum/xeno_caste/queen/primordial
+	upgrade_name = "Primordial"
 	caste_desc = "A fearsome Xeno hulk of titanic proportions. Nothing can stand in it's way."
 	primordial_message = "Destiny bows to our will as the universe trembles before us."
 	upgrade = XENO_UPGRADE_PRIMO

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -72,11 +72,21 @@
 // *********** Name
 // ***************************************
 /mob/living/carbon/xenomorph/queen/generate_name()
-	switch(upgrade)
-		if(XENO_UPGRADE_NORMAL)
-			name = "[hive.prefix]Empress ([nicknumber])"			 //Normal
-		if(XENO_UPGRADE_PRIMO)
-			name = "[hive.prefix]Primordial Empress ([nicknumber])"
+	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
+	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	switch(playtime_mins)
+		if(0 to 600)
+			name = prefix + "Broodling Queen ([nicknumber])"
+		if(601 to 3000)
+			name = prefix + "Mature Queen ([nicknumber])"
+		if(3001 to 9000)
+			name = prefix + "Noble Empress ([nicknumber])"
+		if(9001 to 18000)
+			name = prefix + "Royal Empress ([nicknumber])"
+		if(18001 to INFINITY)
+			name = prefix + "Archon Empress ([nicknumber])"
+		else
+			name = prefix + "Broodling Queen ([nicknumber])"
 
 	real_name = name
 	if(mind)


### PR DESCRIPTION

## About The Pull Request
Queen and King have hard coded names, decided to work with them to give them unique names at each rank; like the olden times when it went Queen to Empress and King to Emperor.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: Queen and King ranks should work now
/:cl:
