### PR TITLE
Fixes throw impact not respecting speed

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -15,6 +15,8 @@
 	var/drag_windup = 1.5 SECONDS
 	var/throwing = FALSE
 	var/thrower = null
+	///Speed of the current throw. 0 When not throwing.
+	var/thrown_speed = 0
 	var/turf/throw_source = null
 	var/throw_speed = 2
 	var/throw_range = 7
@@ -311,7 +313,7 @@
 		return COMPONENT_BUMP_RESOLVED
 	. = ..()
 	if(throwing)
-		. = !throw_impact(A)
+		. = !throw_impact(A, thrown_speed)
 	if(QDELETED(A))
 		return
 	A.Bumped(src)
@@ -531,6 +533,7 @@
 
 	set_throwing(TRUE)
 	src.thrower = thrower
+	thrown_speed = speed
 
 	var/original_layer = layer
 	if(flying)
@@ -625,6 +628,7 @@
 	if(flying)
 		set_flying(FALSE, original_layer)
 	thrower = null
+	thrown_speed = 0
 	throw_source = null
 
 /atom/movable/proc/handle_buckled_mob_movement(NewLoc, direct)


### PR DESCRIPTION
## About The Pull Request
Title.
During Lumi's throw changes, the wall impact was changed to have a "default" speed of 5 if no argument was passed.
Surprise, the impact **never** had the speed passed as impacting things happens in bump (which is outside of the throw itself).
Thus, all impacts were handled as if they were executed with a speed of 5 (resulting in five times higher damage in most cases).
This PR fixes that by preserving current thrown speed.
Unfortunately, has to be a movable var due to no viable vectors to pass it existing (tgmc does not have thrownthing datums like base tg, which would handle this).
## Why It's Good For The Game
args actually being passed seems kinda useful.
## Changelog
:cl:
fix: throw_impact() now actually receives the speed arg.
/:cl:
