### PR TITLE
Nerfs the GL-70 grenade launcher's fire rate and the grenade's explosion delay.

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -107,7 +107,7 @@
 
 ///Adjusts det time, used for grenade launchers
 /obj/item/explosive/grenade/proc/launched_det_time()
-	det_time = min(10, det_time)
+	det_time = min(15, det_time)
 
 ////RAD GRENADE - TOTALLY RAD MAN
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -106,8 +106,8 @@
 	return
 
 ///Adjusts det time, used for grenade launchers
-/obj/item/explosive/grenade/proc/launched_det_time()
-	det_time = min(15, det_time)
+/obj/item/explosive/grenade/proc/launched_det_time(min_delay)
+	det_time = min(min_delay, det_time)
 
 ////RAD GRENADE - TOTALLY RAD MAN
 

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -130,7 +130,7 @@ The Grenade Launchers
 	)
 	starting_attachment_types = list(/obj/item/attachable/stock/t70stock)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
-	fire_delay = 1.5 SECONDS
+	fire_delay = 1.4 SECONDS
 	max_chamber_items = 5
 	launched_detonation_time = 1.2 SECONDS
 

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -60,6 +60,8 @@ The Grenade Launchers
 
 	///the maximum range the launcher can fling the grenade, by default 15 tiles
 	var/max_range = 15
+	///The maximum amount of time the grenade will take to explode after being launched.
+	var/launched_detonation_time = 1 SECONDS
 
 /obj/item/weapon/gun/grenade_launcher/able_to_fire(mob/user)
 	. = ..()
@@ -80,7 +82,7 @@ The Grenade Launchers
 	log_explosion("[key_name(gun_user)] fired a grenade ([grenade_to_launch]) from [src] at [AREACOORD(user_turf)].")
 	log_combat(gun_user, src, "fired a grenade ([grenade_to_launch]) from [src]")
 	play_fire_sound(loc)
-	grenade_to_launch.launched_det_time()
+	grenade_to_launch.launched_det_time(launched_detonation_time)
 	grenade_to_launch.launched = TRUE
 	grenade_to_launch.activate(gun_user)
 	grenade_to_launch.throwforce += grenade_to_launch.launchforce
@@ -130,6 +132,7 @@ The Grenade Launchers
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
 	fire_delay = 1.5 SECONDS
 	max_chamber_items = 5
+	launched_detonation_time = 1.5 SECONDS
 
 /obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded
 	default_ammo_type = null

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -132,7 +132,7 @@ The Grenade Launchers
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
 	fire_delay = 1.5 SECONDS
 	max_chamber_items = 5
-	launched_detonation_time = 1.5 SECONDS
+	launched_detonation_time = 1.2 SECONDS
 
 /obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded
 	default_ammo_type = null

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -128,7 +128,7 @@ The Grenade Launchers
 	)
 	starting_attachment_types = list(/obj/item/attachable/stock/t70stock)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
-	fire_delay = 1.2 SECONDS
+	fire_delay = 1.5 SECONDS
 	max_chamber_items = 5
 
 /obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded


### PR DESCRIPTION
## About The Pull Request
Before you say it. This is 100% a xope PR.
So, usually if someone throws a grenade, there's plenty of ways to counter it, banishing as wraith, or using a fling ability on it to throw it back, unless it's cooked perfectly which is risky for the marine, you have enough time to react, what grenade launchers do is let you shoot 6 grenades, each at a delay of 1.4 second, which is constant, oppresive pain to xenos and incredibly hard to counter without having a crusher, which even then can just get flung around and be unable to do anything due to the explosive stagger slowdown, this PR makes grenade launcher's grenades explode in 1.2 seconds, whereas it used to be in one second, and makes the multinade grenade launcher's fire delay 1.4 seconds as well. You can still shoot grenades near-constantly but now xenos will have 1.2 second of a delay to actually react to the grenade.
## Why It's Good For The Game
Xenos will no longer need godly reaction speeds to counter grenade launchers.
## Changelog
:cl:
balance: GL-70 Grenade launcher's grenades now explode in 12 ticks/1.2 seconds.
balance: GL-70 Grenade launcher's fire rate is now one shot per 14 ticks/1.4 seconds.
/:cl:
TL:DR
Grenades shot from a multi GL blow up 20% slower, 1.2 second delay, and it's fire rate has been changed to 1.4