### PR TITLE
Jump and stun fix

### DIFF
--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -53,7 +53,7 @@
 		return
 	if(jumper.buckled)
 		return
-	if(jumper.incapacitated(TRUE))
+	if(jumper.incapacitated())
 		return
 
 	if(stamina_cost && (jumper.getStaminaLoss() > -stamina_cost))

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -51,7 +51,7 @@
 	SIGNAL_HANDLER
 	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
 		return
-	if(jumper.incapacitated())
+	if(jumper.incapacitated(TRUE))
 		return
 	if(jumper.buckled)
 		return

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -51,11 +51,9 @@
 	SIGNAL_HANDLER
 	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
 		return
-	if(jumper.incapacitated(TRUE))
-		return
 	if(jumper.buckled)
 		return
-	if(jumper.IsStun() || jumper.IsKnockdown() || jumper.IsParalyzed())
+	if(jumper.incapacitated(TRUE))
 		return
 
 	if(stamina_cost && (jumper.getStaminaLoss() > -stamina_cost))

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -49,10 +49,13 @@
 ///Performs the jump
 /datum/component/jump/proc/do_jump(mob/living/jumper)
 	SIGNAL_HANDLER
-	if(jumper.incapacitated(TRUE))
-		return
-
 	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
+		return
+	if(jumper.incapacitated())
+		return
+	if(jumper.buckled)
+		return
+	if(jumper.IsStun() || jumper.IsKnockdown() || jumper.IsParalyzed())
 		return
 
 	if(stamina_cost && (jumper.getStaminaLoss() > -stamina_cost))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -59,7 +59,7 @@
 	ADD_TRAIT(owner, TRAIT_FLOORED, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/incapacitating/knockdown/on_remove()
-	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	REMOVE_TRAIT(owner, TRAIT_FLOORED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -55,9 +55,11 @@
 	. = ..()
 	if(!.)
 		return
+	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	ADD_TRAIT(owner, TRAIT_FLOORED, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/incapacitating/knockdown/on_remove()
+	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	REMOVE_TRAIT(owner, TRAIT_FLOORED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
You can no longer jump while stunned or buckled.
Fixed being able to attack while stunned with a weapon strapped to your hand.

Crucially, you can still do both while simply lying down.

Fixes #14168
## Why It's Good For The Game
Stunned jump funny.
Stunned attack wew.
## Changelog
:cl:
fix: You can no longer jump while stunned or buckled
fix: You can no longer attack with a strapped weapon while stunned
/:cl:
