### PR TITLE
Fix a runtime in stripping hands

### DIFF
--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -63,7 +63,7 @@
 
 	var/mob/mob_source = source
 
-	if(!do_after(user, equipping.equip_delay_other, source, BUSY_ICON_FRIENDLY))
+	if(!do_after(user, equipping.equip_delay_other, TRUE, source, BUSY_ICON_FRIENDLY))
 		return FALSE
 
 	if(!mob_source.can_put_in_hand(equipping, hand_index))


### PR DESCRIPTION
## About The Pull Request

`runtime error: Cannot read /image/progdisplay/friendly (/image/progdisplay/friendly).loc`

https://github.com/tgstation/TerraGov-Marine-Corps/blob/f5c8b3882c27faf0be9f9c5792b339247300c984/code/__HELPERS/mobs.dm#L122-L124

`needhand` was forgotten in the do_after args when strip menu was ported from newer tg, but it still worked anyway on 515 while being broken on 514

```dm
/image/a

/world/New()
	var/atom/a = /image/a
	world.log << a.loc // null on 515, on 514: Cannot read /image/a (/image/a).loc
```