### PR TITLE
Can right click packets and ammo boxes

### DIFF
--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -9,7 +9,7 @@
 /obj/item/ammo_magazine/packet/attack_hand_alternate(mob/living/user)
 	. = ..()
 	if(current_rounds <= 0)
-		to_chat(user, span_notice("[src] is empty. There is nothing to grab."))
+		balloon_alert(user, "Empty")
 		return
 	create_handful(user)
 

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -6,6 +6,13 @@
 	icon_state_mini = "ammo_packet"
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/ammo_magazine/packet/attack_hand_alternate(mob/living/user)
+	. = ..()
+	if(current_rounds <= 0)
+		to_chat(user, span_notice("[src] is empty. There is nothing to grab."))
+		return
+	create_handful(user)
+
 /obj/item/ammo_magazine/packet/p10x24mm
 	name = "box of 10x24mm"
 	desc = "A box containing 150 rounds of 10x24mm caseless."


### PR DESCRIPTION
## About The Pull Request
Allows you to grab bullets from boxes and packets from your inventory like you can with flare packs.
## Why It's Good For The Game
Majorly for the sake of convenience so you dont fumble reloads as much. 
## Changelog
:cl:
add: Take out bullets from packets and boxes now with right click.
:cl:
