### PR TITLE
Wall hit changes

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -42,7 +42,8 @@
 		src.throw_at(get_edge_target_turf(src, get_dir(AM.throw_source, src)), 1, speed * 0.5)
 
 /mob/living/turf_collision(turf/T, speed)
-	take_limb_damage(speed*5)
+	take_overall_damage(speed * 5, BRUTE, MELEE, FALSE, FALSE, TRUE, 0, 2)
+	playsound(src, 'sound/weapons/heavyhit.ogg', 40)
 
 /mob/living/proc/near_wall(direction,distance=1)
 	var/turf/T = get_step(get_turf(src),direction)


### PR DESCRIPTION
## About The Pull Request
Being thrown into a wall now has a sound effect.
The damage inflicted now actually respects armour (no throwing death squad into a wall until they die, sorry)

Also wall impacts may not have even worked in the past, apparently I fixed it incidentally during one of my throw pr's.
## Why It's Good For The Game
Fix and audio feedback
## Changelog
:cl:
fix: fixed wall throws not respecting armour
soundadd: added a sound effect when you're thrown into a wall
/:cl:
