### PR TITLE
No more BIG RED Crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -21,6 +21,7 @@
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
 	xenorespawn_time = 3 MINUTES
+	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE


### PR DESCRIPTION

## About The Pull Request
Blacklists Big Red from being enabled on Crash gamemode.
## Why It's Good For The Game
The map is too big for crash. Silos are too far apart, disks can be either too close or too far from Canter.
Crash is meant more for low pop and smaller maps play a lot better, so Big Red cannot stay.
## Changelog
:cl:
balance: Disables Big Red on crash gamemode
/:cl:
