### PR TITLE
Decrease the amount of flare boxes to 150

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -120,7 +120,7 @@
 			/obj/item/explosive/grenade/sticky/cloaker = 10,
 			/obj/item/explosive/grenade/smokebomb/drain = 10,
 			/obj/item/explosive/grenade/mirage = 100,
-			/obj/item/storage/box/m94 = 200,
+			/obj/item/storage/box/m94 = 150,
 			/obj/item/storage/box/m94/cas = 30,
 		),
 		"Specialized" = list(
@@ -329,7 +329,7 @@
 			/obj/item/explosive/grenade/smokebomb/cloak = 25,
 			/obj/item/explosive/grenade/smokebomb/drain = 10,
 			/obj/item/explosive/grenade/mirage = 100,
-			/obj/item/storage/box/m94 = 200,
+			/obj/item/storage/box/m94 = 150,
 			/obj/item/storage/box/m94/cas = 50,
 		),
 		"Specialized" = list(


### PR DESCRIPTION
## About The Pull Request
Less endless flare spam all day every day

## Why It's Good For The Game

malding after ungas keep spamming 20 flares to cover a single room

## Changelog

:cl:
balance: There are now only 150 flare boxes (m94) in the weapons vendor.
/:cl: