### PR TITLE
Missing smartrifle asset

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_rewards.dm
+++ b/code/datums/gamemodes/campaign/campaign_rewards.dm
@@ -281,10 +281,17 @@
 	uses = 1
 	cost = 4
 	equipment_to_spawn = list(
-		/obj/item/weapon/gun/rifle/standard_smartmachinegun,
+		/obj/item/weapon/gun/rifle/standard_smartmachinegun/patrol,
 		/obj/item/storage/belt/marine/smartgun,
-		/obj/item/weapon/gun/minigun/smart_minigun,
+		/obj/item/weapon/gun/minigun/smart_minigun/motion_detector,
 		/obj/item/ammo_magazine/minigun_powerpack/smartgun,
+		/obj/item/weapon/gun/rifle/standard_smarttargetrifle/motion,
+		/obj/item/storage/belt/marine/target_rifle,
+		/obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary,
+		/obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten,
+		/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact,
+		/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact,
+		/obj/item/ammo_magazine/rifle/standard_spottingrifle/highimpact,
 	)
 
 /datum/campaign_reward/equipment/shotguns_tgmc

--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -888,18 +888,11 @@
 	name = "SG62 Smart Machinegunner"
 	desc = "Flexibility and precision. Equipped with an SG-62 smart target rifle and heavy armor upgraded with a 'Tyr' extra armor mdule. The integrated spotting rifle comes with a variety of flexible ammo types, which combined with high damage, penetration and IFF, makes for a dangerous support loadout."
 
-	belt = /obj/item/storage/belt/marine
+	belt = /obj/item/storage/belt/marine/target_rifle
 	suit_store = /obj/item/weapon/gun/rifle/standard_smarttargetrifle/motion
 
 /datum/outfit/quick/tgmc/smartgunner/target_rifle/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle, SLOT_IN_BELT)
-
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/standard_spottingrifle/tungsten, SLOT_IN_BACKPACK)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -554,6 +554,15 @@
 	new /obj/item/ammo_magazine/standard_smartmachinegun(src)
 	new /obj/item/ammo_magazine/standard_smartmachinegun(src)
 
+/obj/item/storage/belt/marine/target_rifle/Initialize(mapload)
+	. = ..()
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+	new /obj/item/ammo_magazine/rifle/standard_smarttargetrifle(src)
+
 /obj/item/storage/belt/marine/upp
 	name = "\improper Type 41 pattern load rig"
 	desc = "The Type 41 load rig is the standard-issue LBE of the USL pirates. The primary function of this belt is to provide easy access to mags for the Type 71 during operations. Despite being designed for the Type 71 weapon system, the pouches are modular enough to fit other types of ammo and equipment."


### PR DESCRIPTION

## About The Pull Request
spotting rifle was missing from the asset purchase.
Made the loadout use the same preloaded belt.
## Why It's Good For The Game
having ammo is good.
## Changelog
:cl:
fix: The smartgun asset in campaign now has targeting rifle ammo
/:cl:
