### PR TITLE
Vending machines now restock adjacent items.

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -746,8 +746,8 @@
 /obj/machinery/vending/proc/stock_vacuum(mob/user)
 	var/stocked = FALSE
 
-	for(var/obj/item/I in loc)
-		stocked = stock(I, null, FALSE) ? TRUE : stocked
+	for(var/obj/item/item_being_restocked in range(1, src))
+		stocked = stock(item_to_stock = item_being_restocked, user = null, show_feedback = FALSE) ? TRUE : stocked
 
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
 


### PR DESCRIPTION

## About The Pull Request
Makes it so clicking the restock button by a vending machine will restock all the items near it as well.
## Why It's Good For The Game
Reduces clutter in prep. Makes it much easier to restock crap on the ground without having to manually clickdrag every single item in yourself.
## Changelog
:cl:
add: Vending machines restock items near it (instead of only on the same tile) when you click "restock"
/:cl:
