### PR TITLE
X-Ray Laser Rifle minor rebalance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3083,12 +3083,24 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "xray heat bolt"
 	hud_state = "laser_xray"
 	icon_state = "u_laser"
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_SUNDERING|AMMO_HITSCAN
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN
 	damage = 25
 	penetration = 5
 	sundering = 1
 	max_range = 15
 	hitscan_effect_icon = "u_laser_beam"
+	/// Number of debuff stacks to apply when hitting mobs.
+	var/debuff_stacks = 1
+
+/datum/ammo/energy/lasgun/marine/xray/on_hit_mob(mob/M, obj/projectile/proj)
+	if(!isliving(M))
+		return
+	var/mob/living/living_victim = M
+	var/datum/status_effect/stacking/microwave/debuff = living_victim.has_status_effect(STATUS_EFFECT_MICROWAVE)
+	if(debuff)
+		debuff.add_stacks(debuff_stacks)
+	else
+		living_victim.apply_status_effect(STATUS_EFFECT_MICROWAVE, debuff_stacks)
 
 /datum/ammo/energy/lasgun/marine/xray/piercing
 	name = "xray piercing bolt"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3085,12 +3085,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "u_laser"
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN
 	damage = 25
-	penetration = 5
+	penetration = 10
 	sundering = 1
 	max_range = 15
 	hitscan_effect_icon = "u_laser_beam"
 	/// Number of debuff stacks to apply when hitting mobs.
-	var/debuff_stacks = 1
+	var/debuff_stacks = 5
 
 /datum/ammo/energy/lasgun/marine/xray/on_hit_mob(mob/M, obj/projectile/proj)
 	if(!isliving(M))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -949,9 +949,9 @@
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	icon_state = "tex"
 	item_state = "tex"
-	max_shots = 40 //codex stuff
+	max_shots = 50 //codex stuff
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
-	rounds_per_shot = 15
+	rounds_per_shot = 12
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,
@@ -960,7 +960,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
@@ -990,7 +989,7 @@
 	)
 
 /datum/lasrifle/energy_rifle_mode/xray
-	rounds_per_shot = 15
+	rounds_per_shot = 12
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
 	fire_delay = 0.25 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'


### PR DESCRIPTION
## About The Pull Request
Rebalances this weapon slightly. The general intention is to nerf it, but I'm changing some other stuff just a little to compensate for the loss.
- No longer accepts the T-47 rail scope (this was basically a sniper scope).
- Lasers are no longer incendiary, and will not set xenos on fire. Instead, this weapon will now inflict the Microwaved debuff at maximum stacks (5), on every shot.
- Increased penetration from 5 to 10.
- Standard firing mode ammo usage reduced, basically amounting to a maximum of 50 shots (this was 40 before).

## Why It's Good For The Game
The X-Ray Laser Rifle has been allowed to remain in a very questionable spot in terms of balance. Setting xenos on fire, being a valid sniping option, and the preferred reqs option due to how good of a deal it is in terms of point cost and gun power -- all in all, it's become clear that this weapon needs changing for the sake of balance, especially since this is nowhere near fun to engage with as a xeno.

## Changelog
:cl: Lewdcifer
del: X-Ray Laser Rifle no longer accepts the T-47 rail scope.
balance: X-Ray Laser Rifle shots are no longer incendiary. Instead, they now inflict five stacks of the Microwaved debuff.
balance: X-Ray Laser Rifle penetration increased from 5 to 10.
balance: X-Ray Laser Rifle's standard firing mode ammo usage reduced, basically amounting to a maximum of 50 shots (from 40).
/:cl: