### PR TITLE
WP smoke no longer drains plasma

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -246,7 +246,7 @@
 	alpha = 145
 	opacity = FALSE
 	color = "#DBCBB9"
-	smoke_traits = SMOKE_GASP|SMOKE_BLISTERING|SMOKE_OXYLOSS|SMOKE_PLASMALOSS|SMOKE_FOUL
+	smoke_traits = SMOKE_GASP|SMOKE_BLISTERING|SMOKE_OXYLOSS|SMOKE_FOUL
 
 /obj/effect/particle_effect/smoke/phosphorus/mustard
 	opacity = TRUE


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
did you know that the tanglefoot OB came before tanglefoot grenades, and that the plasma drain of WP smoke was increased because they didn't have tanglefoot grenades?
## Changelog
:cl:
balance: WP smoke in all of its forms no longer drains plasma
/:cl:
