### PR TITLE
Retrofits and buffs the technician backpack for engineers

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -358,20 +358,19 @@
 
 /obj/item/storage/backpack/marine/tech
 	name = "\improper TGMC technician backpack"
-	desc = "The standard-issue backpack worn by TGMC technicians. Specially equipped to hold sentry gun and M56D emplacement parts."
+	desc = "The standard-issue backpack worn by TGMC technicians. Specially equipped to hold deployable gun parts and howitzer shells."
 	icon_state = "marinepackt"
 	item_state = "marinepackt"
 	bypass_w_limit = list(
-		/obj/item/weapon/gun/sentry/big_sentry,
-		/obj/item/weapon/gun/sentry/mini,
 		/obj/item/weapon/gun/tl102,
-		/obj/item/ammo_magazine/tl102,
-		/obj/item/ammo_magazine/sentry,
-		/obj/item/ammo_magazine/minisentry,
-		/obj/item/mortal_shell,
+		/obj/item/weapon/gun/standard_minigun,
+		/obj/item/ammo_magazine/heavy_minigun,
+		/obj/item/weapon/gun/heavymachinegun,
+		/obj/item/ammo_magazine/heavymachinegun,
+		/obj/item/weapon/gun/standard_agls,
+		/obj/item/weapon/gun/heavy_laser/deployable,
 		/obj/item/mortar_kit,
-		/obj/item/stack/razorwire,
-		/obj/item/stack/sandbags,
+		/obj/item/mortal_shell/howitzer, // Howitzer shells are BULKY, same size as the mortar kit.
 	)
 
 /obj/item/storage/backpack/marine/satchel

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -362,18 +362,13 @@
 	icon_state = "marinepackt"
 	item_state = "marinepackt"
 	bypass_w_limit = list(
-		/obj/item/weapon/gun/tl102,
-		/obj/item/weapon/gun/standard_minigun,
+		/obj/item/weapon/gun/mounted,
 		/obj/item/ammo_magazine/heavy_minigun,
-		/obj/item/weapon/gun/heavymachinegun,
 		/obj/item/ammo_magazine/heavymachinegun,
-		/obj/item/weapon/gun/standard_agls,
-		/obj/item/weapon/gun/heavy_laser/deployable,
 		/obj/item/ammo_magazine/heavy_laser,
-		/obj/item/mortar_kit,
 		/obj/item/mortal_shell/howitzer // Howitzer shells are BULKY, same size as the mortar kit.
 	)
-
+	storage_type_limits = list(/obj/item/weapon/gun/mounted)
 /obj/item/storage/backpack/marine/satchel
 	name = "\improper TGMC satchel"
 	desc = "A heavy-duty satchel carried by some TGMC soldiers and support personnel."

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -368,7 +368,7 @@
 		/obj/item/ammo_magazine/heavy_laser,
 		/obj/item/mortal_shell/howitzer // Howitzer shells are BULKY, same size as the mortar kit.
 	)
-	storage_type_limits = list(/obj/item/weapon/gun/mounted)
+	storage_type_limits = list(/obj/item/weapon/gun/mounted = 1)
 /obj/item/storage/backpack/marine/satchel
 	name = "\improper TGMC satchel"
 	desc = "A heavy-duty satchel carried by some TGMC soldiers and support personnel."

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -369,8 +369,9 @@
 		/obj/item/ammo_magazine/heavymachinegun,
 		/obj/item/weapon/gun/standard_agls,
 		/obj/item/weapon/gun/heavy_laser/deployable,
+		/obj/item/ammo_magazine/heavy_laser,
 		/obj/item/mortar_kit,
-		/obj/item/mortal_shell/howitzer, // Howitzer shells are BULKY, same size as the mortar kit.
+		/obj/item/mortal_shell/howitzer // Howitzer shells are BULKY, same size as the mortar kit.
 	)
 
 /obj/item/storage/backpack/marine/satchel


### PR DESCRIPTION
## Update: This PR now depends on #14278 before it can be merged.

Additionally, I've removed the mortar from its list to ensure the mortar bag remains the niche bag for that. However, I'm letting it carry howitzer shells since no other bag can do it.

In its current state, it can now carry one heavy deployable gun and any of its ammo alongside anything else a bag can carry.

## About The Pull Request
This PR brings the forgotten technician backpack up to date and makes it a viable pick for engineers.

Prior to checking things myself, I assumed that the technician backpack made it so sentries and the like took up less space, or even made them carry able. This is due in fact to its extended description. However, it appears that at some point it was changed so that any backpack can carry a sentry gun or its ammo.

Regardless, it still had two other unique items on its list, namely the HSG and the Mortar. This gave me the idea to expand on that list and make the technician backpack the go-to bag for deploy-able guns. I've deliberately left the MG-27 out due to its popularity and the fact that it can be fired from the hip. The rest of these all have lengthy deploy times and are otherwise too bulky to move.

Additionally. The fact that it could already carry a mortar is pretty funny considering the mortar bag exists. The mortar bag can carry nothing but the mortar and shells and the only reason to choose it is for the free mortar that comes with it. **I understand that making this PR will bring attention to the uselessness of the mortar bag. However, I didn't want to leave it in the dust.** Alternatively, I could remove the mortar from the list here to keep the two bags with their own niches.

I've also cleaned up the list from all the other items that regular backpacks can carry.
## Why It's Good For The Game

Currently, the state of engineer backpacks is as follows.
1) Uber backpack that needs to be deployed (Dispenser)
2) Normal satchel with some welding fuel (Welding satchel)
3) Normal backpack + Beacon + Reg computer (Radio pack)
4) Free mortar that you can quickdraw but you can only carry shells in it and nothing else (Mortar bag)
5) Normal backpack that is forgotten. Can carry mortar or HSG. (Technician Backpack)
6) A downgraded flamethrower without an under-barrel extinguisher that cannot be mag-harnessed (Flamethrower bag)

Most if not all god engineers know that options 1-3 are the only real viable options. Option 4 is a fun gimmick every now and then. 5 is interesting if you take it for the HSG or Mortar, but probably nobody knew about it before I made this PR. Option 6 is trash.

I'd like to bring the technician backpack up to par as an option alongside all the meta picks we currently have for engineers. Additionally, as much as a balance concern it is, it's still painful to watch people lug around heavy deployables. I doubt this will make deployables surge into popularity more than what they're already at as they remain expensive or other inaccessible. **The technician backpack also exists in req for 50 points, similar to the radiopack.**

Willing to make changes though I can see this PR backfiring and nerfing this backpack to oblivion instead :^) Hoping that doesn't happen.

## Changelog
:cl:
balance: Buffs the technician backpack. It can now carry one of all the deployables that you can fold by hand, except for the MG-27.
/:cl:
