### PR TITLE
Adds balloon alert for when warrior tries to grab something in agility mode.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -48,7 +48,11 @@
 	..()
 
 /mob/living/carbon/xenomorph/warrior/start_pulling(atom/movable/AM, force = move_force, suppress_message = TRUE, lunge = FALSE)
-	if(!check_state() || agility)
+	if(!check_state())
+		return FALSE
+
+	if(agility)
+		balloon_alert(src, "Cannot in agility mode")
 		return FALSE
 
 	var/mob/living/L = AM


### PR DESCRIPTION

## About The Pull Request
Its kinda annoying when you try to grab something and you gain absolutely no response and you don't know is the issue in you or with code or with something else.
## Why It's Good For The Game
It will be a little clearer why you can't grab something in agility mode in the middle of saving someone/or just trying to drag something.
## Changelog
:cl:
qol: There is now a balloon alert popping up when you try to grab something as warrior in agility mode.
/:cl:
