### PR TITLE
realistic window impacts

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -72,6 +72,23 @@
 		if(EXPLODE_WEAK)
 			take_damage(rand(15, 35), BRUTE, BOMB)
 
+/obj/structure/window/hitby(atom/movable/AM, speed = 5)
+	var/throw_damage = speed
+	var/mob/living/thrown_mob
+	if(isobj(AM))
+		var/obj/thrown_obj = AM
+		throw_damage = thrown_obj.throwforce
+	else if(isliving(AM))
+		thrown_mob = AM
+		throw_damage *= thrown_mob.mob_size * 8
+	take_damage(throw_damage)
+	if(obj_integrity > 0) //we only stop if we don't break the window
+		AM.stop_throw()
+		. = TRUE
+	if(thrown_mob)
+		thrown_mob.take_overall_damage(speed * 5, BRUTE, MELEE, !., FALSE, TRUE, 0, 4) //done here for dramatic effect, and to make the damage sharp if we broke the window
+
+
 //TODO: Make full windows a separate type of window.
 //Once a full window, it will always be a full window, so there's no point
 //having the same type for both.


### PR DESCRIPTION

## About The Pull Request
Have you ever felt unsatisfied by hurling people through windows?
No more.

Throwing people into windows now inflicts damage like wall throws, and the damage to the window scales with mob size.
Additionally, if a throw is strong enough to break the glass, the thrown thing will now continue to travel instead of just stopping pathetically.

Line up 3 windows and hurl a nerd through all 3 for combo damage!
## Why It's Good For The Game
Is fun.
## Changelog
:cl:
balance: Throwing things into windows will no longer stop the throw if the window breaks from the impact
balance: Throwing mobs into windows hurts like a wall throw
balance: Throwing mobs into a window scales damage to the window based on mob size
/:cl:
