### PR TITLE
Fix a misplaced admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1305,7 +1305,7 @@
 	togglebuildmode(mob)
 
 /client/proc/toggle_admin_tads()
-	set category = "Fun"
+	set category = "Admin.Fun"
 	set name = "Toggle Tadpole Restrictions"
 
 	if(!check_rights(R_FUN))


### PR DESCRIPTION
## About The Pull Request

These should be in Admin.Fun, not Fun so that statpanel can combine them into one tab if you have the setting enabled

## Changelog

:cl:
admin: Fixed statpanel showing Toggle Tadpole Restrictions in a different tab
/:cl:
