### PR TITLE
C4 timer increased for campaign objectives

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -92,6 +92,7 @@
 		else
 			forceMove(location)
 		armed = TRUE
+		timer = target.plastique_time_mod(timer)
 
 		log_combat(user, target, "attached [src] to")
 		message_admins("[ADMIN_TPMONTY(user)] planted [src] on [target] at [ADMIN_VERBOSEJMP(target.loc)] with [timer] second fuse.")
@@ -227,3 +228,7 @@
 	if(old_flame)
 		qdel(old_flame)
 	new /obj/flamer_fire/autospread(turf_to_burn, 17, 31, flame_color, 0, 0, spread_directions)
+
+///Allows the c4 timer to be tweaked on certain atoms as required
+/atom/proc/plastique_time_mod(time)
+	return time

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -13,6 +13,9 @@
 /obj/structure/campaign_objective/destruction_objective/plastique_act()
 	qdel(src)
 
+/obj/structure/campaign_objective/destruction_objective/plastique_time_mod(time)
+	return max(time, 30)
+
 //Howitzer
 /obj/effect/landmark/campaign_structure/howitzer_objective
 	name = "howitzer objective"


### PR DESCRIPTION

## About The Pull Request
C4 now as a minimum 30 second timer on campaign destruction objectives (you can still set it longer if you wanted to for whatever reason...)
## Why It's Good For The Game
Less cheese opportunity, gives more time for counter ~strike~ play.
## Changelog
:cl:
balance: C4 now takes 30 seconds at minimum to detonate on campaign objectives
/:cl:
