### PR TITLE
Gives Ravager 2 tile slash reach.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -171,6 +171,10 @@
 				continue
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || (target in direct_access)) //Directly accessible atoms
+				if(isxeno(usr))
+					var/mob/living/carbon/xenomorph/slasher = usr
+					if(Adjacent(target) || target.Adjacent(src) || CheckToolReach(src, target, slasher.xeno_caste.slash_reach))
+						return TRUE
 				if(Adjacent(target) || target.Adjacent(src) || (tool && CheckToolReach(src, target, tool.reach))) //Adjacent or reaching attacks
 					return TRUE
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -138,7 +138,7 @@
 		return
 
 	//Standard reach turf to turf or reaching inside storage
-	if(CanReach(A, W))
+	if(CanReach(A, W, usr))
 		if(W)
 			W.melee_attack_chain(src, A, params, modifiers["right"])
 		else
@@ -154,7 +154,7 @@
 			RangedAttack(A, params)
 
 
-/atom/movable/proc/CanReach(atom/ultimate_target, obj/item/tool, view_only = FALSE)
+/atom/movable/proc/CanReach(atom/ultimate_target, obj/item/tool, mob/living/carbon/xenomorph/attacker, view_only = FALSE)
 	// A backwards depth-limited breadth-first-search to see if the target is
 	// logically "in" anything adjacent to us.
 	var/list/direct_access = DirectAccess()
@@ -172,8 +172,7 @@
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || (target in direct_access)) //Directly accessible atoms
 				if(isxeno(usr))
-					var/mob/living/carbon/xenomorph/slasher = usr
-					if(Adjacent(target) || target.Adjacent(src) || CheckToolReach(src, target, slasher.xeno_caste.slash_reach))
+					if(Adjacent(target) || target.Adjacent(src) || (attacker && CheckToolReach(src, target, attacker.xeno_caste.slash_reach)))
 						return TRUE
 				if(Adjacent(target) || target.Adjacent(src) || (tool && CheckToolReach(src, target, tool.reach))) //Adjacent or reaching attacks
 					return TRUE
@@ -248,7 +247,6 @@
 					qdel(dummy)
 					return
 			qdel(dummy)
-
 
 /**
  *Translates into attack_hand, etc.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -138,7 +138,7 @@
 		return
 
 	//Standard reach turf to turf or reaching inside storage
-	if(CanReach(A, W, usr))
+	if(CanReach(A, W, src))
 		if(W)
 			W.melee_attack_chain(src, A, params, modifiers["right"])
 		else
@@ -171,7 +171,7 @@
 				continue
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || (target in direct_access)) //Directly accessible atoms
-				if(isxeno(usr))
+				if(isxeno(attacker))
 					if(Adjacent(target) || target.Adjacent(src) || (attacker && CheckToolReach(src, target, attacker.xeno_caste.slash_reach)))
 						return TRUE
 				if(Adjacent(target) || target.Adjacent(src) || (tool && CheckToolReach(src, target, tool.reach))) //Adjacent or reaching attacks

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -11,6 +11,7 @@
 	// *** Melee Attacks *** //
 	melee_damage = 30
 	attack_delay = 7
+	slash_reach = 2
 
 	// *** Speed *** //
 	speed = -1

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -231,6 +231,8 @@
 	var/evolve_min_xenos = 0
 	// How many of this caste may be alive at once
 	var/maximum_active_caste = INFINITY
+	///Slash range
+	var/slash_reach = 1
 
 ///Add needed component to the xeno
 /datum/xeno_caste/proc/on_caste_applied(mob/xenomorph)


### PR DESCRIPTION

## About The Pull Request
Gives Ravager 2 tile slash reach
## Why It's Good For The Game
Gives Ravager a pretty neat advantage when compared to other xenos. 
Considering he's basically runner-lite but without evasion and less speed, it's really hard for a Rav to catch up to their victim, or even to slash them at times due to their big sprite.
This aims to give Rav the power to rip and tear without falling victim to big-sprite-impossible-to-click-enemy syndrome.

I also just think it's neat that a xeno with scythe arms has above-average slash range. Makes much more sense considering how massive his spear-arms are.
## Changelog
:cl:
balance: Ravager has 2 tiles of slash range
/:cl:
