### PR TITLE
You can no longer hack the shipside Nanotrasen MedPlus

### DIFF
--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -12,17 +12,22 @@
 	var/use_power = IDLE_POWER_USE
 	var/idle_power_usage = 0
 	var/active_power_usage = 0
-	var/machine_current_charge = 0 //Does it have an integrated, unremovable capacitor? Normally 10k if so.
+	///Does it have an integrated, unremovable capacitor? Normally 10k if so.
+	var/machine_current_charge = 0
 	var/machine_max_charge = 0
 	var/power_channel = EQUIP
-	var/list/component_parts //list of all the parts used to build it, if made from certain kinds of frames.
+	///list of all the parts used to build it, if made from certain kinds of frames.
+	var/list/component_parts
 
 	var/wrenchable = FALSE
-	var/obj/item/circuitboard/circuit // Circuit to be created and inserted when the machinery is created
+	///Circuit to be created and inserted when the machinery is created
+	var/obj/item/circuitboard/circuit
 	var/mob/living/carbon/human/operator
 
 	///Whether bullets can bypass the object even though it's dense
 	allow_pass_flags = PASSABLE
+	///Wether you can open the panel of a machine with a screwdriver or not
+	var/panel_openable = TRUE
 
 /obj/machinery/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -345,6 +345,9 @@
 		to_chat(user, "Tip it back upright first!")
 
 	else if(isscrewdriver(I))
+		if(!panel_openable)
+			user.balloon_alert(user, "Can't open panel")
+			return
 		TOGGLE_BITFIELD(machine_stat, PANEL_OPEN)
 		to_chat(user, "You [CHECK_BITFIELD(machine_stat, PANEL_OPEN) ? "open" : "close"] the maintenance panel.")
 		overlays.Cut()

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -228,6 +228,7 @@
 /obj/machinery/vending/medical/shipside
 	isshared = TRUE
 	wrenchable = FALSE
+	panel_openable = FALSE
 
 /obj/machinery/vending/medical/valhalla
 	use_power = NO_POWER_USE


### PR DESCRIPTION

## About The Pull Request
Makes the panel of the Medplus unremovable with a screwdriver.
## Why It's Good For The Game
In order to disincentivize breaking into pharmacy/corpsman prep for pill bottles, this removes the ability to hack the vendor.
In order to get pill bottles, you will have to ask the doctor manning the pharmacy desk and wait in line instead of smashing the window and jumping through.
## Changelog
:cl:
balance: You can no longer hack the shipside Medplus
/:cl:
