### PR TITLE
Makes Tramadol in a harvester no longer have extra damage.

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -179,7 +179,7 @@
 
 	switch(loaded_reagent)
 		if(/datum/reagent/medicine/tramadol)
-			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
+			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected, MELEE)
 			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -179,7 +179,6 @@
 
 	switch(loaded_reagent)
 		if(/datum/reagent/medicine/tramadol)
-			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected, MELEE)
 			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)


### PR DESCRIPTION
## About The Pull Request
Removes the damage bonus of Tramadol.
## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66163761/3eefc9b9-7964-42c0-a5ec-e8142943b025)

## Changelog
:cl:
balance: Tramadol in a harvester weapon no longer has extra damage.
/:cl:
