### PR TITLE
Gives hivemind queen-level psychic cure instead of shrike-level psychic cure

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -59,7 +59,7 @@
 	SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, minions_agressive)
 	update_button_icon()
 
-/datum/action/xeno_action/activable/psychic_cure/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+/datum/action/xeno_action/activable/psychic_cure/queen_give_heal/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
 	if (owner.status_flags & INCORPOREAL)
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -50,7 +50,7 @@
 		/datum/action/xeno_action/rally_hive/hivemind,
 		/datum/action/xeno_action/activable/command_minions,
 		/datum/action/xeno_action/activable/plant_weeds/ranged,
-		/datum/action/xeno_action/activable/psychic_cure/hivemind,
+		/datum/action/xeno_action/activable/psychic_cure/queen_give_heal/hivemind,
 		/datum/action/xeno_action/activable/transfer_plasma/hivemind,
 		/datum/action/xeno_action/pheromones/hivemind,
 		/datum/action/xeno_action/pheromones/emit_recovery,


### PR DESCRIPTION
## About The Pull Request
Title
## Why It's Good For The Game
give hivemind the more available version of psychic cure for a more flexible heal with less cooldown time
## Changelog
:cl:
balance: hiveminds now have the queen's version of psychic cure
/:cl:
