### PR TITLE
Adjusts the amount of supply points lower tier castes gives

### DIFF
--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -34,11 +34,11 @@
 		if(XENO_TIER_MINION)
 			. = 50
 		if(XENO_TIER_ZERO)
-			. = 150
+			. = 70
 		if(XENO_TIER_ONE)
-			. = 300
+			. = 150
 		if(XENO_TIER_TWO)
-			. = 400
+			. = 300
 		if(XENO_TIER_THREE)
 			. = 500
 		if(XENO_TIER_FOUR)


### PR DESCRIPTION
## About The Pull Request
Before:

T1 - 300
T2 - 400
T3 + Shrike - 500
T4 - 1000

After:

T1 - 150
T2 - 300
T3 + shrike - 500
T4 - 1000

Currently in game you need: 2 drone kills to get a teleporter, 1 runny kill to get a plasma cutter, 4 T1 kills to get a b18, etc etc etc

when comparing, 1 sentinel is worth 0.6 defilers, (or 1 defiler is 1.6 sentinels) which just doesn't even feel right. Killing 2 sentinels should not be netting more points than killing a single defiler

Ratio chart:

## Why It's Good For The Game

Basically with higher pop comes a significantly larger amount of T1's, many of which have their sole round contributions being feeding points to the marine team by dying in the strangest ways you could imagine.

This PR seeks to change the point distribution given by xenos to make securing T3 kills more important, while also making T1's less important.

With my changes, 1 runner is equal 0.3 defilers (or 1 defiler = 3.3 runners). 

ratio chart:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/120620754/49d44cbe-ba1c-4f72-89a6-4889b4f66c8e)


## Changelog
:cl:
balance: adjusts the amount of supply points xeno castes give
/:cl:
