### PR TITLE
Restricts boiler from rooting while resting.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -295,6 +295,10 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		set_rooted(FALSE)
 		return
 
+	if(HAS_TRAIT_FROM(owner, TRAIT_FLOORED, RESTING_TRAIT))
+		owner.balloon_alert(owner, "Cannot while lying down!")
+		return
+
 	owner.balloon_alert_to_viewers("Rooting into place...")
 	if(!do_after(owner, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 		owner.balloon_alert(owner, "Interrupted!")


### PR DESCRIPTION

## About The Pull Request
Restricts boiler from rooting in while resting
It was a problem when you try to press Rest in panic but hit the root and just keep lying in-place while getting killed.
## Why It's Good For The Game
Less caused skill issues (it already caused one)
## Changelog
:cl:
fix: boiler now can't root while resting.
/:cl:
