### PR TITLE
Deletes stacking pipes on Pillar of Spring.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3172,9 +3172,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "dUt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
@@ -6988,7 +6985,6 @@
 /area/mainship/hull/lower_hull)
 "iXB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/warning_stripes/thin{


### PR DESCRIPTION

## Why It's Good For The Game
Less runtimes during setup.
## Changelog
:cl:
fix: deleted stacking pipes on Pillar of Spring.
/:cl:
