### PR TITLE
Fixes an incredibly minor issue with the clone vats console

### DIFF
--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -69,7 +69,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 
 	if(!linked_machine)
 		// Try to find the machine nearby
-		linked_machine = locate() in range(1)
+		linked_machine = locate() in orange(1, src)
 		if(!linked_machine)
 			visible_message("[icon2html(src, viewers(src))] <span><b>[src]</b> beeps in error, 'Connection not available'.</span>")
 			return TRUE


### PR DESCRIPTION

## About The Pull Request
Basically, when you clicked the console for the first time to check for a cloning pod to link to, it would check around the user (or well, worse, usr) instead of itself, which'd require you to stand next to both the console and the pod for it to work correctly.
This PR makes it check around itself instead (with the bonus of using orange instead of range)
## Why It's Good For The Game
Disproportionately annoying minor bug.
Fix man good.
## Changelog
:cl:
fix: The cloning vat console now actually checks around itself for clone vats to link to.
/:cl:
