### PR TITLE
Fixes View Variables not opening via HrefToken

### DIFF
--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -604,12 +604,12 @@
 
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
-	if(usr.client != src || !src.holder || !holder.CheckAdminHref(href, href_list))
+		if(usr.client != src || !src.holder || !holder.CheckAdminHref(href, href_list))
 		return
 
 
-	if(href_list["Vars"])
-		debug_variables(locate(href_list["Vars"]))
+	if(href_list["vars"])
+		debug_variables(locate(href_list["vars"]))
 
 
 	else if(href_list["datumrefresh"])

--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -563,9 +563,9 @@
 	else if(istype(value, /datum))
 		var/datum/D = value
 		if("[D]" != "[D.type]") //if the thing as a name var, lets use it.
-			item = "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[VV_HTML_ENCODE(name)] [REF(value)]</a> = [D] [D.type]"
+			item = "<a href='?_src_=vars;[HrefToken()];vars=[REF(value)]'>[VV_HTML_ENCODE(name)] [REF(value)]</a> = [D] [D.type]"
 		else
-			item = "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[VV_HTML_ENCODE(name)] [REF(value)]</a> = [D.type]"
+			item = "<a href='?_src_=vars;[HrefToken()];vars=[REF(value)]'>[VV_HTML_ENCODE(name)] [REF(value)]</a> = [D.type]"
 
 	else if(islist(value))
 		var/list/L = value
@@ -585,9 +585,9 @@
 
 				items += debug_variable(key, val, level + 1, sanitize = sanitize)
 
-			item = "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[VV_HTML_ENCODE(name)] = /list ([length(L)])</a><ul>[items.Join()]</ul>"
+			item = "<a href='?_src_=vars;[HrefToken()];vars=[REF(value)]'>[VV_HTML_ENCODE(name)] = /list ([length(L)])</a><ul>[items.Join()]</ul>"
 		else
-			item = "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[VV_HTML_ENCODE(name)] = /list ([length(L)])</a>"
+			item = "<a href='?_src_=vars;[HrefToken()];vars=[REF(value)]'>[VV_HTML_ENCODE(name)] = /list ([length(L)])</a>"
 
 	else if(name in GLOB.bitfields)
 		var/list/flags = list()

--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -604,7 +604,7 @@
 
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
-		if(usr.client != src || !src.holder || !holder.CheckAdminHref(href, href_list))
+	if(usr.client != src || !src.holder || !holder.CheckAdminHref(href, href_list))
 		return
 
 

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -377,7 +377,7 @@ function draw_mc() {
 		var td2 = document.createElement("td");
 		if (part[2]) {
 			var a = document.createElement("a");
-			a.href = "?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
+			a.href = "?_src_=vars;admin_token=" + href_token + ";vars=" + part[2];
 			a.textContent = part[1];
 			td2.appendChild(a);
 		} else {


### PR DESCRIPTION
## About The Pull Request
### I admittedly didn't understand this section of code much so if a Maintainer can make sure I didn't fuck up somehow, it'd be greatly appreciated.
So in admin tools, we have certain "VV" buttons, found in debugging, player panels, etc. that used to let us View Variables on any atom. After TG statpanel got ported over with #13546, those "VV" buttons stopped working altogether. Some examples below:

Player Panel
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/b5f7c785-7271-4b9b-b251-8c3fafe78cce)
SQDL2 Queries
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/1a4441c7-ea65-42c6-b07f-7f100741984c)

Investigating a little, I decided to review the code changes in the statpanel, and after trying a few things (admittedly because I didn't wholly understand this section of code) I found that this small change made the View Variables menu come up again like before.

I didn't perceive any immediate bugs or runtimes, so I figured this was the solution I was looking for. I might be wrong, and I might've screwed something up. Maintainers please make sure I didn't break game thank you much love.

## Why It's Good For The Game
Bug fix good. Seriously, can I skip this section for bug fixes?

## Changelog
:cl: Lewdcifer
fix: Certain "VV" buttons that weren't working before are now fixed.
/:cl: