### PR TITLE
Makes hypos and injectors viable.

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -1,15 +1,15 @@
 /obj/item/reagent_containers/hypospray/autoinjector
 	name = "generic autoinjector"
-	//desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."
 	desc = "An autoinjector containing... table salt? <i>\"For any client assistance, please contact the coderbus\" is written on the back.</i>"
 	icon_state = "autoinjector"
 	item_state = "hypo"
 	w_class = WEIGHT_CLASS_TINY
 	skilllock = 0
 	init_reagent_flags = DRAWABLE
-	amount_per_transfer_from_this = 10
-	volume = 30
-	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 30)
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 30)
+	amount_per_transfer_from_this = 15
+	volume = 60
+	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 60)
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon_state()
 	if(!(reagents.total_volume) && is_drawable())
@@ -35,21 +35,22 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine
 	name = "tricordrazine autoinjector"
-	desc = "An autoinjector loaded with 3 doses of tricordrazine, a weak general use medicine for treating damage."
+	desc = "An autoinjector loaded with 4 doses of tricordrazine, a weak general use medicine for treating damage."
 	icon_state = "autoinjector-4"
-	list_reagents = list(/datum/reagent/medicine/tricordrazine = 30)
+	list_reagents = list(/datum/reagent/medicine/tricordrazine = 60)
 	description_overlay = "Ti"
 
 /obj/item/reagent_containers/hypospray/autoinjector/combat
 	name = "combat autoinjector"
 	desc = "An autoinjector loaded with 2 doses of healing and painkilling chemicals. Intended for use in active combat."
 	icon_state = "RedGreen"
-	amount_per_transfer_from_this = 15
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 30, 60) //Gigachads will bite the whole injector
+	amount_per_transfer_from_this = 30
 	list_reagents = list(
-		/datum/reagent/medicine/bicaridine = 10,
-		/datum/reagent/medicine/kelotane = 10,
-		/datum/reagent/medicine/tricordrazine = 5,
-		/datum/reagent/medicine/tramadol = 5,
+		/datum/reagent/medicine/bicaridine = 15,
+		/datum/reagent/medicine/kelotane = 15,
+		/datum/reagent/medicine/tricordrazine = 15,
+		/datum/reagent/medicine/tramadol = 15,
 	)
 	description_overlay = "Cb"
 
@@ -57,7 +58,6 @@
 	name = "advanced combat autoinjector"
 	desc = "An autoinjector loaded with 2 doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	icon_state = "Lilac"
-	amount_per_transfer_from_this = 15
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 10,
 		/datum/reagent/medicine/dermaline = 10,
@@ -67,9 +67,11 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/quickclot
 	name = "quick-clot autoinjector"
-	desc = "An autoinjector loaded with three doses of quick-clot, a chemical designed to pause all bleeding. Renew doses as needed."
+	desc = "An autoinjector loaded with 4 doses of quick-clot, a chemical designed to pause all bleeding. Renew doses as needed."
 	icon_state = "autoinjector-7"
-	list_reagents = list(/datum/reagent/medicine/quickclot = 30)
+	amount_per_transfer_from_this = 10
+	volume = 40
+	list_reagents = list(/datum/reagent/medicine/quickclot = 40)
 	description_overlay = "Qk"
 
 /obj/item/reagent_containers/hypospray/autoinjector/quickclotplus
@@ -103,16 +105,16 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/dylovene
 	name = "dylovene autoinjector"
-	desc = "An auto-injector loaded with 3 doses of dylovene, an anti-toxin agent useful in cases of poisoning, overdoses and toxin build-up."
+	desc = "An auto-injector loaded with 4 doses of dylovene, an anti-toxin agent useful in cases of poisoning, overdoses and toxin build-up."
 	icon_state = "autoinjector-1"
-	list_reagents = list(/datum/reagent/medicine/dylovene = 30)
+	list_reagents = list(/datum/reagent/medicine/dylovene = 60)
 	description_overlay = "Dy"
 
 /obj/item/reagent_containers/hypospray/autoinjector/tramadol
 	name = "tramadol autoinjector"
-	desc = "An auto-injector loaded with 3 doses of tramadol, an effective painkiller for normal wounds."
+	desc = "An auto-injector loaded with 4 doses of tramadol, an effective painkiller for normal wounds."
 	icon_state = "autoinjector-10"
-	list_reagents = list(/datum/reagent/medicine/tramadol = 30)
+	list_reagents = list(/datum/reagent/medicine/tramadol = 60)
 	description_overlay = "Ta"
 
 /obj/item/reagent_containers/hypospray/autoinjector/oxycodone
@@ -126,24 +128,24 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/kelotane
 	name = "kelotane autoinjector"
-	desc = "An auto-injector loaded with 3 doses of kelotane, a common burn medicine."
+	desc = "An auto-injector loaded with 4 doses of kelotane, a common burn medicine."
 	icon_state = "autoinjector-5"
-	list_reagents = list(/datum/reagent/medicine/kelotane = 30)
+	list_reagents = list(/datum/reagent/medicine/kelotane = 60)
 	description_overlay = "Ke"
 
 /obj/item/reagent_containers/hypospray/autoinjector/bicaridine
 	name = "bicaridine autoinjector"
-	desc = "An auto-injector loaded with 3 doses of bicaridine, a common brute and circulatory damage medicine."
+	desc = "An auto-injector loaded with 4 doses of bicaridine, a common brute and circulatory damage medicine."
 	icon_state = "autoinjector-3"
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 30)
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 60)
 	description_overlay = "Bi"
 
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
 	name = "inaprovaline autoinjector"
-	desc = "An auto-injector loaded with 2 doses of inaprovaline, an emergency stabilization medicine for patients in critical condition."
+	desc = "An auto-injector loaded with 4 doses of inaprovaline, an emergency stabilization medicine for patients in critical condition."
 	icon_state = "autoinjector-9"
 	amount_per_transfer_from_this = 15
-	list_reagents = list(/datum/reagent/medicine/inaprovaline = 30)
+	list_reagents = list(/datum/reagent/medicine/inaprovaline = 60)
 	description_overlay = "In"
 
 /obj/item/reagent_containers/hypospray/autoinjector/dexalin
@@ -277,12 +279,12 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/isotonic
 	name = "isotonic solution autoinjector"
-	desc = "An auto-injector loaded with 2 doses of isotonic solution, formulated to quickly recover fluid volume after blood loss or trauma."
+	desc = "An auto-injector loaded with 4 doses of isotonic solution, formulated to quickly recover fluid volume after blood loss or trauma."
 	icon_state = "autoinjector-8"
 	amount_per_transfer_from_this = 15
-	volume = 30
+	volume = 60
 	list_reagents = list(
-		/datum/reagent/medicine/saline_glucose = 30,
+		/datum/reagent/medicine/saline_glucose = 60,
 	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/roulettium

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -67,10 +67,11 @@
 	name = "\improper Kelotane bottle"
 	desc = "A small bottle. Contains kelotane - used to treat burned areas."
 	icon_state = "bottle15"
-	list_reagents = list(/datum/reagent/medicine/kelotane = 60)
+	volume = 120
+	list_reagents = list(/datum/reagent/medicine/kelotane = 120)
 
 /obj/item/reagent_containers/glass/bottle/dexalin
-	name = "\improper Dexaline bottle"
+	name = "\improper Dexalin bottle"
 	desc = "A small bottle. Contains dexalin - used to supply blood with oxygen."
 	icon_state = "bottle10"
 	list_reagents = list(/datum/reagent/medicine/dexalin = 60)
@@ -159,20 +160,20 @@
 	name = "\improper Bicaridine bottle"
 	desc = "A small bottle. Contains Bicaridine - Used to treat brute damage by doctors."
 	icon_state = "bottle3"
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 60)
+	volume = 120
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 120)
 
 /obj/item/reagent_containers/glass/bottle/tramadol
 	name = "\improper Tramadol bottle"
 	desc = "A small bottle. Contains Tramadol - Used as a basic painkiller."
 	icon_state = "bottle18"
-	volume = 60
-	list_reagents = list(/datum/reagent/medicine/tramadol = 60)
+	volume = 120
+	list_reagents = list(/datum/reagent/medicine/tramadol = 120)
 
 /obj/item/reagent_containers/glass/bottle/oxycodone
 	name = "\improper Oxycodone bottle"
 	desc = "A very small bottle. Contains Oxycodone - Used as an Extreme Painkiller."
 	icon_state = "bottle2"
-	volume = 60
 	list_reagents = list(/datum/reagent/medicine/oxycodone = 60)
 
 /obj/item/reagent_containers/glass/bottle/hypervene
@@ -186,7 +187,8 @@
 	name = "\improper Tricordrazine bottle"
 	desc = "A small bottle. Contains tricordrazine - used as a generic treatment for injuries."
 	icon_state = "bottle-5"
-	list_reagents = list(/datum/reagent/medicine/tricordrazine = 60)
+	volume = 120
+	list_reagents = list(/datum/reagent/medicine/tricordrazine = 120)
 
 /obj/item/reagent_containers/glass/bottle/meralyne
 	name = "\improper Meralyne bottle"

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -9,8 +9,8 @@
 	item_state = "hypo"
 	icon_state = "hypo"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = null
-	volume = 60
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 30, 60)
+	volume = 120
 	init_reagent_flags = OPENCONTAINER
 	flags_equip_slot = ITEM_SLOT_BELT
 	flags_item = NOBLUDGEON
@@ -218,11 +218,7 @@
 	liquifier = TRUE
 
 
-/obj/item/reagent_containers/hypospray/interact(mob/user)
-	. = ..()
-	if(.)
-		return
-
+/obj/item/reagent_containers/hypospray/open_ui(mob/user)
 	var/dat = {"
 	<B><A href='?src=[text_ref(src)];autolabeler=1'>Activate Autolabeler</A></B><BR>
 	<B>Current Label:</B> [label]<BR>
@@ -230,13 +226,13 @@
 	<B><A href='?src=[text_ref(src)];overlayer=1'>Activate Tagger</A></B><BR>
 	<B>Current Tag:</B> [description_overlay]<BR>
 	<BR>
-	<B><A href='byond://?src=[text_ref(src)];inject_mode=1'>Toggle Mode (Toggles between injecting and draining):</B><BR>
-	<B>Current Mode:</B> [inject_mode ? "Inject" : "Draw"]</A><BR>
+	<B><A href='byond://?src=[text_ref(src)];inject_mode=1'>Toggle Mode:</A></B><BR>
+	<B>Current Mode:</B> [inject_mode ? "Inject" : "Draw"]<BR>
 	<BR>
-	<B><A href='byond://?src=[text_ref(src)];set_transfer=1'>Set Transfer Amount (Change amount drained/injected per use):</A></B><BR>
+	<B><A href='byond://?src=[text_ref(src)];set_transfer=1'>Set Transfer Amount:</A></B><BR>
 	<B>Current Transfer Amount [amount_per_transfer_from_this]</B><BR>
 	<BR>
-	<B><A href='byond://?src=[text_ref(src)];flush=1'>Flush Hypospray (Empties the hypospray of all contents):</A></B><BR>
+	<B><A href='byond://?src=[text_ref(src)];flush=1'>Empty Hypospray:</A></B><BR>
 	<BR>"}
 
 	var/datum/browser/popup = new(user, "hypospray")
@@ -244,10 +240,7 @@
 	popup.open()
 
 
-/obj/item/reagent_containers/hypospray/advanced/interact(mob/user)
-	. = ..()
-	if(.)
-		return
+/obj/item/reagent_containers/hypospray/advanced/open_ui(mob/user)
 	var/dat = {"
 	<B><A href='?src=[text_ref(src)];autolabeler=1'>Activate Autolabeler</A></B><BR>
 	<B>Current Label:</B> [label]<BR>
@@ -264,7 +257,7 @@
 	<B><A href='byond://?src=[text_ref(src)];displayreagents=1'>Display Reagent Content:</A></B><BR>
 	<BR>
 	<BR>
-	<B><A href='byond://?src=[text_ref(src)];flush=1'>Flush Hypospray (Empties the hypospray of all contents):</A></B><BR>
+	<B><A href='byond://?src=[text_ref(src)];flush=1'>Empty Hypospray:</A></B><BR>
 	<BR>"}
 
 	var/datum/browser/popup = new(user, "hypospray")
@@ -307,7 +300,7 @@
 		update_icon()
 
 	else if(href_list["set_transfer"])
-		var/N = tgui_input_list(usr, "Amount per transfer from this:", "[src]", list(30, 20, 15, 10, 5, 3, 1))
+		var/N = tgui_input_list(usr, "Amount per transfer from this:", "[src]", possible_transfer_amounts)
 		if(!N)
 			return
 
@@ -402,7 +395,7 @@
 	name = "bicaridine hypospray"
 	desc = "A hypospray loaded with bicaridine. A chemical that heal cuts and bruises."
 	list_reagents = list(
-		/datum/reagent/medicine/bicaridine = 60,
+		/datum/reagent/medicine/bicaridine = 120,
 	)
 	description_overlay = "Bi"
 
@@ -410,7 +403,7 @@
 	name = "kelotane hypospray"
 	desc = "A hypospray loaded with kelotane. A chemical that heal burns."
 	list_reagents = list(
-		/datum/reagent/medicine/kelotane = 60,
+		/datum/reagent/medicine/kelotane = 120,
 	)
 	description_overlay = "Ke"
 
@@ -418,7 +411,7 @@
 	name = "tramadol hypospray"
 	desc = "A hypospray loaded with tramadol. A chemical that numbs pain."
 	list_reagents = list(
-		/datum/reagent/medicine/tramadol = 60,
+		/datum/reagent/medicine/tramadol = 120,
 	)
 	description_overlay = "Ta"
 
@@ -426,7 +419,7 @@
 	name = "tricordrazine hypospray"
 	desc = "A hypospray loaded with tricordrazine. A chemical that heal cuts, bruises, burns, toxicity, and oxygen deprivation."
 	list_reagents = list(
-		/datum/reagent/medicine/tricordrazine = 60,
+		/datum/reagent/medicine/tricordrazine = 120,
 	)
 	description_overlay = "Ti"
 
@@ -434,7 +427,7 @@
 	name = "dylovene hypospray"
 	desc = "A hypospray loaded with dylovene. A chemical that heal toxicity whilst purging toxins, hindering stamina in the process."
 	list_reagents = list(
-		/datum/reagent/medicine/dylovene = 60,
+		/datum/reagent/medicine/dylovene = 120,
 	)
 	description_overlay = "Dy"
 
@@ -443,7 +436,7 @@
 	desc = "A hypospray loaded with inaprovaline."
 	amount_per_transfer_from_this = 15
 	list_reagents = list(
-		/datum/reagent/medicine/inaprovaline = 60,
+		/datum/reagent/medicine/inaprovaline = 120,
 	)
 	description_overlay = "In"
 
@@ -471,7 +464,7 @@
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 20,
 		/datum/reagent/medicine/dermaline = 20,
-		/datum/reagent/medicine/tramadol = 20,
+		/datum/reagent/medicine/oxycodone = 20,
 	)
 	description_overlay = "Av"
 
@@ -487,7 +480,7 @@
 /obj/item/reagent_containers/hypospray/advanced/oxycodone
 	name = "oxycodone hypospray"
 	desc = "A hypospray loaded with oxycodone. An advanced but highly addictive chemical which almost entirely negates pain and shock."
-	list_reagents = list(/datum/reagent/medicine/oxycodone = 60)
+	list_reagents = list(/datum/reagent/medicine/oxycodone = 120)
 	description_overlay = "Ox"
 
 /obj/item/reagent_containers/hypospray/advanced/hypervene
@@ -495,7 +488,7 @@
 	desc = "A hypospray loaded with hypervene. A chemical that rapdidly flushes the body of all chemicals and toxins."
 	amount_per_transfer_from_this = 3
 	list_reagents = list(
-		/datum/reagent/hypervene = 60,
+		/datum/reagent/hypervene = 120,
 	)
 	description_overlay = "Ht"
 
@@ -533,13 +526,13 @@
 	item_state = "hypomed"
 	icon_state = "hypomed"
 	core_name = "hypospray"
-	volume = 120
+	volume = 240
 
 /obj/item/reagent_containers/hypospray/advanced/big/bicaridine
 	name = "big bicaridine hypospray"
 	desc = "A hypospray loaded with bicaridine. A chemical that heal cuts and bruises."
 	list_reagents = list(
-		/datum/reagent/medicine/bicaridine = 120,
+		/datum/reagent/medicine/bicaridine = 240,
 	)
 	description_overlay = "Bi"
 
@@ -547,7 +540,7 @@
 	name = "big kelotane hypospray"
 	desc = "A hypospray loaded with kelotane. A chemical that heal burns."
 	list_reagents = list(
-		/datum/reagent/medicine/kelotane = 120,
+		/datum/reagent/medicine/kelotane = 240,
 	)
 	description_overlay = "Ke"
 
@@ -555,7 +548,7 @@
 	name = "big tramadol hypospray"
 	desc = "A hypospray loaded with tramadol. A chemical that numbs pain."
 	list_reagents = list(
-		/datum/reagent/medicine/tramadol = 120,
+		/datum/reagent/medicine/tramadol = 240,
 	)
 	description_overlay = "Ta"
 
@@ -563,19 +556,19 @@
 	name = "big tricordrazine hypospray"
 	desc = "A hypospray loaded with tricordrazine. A chemical that heal cuts, bruises, burns, toxicity, and oxygen deprivation."
 	list_reagents = list(
-		/datum/reagent/medicine/tricordrazine = 120,
+		/datum/reagent/medicine/tricordrazine = 240,
 	)
 	description_overlay = "Ti"
 
 /obj/item/reagent_containers/hypospray/advanced/big/combatmix
 	name = "big combat mix hypospray"
-	desc = "A hypospray loaded with combat mix. There's a tag that reads BKTT 40:40:20:20."
+	desc = "A hypospray loaded with combat mix. There's a tag that reads BKTT 60:60:60:60."
 	amount_per_transfer_from_this = 15
 	list_reagents = list(
-		/datum/reagent/medicine/bicaridine = 40,
-		/datum/reagent/medicine/kelotane = 40,
-		/datum/reagent/medicine/tramadol = 20,
-		/datum/reagent/medicine/tricordrazine = 20,
+		/datum/reagent/medicine/bicaridine = 60,
+		/datum/reagent/medicine/kelotane = 60,
+		/datum/reagent/medicine/tramadol = 60,
+		/datum/reagent/medicine/tricordrazine = 60,
 	)
 	description_overlay = "Cm"
 
@@ -583,7 +576,7 @@
 	name = "big dylovene hypospray"
 	desc = "A hypospray loaded with dylovene. A chemical that heal toxicity whilst purging toxins, hindering stamina in the process."
 	list_reagents = list(
-		/datum/reagent/medicine/dylovene = 120,
+		/datum/reagent/medicine/dylovene = 240,
 	)
 	description_overlay = "Dy"
 
@@ -592,7 +585,7 @@
 	desc = "A hypospray loaded with inaprovaline. An emergency chemical used to stabilize and heal critical patients."
 	amount_per_transfer_from_this = 15
 	list_reagents = list(
-		/datum/reagent/medicine/inaprovaline = 120,
+		/datum/reagent/medicine/inaprovaline = 240,
 	)
 	description_overlay = "In"
 
@@ -600,7 +593,7 @@
 	name = "big isotonic hypospray"
 	desc = "A hypospray loaded with isotonic. A chemical that aids in replenishing blood."
 	list_reagents = list(
-		/datum/reagent/medicine/saline_glucose = 120,
+		/datum/reagent/medicine/saline_glucose = 240,
 	)
 	description_overlay = "Is"
 
@@ -608,16 +601,17 @@
 	name = "big spaceacillin hypospray"
 	desc = "A hypospray loaded with spaceacillin. A chemical which fights viral and bacterial infections."
 	list_reagents = list(
-		/datum/reagent/medicine/spaceacillin = 120,
+		/datum/reagent/medicine/spaceacillin = 240,
 	)
 	description_overlay = "Sp"
 
 /obj/item/reagent_containers/hypospray/advanced/imialky
 	name = "big imialky hypospray"
 	desc = "A hypospray loaded with a mixture of imidazoline and alkysine. Chemicals that will heal the brain and eyes."
+	amount_per_transfer_from_this = 8
 	list_reagents = list(
-		/datum/reagent/medicine/imidazoline = 30,
-		/datum/reagent/medicine/alkysine = 30,
+		/datum/reagent/medicine/imidazoline = 96,
+		/datum/reagent/medicine/alkysine = 24,
 	)
 	description_overlay = "Im"
 
@@ -625,6 +619,6 @@
 	name = "big quick-clot hypospray"
 	desc = "A hypospray loaded with quick-clot. A chemical that halts internal bleeding and restores blood."
 	list_reagents = list(
-		/datum/reagent/medicine/quickclot = 120,
+		/datum/reagent/medicine/quickclot = 240,
 	)
 	description_overlay = "Qk"

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -13,6 +13,7 @@
 	throw_range = 5
 	var/init_reagent_flags
 	var/amount_per_transfer_from_this = 5
+	///Used to adjust how many units are transfered/injected in a single click
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
 	var/liquifier = FALSE //Can liquify/grind pills without needing fluid to dissolve.
@@ -40,6 +41,10 @@
 	if(.)
 		return
 
+	open_ui(user)
+
+///Opens the relevant UI
+/obj/item/reagent_containers/proc/open_ui(mob/user)
 	if(!length(possible_transfer_amounts))
 		return
 
@@ -48,7 +53,6 @@
 		return
 
 	amount_per_transfer_from_this = N
-
 
 /obj/item/reagent_containers/verb/set_APTFT()
 	set name = "Set transfer amount"


### PR DESCRIPTION

## About The Pull Request
Injector capacity buffed from 30u -> 60u
Hypospray capacity buffed from 60u -> 120u
Big hypospray capacity buffed from 120u -> 240u
gives advanced combat hypo oxycodone instead of tram (to match the advanced combat injector)
Combatmix now equal parts bktt
## Why It's Good For The Game
This is an attempt to make injectors/hypos more on par with the standard issue pill packets, and hopefully it's no longer just a noobtrap.
1 pill packet can hold 8 pills of 15u each, for a total of 120u of chems.
1 injector used to hold 30u of chem.
This meant that for the, for the same inventory space, 1 pill packet was equivalent to 4 injectors (while only taking the space of 2.)
This gets even more drastic with pill bottles, holding the chem equivalent of 8 injectors, which means that injectors are just a complete noob trap when compared to pill packets/bottles.

BKTT Bottles were also increased to 120u (the same capacity of a packet), for the sake of making hypobelt possibly viable.
## Changelog
:cl:
balance: Injectors hold 60u of chems
balance: Hyposprays hold 120u of chem
balance: Big Hypos hold 240u of chem
spellcheck: Dexaline -> Dexalin
code: un-hardcodes possible_transfer_amounts from the UI
/:cl:
