### PR TITLE
Updates Crest Toss' Description

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -65,7 +65,7 @@
 /datum/action/xeno_action/activable/cresttoss
 	name = "Crest Toss"
 	action_icon_state = "cresttoss"
-	desc = "Fling an adjacent target over and behind you. Also works over barricades."
+	desc = "Fling an adjacent target over and behind you, or away from you while on harm intent. Also works over barricades."
 	ability_name = "crest toss"
 	plasma_cost = 75
 	cooldown_timer = 12 SECONDS


### PR DESCRIPTION

## About The Pull Request
This pr updates the description of the crusher's Crest Toss ability to mention how harm intent changes it's action.
## Why It's Good For The Game
Letting players know how the ability works is good.
## Changelog
:cl:
spellcheck: Changed Crest Toss' description to mention it's effects while on harm intent.
/:cl:
