### PR TITLE
Adjust reagent pouch ratio

### DIFF
--- a/code/game/objects/items/storage/reagent_pouch.dm
+++ b/code/game/objects/items/storage/reagent_pouch.dm
@@ -179,11 +179,20 @@
 				dat += "\n \t <b>Unknown:</b> [R.volume]|[percent]%</br>"
 	return span_notice("[src]'s reagent display shows the following contents: [dat.Join(" ")]")
 
+/obj/item/storage/pouch/pressurized_reagent_pouch/empty //So you can mix to your hearts content
+	desc = "A very large reagent pouch. It is used to refill custom injectors, and can also store one. \
+	You can Alt-Click to remove the canister in order to refill it. \
+	This one is empty, allowing you to freely mix whatever you want."
+	chemicals_to_fill = null
+
 /obj/item/storage/pouch/pressurized_reagent_pouch/bktt //Pre-filled with equal parts BKTT and a basic auto injector
+	name = "bktt reagent pouch"
+	desc = "A very large reagent pouch. It is used to refill custom injectors, and can also store one.\
+	You can Alt-Click to remove the canister in order to refill it. \
+	This one comes preloaded with BKTT."
 	chemicals_to_fill = list(
 		/datum/reagent/medicine/bicaridine = 300,
 		/datum/reagent/medicine/kelotane = 300,
-		/datum/reagent/medicine/tramadol = 300,
+		/datum/reagent/medicine/tramadol = 150, //Half metabolism
 		/datum/reagent/medicine/tricordrazine = 300,
 	)
-

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1229,6 +1229,7 @@
 			/obj/item/storage/pouch/explosive = -1,
 			/obj/item/storage/pouch/medkit = -1,
 			/obj/item/storage/pouch/medical_injectors = -1,
+			/obj/item/storage/pouch/pressurized_reagent_pouch/empty = -1,
 			/obj/item/storage/pouch/pressurized_reagent_pouch/bktt = -1,
 			/obj/item/storage/pouch/med_lolipops = -1,
 			/obj/item/storage/pouch/berrypouch = -1,


### PR DESCRIPTION

## About The Pull Request
Adjust the default mix to have half as much trama.
Also adds in a variant of the pouch that spawns empty in the clothing vendor.
## Why It's Good For The Game
Tram metabolizes at half the rate, so you would eventually get tram OD if you keep using a 1:1:1:1 mix, so this addresses that.
## Changelog
:cl:
add: Added an empty reagent pouch to the clothing vendor.
balance: Adjust reagent pouch to 2:2:1:2 BKTT
/:cl:
