### PR TITLE
remove miniscope on recoilless rocket

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -787,7 +787,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	general_codex_key = "explosive weapons"
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/buildasentry,
 		/obj/item/attachable/shoulder_mount,
 	)


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

This might be harder to shallow compared to removing miniscope on RR, though it had been argued that RR is stronger than SADAR and the fact that an offscreen weapon with high burst damage is not okay on the receiving end of said weapon (xenomorph players).

Would like to see maintainer's thoughts on this. If they say no to this, then this PR is a precedence for having miniscope on RR.

## Changelog

:cl:
del: remove miniscope on recoilless rocket
/:cl:

