### PR TITLE
maptable fixes

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -6266,7 +6266,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "ftG" = (
-/obj/machinery/cic_maptable_big{
+/obj/machinery/cic_maptable/drawable/big{
 	pixel_x = -19
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{

--- a/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
+++ b/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
@@ -1438,7 +1438,7 @@
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som/barracks)
 "sL" = (
-/obj/machinery/cic_maptable_big/som{
+/obj/machinery/cic_maptable/drawable/big/som{
 	pixel_x = -3
 	},
 /turf/open/floor/plating/ground/concrete,
@@ -3802,7 +3802,7 @@
 /turf/open/floor/mainship_hull,
 /area/mainship/patrol_base/som/hanger)
 "Ug" = (
-/obj/machinery/cic_maptable_big/som{
+/obj/machinery/cic_maptable/drawable/big/som{
 	pixel_x = -3
 	},
 /turf/open/floor/mainship/office,

--- a/_maps/map_files/Iteron/Iteron.dmm
+++ b/_maps/map_files/Iteron/Iteron.dmm
@@ -1145,7 +1145,7 @@
 	},
 /area/mainship/patrol_base)
 "qv" = (
-/obj/machinery/cic_maptable_big,
+/obj/machinery/cic_maptable/drawable/big,
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base)
 "qy" = (
@@ -3024,7 +3024,7 @@
 	},
 /area/mainship/patrol_base/command)
 "Pp" = (
-/obj/machinery/cic_maptable_big{
+/obj/machinery/cic_maptable/drawable/big{
 	pixel_x = -3
 	},
 /turf/open/floor/mainship/mono,

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -16987,7 +16987,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/tankerbunks)
 "vjs" = (
-/obj/machinery/cic_maptable_big,
+/obj/machinery/cic_maptable/drawable/big,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "vjC" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -4018,7 +4018,7 @@
 	},
 /area/sulaco/bridge)
 "avb" = (
-/obj/machinery/cic_maptable_big,
+/obj/machinery/cic_maptable/drawable/big,
 /turf/open/floor/mainship/terragov{
 	dir = 8
 	},

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -17509,7 +17509,7 @@
 /turf/open/floor/plating,
 /area/mainship/medical/upper_medical)
 "syG" = (
-/obj/machinery/cic_maptable_big,
+/obj/machinery/cic_maptable/drawable/big,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "syT" = (

--- a/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
+++ b/_maps/map_files/combat_patrol_base/combat_patrol_base.dmm
@@ -818,7 +818,7 @@
 	},
 /area/mainship/patrol_base/som)
 "mC" = (
-/obj/machinery/cic_maptable_big{
+/obj/machinery/cic_maptable/drawable/big{
 	pixel_x = -3
 	},
 /turf/open/floor/mainship/office,
@@ -2976,7 +2976,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base/som)
 "Ri" = (
-/obj/machinery/cic_maptable_big,
+/obj/machinery/cic_maptable/drawable/big,
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base)
 "Rr" = (

--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -8,7 +8,7 @@
 	density = TRUE
 	idle_power_usage = 2
 	///flags that we want to be shown when you interact with this table
-	var/allowed_flags = MINIMAP_FLAG_MARINE
+	var/minimap_flag = MINIMAP_FLAG_MARINE
 	///by default Zlevel 2, groundside is targetted
 	var/targetted_zlevel = 2
 	///minimap obj ref that we will display to users
@@ -31,7 +31,7 @@
 	if(interact_checks())
 		return
 	if(!map)
-		map = SSminimaps.fetch_minimap_object(targetted_zlevel, allowed_flags)
+		map = SSminimaps.fetch_minimap_object(targetted_zlevel, minimap_flag)
 	user.client.screen += map
 	interactees += user
 	if(isobserver(user))
@@ -73,10 +73,10 @@
 	icon_state = "droppodtable"
 
 /obj/machinery/cic_maptable/som_maptable
-	allowed_flags = MINIMAP_FLAG_MARINE_SOM
+	minimap_flag = MINIMAP_FLAG_MARINE_SOM
 
 /obj/machinery/cic_maptable/no_flags
-	allowed_flags = NONE
+	minimap_flag = NONE
 
 /obj/machinery/cic_maptable/drawable
 	desc = "A table that displays a map of the current target location that also allows drawing onto it"
@@ -100,7 +100,7 @@
 
 	var/list/atom/movable/screen/actions = list()
 	for(var/path in drawing_tools)
-		actions += new path(null, targetted_zlevel, allowed_flags)
+		actions += new path(null, targetted_zlevel, minimap_flag)
 	drawing_tools = actions
 
 /obj/machinery/cic_maptable/drawable/Destroy()

--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!user.client)
+	if(interact_checks())
 		return
 	if(!map)
 		map = SSminimaps.fetch_minimap_object(targetted_zlevel, allowed_flags)
@@ -37,6 +37,10 @@
 	if(isobserver(user))
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
+///Returns true if something prevents the user from interacting with this. used mainly with the drawtable
+/obj/machinery/cic_maptable/proc/interact_checks(mob/user)
+	if(!user.client)
+		return TRUE
 
 //Bugfix to handle cases for ghosts/observers that dont automatically close uis on move.
 /obj/machinery/cic_maptable/proc/on_move(mob/dead/observer/source, oldloc)
@@ -61,7 +65,7 @@
 /obj/machinery/cic_maptable/on_unset_interaction(mob/user)
 	. = ..()
 	interactees -= user
-	user.client.screen -= map
+	user?.client?.screen -= map
 
 /obj/machinery/cic_maptable/droppod_maptable
 	name = "Athena tactical map console"
@@ -74,20 +78,8 @@
 /obj/machinery/cic_maptable/no_flags
 	allowed_flags = NONE
 
-/obj/machinery/cic_maptable_big
-	name = "map table"
+/obj/machinery/cic_maptable/drawable
 	desc = "A table that displays a map of the current target location that also allows drawing onto it"
-	interaction_flags = INTERACT_MACHINE_DEFAULT
-	use_power = IDLE_POWER_USE
-	density = TRUE
-	idle_power_usage = 2
-	icon = 'icons/Marine/mainship_props96.dmi'
-	icon_state = "maptable"
-	layer = ABOVE_OBJ_LAYER
-	pixel_x = -16
-	pixel_y = -14
-	coverage = 75
-	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE
 	/// List of references to the tools we will be using to shape what the map looks like
 	var/list/atom/movable/screen/drawing_tools = list(
 		/atom/movable/screen/minimap_tool/draw_tool/red,
@@ -98,18 +90,9 @@
 		/atom/movable/screen/minimap_tool/label,
 		/atom/movable/screen/minimap_tool/clear,
 	)
-	/// the Zlevel that this table views
-	var/targetted_zlevel = 2
-	/// The minimap flag we will be allowing to edit
-	var/minimap_flag = MINIMAP_FLAG_MARINE
-	///minimap obj ref that we will display to users
-	var/atom/movable/screen/minimap/map
-	///List of currently interacting mobs
-	var/list/mob/interactees = list()
 
-/obj/machinery/cic_maptable_big/Initialize(mapload)
+/obj/machinery/cic_maptable/drawable/Initialize(mapload)
 	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_LOADED, PROC_REF(change_targeted_z))
 	var/static/list/connections = list(
 		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
 	)
@@ -117,58 +100,59 @@
 
 	var/list/atom/movable/screen/actions = list()
 	for(var/path in drawing_tools)
-		actions += new path(null, targetted_zlevel, minimap_flag)
+		actions += new path(null, targetted_zlevel, allowed_flags)
 	drawing_tools = actions
 
-/obj/machinery/cic_maptable_big/Destroy()
+/obj/machinery/cic_maptable/drawable/Destroy()
 	. = ..()
 	QDEL_LIST(drawing_tools)
 
-/obj/machinery/cic_maptable_big/examine(mob/user)
+/obj/machinery/cic_maptable/drawable/examine(mob/user)
 	. = ..()
 	. += span_warning("Note that abuse may result in a command role ban.")
 
-/obj/machinery/cic_maptable_big/interact(mob/user)
+/obj/machinery/cic_maptable/drawable/interact_checks(mob/user)
 	. = ..()
 	if(.)
 		return
-	if(!user.client)
-		return
 	if(user.skills.getRating(SKILL_LEADERSHIP) < SKILL_LEAD_EXPERT)
 		user.balloon_alert(user, "Can't use that!")
-		return
+		return TRUE
 	if(is_banned_from(user.client.ckey, GLOB.roles_allowed_minimap_draw))
 		to_chat(user, span_boldwarning("You have been banned from a command role. You may not use [src] until the ban has been lifted."))
-		return
-	if(!map)
-		map = SSminimaps.fetch_minimap_object(targetted_zlevel, minimap_flag)
-	user.client.screen += map
-	user.client.screen += drawing_tools
-	interactees += user
+		return TRUE
 
-///Handles closing the map, including removing all on-screen indicators and similar
-/obj/machinery/cic_maptable_big/on_unset_interaction(mob/user)
+/obj/machinery/cic_maptable/drawable/interact(mob/user)
 	. = ..()
-	interactees -= user
-	user.client.screen -= map
-	user.client.screen -= drawing_tools
-	user.client.mouse_pointer_icon = null
+	if(.)
+		return
+	user.client.screen += drawing_tools
+
+/obj/machinery/cic_maptable/drawable/on_unset_interaction(mob/user)
+	. = ..()
+	user?.client?.screen -= drawing_tools
+	user?.client?.mouse_pointer_icon = null
 	for(var/atom/movable/screen/minimap_tool/tool AS in drawing_tools)
 		tool.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP))
 
 ///Updates the z-level this maptable views
-/obj/machinery/cic_maptable_big/proc/change_targeted_z(datum/source, new_z)
-	SIGNAL_HANDLER
-	if(!isnum(new_z))
-		return
-	for(var/mob/user AS in interactees)
-		on_unset_interaction(user)
-	map = null
-	targetted_zlevel = new_z
+/obj/machinery/cic_maptable/drawable/change_targeted_z(datum/source, new_z)
+	. = ..()
 
 	for(var/atom/movable/screen/minimap_tool/tool AS in drawing_tools)
 		tool.zlevel = new_z
 		tool.set_zlevel(new_z, tool.minimap_flag)
 
-/obj/machinery/cic_maptable_big/som
+/////////////////////////////////////
+
+/obj/machinery/cic_maptable/drawable/big
+	icon = 'icons/Marine/mainship_props96.dmi'
+	icon_state = "maptable"
+	layer = ABOVE_OBJ_LAYER
+	pixel_x = -16
+	pixel_y = -14
+	coverage = 75
+	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE
+
+/obj/machinery/cic_maptable/drawable/big/som
 	minimap_flag = MINIMAP_FLAG_MARINE_SOM


### PR DESCRIPTION

## About The Pull Request
This has bugged me for a while.

The big map table is no longer an entirely separate object with 95% copy pasted code, and is now a child type.
You can also have small drawable map tables now, if you want.

Also fixed a runtime with mobs disconnecting with a map open
## Why It's Good For The Game
Better code
## Changelog
:cl:
code: Updated some maptable code
/:cl:
