### PR TITLE
Fixes plasma pistol not losing attachment trait on detach.

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -135,11 +135,11 @@
 	return FALSE
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_attach(obj/item/attached_to, mob/user)
-	flags_gun_features |= GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features |= (GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY)
 	return ..()
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_detach(obj/item/attached_to, mob/user)
-	flags_gun_features &= ~GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features &= ~(GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY)
 	return ..()
 
 /obj/item/weapon/gun/pistol/plasma_pistol/guardsman_pistol


### PR DESCRIPTION

## About The Pull Request
It was deleting just `GUN_WIELDED_STABLE_FIRING_ONLY` and forgot about `GUN_WIELDED_FIRING_ONLY`
Because of which you couldn't fire from one hand after detach.

There is also a bug that you can't shoot from it after detach without dropping and picking it up, but I have no idea why it happens.
## Why It's Good For The Game
Less bugs.
## Changelog
:cl:
fix: fixed plasma pistol not shooting from one hand after detaching it as attachment from somewhere.
/:cl:
