### PR TITLE
Locks LV to HvH votes only. Sets the default maps to Debugdalus and Vapor Processing

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///If the gamemode has a whitelist of valid ground maps. Whitelist overrides the blacklist
 	var/list/whitelist_ground_maps
 	///If the gamemode has a blacklist of disallowed ground maps
-	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
+	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
 	///if fun tads are enabled by default
 	var/enable_fun_tads = FALSE
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -5,7 +5,7 @@
 
 /datum/map_config
 	// Metadata
-	var/config_filename = "_maps/LV624.json"
+	var/config_filename = "_maps/vapor_processing.json"
 	var/defaulted = TRUE  // set to FALSE by LoadConfig() succeeding
 	// Config from maps.txt
 	var/config_max_users = 0
@@ -13,9 +13,9 @@
 	var/voteweight = 1
 
 	// Config actually from the JSON - default values
-	var/map_name = "LV624"
-	var/map_path = "map_files/LV624"
-	var/map_file = "LV624.dmm"
+	var/map_name = "Vapor Processing"
+	var/map_path = "map_files/Vapor_Processing"
+	var/map_file = "Vapor_Processing.dmm"
 
 	var/traits = null
 	var/space_empty_levels = 1
@@ -70,9 +70,9 @@
 			return
 		switch(maptype)
 			if(GROUND_MAP)
-				return LoadConfig("_maps/lv624.json", error_if_missing, maptype)
+				return LoadConfig("_maps/vapor_processing.json", error_if_missing, maptype)
 			if(SHIP_MAP)
-				return LoadConfig("_maps/pillar_of_spring.json", error_if_missing, maptype)
+				return LoadConfig("_maps/debugdalus.json", error_if_missing, maptype)
 
 	var/json = file(filename)
 	if(!json)

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,7 +13,6 @@ Format:
 endmap
 
 map lv624
-	default
 	minplayers 25
 endmap
 
@@ -31,6 +30,7 @@ map prison_station_fop
 endmap
 
 map vapor_processing
+	default
 endmap
 
 map icy_caves


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. Debugdalus and Vapor Procecssing have the fastest load times; if someone is compiling for the first time, that is what they want. I understand this PR will likely be highly controversial; please put some thought into your comments as I know Grayson reads them and takes them into consideration; we all play on this map, after all.
## Why It's Good For The Game
**MEGA RANT INCOMING**
_Preface_
LV is one of the most polarizing maps in TGMC. On one hand, people love the theme of a jungle hell (hey, I do too) that is wet and hostile. On the other hand, and to which I believe is more important, is the map is absolutely abysmal for our current HvX gamemodes. The foundation it is built on it rotten and irreparable, from an age old that has next to no resemblance to the game we play today.
_Distress Signal_
As I know it, LV is one of the actual first CM designed maps. As so, the flow is extremely basic at a fundamental level: Marines push north to the beach and caves, and fight Xenos on the way. This is how it still plays on CM today. A big difference that we have from CM, however, is that we do not play on Distress Signal anymore. We play on Nuclear War where it is encouraged to actually do disks and hold objectives. Due to the design of LV, the current disk spots are about the only place mappers can place them. These spots are horrible to fight from a Xeno perspective, being backed up by a unweedable river or unweedable grass. The bottom line is that marines _never have to go inside of caves, where the risk they take is much higher_. Some maps do not require marines to go into caves; but they can work because the colony is fightable. LV is designed for colony (the south side of the map) to be a transition area for marines to push north, not where xenos can fight and hold. They can only do that when marines are completely braindead (to their credit can be quite often).
_Weedability_
You may ask, however, "Barnet, why not just make grass/water weedable?" Fair point. However, if it was that simple LV would have been fixed a long time ago. In short, we would not be able to make river or grass weedable without _a complete redesign of the map, which at that point is making a new map._ It has been tried before by Grayson, and he himself was not able to remedy the issues LV has with that alone. I reckon weedable water will share the same fate; LV just isn't made for it. Unweedable areas can make work from a mapper standpoint for nerds like me, but in the multiple years of practice they are **extremely** player unfriendly. While this unfriendliness might be removed if you enable weeding, you set the entire map on fire and throw it in the dumpster; you literally cannot win either way you go.
_Reworks_
This map has been fiddled with more than any other map on this codebase. It has upwards of 20 PR's alone tweaking or attempting to fully rework. So far, none have worked and sticked. With this, I doubt the next "big rework" will solve anything short of remaking the entire map from the ground up, which at that point just removes the map in a different way. Trying to fix or rework LV is a waste of time, and could even make it worse than it already is.
_Disks_
Going into more depth from what I said in Distress Signal, the fact that this map is only played in gamemodes with disks on HvH also makes it considerably worse. About no map in the game was _made_ for disk gameplay, as many came before disks, but some definitely work better with them than others (Like BR, BR is made of magic apparently). LV has gotten by far the worst treatment from disk placement, and the worst part is that _they cannot be changed._ The only disk change that was attempted was from Hydro to Engineering, but both have their immense problems. Hydro allowed marines to camp on the river and essentially cut out any counterplay from the Xenos, and Engineering also allows logistics to chill on the river, especially if the building is OB'd; it is extremely hard to push the disk as xeno if Marines hold the cave chokepoint, or do not push caves at all. The bar disk also sits on the river, and is also hard to deal with if Marines commit to it. The only "contestable" disk is the Temple disk, but even then Marines can shape it to their will given sandbox tools. Temple disk is probably the only disk that half works.
_Caves_
The caves on LV are sub-par at best. CM elected to expand the caves immensely; but again, that wouldn't work without us being on Distress Signal. If we threw a disk in the expanded caves it would be absolute hell to play around. And even then, if we expanded caves, as long as marines avoid it (they very well can), the caves will not act as a Xeno strongpoint as they do on Distress Signal.
_Variety_
Another argument used is that LV needs to exist for map variety. In truth, with so many (justified) map removals recently, we are running lower and lower on maps. However, I don't think that is a valid reason to force people onto a round that people already know will suck. You will genuinely see people refuse to play xeno and hop on Marine leading to high burrowed hives, exasperating the issue. Desparity, Lawanka and even Slumbridge to an extent fill this niche; if need be I or someone else can make another jungle map, LV simply lives on "nostalgia".
_Conclusion_
I believe that is most of what I wanted to say on the map. The reason for the HvH lock is so
1) If someone truly, truly believes they can rework (tear up the map) LV into a more than abysmal state, it is there.
2) There isn't exactly anything wrong with this map on non-HvX gamemodes; about any map works for them.
## Changelog
:cl:
del: LV is now only voteable on HvH gamemodes.
code: Sets Debugdalus and Vapor Processing to the default maps
/:cl:
