### PR TITLE
Buffs CAS export percentage point gain from 5% to 10%.

### DIFF
--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -5,7 +5,7 @@
 		return FALSE
 
 	SSpoints.supply_points[faction_selling] += points
-	SSpoints.dropship_points += points * 0.08
+	SSpoints.dropship_points += points * 0.1
 	return new /datum/export_report(points, name, faction_selling)
 
 /mob/living/carbon/human/supply_export(faction_selling)

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -5,7 +5,7 @@
 		return FALSE
 
 	SSpoints.supply_points[faction_selling] += points
-	SSpoints.dropship_points += points * 0.05
+	SSpoints.dropship_points += points * 0.08
 	return new /datum/export_report(points, name, faction_selling)
 
 /mob/living/carbon/human/supply_export(faction_selling)


### PR DESCRIPTION

## About The Pull Request

As in title.

## Why It's Good For The Game

In my original PR, many of the cost adjustments were made with the idea that marines would be generating roughly 2000 points per 10 minutes, or an average of 200 points a minute, as well as holding 2.5 miners at a time. In practice, it seems this was an overestimation, and marines generate less than this total. This means that the alterations made to the prices of several items, originally only intended to cause items per minute to stay the same (while rewarding exceptional marines and punishing ones not selling bodies) instead just nerfed CAS economy across the board. By bumping it to 10% (in parity with the miner percentage) CAS should ideally have roughly the same effective generation as before after exports are factored in.

## Changelog
:cl:
balance: The dropship fabricator now recieves 10% of the value of exports, rather than 5%.
/:cl:
