### PR TITLE
Icy cave balance changes

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -501,7 +501,7 @@
 /area/icy_caves/caves/northwestmonorail/medbay)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
+/turf/closed/wall/r_wall,
 /area/icy_caves/caves/northwestmonorail)
 "cw" = (
 /obj/effect/landmark/xeno_silo_spawn,
@@ -512,7 +512,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "cy" = (
@@ -520,9 +519,9 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "cz" = (
-/obj/structure/grille/smoothing,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "cA" = (
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/tile/dark,
@@ -538,10 +537,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
-"cD" = (
-/obj/item/tool/surgery/circular_saw,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
 "cE" = (
 /turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 1
@@ -580,7 +575,6 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northwestmonorail/breakroom)
 "cK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/smooth/darkfrostwall,
 /area/icy_caves/caves/northwestmonorail)
 "cL" = (
@@ -593,10 +587,9 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
 "cO" = (
-/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/breakroom)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northwestmonorail)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -630,7 +623,7 @@
 	},
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "df" = (
 /obj/machinery/power/apc/drained,
@@ -882,7 +875,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "Canteen"
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
 "eD" = (
@@ -1043,6 +1035,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "fl" = (
@@ -1086,6 +1079,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"fC" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "fD" = (
 /obj/machinery/light{
 	dir = 1
@@ -1122,7 +1121,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "gg" = (
 /turf/open/floor/plating,
 /area/icy_caves/caves/northern)
@@ -1134,8 +1133,10 @@
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
 "gr" = (
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "gx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -1334,7 +1335,7 @@
 "hT" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1436,6 +1437,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "iq" = (
@@ -1596,7 +1598,7 @@
 /obj/item/tool/surgery/cautery,
 /obj/item/tool/surgery/retractor,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "jm" = (
 /obj/item/toy/dice/d20,
 /obj/structure/table/gamblingtable,
@@ -1731,8 +1733,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "kf" = (
@@ -1768,16 +1773,17 @@
 /turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northwestmonorail)
 "kp" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northwestmonorail)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "kt" = (
 /obj/effect/spawner/random/weaponry/gun,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
@@ -1814,10 +1820,19 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kC" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "kE" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "kF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1910,9 +1925,8 @@
 /area/icy_caves/outpost/dorms)
 "ll" = (
 /obj/effect/ai_node,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "lo" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -2040,10 +2054,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/lowcharge{
-	dir = 8
-	},
 /turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
@@ -2079,7 +2089,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "mj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -2137,7 +2147,7 @@
 	},
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "mt" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -2172,12 +2182,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"mF" = (
-/obj/effect/spawner/random/misc/structure/closet/electrical,
-/turf/open/floor/tile/dark/yellow2,
-/area/icy_caves/outpost/LZ2)
 "mG" = (
-/obj/structure/dispenser,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
@@ -2245,13 +2253,11 @@
 	},
 /area/icy_caves/outpost/LZ2)
 "nd" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "ne" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
+/turf/closed/mineral/smooth/bluefrostwall,
 /area/icy_caves/caves/northern)
 "nf" = (
 /turf/open/floor/tile/dark/brown2{
@@ -2274,10 +2280,12 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
 "nl" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
 /turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "nm" = (
-/obj/effect/spawner/random/misc/structure/closet/electrical,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 6
 	},
@@ -2307,7 +2315,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -2330,9 +2338,9 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
 "ny" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves/rock)
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "nz" = (
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -2382,7 +2390,8 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "nK" = (
-/obj/structure/largecrate/random/secure,
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "nL" = (
@@ -2456,9 +2465,9 @@
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "oi" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northwestmonorail)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northwestmonorail/hallway)
 "ol" = (
 /turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/engineering)
@@ -2488,11 +2497,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northwestmonorail)
 "oq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail/medbay)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -2718,7 +2725,7 @@
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "pF" = (
 /obj/structure/rack,
@@ -2807,9 +2814,8 @@
 /area/icy_caves/outpost/outside)
 "pZ" = (
 /obj/item/paper/crumpled/bloody,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "qa" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
@@ -3071,7 +3077,7 @@
 "rj" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "rk" = (
 /obj/structure/table/reinforced,
 /obj/structure/xenoautopsy,
@@ -3454,7 +3460,7 @@
 "sC" = (
 /obj/effect/spawner/gibspawner/human,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "sD" = (
 /obj/machinery/light{
@@ -3520,9 +3526,12 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
 "sX" = (
-/obj/structure/largecrate/supply/supplies/coifs,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -3651,11 +3660,12 @@
 	},
 /area/icy_caves/caves/northwestmonorail)
 "tG" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
+/obj/machinery/power/apc/drained{
+	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northwestmonorail/hallway)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -3719,7 +3729,7 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
 /turf/open/floor/mainship/mono,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "tU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -3802,16 +3812,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "up" = (
-/obj/machinery/button/door/open_only/landing_zone/lz2,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northwestmonorail/hallway)
 "uq" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -4048,8 +4051,7 @@
 "vv" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -4139,13 +4141,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "vT" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/hallway)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/alienstuff)
 "vX" = (
 /obj/effect/spawner/random/engineering/structure/handheld_lighting,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4197,7 +4195,7 @@
 "wh" = (
 /obj/structure/morgue/crematorium,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -4233,7 +4231,7 @@
 "ws" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4300,7 +4298,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "wK" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced/windowstake{
@@ -4431,7 +4429,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "xq" = (
 /obj/effect/decal/remains/human,
@@ -4445,9 +4443,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
 "xt" = (
-/obj/structure/largecrate/supply/medicine,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/alienstuff)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4461,11 +4461,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"xx" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "xy" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/weaponry/gun,
@@ -4492,7 +4487,6 @@
 /area/icy_caves/outpost/LZ1)
 "xK" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "xO" = (
@@ -4505,7 +4499,7 @@
 "xS" = (
 /obj/machinery/computer3/server,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4569,10 +4563,7 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "yk" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -4802,7 +4793,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
@@ -4854,7 +4844,6 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "zF" = (
-/obj/effect/spawner/random/engineering/structure/atmospherics_portable/icecolony,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 10
 	},
@@ -5131,7 +5120,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "AR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/drained,
@@ -5304,12 +5293,11 @@
 /turf/closed/mineral/smooth/bluefrostwall,
 /area/icy_caves/caves/northern)
 "BO" = (
-/obj/machinery/door/airlock/multi_tile/secure{
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/hallway)
 "BQ" = (
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
@@ -5387,7 +5375,7 @@
 "Ch" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -5419,7 +5407,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -5458,9 +5446,14 @@
 	},
 /area/icy_caves/outpost/research)
 "CD" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/medbay)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark/green2{
+	dir = 4
+	},
+/area/icy_caves/caves/alienstuff)
 "CF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -5505,13 +5498,12 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
 "CU" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "CV" = (
@@ -5733,7 +5725,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5839,6 +5831,13 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"EB" = (
+/obj/structure/largecrate/random/case,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "EE" = (
 /obj/machinery/light{
 	dir = 4
@@ -6026,8 +6025,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "Fw" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/medbay)
+/area/icy_caves/caves/northwestmonorail/hallway)
 "Fx" = (
 /turf/closed/shuttle/dropship2/walltwo,
 /area/icy_caves/caves/northwestmonorail)
@@ -6166,7 +6168,6 @@
 	dir = 4
 	},
 /obj/structure/table/mainship,
-/obj/structure/nuke_disk_candidate,
 /turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northwestmonorail)
 "Gi" = (
@@ -6177,10 +6178,10 @@
 	},
 /area/icy_caves/caves/alienstuff)
 "Gj" = (
-/obj/machinery/computer/operating,
 /obj/structure/table/reinforced,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -6203,9 +6204,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
 "Gn" = (
-/obj/effect/spawner/random/misc/structure/barrel,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -6241,7 +6244,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "Gy" = (
 /obj/effect/decal/remains/human,
@@ -6413,6 +6416,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "Hx" = (
@@ -6450,6 +6454,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"HG" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "HH" = (
 /obj/effect/ai_node,
 /obj/effect/decal/cleanable/blood,
@@ -6477,7 +6487,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "HL" = (
 /turf/open/floor/mainship_hull/dir{
@@ -6593,7 +6603,6 @@
 /area/icy_caves/outpost/outside)
 "Ij" = (
 /obj/effect/spawner/random/misc/structure/barrel,
-/obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Ik" = (
@@ -6668,7 +6677,7 @@
 "IB" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "ID" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6759,10 +6768,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"IY" = (
-/obj/item/tool/surgery/hemostat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
 "IZ" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/closed/wall/r_wall,
@@ -6807,7 +6812,7 @@
 "Jn" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -7132,10 +7137,12 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "KX" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/breakroom)
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northwestmonorail/hallway)
 "KY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/weapon_vault)
@@ -7151,7 +7158,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Le" = (
 /obj/effect/decal/remains/human,
@@ -7374,9 +7381,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "LY" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/icy_caves/outpost/outside)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7402,6 +7408,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "Mh" = (
@@ -7462,13 +7469,13 @@
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Mx" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "My" = (
 /obj/structure/cable,
@@ -7970,7 +7977,6 @@
 	},
 /area/icy_caves/caves/cavesbrig)
 "Pc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
@@ -7999,7 +8005,7 @@
 "Pm" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -8195,6 +8201,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"Qt" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Qu" = (
 /obj/structure/flora/jungle/planttop1,
 /obj/structure/window/reinforced{
@@ -8418,9 +8428,8 @@
 /area/icy_caves/outpost/engineering)
 "Rr" = (
 /obj/effect/spawner/gibspawner/human,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/random/misc/paperbin,
@@ -8723,7 +8732,7 @@
 "Tq" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -8775,9 +8784,6 @@
 	},
 /turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northwestmonorail)
-"TD" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -8799,6 +8805,7 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "TM" = (
@@ -8906,9 +8913,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
 "Uo" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/rock)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -8933,8 +8939,10 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
 "Uy" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
@@ -9020,10 +9028,10 @@
 /area/icy_caves/caves/northwestmonorail)
 "UW" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
+/turf/open/floor/tile/dark/red2{
+	dir = 8
 	},
 /area/icy_caves/outpost/LZ2)
 "UX" = (
@@ -9234,7 +9242,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/hallway)
 "VX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -9310,18 +9318,26 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Wp" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/machinery/power/apc/lowcharge,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Wq" = (
 /turf/open/floor/prison/red{
 	dir = 10
 	},
 /area/icy_caves/caves/cavesbrig)
 "Wr" = (
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Ws" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -9442,13 +9458,20 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
 "Xb" = (
-/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/machinery/button/door/open_only/landing_zone/lz2,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Xc" = (
 /obj/machinery/light,
@@ -9551,7 +9574,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Xv" = (
 /obj/effect/spawner/random/engineering/structure/atmospherics_portable/icecolony,
 /turf/open/floor/tile/dark/red2{
@@ -9560,9 +9583,8 @@
 /area/icy_caves/outpost/security)
 "Xx" = (
 /obj/item/tool/surgery/circular_saw,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "Xy" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	dir = 2
@@ -9643,9 +9665,8 @@
 /area/icy_caves/caves/northwestmonorail)
 "XR" = (
 /obj/item/tool/surgery/hemostat,
-/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "XS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -9838,7 +9859,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/medbay)
+/area/icy_caves/caves/northwestmonorail/hallway)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -9854,7 +9875,7 @@
 "YV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "YX" = (
 /obj/structure/bed/chair{
@@ -9891,9 +9912,13 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "Zf" = (
-/obj/structure/cable,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northwestmonorail/hallway)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Zg" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -10015,8 +10040,9 @@
 	},
 /area/icy_caves/outpost/LZ2)
 "ZN" = (
-/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ2)
 "ZP" = (
 /turf/closed/mineral/smooth/darkfrostwall,
@@ -10058,7 +10084,7 @@
 	dir = 2
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/morgue)
+/area/icy_caves/caves/northwestmonorail/medbay)
 
 (1,1,1) = {"
 EM
@@ -11328,13 +11354,13 @@ qI
 qI
 AT
 qI
-nK
-Gn
-XV
+qI
+qI
+qI
 AT
-qI
+nd
 yS
-qI
+ny
 XV
 ZP
 ZP
@@ -11485,12 +11511,12 @@ Qr
 dL
 qI
 qI
-Gn
-XV
+qI
+qI
 qI
 qI
 qk
-qI
+ny
 XV
 vk
 vk
@@ -11499,16 +11525,16 @@ vk
 vk
 vk
 vk
-ls
-Fw
-CD
-ls
-Wf
-Fw
+vk
+Nb
+Pp
+vk
+up
+Nb
 YP
-Wf
-ls
-ls
+up
+vk
+vk
 vk
 vk
 vk
@@ -11642,7 +11668,7 @@ Px
 Px
 Px
 Px
-kd
+Px
 Px
 Px
 UU
@@ -11655,7 +11681,7 @@ CJ
 Nb
 Nb
 Nb
-Nb
+tG
 Nb
 Nb
 Nb
@@ -11798,7 +11824,7 @@ qI
 qI
 qI
 qI
-Wp
+qI
 qI
 qI
 Wd
@@ -11811,7 +11837,7 @@ cR
 TN
 cR
 Yk
-Nb
+oi
 Nb
 Nb
 Nb
@@ -11958,14 +11984,14 @@ qI
 qI
 qI
 ms
-Cl
+cO
 Cl
 Tq
-Ts
-Ts
-Ts
+oi
+oi
+oi
 IB
-Ts
+oi
 Lc
 YV
 YV
@@ -11974,15 +12000,15 @@ YV
 YV
 YV
 vv
-Ts
-Ts
-Ts
+oi
+oi
+oi
 sC
-Ts
+oi
 IB
-Ts
-Wn
-Ts
+oi
+KX
+oi
 zZ
 Ts
 Ts
@@ -12110,7 +12136,7 @@ qI
 qI
 qI
 qI
-EP
+qI
 qI
 qI
 Gx
@@ -12120,7 +12146,7 @@ Nb
 Nb
 Nb
 Nb
-Ts
+Nb
 Nb
 pL
 Nb
@@ -12129,7 +12155,7 @@ Nb
 Nb
 Nb
 Nb
-Lc
+Fw
 cR
 un
 cR
@@ -12266,7 +12292,7 @@ Qr
 qI
 qI
 qI
-XV
+qI
 qI
 qI
 Gx
@@ -12276,7 +12302,7 @@ Nb
 Nb
 Nb
 Nb
-Ts
+Nb
 Nb
 zr
 KR
@@ -12285,7 +12311,7 @@ Nb
 Nb
 Nb
 Nb
-Wn
+zr
 Nb
 Nb
 KR
@@ -12429,13 +12455,13 @@ Gx
 qI
 XV
 vk
-gr
-gr
-TD
+vk
+vk
+Nb
 BO
-gr
+vk
 VS
-gr
+vk
 vk
 vk
 vk
@@ -12585,19 +12611,19 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 hT
-TD
 Wr
-TD
+Wr
+Wr
 AQ
-gr
+ls
 ZP
 ZP
 ZP
 vk
 Nb
-Wn
+zr
 vk
 DV
 EX
@@ -12741,19 +12767,19 @@ mg
 qI
 XV
 ZP
-gr
+ls
 tT
-TD
+Wr
 pZ
-IY
+XR
 wI
-gr
+ls
 ZP
 ZP
 ZP
 vk
 Nb
-Lc
+Fw
 za
 ZV
 ZV
@@ -12897,13 +12923,13 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 Ch
-TD
+Wr
 Xx
-TD
+Wr
 Cn
-gr
+ls
 ZP
 ZP
 ZP
@@ -13053,19 +13079,19 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 WX
 Wr
 Rr
 Mv
 ns
-gr
+ls
 vk
 vk
 vk
 vk
 Nb
-Wn
+zr
 vk
 vk
 vk
@@ -13209,19 +13235,19 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 xS
-TD
+Wr
 XR
 jk
 wI
-gr
+ls
 EX
 jd
 ze
 vk
 Nb
-Wn
+zr
 vk
 ZP
 ZP
@@ -13365,19 +13391,19 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 Gj
-cD
+Xx
 ll
 Wr
 Xt
 Ea
 Ij
-Zf
-Zf
+jd
+jd
 zZ
-Tq
-vT
+Pp
+iI
 vk
 ZP
 ZP
@@ -13521,13 +13547,13 @@ Gx
 qI
 XV
 ZP
-gr
+ls
 ws
 rj
-TD
+Wr
 ZZ
-TD
-gr
+oq
+ls
 vk
 vk
 vk
@@ -13677,13 +13703,13 @@ mg
 qI
 XV
 ZP
-gr
+ls
 wh
-TD
+Wr
 gb
 ZZ
-TD
-gr
+sX
+ls
 ZP
 ZP
 ZP
@@ -13833,13 +13859,13 @@ Gx
 qI
 XV
 ZP
-gr
-gr
-gr
-gr
-gr
-gr
-gr
+ls
+ls
+ls
+ls
+ls
+ls
+ls
 ZP
 ZP
 ZP
@@ -13968,20 +13994,20 @@ ZP
 XV
 aY
 hd
-XV
-qI
-qI
-dL
-qI
-qI
-yS
-qI
-qI
-qI
-qI
-qI
-qI
-qI
+cv
+cz
+cz
+gr
+cz
+cz
+kd
+cz
+cz
+cz
+cz
+cz
+cz
+cz
 AT
 qI
 qI
@@ -14124,7 +14150,7 @@ ZP
 XV
 cs
 aY
-XV
+cv
 qI
 qI
 qI
@@ -14137,7 +14163,7 @@ qI
 qI
 dL
 qI
-qI
+cz
 qI
 qI
 qI
@@ -14280,23 +14306,23 @@ ZP
 XV
 cH
 in
-XV
+cv
 qI
 DA
-Cl
-Cl
-Cl
+cO
+cO
+cO
 Gx
-Cl
+cO
 Jn
-Cl
-Cl
-Cl
-Cl
-Cl
+cO
+cO
+cO
+cO
+kp
 HK
 xp
-Cl
+cO
 Gx
 qI
 XV
@@ -14436,10 +14462,10 @@ ZP
 XV
 df
 jA
-XV
+cv
 vY
 qI
-Cl
+cO
 qI
 qI
 Wi
@@ -14447,8 +14473,8 @@ Px
 Px
 Px
 Px
-qI
-qI
+Px
+Px
 Hw
 sG
 sG
@@ -14593,8 +14619,8 @@ XV
 di
 jY
 ip
-Cl
-Cl
+cO
+cO
 pE
 qA
 IN
@@ -14669,7 +14695,7 @@ ZI
 ZI
 ZU
 ZU
-kE
+ZU
 ZU
 SF
 ZU
@@ -14748,7 +14774,7 @@ ZP
 XV
 XV
 XV
-XV
+cv
 XV
 XV
 qI
@@ -14760,8 +14786,8 @@ XV
 XV
 xW
 qI
-qI
-qI
+DA
+cz
 yA
 Ia
 qI
@@ -14904,7 +14930,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 XV
 qI
@@ -14917,7 +14943,7 @@ XV
 hB
 qI
 qI
-qI
+cz
 qI
 qI
 qI
@@ -15060,7 +15086,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 XV
 qI
@@ -15073,7 +15099,7 @@ XV
 UR
 dL
 qI
-qI
+cz
 qI
 qI
 qI
@@ -15216,20 +15242,20 @@ ZP
 ZP
 ZP
 ZP
-ZP
-ZP
-oi
-cv
-cv
-cv
-cx
-oi
 Mr
-oi
+ZP
+XV
+qI
+qI
+qI
+cx
+XV
+ZP
+XV
 XV
 qI
 XV
-XV
+cv
 qI
 qI
 zc
@@ -15373,8 +15399,8 @@ ZP
 ZP
 ZP
 cJ
-cJ
-cJ
+sP
+sP
 jq
 IU
 Wc
@@ -15385,7 +15411,7 @@ cK
 XV
 qI
 XV
-XV
+cv
 qI
 qI
 qI
@@ -15537,11 +15563,11 @@ IU
 pW
 sP
 sP
-cJ
+sP
 XV
 vY
 qI
-qI
+cz
 qI
 qI
 qI
@@ -15693,11 +15719,11 @@ IU
 cC
 IU
 IU
-cJ
+sP
 qI
 fr
 Px
-Px
+kE
 Px
 Px
 Px
@@ -15849,11 +15875,11 @@ cw
 HQ
 Xh
 IU
-cO
+jq
 qI
 qI
 qI
-qI
+cz
 qI
 qI
 qI
@@ -16009,7 +16035,7 @@ eC
 qI
 dL
 qI
-qI
+cz
 qI
 qI
 Qr
@@ -16161,14 +16187,14 @@ PZ
 IK
 oM
 PZ
-KX
-Cl
-Cl
-Cl
-Cl
-Cl
-Cl
-Cl
+PZ
+cO
+cO
+cO
+kp
+cO
+cO
+cO
 Gx
 qI
 XV
@@ -16317,11 +16343,11 @@ IU
 QQ
 BW
 IU
-cO
+jq
 qI
 oL
 qI
-qI
+cz
 qI
 qI
 qI
@@ -16473,11 +16499,11 @@ zH
 eP
 sW
 GJ
-cJ
+sP
 XV
 XV
 XV
-XV
+cv
 qI
 qI
 qI
@@ -16629,11 +16655,11 @@ CX
 IU
 IU
 IU
-cJ
+sP
 ZP
 ZP
 ZP
-XV
+cv
 vY
 qI
 qI
@@ -16777,19 +16803,19 @@ ZP
 ZP
 ZP
 cJ
-cJ
-cJ
-cJ
-cJ
-cJ
-cJ
-cJ
-cJ
-cJ
+sP
+sP
+sP
+sP
+sP
+sP
+sP
+sP
+sP
 ZP
 ZP
 ZP
-XV
+cv
 yS
 qI
 qI
@@ -16932,6 +16958,9 @@ ZP
 ZP
 ZP
 ZP
+Mr
+Mr
+Mr
 ZP
 ZP
 ZP
@@ -16942,10 +16971,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
-ZP
-ZP
-XV
+cv
 NU
 Px
 Px
@@ -17090,6 +17116,7 @@ ZP
 ZP
 ZP
 ZP
+Mr
 ZP
 ZP
 ZP
@@ -17100,14 +17127,13 @@ ZP
 ZP
 ZP
 ZP
-ZP
-XV
-qI
-qI
-dL
-qI
-qI
-EP
+cv
+cz
+cz
+gr
+cz
+cz
+nK
 Zl
 Zl
 Zl
@@ -17246,7 +17272,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -17263,7 +17289,7 @@ Cl
 xZ
 Xz
 XV
-XV
+cv
 ZI
 ZI
 ZI
@@ -17402,7 +17428,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -17419,7 +17445,7 @@ SR
 SR
 SR
 ZI
-ZI
+Sb
 ZI
 ZI
 ZI
@@ -17559,22 +17585,22 @@ ZP
 ZP
 ZP
 Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Sb
-Sb
-Sb
-yh
-yh
-yh
-yh
-Sb
-Sb
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZI
+ZI
+ZI
+SR
+SR
+SR
+SR
+ZI
+ZI
 Sb
 Sb
 ZI
@@ -17960,7 +17986,7 @@ ZP
 ZP
 ZP
 ZP
-ny
+ZP
 ZP
 ow
 li
@@ -19232,7 +19258,7 @@ li
 DD
 pC
 DD
-my
+oN
 HA
 li
 YA
@@ -21941,23 +21967,23 @@ ZP
 ZP
 ZP
 ZP
-ZI
-ZI
-ZI
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-ZI
-ZI
+Sb
+Sb
+Sb
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+Sb
+Sb
 ZI
 ZI
 ZI
@@ -22097,7 +22123,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 SR
@@ -22113,7 +22139,7 @@ SR
 bl
 Zb
 ZI
-ZI
+Sb
 ZI
 ZI
 ZI
@@ -22253,7 +22279,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -22269,7 +22295,7 @@ ZI
 bl
 SR
 bl
-ZI
+Sb
 ZI
 ZI
 SR
@@ -22409,7 +22435,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -22425,7 +22451,7 @@ ZI
 ZI
 SR
 SR
-bp
+Gn
 SR
 SR
 SR
@@ -22565,10 +22591,10 @@ ZP
 ZP
 ZP
 ZP
+Mr
 ZP
 ZP
 ZP
-ZP
 SR
 SR
 SR
@@ -22581,7 +22607,7 @@ ZI
 ZI
 SR
 SR
-SR
+yh
 SR
 SR
 SR
@@ -22721,7 +22747,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -22737,7 +22763,7 @@ ZI
 ZP
 SR
 SR
-SR
+yh
 ZP
 ZP
 SR
@@ -22877,7 +22903,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 bS
 tf
@@ -22893,7 +22919,7 @@ ZI
 ZP
 ZP
 SR
-SR
+cb
 ZP
 ZP
 pK
@@ -23033,7 +23059,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 tf
 iP
@@ -23049,7 +23075,7 @@ ZI
 ZP
 ZP
 SR
-SR
+yh
 ZP
 SR
 SR
@@ -23189,7 +23215,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 tf
 oa
@@ -23205,7 +23231,7 @@ ZI
 ZP
 ZP
 SR
-SR
+yh
 SR
 SR
 Zb
@@ -23345,7 +23371,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 tf
 uS
@@ -23361,7 +23387,7 @@ ZI
 ZP
 ZP
 ZP
-SR
+yh
 SR
 SR
 ZI
@@ -23501,7 +23527,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 bS
 tf
@@ -23517,7 +23543,7 @@ ZI
 ZP
 ZP
 SR
-SR
+yh
 SR
 ZI
 ZI
@@ -23657,7 +23683,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -23666,14 +23692,14 @@ ZI
 ZI
 SR
 SR
-SR
+bC
 SR
 ZI
 ZI
 SR
 SR
 SR
-bl
+jo
 ZI
 ZI
 mf
@@ -23813,7 +23839,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -23828,8 +23854,8 @@ SR
 SR
 SR
 SR
-bl
-ZP
+jo
+Mr
 ZP
 mf
 mf
@@ -23969,7 +23995,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -23979,12 +24005,12 @@ SR
 SR
 SR
 SR
+im
 SR
 SR
 SR
 SR
-SR
-SR
+yh
 ZP
 ZP
 mf
@@ -24003,7 +24029,7 @@ ym
 ym
 dT
 ZI
-mO
+ZI
 ZI
 ZI
 ZI
@@ -24125,7 +24151,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -24139,8 +24165,8 @@ SR
 VP
 mf
 mf
-mf
-mf
+vT
+vT
 mf
 mf
 mf
@@ -24281,7 +24307,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -24437,7 +24463,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZP
@@ -24451,7 +24477,7 @@ SR
 SR
 yW
 qU
-Cb
+xt
 Dy
 JV
 JV
@@ -24593,7 +24619,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZI
@@ -24607,7 +24633,7 @@ SR
 VP
 mf
 yW
-xz
+CD
 qU
 Iu
 dP
@@ -24749,7 +24775,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+Mr
 ZP
 ZP
 ZI
@@ -24763,7 +24789,7 @@ SR
 SR
 mf
 mf
-mf
+vT
 iq
 Qu
 CK
@@ -24919,7 +24945,7 @@ yh
 Sb
 Sb
 Sb
-mf
+vT
 iq
 MU
 iz
@@ -25061,7 +25087,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -25074,7 +25100,7 @@ SR
 SR
 ZI
 ZI
-Sb
+ZI
 mf
 iq
 JV
@@ -25217,7 +25243,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -25230,7 +25256,7 @@ ZI
 ZI
 ZI
 ZI
-Sb
+ZI
 mf
 Aj
 ef
@@ -25373,7 +25399,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -25386,7 +25412,7 @@ ZI
 ZI
 ZI
 ZI
-Sb
+ZI
 mf
 mf
 mf
@@ -25440,13 +25466,13 @@ ZI
 ZI
 ZI
 XO
-XO
-XO
 pR
 pR
-XO
 pR
-ZI
+pR
+pR
+pR
+Uo
 XO
 XO
 Za
@@ -25456,8 +25482,8 @@ XO
 XO
 XO
 XO
-ZI
-ZI
+Uo
+Uo
 oO
 Za
 oO
@@ -25529,20 +25555,20 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZP
 ZP
 SR
-bC
 SR
 SR
+SR
 ZI
 ZI
 ZI
 ZI
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -25596,26 +25622,26 @@ ZI
 ZI
 XO
 Za
-XO
-XO
 pR
-ZI
 pR
-ZI
-ZI
+pR
+Uo
+pR
+Uo
+Uo
 Za
 XO
-ZI
-XO
+Uo
+pR
 Za
 XO
 XO
-ZI
-ZI
-ZI
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
 XO
 oO
 xh
@@ -25685,7 +25711,7 @@ ZP
 ZP
 ZP
 ZP
-Sb
+ZI
 ZI
 ZP
 ZP
@@ -25698,7 +25724,7 @@ SR
 ZI
 ZI
 ZI
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -25752,27 +25778,27 @@ ZI
 XO
 XO
 Za
-XO
-ZI
-ZI
-ZI
-ZI
-ZI
-XO
+pR
+Uo
+Uo
+Uo
+Uo
+Uo
+pR
 Za
 XO
-ZI
-XO
+Uo
+pR
 Za
 Za
 XO
 pR
-ZI
-ZI
-ZI
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
 XO
 Za
 Za
@@ -25841,7 +25867,7 @@ ZP
 ZP
 ZP
 ZI
-Sb
+ZI
 ZI
 ZI
 SR
@@ -25854,7 +25880,7 @@ im
 SR
 ZI
 ZI
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -25908,24 +25934,24 @@ XO
 Za
 Za
 XO
-XO
-ZI
-ZI
-ZI
-ZI
-ZI
-XO
+pR
+Uo
+Uo
+Uo
+Uo
+Uo
+pR
 Za
 XO
-ZI
-ZI
+Uo
+Uo
 XO
 Za
 Za
 XO
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
 XO
 XO
 XO
@@ -25997,7 +26023,7 @@ ZP
 ZP
 ZI
 ZI
-Sb
+ZI
 ZI
 SR
 SR
@@ -26010,7 +26036,7 @@ bl
 SR
 SR
 ZI
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -26064,16 +26090,16 @@ Za
 Za
 XO
 XO
-XO
 pR
-XO
-XO
-XO
-ZI
-XO
+pR
+pR
+pR
+pR
+Uo
+pR
 Za
 XO
-ZI
+Uo
 pR
 Za
 Za
@@ -26153,7 +26179,7 @@ ZP
 ZP
 ZI
 ZI
-BM
+ne
 SR
 bl
 SR
@@ -26166,7 +26192,7 @@ SR
 bl
 SR
 SR
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -26229,7 +26255,7 @@ XO
 Za
 Za
 XO
-ZI
+Uo
 XO
 XO
 XO
@@ -26243,7 +26269,7 @@ XO
 XO
 XO
 pR
-ZI
+Uo
 ZI
 ZI
 Fr
@@ -26309,20 +26335,20 @@ ZP
 ZI
 ZI
 ZI
-yh
-jo
-kp
-yh
-Sb
-Sb
-Sb
-Sb
-Sb
-Sb
-yh
-jo
-ne
-yh
+SR
+bl
+GH
+SR
+ZI
+ZI
+ZI
+ZI
+ZI
+ZI
+SR
+bl
+Zb
+SR
 ZI
 ZI
 ZI
@@ -26398,9 +26424,9 @@ Za
 Za
 Za
 Za
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
 ZI
 tH
 hr
@@ -26554,7 +26580,7 @@ pR
 pR
 Za
 Za
-ZI
+Uo
 pR
 pR
 XO
@@ -27472,8 +27498,8 @@ ZI
 ZI
 ZI
 ZI
-wa
-oP
+mH
+mH
 oP
 oP
 oP
@@ -27492,9 +27518,9 @@ nI
 nI
 ZI
 ZI
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
 oP
 iK
 XO
@@ -27628,21 +27654,21 @@ ZI
 ZI
 ZI
 ZI
-cz
+mH
+mH
 on
 on
 on
 on
 on
-Xb
 Sc
 at
 Kz
 Sc
-Xb
 on
 on
 on
+on
 ZI
 ZI
 ZI
@@ -27650,7 +27676,7 @@ ZI
 ZI
 ZI
 ZI
-ZI
+Uo
 oP
 iK
 XO
@@ -27774,7 +27800,7 @@ ZI
 XO
 pR
 XO
-ZI
+hi
 Za
 Za
 pR
@@ -27788,7 +27814,7 @@ oP
 RA
 Sc
 WA
-WA
+UW
 WA
 WA
 WA
@@ -27796,17 +27822,17 @@ cG
 Ko
 WA
 Oy
-ZN
-nd
-oq
-tL
-tL
+IT
+IT
+mP
+on
+fC
 jW
 ZI
 ZI
 ZI
-ZI
-ZI
+Uo
+Uo
 oP
 iK
 XO
@@ -27935,7 +27961,7 @@ XO
 Za
 XO
 Wu
-ZI
+hi
 on
 wa
 wa
@@ -27952,17 +27978,17 @@ hP
 Kt
 nc
 LB
-LY
+IT
+IT
+IT
+HG
+fC
 tL
-tL
-tL
-tL
-jW
 ZI
 ZI
 ZI
 ZI
-ZI
+Uo
 nI
 Tl
 Za
@@ -28085,7 +28111,7 @@ ZP
 ZP
 pR
 pR
-pR
+LY
 XO
 XO
 Za
@@ -28101,19 +28127,19 @@ oP
 IT
 IT
 IT
-RQ
-on
-on
-Pc
+IT
+IT
+IT
+hP
 QW
 nf
 rm
-tL
-tL
-tL
-tL
-tL
-tL
+IT
+IT
+IT
+on
+EB
+Qt
 ZI
 ZI
 ZI
@@ -28241,7 +28267,7 @@ ZP
 ZP
 pR
 pR
-XO
+Lv
 ZI
 XO
 XO
@@ -28262,16 +28288,16 @@ IT
 IT
 hP
 QW
+ZN
 IT
 IT
-Wm
-tL
-tL
+IT
+IT
 on
 on
 on
-on
-on
+mH
+mH
 ZI
 nI
 nI
@@ -28396,9 +28422,9 @@ ZP
 ZP
 ZP
 pR
-pR
-XO
-XO
+Lv
+Lv
+Lv
 np
 XO
 Za
@@ -28411,19 +28437,19 @@ IT
 td
 IT
 on
-IT
+Uy
 IT
 IT
 IT
 IT
 hP
 QW
+ZN
 IT
 IT
-on
-tL
-nd
-on
+IT
+IT
+Wm
 oP
 wa
 wa
@@ -28552,8 +28578,8 @@ ZP
 ZP
 ZP
 pR
-XO
-XO
+LY
+Lv
 XO
 XO
 XO
@@ -28574,12 +28600,12 @@ IT
 IT
 hP
 QW
+ZN
 IT
 IT
-on
-tL
-Uy
-on
+IT
+IT
+ka
 wa
 oP
 nI
@@ -28728,14 +28754,14 @@ on
 on
 on
 on
-hP
+Wp
 QW
+ZN
 IT
 IT
-on
-xt
-Uo
-on
+IT
+IT
+IT
 oP
 wa
 nI
@@ -28884,14 +28910,14 @@ IT
 mP
 IT
 on
-hP
+Xb
 QW
+ZN
 IT
 IT
-on
-on
-on
-on
+IT
+IT
+Wm
 wa
 wa
 nI
@@ -29040,14 +29066,14 @@ IT
 IT
 IT
 ka
-hP
+Zf
 QW
+ZN
 IT
 IT
 IT
-mP
 IT
-Wm
+on
 wa
 wa
 nI
@@ -29196,14 +29222,14 @@ IT
 iV
 IT
 IT
-hP
+Zf
 QW
 nc
 nc
 nc
 nc
-nc
-ka
+kC
+on
 wa
 wa
 nI
@@ -29352,14 +29378,14 @@ lo
 lo
 IT
 on
-hP
+Zf
 Kt
 nf
 nf
 nf
 nf
 nf
-IT
+on
 wa
 wa
 oP
@@ -29508,7 +29534,7 @@ lo
 lo
 IT
 on
-hP
+Zf
 QW
 IT
 IT
@@ -29666,12 +29692,12 @@ RQ
 on
 Pc
 QW
-on
-on
-on
-on
-on
-on
+IT
+IT
+IT
+IT
+IT
+ka
 oP
 oP
 nI
@@ -29820,18 +29846,18 @@ IT
 iV
 IT
 on
-hP
+Zf
 QW
-on
-tG
+yk
+qL
 qL
 qL
 zF
-on
+IT
 oP
 nI
-ZI
-ZI
+Uo
+Uo
 oP
 wa
 oP
@@ -29976,19 +30002,19 @@ lo
 lo
 IT
 ka
-hP
+Zf
 Kt
 yk
 IT
 IT
 IT
 nl
-on
+Wm
 oP
 wa
-ZI
-ZI
-ZI
+Uo
+Uo
+Uo
 wa
 oP
 ZI
@@ -30132,20 +30158,20 @@ lo
 lo
 IT
 IT
-hP
+Zf
 QW
-xx
+yk
 IT
 IT
 IT
-mF
+yk
 on
-oP
-wa
+mH
+mH
 ZI
 ZI
-oP
-wa
+nI
+nI
 oP
 ZI
 Uj
@@ -30288,20 +30314,20 @@ ZD
 lp
 IT
 on
-hP
+Zf
 QW
-on
+yk
 ZM
 mG
-UW
+ZM
 nm
 on
 on
 on
 ZI
 ZI
+mH
 on
-cz
 ZI
 ZI
 Uj
@@ -30444,9 +30470,9 @@ on
 on
 on
 on
-hP
+Zf
 QW
-on
+IT
 on
 on
 on
@@ -30912,9 +30938,9 @@ IT
 IT
 IT
 lQ
-on
-on
-up
+IT
+IT
+IT
 IT
 IT
 IT
@@ -31068,7 +31094,7 @@ IT
 IT
 oP
 lS
-sX
+IT
 IT
 IT
 oP


### PR DESCRIPTION


## About The Pull Request

Attempts to fix LZ2 to make it more appealing to choose for Marines and removes some ice rocks that made cover for xenos to easy. Adds more crash spawns for canterbury and removes the spawns where it could crash right beside the fog which makes life bad for marines, also removes it from crashing right beside disks. Moves the Disc spawn in Monorail area to be in the medbay/morgue area, i believe this to be best for both sides.

extends the fog in north monorail a bit more. also made the nuke hallway of death west spawn for xenos, further away to be more fair for marines.

## Why It's Good For The Game

This should hopefully make crash in Icy caves more bareable, and also make nuclear-war there better with the option of a more open LZ2 

## Changelog

:cl:
balance: Lz2 is more open and less cluttered.
balance: cantabury no longer crashes right besides discs or fog.
balance: north monorail disc will be better to defend and attack.
/:cl:

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/64131993/a541700b-b343-4ddb-ac71-96564a7e02e4)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/64131993/51198426-b162-430b-8722-5618f1332cb3)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/64131993/479ef952-731f-4f78-a452-2babb31cfc4f)

