### PR TITLE
Fixes an issue where the TE-X Piercing Mode inflicted Microwaved

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3092,16 +3092,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	/// Number of debuff stacks to apply when hitting mobs.
 	var/debuff_stacks = 5
 
-/datum/ammo/energy/lasgun/marine/xray/on_hit_mob(mob/M, obj/projectile/proj)
-	if(!isliving(M))
-		return
-	var/mob/living/living_victim = M
-	var/datum/status_effect/stacking/microwave/debuff = living_victim.has_status_effect(STATUS_EFFECT_MICROWAVE)
-	if(debuff)
-		debuff.add_stacks(debuff_stacks)
-	else
-		living_victim.apply_status_effect(STATUS_EFFECT_MICROWAVE, debuff_stacks)
-
 /datum/ammo/energy/lasgun/marine/xray/piercing
 	name = "xray piercing bolt"
 	icon_state = "xray"
@@ -3110,6 +3100,16 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration = 100
 	max_range = 10
 	hitscan_effect_icon = "xray_beam"
+
+/datum/ammo/energy/lasgun/marine/xray/standard/on_hit_mob(mob/M, obj/projectile/proj)
+	if(!isliving(M))
+		return
+	var/mob/living/living_victim = M
+	var/datum/status_effect/stacking/microwave/debuff = living_victim.has_status_effect(STATUS_EFFECT_MICROWAVE)
+	if(debuff)
+		debuff.add_stacks(debuff_stacks)
+	else
+		living_victim.apply_status_effect(STATUS_EFFECT_MICROWAVE, debuff_stacks)
 
 /datum/ammo/energy/lasgun/marine/heavy_laser
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_INCENDIARY

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -951,7 +951,7 @@
 	icon_state = "tex"
 	item_state = "tex"
 	max_shots = 50 //codex stuff
-	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
+	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray/standard
 	rounds_per_shot = 12
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
@@ -991,7 +991,7 @@
 
 /datum/lasrifle/energy_rifle_mode/xray
 	rounds_per_shot = 12
-	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
+	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray/standard
 	fire_delay = 0.25 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	message_to_user = "You set the xray rifle's charge mode to standard fire."


### PR DESCRIPTION
## About The Pull Request
Per title. This was unintended, and only the standard mode is meant to inflict the debuff.

## Why It's Good For The Game
Unintended features, begone. Balance is not yet too far gone.

## Changelog
:cl: Lewdcifer
fix: TE-X piercing mode no longer inflicts Microwaved due to a code oopsie.
/:cl: