### PR TITLE
Egg Lay Ability Description

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1014,6 +1014,7 @@
 /datum/action/xeno_action/lay_egg
 	name = "Lay Egg"
 	action_icon_state = "lay_egg"
+	desc = "Create an egg that will grow a larval hugger after a short delay. Empty eggs can have huggers inserted into them."
 	plasma_cost = 200
 	cooldown_timer = 12 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION

## About The Pull Request
Gives the lay egg ability a description, describing how it behaves, and how empty eggs can have huggers inserted into them.
## Why It's Good For The Game
This ability currently doesn't have a description, which is bad.
## Changelog
:cl:
spellcheck: Added a description to the "lay egg" ability
/:cl:
