### PR TITLE
Russian Red is no longer commonly accessible, adds to Corpsman preps vendors

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -99,12 +99,14 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/effect/vendor_bundle/medic = list(CAT_ESS, "Essential Medic Set", 0, "white"),
 		/obj/item/storage/pill_bottle/meralyne = list(CAT_MEDSUP, "Meralyne pills", 16, "orange"),
 		/obj/item/storage/pill_bottle/dermaline = list(CAT_MEDSUP, "Dermaline pills", 16, "orange"),
+		/obj/item/storage/pill_bottle/russian_red = list(CAT_MEDSUP, "Russian Red pills", 16, "orange"),
 		/obj/item/storage/syringe_case/meralyne = list(CAT_MEDSUP, "syringe Case (120u Meralyne)", 16, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/meralyne = list(CAT_MEDSUP, "hypospray (60u Meralyne)", 8, "black"), //half the units of the mera case half the price
 		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/dermaline = list(CAT_MEDSUP, "hypospray (60u dermaline)", 8, "black"), //half the units of the derm case half the price
 		/obj/item/storage/syringe_case/meraderm = list(CAT_MEDSUP, "syringe Case (120u Meraderm)", 16, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced/meraderm = list(CAT_MEDSUP, "hypospray (60u Meraderm)", 8, "black"), //half the units of the meraderm case half the price
+		/obj/item/reagent_containers/hypospray/advanced/russian_red = list(CAT_MEDSUP, "hypospray (60u Russian Red)", 8, "black"),
 		/obj/item/storage/syringe_case/nanoblood = list(CAT_MEDSUP, "syringe Case (120u Nanoblood)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/nanoblood = list(CAT_MEDSUP, "hypospray (60u Nanoblood)", 3, "orange"), //bit more than half of the nanoblood case
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -501,6 +501,15 @@
 	)
 	description_overlay = "Na"
 
+/obj/item/reagent_containers/hypospray/advanced/russian_red
+	name = "russian red hypospray"
+	desc = "A hypospray loaded with Russian Red, a chemical that heals all damage rapidly at the cost of small amounts of clone loss."
+	amount_per_transfer_from_this = 5
+	list_reagents = list(
+		/datum/reagent/medicine/russian_red = 60,
+	)
+	description_overlay = "RR"
+
 /obj/item/reagent_containers/hypospray/advanced/peridaxonplus
 	name = "Peridaxon+ hypospray"
 	desc = "A hypospray loaded with Peridaxon Plus, a chemical that heals organs while causing a buildup of toxins. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -192,7 +192,6 @@
 	for(var/i in 1 to 5)
 		new /obj/item/clothing/mask/cigarette/antitox(src)
 
-	new /obj/item/clothing/mask/cigarette/emergency(src)
 	new /obj/item/tool/lighter(src)
 
 /obj/item/storage/fancy/chemrettes/update_icon_state()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -72,8 +72,8 @@
 	new /obj/item/healthanalyzer(src)
 	new /obj/item/stack/medical/heal_pack/gauze(src)
 	new /obj/item/stack/medical/heal_pack/ointment(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/bicaridine(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/kelotane(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tramadol(src)
 	new /obj/item/stack/medical/splint(src)
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -72,10 +72,10 @@
 	new /obj/item/healthanalyzer(src)
 	new /obj/item/stack/medical/heal_pack/gauze(src)
 	new /obj/item/stack/medical/heal_pack/ointment(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/bicaridine(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/kelotane(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tramadol(src)
 	new /obj/item/stack/medical/splint(src)
-	new /obj/item/storage/pill_bottle/packet/russian_red(src)
 
 
 /obj/item/storage/firstaid/toxin
@@ -133,7 +133,7 @@
 
 /obj/item/storage/firstaid/rad/fill_firstaid_kit()
 	new /obj/item/healthanalyzer(src)
-	new /obj/item/storage/pill_bottle/russian_red(src)
+	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -526,7 +526,7 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/dylovene (src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine (src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/russian_red (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine (src)
 
 /obj/item/storage/pouch/medical_injectors/medic/Initialize(mapload) //corpsman autoinjector pouch gets upgraded, but more general chems.
 	. = ..()

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -898,7 +898,6 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/imidazoline = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites = 20,
-			/obj/item/reagent_containers/hypospray/autoinjector/russian_red = 30,
 		),
 		"Heal Pack" = list(
 			/obj/item/stack/medical/heal_pack/gauze = -1,

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -174,7 +174,6 @@
 			/obj/item/storage/pill_bottle/imidazoline = 6,
 			/obj/item/storage/pill_bottle/quickclot = 6,
 			/obj/item/storage/pill_bottle/hypervene = 6,
-			/obj/item/storage/pill_bottle/russian_red = 6,
 		),
 		"Hypospray" = list (
 			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 10,
@@ -393,9 +392,6 @@
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 5,
 			/obj/item/healthanalyzer = 1,
 			/obj/item/stack/medical/splint = 1,
-		),
-		"EMERGENCY USE!" = list(
-			/obj/item/storage/pill_bottle/russian_red = 1,
 		),
 	)
 


### PR DESCRIPTION
## About The Pull Request
- Adds a Russian Red hypospray.
- Adds Russian Red pill bottles and hyposprays to corpsmen preps vendors, for 16 and 8 points each.
- Removes Russian Red from the following storage options, replacing them with other chemicals in certain cases:
  - Chemrette packs (in the form of Red Comrade / R.R. cigarettes).
  - Standard first aid kits. Replaced with another tricordrazine autoinjector.
  - Radiation aid kits. Replaced with another dylovene pill bottle.
  - Corpsman pouches. Replaced with another synaptizine autoinjector.
  - Common medical vendors.

Bear in mind Valhalla, ERTs, and HvH loadouts are excluded from this treatment.

## Why It's Good For The Game
This chemical is very powerful for what it does, and I already attempted to nerf this before in #14061. If the issue was that nerfing it would make it useless, then the next option in the list is making it a limited chemical.

## Changelog
:cl: Lewdcifer
add: Added Russian Red hyposprays.
add: Added Russian Red pill bottles and hyposprays to corpsmen preps vendors, for 16 and 8 points each.
balance: Russian Red is no longer commonly accessible, and has been replaced where appropriate.
/:cl: