### PR TITLE
If you have a stronger acid, you can now click on weaker acid directly to upgrade it.

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -149,10 +149,11 @@
 	acid_damage = 175
 	icon_state = "acid_strong"
 
-/obj/effect/xenomorph/acid/Initialize(mapload, target, melting_rate)
+/obj/effect/xenomorph/acid/Initialize(mapload, target, melting_rate, existing_ticks)
 	. = ..()
 	acid_melt_multiplier = melting_rate
 	acid_t = target
+	ticks = existing_ticks
 	if(!acid_t)
 		return INITIALIZE_HINT_QDEL
 	layer = acid_t.layer

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -153,7 +153,7 @@
 	. = ..()
 	acid_melt_multiplier = melting_rate
 	acid_t = target
-	ticks = existing_ticks
+	ticks += existing_ticks
 	if(!acid_t)
 		return INITIALIZE_HINT_QDEL
 	layer = acid_t.layer

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -618,6 +618,12 @@
 
 /datum/action/xeno_action/activable/corrosive_acid/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
+
+	// Check if it's an acid object we're upgrading
+	if (istype(A, /obj/effect/xenomorph/acid))
+		var/obj/effect/xenomorph/acid/existing_acid = A
+		A = existing_acid.acid_t // Swap the target to the target of the acid
+
 	if(!A.dissolvability(initial(acid_type.acid_strength)))
 		return fail_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -648,26 +648,6 @@
 	span_xenowarning("We vomit globs of vile stuff all over \the [A]. It begins to sizzle and melt under the bubbling mess of acid!"), null, 5)
 	playsound(X.loc, "sound/bullets/acid_impact1.ogg", 25)
 
-/datum/action/xeno_action/activable/corrosive_acid/proc/acid_progress_transfer(acid_type, obj/O, turf/T)
-	if(!O && !T)
-		return
-
-	var/obj/effect/xenomorph/acid/new_acid = acid_type
-
-	var/obj/effect/xenomorph/acid/current_acid
-
-	if(T)
-		current_acid = T.current_acid
-
-	else if(O)
-		current_acid = O.current_acid
-
-	if(!current_acid) //Sanity check. No acid
-		return
-	new_acid.ticks = current_acid.ticks //Inherit the old acid's progress
-	qdel(current_acid)
-
-
 // ***************************************
 // *********** Super strong acid
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -596,6 +596,10 @@
 	use_state_flags = XACT_USE_BUCKLED
 
 /datum/action/xeno_action/activable/corrosive_acid/can_use_ability(atom/A, silent = FALSE, override_flags)
+	// Check if it's an acid object we're upgrading
+	if (istype(A, /obj/effect/xenomorph/acid))
+		var/obj/effect/xenomorph/acid/existing_acid = A
+		A = existing_acid.acid_t // Swap the target to the target of the acid
 	. = ..()
 	if(!.)
 		return FALSE
@@ -636,7 +640,7 @@
 	if(!can_use_ability(A, TRUE))
 		return fail_activate()
 
-	var/old_acid_ticks = A.current_acid.ticks
+	var/old_acid_ticks = A.current_acid?.ticks
 	QDEL_NULL(A.current_acid)
 	A.current_acid = new acid_type(get_turf(A), A, A.dissolvability(initial(acid_type.acid_strength)), old_acid_ticks)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -636,8 +636,9 @@
 	if(!can_use_ability(A, TRUE))
 		return fail_activate()
 
+	var/old_acid_ticks = A.current_acid.ticks
 	QDEL_NULL(A.current_acid)
-	A.current_acid = new acid_type(get_turf(A), A, A.dissolvability(initial(acid_type.acid_strength)))
+	A.current_acid = new acid_type(get_turf(A), A, A.dissolvability(initial(acid_type.acid_strength)), old_acid_ticks)
 
 	succeed_activate()
 


### PR DESCRIPTION
## About The Pull Request

If you have a stronger acid, you can now click on weaker acid directly to upgrade it.
Fixes a bug with acid upgrading not transferring the existing ticks

## Why It's Good For The Game

Huge acid QoL, especially for shit like flares and their animated sprite
Bug fix good

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/ef894ac0-45ae-4a67-8cf9-4e030b88334a)


## Changelog
:cl:
add: If you have a stronger acid, you can now click on weaker acid directly to upgrade it.
fix: Fixed acid upgrading not inheriting the existing melt progress
/:cl:


