### PR TITLE
Filter Supply Beacon Drop Locations if its in the Air

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -114,6 +114,11 @@
 	SIGNAL_HANDLER
 	beacon_datum = null
 
+/obj/item/beacon/supply_beacon/onTransitZ(old_z,new_z)
+	. = ..()
+	//Assumes doMove sets loc before onTransitZ
+	beacon_datum.drop_location = loc
+
 /obj/item/beacon/supply_beacon/activate(mob/living/carbon/human/H)
 	var/area/A = get_area(H)
 	. = ..()

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -101,7 +101,7 @@
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("There wasn't any supplies found on the squads supply pad. Double check the pad.")]")
 				return
 
-			if(!istype(supply_beacon.drop_location))
+			if(!istype(supply_beacon.drop_location) || !is_ground_level(supply_beacon.drop_location.z))
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("The [supply_beacon.name] was not detected on the ground.")]")
 				return
 			if(isspaceturf(supply_beacon.drop_location) || supply_beacon.drop_location.density)

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -167,6 +167,10 @@
 		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! Supply beacon signal lost.")]")
 		return
 
+	if(!is_ground_level(supply_beacon.drop_location.z))
+		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! Supply beacon is not groundside.")]")
+		return
+
 	if(!length(supplies))
 		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! No deployable object detected on the drop pad.")]")
 		return


### PR DESCRIPTION
## About The Pull Request

The req launch console now does not allow sending crates to supply beacons that are not on the ground. Thus when tad launches with beacons onboard, an oblivious RO will not deliver B18's to the hive. Also when tad lands, crates will be sent to the right place.
## Why It's Good For The Game
RO does not know when tad launches and has to ask the pilot if they moved every time a crate needs to be sent. This is silly.

Unlike antennas, beacons are static objects and should update their drop locations when moved.

Fixes issue #13039.
## Changelog
:cl:
qol: req can be confident that crates to a supply beacon on tad will arrive on tad.
fix: A supply beacon on tad will work after tad moves.
/:cl:
