### PR TITLE
Autobalance Fix

### DIFF
--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -186,7 +186,7 @@ SUBSYSTEM_DEF(monitor)
 	if(current_state >= STATE_BALANCED || ((xeno_job.total_positions - xeno_job.current_positions) <= (length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) * TOO_MUCH_BURROWED_PROPORTION)) || length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]) == 0)
 		return 1
 	var/datum/hive_status/normal/HN = GLOB.hive_datums[XENO_HIVE_NORMAL]
-	var/xeno_alive_plus_burrowed = length(HN.get_total_xeno_number()) + (xeno_job.total_positions - xeno_job.current_positions)
+	var/xeno_alive_plus_burrowed = HN.total_xenos_for_evolving()
 	var/buff_needed_estimation = min( MAXIMUM_XENO_BUFF_POSSIBLE , 1 + (xeno_job.total_positions-xeno_job.current_positions) / (xeno_alive_plus_burrowed ? xeno_alive_plus_burrowed : 1))
 	// No need to ask admins every time
 	if(GLOB.xeno_stat_multiplicator_buff != 1)


### PR DESCRIPTION

## About The Pull Request
So for some reason Bravemole used a length on a number making it always return 0, meaning the calculation for how much of a stat buff xenos would get would always be 150%.
In normal people terms this means that the autobalance stat buff will care about how many burrowed there actually are
## Why It's Good For The Game
Bug left unfixed for 2 years bad
## Changelog
:cl:
fix: Autobalance will now care about the ratio of alive xenos to burrowed xenos when giving out stat buffs
/:cl:
