### PR TITLE
Campaign asset fixes

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -18,8 +18,13 @@
 #define CAMPAIGN_MAX_LOSS_BONUS 0.45
 
 //mission defines
+///Mission has not been loaded
 #define MISSION_STATE_NEW "mission state new"
+///Mission loaded but not yet active
+#define MISSION_STATE_LOADED "mission state loaded"
+///Mission actively running
 #define MISSION_STATE_ACTIVE "mission state active"
+///Mission ended
 #define MISSION_STATE_FINISHED "mission state finished"
 
 #define MISSION_OUTCOME_MAJOR_VICTORY "major victory"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -101,6 +101,11 @@
 ///Override code for NT base rescue mission
 #define COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE "!campaign_nt_override_code"
 
+///Campaign asset activation successful
+#define COMSIG_CAMPAIGN_ASSET_ACTIVATION "campaign_asset_activation"
+///Campaign asset disabler activated
+#define COMSIG_CAMPAIGN_DISABLER_ACTIVATION "campaign_disabler_activation"
+
 //////////////////////////////////////////////////////////////////
 
 // /datum signals

--- a/code/datums/gamemodes/campaign/campaign_assets.dm
+++ b/code/datums/gamemodes/campaign/campaign_assets.dm
@@ -65,8 +65,8 @@
 		immediate_effect()
 
 ///Handles the activated asset process
-/datum/campaign_asset/proc/attempt_activatation()
-	if(activation_checks())
+/datum/campaign_asset/proc/attempt_activatation(mob/user)
+	if(activation_checks(user))
 		return FALSE
 
 	activated_effect()
@@ -78,26 +78,34 @@
 	uses --
 	if(uses <= 0)
 		asset_flags |= ASSET_CONSUMED
+	SEND_SIGNAL(src, COMSIG_CAMPAIGN_ASSET_ACTIVATION)
 	return TRUE
 
 ///Returns TRUE if unable to be activated
-/datum/campaign_asset/proc/activation_checks()
+/datum/campaign_asset/proc/activation_checks(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if((asset_flags & ASSET_CONSUMED) || asset_flags & ASSET_DISABLED || uses <= 0)
+	if(!(asset_flags & ASSET_ACTIVATED_EFFECT))
 		return TRUE
-
+	if((asset_flags & ASSET_CONSUMED))
+		to_chat(user, span_warning("This asset is inactive."))
+		return TRUE
+	if(uses <= 0)
+		to_chat(user, span_warning("No further uses of this assets available."))
+		return TRUE
+	if(asset_flags & ASSET_DISABLED)
+		to_chat(user, span_warning("External interferance prevents the activation of this asset."))
+		return TRUE
 	if((asset_flags & ASSET_DISALLOW_REPEAT_USE) && (asset_flags & ASSET_ACTIVE))
-		to_chat(faction.faction_leader, span_warning(already_active_message))
+		to_chat(user, span_warning(already_active_message))
 		return TRUE
-
 	if(asset_flags & ASSET_ACTIVE_MISSION_ONLY)
 		var/datum/game_mode/hvh/campaign/mode = SSticker.mode
 		var/datum/campaign_mission/current_mission = mode.current_mission
-		if(!current_mission || (current_mission.mission_state == MISSION_STATE_FINISHED))
-			to_chat(faction.faction_leader, span_warning("Unavailable until next mission confirmed."))
+		if(!current_mission || (current_mission.mission_state == MISSION_STATE_NEW) || (current_mission.mission_state == MISSION_STATE_FINISHED))
+			to_chat(user, span_warning("Unavailable until next mission confirmed."))
 			return TRUE
 		if(blacklist_mission_flags & current_mission.mission_flags)
-			to_chat(faction.faction_leader, span_warning(blacklist_message))
+			to_chat(user, span_warning(blacklist_message))
 			return TRUE
 
 	return FALSE

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -157,7 +157,7 @@
 /datum/campaign_mission/proc/load_map()
 	mission_z_level = load_new_z_level(map_file, map_name, TRUE, map_traits)
 	set_z_lighting(mission_z_level.z_value, map_light_colours[1], map_light_levels[1], map_light_colours[2], map_light_levels[2], map_light_colours[3], map_light_levels[3], map_light_colours[4], map_light_levels[4])
-
+	mission_state = MISSION_STATE_LOADED
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_LOADED, mission_z_level.z_value)
 
 ///Generates the mission brief for the mission if it needs to be late loaded

--- a/code/datums/gamemodes/campaign/rewards/disablers.dm
+++ b/code/datums/gamemodes/campaign/rewards/disablers.dm
@@ -27,7 +27,10 @@
 	if(current_mission.mission_flags & blacklist_mission_flags)
 		return
 
-	for(var/datum/campaign_asset/asset_type AS in faction.faction_assets)
+	for(var/i in faction.faction_assets)
+		var/datum/campaign_asset/asset_type = faction.faction_assets[i]
+		if(!asset_type)
+			continue
 		if(asset_type.type in types_disabled)
 			asset_type.asset_flags |= ASSET_DISABLED
 			types_currently_disabled += asset_type
@@ -37,6 +40,7 @@
 	if(!uses)
 		UnregisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_LOADED)
 		asset_flags &= ~ASSET_DEBUFF
+	SEND_SIGNAL(src, COMSIG_CAMPAIGN_DISABLER_ACTIVATION)
 
 /datum/campaign_asset/asset_disabler/tgmc_cas
 	name = "CAS disabled"


### PR DESCRIPTION

## About The Pull Request
Fixes asset activation checks not actually checking for the activatable flag. (you can no longer activate hostile assets!)
Added more feedback messages for various reasons why you couldn't activate an asset.
Messages now go to the person pressing the button instead of no one/the faction leader.

Fixed a bug that stopped disabler assets working correctly.
## Why It's Good For The Game
Fixes good, player feedback good.
## Changelog
:cl:
qol: failure to activate a campaign asset now provided more feedback to the user
fix: fixed a few issues with activating some campaign assets
/:cl:
