### PR TITLE
Fix: Banelings will no longer bring sticky nades back to their pod upon dying

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
@@ -71,6 +71,7 @@
 	if(isnull(source))
 		return
 	var/mob/living/carbon/xenomorph/xeno_ref = source
+	cleanup_baneling(xeno_ref)
 	xeno_ref.forceMove(src)
 	ADD_TRAIT(xeno_ref, TRAIT_STASIS, BANELING_STASIS_TRAIT)
 	if(xeno_ref.stored_charge >= BANELING_CHARGE_MAX)
@@ -84,6 +85,15 @@
 		to_chat(xeno_ref.client, span_xenohighdanger("We have perished and detonated. We will reform in [(BANELING_CHARGE_RESPAWN_TIME*4)/10] seconds in our pod..."))
 		addtimer(CALLBACK(src, PROC_REF(spawn_baneling), xeno_ref), BANELING_CHARGE_RESPAWN_TIME*4)
 	return COMPONENT_CANCEL_DEATH
+
+/// Handles cleaning up the baneling before teleporting it back to the pod
+/obj/structure/xeno/baneling_pod/proc/cleanup_baneling(mob/living/carbon/xenomorph/baneling)
+	// Sticky grenades
+	for (var/obj/item/explosive/grenade/sticky/nade in baneling)
+		nade.clean_refs()
+		nade.forceMove(get_turf(baneling))
+	// Fire
+	baneling.ExtinguishMob()
 
 /// Increase our current charge
 /obj/structure/xeno/baneling_pod/proc/increase_charge(datum/source)


### PR DESCRIPTION
## About The Pull Request

same type beat as #13796
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/5d7b7ec1-3737-4b82-a127-690801bcbcdf)
i don't really want to write the signal shit for this right now, i have other bugs to fix

## Why It's Good For The Game

Fix #14179 
Fix #13795

uhh this also might address bug I've seen where banelings can go into crit negative despite not dying as such


![gasstation](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/9ef11fd0-4d3b-4426-8d0b-f06ffb16d8ee)

## Changelog
:cl:
fix: Banelings will no longer bring sticky nades back to their pod upon dying.
/:cl:
