### PR TITLE
Fix xenos resin spitting on space tiles

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3578,7 +3578,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	drop_resin(T.density ? P.loc : T)
 
 /datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
-	if(T.density)
+	if(T.density || istype(T, /turf/open/space)) // No structures in space
 		return
 
 	for(var/obj/O in T.contents)


### PR DESCRIPTION
## About The Pull Request

The problem is that tg derivatives have space as a `/turf/open` (aka density `0`), thus making space not exit early there.
I didn't really see any other clean solution, thus leading to the `istype` (since we want to have special behavior for just a single `turf/open` child).

Edit: while I was sleeping, I guess you could switch on the behavior of if a turf is constructable on or not, unsure how that's handled in tg code (or is it just density and blacklist)

## Why It's Good For The Game

fixes #13782

## Changelog
 // still don't know why you guys log bugfixes like these

:cl:
fix: Xenos can no longer spit onto space turfs
/:cl:
