### PR TITLE
Makes Prison Station a HvH only map

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///If the gamemode has a whitelist of valid ground maps. Whitelist overrides the blacklist
 	var/list/whitelist_ground_maps
 	///If the gamemode has a blacklist of disallowed ground maps
-	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
+	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
 	///if fun tads are enabled by default
 	var/enable_fun_tads = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
https://github.com/tgstation/TerraGov-Marine-Corps/pull/13496
You can see my whole rant in there about it as a NW map, but with many bad maps it seems to work fine in HvH so a full removal is likely not warranted. Also allows it to be used for campaign and such
## Changelog
:cl:
del: Prison Station is now only voteable on HvH gamemodes.
/:cl:
