### PR TITLE
Campaign: Mission parameters

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -42,6 +42,10 @@
 	var/starting_faction_mission_brief = "starting faction mission brief here"
 	///Detailed mission description for the hostile faction
 	var/hostile_faction_mission_brief = "hostile faction mission brief here"
+	///Optional mission parameters for the starting faction. Some are autopopulated
+	var/starting_faction_mission_parameters
+	///Optional mission parameters for the hostile faction. Some are autopopulated
+	var/hostile_faction_mission_parameters
 	///Any additional rewards for the starting faction, for display purposes
 	var/starting_faction_additional_rewards = "starting faction mission rewards here"
 	///Any additional rewards for the hostile faction, for display purposes

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -270,6 +270,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	current_mission_data["outcome"] = current_mission.outcome
 	current_mission_data["objective_description"] = (faction == current_mission.starting_faction ? current_mission.starting_faction_objective_description : current_mission.hostile_faction_objective_description)
 	current_mission_data["mission_brief"] = (faction == current_mission.starting_faction ? current_mission.starting_faction_mission_brief : current_mission.hostile_faction_mission_brief)
+	current_mission_data["mission_parameters"] = (faction == current_mission.starting_faction ? current_mission.starting_faction_mission_parameters : current_mission.hostile_faction_mission_parameters)
 	current_mission_data["mission_rewards"] = (faction == current_mission.starting_faction ? current_mission.starting_faction_additional_rewards : current_mission.hostile_faction_additional_rewards)
 	current_mission_data["vp_major_reward"] = (faction == current_mission.starting_faction ? current_mission.victory_point_rewards[MISSION_OUTCOME_MAJOR_VICTORY][1] : current_mission.victory_point_rewards[MISSION_OUTCOME_MAJOR_LOSS][2])
 	current_mission_data["vp_minor_reward"] = (faction == current_mission.starting_faction ? current_mission.victory_point_rewards[MISSION_OUTCOME_MINOR_VICTORY][1] : current_mission.victory_point_rewards[MISSION_OUTCOME_MINOR_LOSS][2])
@@ -308,6 +309,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		mission_data["outcome"] = finished_mission.outcome
 		mission_data["objective_description"] = (faction == finished_mission.starting_faction ? finished_mission.starting_faction_objective_description : finished_mission.hostile_faction_objective_description)
 		mission_data["mission_brief"] = (faction == finished_mission.starting_faction ? finished_mission.starting_faction_mission_brief : finished_mission.hostile_faction_mission_brief)
+		mission_data["mission_parameters"] = (faction == finished_mission.starting_faction ? finished_mission.starting_faction_mission_parameters : finished_mission.hostile_faction_mission_parameters)
 		mission_data["mission_rewards"] = (faction == finished_mission.starting_faction ? finished_mission.starting_faction_additional_rewards : finished_mission.hostile_faction_additional_rewards)
 		finished_missions_data += list(mission_data)
 	data["finished_missions"] = finished_missions_data

--- a/code/game/objects/structures/campaign_structures/deploy_blockers.dm
+++ b/code/game/objects/structures/campaign_structures/deploy_blockers.dm
@@ -20,11 +20,21 @@
 	var/flags_to_remove = MISSION_DISALLOW_TELEPORT
 	///The faction this belongs to
 	var/faction = FACTION_TERRAGOV
+	var/owning_faction_notification = "A teleportation disruptor has been deployed in this area. Protect the disruptor to ensure hostile forces cannot deploy via teleportation. "
+	var/hostile_faction_notification = "The enemy has a device in this area that will prevent the use of the teleporter array. Destroy this first to allow for teleportation insertion against primary objectives. "
 
 /obj/structure/campaign_deployblocker/Initialize(mapload)
 	. = ..()
 	GLOB.campaign_structures += src
 	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "tele_block"))
+	var/datum/game_mode/hvh/campaign/mode = SSticker.mode
+	if(!istype(mode))
+		return
+	var/datum/campaign_mission/current_mission = mode.current_mission
+	if(!current_mission)
+		return
+	current_mission.starting_faction_mission_parameters += current_mission.starting_faction == faction ? owning_faction_notification : hostile_faction_notification
+	current_mission.hostile_faction_mission_parameters += current_mission.starting_faction == faction ? hostile_faction_notification : owning_faction_notification
 
 /obj/structure/campaign_deployblocker/Destroy()
 	deactivate()
@@ -50,7 +60,9 @@
 	spawn_object = /obj/structure/campaign_deployblocker/drop_blocker
 
 /obj/structure/campaign_deployblocker/drop_blocker
-	name = "DROPBLOCKER"
-	desc = "THIS PROBABLY BLOCKS DROPPODS OR SOMETHING, PAY A SPRITER FOR A NONPLACEHOLDER"
+	name = "drop pod guidance disruptor array"
+	desc = "A sophisticated device intended to severely disrupt drop pod guidance systems, rendering them unusable while the tower stands."
 	flags_to_remove = MISSION_DISALLOW_DROPPODS
 	faction = FACTION_SOM
+	owning_faction_notification = "A drop pod disruptor has been deployed in this area. Protect the disruptor to ensure hostile forces cannot deploy via drop pod. "
+	hostile_faction_notification = "The enemy has a device in this area that will prevent the use of our drop pods. Destroy this first to allow for drop pod assault against primary objectives. "

--- a/tgui/packages/tgui/interfaces/CampaignMenu/CampaignOverview.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/CampaignOverview.tsx
@@ -18,6 +18,7 @@ export const CampaignOverview = (props, context) => {
     map_name,
     objective_description,
     mission_brief,
+    mission_parameters,
     vp_major_reward,
     ap_major_reward,
     vp_minor_reward,
@@ -50,6 +51,9 @@ export const CampaignOverview = (props, context) => {
           </LabeledList.Item>
           <LabeledList.Item label="Mission Brief">
             {mission_brief}
+          </LabeledList.Item>
+          <LabeledList.Item label="Mission Parameters">
+            {mission_parameters}
           </LabeledList.Item>
           <LabeledList.Item label="Current Attrition">
             {active_attrition_points}

--- a/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
@@ -31,6 +31,7 @@ export type MissionData = {
 
   objective_description: string;
   mission_brief: string;
+  mission_parameters: string;
   mission_rewards: string;
   vp_major_reward: number;
   vp_minor_reward: number;


### PR DESCRIPTION

## About The Pull Request
Added some extra info for the current mission. Mission params details any special factors that effect the mission. Currently is only used for Tele/droppod blockers, but other things can be plugged or, or specific info can be manually added for particular missions.
## Why It's Good For The Game
More info good.
## Changelog
:cl:
qol: Campaign missions will specify if a teleport or drop pod blocker is active in the current mission
/:cl:
