### PR TITLE
Decap respawn fix

### DIFF
--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -126,6 +126,7 @@
 		H.mind.transfer_to(brainmob)
 	brainmob.container = src
 	brainmob.copy_known_languages_from(H, TRUE)
+	brainmob.job = H.job
 
 //synthetic head, allowing brain mob inside to talk
 /obj/item/limb/head/synth


### PR DESCRIPTION
## About The Pull Request
Decapping no longer bypasses the respawn timer.
Fixes #14444
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: Getting decapped should no longer bypass the respawn timer
/:cl:
