### PR TITLE
Breaching axe nerf

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -213,6 +213,7 @@
 	force_wielded = 80
 	penetration = 35
 	flags_equip_slot = ITEM_SLOT_BACK
+	attack_speed = 15
 
 /obj/item/weapon/twohanded/fireaxe/som/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Breaching axe attack speed is 15 instead of 11. This probably will make no practical difference since you're still going to crump a nerd in two hits. Mainly just did this because it seems weird a 2 handed axe can swing faster than a one handed sword.
## Why It's Good For The Game
You'll now have an additional 0.4 seconds to reconsider your life choices before a breaching axe caves in your skull for the second time.
## Changelog
:cl:
balance: Breaching axe attack speed reduced to 15 from 11
/:cl:
