### PR TITLE
Campaign RTB stun

### DIFF
--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -200,6 +200,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		human_mob.overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 		human_mob.overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
 		human_mob.forceMove(pick(GLOB.spawns_by_job[human_mob.job.type]))
+		human_mob.Stun(1 SECONDS) //so you don't accidentally shoot your team etc
 
 ///Generates status tab info for the mission
 /datum/faction_stats/proc/get_status_tab_items(mob/source, list/items)


### PR DESCRIPTION

## About The Pull Request
When you return to base after a mission ends, it now applies a 1 second stun, to prevent the hilariously common post teleport FF.
## Why It's Good For The Game
Getting shotgun pb'd by your friend by accident is guh.
## Changelog
:cl:
qol: A 1 second stun is applied when returning to base after a campaign mission ends
/:cl:
