### PR TITLE
Remove gorger weed speed penalty

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -14,7 +14,8 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.6
+	speed = -0.4
+	weeds_speed_mod = -0.2
 
 	// *** Plasma *** //
 	plasma_max = 400

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -15,7 +15,6 @@
 
 	// *** Speed *** //
 	speed = -0.6
-	weeds_speed_mod = 0.2
 
 	// *** Plasma *** //
 	plasma_max = 400


### PR DESCRIPTION

## About The Pull Request
Switches gorger from being punished on weed, to being rewarded on weeds.
## Why It's Good For The Game
It makes no sense for a xeno to be punished for being on weeds.
This keeps the gorger top speed the same at -0.6
## Changelog
:cl:
balance: Gorger no longer gets slowdown from weeds
/:cl:
