### PR TITLE
tier 4 hivemind

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -4,7 +4,7 @@
 	upgrade_name = ""
 	caste_desc = "The mind of the hive"
 	caste_type_path = /mob/living/carbon/xenomorph/hivemind
-	tier = XENO_TIER_ZERO
+	tier = XENO_TIER_FOUR
 	upgrade = XENO_UPGRADE_BASETYPE
 	wound_type = ""
 	// *** Melee Attacks *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -19,7 +19,7 @@
 	health = 1000
 	maxHealth = 1000
 	plasma_stored = 5
-	tier = XENO_TIER_ZERO
+	tier = XENO_TIER_FOUR
 	upgrade = XENO_UPGRADE_BASETYPE
 
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE


### PR DESCRIPTION

## About The Pull Request

Makes the hivemind tier 4

## Why It's Good For The Game
doesn't have any gameplay changes, just makes the hivemind tier 4 since it's a one of a kind caste. looks nicer to see hivemind up in the tier 4 part of hive status rather than down in tier 0 with larba

## Changelog
:cl:
add: hivemind is tier 4 now, no gameplay changes except hive status looking nicer
/:cl:
