### PR TITLE
Removes the stalemate system

### DIFF
--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -77,20 +77,6 @@ SUBSYSTEM_DEF(monitor)
 			SSspawning.spawnerdata[spawner].required_increment = max(45 SECONDS, 3 MINUTES - SSmonitor.maximum_connected_players_count * SPAWN_RATE_PER_PLAYER) / SSspawning.wait
 			SSspawning.spawnerdata[spawner].max_allowed_mobs = max(2, MAX_SPAWNABLE_MOB_PER_PLAYER * SSmonitor.maximum_connected_players_count)
 
-
-	//Automatic respawn buff, if a stalemate is detected and a lot of ghosts are waiting to play
-	if(current_state != STATE_BALANCED || !stalemate || length(GLOB.observer_list) <= 0.5 * total_living_players)
-		SSsilo.larva_spawn_rate_temporary_buff = 0
-		return
-	for(var/mob/dead/observer/observer AS in GLOB.observer_list)
-		GLOB.key_to_time_of_role_death[observer.key] -= 5 MINUTES //If we are in a constant stalemate, every 5 minutes we remove 5 minutes of respawn time to become a marine
-	message_admins("Stalemate detected, respawn buff system in action : 5 minutes were removed from the respawn time of everyone, xeno won : [length(GLOB.observer_list) * 0.75 * 5] larvas")
-	log_game("5 minutes were removed from the respawn time of everyone, xeno won : [length(GLOB.observer_list) * 0.75 * 5] larvas")
-	//This will be in effect for 5 SSsilo runs. For 30 ghosts that makes 1 new larva every 2.5 minutes
-	SSsilo.larva_spawn_rate_temporary_buff = length(GLOB.observer_list) * 0.75
-
-
-
 /datum/controller/subsystem/monitor/proc/set_groundside_calculation()
 	SIGNAL_HANDLER
 	gamestate = GROUNDSIDE

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -6,8 +6,6 @@ SUBSYSTEM_DEF(silo)
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
-	///A temporary buff for larva generation, that comes from the monitor system detecting a stalemate
-	var/larva_spawn_rate_temporary_buff = 0
 
 /datum/controller/subsystem/silo/Initialize()
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), PROC_REF(start_spawning))
@@ -28,8 +26,6 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
 	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
-
-	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
 


### PR DESCRIPTION

## About The Pull Request
Removes the stalemate system that procs rarely to decrease respawn timer by 5 and give xenos a larva buff
## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/c8d8453f-04fa-4dc3-98a2-ba7aba5dd431)
I don't think it has ever worked, and the game handles "stalemates" better than what the system can do, in req and psy points. How the game determines a stalemate is dubious as well
## Changelog
:cl:
del: Removed stalemate system
/:cl:
