### PR TITLE
Fixes puppeteer evolution threshold

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -17,7 +17,7 @@
 	plasma_icon_state = "fury"
 	max_health = 365
 	upgrade_threshold = TIER_TWO_THRESHOLD
-	evolution_threshold = 80
+	evolution_threshold = 225
 
 	evolves_to = list(/mob/living/carbon/xenomorph/widow, /mob/living/carbon/xenomorph/warlock)
 	deevolves_to = list(/mob/living/carbon/xenomorph/defender)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. Sets to the normal t2 threshold.
## Why It's Good For The Game
Bug bad.
## Changelog
:cl:
fix: Puppeteer now has the proper evolution threshold
/:cl:
