### PR TITLE
Better larva queue removal handling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1105,6 +1105,9 @@ to_chat will check for valid clients itself already so no need to double check f
 
 /// Remove a client from the larva candidate queue
 /datum/hive_status/proc/remove_from_larva_candidate_queue(client/waiter)
+	var/larva_position = SEND_SIGNAL(waiter, COMSIG_CLIENT_GET_LARVA_QUEUE_POSITION)
+	if (!larva_position)
+		return // We weren't in the queue
 	LAZYREMOVE(candidates, waiter)
 	UnregisterSignal(waiter, COMSIG_QDELETING)
 	SEND_SIGNAL(waiter, COMSIG_CLIENT_SET_LARVA_QUEUE_POSITION, 0)


### PR DESCRIPTION
## About The Pull Request

If the client wasn't in the larva queue, there's no need to do the whole process of removing them and letting them know they've been removed.

## Why It's Good For The Game

Annoying getting incorrect messages

## Changelog

:cl:
fix: You should no longer get the 'You left the Larva queue.' message when returning to your corpse.
/:cl:
