### PR TITLE
freelancer fix

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/campaign_asset_jobs.dm
+++ b/code/datums/gamemodes/campaign/rewards/campaign_asset_jobs.dm
@@ -445,17 +445,17 @@ What you lack in equipment and military training you make up in bravery and conv
 	job_cost = 0
 	outfits = list(
 		/datum/outfit/job/freelancer/standard/campaign,
-		/datum/outfit/job/freelancer/standard/one,
-		/datum/outfit/job/freelancer/standard/two,
+		/datum/outfit/job/freelancer/standard/one/campaign,
+		/datum/outfit/job/freelancer/standard/two/campaign,
 	)
 
 /datum/outfit/job/freelancer/standard/campaign
 	ears = /obj/item/radio/headset/mainship
 
-/datum/outfit/job/freelancer/standard/one
+/datum/outfit/job/freelancer/standard/one/campaign
 	ears = /obj/item/radio/headset/mainship
 
-/datum/outfit/job/freelancer/standard/two
+/datum/outfit/job/freelancer/standard/two/campaign
 	ears = /obj/item/radio/headset/mainship
 
 


### PR DESCRIPTION

## About The Pull Request
I had a couple of campaign loadouts with the wrong typepath, so some freelancer standards in erts were just having their headsets exploding on spawn. aylmao.
## Why It's Good For The Game
Bug fix.
## Changelog
:cl:
fix: fixed a couple of freelancer ert loadouts having the wrong headset
/:cl:
