### PR TITLE
Amends missing changes in Runner stuff, fixes an issue with Evasion's HUD indicator

### DIFF
--- a/code/__DEFINES/action.dm
+++ b/code/__DEFINES/action.dm
@@ -30,6 +30,8 @@
 #define VREF_MUTABLE_LANDSLIDE "VREF_LANDSLIDE"
 // extra reference for the amount of earth pillars we have
 #define VREF_MUTABLE_EARTH_PILLAR "VREF_EARTH_PILLAR"
+// extra reference for savage's cooldown
+#define VREF_MUTABLE_SAVAGE_COOLDOWN "VREF_SAVAGE_COOLDOWN"
 
 
 /// Actions that toggle on click/trigger

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -283,7 +283,7 @@
 
 /datum/action/xeno_action/activable/pounce/on_cooldown_finish()
 	owner.balloon_alert(owner, "Pounce ready")
-	playsound(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
+	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.usedPounce = FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -3,6 +3,7 @@
 // ***************************************
 #define RUNNER_POUNCE_RANGE 6 // in tiles
 #define RUNNER_SAVAGE_DAMAGE_MINIMUM 15
+#define RUNNER_SAVAGE_COOLDOWN 30 SECONDS
 
 /datum/action/xeno_action/activable/pounce/runner
 	desc = "Leap at your target, tackling and disarming them. Alternate use toggles Savage off or on."
@@ -15,6 +16,15 @@
 	pounce_range = RUNNER_POUNCE_RANGE
 	/// Whether Savage is active or not.
 	var/savage_activated = TRUE
+	/// Savage's cooldown.
+	COOLDOWN_DECLARE(savage_cooldown)
+
+/datum/action/xeno_action/activable/pounce/runner/give_action(mob/living/L)
+	. = ..()
+	var/mutable_appearance/savage_maptext = mutable_appearance(icon = null, icon_state = null, layer = ACTION_LAYER_MAPTEXT)
+	savage_maptext.pixel_x = 12
+	savage_maptext.pixel_y = -5
+	visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN] = savage_maptext
 
 /datum/action/xeno_action/activable/pounce/runner/alternate_action_activate()
 	savage_activated = !savage_activated
@@ -26,15 +36,34 @@
 	. = ..()
 	if(!savage_activated)
 		return
-	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	var/savage_cost = RUNNER_SAVAGE_DAMAGE_MINIMUM * 2
-	if(xeno_owner.plasma_stored < savage_cost)
-		owner.balloon_alert(owner, "Not enough plasma to Savage")
+	if(!COOLDOWN_CHECK(src, savage_cooldown))
+		owner.balloon_alert(owner, "Savage on cooldown ([COOLDOWN_TIMELEFT(src, savage_cooldown) * 0.1]s)")
 		return
-	living_target.attack_alien_harm(xeno_owner, max(RUNNER_SAVAGE_DAMAGE_MINIMUM, xeno_owner.plasma_stored * 0.15))
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	var/savage_damage = max(RUNNER_SAVAGE_DAMAGE_MINIMUM, xeno_owner.plasma_stored * 0.15)
+	var/savage_cost = savage_damage * 2
+	if(xeno_owner.plasma_stored < savage_cost)
+		owner.balloon_alert(owner, "Not enough plasma to Savage ([savage_cost])")
+		return
+	living_target.attack_alien_harm(xeno_owner, savage_damage)
 	xeno_owner.use_plasma(savage_cost)
+	COOLDOWN_START(src, savage_cooldown, RUNNER_SAVAGE_COOLDOWN)
+	START_PROCESSING(SSprocessing, src)
 	GLOB.round_statistics.runner_savage_attacks++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_savage_attacks")
+
+/datum/action/xeno_action/activable/pounce/runner/process()
+	if(COOLDOWN_CHECK(src, savage_cooldown))
+		button.cut_overlay(visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN])
+		owner.balloon_alert(owner, "Savage ready")
+		owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
+		STOP_PROCESSING(SSprocessing, src)
+		return
+	button.cut_overlay(visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN])
+	var/mutable_appearance/cooldown = visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN]
+	cooldown.maptext = MAPTEXT("[round(COOLDOWN_TIMELEFT(src, savage_cooldown) * 0.1)]s")
+	visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN] = cooldown
+	button.add_overlay(visual_references[VREF_MUTABLE_SAVAGE_COOLDOWN])
 
 
 // ***************************************
@@ -110,12 +139,12 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_evasions")
 
 /datum/action/xeno_action/evasion/process()
+	var/mob/living/carbon/xenomorph/runner/runner_owner = owner
+	runner_owner.hud_set_evasion(evasion_duration)
 	if(evasion_duration <= 0)
 		evasion_deactivate()
 		return
 	evasion_duration--
-	var/mob/living/carbon/xenomorph/runner/runner_owner = owner
-	runner_owner.hud_set_evasion(evasion_duration)
 
 /**
  * Called when the owner is hit by a flamethrower projectile.


### PR DESCRIPTION
## About The Pull Request
Amends various mistakes done in #14099 due to changes I didn't commit.
- All cooldown sounds are now played locally, meaning only the user will hear them. Previously, surrounding players could also hear them, which I had meant to change.
- Re-added the Savage cooldown. I completely missed this. It's the same as before (30s).
  - Savage cooldown now has a duration indicator on the ability icon.
- Fixed an issue with Savage's plasma cost being half of what it should actually be.
- Fixed an issue where Runner's Evasion duration HUD indicator would persist sometimes. The indicator will now correctly disappear when it should.

## Why It's Good For The Game
- The sound changes were something I meant to do because it allows Runners and Hunters to engage in stealthy activities a bit better.
- I accidentally made Runner stronger than it was before. This is not good for game balance.
- Bug fixes good.

## Changelog
:cl: Lewdcifer
add: With Runner QoL changes introduced before, a missing commit caused some changes to be missing. This has been amended with the following changes:
balance: All ability cooldown sounds are now played locally, meaning only the user will hear them. Go do some stealth!
balance: Re-added Savage's cooldown. The cooldown now has a duration indicator on the ability icon.
balance: Fixed an issue with Savage's plasma cost being half of what it should actually be.
fix: Fixed an issue where Runner's Evasion duration HUD indicator would persist sometimes. The indicator will now correctly disappear when it should.
/:cl: