### PR TITLE
Adds a rouny plushie to Arachne

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -7205,6 +7205,7 @@
 /area/mainship/living/pilotbunks)
 "glX" = (
 /obj/structure/rack,
+/obj/item/toy/plush/rouny,
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request
Adds a rouny plushie to Arachne. It's in far northwest maintenance, in the hidden hydroponics room.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/6a11473a-b4c0-4af9-ab11-1ecdb38ee181)

## Why It's Good For The Game
Rouny plushie missing. Add rouny plushie. Elder gods satisfied.
Just some incredibly minor fun for plushie lovers.

## Changelog
:cl: Lewdcifer
add: Added a rouny plushie to Arachne. It's in the hidden hydroponics room, far northwest in maintenance.
/:cl: