### PR TITLE
Baneling can now watch other xenos while in pod

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -164,3 +164,5 @@
 	X.record_tactical_unalive()
 	X.death(FALSE)
 
+/datum/action/xeno_action/watch_xeno/baneling
+	use_state_flags = XACT_USE_LYING|XACT_USE_NOTTURF

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
@@ -45,7 +45,7 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/watch_xeno/baneling,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/spawn_pod,
 		/datum/action/xeno_action/select_reagent/baneling,
@@ -64,7 +64,7 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/watch_xeno/baneling,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/spawn_pod,
 		/datum/action/xeno_action/select_reagent/baneling,


### PR DESCRIPTION

## About The Pull Request

Baneling can now watch other xenos while in pod

## Why It's Good For The Game

Makes waiting for respawn less boring

## Changelog
:cl:
qol: Baneling can now watch other xenos while in pod
/:cl:
