### PR TITLE
Crusher toss fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -103,8 +103,6 @@
 	var/turf/target_turf = throw_origin //throw distance is measured from the xeno itself
 	var/big_mob_message
 
-	//if(isclosedturf(throw_origin)) //shouldn't be possible anyway
-	//	return
 	if(!X.issamexenohive(A)) //xenos should be able to fling xenos into xeno passable areas!
 		for(var/obj/effect/forcefield/fog/fog in throw_origin)
 			A.balloon_alert(X, "cannot, fog")

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -121,12 +121,7 @@
 	if(X.a_intent == INTENT_HARM) //If we use the ability on hurt intent, we throw them in front; otherwise we throw them behind.
 		facing = get_dir(X, A)
 	else
-		for(var/obj/O in throw_origin)
-			if(!istype(O, /obj/structure/barricade) && !O.CanPass(A, throw_origin)) //Ignore barricades because they will once thrown anyway
-				to_chat(X, span_xenowarning("We try to fling [A] behind us, but there's no room!"))
-				return fail_activate()
 		facing = get_dir(A, X)
-	A.forceMove(throw_origin)
 
 	var/turf/temp
 	for(var/x in 1 to toss_distance)
@@ -142,6 +137,7 @@
 
 	succeed_activate()
 
+	A.forceMove(throw_origin)
 	A.throw_at(target_turf, toss_distance, 1, X, TRUE, TRUE)
 
 	//Handle the damage

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -99,10 +99,16 @@
 	X.face_atom(A) //Face towards the target so we don't look silly
 	var/facing = get_dir(X, A)
 	var/toss_distance = X.xeno_caste.crest_toss_distance
-	var/turf/T = X.loc
-	var/turf/temp = X.loc
+	var/turf/throw_origin = get_turf(X)
+	var/turf/target_turf = throw_origin //throw distance is measured from the xeno itself
 	var/big_mob_message
 
+	//if(isclosedturf(throw_origin)) //shouldn't be possible anyway
+	//	return
+	if(!X.issamexenohive(A)) //xenos should be able to fling xenos into xeno passable areas!
+		for(var/obj/effect/forcefield/fog/fog in throw_origin)
+			A.balloon_alert(X, "cannot, fog")
+			return fail_activate()
 	if(isliving(A))
 		var/mob/living/L = A
 		if(L.mob_size >= MOB_SIZE_BIG) //Penalize toss distance for big creatures
@@ -113,32 +119,21 @@
 		big_mob_message = ", struggling mightily to heft its bulk"
 
 	if(X.a_intent == INTENT_HARM) //If we use the ability on hurt intent, we throw them in front; otherwise we throw them behind.
-		for(var/x in 1 to toss_distance)
-			temp = get_step(T, facing)
-			if (!temp)
-				break
-			T = temp
+		facing = get_dir(X, A)
 	else
-		facing = get_dir(A, X)
-		var/turf/throw_origin = get_step(T, facing)
-		if(isclosedturf(throw_origin)) //Make sure the victim can actually go to the target turf
-			to_chat(X, span_xenowarning("We try to fling [A] behind us, but there's no room!"))
-			return fail_activate()
-		if(!X.issamexenohive(A)) //xenos should be able to fling xenos into xeno passable areas!
-			for(var/obj/effect/forcefield/fog/fog in T)
-				A.balloon_alert(X, "cannot, fog")
-				return fail_activate()
 		for(var/obj/O in throw_origin)
-			if(!O.CanPass(A, get_turf(X)) && !istype(O, /obj/structure/barricade)) //Ignore barricades because they will once thrown anyway
+			if(!istype(O, /obj/structure/barricade) && !O.CanPass(A, throw_origin)) //Ignore barricades because they will once thrown anyway
 				to_chat(X, span_xenowarning("We try to fling [A] behind us, but there's no room!"))
 				return fail_activate()
+		facing = get_dir(A, X)
+	A.forceMove(throw_origin)
 
-		A.forceMove(throw_origin) //Move the victim behind us before flinging
-		for(var/x = 0, x < toss_distance, x++)
-			temp = get_step(T, facing)
-			if (!temp)
-				break
-			T = temp //Throw target
+	var/turf/temp
+	for(var/x in 1 to toss_distance)
+		temp = get_step(target_turf, facing)
+		if(!temp)
+			break
+		target_turf = temp
 
 	X.icon_state = "Crusher Charging"  //Momentarily lower the crest for visual effect
 
@@ -147,7 +142,7 @@
 
 	succeed_activate()
 
-	A.throw_at(T, toss_distance, 1, X, TRUE)
+	A.throw_at(target_turf, toss_distance, 1, X, TRUE, TRUE)
 
 	//Handle the damage
 	if(!X.issamexenohive(A) && isliving(A)) //Friendly xenos don't take damage.

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -97,7 +97,7 @@
 /datum/action/xeno_action/activable/cresttoss/use_ability(atom/movable/A)
 	var/mob/living/carbon/xenomorph/X = owner
 	X.face_atom(A) //Face towards the target so we don't look silly
-	var/facing = get_dir(X, A)
+	var/facing
 	var/toss_distance = X.xeno_caste.crest_toss_distance
 	var/turf/throw_origin = get_turf(X)
 	var/turf/target_turf = throw_origin //throw distance is measured from the xeno itself


### PR DESCRIPTION
## About The Pull Request
Fixes #14265

Crest toss tosses the victim from the CRUSHER'S turf instead of teleporting the victim behind you or tossing from their turf (forwards).
This means some cases where previously you couldn't throw someone because there was a wall behind you will now allow a throw (into the wall, but still).

Crest toss now properly respects the intended throw range, as the victim is actually thrown from the xeno's turf.
The victim now has the hover flag when thrown, so they'll properly fly over cades instead of relying on funny snowflake checks. This also means they won't burst into flame when thrown OVER a flaming turf.

Previously, the throw TARGET was based on the range from the crusher. But the victim being on a different turf meant that max range was actually further than this. This caused no issues when throwing in cardinal directions as it would just reach the target turf, but on diagonal throws this would cause them to be thrown further than expected.

Note that while this is a nerf, the diagonal toss range is still considerably better than it used to be prior to my euclide diagonal throw change.

Also just generally cleaned up the code as it was god awful.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: Crest toss now throws the correct distance diagonally
balance: Crest toss is from the xeno's turf, so some tosses will be possible that were not previously
/:cl:
