### PR TITLE
Adds respawn charge indicator to the baneling explode ability

### DIFF
--- a/code/__DEFINES/action.dm
+++ b/code/__DEFINES/action.dm
@@ -22,9 +22,9 @@
 #define VREF_MUTABLE_EMPOWERED_FRAME "VREF_EMPOWERED_FRAME"
 /// A image to show the clock delay ticking.
 #define VREF_IMAGE_XENO_CLOCK "VREF_ACTION_CLOCK"
-// extra reference for ravager leech
-#define VREF_MUTABLE_RAV_LEECH "VREF_RAV_LEECH"
-// a reference for the  build counter of a xeno
+/// A reference for baneling's respawn charges
+#define VREF_MUTABLE_BANE_CHARGES "VREF_BANE_CHARGES"
+/// A reference for the build counter of a xeno
 #define VREF_MUTABLE_BUILDING_COUNTER "VREF_BUILD_COUNTER"
 // extra reference for the amount of landslide charges we have
 #define VREF_MUTABLE_LANDSLIDE "VREF_LANDSLIDE"

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -17,10 +17,32 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BANELING_EXPLODE,
 	)
 
+/datum/action/xeno_action/baneling_explode/handle_button_status_visuals()
+	var/mob/living/carbon/xenomorph/baneling = owner
+	button.cut_overlay(visual_references[VREF_MUTABLE_BANE_CHARGES])
+	var/mutable_appearance/number = visual_references[VREF_MUTABLE_BANE_CHARGES]
+	number.maptext = MAPTEXT("[baneling.stored_charge]")
+	visual_references[VREF_MUTABLE_BANE_CHARGES] = number
+	button.add_overlay(visual_references[VREF_MUTABLE_BANE_CHARGES])
+	. = ..()
+
 /datum/action/xeno_action/baneling_explode/give_action(mob/living/L)
 	. = ..()
 	var/mob/living/carbon/xenomorph/X = L
+	var/mutable_appearance/charge_maptext = mutable_appearance(icon = null, icon_state = null, layer = ACTION_LAYER_MAPTEXT)
+	charge_maptext.pixel_x = 12
+	charge_maptext.pixel_y = -5
+	visual_references[VREF_MUTABLE_BANE_CHARGES] = charge_maptext
 	RegisterSignal(X, COMSIG_MOB_PRE_DEATH, PROC_REF(handle_smoke))
+
+/datum/action/xeno_action/baneling_explode/remove_action(mob/living/L)
+	. = ..()
+	var/mob/living/carbon/xenomorph/X = L
+	UnregisterSignal(X, COMSIG_MOB_PRE_DEATH)
+
+/datum/action/xeno_action/baneling_explode/clean_action()
+	button.cut_overlay(visual_references[VREF_MUTABLE_BANE_CHARGES])
+	visual_references[VREF_MUTABLE_BANE_CHARGES] = null
 
 /datum/action/xeno_action/baneling_explode/action_activate()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -24,7 +24,7 @@
 	number.maptext = MAPTEXT("[baneling.stored_charge]")
 	visual_references[VREF_MUTABLE_BANE_CHARGES] = number
 	button.add_overlay(visual_references[VREF_MUTABLE_BANE_CHARGES])
-	. = ..()
+	return ..()
 
 /datum/action/xeno_action/baneling_explode/give_action(mob/living/L)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/baneling_explode
 	name = "Baneling Explode"
 	action_icon_state = "baneling_explode"
-	desc = "Explode and spread dangerous toxins to hinder or kill your foes. You will respawn in your pod after you detonate, should your pod be planted."
+	desc = "Explode and spread dangerous toxins to hinder or kill your foes. You will respawn in your pod after you detonate, should your pod be planted. By staying alive, you gain charges to respawn quicker."
 	ability_name = "baneling explode"
 	var/static/list/baneling_smoke_list = list(
 		/datum/reagent/toxin/xeno_neurotoxin = /datum/effect_system/smoke_spread/xeno/neuro/medium,

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -497,7 +497,7 @@
 
 /datum/action/xeno_action/vampirism
 	name = "Toggle vampirism"
-	action_icon_state = "rage"
+	action_icon_state = "neuroclaws_off"
 	desc = "Toggle on to enable boosting on "
 	ability_name = "Vampirism"
 	plasma_cost = 0 //We're limited by nothing, rip and tear
@@ -513,18 +513,9 @@
 	/// Ref to our particle deletion timer
 	var/timer_ref
 
-/datum/action/xeno_action/vampirism/New(Target)
-	..()
-	var/mutable_appearance/leech_appeareace = mutable_appearance(null,null, ACTION_LAYER_IMAGE_ONTOP)
-	visual_references[VREF_MUTABLE_RAV_LEECH] = leech_appeareace
-
 /datum/action/xeno_action/vampirism/update_button_icon()
 	var/mob/living/carbon/xenomorph/xeno = owner
 	action_icon_state = xeno.vampirism ? "neuroclaws_on" : "neuroclaws_off"
-	button.cut_overlay(visual_references[VREF_MUTABLE_RAV_LEECH])
-	var/mutable_appearance/number = visual_references[VREF_MUTABLE_RAV_LEECH]
-	visual_references[VREF_MUTABLE_RAV_LEECH] = number
-	button.add_overlay(visual_references[VREF_MUTABLE_RAV_LEECH])
 	return ..()
 
 /datum/action/xeno_action/vampirism/give_action(mob/living/L)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -513,6 +513,11 @@
 	/// Ref to our particle deletion timer
 	var/timer_ref
 
+/datum/action/xeno_action/vampirism/clean_action()
+	QDEL_NULL(particle_holder)
+	timer_ref = null
+	. = ..()
+
 /datum/action/xeno_action/vampirism/update_button_icon()
 	var/mob/living/carbon/xenomorph/xeno = owner
 	action_icon_state = xeno.vampirism ? "neuroclaws_on" : "neuroclaws_off"

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -516,7 +516,7 @@
 /datum/action/xeno_action/vampirism/clean_action()
 	QDEL_NULL(particle_holder)
 	timer_ref = null
-	. = ..()
+	return ..()
 
 /datum/action/xeno_action/vampirism/update_button_icon()
 	var/mob/living/carbon/xenomorph/xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -526,6 +526,8 @@
 
 /datum/action/xeno_action/vampirism/remove_action(mob/living/L)
 	. = ..()
+	var/mob/living/carbon/xenomorph/xeno = L
+	xeno.vampirism = FALSE
 	UnregisterSignal(L, COMSIG_XENOMORPH_ATTACK_LIVING)
 
 /datum/action/xeno_action/vampirism/action_activate()


### PR DESCRIPTION
## About The Pull Request
Shows the amount of respawn charges you currently have via maptext.
Removed some vestigial ravager code from before the primo rework.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/41ae3d14-0df3-4f5b-b956-5e325b061ce3)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/eb32662c-b274-41bd-8dda-5608954375ec)

## Why It's Good For The Game
Helps people know this feature even exists without reading a throwaway sentence on the wiki.

<p float="left">
  <span>Banelings can make more informed decisions on when to gas tad and induce malding in ungas.</span>
  <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/4741640/279558227-18d2f30e-407d-413f-a454-dfdae0cc9e7e.png" width="20" /> 
</p>

![wheeee](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/d775acbb-f792-4851-a100-b696b1628d66)


## Changelog
:cl:
add: Added a 'respawn charge' indicator for banelings on the explode ability.
code: Removed some vestigial ravager code from before the primo rework.
/:cl:
