### PR TITLE
Heavy jetpack

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -519,6 +519,7 @@
 #define COMSIG_LIVING_MELEE_ALIEN_DISARMED "living_melee_alien_disarmed"	//from /mob/living/proc/attack_alien_disarm(): (mob/living/carbon/xenomorph/X)
 #define COMSIG_LIVING_SHIELDCALL "living_shieldcall"
 #define COMSIG_LIVING_PROJECTILE_STUN "living_stun_mitigation" //from /datum/ammo/proc/staggerstun
+#define COMSIG_LIVING_JETPACK_STUN "living_jetpack_stun" //from /obj/item/jetpack_marine/heavy/proc/mob_hit()
 ///from /mob/living/proc/set_lying_angle
 #define COMSIG_LIVING_SET_LYING_ANGLE "living_set_lying_angle"
 #define COMSIG_LIVING_IGNITED "living_ignited" //from /mob/living/proc/IgniteMob() : (fire_stacks)

--- a/code/datums/components/stun_mitigation.dm
+++ b/code/datums/components/stun_mitigation.dm
@@ -86,7 +86,7 @@
 
 ///Actually activates the mitigation effect
 /datum/component/stun_mitigation/proc/activate_with_user()
-	RegisterSignal(affected, COMSIG_LIVING_PROJECTILE_STUN, PROC_REF(on_attack_stun_mitigation))
+	RegisterSignals(affected, list(COMSIG_LIVING_PROJECTILE_STUN, COMSIG_LIVING_JETPACK_STUN), PROC_REF(on_attack_stun_mitigation))
 
 ///Actually deactivates the mitigation effect
 /datum/component/stun_mitigation/proc/deactivate_with_user()

--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -486,10 +486,10 @@
 
 /datum/outfit/quick/tgmc/marine/machete
 	name = "Assault Marine"
-	desc = "This doesn't look standard issue... Equipped with a SMG-25 submachine gun, machete and jetpack, along with light armor upgraded with a 'svallin' shield module. It's not clear why this is here, nevertheless it has excellent mobility, and would likely be devastating against anyone you manage to actually reach."
+	desc = "This doesn't look standard issue... Equipped with a SMG-25 submachine gun, machete and heavy lift jetpack, along with light armor upgraded with a 'svallin' shield module. It's not clear why this is here, nevertheless it has excellent mobility, and would likely be devastating against anyone you manage to actually reach."
 
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/light/shield
-	back = /obj/item/jetpack_marine
+	back = /obj/item/jetpack_marine/heavy
 	belt = /obj/item/storage/holster/blade/machete/full
 	suit_store = /obj/item/weapon/gun/smg/m25/magharness
 

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -82,6 +82,7 @@
 
 ///remove the flame overlay
 /obj/item/jetpack_marine/proc/reset_flame(mob/living/carbon/human/human_user)
+	SIGNAL_HANDLER
 	UnregisterSignal(human_user, COMSIG_MOVABLE_POST_THROW)
 	lit = FALSE
 	update_icon()

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -251,18 +251,19 @@
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, MELEE))
 			human_user.Knockdown(0.5 SECONDS)
 			human_user.set_throwing(FALSE)
+			INVOKE_NEXT_TICK(human_user, TYPE_PROC_REF(/atom/movable, knockback), human_target, 1, 5)
 			human_user.visible_message(span_danger("[human_user] crashes into [hit_mob]!"))
 			return COMPONENT_MOVABLE_PREBUMP_STOPPED
 
 	var/knockdown_duration = 0.5 SECONDS
 	var/list/stunlist = list(0, knockdown_duration, 0, 0)
 	if(SEND_SIGNAL(hit_mob, COMSIG_LIVING_JETPACK_STUN, stunlist, MELEE))
-		knockdown_duration = stunlist[2]
 		hit_mob.adjust_stagger(stunlist[3])
 		hit_mob.add_slowdown(stunlist[4])
-
-	hit_mob.Knockdown(knockdown_duration)
-	human_user.forceMove(get_turf(hit_mob))
+		hit_mob.knockback(human_user, 1, 5) //if we don't stun, we knockback
+	else
+		hit_mob.Knockdown(knockdown_duration)
+		human_user.forceMove(get_turf(hit_mob))
 	hit_mob.apply_damage(40, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
 	hit_mob.visible_message(span_danger("[human_user] slams into [hit_mob]!"))
 

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -1,7 +1,6 @@
 #define FUEL_USE 5
 #define FUEL_INDICATOR_FULL 35
 #define FUEL_INDICATOR_HALF_FULL 20
-#define JETPACK_COOLDOWN_TIME 10 SECONDS
 
 /obj/item/jetpack_marine
 	name = "marine jetpack"
@@ -15,6 +14,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags_equip_slot = ITEM_SLOT_BACK
 	obj_flags = CAN_BE_HIT
+	///Time between uses
+	var/cooldown_time = 10 SECONDS
 	///maximum amount of fuel in the jetpack
 	var/fuel_max = 75
 	///current amount of fuel in the jetpack
@@ -96,7 +97,7 @@
 		return FALSE
 	if(!do_after(user = human_user, delay = 0.3 SECONDS, needhand = FALSE, target = A, ignore_turf_checks = TRUE))
 		return FALSE
-	TIMER_COOLDOWN_START(src, COOLDOWN_JETPACK, JETPACK_COOLDOWN_TIME)
+	TIMER_COOLDOWN_START(src, COOLDOWN_JETPACK, cooldown_time)
 	lit = TRUE
 	playsound(human_user,'sound/items/jetpack_sound.ogg',45)
 	fuel_left -= FUEL_USE
@@ -205,7 +206,9 @@
 	update_icon()
 
 
-//
+/obj/item/jetpack_marine/heavy
+	cooldown_time = 5 SECONDS
+
 /obj/item/jetpack_marine/heavy/use_jetpack(atom/A, mob/living/carbon/human/human_user)
 	. = ..()
 	if(!.)

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -236,7 +236,7 @@
 	UnregisterSignal(human_user, COMSIG_MOVABLE_PREBUMP_MOVABLE)
 
 ///Handles the user colliding with a mob
-/obj/item/jetpack_marine/heavy/proc/mob_hit(mob/living/carbon/human/owner, mob/living/hit_mob)
+/obj/item/jetpack_marine/heavy/proc/mob_hit(mob/living/carbon/human/human_user, mob/living/hit_mob)
 	SIGNAL_HANDLER
 	if(!istype(hit_mob))
 		return
@@ -246,14 +246,16 @@
 	if(ishuman(hit_mob) && (hit_mob.dir in reverse_nearby_direction(hit_mob.dir)))
 		var/mob/living/carbon/human/human_target = hit_mob
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, MELEE))
-			owner.Paralyze(0.5 SECONDS)
-			owner.set_throwing(FALSE)
+			human_user.Knockdown(0.5 SECONDS)
+			human_user.set_throwing(FALSE)
+			human_user.visible_message(span_danger("[human_user] crashes into [hit_mob]!"))
 			return COMPONENT_MOVABLE_PREBUMP_STOPPED
 
-	owner.forceMove(get_turf(hit_mob))
+	human_user.forceMove(get_turf(hit_mob))
 	hit_mob.Knockdown(0.5 SECONDS)
 	hit_mob.apply_damage(40, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
+	hit_mob.visible_message(span_danger("[human_user] slams into [hit_mob]!"))
 	playsound(hit_mob, 'sound/weapons/heavyhit.ogg', 40)
 
-	owner.set_throwing(FALSE)
+	human_user.set_throwing(FALSE)
 	return COMPONENT_MOVABLE_PREBUMP_STOPPED

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -207,8 +207,8 @@
 
 
 /obj/item/jetpack_marine/heavy
-	name = "marine heavy jetpack"
-	desc = "A upgraded jetpack with enough fuel to send a person flying for a short while with extreme force. It provides better mobility for heavy users and enough thrust to be used in an aggressive manner. <b>Alt right click or middleclick to fly to a destination when the jetpack is equipped.</b>"
+	name = "heavy lift jetpack"
+	desc = "An upgraded jetpack with enough fuel to send a person flying for a short while with extreme force. It provides better mobility for heavy users and enough thrust to be used in an aggressive manner. <b>Alt right click or middleclick to fly to a destination when the jetpack is equipped.</b>"
 	cooldown_time = 5 SECONDS
 	speed = 2
 

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -210,6 +210,7 @@
 	name = "marine heavy jetpack"
 	desc = "A upgraded jetpack with enough fuel to send a person flying for a short while with extreme force. It provides better mobility for heavy users and enough thrust to be used in an aggressive manner. <b>Alt right click or middleclick to fly to a destination when the jetpack is equipped.</b>"
 	cooldown_time = 5 SECONDS
+	speed = 2
 
 /obj/item/jetpack_marine/heavy/calculate_range(mob/living/carbon/human/human_user)
 	var/range_limiting_factor = human_user.additive_flagged_slowdown(SLOWDOWN_IMPEDE_JETPACK)


### PR DESCRIPTION

## About The Pull Request
Adds a heavy jetpack to HvH.
I will likely lock the upgrade behind something, but doesn't hurt to let people test it for now.

1. Travel speed is higher (critical for flying directly through windows)
2. Distance penalties for high slowdown are significantly lower (i.e. you can jetpack further with heavy armour/tyr/shield etc)
3. 5 second CD instead of 10
4. **If you are not on help intent, you will smash into mobs, stunning them briefly** (or yourself)

And some tweaks/improvements to jetpack code, only player facing change is using a jetpack will now actually tell you how much is left on the cooldown, if its not ready.
## Why It's Good For The Game
## Changelog
:cl:
add: Added a heavy lift jetpack to HvH, capable of travelling further with a heavy load, or smashing directly into mobs
qol: Jetpacks say how long is left on CD if you try use it
code: minor code improvements for jetpacks
/:cl:
