### PR TITLE
Fix runtime in spatial agent shortcut

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -958,9 +958,13 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		return FALSE
 	visible_message(span_deadsay("[span_name("[src]")] points at [pointed_atom]."))
 
-/mob/dead/observer/CtrlShiftClickOn(mob/target_ghost)
-	if(ghost_vision && check_rights(R_SPAWN))
-		if(src == target_ghost)
-			client.holder.spatial_agent()
-		else
-			target_ghost.change_mob_type(/mob/living/carbon/human , null, null, TRUE) //always delmob, ghosts shouldn't be left lingering
+/mob/dead/observer/CtrlShiftClickOn(mob/dead/observer/target_ghost)
+	if(!istype(target_ghost))
+		return
+	if(!check_rights(R_SPAWN))
+		return
+
+	if(src == target_ghost)
+		client.holder.spatial_agent()
+	else
+		target_ghost.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)


### PR DESCRIPTION
## About The Pull Request

It wasn't checking for `istype` at all

## Changelog

:cl:
fix: Fix runtime in spatial agent shortcut
/:cl:
