### PR TITLE
Various minor Behemoth tweaks (and a fix)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -421,7 +421,6 @@
 	if(LinkBlocked(owner_turf, direct_turf))
 		playsound(direct_turf, 'sound/effects/behemoth/behemoth_stomp.ogg', 40, TRUE)
 		xeno_owner.do_attack_animation(direct_turf)
-		shake_camera(xeno_owner, 1, 0.5)
 		addtimer(CALLBACK(src, PROC_REF(end_charge)), LANDSLIDE_ENDING_COLLISION_DELAY)
 		return
 	which_step = !which_step
@@ -454,7 +453,6 @@
 		if(LinkBlocked(owner_turf, direct_turf))
 			playsound(direct_turf, 'sound/effects/behemoth/behemoth_stomp.ogg', 40, TRUE)
 			xeno_owner.do_attack_animation(direct_turf)
-			shake_camera(xeno_owner, 1, 0.5)
 		new /obj/effect/temp_visual/behemoth/crack/landslide(get_turf(owner), direction, pick(1, 2))
 		end_charge()
 		return
@@ -523,7 +521,7 @@
 		new /obj/effect/temp_visual/behemoth/landslide/hit(get_turf(living_target))
 		playsound(living_target, 'sound/effects/behemoth/landslide_hit_mob.ogg', 30, TRUE)
 	living_target.emote("scream")
-	shake_camera(living_target, LANDSLIDE_KNOCKDOWN_DURATION, 0.8)
+	shake_camera(living_target, 1, 0.8)
 	living_target.apply_damage(damage, BRUTE, blocked = MELEE)
 
 /**
@@ -858,7 +856,7 @@
 				if(xeno_owner.issamexenohive(affected_living) || affected_living.stat == DEAD || CHECK_BITFIELD(affected_living.status_flags, INCORPOREAL|GODMODE))
 					continue
 				affected_living.emote("scream")
-				shake_camera(affected_living, SEISMIC_FRACTURE_PARALYZE_DURATION, 0.8)
+				shake_camera(affected_living, 1, 0.8)
 				affected_living.Paralyze(SEISMIC_FRACTURE_PARALYZE_DURATION)
 				affected_living.apply_damage(damage, BRUTE, blocked = MELEE)
 				if(instant)
@@ -1061,7 +1059,6 @@
 	for(var/mob/living/affected_living in cheap_get_humans_near(owner, PRIMAL_WRATH_RANGE) + owner)
 		if(!affected_living.hud_used)
 			continue
-		shake_camera(affected_living, 1, 0.1)
 		var/atom/movable/screen/plane_master/floor/floor_plane = affected_living.hud_used.plane_masters["[FLOOR_PLANE]"]
 		var/atom/movable/screen/plane_master/game_world/world_plane = affected_living.hud_used.plane_masters["[GAME_PLANE]"]
 		if(floor_plane.get_filter("primal_wrath") || world_plane.get_filter("primal_wrath"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -90,7 +90,6 @@
 		for(var/mob/living/target_living in target_turf)
 			if(xeno_owner.issamexenohive(target_living) || target_living.stat == DEAD || CHECK_BITFIELD(target_living.status_flags, INCORPOREAL|GODMODE))
 				continue
-			shake_camera(target_living, max(1, duration), 0.5)
 
 
 // ***************************************
@@ -532,7 +531,7 @@
  * * object_target: The targeted object.
 */
 /datum/action/xeno_action/activable/landslide/proc/hit_object(obj/object_target)
-	if(!object_target)
+	if(!object_target || istype(object_target, /obj/structure/mineral_door/resin))
 		return
 	var/object_turf = get_turf(object_target)
 	if(istype(object_target, /obj/machinery/vending))
@@ -593,7 +592,7 @@
 	name = "Earth Riser"
 	ability_name = "Earth Riser"
 	action_icon_state = "earth_riser"
-	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it interacts with other abilities for offensive usage. Alternate use destroys active pillars, starting with the oldest one."
+	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it reacts with your other abilities. Clickdrag the rock anywhere to throw it. Alternate use destroys active pillars, starting with the oldest one."
 	plasma_cost = 30
 	cooldown_timer = 15 SECONDS
 	keybinding_signals = list(
@@ -671,7 +670,6 @@
 	for(var/mob/living/affected_living in target_turf)
 		if(xeno_owner.issamexenohive(affected_living) || affected_living.stat == DEAD)
 			continue
-		shake_camera(affected_living, 1, 0.5)
 		step_away(affected_living, target_turf, 1, 2)
 	active_pillars += new /obj/structure/earth_pillar(target_turf, xeno_owner)
 	update_button_icon()
@@ -1056,7 +1054,7 @@
 	if(!currently_roaring)
 		return
 	new /obj/effect/temp_visual/shockwave/primal_wrath(get_turf(owner), 4, owner.dir)
-	for(var/mob/living/affected_living in cheap_get_humans_near(owner, PRIMAL_WRATH_RANGE) + cheap_get_xenos_near(owner, PRIMAL_WRATH_RANGE))
+	for(var/mob/living/affected_living in cheap_get_humans_near(owner, PRIMAL_WRATH_RANGE) + owner)
 		if(!affected_living.hud_used)
 			continue
 		shake_camera(affected_living, 1, 0.1)
@@ -1064,7 +1062,7 @@
 		var/atom/movable/screen/plane_master/game_world/world_plane = affected_living.hud_used.plane_masters["[GAME_PLANE]"]
 		if(floor_plane.get_filter("primal_wrath") || world_plane.get_filter("primal_wrath"))
 			continue
-		var/filter_size = 0.02
+		var/filter_size = 0.01
 		world_plane.add_filter("primal_wrath", 2, radial_blur_filter(filter_size))
 		animate(world_plane.get_filter("primal_wrath"), size = filter_size * 2, time = 0.5 SECONDS, loop = -1)
 		floor_plane.add_filter("primal_wrath", 2, radial_blur_filter(filter_size))

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -531,7 +531,7 @@
  * * object_target: The targeted object.
 */
 /datum/action/xeno_action/activable/landslide/proc/hit_object(obj/object_target)
-	if(!object_target || istype(object_target, /obj/structure/mineral_door/resin))
+	if(!object_target)
 		return
 	var/object_turf = get_turf(object_target)
 	if(istype(object_target, /obj/machinery/vending))
@@ -543,6 +543,10 @@
 	if(istype(object_target, /obj/structure/reagent_dispensers/fueltank))
 		var/obj/structure/reagent_dispensers/fueltank/tank_target = object_target
 		tank_target.explode()
+		return
+	if(istype(object_target, /obj/structure/mineral_door/resin))
+		var/obj/structure/mineral_door/resin/resin_door = object_target
+		resin_door.toggle_state()
 		return
 	if(object_target.obj_integrity <= LANDSLIDE_OBJECT_INTEGRITY_THRESHOLD || istype(object_target, /obj/structure/closet))
 		playsound(object_turf, 'sound/effects/meteorimpact.ogg', 30, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -402,7 +402,8 @@
 				if(affected_living.stat == DEAD)
 					continue
 				if(xeno_owner.issamexenohive(affected_living) && !affected_living.lying_angle)
-					step_away(affected_living, xeno_owner, 2, 1)
+					if(affected_living in direct_turf)
+						step_away(affected_living, xeno_owner, 2, 1)
 					continue
 				hit_living(affected_living, damage)
 			if(isobj(affected_atom))

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -595,7 +595,7 @@
 	name = "Earth Riser"
 	ability_name = "Earth Riser"
 	action_icon_state = "earth_riser"
-	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it reacts with your other abilities. Clickdrag the rock anywhere to throw it. Alternate use destroys active pillars, starting with the oldest one."
+	desc = "Raise a pillar of earth at the selected location. This solid structure can be used for defense, and it interacts with other abilities for offensive usage. Alternate use destroys active pillars, starting with the oldest one."
 	plasma_cost = 30
 	cooldown_timer = 15 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION
## About The Pull Request
- Removes all screenshaking from Behemoth's ability warnings, and from abilities in most cases.
- Fixed a bug where Landslide would displace adjacent allies. This is only meant to happen if said ally is directly in front of you.
- Fixed a bug where Landslide could destroy resin doors. Instead, resin doors will now open, letting the charge continue normally.
- Reduced Primal Wrath's screen distortion a little. Additionally, this effect no longer applies to allied xenos besides yourself.

## Why It's Good For The Game
Bug fixes good, clarity always appreciated, and screen changes too wack in excess.

## Changelog
:cl: Lewdcifer
del: Behemoth's ability warnings no longer cause screen shaking.
del: Behemoth's abilities have lost screen shaking in various cases.
qol: Reduced Primal Wrath's screen distortion a little. Additionally, this effect no longer applies to allied xenos besides yourself.
fix: Behemoth's Landslide no longer displaces adjacent allies, only those directly in front of you.
fix: Behemoth's Landslide no longer destroys resin doors. Instead, they will open and let you proceed.
/:cl: