### PR TITLE
Increases resin wall bullet armor

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -15,7 +15,7 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_XENO_STRUCTURES)
 	canSmoothWith = list(SMOOTH_GROUP_XENO_STRUCTURES)
-	soft_armor = list(MELEE = 0, BULLET = 60, LASER = 60, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 70, LASER = 60, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	resistance_flags = UNACIDABLE
 
 /turf/closed/wall/resin/add_debris_element()


### PR DESCRIPTION
## About The Pull Request
Increases resin wall bullet armor from 60 to 70
## Why It's Good For The Game
Someone requested this PR

considering how ammo is infinite and how recently people have just been using aimmode MG's to shoot down walls, I dont think this is something that is as big as you say it is.

The optimal play for marines right now is to get 3 MG's who either carry an ammo box with them or better yet, use the free req beacon helmet module to have RO send them ammo all on aimmode to shoot down walls. This is the meta rn because:

zero risk of flamer FF or losing a PC
you can cover your teammates who do get close to the walls because you can just stop shooting the walls and aim at the xeno
hard to counter since any xeno that peaks will just get mowed down by the 3 MG's on aimmode 8 tiles away
the reason we got to this is from a many separate changes compounding to create this strange meta of aimmode MG clearing
## Changelog
:cl:
balance: made resin walls have 70 bullet armor (up from 60)
/:cl:
