### PR TITLE
Fixes pouches looking empty on spawn while they aren't.

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -16,6 +16,9 @@
 	if(fill_number && fill_type)
 		for(var/i in 1 to fill_number)
 			new fill_type(src)
+
+/obj/item/storage/pouch/LateInitialize()
+	. = ..()
 	update_icon()
 
 /obj/item/storage/pouch/examine(mob/user)


### PR DESCRIPTION

## About The Pull Request
So, `update_icon()` was getting called before the pouches were getting filled in the `Initialize()`, so I just put it in the `LateInitialize()` so it first loads up the stuff inside the pouch and only then updates it's look.
## Why It's Good For The Game
Fancy pouches in EORD.
## Changelog
:cl:
fix: Full pouches now don't look empty on spawn.
/:cl:
