### PR TITLE
Bump Python version

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -19,4 +19,4 @@ export SPACEMAN_DMM_VERSION=suite-1.7.2
 export SPACEMAN_DMM_COMMIT_HASH=3588de97ff09fdd02d96f178392f3c59b19ebfc4
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.7.9
+export PYTHON_VERSION=3.10.11

--- a/tools/bootstrap/python37._pth
+++ b/tools/bootstrap/python37._pth
@@ -1,6 +1,0 @@
-python37.zip
-.
-..\..\..
-
-# Uncomment to run site.main() automatically
-import site

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -49,8 +49,13 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
+	$PythonVersionArray = $PythonVersion.Split(".")
+	$PythonVersionString = "python$($PythonVersionArray[0])$($PythonVersionArray[1])"
+	Write-Output "Generating PATH descriptor."
+	New-Item "$Cache/$PythonVersionString._pth" | Out-Null
+	Set-Content "$Cache/$PythonVersionString._pth" "$PythonVersionString.zip`n.`n..\..\..`nimport site`n"
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
+	Copy-Item "$Cache/$PythonVersionString._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-pygit2==1.7.2
+pygit2==1.13.1
 bidict==0.22.0
 Pillow==10.0.1
 


### PR DESCRIPTION
#14076 and #14077 were blindly merged so tooling broke as pillow now requires python>=3.8. ~~Bumped python to 3.11.0 which is the highest version pygit2 currently has wheels for windows~~