### PR TITLE
Fixes LV being voteable on Crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -21,7 +21,7 @@
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
 	xenorespawn_time = 3 MINUTES
-	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
+	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE


### PR DESCRIPTION

## About The Pull Request
Crash used to have the same blacklist from gamemode.dm, but that changed. All future maps blacklisting maps from HvX will have to do it in both areas.
## Why It's Good For The Game
Bug fix good. Totally blame Xander.
## Changelog
:cl:
fix: LV is no longer voteable on Crash.
/:cl:
