### PR TITLE
firesupport bino QOL

### DIFF
--- a/code/datums/fire_support.dm
+++ b/code/datums/fire_support.dm
@@ -67,7 +67,7 @@
 
 ///Actually begins the fire support attack
 /datum/fire_support/proc/start_fire_support(turf/target_turf)
-	cooldown_timer = addtimer(VARSET_CALLBACK(src, cooldown_timer, null), cooldown_duration)
+	cooldown_timer = addtimer(VARSET_CALLBACK(src, cooldown_timer, null), cooldown_duration, TIMER_STOPPABLE)
 	select_target(target_turf)
 
 	if(start_visual)

--- a/code/game/objects/items/firesupport_binoculars.dm
+++ b/code/game/objects/items/firesupport_binoculars.dm
@@ -33,7 +33,12 @@
 
 /obj/item/binoculars/fire_support/examine(mob/user)
 	. = ..()
-	. += span_notice("They are currently set to [mode.name] targeting mode.")
+	if(!mode)
+		return
+	. += span_boldnotice("They are currently set to [mode.name] mode: [mode.uses == -1 ? "unlimited" : "[mode.uses]"] uses remaining.")
+	if(!mode.cooldown_timer)
+		return
+	. += span_warning("Available in [round(timeleft(mode.cooldown_timer) MILLISECONDS)] seconds.")
 
 /obj/item/binoculars/fire_support/Destroy()
 	if(laser)


### PR DESCRIPTION

## About The Pull Request
Fire support binos in campaign now on examine display:
Firemode type
Uses remaining
Cooldown remaining (if on CD)

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/2c449b59-6975-47bf-87f5-5057b5bb12c4)
## Why It's Good For The Game
Access to info is good.
## Changelog
:cl:
qol: Campaign firesupport binos show current mode uses and cooldown remaining if applicable
/:cl:
