### PR TITLE
Req ARSR and drop console aren't deconstructable anymore

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -38,6 +38,9 @@
 	supply_pad = null
 	return ..()
 
+/obj/machinery/computer/supplydrop_console/screwdriver_act(mob/living/user, obj/item/I)
+	return TRUE //no deconstructing this please
+
 /obj/machinery/computer/supplydrop_console/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -262,6 +262,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		SU.faction = faction
 	return SU.interact(user)
 
+/obj/machinery/computer/supplycomp/screwdriver_act(mob/living/user, obj/item/I)
+	return TRUE //no deconstructing this please
+
 /datum/supply_ui
 	interaction_flags = INTERACT_MACHINE_TGUI
 	var/atom/source_object


### PR DESCRIPTION

## About The Pull Request

Don't move these guh!
## Why It's Good For The Game

These really shouldn't be moved since it screws over req.
## Changelog
:cl:
del: Req ARSR and drop console aren't deconstructable anymore
/:cl:
