### PR TITLE
ghost runechat

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -96,7 +96,7 @@
 		displayed_key = null
 
 	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key)
-
+	create_chat_message(src, /datum/language/common, message)
 
 /mob/living/proc/get_message_mode(message)
 	var/key = message[1]


### PR DESCRIPTION

## About The Pull Request
Adds ghost runechat
## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66163761/ea1cf111-4a17-4f5e-8c1b-ecea337a8641)
Makes it easier for communication between ghosts without your message getting lost in a sea of dchat and OOC
## Changelog
:cl:
add: ghost runechat
/:cl:
