### PR TITLE
Quality of life changes aswell as a few additions

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -113,15 +113,16 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "aF" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/mainship/sterile,
-/area/shuttle/canterbury/medical)
+/obj/machinery/computer/cryopod,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "aG" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile,
-/area/shuttle/canterbury/medical)
+/obj/machinery/light,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/canterbury)
 "aH" = (
-/obj/machinery/vending/MarineMed/Blood,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "aI" = (
@@ -228,7 +229,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aY" = (
-/obj/machinery/computer/cryopod,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "aZ" = (
@@ -242,7 +243,14 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "ba" = (
-/obj/machinery/vending/marineFood,
+/obj/effect/turf_decal/warning_stripes/box/threeside,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bc" = (
@@ -270,17 +278,21 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bh" = (
-/obj/machinery/fuelcell_recycler,
-/turf/open/floor/mainship/tcomms,
-/area/shuttle/canterbury)
-"bi" = (
-/obj/structure/barricade/plasteel{
+/obj/machinery/door/window/right{
 	dir = 8
 	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
+"bi" = (
 /obj/machinery/door_control{
 	id = "port_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
+	},
+/obj/structure/barricade/plasteel{
+	dir = 8;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -298,12 +310,16 @@
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "bl" = (
-/obj/machinery/power/monitor,
 /obj/structure/cable,
+/obj/machinery/power/smes/preset,
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "bm" = (
 /obj/structure/cable,
+/obj/effect/landmark/start/job/crash/synthetic,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 1
+	},
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bn" = (
@@ -330,9 +346,7 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "bq" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/tool/weldpack,
-/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
+/obj/machinery/fuelcell_recycler,
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "br" = (
@@ -401,13 +415,15 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "bC" = (
-/obj/structure/barricade/plasteel{
-	dir = 4
-	},
 /obj/machinery/door_control{
 	id = "starboard_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
+	},
+/obj/structure/barricade/plasteel{
+	dir = 4;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -484,16 +500,12 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bR" = (
-/obj/structure/table/mainship,
-/obj/item/clipboard,
-/obj/item/tool/pen,
-/obj/effect/spawner/random/misc/paperbin,
+/obj/structure/closet/secure_closet/guncabinet/canterbury,
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
 /area/shuttle/canterbury/cic)
 "bS" = (
-/obj/structure/closet/secure_closet/guncabinet/canterbury,
 /turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bT" = (
@@ -547,9 +559,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "cR" = (
-/obj/machinery/door/window/right{
-	dir = 8
-	},
 /turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "fL" = (
@@ -559,12 +568,17 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "gv" = (
-/obj/structure/barricade/plasteel,
+/obj/structure/barricade/plasteel{
+	is_wired = 1;
+	linked = 1
+	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "hc" = (
 /obj/structure/barricade/plasteel{
-	dir = 4
+	dir = 4;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -590,10 +604,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "Interior_Emergency_umbilical";
+	name = "\improper Umbillical Airlock"
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "lu" = (
-/obj/machinery/cryopod,
+/obj/machinery/vending/medical,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "mi" = (
@@ -632,8 +651,13 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "nM" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "Interior_Emergency_umbilical";
+	name = "\improper Umbillical Airlock"
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "oa" = (
 /obj/structure/window/reinforced{
@@ -646,10 +670,7 @@
 /area/shuttle/canterbury)
 "oj" = (
 /obj/structure/cable,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 1
-	},
-/obj/effect/landmark/start/job/crash/synthetic,
+/obj/machinery/power/monitor,
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "ow" = (
@@ -665,14 +686,22 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "qh" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/cargo,
-/area/shuttle/canterbury)
-"ql" = (
 /obj/structure/rack,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wrench,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/stack/razorwire/full,
+/obj/item/stack/razorwire/full,
+/obj/item/tool/shovel/etool,
+/obj/item/stack/barbed_wire/full,
+/obj/machinery/door_control{
+	id = "Interior_Emergency_umbilical";
+	name = "Emergency door-control";
+	pixel_y = 32
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "qE" = (
@@ -701,18 +730,12 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "sR" = (
-/obj/machinery/marine_selector/clothes/synth,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "te" = (
-/obj/structure/rack,
-/obj/machinery/air_alarm{
-	dir = 8
-	},
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/cryopod,
+/turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "tP" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -728,6 +751,14 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/red/full,
+/area/shuttle/canterbury)
+"ua" = (
+/obj/machinery/door_control{
+	id = "Interior_Emergency_umbilical";
+	name = "Emergency door-control";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "ul" = (
 /obj/machinery/light,
@@ -770,9 +801,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "vW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -818,18 +846,25 @@
 	},
 /area/shuttle/canterbury/cic)
 "zy" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "Interior_Emergency_umbilical";
+	name = "\improper Umbillical Airlock"
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "AS" = (
-/obj/structure/largecrate/supply/supplies/flares,
+/obj/structure/rack,
+/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/ammo_magazine/tl102/hsg_nest,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "BZ" = (
-/obj/machinery/vending/cola,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "CA" = (
@@ -843,7 +878,9 @@
 /area/shuttle/canterbury)
 "DH" = (
 /obj/structure/barricade/plasteel{
-	dir = 8
+	dir = 8;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -866,7 +903,10 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "FZ" = (
-/obj/structure/largecrate/supply/supplies/sandbags,
+/obj/structure/rack,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wrench,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "GE" = (
@@ -879,17 +919,26 @@
 /obj/machinery/marine_selector/clothes,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"Jn" = (
+/obj/machinery/vending/marineFood,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "JM" = (
 /obj/machinery/marine_selector/gear/smartgun,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "JN" = (
 /obj/machinery/light/small,
-/obj/machinery/cryopod,
+/obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
+"JQ" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/canterbury)
 "JX" = (
-/obj/machinery/vending/coffee,
+/obj/structure/bed/chair/dropship/passenger,
+/obj/effect/landmark/start/job/crash/cmo,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Kh" = (
@@ -903,15 +952,10 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Kk" = (
-/obj/structure/rack,
-/obj/item/facepaint/sniper,
-/obj/item/pizzabox/meat,
-/obj/item/binoculars,
-/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
-/obj/item/tool/shovel/etool,
 /obj/machinery/air_alarm{
 	dir = 4
 	},
+/obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "KD" = (
@@ -922,10 +966,10 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "Mj" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/obj/item/tool/hand_labeler,
-/obj/item/stack/barbed_wire/full,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "MY" = (
@@ -953,6 +997,12 @@
 	dir = 4
 	},
 /area/shuttle/canterbury/cic)
+"Pb" = (
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "PW" = (
 /obj/machinery/marine_selector/clothes/medic,
 /turf/open/floor/mainship/mono,
@@ -965,6 +1015,10 @@
 "Rd" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/start/job/crash/squadleader,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
+"Rk" = (
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "RT" = (
@@ -996,7 +1050,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"TD" = (
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "TE" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "TS" = (
@@ -1019,7 +1081,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "Ul" = (
 /obj/machinery/vending/nanomed,
@@ -1045,8 +1109,7 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "UP" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/start/job/crash/cmo,
+/obj/machinery/cryopod,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Wb" = (
@@ -1060,16 +1123,26 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Wk" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/start/job/crash/squadengineer,
+/obj/machinery/marine_selector/clothes/synth,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Wl" = (
-/obj/machinery/vending/snack,
+/obj/effect/turf_decal/warning_stripes/box/threeside{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "WY" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
+/obj/item/weapon/gun/sentry/big_sentry/premade{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "Xb" = (
@@ -1095,7 +1168,8 @@
 /area/shuttle/canterbury/medical)
 "Xp" = (
 /obj/machinery/door/window,
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "XO" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -1103,6 +1177,12 @@
 	},
 /obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
+"Yf" = (
+/obj/structure/cable,
+/obj/effect/attach_point/crew_weapon/dropship1,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "Yn" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -1117,8 +1197,12 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Zn" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door_control{
+	id = "Interior_Emergency_umbilical";
+	name = "Emergency door-control";
+	pixel_y = 32
+	},
+/turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/canterbury)
 
 (1,1,1) = {"
@@ -1178,7 +1262,7 @@ av
 aq
 ay
 aq
-aF
+ay
 az
 aU
 vF
@@ -1203,7 +1287,7 @@ DH
 DH
 DH
 ab
-bh
+aS
 TE
 bl
 ap
@@ -1211,7 +1295,7 @@ aw
 aq
 aB
 aq
-aG
+aB
 az
 aV
 aA
@@ -1229,7 +1313,7 @@ ad
 ad
 al
 UE
-ac
+as
 ab
 CA
 an
@@ -1262,10 +1346,10 @@ zk
 bL
 al
 Rd
-jq
+aG
 ab
 iy
-WY
+an
 ac
 tP
 ab
@@ -1295,7 +1379,7 @@ MY
 bM
 al
 AS
-ac
+as
 ab
 YN
 an
@@ -1328,10 +1412,10 @@ uu
 bN
 al
 FZ
-ac
+as
 ab
 uZ
-an
+WY
 ac
 uT
 sR
@@ -1348,7 +1432,7 @@ at
 au
 au
 au
-au
+ap
 ap
 ab
 "}
@@ -1361,7 +1445,7 @@ MY
 bS
 al
 qh
-ac
+as
 ab
 Wk
 an
@@ -1371,7 +1455,7 @@ ac
 ac
 ac
 as
-ac
+Rk
 ac
 ac
 as
@@ -1381,7 +1465,7 @@ Yn
 qE
 XO
 ac
-gv
+ar
 bW
 Uo
 "}
@@ -1392,13 +1476,13 @@ ad
 af
 bK
 Ul
-al
-zy
+ad
 ac
+as
 ki
 ac
 an
-ac
+Pb
 ac
 ac
 ac
@@ -1428,10 +1512,10 @@ ao
 bD
 as
 as
+nM
 as
 as
-as
-as
+Yf
 as
 as
 aa
@@ -1443,9 +1527,9 @@ as
 as
 an
 an
+JQ
 an
 an
-WY
 an
 gv
 bW
@@ -1458,13 +1542,13 @@ ad
 bI
 OS
 bP
-al
-nM
+ad
 ac
 ac
+zy
 ac
 an
-ac
+TD
 ac
 ac
 ac
@@ -1492,18 +1576,18 @@ bJ
 MY
 bQ
 al
-Wl
 ac
+ba
 Zn
-Wk
-an
+Wl
+ua
 ac
 FQ
 Fl
 Fl
 bG
 an
-ac
+Jn
 Kh
 ny
 RT
@@ -1513,7 +1597,7 @@ ac
 SA
 RT
 ac
-gv
+ar
 Xb
 Uo
 "}
@@ -1529,7 +1613,7 @@ JX
 ac
 ab
 ms
-an
+WY
 ac
 su
 ab
@@ -1559,7 +1643,7 @@ MY
 bO
 al
 BZ
-ac
+bh
 ab
 uZ
 an
@@ -1591,11 +1675,11 @@ al
 Uw
 bT
 al
-Rd
+aF
 jq
 ab
 qM
-WY
+an
 ac
 OL
 ab
@@ -1643,7 +1727,7 @@ bA
 aT
 UO
 aX
-ba
+bg
 bA
 bg
 ab
@@ -1690,7 +1774,7 @@ Uo
 Uo
 Uo
 al
-ql
+te
 te
 ab
 bV

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -119,20 +119,13 @@
 	},
 /area/shuttle/canterbury/cic)
 "au" = (
-/obj/structure/rack,
-/obj/item/tool/shovel/etool,
-/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
-/obj/item/pizzabox/meat{
-	pixel_y = 8
-	},
-/obj/item/binoculars,
-/obj/item/facepaint/sniper,
 /obj/machinery/air_alarm,
 /obj/machinery/door_control{
 	dir = 4;
 	id = "port_umbilical_outer";
 	name = "outer door-control"
 	},
+/obj/structure/largecrate/supply/supplies/sandbags,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "av" = (
@@ -146,6 +139,16 @@
 	dir = 1
 	},
 /obj/item/stack/barbed_wire/full,
+/obj/item/stack/razorwire/full,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/tool/wrench,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/screwdriver,
+/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/ammo_magazine/tl102/hsg_nest,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aw" = (
@@ -154,34 +157,36 @@
 	name = "\improper Command Cockpit"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "Interior_Emergency_umbilical";
+	name = "\improper Umbillical Airlock"
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/cic)
 "ax" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/wrench,
-/obj/item/tool/screwdriver,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "ay" = (
-/obj/structure/largecrate/supply/supplies/sandbags,
 /obj/machinery/air_alarm,
 /obj/machinery/door_control{
 	dir = 8;
 	id = "starboard_umbilical_outer";
 	name = "outer door-control"
 	},
+/obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aA" = (
 /obj/structure/barricade/plasteel{
-	dir = 8
+	dir = 8;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -199,7 +204,9 @@
 /area/shuttle/canterbury)
 "aF" = (
 /obj/structure/barricade/plasteel{
-	dir = 4
+	dir = 4;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -212,7 +219,9 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aI" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
+/obj/item/weapon/gun/sentry/big_sentry/premade{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "aJ" = (
@@ -227,14 +236,14 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aL" = (
+/obj/effect/landmark/start/job/crash/squadmarine,
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aN" = (
-/obj/effect/spawner/random/machinery/machine_frame,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aO" = (
@@ -255,23 +264,7 @@
 /turf/open/floor/plating,
 /area/shuttle/canterbury)
 "aT" = (
-/obj/item/fuel_cell/full,
-/obj/item/fuel_cell/full,
-/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/t_scanner,
-/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
-/obj/item/storage/backpack/marine/engineerpack,
-/obj/item/storage/belt/utility/full,
-/obj/item/flashlight,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/structure/table/mainship,
-/obj/item/facepaint/black,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "aV" = (
@@ -342,10 +335,14 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "bl" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/tool/weldpack,
-/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
-/turf/open/floor/mainship/orange/full,
+/obj/item/lightreplacer,
+/obj/item/clothing/glasses/welding,
+/obj/item/cell/high,
+/obj/machinery/cell_charger,
+/obj/item/radio,
+/obj/item/tool/crowbar,
+/obj/structure/table/reinforced,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bn" = (
 /obj/machinery/cryopod,
@@ -376,13 +373,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bt" = (
-/obj/item/lightreplacer,
-/obj/item/clothing/glasses/welding,
-/obj/item/cell/high,
-/obj/machinery/cell_charger,
-/obj/item/radio,
-/obj/item/tool/crowbar,
-/obj/structure/table/reinforced,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bu" = (
@@ -434,6 +425,7 @@
 /area/shuttle/canterbury)
 "bC" = (
 /obj/item/fuel_cell/full,
+/obj/item/fuel_cell/random,
 /obj/item/fuel_cell/random,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
@@ -573,14 +565,10 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "ci" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/obj/effect/landmark/start/job/crash/squadmarine,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/dropship/passenger,
+/obj/effect/landmark/start/job/crash/squadsmartgunner,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "ck" = (
 /obj/item/radio/intercom{
@@ -590,7 +578,9 @@
 	pixel_y = -28
 	},
 /obj/structure/barricade/plasteel{
-	dir = 8
+	dir = 8;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -690,10 +680,6 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "cN" = (
-/obj/item/storage/bag/trash,
-/obj/structure/closet/crate/trashcart,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
@@ -759,7 +745,9 @@
 	pixel_y = -28
 	},
 /obj/structure/barricade/plasteel{
-	dir = 4
+	dir = 4;
+	is_wired = 1;
+	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -767,12 +755,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/barricade/plasteel,
+/obj/structure/barricade/plasteel{
+	is_wired = 1;
+	linked = 1
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "cZ" = (
-/obj/structure/barricade/plasteel,
+/obj/structure/barricade/plasteel{
+	is_wired = 1;
+	linked = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "da" = (
@@ -782,8 +775,10 @@
 /obj/machinery/air_alarm{
 	dir = 8
 	},
-/obj/structure/largecrate/supply/supplies/flares,
-/obj/structure/barricade/plasteel,
+/obj/structure/barricade/plasteel{
+	is_wired = 1;
+	linked = 1
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "db" = (
@@ -795,6 +790,13 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/red,
+/area/shuttle/canterbury)
+"eo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "pY" = (
 /obj/machinery/door/airlock/mainship/marine/canterbury{
@@ -834,13 +836,25 @@
 /obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
+"HZ" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/canterbury)
 "KE" = (
 /obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"MS" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/canterbury)
 "RS" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/effect/attach_point/crew_weapon/dropship1,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "UG" = (
 /obj/machinery/marine_selector/clothes/synth,
@@ -927,7 +941,7 @@ aa
 an
 av
 aB
-aI
+aJ
 Bu
 an
 aR
@@ -951,7 +965,7 @@ ab
 ab
 cV
 aJ
-aL
+aD
 aN
 zN
 cv
@@ -973,7 +987,7 @@ ai
 ap
 ab
 cF
-aJ
+aI
 cR
 UG
 vY
@@ -1020,7 +1034,7 @@ ar
 aw
 bO
 bO
-bO
+RS
 bO
 ao
 bO
@@ -1030,8 +1044,8 @@ bO
 bO
 aJ
 aJ
+HZ
 aJ
-aI
 cZ
 co
 "}
@@ -1041,15 +1055,15 @@ ag
 aj
 as
 ab
-RS
-aJ
+aL
+bO
 aD
 aD
 be
 aD
 aJ
 aD
-ci
+aD
 aD
 aJ
 KE
@@ -1065,14 +1079,14 @@ am
 at
 ab
 cP
-aJ
+MS
 cS
 aO
 Hv
 bd
 aJ
 bJ
-an
+eo
 cH
 aJ
 cK
@@ -1088,7 +1102,7 @@ ac
 ab
 ab
 cQ
-aJ
+bO
 cT
 an
 aV
@@ -1110,8 +1124,8 @@ aa
 aa
 an
 ax
-cQ
-aI
+ci
+bO
 cU
 an
 aW


### PR DESCRIPTION
## About The Pull Request

This Pull request Adds quality of life changes to both shuttle maps. such as pre linked and pre wired cades, sentrys facing the right directions, removing useless things that take room, adding some emergency podlocks, and other additions for a little more balance such as a machine gun nest for a rear attach as an extra defensive method.

## Why It's Good For The Game

No one Can be bothered every time during a crash round to wire and link cades, move sentrys so they face the proper directions, especially when low-pop crash happens and no engineers available, that's if they can be bothered.

In regards to the Rear attachment and the machinegun nests, giving marines a chance to defend the ship is often hard when your team wipes due to incompetence or because they failed,  i feel making them have a chance to defend until more players join makes things more exciting for both sides.

I've played both Marines and xenomorphs and often want to join but stop myself due to knowing its very easy to sway balance, at least this way marines will have a safety net. As a xenomorph main player, an exciting round is when both sides can be neck and neck, and a round earnt after a tough fight are the memorable ones.

## Changelog

:cl:
qol: Cades are now linked and wired during round start.
qol: Sentrys are facing the right directions.
add: rear attach & machinegun nest with powersuits present.
qol: tidy up some useless junk that clutters around.
qol: fuel tank now has its own spot instead of always getting pushed around.
balance: big-bury now has an extra Auto-Doc and marine med
qol: big-bury has an extra fusion reactor and power storage unit due to power drain issues
add: emergency interior pod-locks that lead to cockpit for a bit more realism.
/:cl:


Note: Dont let the sentry and cade icons fool you, ingame they are working and pointing in the right directions, and cades are wired and linked. the icon states dont have all the right directions.
Cantabury
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/64131993/e9616642-2439-4ed5-bf98-3adb0c77314d)

Bigbury
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/64131993/24fa7e73-3ecf-4e5b-8ab2-048b10c1a383)
