### PR TITLE
Updates Earth Riser Desc

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -593,7 +593,7 @@
 	name = "Earth Riser"
 	ability_name = "Earth Riser"
 	action_icon_state = "earth_riser"
-	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it interacts with other abilities for offensive usage. Alternate use destroys active pillars, starting with the oldest one."
+	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it interacts with other abilities for offensive usage. The pillar can be launched by click-dragging it in a direction. Alternate use destroys active pillars, starting with the oldest one."
 	plasma_cost = 30
 	cooldown_timer = 15 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION

## About The Pull Request
Updates the description of Earth Riser to mention that the pillars can be launched by click-dragging them in a direction.
## Why It's Good For The Game
Apparently you can do this, and there is no info in-game about this being the case. This will help inform players about this ability, especially useful considering this is a relatively new caste.
## Changelog
:cl:
spellcheck: Changed the description of Behemoth's Earth Riser to mention the click-drag launching function.
/:cl:
