### PR TITLE
Removes BR's marshall's disk spawn from all modulars

### DIFF
--- a/_maps/modularmaps/big_red/bigredlzvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar1.dmm
@@ -1585,11 +1585,6 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
-"SF" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "SO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Marshal Office Isolation"
@@ -5060,7 +5055,7 @@ Dh
 Ym
 Uq
 sD
-SF
+En
 sD
 Ym
 NK

--- a/_maps/modularmaps/big_red/bigredlzvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar2.dmm
@@ -455,10 +455,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
-"mm" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "ms" = (
 /obj/structure/window/reinforced,
 /obj/machinery/hydroponics,
@@ -5026,7 +5022,7 @@ er
 Sw
 fo
 bc
-mm
+bc
 bc
 Sw
 jc

--- a/_maps/modularmaps/big_red/bigredlzvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar3.dmm
@@ -1819,10 +1819,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/nw)
-"Vc" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "Vj" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tech_supply,
@@ -5128,7 +5124,7 @@ So
 iD
 gw
 gf
-Vc
+gf
 gf
 iD
 JS

--- a/_maps/modularmaps/big_red/bigredlzvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar4.dmm
@@ -1900,11 +1900,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
-"ZZ" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 
 (1,1,1) = {"
 mL
@@ -5061,7 +5056,7 @@ ay
 oA
 Om
 vp
-ZZ
+wF
 vp
 oA
 lR

--- a/_maps/modularmaps/big_red/bigredlzvar5.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar5.dmm
@@ -1876,11 +1876,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
-"Zk" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "Zo" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -5053,7 +5048,7 @@ bB
 fF
 Rr
 nX
-Zk
+ql
 nX
 fF
 aM

--- a/_maps/modularmaps/big_red/bigredlzvar6.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar6.dmm
@@ -1458,10 +1458,6 @@
 "LY" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
-"Mn" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "Mu" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -5131,7 +5127,7 @@ uy
 jH
 AH
 KW
-Mn
+KW
 KW
 jH
 pO

--- a/_maps/modularmaps/big_red/bigredlzvar7.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar7.dmm
@@ -983,11 +983,6 @@
 	dir = 10
 	},
 /area/bigredv2/outside/nw)
-"yW" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "zj" = (
 /obj/effect/ai_node,
 /obj/machinery/landinglight/lz1{
@@ -5185,7 +5180,7 @@ kl
 Ly
 uf
 qu
-yW
+Rs
 qu
 Ly
 qo

--- a/_maps/modularmaps/big_red/bigredlzvar8.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar8.dmm
@@ -384,10 +384,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/marshal_office)
-"lF" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/marshal_office)
 "lH" = (
 /obj/structure/window/reinforced,
 /obj/machinery/hydroponics,
@@ -5041,7 +5037,7 @@ zE
 GD
 Cn
 WH
-lF
+WH
 WH
 GD
 Cz


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
The map seems to flow better when the Marshall's disk is not there, with instead the first three original disk spawns in Admin, Engineering and ETA. Marshalls is not a place Marines want to be, so they often will die there slightly, retreat to FOB and are encouraged to initiate a 2 hour FOB siege, since they are right next to it. When there are the 3 original disks, there will always be a disk in ETA, and marines have to actually push past Medbay to get to the first disk. This may lead to a Medbay wipe, but at the least they are not encouraged to hold there and die like if there was a disk there.
## Changelog
:cl:
balance: Big Red's Marshall disk spawn is now removed from all modulars.
/:cl:
