### PR TITLE
throw bounce change

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -470,12 +470,35 @@
 		O.hitby(src, speed)
 
 	else if(isturf(hit_atom))
+		var/old_throw_source = throw_source
 		stop_throw()
 		var/turf/T = hit_atom
 		if(T.density)
 			if(bounce)
 				spawn(2)
-					step(src, turn(dir, 180))
+					//step(src, turn(dir, 180))
+					//
+					var/dir_to_proj = get_dir(T, old_throw_source)
+					if(ISDIAGONALDIR(dir_to_proj))
+						var/list/cardinals = list(turn(dir_to_proj, 45), turn(dir_to_proj, -45))
+						for(var/direction in cardinals)
+							var/turf/turf_to_check = get_step(T, direction)
+							if(turf_to_check.density)
+								cardinals -= direction
+						dir_to_proj = pick(cardinals)
+
+					var/perpendicular_angle = Get_Angle(T, get_step(T, dir_to_proj))
+					var/new_angle = (perpendicular_angle + (perpendicular_angle - Get_Angle(src, old_throw_source) - 180) + rand(-10, 10))
+
+					if(new_angle < -360)
+						new_angle += 720 //north is 0 instead of 360
+					else if(new_angle < 0)
+						new_angle += 360
+					else if(new_angle > 360)
+						new_angle -= 360
+
+					step(src, angle_to_dir(new_angle))
+
 			if(isliving(src))
 				var/mob/living/M = src
 				M.turf_collision(T, speed)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1194,6 +1194,6 @@
 		return SSmapping.gravity_by_z_level["[src_turf.z]"]
 	return 1 //if both fail we're in nullspace, just return a 1 as a fallback
 
-//This is called when the mob is thrown into a dense turf
+//This is called when the AM is thrown into a dense turf
 /atom/movable/proc/turf_collision(turf/T, speed)
 	return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -463,47 +463,40 @@
 		var/mob/living/M = hit_atom
 		M.hitby(src, speed)
 
-	else if(isobj(hit_atom)) // Thrown object hits another object and moves it
-		var/obj/O = hit_atom
-		if(!O.anchored && (O.move_resist < MOVE_FORCE_STRONG))
-			step(O, dir)
-		O.hitby(src, speed)
-
-	else if(isturf(hit_atom))
+	else
 		var/old_throw_source = throw_source
-		stop_throw()
-		var/turf/T = hit_atom
-		if(T.density)
-			if(bounce)
-				spawn(2)
-					//step(src, turn(dir, 180))
-					//
-					var/dir_to_proj = get_dir(T, old_throw_source)
-					if(ISDIAGONALDIR(dir_to_proj))
-						var/list/cardinals = list(turn(dir_to_proj, 45), turn(dir_to_proj, -45))
-						for(var/direction in cardinals)
-							var/turf/turf_to_check = get_step(T, direction)
-							if(turf_to_check.density)
-								cardinals -= direction
-						dir_to_proj = pick(cardinals)
-
-					var/perpendicular_angle = Get_Angle(T, get_step(T, dir_to_proj))
-					var/new_angle = (perpendicular_angle + (perpendicular_angle - Get_Angle(src, old_throw_source) - 180) + rand(-10, 10))
-
-					if(new_angle < -360)
-						new_angle += 720 //north is 0 instead of 360
-					else if(new_angle < 0)
-						new_angle += 360
-					else if(new_angle > 360)
-						new_angle -= 360
-
-					step(src, angle_to_dir(new_angle))
-
-			if(isliving(src))
-				var/mob/living/M = src
-				M.turf_collision(T, speed)
+		hit_atom.hitby(src, speed)
+		if(bounce && hit_atom.density)
+			INVOKE_NEXT_TICK(src, PROC_REF(throw_bounce), hit_atom, old_throw_source)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_IMPACT, hit_atom)
+
+///Bounces the AM off hit_atom
+/atom/movable/proc/throw_bounce(atom/hit_atom, turf/old_throw_source)
+	if(QDELETED(src))
+		return
+	if(!isturf(loc))
+		return
+	var/dir_to_proj = get_dir(hit_atom, old_throw_source)
+	if(ISDIAGONALDIR(dir_to_proj))
+		var/list/cardinals = list(turn(dir_to_proj, 45), turn(dir_to_proj, -45))
+		for(var/direction in cardinals)
+			var/turf/turf_to_check = get_step(hit_atom, direction)
+			if(turf_to_check.density)
+				cardinals -= direction
+		dir_to_proj = pick(cardinals)
+
+	var/perpendicular_angle = Get_Angle(hit_atom, get_step(hit_atom, dir_to_proj))
+	var/new_angle = (perpendicular_angle + (perpendicular_angle - Get_Angle(old_throw_source, src) - 180) + rand(-10, 10))
+
+	if(new_angle < -360)
+		new_angle += 720 //north is 0 instead of 360
+	else if(new_angle < 0)
+		new_angle += 360
+	else if(new_angle > 360)
+		new_angle -= 360
+
+	step(src, angle_to_dir(new_angle))
 
 /atom/movable/proc/throw_at(atom/target, range, speed, thrower, spin, flying = FALSE, targetted_throw = TRUE)
 	set waitfor = FALSE
@@ -1200,3 +1193,7 @@
 	if(src_turf?.z)
 		return SSmapping.gravity_by_z_level["[src_turf.z]"]
 	return 1 //if both fail we're in nullspace, just return a 1 as a fallback
+
+//This is called when the mob is thrown into a dense turf
+/atom/movable/proc/turf_collision(turf/T, speed)
+	return

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -89,6 +89,8 @@
 
 /obj/hitby(atom/movable/AM, speed = 5)
 	. = ..()
+	if(!anchored && (move_resist < MOVE_FORCE_STRONG))
+		step(src, AM.dir)
 	visible_message(span_warning("[src] was hit by [AM]."), visible_message_flags = COMBAT_MESSAGE)
 	var/tforce = 0
 	if(ismob(AM))

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -16,6 +16,10 @@
 	. = ..()
 	add_debris_element()
 
+/turf/closed/hitby(atom/movable/AM, speed = 5)
+	AM.stop_throw()
+	AM.turf_collision(src, speed)
+
 /turf/closed/mineral
 	name = "rock"
 	icon = 'icons/turf/walls.dmi'

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -40,9 +40,8 @@
 		visible_message(span_warning(" [src] staggers under the impact!"),span_warning(" You stagger under the impact!"), null, 5)
 		src.throw_at(get_edge_target_turf(src, get_dir(AM.throw_source, src)), 1, speed * 0.5)
 
-//This is called when the mob is thrown into a dense turf
-/mob/living/proc/turf_collision(turf/T, speed)
-	src.take_limb_damage(speed*5)
+/mob/living/turf_collision(turf/T, speed)
+	take_limb_damage(speed*5)
 
 /mob/living/proc/near_wall(direction,distance=1)
 	var/turf/T = get_step(get_turf(src),direction)


### PR DESCRIPTION

## About The Pull Request
Another throw pr, time for 6 months of bugs.

Throwing things into dense turfs or objects now makes them bounce off in a semi realistic way.
Currently, the thrown thing bounces DIRECTLY back at the thrower, which although comical for grenade FF, makes absolutely no sense as you watch things bounce in bizarre and impossible ways.

Or if you prefer quality pictures, we get blue instead of red.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/6e6d2482-147a-4518-955d-34f090f43155)

ALso some mild reorg of some related code. Everything about throwing is fucking god awful though and need more of a rework but that's for another day.

Additionally fixes some exploits regarding grabbing items before they bounce.
I swear there was a bug report or 2 to close, but I can't find them.
## Why It's Good For The Game
More realistic/less guh throw bounce mechanics
## Changelog
:cl:
fix: Objects will no longer bounce at impossible angles when hitting solid turfs or objects
/:cl:
