### PR TITLE
Fixed an invisible sprite

### DIFF
--- a/code/game/objects/structures/campaign_structures/deploy_blockers.dm
+++ b/code/game/objects/structures/campaign_structures/deploy_blockers.dm
@@ -52,6 +52,5 @@
 /obj/structure/campaign_deployblocker/drop_blocker
 	name = "DROPBLOCKER"
 	desc = "THIS PROBABLY BLOCKS DROPPODS OR SOMETHING, PAY A SPRITER FOR A NONPLACEHOLDER"
-	icon_state = "drop_block"
 	flags_to_remove = MISSION_DISALLOW_DROPPODS
 	faction = FACTION_SOM


### PR DESCRIPTION

## About The Pull Request
Drop pod blocker in campaign had an invisible sprite. This one is technically still a placeholder, but eh.
## Why It's Good For The Game
Invisible object bad.
## Changelog
:cl:
fix: Drop pod blocker objects in Campaign are no longer invisible
/:cl:
