### PR TITLE
Very quick speed pass

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -166,7 +166,7 @@
 		return fail_activate()
 	RegisterSignals(X, list(COMSIG_MOVABLE_POST_THROW, COMSIG_XENO_OBJ_THROW_HIT), PROC_REF(charge_complete))
 	RegisterSignal(X, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
-	X.throw_at(A, range, 70, X)
+	X.throw_at(A, range, 7, X)
 
 /// Whenever we hit something living, if its a human we knock them down for 2 seconds and keep throwing ourselves. If we hit xeno, we get blocked and explode on them
 /datum/action/xeno_action/activable/dash_explosion/proc/mob_hit(datum/source, mob/M)

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
@@ -23,5 +23,5 @@
 	H.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
-	H.throw_at(get_turf(target_turf), 4, 70, H)
+	H.throw_at(get_turf(target_turf), 4, 5, H)
 	H.Paralyze(2 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -156,7 +156,7 @@
 	RegisterSignal(X, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
 	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
 
-	X.throw_at(A, range, 70, X)
+	X.throw_at(A, range, 5, X)
 
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -58,7 +58,7 @@
 	H.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
-	H.throw_at(get_turf(target_turf), 4, 70, src)
+	H.throw_at(get_turf(target_turf), 4, 5, src)
 	H.Paralyze(4 SECONDS)
 
 /mob/living/carbon/xenomorph/defender/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
Some outliers in throw speeds have some.. questionably high numbers.
To avoid death, this amends them to be in reasonable ranges (for abilities I assumed intent was to finish the throw in one tick, thus they're set to be slightly above range of the ability)
## Why It's Good For The Game
Who knew that fixing something broken for a long time might open up a rabbit hole.
## Changelog
:cl:
fix: Some throw speeds that were extremely high have been normalized.
/:cl:
