### PR TITLE
Adds Library disk to Big Red, hardsets ETA disk.

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -4675,7 +4675,6 @@
 /area/bigredv2/outside/hydroponics)
 "aRs" = (
 /obj/machinery/light,
-/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
 "aRx" = (
@@ -8517,7 +8516,9 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "eIX" = (
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	force_for_sets = list("basic")
+	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "eKb" = (

--- a/_maps/modularmaps/big_red/bigredlibraryvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredlibraryvar1.dmm
@@ -27,12 +27,12 @@
 /area/bigredv2/outside/library)
 "e" = (
 /turf/open/floor/carpet/side{
-	dir = 1;
+	dir = 1
 	},
 /area/bigredv2/outside/library)
 "f" = (
 /turf/open/floor/carpet/side{
-	dir = 9;
+	dir = 9
 	},
 /area/bigredv2/outside/library)
 "g" = (
@@ -67,7 +67,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "l" = (
@@ -89,7 +89,7 @@
 "n" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet/side{
-	dir = 6;
+	dir = 6
 	},
 /area/bigredv2/outside/library)
 "o" = (
@@ -102,7 +102,7 @@
 /area/bigredv2/outside/library)
 "p" = (
 /turf/open/floor/carpet/side{
-	dir = 5;
+	dir = 5
 	},
 /area/bigredv2/outside/library)
 "q" = (
@@ -140,8 +140,11 @@
 	dir = 5
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
+/area/bigredv2/outside/library)
+"w" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "x" = (
 /obj/machinery/door_control{
@@ -169,7 +172,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "C" = (
@@ -182,8 +185,7 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "E" = (
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "F" = (
 /obj/structure/bookcase{
@@ -199,13 +201,13 @@
 "H" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "I" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet/side{
-	dir = 5;
+	dir = 5
 	},
 /area/bigredv2/outside/library)
 "J" = (
@@ -238,22 +240,21 @@
 /area/bigredv2/outside/library)
 "O" = (
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "P" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "Q" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "R" = (
 /obj/machinery/light,
@@ -300,7 +301,7 @@
 /area/bigredv2/outside/library)
 "Y" = (
 /turf/open/floor/carpet/side{
-	dir = 10;
+	dir = 10
 	},
 /area/bigredv2/outside/library)
 "Z" = (
@@ -331,7 +332,7 @@ a
 a
 A
 L
-A
+L
 t
 F
 L
@@ -351,7 +352,7 @@ Z
 a
 A
 L
-A
+L
 t
 A
 L
@@ -369,7 +370,7 @@ Z
 "}
 (4,1,1) = {"
 a
-A
+w
 L
 G
 d

--- a/_maps/modularmaps/big_red/bigredlibraryvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredlibraryvar2.dmm
@@ -216,7 +216,6 @@
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Library Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "Ey" = (
@@ -397,11 +396,7 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "ZP" = (
-/obj/structure/bookcase{
-	density = 0
-	},
-/obj/item/book/manual/robotics_cyborgs,
-/obj/item/book/manual/security_space_law,
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 
@@ -429,7 +424,7 @@ yy
 yy
 AY
 AJ
-ZP
+AJ
 EI
 OB
 AJ
@@ -449,7 +444,7 @@ QC
 yy
 eF
 AJ
-qr
+AJ
 EI
 PW
 AJ
@@ -467,7 +462,7 @@ QC
 "}
 (4,1,1) = {"
 yy
-Nh
+ZP
 AJ
 aA
 vg

--- a/_maps/modularmaps/big_red/bigredlibraryvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredlibraryvar3.dmm
@@ -2,7 +2,7 @@
 "ag" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "aV" = (
@@ -25,7 +25,7 @@
 /area/bigredv2/outside/library)
 "cM" = (
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "de" = (
@@ -57,13 +57,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/paper,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "eI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet/side{
-	dir = 5;
+	dir = 5
 	},
 /area/bigredv2/outside/library)
 "eV" = (
@@ -105,7 +105,7 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/side{
-	dir = 5;
+	dir = 5
 	},
 /area/bigredv2/outside/library)
 "ke" = (
@@ -145,7 +145,7 @@
 /area/bigredv2/outside/library)
 "nb" = (
 /turf/open/floor/carpet/side{
-	dir = 1;
+	dir = 1
 	},
 /area/bigredv2/outside/library)
 "nr" = (
@@ -157,7 +157,7 @@
 /area/bigredv2/outside/library)
 "nL" = (
 /turf/open/floor/carpet/side{
-	dir = 9;
+	dir = 9
 	},
 /area/bigredv2/outside/library)
 "qw" = (
@@ -199,13 +199,13 @@
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "up" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet/side{
-	dir = 6;
+	dir = 6
 	},
 /area/bigredv2/outside/library)
 "uy" = (
@@ -226,8 +226,7 @@
 /area/bigredv2/outside/library)
 "ve" = (
 /obj/effect/spawner/random/misc/trash,
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "vN" = (
 /obj/machinery/light{
@@ -249,6 +248,10 @@
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/food/drinks/bottle/absinthe,
+/turf/open/floor/wood,
+/area/bigredv2/outside/library)
+"wI" = (
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "xB" = (
@@ -286,13 +289,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "CH" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "CM" = (
@@ -300,8 +303,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "Ey" = (
 /turf/open/floor/wood,
@@ -334,13 +336,13 @@
 	pixel_y = 4
 	},
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "Gj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "HS" = (
@@ -356,7 +358,7 @@
 /obj/item/toy/dice/d20,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "Kh" = (
@@ -365,12 +367,11 @@
 /area/bigredv2/outside/library)
 "Mt" = (
 /turf/open/floor/carpet/side{
-	dir = 10;
+	dir = 10
 	},
 /area/bigredv2/outside/library)
 "MR" = (
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "Nb" = (
 /obj/structure/table/woodentable,
@@ -387,7 +388,7 @@
 "PL" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/side{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/library)
 "Qv" = (
@@ -430,7 +431,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet/side{
-	dir = 4;
+	dir = 4
 	},
 /area/bigredv2/outside/library)
 "Tc" = (
@@ -440,7 +441,7 @@
 "Tr" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/side{
-	dir = 1;
+	dir = 1
 	},
 /area/bigredv2/outside/library)
 "Tw" = (
@@ -479,8 +480,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
-/turf/open/floor/carpet/side{
-	},
+/turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "WZ" = (
 /obj/structure/bed/chair/wood/normal{
@@ -543,7 +543,7 @@ jK
 jK
 uy
 Ey
-uy
+Ey
 qw
 nr
 Ey
@@ -563,7 +563,7 @@ VX
 jK
 uy
 Ey
-uy
+Ey
 AA
 uy
 St
@@ -581,7 +581,7 @@ VX
 "}
 (4,1,1) = {"
 jK
-uy
+wI
 HS
 NF
 Qv


### PR DESCRIPTION
## About The Pull Request
There is a now a chance for a disk to spawn in Library on BR. However, there will **_always_** be a disk in ETA now.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/ad56b1d8-685b-4273-9ba9-4172cb31c381)
Also removes one crash spot since it would krill library disk
## Why It's Good For The Game
People like variety and I figure it is worth testing out. The old marshalls disk had the issue of being way close to FOB leading to FOB camping, this might have the issue of being too far out the way if there isn't an admin disk. An alternative would to also hardset Admin disk, and have engi/library disk swap, but needs testing first.
## Changelog
:cl:
add: Big Red now has a library disk
balance: Big Red ETA disk is now guaranteed. 
/:cl:
