### PR TITLE
Robots convert damage to clone under a threshold

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -465,7 +465,7 @@
 	H.voice_filter = initial(H.voice_filter)
 	H.health_threshold_crit = -50
 
-#define CLONELOSS_THRESHOLD 0
+#define CLONELOSS_THRESHOLD -50
 #define CLONELOSS_PER_CYCLE 1
 #define MAX_CLONELOSS 51
 /datum/species/robot/handle_unique_behavior(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -479,6 +479,11 @@
 		H.clear_fullscreen("robothalf")
 		H.clear_fullscreen("robotlow")
 
+	if(H.health > -25) //Staggerslowed if below crit threshold.
+		return
+	H.Stagger(2 SECONDS)
+	H.adjust_slowdown(1)
+
 	if(H.health <= CLONELOSS_THRESHOLD && H.life_tick % 15 == 0)
 		var/loss_amt = clamp(MAX_CLONELOSS - (H.cloneloss + CLONELOSS_PER_CYCLE), 0, CLONELOSS_PER_CYCLE)
 		if(H.getBruteLoss())
@@ -494,11 +499,6 @@
 
 	if(prob(20))
 		to_chat(H, span_danger("[pick("You feel like you're falling apart", "Error text flashes through your processor", "You hear a strange sound, like scraping metal")]."))
-
-	if(H.health > -25) //Staggerslowed if below crit threshold.
-		return
-	H.Stagger(2 SECONDS)
-	H.adjust_slowdown(1)
 
 #undef CLONELOSS_THRESHOLD
 #undef CLONELOSS_PER_CYCLE


### PR DESCRIPTION
## About The Pull Request
Combat robots, while under `-50` health, will convert BRUTE and BURN damage to clone damage at a rate of  `1` every `30` seconds, to a maximum of `50` clone damage. They will receive scary messages to let them know when this is happening.
## Why It's Good For The Game
Currently, combat robots can take plenty of punishment, heal back, and not have to limp back to medbay unless they die or take high burst damage. Robots will be encouraged to stay healthy and not overclock more than necessary (or at all... even more than before), and xenos will feel more like they're doing lasting damage against the metal blitzkrieg.
## Changelog
:cl: Tanker
balance: Combat robots now slowly convert damage to clone damage while under a certain health threshold.
/:cl:
