### PR TITLE
Mounted gun req and seasonal fix

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -337,9 +337,7 @@ SUBSYSTEM_DEF(persistence)
 	name = "Wall and Armor Shredder Weapons"
 	description = "Flak gun and Railgun for roundstart vendors."
 	item_list = list(
-		/obj/item/weapon/gun/standard_auto_cannon = 1,
-		/obj/item/ammo_magazine/auto_cannon = 3,
-		/obj/item/ammo_magazine/auto_cannon/flak = 3,
+		/obj/structure/largecrate/supply/weapons/standard_flakgun = 1,
 		/obj/item/weapon/gun/rifle/railgun/unloaded = 2,
 		/obj/item/ammo_magazine/railgun = 12,
 		/obj/item/ammo_magazine/railgun/smart = 6,

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -151,6 +151,15 @@
 		/obj/item/ammo_magazine/standard_atgun/he = 3,
 	)
 
+/obj/structure/largecrate/supply/weapons/standard_flakgun
+	name = "\improper ATR-22 flak gun and ammo chest (x1, x6)"
+	desc = "A supply crate containing a AT-36 and a full set of ammo to load into the sponson."
+	supplies = list(
+		/obj/item/weapon/gun/standard_auto_cannon = 1,
+		/obj/item/ammo_magazine/auto_cannon = 3,
+		/obj/item/ammo_magazine/auto_cannon/flak = 3,
+	)
+
 /obj/structure/largecrate/supply/ammo
 	name = "ammunition case"
 	icon_state = "case"

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -153,7 +153,7 @@
 
 /obj/structure/largecrate/supply/weapons/standard_flakgun
 	name = "\improper ATR-22 flak gun and ammo chest (x1, x6)"
-	desc = "A supply crate containing a AT-36 and a full set of ammo to load into the sponson."
+	desc = "A supply crate containing a ATR-22 and a full set of ammo to load into the sponson."
 	supplies = list(
 		/obj/item/weapon/gun/standard_auto_cannon = 1,
 		/obj/item/ammo_magazine/auto_cannon = 3,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -315,7 +315,7 @@ WEAPONS
 
 /datum/supply_packs/weapons/heayvlaser_emplacement
 	name = "Mounted Heavy Laser"
-	contains = list(/obj/item/weapon/gun/heavy_laser)
+	contains = list(/obj/item/weapon/gun/heavy_laser/deployable)
 	cost = 800
 
 


### PR DESCRIPTION

## About The Pull Request
Fixes the flak gun infinitiy exploit by making it a crate.
Fixes req heavy las
## Why It's Good For The Game
Things being broken are bad.
## Changelog
:cl:
fix: You can't infinitely dupe flak guns in seasonal, they now spawn in a crate like TAT for consistency.
fix: Heavy laser is now the deployable variant in req for the deployable version.
/:cl:
