### PR TITLE
Adds syringe case to NTMED

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -57,6 +57,9 @@
 		var/image/lid = image(icon, src, "lid_bottle")
 		overlays += lid
 
+/obj/item/reagent_containers/glass/bottle/empty //Because the parent has RNG icon_state
+	icon_state = "bottle-1" //Same one when you make a bottle in the chem master
+
 /obj/item/reagent_containers/glass/bottle/inaprovaline
 	name = "\improper Inaprovaline bottle"
 	desc = "A small bottle. Contains inaprovaline - used to stabilize patients."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -158,6 +158,12 @@
 		/obj/item/reagent_containers/syringe,
 	)
 
+/obj/item/storage/syringe_case/empty/Initialize(mapload, ...)
+	. = ..()
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/glass/bottle/empty(src)
+	new /obj/item/reagent_containers/glass/bottle/empty(src)
+
 /obj/item/storage/syringe_case/regular
 	name = "basic syringe case"
 	desc = "It's a medical case for storing syringes and bottles. This one contains basic meds."

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -201,6 +201,7 @@
 		),
 		"Chemistry Equipment" = list(
 			/obj/item/reagent_containers/syringe = -1,
+			/obj/item/storage/syringe_case/empty = -1,
 			/obj/item/reagent_containers/glass/beaker = -1,
 			/obj/item/reagent_containers/glass/beaker/large = -1,
 			/obj/item/reagent_containers/glass/beaker/vial = -1,


### PR DESCRIPTION

## About The Pull Request
Adds Syringe cases to the "Chemistry Equipment" Section of the NT Med.
## Why It's Good For The Game
These can hold at most 180u if you fill it with 3 bottles, which is still a lower capacity than a pill bottle.
On top of that, you can't directly drink liquid out of a bottle, so you need to either keep the syringe it comes with, or carry an autoinjector that you can refill.
## Changelog
:cl:
add: Syringe cases in the NT Medplus
/:cl:
