### PR TITLE
Adds a rouny plushie to Pillar of Spring

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4794,6 +4794,7 @@
 	pixel_x = 5;
 	pixel_y = 10
 	},
+/obj/item/toy/plush/rouny,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/command/cic)
 "gaD" = (


### PR DESCRIPTION
## About The Pull Request
Adds a rouny plushie to Pillar of Spring's CIC storage.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/c01f5809-8576-49e1-a09f-148b42c3bce5)


## Why It's Good For The Game
Rouny plushies are: cute, adorable, based, and should have never been removed from PoS in the first place.
I bring it back, to please the elder gods.

Jokes aside, there's not really much proper reason beyond incredibly minor fun.

## Changelog
:cl: Lewdcifer
add: (Re-)added a rouny plushie to Pillar of Spring. It is located in CIC storage.
/:cl:
