### PR TITLE
Teleblock changes

### DIFF
--- a/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
+++ b/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
@@ -9,6 +9,7 @@
 "aai" = (
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/turf_decal/tile/full/black,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "aaz" = (
@@ -1918,6 +1919,7 @@
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/turf_decal/tile/full/black,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "buS" = (
@@ -3984,6 +3986,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "cWO" = (
@@ -4557,6 +4560,7 @@
 "dsc" = (
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/landmark/campaign_structure/nt_pod,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "dsf" = (
@@ -6160,6 +6164,7 @@
 /area/gelida/indoors/a_block/corpo)
 "ezl" = (
 /obj/effect/turf_decal/tile/full/black,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "ezx" = (
@@ -14106,6 +14111,7 @@
 "kxK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/full/black,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "kxO" = (
@@ -14581,6 +14587,7 @@
 /obj/machinery/door/poddoor/nt_lockdown/red{
 	dir = 1
 	},
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "kNR" = (
@@ -26507,6 +26514,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/full/black,
 /obj/effect/turf_decal/tile/full/black,
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "tmH" = (
@@ -30894,6 +30902,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/abstract/tele_blocker,
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "wDw" = (

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -310,6 +310,7 @@
 #define COMSIG_TURF_RESUME_PROJECTILE_MOVE "resume_projetile"
 #define COMSIG_TURF_PROJECTILE_MANIPULATED "projectile_manipulated"
 #define COMSIG_TURF_CHECK_COVERED "turf_check_covered" //from /turf/open/liquid/Entered checking if something is covering the turf
+#define COMSIG_TURF_TELEPORT_CHECK "turf_teleport_check" //from /turf/proc/can_teleport_here()
 
 // /obj signals
 #define COMSIG_OBJ_SETANCHORED "obj_setanchored"				//called in /obj/structure/setAnchored(): (value)

--- a/code/game/objects/effects/tele_blocker.dm
+++ b/code/game/objects/effects/tele_blocker.dm
@@ -1,0 +1,16 @@
+//blocks teleporters
+/obj/effect/abstract/tele_blocker
+	invisibility = INVISIBILITY_ABSTRACT
+	anchored = TRUE
+
+/obj/effect/abstract/tele_blocker/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_TURF_TELEPORT_CHECK = PROC_REF(tele_check),
+	)
+	AddElement(/datum/element/connect_loc, connections)
+
+///Tells the turf that nothing can teleport there
+/obj/effect/abstract/tele_blocker/proc/tele_check(datum/source)
+	SIGNAL_HANDLER
+	return TRUE

--- a/code/game/objects/items/blink_drive.dm
+++ b/code/game/objects/items/blink_drive.dm
@@ -149,7 +149,7 @@
 		pulled_target.forceMove(target_turf)
 	teleport_debuff_aoe(user)
 
-	if(target_turf.density || isspaceturf(target_turf))
+	if(!target_turf.can_teleport_here())
 		user.emote("gored")
 		user.gib() //telegibbed
 		if(pulled_target && ismob(pulled_target))

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -97,6 +97,8 @@
 			var/mob/living/spaceman = leaver
 			spaceman.remove_status_effect(debuff_type)
 
+/turf/open/space/can_teleport_here()
+	return FALSE
 
 /turf/open/space/sea //used on prison for flavor
 	icon = 'icons/misc/beach.dmi'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -928,3 +928,12 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	underlay_appearance.icon_state = icon_state
 	underlay_appearance.dir = adjacency_dir
 	return TRUE
+
+///Are we able to teleport to this turf using in game teleport mechanics
+/turf/proc/can_teleport_here()
+	if(density)
+		return FALSE
+	//var/signalreturn = SEND_SIGNAL(src, COMSIG_TURF_TELEPORT_CHECK)
+	if(SEND_SIGNAL(src, COMSIG_TURF_TELEPORT_CHECK))
+		return FALSE
+	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -933,7 +933,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 /turf/proc/can_teleport_here()
 	if(density)
 		return FALSE
-	//var/signalreturn = SEND_SIGNAL(src, COMSIG_TURF_TELEPORT_CHECK)
 	if(SEND_SIGNAL(src, COMSIG_TURF_TELEPORT_CHECK))
 		return FALSE
 	return TRUE

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -629,6 +629,7 @@
 #include "code\game\objects\effects\proximity.dm"
 #include "code\game\objects\effects\spiders.dm"
 #include "code\game\objects\effects\step_triggers.dm"
+#include "code\game\objects\effects\tele_blocker.dm"
 #include "code\game\objects\effects\turf_overunderlays.dm"
 #include "code\game\objects\effects\weeds.dm"
 #include "code\game\objects\effects\decals\cleanable.dm"


### PR DESCRIPTION

## About The Pull Request
Changed blinkdrives to check a turf proc to see if a turf can be teleported to.
This sends a signal, and added an effect object to listen to that and make turfs unable to teleport to.
## Why It's Good For The Game
Teleporting to the objective on Base rescue to bypass the mission bad.
Telegib good.
## Changelog
:cl:
fix: Can no longer teleport to the objective on Base Rescue in campaign
/:cl:
