### PR TITLE
Fixes inconsistent MG27 Magazine description

### DIFF
--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -42,7 +42,7 @@
 
 /obj/item/ammo_magazine/standard_mmg
 	name = "MG-27 box magazine (10x27m Caseless)"
-	desc = "A box of 100 10x27mm caseless rounds for the MG-27 medium machinegun."
+	desc = "A box of 150 10x27mm caseless rounds for the MG-27 medium machinegun."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/Marine/marine-mmg.dmi'
 	icon_state = "mag"


### PR DESCRIPTION

## About The Pull Request

Simply changes MG27 Box Mag desc to accurately reflect ammo count, somehow this got past whoever changed it last.
![mg27 actual](https://github.com/tgstation/TerraGov-Marine-Corps/assets/102577236/bb673679-c869-4098-b03a-c2c00da05095)


## Why It's Good For The Game

incorrect descriptions bad

## Changelog
:cl:
fix: MG-27 Box Magazine description now quotes correct ammo count
/:cl:
