### PR TITLE
A harvester weapon with Kelotane applies some sunder.

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -183,6 +183,7 @@
 			target.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)
+			target.adjust_sunder(7.5) //Same amount as a shotgun slug
 			target.flamer_fire_act(10)
 			target.apply_damage(max(0, 20 - 20*target.hard_armor.getRating("fire")), BURN, user.zone_selected, FIRE)
 			var/list/cone_turfs = generate_cone(target, 1, 0, 181, Get_Angle(user, target.loc))


### PR DESCRIPTION

## About The Pull Request
A harvester weapon with Kelotane applies some sunder, I plugged in the value of a slug shotgun, but if thats too high/low I can adjust.
## Why It's Good For The Game
Kelotane is currently really bad, and I think this differentiates it from Tramadol.
You would use the Tram for the slowdown, and Kelotane for the armor damage.
I think this would give both chems a fair niche.
## Changelog
:cl:
balance: Harvester weapon with Kelotane causes sundering
/:cl:
