### PR TITLE
Mild adjustment to fire stack logic (aka fire buff)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -188,7 +188,7 @@
 #define TRAIT_INTOXICATION_IMMUNE "intoxication_immune" // Immune to the Intoxication debuff.
 #define TRAIT_INTOXICATION_RESISTANT "intoxication_resistant" // Resistant to the Intoxication debuff. Maximum amount of stacks limited.
 #define TRAIT_PAIN_IMMUNE "pain_immune" // We don't feel pain.
-///Prevent mob from being ignited due to IgniteMob()
+///Prevent mob from being ignited due to IgniteMob(), aswell as the DoT from already being on fire if the case.
 #define TRAIT_NON_FLAMMABLE "non-flammable"
 /// Prevents mob from riding mobs when buckled onto something
 #define TRAIT_CANT_RIDE "cant_ride"

--- a/code/modules/mob/living/carbon/human/life/handle_fire.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_fire.dm
@@ -5,7 +5,7 @@
 	if(.)
 		return
 	var/thermal_protection = get_flags_heat_protection(30000) //If you don't have fire suit level protection, you get a temperature increase and burns
-	if((1 - thermal_protection) > 0.0001)
+	if((1 - thermal_protection) > 0.0001 && !HAS_TRAIT(src, TRAIT_NON_FLAMMABLE))
 		adjust_bodytemperature(BODYTEMP_HEATING_MAX)
 		adjustFireLoss(0.5 * fire_stacks)
 	species?.handle_fire(src)

--- a/code/modules/mob/living/carbon/human/life/handle_fire.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_fire.dm
@@ -7,5 +7,5 @@
 	var/thermal_protection = get_flags_heat_protection(30000) //If you don't have fire suit level protection, you get a temperature increase and burns
 	if((1 - thermal_protection) > 0.0001)
 		adjust_bodytemperature(BODYTEMP_HEATING_MAX)
-		apply_damage(10, BURN, blocked = FIRE)
+		adjustFireLoss(0.5 * fire_stacks)
 	species?.handle_fire(src)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -40,7 +40,7 @@
 		if(resting && fire_stacks > 0)
 			adjust_fire_stacks(-1)	//Passively lose firestacks when not on fire while resting and having firestacks built up.
 		return
-	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Sanity check; have to be on fire to actually take the damage.
+	if(!((xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) || HAS_TRAIT(src, TRAIT_NON_FLAMMABLE))) //Ignore damage if currently immune to fire.
 		adjustFireLoss(fire_stacks + 3)
 
 /mob/living/carbon/xenomorph/proc/handle_living_health_updates()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -41,7 +41,7 @@
 			adjust_fire_stacks(-1)	//Passively lose firestacks when not on fire while resting and having firestacks built up.
 		return
 	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Sanity check; have to be on fire to actually take the damage.
-		apply_damage((fire_stacks + 3), BURN, blocked = FIRE)
+		adjustFireLoss(fire_stacks + 3)
 
 /mob/living/carbon/xenomorph/proc/handle_living_health_updates()
 	if(health < 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -144,7 +144,7 @@
 		fire_stacks++ //If we've doused ourselves in water to avoid fire, dry off slowly
 		fire_stacks = min(0, fire_stacks)//So we dry ourselves back to default, nonflammable.
 	if(!on_fire)
-		return 1
+		return TRUE
 	if(fire_stacks > 0)
 		adjust_fire_stacks(-1) //the fire is consumed slowly
 


### PR DESCRIPTION
## About The Pull Request
As some of you may remember, a long long while ago I investigated fire armor not mattering at all and rewrote some fire code related to it.
During that time, I made the (for myself) questionable decision to have fire armor effectively doubledip in one particular scenario.

Usually, for fire damage like walking onto fire / getting shot with fire damage type, it's simple: Take damage, apply armor, apply modified damage.

However, this is not the case for "fire stacks", the DoT component of fire.
Here, I (back then) made the decision to have armor apply to the *stacks* being applied (aka how long / how intense the fire will be), but *also* applied it to the actual DoT from life when the fire stacks are being resolved.
It made sense for me back then, but here I am today revisiting it since I'm feeling it gimped the DoT component from fire a bit too much.

So, backstory aside, what *does* this PR actually do?
Fire armor now **only** changes the fire stacks being *applied*.
The DoT from fire stacks already *on* you now is true damage, not modified by any armor

It also adjusts the damage applied to humans by firestack DoT to be 0.5 * fire stacks (firestacks max at 20), instead of a flat 10, which means you will take less damage on average, but if you actually get flamed for full stacks, it will be more lethal.
It also means your DoT will slowly decrease over time instead of being the same regardless of if you have 1 or 20 stacks.

tl;dr:
Armor only affects fire stacks being applied.
The actual DoT from already gained stacks is now true damage.
Damage to humans now scales with stacks, instead of being constant.
## Why It's Good For The Game
My past decisions on fire stack handling may have gimped the effectiveness of fire damage a bit.
This revisits that and attempts to improve the DoT component of fire, since having armor apply twice made it a bit too weak.
## Changelog
:cl:
balance: Fire armor now doesn't apply to the damage from already present firestacks, which is now true damage, only affecting firestacks being gained instead. (This has no effect on anything except for firestacks, aka "being set on fire")
balance: Firestack DoT now scales for humans (similar to xenos), instead of always being 10 damage / life tick.
/:cl:
