### PR TITLE
Fixes an issue with the Runner HUD not updating properly when cancelled

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -188,6 +188,7 @@
 		))
 	evade_active = FALSE
 	evasion_stacks = 0
+	evasion_duration = 0
 	owner.balloon_alert(owner, "Evasion ended")
 	owner.playsound_local(owner, 'sound/voice/hiss5.ogg', 50)
 	var/mob/living/carbon/xenomorph/runner/runner_owner = owner


### PR DESCRIPTION
## About The Pull Request
Per title. The HUD wasn't updating properly when Evasion was cancelled by something like fire, stagger, etc.

## Why It's Good For The Game
Bug fix good.

## Changelog
:cl: Lewdcifer
fix: Fixed an issue with the Runner HUD not updating properly when cancelled.
/:cl:
