### PR TITLE
Sentry IFF fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -685,6 +685,11 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	hit_chance = min(hit_chance , hit_chance + 100 - proj.accuracy)
 	return prob(hit_chance)
 
+/obj/machinery/deployable/mounted/sentry/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(proj.iff_signal & iff_signal)
+		return FALSE
+	return ..()
+
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 


### PR DESCRIPTION

## About The Pull Request
Shooting sentries will now check its IFF flag.

Currently, all deployed guns (including sentries) only checked the IFF flag of the mob manning it, if any.
As far as I can tell, this is an oversight.
## Why It's Good For The Game
IFF working is good.
## Changelog
:cl:
fix: Sentry IFF flags are correctly checked when IFF projectile try to hit them
/:cl:
