### PR TITLE
Funny minimap fix

### DIFF
--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -42,7 +42,8 @@
 		return FALSE
 	newoccupant.drop_all_held_items()
 	add_occupant(newoccupant)
-	newoccupant.forceMove(src)
+	if(newoccupant.loc != src)
+		newoccupant.forceMove(src)
 	newoccupant.update_mouse_pointer()
 	add_fingerprint(newoccupant, "moved in as pilot")
 	log_message("[newoccupant] moved in as pilot.", LOG_MECHA)


### PR DESCRIPTION

## About The Pull Request
Fixes the minimap not tracking you while inside objects (i.e. mechs/bodybags).

I put this in the campaign pr because this bug became VERY apparent during mech war. This should be a separate pr though.

Also this solution is kinda scuffed, there's probably a better solution but eh.

Added the line in mech code because it would forcemove you into the mech twice.
## Why It's Good For The Game
Minimap work good.
## Changelog
:cl:
fix: Minimap properly tracks you inside objects like mechs or bodybags
/:cl:
