### PR TITLE
Nerfs the scout rifle's sundering stats

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -753,7 +753,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "hivelo_impact"
 	damage = 30
 	penetration = 10
-	sundering = 6.5
+	sundering = 7
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -736,7 +736,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accurate_range = 15
 	damage = 40
 	penetration = 20
-	sundering = 10
+	sundering = 5
 	bullet_color = COLOR_SOFT_RED
 
 /datum/ammo/bullet/rifle/tx8/incendiary
@@ -753,7 +753,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "hivelo_impact"
 	damage = 30
 	penetration = 10
-	sundering = 12.5
+	sundering = 6.5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)


### PR DESCRIPTION
## About The Pull Request
Normal magazine sundering reduced from 10 > 5.
Impact magazine sundering reduced from 12.5 > 6.5

## Why It's Good For The Game
The scout rifle deletes armor really, _really_ quickly. This should be a tad bit more fair.

## Changelog
:cl: Lewdcifer
balance: Scout rifle: normal mag sunder reduced from 10 > 5, impact mag sunder reduced from 12.5 > 6.5.
/:cl: