### PR TITLE
Gorger transfusion buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -197,7 +197,7 @@
 
 	if(owner.do_actions)
 		return FALSE
-	if(!line_of_sight(owner, target_xeno, 2) || get_dist(owner, target_xeno) > 2)
+	if(!line_of_sight(owner, target_xeno, 3))
 		if(!silent)
 			to_chat(owner, span_notice("It is beyond our reach, we must be close and our way must be clear."))
 		return FALSE
@@ -206,7 +206,7 @@
 			to_chat(owner, span_notice("We can only help living sisters."))
 		return FALSE
 	target_health = target_xeno.health
-	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(extra_health_check), target_xeno)))
+	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(extra_health_check), target_xeno)))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Atomization: https://github.com/tgstation/TerraGov-Marine-Corps/pull/13317
Increase Transfusion range by 1
Can cast transfusion while moving
## Why It's Good For The Game
Gives Gorger a lot of quality of life, being able to be able to heal through shuffle makes overhealing xenos less painful.

## Changelog
:cl:
balance: Gorger can move during transfusion
balance: Gorger has 1 more tile range for transfusion
/:cl:
