### PR TITLE
Fix statpanel not loading turf icons

### DIFF
--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -30,7 +30,6 @@ var permanent_tabs = []; // tabs that won't be cleared by wipes
 var turfcontents = [];
 var turfname = "";
 var imageRetryDelay = 500;
-var imageRetryLimit = 50;
 var menu = document.getElementById('menu');
 var under_menu = document.getElementById('under_menu');
 var statcontentdiv = document.getElementById('statcontent');
@@ -423,14 +422,7 @@ function iconError(e) {
 	}
 	setTimeout(function () {
 		var node = e.target;
-		var current_attempts = Number(node.getAttribute("data-attempts")) || 0
-		if (current_attempts > imageRetryLimit) {
-			return;
-		}
-		var src = node.src;
-		node.src = null;
-		node.src = src + '#' + current_attempts;
-		node.setAttribute("data-attempts", current_attempts + 1)
+		storedimages[node.id] = storedimages[node.id] + '#' + Math.random();
 		draw_listedturf();
 	}, imageRetryDelay);
 }


### PR DESCRIPTION
## About The Pull Request

Fixes #14209, which was because it was spamming a bunch of requests to these icons
<details>
<summary>a</summary>
Why is it not this way upstream? I don't know. The reason it wasn't working before is because it tried reloading them but then called draw_listedturf immediately afterwards which just removes the old elements and makes new ones. And yes, the URL will be huge if it fails to load many times but I don't think it's a problem
</details>

## Changelog

:cl:
fix: Fix statpanel not loading turf icons
/:cl: