### PR TITLE
FK-88 no longer has windup.

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -257,7 +257,6 @@
 
 	scatter = 10
 	deployed_scatter_change = -10
-	windup_delay = 8 SECONDS
 	fire_delay = 10 SECONDS
 
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE|DEPLOYED_ANCHORED_FIRING_ONLY


### PR DESCRIPTION

## About The Pull Request
You no longer need to windup the FK-88 to fire it.
## Why It's Good For The Game
This used to be here since I had it since you didn't need to anchor it at the start of design, but ended up making it a requirement. So this is pretty necessary to make it more 'useable' in most scenarios considering the setup time of like half a minute.
## Changelog
:cl:
balance: You no longer need to wind up the FK-88 to fire.
/:cl:
