### PR TITLE
Tanky xenos get more sundering capacity

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -23,6 +23,9 @@
 	// *** Health *** //
 	max_health = 400
 
+	// *** Sunder *** //
+	sunder_max = 200
+
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -23,6 +23,9 @@
 	// *** Health *** //
 	max_health = 320
 
+	// *** Sunder *** //
+	sunder_max = 150
+
 	// *** Evolution *** //
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -22,6 +22,9 @@
 	// *** Health *** //
 	max_health = 650
 
+	// *** Sunder *** //
+	sunder_max = 150
+
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -23,6 +23,9 @@
 	// *** Health *** //
 	max_health = 500
 
+	// *** Sunder *** //
+	sunder_max = 150
+
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	evolve_min_xenos = 8

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -118,7 +118,7 @@
 	if(xeno_caste.plasma_max > 0)
 		. += "Plasma: [plasma_stored]/[xeno_caste.plasma_max]"
 
-	. += "Sunder: [100-sunder]% armor left"
+	. += "Sunder: [round(100 - sunder * 100 / xeno_caste.sunder_max, 1)]% armor left"
 
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""


### PR DESCRIPTION
## About The Pull Request

Queen 100 > 150 sunder
King 100 > 150 sunder
Crusher 100 > 200 sunder
Defender 100 > 150 sunder

## Why It's Good For The Game

Hopefully this makes slow tanky xenos more comfortable to play since they suffer the most from sundering feature.

## Changelog
:cl:
balance: Queen, King, Crusher and Defender get more sundering capacity
/:cl:
