### PR TITLE
Gives the AR-21 10x26.5mm bullets (BR-64 bullets)

### DIFF
--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -422,8 +422,9 @@
 	desc = "A magazine filled with 10x25mm rifle rounds for the AR-21."
 	caliber = CALIBER_10X25_CASELESS
 	icon_state = "t21"
-	icon_state_mini = "mag_rifle"
-	default_ammo = /datum/ammo/bullet/rifle/heavy
+	caliber = CALIBER_10x265_CASELESS
+	w_class = WEIGHT_CLASS_NORMAL
+	default_ammo = /datum/ammo/bullet/rifle/standard_br
 	max_rounds = 30
 
 //ALF-51B


### PR DESCRIPTION

## About The Pull Request

changes AR-21 bullets to BR-64 bullets, this does 3 things:

Damage: 30 -> 32.5

AP: 10 -> 15

Allows AR-21 users to not need rely on rarely carried ammo packs for their bullets (no other guns that marines had used 10x25mm, just AR-21). this will allow for some other changes in the future

this doesnt touch RPM, sunder, ammo per mag, or anything else used 
## Why It's Good For The Game

AR-21 is a challenge gun, its fun to use as a challenge but like its worse than the other rifles in pretty much everyway and has 0 clearly defined niche. 

It has literally 2 stats that arent worse or equivalent than the BR-64 (accuracy and scatter). this slightly buffs its damage and buffs its AP pretty well, allowing it to fit more into its niche as a harder hitting rifle, since the AR-21's DPS was the lowest **by far** of the basic rifles to both unarmored and armored xenos.
## Changelog
:cl:
balance: rebalanced something
/:cl:
