### PR TITLE
increases sg62 target rifle bullet range

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1285,6 +1285,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 40
+	max_range = 40
 	penetration = 30
 	sundering = 5
 	shell_speed = 4


### PR DESCRIPTION

## About The Pull Request
increases the bullet range of the SG62 target rifle up to 40, which is the same as normal marksman gun bullets
doesnt touch the spotting rifle range, that's still 20
## Why It's Good For The Game
if you stick a scope on the SG62, you currently cant hit anything in the last two rows of tiles when facing N/S because the bullet disappears before then, which seems unintuitive
if 40 is too high, I'd be willing to move it lower just so that it at least covers the range of what you'd see on your screen when using a t47 scope
## Changelog
:cl:
balance: sg62 bullets now have a max range of 40, equivalent to other marksman guns
/:cl:
