### PR TITLE
Clarifies Smart Pistol Vendor Purchase

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 //A way to give them everything at once that still works with loadouts would be nice, but barring that make sure that your point calculation is set up so they don't get more than what they're supposed to
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/clothing/glasses/night/m56_goggles = list(CAT_ESS, "KLTD Smart Goggles", 0, "white"),
-	/obj/effect/vendor_bundle/smartgunner_pistol = list(CAT_ESS, "SP-13 smart pistol bundle", 0, "white"),
+	/obj/effect/vendor_bundle/smartgunner_pistol = list(CAT_ESS, "SP-13 smart pistol and KLTD Smart Goggles bundle", 0, "white"),
 	/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = list(CAT_SGSUP, "SP-13 smart pistol ammo", 2, "black"),
 	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Smart Machine Gun", 29, "orange"), //If a smartgunner buys a SG-29, then they will have 16 points to purchase 4 SG-29 drums
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Ammo Drum", 4, "black"),


### PR DESCRIPTION

## About The Pull Request
This PR clarifies that the smart pistol bundle includes smart goggles in the purchase
![Change Me - Pillar of Spring 10_4_2023 3_01_00 PM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/7c63788a-def6-4cf6-a58c-e840829f2861)
## Why It's Good For The Game
It is very unclear that the bundle includes the smart goggles as well, so this clarifies that.
## Changelog
:cl:
spellcheck: Changed the smart pistol bundle's name in the smart gunner vendor to clarify that it comes with smart goggles.
/:cl:
