### PR TITLE
Reduces engineer point cost for st580 point defense sentry

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/explosive/plastique = list(CAT_ENGSUP, "Plastique explosive", 2, "black"),
 		/obj/item/explosive/plastique/genghis_charge = list(CAT_ENGSUP, "EX-62 Genghis incendiary charge", 15, "black"),
 		/obj/item/detpack = list(CAT_ENGSUP, "Detonation pack", 5, "black"),
-		/obj/item/storage/box/crate/minisentry = list(CAT_ENGSUP, "ST-580 point defense sentry kit", 50, "black"),
+		/obj/item/storage/box/crate/minisentry = list(CAT_ENGSUP, "ST-580 point defense sentry kit", 40, "black"),
 		/obj/structure/closet/crate/uav_crate = list(CAT_ENGSUP, "Iguana Unmanned Vehicle", 50, "black"),
 		/obj/item/attachable/buildasentry = list(CAT_ENGSUP, "Build-A-Sentry Attachment", 30, "black"),
 		/obj/item/binoculars/tactical/range = list(CAT_ENGSUP, "Range Finder", 10, "black"),


### PR DESCRIPTION

## About The Pull Request

Reduces the cost of the ST580 point defense sentry in engineer vendor from 50->40
## Why It's Good For The Game

This is currently a weak option in terms of req value (relative to mats and pcs).

Setting this value at 40 will still restrict engineers to 1 turret while allowing them to take some more mats and QOL items.

Should make this a more viable choice.
## Changelog
:cl:
balance: reduced engineer vendor cost for point defense sentry from 50->40
/:cl:
