### PR TITLE
Nerfs Behemoth's health, nerfs Primal Wrath gain

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -932,7 +932,7 @@
 #define PRIMAL_WRATH_SPEED_BONUS -0.3
 #define PRIMAL_WRATH_DECAY_MULTIPLIER 1.2
 #define PRIMAL_WRATH_ACTIVE_DECAY_DIVISION 40
-#define PRIMAL_WRATH_GAIN_MULTIPLIER 0.5
+#define PRIMAL_WRATH_GAIN_MULTIPLIER 0.3
 
 /particles/primal_wrath
 	icon = 'icons/effects/particles/generic_particles.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
@@ -5,8 +5,8 @@
 	icon = 'icons/Xeno/castes/behemoth.dmi'
 	icon_state = "Behemoth Walking"
 	bubble_icon = "alienleft"
-	health = 800
-	maxHealth = 800
+	health = 750
+	maxHealth = 750
 	plasma_stored = 200
 	tier = XENO_TIER_THREE
 	upgrade = XENO_UPGRADE_NORMAL

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -59,7 +59,7 @@
 	upgrade = XENO_UPGRADE_PRIMO
 
 	// *** Wrath *** //
-	wrath_max = 800
+	wrath_max = 750
 
 	// *** Abilities *** ///
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -20,7 +20,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 800
+	max_health = 750
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD


### PR DESCRIPTION
## About The Pull Request
- Reduces Behemoth's maximum health from 800 to 750.
- Reduces Behemoth's Wrath gain from 50% of damage received to 30%.
- Reduces the maximum amount of Wrath that can be attained from 800 to 750.

## Why It's Good For The Game
Behemoth was a tad bit too tanky, and Primal Wrath was being used much too often.

## Changelog
:cl: Lewdcifer
balance: Behemoth's maximum health reduced from 800 to 750.
balance: Behemoth's Wrath gain reduced from 50% of damage received to 30%.
/:cl: