### PR TITLE
baneling overwatch 2

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -165,4 +165,4 @@
 	X.death(FALSE)
 
 /datum/action/xeno_action/watch_xeno/baneling
-	use_state_flags = XACT_USE_LYING|XACT_USE_NOTTURF
+	use_state_flags = XACT_USE_LYING|XACT_USE_NOTTURF|XACT_USE_INCAP


### PR DESCRIPTION

## About The Pull Request

I did not properly test my previous PR and turns out you could only watch xenos if you suicide from ability. If you died from normal death you still couldnt watch other xenos.

## Why It's Good For The Game

fix

## Changelog
:cl:
fix: baneling now can overwatch xenos if died from normal death
/:cl:
