### PR TITLE
Expands on random disks by adding disk sets

### DIFF
--- a/_maps/bigred_v2.json
+++ b/_maps/bigred_v2.json
@@ -2,6 +2,9 @@
     "map_name": "Big Red",
     "map_path": "map_files/BigRed_v2",
     "map_file": "BigRed_v2.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
 	"quickbuilds": 1800,
 	"announce_text": "A second generation colony has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!",
 	"traits":[{

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -2,6 +2,9 @@
     "map_name": "Delta Station",
     "map_path": "map_files/deltastation",
     "map_file": "deltastation.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "announce_text": "The ship's comms array detected an emergency evacuation signal from a Delta class research station owned by a private corporation. The message indicated that the station had collided with a large asteroid and was overrun with hostile lifeforms. As part of peacekeeping operations the ship is nearing the station to begin clearing operations. TGMC, get equipped and prepare for boarding action!",
     "armor": "prison"
 }

--- a/_maps/desparity.json
+++ b/_maps/desparity.json
@@ -2,6 +2,9 @@
     "map_name": "Desparity",
     "map_path": "map_files/desparity",
     "map_file": "desparity.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "jungle",
 	"announce_text": "An emergency broadcast has been picked up by our scanners, triangulated to a jungle outpost near LV624, known as Desparity. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
 	"traits":[{

--- a/_maps/gelida_iv.json
+++ b/_maps/gelida_iv.json
@@ -5,6 +5,9 @@
     "environment_traits": {
         "COLD": true
     },
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "ice",
 	"quickbuilds": 1600,
 	"announce_text": "Our comms array has detected an automated emergency signal broadcasting over a frequency reserved for the highest level of emergencies. The message was traced to the northern reaches of the research colony Gelida IV. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",

--- a/_maps/ice_colony_v2.json
+++ b/_maps/ice_colony_v2.json
@@ -5,6 +5,9 @@
     "environment_traits": {
         "COLD": true
     },
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "ice",
 	"quickbuilds": 1600,
 	"announce_text": "A garbled, unintelligible communications message was broadcasted over a general frequency, and picked up by our comms relay. The message appears to have come from a second generation settlement, located on an ice cold planet. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",

--- a/_maps/icy_caves.json
+++ b/_maps/icy_caves.json
@@ -5,6 +5,9 @@
     "environment_traits": {
         "COLD": true
     },
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "ice",
 	"quickbuilds": 1200,
 	"announce_text": "A garbled, unintelligible communications message was broadcasted over a general frequency, and picked up by our comms relay. The message appears to have come from a mining outpost, located on an ice cold planet. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",

--- a/_maps/lawanka.json
+++ b/_maps/lawanka.json
@@ -2,6 +2,9 @@
     "map_name": "Lawanka Outpost",
     "map_path": "map_files/Lawanka_Outpost",
     "map_file": "LawankaOutpost.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
 	"quickbuilds": 1800,
 	"announce_text": "An AI from a Nanotrasen sponsored Research Colony has been sending a distress signal, nonstop. Nanotrasen has hired us to reclaim the Colony in any form. TGMC, prepare to deploy!"
 }

--- a/_maps/lv624.json
+++ b/_maps/lv624.json
@@ -2,6 +2,9 @@
     "map_name": "LV624",
     "map_path": "map_files/LV624",
     "map_file": "LV624.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "jungle",
 	"quickbuilds": 1400,
 	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a third generation colony, known as LV-624. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",

--- a/_maps/magmoor_digsite_iv.json
+++ b/_maps/magmoor_digsite_iv.json
@@ -2,6 +2,9 @@
     "map_name": "Magmoor Digsite IV",
     "map_path": "map_files/Magmoor_Digsite_IV",
     "map_file": "Magmoor_Digsite_IV.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
 	"quickbuilds": 1800,
     "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a mining and archaeological site, known as Magmoor Digsite IV. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!"
 }

--- a/_maps/orion_outpost.json
+++ b/_maps/orion_outpost.json
@@ -2,6 +2,9 @@
     "map_name": "Orion Military Outpost",
     "map_path": "map_files/Orion_Military_Outpost",
     "map_file": "orionoutpost.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "jungle",
 	"quickbuilds": 1000,
 	"announce_text": "The automatic emergency beacon has activated at the Orion Military Outpost on the moon of Trivonus IV, a xenomorph infestation is likely. TGMC, get prepared and ready for a fight!"

--- a/_maps/prison_station_fop.json
+++ b/_maps/prison_station_fop.json
@@ -2,6 +2,9 @@
     "map_name": "Prison Station",
     "map_path": "map_files/Prison_Station_FOP",
     "map_file": "Prison_Station_FOP.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "armor": "prison",
 	"quickbuilds": 1200,
 	"announce_text": "A Nanotrasen maximum security prison has activated its distress signal. The ship is swiftly cruising through space, and nearing the vicinity of the prison station. TGMC, get moving!"

--- a/_maps/research_outpost.json
+++ b/_maps/research_outpost.json
@@ -2,6 +2,9 @@
     "map_name": "Research Outpost",
     "map_path": "map_files/Research_Outpost",
     "map_file": "Research_Outpost.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
 	"quickbuilds": 1000,
     "announce_text": "A research outpost has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!"
 }

--- a/_maps/slumbridge.json
+++ b/_maps/slumbridge.json
@@ -2,6 +2,9 @@
     "map_name": "Slumbridge",
     "map_path": "map_files/slumbridge",
     "map_file": "slumbridge.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
 	"quickbuilds": 2000,
 	"announce_text": "We've received not one, but four distress signals at once coming from the same location. Ground-penetrating scanners and sensors show an unusual arrangement of a segmented asteroid with artificial gravity online. Not only that, but the four segments look nothing alike. TGMC, prepare for deployment and expect the worst."
 }

--- a/_maps/vapor_processing.json
+++ b/_maps/vapor_processing.json
@@ -2,5 +2,8 @@
     "map_name": "Vapor Processing",
     "map_path": "map_files/Vapor_Processing",
     "map_file": "Vapor_Processing.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
     "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a Vapor Processing colony, known as LV-984. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!"
 }

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -902,15 +902,24 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(!length(SSmapping.configs[GROUND_MAP].disk_sets))
 		CRASH("Map Json invalid for generating nuke disks on this map - set up at least one disk set in it. Have you tried \"basic\", assuming only one disk set exists?")
 	var/chosen_disk_set = pickweight(SSmapping.configs[GROUND_MAP].disk_sets)
-	message_admins("disk set chosen: [chosen_disk_set]!") //DEBUG!!!
 	var/list/viable_disks = list()
+	var/list/forced_disks = list()
 	for(var/obj/structure/nuke_disk_candidate/candidate AS in GLOB.nuke_disk_spawn_locs)
 		if(chosen_disk_set in candidate.set_associations)
-			viable_disks += candidate
-	if(length(viable_disks) < length(GLOB.nuke_disk_generator_types)) //Lets in maps with > 3 disks for a given set and just behaves like the previous rng in that case.
+			if(chosen_disk_set in candidate.force_for_sets)
+				forced_disks += candidate
+			else
+				viable_disks += candidate
+	if((length(viable_disks) + length(forced_disks)) < length(GLOB.nuke_disk_generator_types)) //Lets in maps with > 3 disks for a given set and just behaves like the previous rng in that case.
 		CRASH("Warning: Current map has too few nuke disk generators to correctly generate disks for set \">[chosen_disk_set]<\". Make sure both generators and json are set up correctly.")
+	if(length(forced_disks) > length(GLOB.nuke_disk_generator_types))
+		CRASH("Warning: Current map has too many forced disks for the current set type \">[chosen_disk_set]<\". Amount is [length(forced_disks)]. Please revisit your disk candidates.")
 	for(var/obj/machinery/computer/nuke_disk_generator AS in GLOB.nuke_disk_generator_types)
-		var/spawn_loc = pick_n_take(viable_disks)
+		var/spawn_loc
+		if(length(forced_disks))
+			spawn_loc = pick_n_take(forced_disks)
+		else
+			spawn_loc = pick_n_take(viable_disks)
 		new nuke_disk_generator(get_turf(spawn_loc))
 		qdel(spawn_loc)
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -20,6 +20,8 @@
 	var/traits = null
 	var/space_empty_levels = 1
 	var/list/environment_traits = list()
+	///Which disk sets this map has, key-value = name - weight for choosing.
+	var/list/disk_sets = list()
 	var/armor_style = "default"
 	var/quickbuilds = 1000
 	var/list/gamemodes = list()
@@ -156,6 +158,12 @@
 
 	if(json["quickbuilds"])
 		quickbuilds = json["quickbuilds"]
+
+	if(islist(json["disk_sets"]))
+		disk_sets = json["disk_sets"]
+	else if(!isnull(json["disk_sets"]))
+		log_world("map_config disk sets are not a list!")
+		return
 
 	if(islist(json["environment_traits"]))
 		environment_traits = json["environment_traits"]

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -213,6 +213,8 @@ GLOBAL_LIST_INIT(nuke_disk_generator_types, list(/obj/machinery/computer/nuke_di
 	density = TRUE
 	anchored = TRUE
 	resistance_flags = RESIST_ALL
+	///This list contains disk set keys this list as associated with. Keys must be contained in the map's json combined with their weight. Intended to be at least 3 disks per key. Supports more, does NOT support less.
+	var/list/set_associations = list("basic") //These are set by mappers via map vars. Setting this one as its base type so people can skip that part if they only have 3 disks on a map.
 
 //Randomised spawn points for nuke disk generators
 /obj/structure/nuke_disk_candidate/Initialize(mapload)

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -215,6 +215,8 @@ GLOBAL_LIST_INIT(nuke_disk_generator_types, list(/obj/machinery/computer/nuke_di
 	resistance_flags = RESIST_ALL
 	///This list contains disk set keys this list as associated with. Keys must be contained in the map's json combined with their weight. Intended to be at least 3 disks per key. Supports more, does NOT support less.
 	var/list/set_associations = list("basic") //These are set by mappers via map vars. Setting this one as its base type so people can skip that part if they only have 3 disks on a map.
+	///This will FORCE this disk location to exist for these specific sets. Please do not force more than 3 for a set or I will scream at you.
+	var/list/force_for_sets = list() //Mapper var. Edit in map.
 
 //Randomised spawn points for nuke disk generators
 /obj/structure/nuke_disk_candidate/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
This is a purely backend change that will not affect anything until mappers make use of it.

This PR makes makes nuke disk candidates belong to at least one "set" of disks, which are defined in the json of the map.
How this works (For you, mysterious Mapper) is:
You set up the json by having a name-weight list for your disk set's name.
You add the disk candidates to the map, and adjust their "set_associations" list accordingly.
You are done.
If you would like to, you can also add sets to "force_for_sets" on the disk candidate (**aswell as having said sets in the associations of the candidate**), which will make that candidate always appear for the given sets. This is only useful for sets with more than 3 disks (aka "base rng")

Disk sets must be at least 3 candidates. If more than 3, it behaves like the current iteration where it will pick 3 random disk locations from the potential ones in the set.
Disk candidates default to the "basic" set if you do not edit the set_associations var. If your map has a single disk set, just add a info for the basic set into the json (like i have done for all current maps, just copypaste that), and it'll behave.

(Note that json changes require a map change to take effect due to how the mapping subsystem backups the current map's json, so change your map when localtesting json changes)
(Disk candidates can belong to multiple sets, which is why the list of associations is a list and not a var)

When disk generators are next loaded, it will pick one of the disk sets you gave in it the json (going by weighted rng depending on the weight you gave each se),
then take as many candidates as it needs (3) from the set (prioritizing ones forced), and turn them into the actual computers.
If it doesn't manage, it will yell.

This PR adjusts all current jsons of maps that have nuke disks accordingly. If I forgot one (reads: the nuke disks do not load correctly and it starts yelling in runtimes), do tell. Should only happen is cases of badly mapped canter crash sites though. Fixing those is outside the scope of this PR however.


**Scuffed screenies:**
Json:
![grafik](https://github.com/tgstation/TerraGov-Marine-Corps/assets/46569814/7058330f-079f-4ffc-9878-3d8754c606bc)

Vars to touch in map:
![grafik](https://github.com/tgstation/TerraGov-Marine-Corps/assets/46569814/be4c59cd-ed73-4572-8ce5-f93a9de46d64)
## Why It's Good For The Game
Adds some more flavor for nuke disk location mapping, allowing mappers to not only clearly define how rng sets can look like (besides color), but also making it possible to force certain computers, and to have some sets be less common than others.
## Changelog
:cl:
code: Nuke disk generator candidates now support sets for mapping, which allows more control over which disk groups appear aswell as how common they are. Look at this PR if you need to know how.
code: Nuke disk generators can also be forced to always appear for specific sets.
/:cl:
