### PR TITLE
Nerfs Synth CQC skill

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -330,7 +330,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_MASTER
 	firearms = SKILL_FIREARMS_UNTRAINED
 	medical = SKILL_MEDICAL_EXPERT
-	cqc = SKILL_CQC_MASTER
+	cqc = SKILL_CQC_TRAINED
 	surgery = SKILL_SURGERY_EXPERT
 	pilot = SKILL_PILOT_TRAINED
 	melee_weapons = SKILL_MELEE_DEFAULT
@@ -344,7 +344,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_INHUMAN
 	firearms = SKILL_FIREARMS_UNTRAINED
 	medical = SKILL_SURGERY_PROFESSIONAL
-	cqc = SKILL_CQC_MASTER
+	cqc = SKILL_CQC_TRAINED
 	surgery = SKILL_SURGERY_PROFESSIONAL
 	pilot = SKILL_PILOT_TRAINED
 	melee_weapons = SKILL_MELEE_DEFAULT


### PR DESCRIPTION

## About The Pull Request
Nerfs Synth CQC to SKILL_CQC_TRAINED (Same as marines)
I would reduce it to lower, but then Synth can no longer easily deweed.
## Why It's Good For The Game
Synth is a non-combat oriented role. People should not be incentivized to pick Synth due to them having an extra 4 melee damage from skills compared to a normal marine.
## Changelog
:cl:
balance: Reduces Synth CQC level.
/:cl:
