### PR TITLE
Berry Bar Minor Buff

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -1491,7 +1491,7 @@
 	icon_state = "berrybar"
 	wrapper = /obj/item/trash/berrybar
 	list_reagents = list(
-		/datum/reagent/consumable/nutriment = 1,
+		/datum/reagent/consumable/nutriment = 2,
 		/datum/reagent/consumable/drink/berryjuice = 1,
 		/datum/reagent/medicine/tramadol = 10,
 		/datum/reagent/medicine/bicaridine = 10,


### PR DESCRIPTION

## About The Pull Request

Simply increases the berry bar's nutriment content from 1u to 2u.
## Why It's Good For The Game

After doing a lot of testing with the berry bars I found that they are out classed by many other food objects and healing items. They only provide 1u of nutriments. While they shouldn't be as strong as our regular food items I feel they should satisfy hunger much more than they do now. It took an entire pouch's worth of berry bars just to get from red hunger to green hunger. But with this buff it now only takes 3 bars to get to get the same results. While this wont make berry bars as good an an MRE pack or protein bar (given how it takes an entire pouch to not even match an MRE in nutri content or the speed of a protein bar) I feel this will make it more viable and less gimmicky to take the pouch or even put a bar in your helmet.
## Changelog
:cl:
balance: Changes the Berry Bar's nutriment content from 1u to 2u
/:cl:
