### PR TITLE
Fix Defiler inject egg range

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -303,7 +303,7 @@
 	var/mob/living/carbon/xenomorph/defiler/X = owner
 
 	if(!owner.Adjacent(A))
-		A.balloon_alert(X, "Cannot reach")
+		A.balloon_alert(X, "Out of reach")
 		return fail_activate()
 
 	if(istype(A, /obj/alien/egg/gas))

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -302,6 +302,10 @@
 /datum/action/xeno_action/activable/inject_egg_neurogas/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/defiler/X = owner
 
+	if(!owner.Adjacent(A))
+		A.balloon_alert(X, "Cannot reach")
+		return fail_activate()
+
 	if(istype(A, /obj/alien/egg/gas))
 		A.balloon_alert(X, "Egg already injected")
 		return fail_activate()


### PR DESCRIPTION

## About The Pull Request
Defiler can inject eggs with neurogas from any range and this PR fixes it by adding an adjacent check to the ability.
## Why It's Good For The Game
Fixes an exploit and now the ability makes logical sense.
## Changelog
:cl:
fix: Defiler can only inject eggs adjacent to them.
/:cl:
