### PR TITLE
Reduces the healing effectiveness of Russian Red

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -589,7 +589,7 @@
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/russian_red/on_mob_life(mob/living/L, metabolism)
-	L.heal_overall_damage(10*effect_str, 10*effect_str)
+	L.heal_overall_damage(5*effect_str, 5*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -589,7 +589,7 @@
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/russian_red/on_mob_life(mob/living/L, metabolism)
-	L.heal_overall_damage(5*effect_str, 5*effect_str)
+	L.heal_overall_damage(7*effect_str, 7*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
I am going to be very honest with you, I tire of writing the exact same thing in different words and dealing with balance in general so just refer to "Why it's good for the game" in PRs #14170 and #14061.

## Changelog
:cl: Lewdcifer
balance: Halves the healing effectiveness of Russian Red.
/:cl: