### PR TITLE
CL no longer gives shock

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -57,12 +57,11 @@
 		traumatic_shock = 0
 		return
 
-	traumatic_shock = 			\
-	0.75	* getOxyLoss() + 		\
-	0.75	* getToxLoss() + 		\
-	1.20	* getFireLoss() + 		\
-	1		* getBruteLoss() + 		\
-	1		* getCloneLoss()
+	traumatic_shock = \
+	0.75 * getOxyLoss() + \
+	0.75 * getToxLoss() + \
+	1.20 * getFireLoss() + \
+	1 * getBruteLoss()
 
 	traumatic_shock += reagent_shock_modifier
 


### PR DESCRIPTION

## About The Pull Request
Removes Cloneloss from giving shock.
## Why It's Good For The Game
Reducing your max HP by a certain amount is already enough punishment. I don't think further punishing by giving you shock as well is needed.
## Changelog
:cl:
balance: Cloneloss no longer gives shock
/:cl:
