### PR TITLE
Changes xeno ranks to hatchling - ancient

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -40,7 +40,7 @@
 		if(18001 to INFINITY)
 			name = prefix + "Ancient Emperor ([nicknumber])"
 		else
-			name = prefix + "Young King ([nicknumber])"
+			name = prefix + "Hatchling King ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -30,17 +30,17 @@
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	switch(playtime_mins)
 		if(0 to 600)
-			name = prefix + "Broodling King ([nicknumber])"
+			name = prefix + "Hatchling King ([nicknumber])"
 		if(601 to 3000)
-			name = prefix + "Mature King ([nicknumber])"
+			name = prefix + "Young King ([nicknumber])"
 		if(3001 to 9000)
-			name = prefix + "Noble Emperor ([nicknumber])"
+			name = prefix + "Mature Emperor ([nicknumber])"
 		if(9001 to 18000)
-			name = prefix + "Royal Emperor ([nicknumber])"
+			name = prefix + "Elder Emperor ([nicknumber])"
 		if(18001 to INFINITY)
-			name = prefix + "Archon Emperor ([nicknumber])"
+			name = prefix + "Ancient Emperor ([nicknumber])"
 		else
-			name = prefix + "Broodling King ([nicknumber])"
+			name = prefix + "Young King ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -76,17 +76,17 @@
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	switch(playtime_mins)
 		if(0 to 600)
-			name = prefix + "Broodling Queen ([nicknumber])"
+			name = prefix + "Hatchling Queen ([nicknumber])"
 		if(601 to 3000)
-			name = prefix + "Mature Queen ([nicknumber])"
+			name = prefix + "Young Queen ([nicknumber])"
 		if(3001 to 9000)
-			name = prefix + "Noble Empress ([nicknumber])"
+			name = prefix + "Mature Empress ([nicknumber])"
 		if(9001 to 18000)
-			name = prefix + "Royal Empress ([nicknumber])"
+			name = prefix + "Elder Empress ([nicknumber])"
 		if(18001 to INFINITY)
-			name = prefix + "Archon Empress ([nicknumber])"
+			name = prefix + "Ancient Empress ([nicknumber])"
 		else
-			name = prefix + "Broodling Queen ([nicknumber])"
+			name = prefix + "Hatchling Queen ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -151,17 +151,17 @@
 	var/rank_name
 	switch(playtime_mins)
 		if(0 to 600)
-			rank_name = "Broodling"
+			rank_name = "Hatchling"
 		if(601 to 3000)
-			rank_name = "Mature"
+			rank_name = "Young"
 		if(3001 to 9000)
-			rank_name = "Noble"
+			rank_name = "Mature"
 		if(9001 to 18000)
-			rank_name = "Royal"
+			rank_name = "Elder"
 		if(18001 to INFINITY)
-			rank_name = "Archon"
+			rank_name = "Ancient"
 		else
-			rank_name = "Broodling"
+			rank_name = "Hatchling"
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	name = prefix + "[rank_name ? "[rank_name] " : ""][xeno_caste.display_name] ([nicknumber])"
 


### PR DESCRIPTION

## About The Pull Request
Replaces the current ranks of broodling - archon with hatchling - ancient
Hatchling
Young
Mature
Elder
Ancient
## Why It's Good For The Game
After talking to Tivi I came to the realization that the ranks that I gave xenos were just really bad in clarity, the young - ancient we had previous is alot more clear in what ranking a xeno is.
Yes, this will mean that Elder with have the old Ancient icon next to them, and ancient will have the old primo icon next to them. Will take some getting used to
## Changelog
:cl:
spellcheck: Xeno ranks now go hatchling > young > mature > elder > ancient
/:cl:
