### PR TITLE
Fix boiler being able to ventcrawl

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -35,7 +35,8 @@
 
 	// *** Flags *** //
 	caste_flags = CASTE_ACID_BLOOD|CASTE_EVOLUTION_ALLOWED
-	can_flags =CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
+	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
+	caste_traits = null
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 45, BULLET = 45, LASER = 45, ENERGY = 45, BOMB = 0, BIO = 35, FIRE = 45, ACID = 35)


### PR DESCRIPTION
## About The Pull Request

This was a regression from #12253, where MOB_SIZE_BIG xenos previously couldn't ventcrawl

## Changelog

:cl:
fix: Fix boiler being able to ventcrawl
/:cl: