### PR TITLE
Ensure saved gear is in gear_datums when loading prefs

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -479,6 +479,7 @@
 	slot_draw_order_pref = sanitize_islist(slot_draw_order_pref, SLOT_DRAW_ORDER, length(SLOT_DRAW_ORDER), TRUE, SLOT_DRAW_ORDER)
 	for(var/quick_equip_slots in quick_equip)
 		quick_equip_slots = sanitize_inlist(quick_equip_slots, SLOT_DRAW_ORDER[quick_equip], quick_equip_slots)
+	gear = sanitize_islist(gear, default = list(), check_valid = TRUE, possible_input_list = GLOB.gear_datums)
 	if(gender == MALE)
 		underwear = sanitize_integer(underwear, 1, length(GLOB.underwear_m), initial(underwear))
 		undershirt = sanitize_integer(undershirt, 1, length(GLOB.undershirt_m), initial(undershirt))


### PR DESCRIPTION
## About The Pull Request

Fixes #14230

## Changelog

:cl:
fix: Fixed prefs bluescreening when invalid gear is saved
/:cl:
