### PR TITLE
Removes random CIC blast door on smallbury

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -157,11 +157,6 @@
 	name = "\improper Command Cockpit"
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/mainship{
-	dir = 2;
-	id = "Interior_Emergency_umbilical";
-	name = "\improper Umbillical Airlock"
-	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/cic)
 "ax" = (


### PR DESCRIPTION

## About The Pull Request
Read what is on the tin. Marines literally couldn't open it.
## Why It's Good For The Game
This blast door was placed without buttons. Even if it worked, I really don't see why you would want it. The blast doors on the bigbury make more sense.
## Changelog
:cl:
fix: Removes unopenable blast door on smallbury CIC
/:cl:
