### PR TITLE
Ravager endure vali slowdown protection

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -180,6 +180,10 @@
 	switch(loaded_reagent)
 		if(/datum/reagent/medicine/tramadol)
 			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
+			if(isxeno(target))
+				var/mob/living/carbon/xenomorph/xeno_target = target
+				if(xeno_target.endure)
+					return
 			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -182,9 +182,10 @@
 			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
 			if(isxeno(target))
 				var/mob/living/carbon/xenomorph/xeno_target = target
-				if(xeno_target.endure)
-					return
-			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
+				if(!xeno_target.endure)
+					target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
+			else
+				target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)
 			target.flamer_fire_act(10)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -180,12 +180,7 @@
 	switch(loaded_reagent)
 		if(/datum/reagent/medicine/tramadol)
 			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
-			if(isxeno(target))
-				var/mob/living/carbon/xenomorph/xeno_target = target
-				if(!xeno_target.endure)
-					target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
-			else
-				target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
+			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)
 			target.flamer_fire_act(10)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -389,6 +389,8 @@
 	. = ..()
 	if(!.)
 		return
+	if(HAS_TRAIT(owner, TRAIT_SLOWDOWNIMMUNE))
+		return
 	owner.add_movespeed_modifier(MOVESPEED_ID_HARVEST_TRAM_SLOWDOWN, TRUE, 0, NONE, TRUE, debuff_slowdown)
 
 /datum/status_effect/incapacitating/harvester_slowdown/on_remove()


### PR DESCRIPTION

## About The Pull Request

Protects Ravagers in Endure from getting slowed down by vali tramadol attack

## Why It's Good For The Game

Fixing an oversight/inconsistency between vali and bullets slowdown for ravager

## Changelog
:cl:
balance: Ravagers in Endure are no longer slowed down by vali tramadol attack
/:cl:
