### PR TITLE
Reduces Puppeteer's max puppets to 3

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -27,7 +27,7 @@
 	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 20, FIRE = 20, ACID = 20)
 	minimap_icon = "puppeteer"
 	flay_plasma_gain = 100
-	max_puppets = 5
+	max_puppets = 3
 	aura_strength = 2.8
 
 	actions = list(
@@ -57,7 +57,7 @@
 	plasma_max = 750
 	max_health = 385
 	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 20, FIRE = 20, ACID = 20)
-	max_puppets = 5
+	max_puppets = 3
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION

## About The Pull Request
Read title.
## Why It's Good For The Game
Puppeteer does uh, a _bit_ too much damage and is quite hard to kill due to how many puppet they can have blocking them. And in the wonderful words of Bowl: 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/df17856c-59ec-4c56-b34c-d4eb6e0f41e5)
## Changelog
:cl:
balance: Puppeteer's max puppets reduced to 3
/:cl:
