### PR TITLE
explosions clear smoke

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -81,8 +81,8 @@
 
 	opacity = FALSE
 	alpha = 0
-	animate(src, 7 SECONDS, easing = CIRCULAR_EASING|EASE_IN, alpha = 255)
-	addtimer(VARSET_CALLBACK(src, opacity, TRUE), 5 SECONDS)
+	animate(src, 7 SECONDS, easing = CIRCULAR_EASING|EASE_IN, alpha = initial(alpha))
+	addtimer(VARSET_CALLBACK(src, opacity, initial(opacity)), 5 SECONDS)
 
 
 /obj/effect/particle_effect/smoke/proc/on_cross(datum/source, atom/movable/O, oldloc, oldlocs)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -11,6 +11,7 @@
 	layer = FLY_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASS_AIR
+	resistance_flags = UNACIDABLE|PLASMACUTTER_IMMUNE|PROJECTILE_IMMUNE|CRUSHER_IMMUNE
 	var/amount = 3
 	var/lifetime = 5
 	///time in decisecond for a smoke to spread one tile.
@@ -72,6 +73,17 @@
 		return FALSE
 	apply_smoke_effect(get_turf(src))
 	return TRUE
+
+/obj/effect/particle_effect/smoke/ex_act(severity)
+	if(lifetime <= 3)
+		qdel(src)
+		return
+
+	opacity = FALSE
+	alpha = 0
+	animate(src, 7 SECONDS, easing = CIRCULAR_EASING|EASE_IN, alpha = 255)
+	addtimer(VARSET_CALLBACK(src, opacity, TRUE), 5 SECONDS)
+
 
 /obj/effect/particle_effect/smoke/proc/on_cross(datum/source, atom/movable/O, oldloc, oldlocs)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Drop bomb in smoke, visibility clears for a bit.
The smoke doesn't actually vanish so you'll still suffer any negative effects from it.

This in my original idea that no one in gaming has ever thought of before. donutsteel.


https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/376f6b27-0f84-4545-9a8b-631d4e50f830
## Why It's Good For The Game
Cool effect, a way to temporarily counter the visibility limiting power of dense smoke.
## Changelog
:cl:
balance: Explosions will now temporarily reduce the opacity of dense smoke caught in the radius.
/:cl:
