### PR TITLE
adds cameras to campaign ship maps

### DIFF
--- a/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
+++ b/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
@@ -30,6 +30,14 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/mainship/patrol_base/som)
+"aq" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
+/area/mainship/patrol_base/som/barracks)
 "as" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/warning_stripes/box/empty,
@@ -361,7 +369,7 @@
 /area/mainship/patrol_base/som)
 "eh" = (
 /obj/structure/window/reinforced/tinted/frosted,
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname/mainship/somship,
 /turf/open/floor/freezer,
 /area/mainship/patrol_base/som/barracks)
 "ei" = (
@@ -384,6 +392,14 @@
 	dir = 6
 	},
 /turf/open/shuttle/escapepod/plain,
+/area/mainship/patrol_base/som)
+"es" = (
+/obj/effect/landmark/campaign/mech_spawner/som/light,
+/obj/effect/turf_decal/warning_stripes/thick/autosmooth,
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "ev" = (
 /obj/structure/bed/chair/dropship/passenger,
@@ -586,6 +602,10 @@
 	},
 /turf/open/floor/mainship/office,
 /area/mainship/patrol_base/som/prep)
+"hi" = (
+/obj/machinery/camera/autoname/mainship/somship,
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som)
 "hk" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	dir = 2
@@ -634,6 +654,14 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/mainship/white,
 /area/mainship/patrol_base/som/hanger)
+"hD" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 8
+	},
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/patrol_base/som/barracks)
 "hI" = (
 /turf/open/floor/mainship_hull/gray,
 /area/mainship/patrol_base/som)
@@ -715,6 +743,13 @@
 	dir = 9
 	},
 /area/mainship/patrol_base/som)
+"iT" = (
+/obj/machinery/cic_maptable/som_maptable,
+/obj/machinery/camera/autoname/mainship/somship,
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
+/area/mainship/patrol_base/som/command)
 "iV" = (
 /turf/open/shuttle/dropship/seven,
 /area/mainship/patrol_base/som)
@@ -812,6 +847,13 @@
 	},
 /turf/open/floor/mainship_hull/gray,
 /area/mainship/patrol_base/som)
+"kH" = (
+/obj/machinery/quick_vendor/som,
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/patrol_base/som/prep)
 "kN" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/mainship,
@@ -990,6 +1032,12 @@
 /obj/structure/barricade/guardrail,
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base/som)
+"np" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som)
 "nt" = (
 /obj/effect/turf_decal/trimline/red/arrow_ccw{
 	dir = 1
@@ -1096,6 +1144,15 @@
 /obj/structure/prop/mainship/doorblocker/patrol_base/wide_right,
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
+"oy" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 8
+	},
+/turf/open/floor/mainship/office,
+/area/mainship/patrol_base/som/barracks)
 "oA" = (
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -1162,6 +1219,14 @@
 /obj/structure/benchpress,
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som/barracks)
+"pS" = (
+/obj/effect/landmark/campaign/mech_spawner/som,
+/obj/effect/turf_decal/warning_stripes/thick/autosmooth,
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som)
 "pT" = (
 /obj/structure/sink{
 	dir = 1
@@ -2100,6 +2165,12 @@
 	dir = 8
 	},
 /area/mainship/patrol_base/som)
+"zS" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/mainship/office,
+/area/mainship/patrol_base/som/barracks)
 "zU" = (
 /obj/structure/platform{
 	dir = 5
@@ -2127,6 +2198,12 @@
 "Ap" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/mainship/patrol_base/som)
+"As" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som/barracks)
 "At" = (
 /obj/structure/somcas/left{
 	dir = 4
@@ -2314,6 +2391,7 @@
 /obj/structure/sign/safety/high_radiation{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship/somship,
 /turf/open/floor/mainship/white{
 	dir = 1
 	},
@@ -2911,6 +2989,15 @@
 	},
 /turf/open/floor/mainship/white/full,
 /area/mainship/patrol_base/som)
+"Jk" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som)
 "Jl" = (
 /obj/structure/window/framed/prison/reinforced/nonshutter_hull,
 /obj/machinery/door/poddoor/campaign/som{
@@ -3217,6 +3304,13 @@
 	},
 /turf/open/floor/mainship/blue/full,
 /area/mainship/patrol_base/som/prep)
+"MZ" = (
+/obj/machinery/quick_vendor/som,
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/patrol_base/som/prep)
 "Nd" = (
 /obj/effect/landmark/start/job/som/staff_officer,
 /turf/open/floor/mainship/red/corner{
@@ -3225,6 +3319,7 @@
 /area/mainship/patrol_base/som)
 "Ne" = (
 /obj/structure/prop/mainship/sensor_computer3,
+/obj/machinery/camera/autoname/mainship/somship,
 /turf/open/floor/mainship/silver{
 	dir = 1
 	},
@@ -3285,6 +3380,14 @@
 	dir = 8
 	},
 /area/mainship/patrol_base/som)
+"NL" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
 "NR" = (
 /obj/machinery/telecomms/receiver/preset_right/som,
 /turf/open/floor/mainship,
@@ -3329,6 +3432,9 @@
 /turf/open/floor/mainship,
 /area/mainship/patrol_base/som)
 "Of" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 1
+	},
 /turf/open/floor/mainship/white,
 /area/mainship/patrol_base/som)
 "Oj" = (
@@ -3349,6 +3455,12 @@
 	dir = 1
 	},
 /turf/open/floor/mainship_hull,
+/area/mainship/patrol_base/som)
+"Ot" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "Ow" = (
 /obj/machinery/status_display,
@@ -3683,6 +3795,28 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/office,
 /area/mainship/patrol_base/som/barracks)
+"Sq" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/item/attachable/magnetic_harness,
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/mainship/patrol_base/som/prep)
 "Sr" = (
 /obj/structure/platform{
 	dir = 6
@@ -3910,10 +4044,22 @@
 	dir = 8
 	},
 /area/mainship/patrol_base/som/barracks)
+"VL" = (
+/obj/machinery/camera/autoname/mainship/somship{
+	dir = 8
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/patrol_base/som/hanger)
 "VN" = (
 /obj/structure/prop/mainship/prop_sominf,
 /turf/open/floor/mainship/office,
 /area/mainship/patrol_base/som/command)
+"VO" = (
+/obj/machinery/camera/autoname/mainship/somship,
+/turf/open/floor/mainship/red,
+/area/mainship/patrol_base/som)
 "VP" = (
 /obj/machinery/computer/camera_advanced/overwatch/main/som,
 /turf/open/floor/mainship/red{
@@ -8243,7 +8389,7 @@ tj
 NA
 NA
 NA
-NA
+VL
 tj
 NA
 NA
@@ -8252,7 +8398,7 @@ nt
 NA
 NA
 tj
-NA
+VL
 NA
 NA
 NA
@@ -9234,7 +9380,7 @@ Aw
 os
 Aw
 Aw
-Aw
+Ot
 Aw
 Aw
 wf
@@ -9470,7 +9616,7 @@ Aw
 Aw
 aL
 Aw
-uG
+Jk
 vz
 Aw
 Aw
@@ -9718,7 +9864,7 @@ Aw
 Aw
 BG
 nQ
-nQ
+kH
 Yt
 MJ
 cl
@@ -9737,7 +9883,7 @@ iC
 rE
 YS
 rE
-rE
+As
 YS
 rE
 iC
@@ -10187,7 +10333,7 @@ Uk
 Uk
 Uk
 RO
-vB
+iT
 Sy
 Sy
 Sy
@@ -10439,7 +10585,7 @@ Sy
 Va
 RO
 vz
-Aw
+hi
 Aw
 Aw
 xU
@@ -10720,7 +10866,7 @@ zO
 Vr
 Vr
 Vr
-Vr
+aq
 Vr
 zO
 Vr
@@ -10949,7 +11095,7 @@ vN
 vN
 vN
 vN
-vN
+zS
 xW
 xW
 WU
@@ -11049,7 +11195,7 @@ vz
 vz
 vz
 vz
-xU
+VO
 sL
 Dp
 xg
@@ -11058,7 +11204,7 @@ sB
 sB
 ve
 mt
-BG
+Sq
 nQ
 nQ
 nQ
@@ -11166,7 +11312,7 @@ YQ
 Aw
 Zb
 xl
-Zb
+es
 Zb
 xl
 Zb
@@ -11432,7 +11578,7 @@ dO
 CH
 hX
 uz
-Df
+oy
 vN
 vN
 vN
@@ -11690,7 +11836,7 @@ Jx
 Ah
 Jx
 Jx
-Jx
+hD
 Jx
 Ah
 Jx
@@ -12264,7 +12410,7 @@ YQ
 Aw
 zV
 GH
-zV
+pS
 zV
 GH
 zV
@@ -12391,7 +12537,7 @@ vz
 vz
 vz
 vz
-Aw
+hi
 Aw
 Aw
 Aw
@@ -12524,7 +12670,7 @@ Aw
 Aw
 BG
 nQ
-nQ
+MZ
 SZ
 qg
 Yl
@@ -12874,7 +13020,7 @@ vz
 QT
 zQ
 sB
-sB
+NL
 ZH
 Dj
 vz
@@ -13247,7 +13393,7 @@ vz
 cd
 vz
 vz
-Aw
+hi
 Aw
 Aw
 ie
@@ -14594,7 +14740,7 @@ Aw
 Aw
 Aw
 Aw
-Aw
+np
 vz
 Uk
 Uk

--- a/_maps/map_files/Iteron/Iteron.dmm
+++ b/_maps/map_files/Iteron/Iteron.dmm
@@ -35,6 +35,12 @@
 	},
 /turf/open/floor/prison/plate,
 /area/mainship/patrol_base)
+"aJ" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange,
+/area/mainship/patrol_base)
 "aL" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -346,6 +352,35 @@
 	dir = 5
 	},
 /area/mainship/patrol_base)
+"dY" = (
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/patrol_base/barracks)
 "ec" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -372,6 +407,15 @@
 "ev" = (
 /turf/closed/wall/mainship/outer/reinforced,
 /area/mainship/patrol_base/command)
+"ey" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/prison/plate,
+/area/mainship/patrol_base/hanger)
 "eA" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship/mono,
@@ -557,7 +601,7 @@
 /area/mainship/patrol_base)
 "hl" = (
 /obj/structure/window/reinforced/tinted/frosted,
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/freezer,
 /area/mainship/patrol_base)
 "hm" = (
@@ -590,6 +634,38 @@
 /turf/open/floor/mainship/red{
 	dir = 9
 	},
+/area/mainship/patrol_base/prep)
+"ia" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/patrol_base/prep)
 "if" = (
 /turf/open/floor/mainship/red{
@@ -653,6 +729,7 @@
 /area/mainship/patrol_base)
 "iG" = (
 /obj/structure/prop/mainship/sensor_computer3,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base)
 "iI" = (
@@ -733,6 +810,12 @@
 /obj/structure/droppod/leader,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)
+"jK" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/patrol_base)
 "jL" = (
 /obj/structure/drop_pod_launcher,
 /obj/structure/droppod/nonmob/turret_pod,
@@ -883,6 +966,37 @@
 	dir = 4
 	},
 /area/mainship/patrol_base)
+"lO" = (
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/patrol_base/barracks)
 "lX" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship/mono,
@@ -971,6 +1085,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/patrol_base/hanger)
+"nQ" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/blue,
+/area/mainship/patrol_base/command)
 "nZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -1074,6 +1195,9 @@
 /obj/effect/landmark/campaign/mech_spawner,
 /obj/effect/turf_decal/warning_stripes/box/empty,
 /obj/machinery/light,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/prison/plate,
 /area/mainship/patrol_base)
 "pk" = (
@@ -1138,6 +1262,13 @@
 	},
 /turf/open/floor/freezer,
 /area/mainship/patrol_base)
+"qg" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/mainship/patrol_base/command)
 "qk" = (
 /obj/machinery/quick_vendor,
 /obj/machinery/light{
@@ -1454,6 +1585,14 @@
 	dir = 6
 	},
 /area/mainship/patrol_base)
+"uA" = (
+/obj/structure/droppod,
+/obj/structure/drop_pod_launcher,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/prison/cleanmarked,
+/area/mainship/patrol_base/hanger)
 "uD" = (
 /obj/structure/platform{
 	dir = 8
@@ -1643,6 +1782,12 @@
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base/barracks)
+"xJ" = (
+/obj/structure/droppod,
+/obj/structure/drop_pod_launcher,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/prison/cleanmarked,
+/area/mainship/patrol_base/hanger)
 "xO" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/black{
@@ -1875,6 +2020,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/prison/plate,
 /area/mainship/patrol_base)
 "zD" = (
@@ -2069,6 +2215,12 @@
 	dir = 8
 	},
 /area/mainship/patrol_base/command)
+"Ct" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/patrol_base)
 "Cu" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -2870,6 +3022,42 @@
 /obj/item/stack/medical/heal_pack/advanced/bruise_pack,
 /turf/open/floor/prison/sterilewhite,
 /area/mainship/patrol_base)
+"Nb" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/patrol_base/prep)
+"Nd" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/blue,
+/area/mainship/patrol_base)
 "Nf" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/adv,
@@ -3049,6 +3237,15 @@
 	},
 /turf/open/floor/mainship/blue/full,
 /area/mainship/patrol_base)
+"OL" = (
+/obj/structure/bed/chair/nometal{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue/full,
+/area/mainship/patrol_base)
 "OP" = (
 /obj/structure/ship_ammo/cas/minirocket,
 /turf/open/floor/mainship/orange{
@@ -3161,6 +3358,9 @@
 /turf/open/floor/prison/plate,
 /area/mainship/patrol_base/hanger)
 "Rj" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
@@ -3189,6 +3389,15 @@
 	dir = 4
 	},
 /turf/open/floor/prison/plate,
+/area/mainship/patrol_base/hanger)
+"Ry" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black,
 /area/mainship/patrol_base/hanger)
 "RJ" = (
 /obj/structure/ship_ammo/cas/minirocket,
@@ -3377,6 +3586,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/patrol_base/command)
 "TQ" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/green{
 	dir = 5
 	},
@@ -3437,6 +3649,12 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/prison/bright_clean,
 /area/mainship/patrol_base/hanger)
+"UQ" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/patrol_base)
 "UR" = (
 /obj/effect/turf_decal/warning_stripes/box/arrow{
 	dir = 4
@@ -3805,6 +4023,15 @@
 	dir = 10
 	},
 /area/mainship/patrol_base)
+"ZA" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/prison/plate,
+/area/mainship/patrol_base/hanger)
 "ZD" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -19735,7 +19962,7 @@ ef
 ef
 ef
 kf
-hX
+qg
 gC
 pK
 xy
@@ -19745,7 +19972,7 @@ IP
 bg
 pK
 gC
-iE
+nQ
 ev
 ef
 ef
@@ -21677,7 +21904,7 @@ wa
 ev
 iJ
 Ff
-us
+Nd
 ev
 Mt
 vQ
@@ -23368,7 +23595,7 @@ kF
 kF
 sZ
 bu
-zS
+UQ
 fV
 Ff
 Jc
@@ -25791,7 +26018,7 @@ bu
 zS
 fV
 Ff
-Jc
+Ct
 bu
 bu
 bu
@@ -27483,9 +27710,9 @@ hN
 tH
 xt
 xt
-Dy
+lO
 Gc
-Dy
+dY
 xt
 xt
 Qh
@@ -29907,7 +30134,7 @@ kP
 GR
 kP
 kP
-yr
+ia
 hP
 hP
 hP
@@ -30143,7 +30370,7 @@ il
 hP
 hP
 hP
-yr
+Nb
 kP
 kP
 kP
@@ -36926,7 +37153,7 @@ Ff
 fV
 UR
 OJ
-OJ
+OL
 fV
 Un
 Un
@@ -37399,7 +37626,7 @@ ab
 aU
 ct
 aU
-aU
+ZA
 aU
 aU
 ct
@@ -37413,7 +37640,7 @@ aU
 Rd
 aU
 aU
-aU
+ZA
 aU
 Rd
 aU
@@ -41029,7 +41256,7 @@ ab
 bo
 da
 bo
-bo
+ey
 bo
 bo
 da
@@ -41043,7 +41270,7 @@ uf
 Rw
 bo
 bo
-bo
+ey
 bo
 Rw
 bo
@@ -41280,7 +41507,7 @@ Bl
 kM
 HQ
 kM
-Ln
+Ry
 ab
 ab
 ab
@@ -41995,7 +42222,7 @@ ef
 ef
 ef
 bu
-do
+jK
 fH
 jk
 fH
@@ -42255,7 +42482,7 @@ fH
 fH
 fH
 fH
-Zp
+aJ
 bu
 ef
 ef
@@ -43212,7 +43439,7 @@ nz
 nz
 nL
 ab
-zS
+UQ
 fV
 Fx
 fV
@@ -43930,7 +44157,7 @@ ef
 ef
 ef
 ab
-bJ
+xJ
 bJ
 bJ
 jy
@@ -43950,7 +44177,7 @@ UP
 jy
 bJ
 bJ
-bJ
+uA
 ab
 ef
 ef
@@ -45866,7 +46093,7 @@ ef
 ef
 ef
 ab
-bJ
+xJ
 bJ
 bJ
 jy
@@ -45878,7 +46105,7 @@ zS
 fV
 Fx
 fV
-Jc
+Ct
 ab
 ab
 TF
@@ -45886,7 +46113,7 @@ Vo
 jy
 bJ
 bJ
-bJ
+uA
 ab
 ef
 ef


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

So it turns out the way cameranets are setup means headset cameras are not actually picked up at all to begin with, until chunks are already generated AND the headset cam moves enough to update chunks.

This gets around that. Also nice for command to be able to look around their base I guess.
## Why It's Good For The Game
Funny cameracode
## Changelog
:cl:
fix: fixed a camera issue in campaign
/:cl:
