### PR TITLE
Table fixes.

### DIFF
--- a/code/game/objects/effects/spawners/random/misc_structure.dm
+++ b/code/game/objects/effects/spawners/random/misc_structure.dm
@@ -235,7 +235,7 @@
 	spawn_loot_chance = 95
 	loot = list(
 		/obj/item/frame/table = 15,
-		/obj/item/frame/table/nometal = 10,
+		/obj/item/frame/table/mainship/nometal = 10,
 		/obj/item/frame/table/reinforced = 10,
 		/obj/item/frame/table/wood = 5,
 		/obj/item/frame/table/fancywood = 5,

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -73,7 +73,6 @@
 */
 
 /obj/item/frame/table/mainship
-	name = "ship table parts"
 	table_type = /obj/structure/table/mainship
 
 /obj/item/frame/table/mainship/nometal

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -24,8 +24,9 @@
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
+	var/turf/table_turf = get_turf(src)
 	if(iswrench(I) && deconstruct_type)
-		new deconstruct_type(loc)
+		new deconstruct_type(table_turf)
 		qdel(src)
 
 	else if(istype(I, /obj/item/stack/rods))
@@ -34,7 +35,7 @@
 			to_chat(user, span_warning("You need at least four rods to reinforce [src]."))
 			return
 
-		new /obj/item/frame/table/reinforced(loc)
+		new /obj/item/frame/table/reinforced(table_turf)
 		to_chat(user, span_notice("You reinforce [src]."))
 		user.temporarilyRemoveItemFromInventory(src)
 		qdel(src)
@@ -46,8 +47,8 @@
 			to_chat(user, span_warning("You need at least two wood sheets to swap the metal parts of [src]."))
 			return
 
-		new /obj/item/frame/table/wood(loc)
-		new /obj/item/stack/sheet/metal(loc)
+		new /obj/item/frame/table/wood(table_turf)
+		new /obj/item/stack/sheet/metal(table_turf)
 		to_chat(user, span_notice("You replace the metal parts of [src]."))
 		user.temporarilyRemoveItemFromInventory(src)
 		qdel(src)
@@ -68,6 +69,18 @@
 	deconstruct_type = null
 
 /*
+* Mainship Table Parts
+*/
+
+/obj/item/frame/table/mainship
+	name = "ship table parts"
+	table_type = /obj/structure/table/mainship
+
+/obj/item/frame/table/mainship/nometal
+	deconstruct_type = null
+	table_type = /obj/structure/table/mainship/nometal
+
+/*
 * Reinforced Table Parts
 */
 
@@ -77,7 +90,6 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "reinf_tableparts"
 	table_type = /obj/structure/table/reinforced
-
 
 /*
 * Wooden Table Parts

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -29,10 +29,6 @@
 	smoothing_groups = list(SMOOTH_GROUP_TABLES_GENERAL)
 	canSmoothWith = list(SMOOTH_GROUP_TABLES_GENERAL)
 
-/obj/structure/table/mainship/nometal
-	parts = /obj/item/frame/table/nometal
-	dropmetal = FALSE
-
 /obj/structure/table/deconstruct(disassembled)
 	if(disassembled)
 		new parts(loc)
@@ -491,7 +487,11 @@
 	icon_state = "mainship_table-0"
 	base_icon_state = "mainship_table"
 	table_prefix = "ship"
+	parts = /obj/item/frame/table/mainship
 
+/obj/structure/table/mainship/nometal
+	parts = /obj/item/frame/table/mainship/nometal
+	dropmetal = FALSE
 
 /*
 * Racks


### PR DESCRIPTION

## About The Pull Request
Fixed tables teleporting to nowhere upon using wood/rods on them.
Also ship tables now give you metal, otherwise why would there be nometal subtype.
And also fixed transforming ship tables upon wrenching, installing and wrenching them again to gain metal, as you should.
## Why It's Good For The Game
Working dead feature.
## Changelog
:cl:
fix: You can now gain metal from ship tables without transforming them. They also won't transform upon construction now.
fix: Table frames no longer will teleport to nowhere upon using wood/rods on them.
/:cl:
