### PR TITLE
Alkysine now heals ear damage

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -616,6 +616,7 @@
 /datum/reagent/medicine/alkysine/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_LIGHT
 	L.adjustBrainLoss(-1.5*effect_str)
+	L.adjust_ear_damage(-2 * effect_str, -2 * effect_str)
 	return ..()
 
 /datum/reagent/medicine/alkysine/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request
Per title. The healing is 2 per tick.

## Why It's Good For The Game
Gives another rare niche to Alkysine, and also gives ungas a way to clear hearing damage commonly caused by explosions and the like. This is an incredibly minor change with minimal impact on balance anyway, at least in my opinion.

## Changelog
:cl: Lewdcifer
balance: Alkysine now slightly heals ear damage.
/:cl: