### PR TITLE
Micro v34 adjustment

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1403,6 +1403,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	accuracy_mod = 0.2
 	recoil_mod = -2
 	scatter_mod = -8
+	aim_speed_mod = 0.05
 
 /obj/item/attachable/foldable/icc_machinepistol
 	name = "\improper PL-38 machinepistol stock"


### PR DESCRIPTION

## About The Pull Request
V34 stock now increases wielded slowdown by 0.05.
Super tiny change, but the gun is just slightly too quick to run with. Added to the stock instead of the gun so there's (a very small) extra point of difference for why you might want to not use the stock. It's still probably a bad idea though.
## Why It's Good For The Game
Brrt gun very slightly slower
## Changelog
:cl:
balance: V-34 stock now increases slowdown by 0.05
/:cl:
