### PR TITLE
The Judge has been found guilty. (Walance)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -528,6 +528,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 30
 	penetration = 10
 
+/datum/ammo/bullet/revolver/marksman/judge
+	damage = 70
+
 /datum/ammo/bullet/revolver/heavy
 	name = "heavy revolver bullet"
 	hud_state = "revolver_heavy"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -528,8 +528,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 30
 	penetration = 10
 
-/datum/ammo/bullet/revolver/marksman/judge
+/datum/ammo/bullet/revolver/judge
+	name = "oversized revolver bullet"
+	hud_state = "revolver_slim"
+	shrapnel_chance = 0
+	damage_falloff = 0
+	accuracy = 15
+	accurate_range = 15
 	damage = 70
+	penetration = 10
 
 /datum/ammo/bullet/revolver/heavy
 	name = "heavy revolver bullet"

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -265,7 +265,7 @@
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 22,"rail_x" = 17, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
 
-	fire_delay = 0.35 SECONDS
+	fire_delay = 0.8 SECONDS
 	scatter = 8 // Only affects buckshot considering marksman has -15 scatter.
 	damage_falloff_mult = 1.2
 

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -73,7 +73,7 @@
 /obj/item/ammo_magazine/revolver/judge
 	name = "\improper Judge speed loader (.45L)"
 	desc = "A revolver speed loader for the Judge, these rounds have a high velocity propellant, leading to next to no scatter and falloff."
-	default_ammo = /datum/ammo/bullet/revolver/marksman
+	default_ammo = /datum/ammo/bullet/revolver/marksman/judge
 	caliber = CALIBER_45L
 	max_rounds = 5
 	icon_state = "m_m44"

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -73,7 +73,7 @@
 /obj/item/ammo_magazine/revolver/judge
 	name = "\improper Judge speed loader (.45L)"
 	desc = "A revolver speed loader for the Judge, these rounds have a high velocity propellant, leading to next to no scatter and falloff."
-	default_ammo = /datum/ammo/bullet/revolver/marksman/judge
+	default_ammo = /datum/ammo/bullet/revolver/judge
 	caliber = CALIBER_45L
 	max_rounds = 5
 	icon_state = "m_m44"


### PR DESCRIPTION
## About The Pull Request

judge fire rate nerfed from .35s to .8s
normal judge round damage changed from 30 to 70 damage to compensate

## Why It's Good For The Game

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/112458553/734db9b5-a1ef-4372-8568-9d89e7a188df)
(image credit of Wormgang/ClosetedSkeleton)
buckshot judge is absurdly broken. it has equivalent DPS to a DB, can fire for longer, can be dual wielded (for even HIGHER effective DPS), and can aim mode. Akimboing judges with buckshot will melt most T3s in less than a second. It's genuinely baffling to me that it took the community this long to figure out just how comically broken it is. This nerf should make it serve its intended role as a powerful sidearm with multiple options available to it without it just being a "lol I win" gun.

## Changelog
:cl: dopamiin

balance: the Judge now has a much longer fire delay, but its standard rounds are more powerful.
/:cl:
