### PR TITLE
Laser rifle can't use a full scope anymore

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -448,7 +448,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
Big scope makes the laser rifle step on the toes of the laser sniper severely, much more so than projectile weapons.
## Why It's Good For The Game
More clear cut roles
## Changelog
:cl:
balance: Laser rifles can no longer equip full scopes
/:cl:
