### PR TITLE
Adds a rouny plushie to Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -17351,6 +17351,7 @@
 	id = "tcomwind";
 	name = "Telecomms Window Control"
 	},
+/obj/item/toy/plush/rouny,
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
 "lvm" = (


### PR DESCRIPTION
## About The Pull Request
Adds a rouny plushie to Sulaco's telecomms room.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/f7263d90-8210-4141-a681-5e86f3205983)


## Why It's Good For The Game
Sulaco never had a rouny plushie, so here it is. Just incredibly minor fun for peeps that like plushies.

## Changelog
:cl: Lewdcifer
add: Added a rouny plushie to Sulaco. It's in the telecomms room.
/:cl: