### PR TITLE
mission end wrap up fix

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -260,6 +260,7 @@
 ///Mission end wrap up
 /datum/campaign_mission/proc/end_mission()
 	SHOULD_CALL_PARENT(TRUE)
+	unregister_mission_signals()
 	QDEL_LIST(GLOB.campaign_objectives)
 	QDEL_LIST(GLOB.campaign_structures)
 	QDEL_LIST(GLOB.patrol_point_list) //purge all existing links, cutting off the current ground map. Start point links are auto severed, and will reconnect to new points when a new map is loaded and upon use.
@@ -267,7 +268,6 @@
 	mission_state = MISSION_STATE_FINISHED
 	apply_outcome()
 	play_outro()
-	unregister_mission_signals()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
 	for(var/i in GLOB.quick_loadouts)
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]


### PR DESCRIPTION

## About The Pull Request
Minor fix to mission ends.
Signal unregistering was happening after key objects were getting cleaned up, meaning extra map text messages were being spammed saying any remaining objectives had been destroyed etc.

No gameplay change.
## Why It's Good For The Game
Random messages bad
## Changelog
:cl:
fix: Fixed campaign missions ending causing unintended notifications in some instances
/:cl:
