### PR TITLE
Hugger psypoints reward

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -130,6 +130,10 @@
 #define COCOON_PSY_POINTS_REWARD_MAX 3
 //How many psy points are gave every 5 second by a cocoon at high pop
 #define COCOON_PSY_POINTS_REWARD_MIN 1
+//How many psy points are given for each hugger impregnation
+#define IMPREGNATION_PSY_POINTS_REWARD 25
+//How many psy points are given for each succesful lavra birth
+#define CHESTBURSTER_PSY_POINTS_REWARD 75
 
 //The player pop consider to be very high pop
 #define HIGH_PLAYER_POP 80

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -147,6 +147,8 @@
 	new_xeno.transfer_to_hive(hivenumber)
 	new_xeno.update_icons()
 
+	SSpoints.add_psy_points(hivenumber, CHESTBURSTER_PSY_POINTS_REWARD)
+
 	//If we have a candidate, transfer it over.
 	if(picked)
 		picked.mind.transfer_to(new_xeno, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -562,6 +562,7 @@
 		if(!(locate(/obj/item/alien_embryo) in target))
 			var/obj/item/alien_embryo/embryo = new(target)
 			embryo.hivenumber = hivenumber
+			SSpoints.add_psy_points(hivenumber, IMPREGNATION_PSY_POINTS_REWARD)
 			GLOB.round_statistics.now_pregnant++
 			SSblackbox.record_feedback("tally", "round_statistics", 1, "now_pregnant")
 			if(source?.client)


### PR DESCRIPTION
## About The Pull Request

Successfully hugging a marine rewards 25 psypoints.
If lavra is fully grown inside a marine, xenos are rewarded with 75 psypoints.

## Why It's Good For The Game

Makes lavra huggers less useless.

## Changelog
:cl:
balance: Hugger psypoints reward
/:cl:
