### PR TITLE
remove shield from crash vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -297,7 +297,6 @@
 			/obj/item/weapon/twohanded/spear/tactical/harvester = -1,
 			/obj/item/weapon/twohanded/glaive/harvester = -1,
 			/obj/item/weapon/powerfist = -1,
-			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/weapon/shield/riot/marine/deployable = 6,
 			/obj/item/weapon/combat_knife/harvester = 12,
 		),


### PR DESCRIPTION
## About The Pull Request

Removes the riot shield from crash marine vendors.

## Why It's Good For The Game

Marines are nearly immortal on crash if they use shields, vali, RR, and jetpacks which isnt the greatest for balance.

https://streamable.com/ieuzg5
https://streamable.com/a654xy
^ this shouldn't be happening.

## Changelog

Just removes shields from crash.

:cl:
del: Removed Shields from crash.
:cl:
