### PR TITLE
Allows SG-85 to Take Miniscope

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -454,7 +454,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	wield_delay = 1.5 SECONDS
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
 	gun_skill_category = SKILL_SMARTGUN
-	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/motiondetector)
+	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/motiondetector, /obj/item/attachable/scope/mini)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 19, "rail_y" = 29, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12) //Only has rail attachments so only the rail variables are properly aligned
 	aim_slowdown = 1.5
 	actions_types = list()


### PR DESCRIPTION

## About The Pull Request
Now the SG-85 can have a miniscope on the rail attachment slot instead of flashlight, tac sensor, or mag harness. 

## Why It's Good For The Game
The SG-85 is supposed to be more support orientated than the SG-29. Higher wielded slowdown, windup to fire, etc. makes it less ideal for frontlining. The strengths of SG-85 are the higher AP (25 vs 15) and lower falloff (0.1 vs 1, but really more like 0.2 vs 1 since 2 SG-85 bullets = 1 SG-29 bullet) are good, but having lower falloff doesn't matter much when you're stuck with normal vision. This should let SG-85 users specialize more into the support role since they can help from a greater distance where they are less likely to get stunned and their low falloff really shines. Keep in mind that running this will take up back slot (powerpack), belt (belt harness), suit storage (gun), and armor storage module (general with two boxes). Also looking through the miniscope gives another 0.3 slowdown, so SG-85 users would be even slower when using the miniscope. 

## Changelog
:cl:
balance: SG-85 can now use the mini rail scope attachment
/:cl:
