### PR TITLE
Removes Vali's chemical boost multiplier option

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -25,7 +25,7 @@
 	///Amount of substance stored currently
 	var/resource_storage_current = 0
 	///Amount required for operation
-	var/resource_drain_amount = 10
+	var/resource_drain_amount = 8
 	///Actions that the component provides
 	var/list/datum/action/component_actions = list(
 		/datum/action/chem_booster/configure = PROC_REF(configure),


### PR DESCRIPTION
## About The Pull Request
This PR removes the option to change the Vali's chemical boost to x2, meaning it will always be on the default (x1). This is, in fact, a nerf to the armor module.
I have taken the liberty of clearing away unnecessary code to account for this change.
This also changes the resource drain value, from 4 at x1 to 8. The new value is what the drain on x2 normally was.

## Why It's Good For The Game
Vali allows marines to get away with far much more than they should for the sake of balance health. Throwing yourself into hives, surviving multiple xenos like nobody's business, and being able to overdo xenos in melee is a bit _too_ much.

This is my attempt to nerf this package slightly by reducing the regeneration it offers, as opposed to tackling the Vali weaponry or anything else.

## Changelog
:cl: Lewdcifer
del: Removed the option to change Vali's chemical boost, effectively removing the x2 boost.
balance: As per the above, Vali regeneration was essentially nerfed to x1 values. Resource drain changed from 4 in x1 to 8 (this is the rate at which x2 drained).
/:cl: