### PR TITLE
Surplus Clothing vendors are no longer wrenchable

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1145,6 +1145,7 @@
 	icon_vend = "surplus-vend"
 	icon_deny = "surplus_clothes-deny"
 	isshared = TRUE
+	wrenchable = FALSE
 	product_ads = "Be the musician that you parents never approve you of.;You gotta look good when you're in the battlefield.;We have all types of hats here!;What did one hat say to the other on the hiking trip? I'll wait here, you go on ahead;Sometimes, a beret is better than a helmet.;Drip is the priority, marine."
 	products = list(
 		"Standard" = list(


### PR DESCRIPTION

## About The Pull Request

Alternate to #14381 - this prevents them from being unanchored and dragged onto tad

## Why It's Good For The Game

malding after ungas keep spamming 20 flares to cover a single room

They can still be used as infinite flare dispensers but it's much less convenient.

## Changelog
:cl:
balance: Surplus Clothing Vendors are no longer wrenchable.
/:cl:
