### PR TITLE
Add area specific sound enviroments and adds reverb to caves

### DIFF
--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -60,6 +60,9 @@
 	///Used to decide what the maximum time between ambience is
 	var/max_ambience_cooldown = 120 SECONDS
 
+	///What sound eviroment to use
+	var/sound_environment = SOUND_ENVIRONMENT_ROOM
+
 	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
 	var/area_limited_icon_smoothing = FALSE
 

--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -61,7 +61,7 @@
 	var/max_ambience_cooldown = 120 SECONDS
 
 	///What sound environment to use
-	var/sound_environment = SOUND_ENVIRONMENT_ROOM
+	var/sound_environment = SOUND_ENVIRONMENT_NONE
 
 	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
 	var/area_limited_icon_smoothing = FALSE

--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -61,7 +61,7 @@
 	var/max_ambience_cooldown = 120 SECONDS
 
 	///What sound environment to use
-	var/sound_environment = SOUND_ENVIRONMENT_NONE
+	var/sound_environment = SOUND_ENVIRONMENT_ROOM
 
 	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
 	var/area_limited_icon_smoothing = FALSE

--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -60,8 +60,8 @@
 	///Used to decide what the maximum time between ambience is
 	var/max_ambience_cooldown = 120 SECONDS
 
-	///What sound eviroment to use
-	var/sound_environment = SOUND_ENVIRONMENT_ROOM
+	///What sound environment to use
+	var/sound_environment = SOUND_ENVIRONMENT_NONE
 
 	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
 	var/area_limited_icon_smoothing = FALSE

--- a/code/game/area/bigred.dm
+++ b/code/game/area/bigred.dm
@@ -51,6 +51,7 @@
 	ambience = list('sound/ambience/ambicave.ogg', 'sound/ambience/ambilava1.ogg', 'sound/ambience/ambilava2.ogg', 'sound/ambience/ambilava3.ogg')
 	minimap_color = MINIMAP_AREA_CAVES
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/bigredv2/caves/rock
 	name = "Enclosed Area"

--- a/code/game/area/gelida_iv.dm
+++ b/code/game/area/gelida_iv.dm
@@ -439,6 +439,7 @@
 	ceiling = CEILING_DEEP_UNDERGROUND
 	minimap_color = MINIMAP_AREA_CAVES
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/gelida/caves/west_caves
 	name = "Western Caves"

--- a/code/game/area/icecolony.dm
+++ b/code/game/area/icecolony.dm
@@ -168,6 +168,7 @@
 /area/ice_colony/exterior/underground/caves
 	name = "Underground Caves"
 	icon_state = "cave"
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/ice_colony/exterior/underground/caves/ice_nw
 	name = "North Western Ice Caves"

--- a/code/game/area/icy_caves.dm
+++ b/code/game/area/icy_caves.dm
@@ -8,6 +8,7 @@
 	ceiling = CEILING_UNDERGROUND
 	minimap_color = MINIMAP_AREA_CAVES
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/icy_caves/caves/northern
 	name = "Northern Caves"

--- a/code/game/area/lawankaoutpost.dm
+++ b/code/game/area/lawankaoutpost.dm
@@ -8,6 +8,7 @@
 	outside = FALSE
 	minimap_color = MINIMAP_AREA_CAVES
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/lawankaoutpost/caves/rock
 	name = "Enclosed Area"

--- a/code/game/area/magmoor_digsite.dm
+++ b/code/game/area/magmoor_digsite.dm
@@ -32,6 +32,7 @@
 	ambience = list('sound/ambience/ambicave.ogg', 'sound/ambience/ambilava1.ogg', 'sound/ambience/ambilava2.ogg', 'sound/ambience/ambilava3.ogg')
 	minimap_color = MINIMAP_AREA_CAVES
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/magmoor/cave/central
 	name = "Central Caves"

--- a/code/game/area/research_outpost.dm
+++ b/code/game/area/research_outpost.dm
@@ -61,6 +61,7 @@
 	ceiling = CEILING_NONE
 	outside = FALSE
 	always_unpowered = TRUE
+	sound_environment = SOUND_ENVIRONMENT_CAVE
 
 /area/outpost/caves/central
 	name = "Central Caves"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -111,8 +111,8 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 		S.environment = A.sound_environment
 		if(S.environment != SOUND_ENVIRONMENT_NONE)
 			//need room and roomHF to be not -10000 for reverb to work
-			S.echo[3] = 0
-			S.echo[4] = 0
+			S.echo[3] = -1250
+			S.echo[4] = -1250
 
 	SEND_SOUND(src, S)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -109,9 +109,10 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 		//get area sound enviroment and use it for sound
 		var/area/A = get_area(src)
 		S.environment = A.sound_environment
-		//need room and roomHF to be not -10000 for reverb to work
-		S.echo[3] = 0
-		S.echo[4] = 0
+		if(S.environment != SOUND_ENVIRONMENT_NONE)
+			//need room and roomHF to be not -10000 for reverb to work
+			S.echo[3] = 0
+			S.echo[4] = 0
 
 	SEND_SOUND(src, S)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -106,7 +106,9 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 		S.falloff = falloff ? falloff : FALLOFF_SOUNDS * max(round(S.volume * 0.05), 1)
 
 	if(!is_global)
-		S.environment = SOUND_ENVIRONMENT_ROOM
+		//get area sound enviroment and use it for sound
+		var/area/A = get_area(src)
+		S.environment = A.sound_environment
 
 	SEND_SOUND(src, S)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -109,6 +109,9 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 		//get area sound enviroment and use it for sound
 		var/area/A = get_area(src)
 		S.environment = A.sound_environment
+		//need room and roomHF to be not -10000 for reverb to work
+		S.echo[3] = 0
+		S.echo[4] = 0
 
 	SEND_SOUND(src, S)
 


### PR DESCRIPTION

## About The Pull Request

saw some of this when digging through TG code, makes it so areas can have their own sound environments, like caves and hangers having reverb.

also made it so caves on some maps use the cave sound environment, has some reverb.

## Why It's Good For The Game

i think its cool to walk into an area and for it to sound different, caves having some reverb and what not.

## Changelog

:cl:
soundadd: caves now have reverb
/:cl: