### PR TITLE
Overhead campaign objective timers

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -81,7 +81,7 @@
 	color = "#d1d1d1"
 	invisibility = SEE_INVISIBLE_LIVING
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	countdown.pixel_y = 16
+	pixel_y = 16
 
 /obj/effect/countdown/campaign_objective/get_value()
 	if(QDELETED(attached_to))

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -74,3 +74,17 @@
 	if(!N.timer_enabled)
 		return
 	return N.get_time_left()
+
+//campaign objective timer
+/obj/effect/countdown/campaign_objective
+	name = "objective countdown"
+	color = "#d1d1d1"
+	invisibility = SEE_INVISIBLE_LIVING
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	countdown.pixel_y = 16
+
+/obj/effect/countdown/campaign_objective/get_value()
+	if(QDELETED(attached_to))
+		return
+	var/obj/structure/campaign_objective/capture_objective/objective = attached_to
+	return objective.get_time_left()

--- a/code/game/objects/structures/campaign_structures/capture_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/capture_objectives.dm
@@ -15,11 +15,18 @@
 	var/capturing_faction
 	///Timer holder for the current capture/decapture timer
 	var/capture_timer
+	///overhead timer
+	var/obj/effect/countdown/campaign_objective/countdown
+
+/obj/structure/campaign_objective/capture_objective/Initialize(mapload)
+	. = ..()
+	countdown = new(src)
 
 /obj/structure/campaign_objective/capture_objective/Destroy()
 	if(capture_timer)
 		deltimer(capture_timer)
 		capture_timer = null
+	QDEL_NULL(countdown)
 	return ..()
 
 /obj/structure/campaign_objective/capture_objective/update_control_minimap_icon()
@@ -66,12 +73,14 @@
 	if(capture_timer)
 		deltimer(capture_timer)
 		capture_timer = null
+		countdown.stop()
 	if(owning_faction == user.faction) //we already own it, we just stopped the enemy cap
 		capturing_faction = null
 		return
 	capturing_faction = user.faction
 	update_icon()
 	capture_timer = addtimer(CALLBACK(src, PROC_REF(do_capture), user), capture_delay, TIMER_STOPPABLE)
+	countdown.start()
 
 ///Checks if this objective can be captured
 /obj/structure/campaign_objective/capture_objective/proc/capture_check(mob/living/user)
@@ -95,6 +104,7 @@
 /obj/structure/campaign_objective/capture_objective/proc/do_capture(mob/living/user)
 	capturing_faction = null
 	capture_timer = null
+	countdown.stop()
 
 	if(owning_faction)
 		if(owning_faction == user.faction)
@@ -112,6 +122,10 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAPTURED, src, user)
 	update_icon()
 
+///Returns time left on the nuke in seconds
+/obj/structure/campaign_objective/capture_objective/proc/get_time_left()
+	return capture_timer ? round(timeleft(capture_timer) MILLISECONDS) : null
+
 //sensor tower
 /obj/effect/landmark/campaign_structure/sensor_tower
 	name = "sensor tower objective"
@@ -127,6 +141,11 @@
 	icon_state = "sensor"
 	obj_flags = NONE
 	capture_flags = CAPTURE_OBJECTIVE_RECAPTURABLE
+
+/obj/structure/campaign_objective/capture_objective/sensor_tower/Initialize(mapload)
+	. = ..()
+	countdown.pixel_x = 5
+	countdown.pixel_y = 90
 
 /obj/structure/campaign_objective/capture_objective/sensor_tower/update_icon_state()
 	icon_state = initial(icon_state)


### PR DESCRIPTION

## About The Pull Request
When there is a timer running on an objective, you can now see the time left above the objective.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/46a82562-959c-4688-a7a0-fb85cfeef998)
## Why It's Good For The Game
Better visibility
## Changelog
:cl:
qol: Timers on campaign objectives are now visible above the objective
/:cl:
