### PR TITLE
Revert "ghost runechat (#14104)"

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -96,7 +96,7 @@
 		displayed_key = null
 
 	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key)
-	create_chat_message(src, /datum/language/common, message)
+
 
 /mob/living/proc/get_message_mode(message)
 	var/key = message[1]


### PR DESCRIPTION
It's currently broken (only the speaker can see it) and it's a stupid idea anyway, it takes up a sizable portion of actual gameplay and the only toggle is disabling ghost vision entirely