### PR TITLE
Adds base pill bottles to light medical belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -95,6 +95,7 @@
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
+		/obj/item/storage/pill_bottle,
 		/obj/item/storage/pill_bottle/packet,
 		/obj/item/stack/medical,
 		/obj/item/reagent_containers/hypospray/autoinjector,


### PR DESCRIPTION

## About The Pull Request
Adds base pill bottles to light medical belt
## Why It's Good For The Game
Since marines have access to pill bottles now, I think it's fair that they should fit in the light medical rig belt.
## Changelog
:cl:
balance: Light medical belt holds pill bottles
/:cl:
