### PR TITLE
Allows sticky grenades to be applied to self from your hand

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -146,18 +146,8 @@
 		clean_refs()
 	qdel(src)
 
-/obj/item/explosive/grenade/sticky/trailblazer/throw_impact(atom/hit_atom, speed)
+/obj/item/explosive/grenade/sticky/trailblazer/stuck_to(atom/hit_atom)
 	. = ..()
-	if(!.)
-		return
-	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
-	var/turf/T = get_turf(src)
-	T.ignite(25, 25)
-
-/obj/item/explosive/grenade/sticky/trailblazer/afterattack(atom/target, mob/user)
-	. = ..()
-	if(!self_sticky || target != user)
-		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
 	T.ignite(25, 25)
@@ -197,16 +187,8 @@
 		clean_refs()
 	qdel(src)
 
-/obj/item/explosive/grenade/sticky/cloaker/throw_impact(atom/hit_atom, speed)
+/obj/item/explosive/grenade/sticky/cloaker/stuck_to(atom/hit_atom)
 	. = ..()
-	if(!.)
-		return
-	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
-
-/obj/item/explosive/grenade/sticky/cloaker/afterattack(atom/target, mob/user)
-	. = ..()
-	if(!self_sticky || target != user)
-		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
 
 ///causes fire tiles underneath target when stuck_to

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -86,12 +86,7 @@
 	///if this specific grenade should be allowed to self sticky
 	var/self_sticky = FALSE
 
-/obj/item/explosive/grenade/sticky/throw_impact(atom/hit_atom, speed)
-	. = ..()
-	if(!.)
-		return
-	if(!active || stuck_to || isturf(hit_atom))
-		return
+/obj/item/explosive/grenade/sticky/proc/stuck_to(atom/hit_atom)
 	var/image/stuck_overlay = image(icon, hit_atom, initial(icon_state) + "_stuck")
 	stuck_overlay.pixel_x = rand(-5, 5)
 	stuck_overlay.pixel_y = rand(-7, 7)
@@ -101,22 +96,24 @@
 	stuck_to = hit_atom
 	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
+/obj/item/explosive/grenade/sticky/throw_impact(atom/hit_atom, speed)
+	. = ..()
+	if(!.)
+		return
+	if(!active || stuck_to || isturf(hit_atom))
+		return
+	stuck_to(hit_atom)
+
 /obj/item/explosive/grenade/sticky/afterattack(atom/target, mob/user, has_proximity, click_parameters)
 	. = ..()
 	if(target != user)
 		return
-	if(self_sticky == FALSE)
-		return
+	if(!self_sticky)
+		return FALSE
 	user.drop_held_item()
 	activate()
-	var/image/stuck_overlay = image(icon, user, initial(icon_state) + "_stuck")
-	stuck_overlay.pixel_x = rand(-5, 5)
-	stuck_overlay.pixel_y = rand(-7, 7)
-	user.add_overlay(stuck_overlay)
-	forceMove(user)
-	saved_overlay = stuck_overlay
-	stuck_to = user
-	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
+	var/hit_atom = target
+	stuck_to(hit_atom)
 
 /obj/item/explosive/grenade/sticky/prime()
 	if(stuck_to)
@@ -159,9 +156,7 @@
 
 /obj/item/explosive/grenade/sticky/trailblazer/afterattack(atom/target, mob/user)
 	. = ..()
-	if(target != user)
-		return
-	if(self_sticky == FALSE)
+	if(!.)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
@@ -210,9 +205,7 @@
 
 /obj/item/explosive/grenade/sticky/cloaker/afterattack(atom/target, mob/user)
 	. = ..()
-	if(target != user)
-		return
-	if(self_sticky == FALSE)
+	if(!.)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -99,21 +99,6 @@
 	stuck_to = hit_atom
 	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
-/obj/item/explosive/grenade/sticky/afterattack(atom/target, mob/user)
-	. = ..()
-	if(target != user)
-		return
-	user.drop_held_item()
-	activate()
-	var/image/stuck_overlay = image(icon, user, initial(icon_state) + "_stuck")
-	stuck_overlay.pixel_x = rand(-5, 5)
-	stuck_overlay.pixel_y = rand(-7, 7)
-	user.add_overlay(stuck_overlay)
-	forceMove(user)
-	saved_overlay = stuck_overlay
-	stuck_to = user
-	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
-
 /obj/item/explosive/grenade/sticky/prime()
 	if(stuck_to)
 		clean_refs()
@@ -156,9 +141,19 @@
 	. = ..()
 	if(target != user)
 		return
+	user.drop_held_item()
+	activate()
+	var/image/stuck_overlay = image(icon, user, initial(icon_state) + "_stuck")
+	stuck_overlay.pixel_x = rand(-5, 5)
+	stuck_overlay.pixel_y = rand(-7, 7)
+	user.add_overlay(stuck_overlay)
+	forceMove(user)
+	saved_overlay = stuck_overlay
+	stuck_to = user
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
 	T.ignite(25, 25)
+	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
 ///causes fire tiles underneath target when stuck_to
 /obj/item/explosive/grenade/sticky/trailblazer/proc/make_fire(datum/source, old_loc, movement_dir, forced, old_locs)
@@ -204,7 +199,17 @@
 	. = ..()
 	if(target != user)
 		return
+	user.drop_held_item()
+	activate()
+	var/image/stuck_overlay = image(icon, user, initial(icon_state) + "_stuck")
+	stuck_overlay.pixel_x = rand(-5, 5)
+	stuck_overlay.pixel_y = rand(-7, 7)
+	user.add_overlay(stuck_overlay)
+	forceMove(user)
+	saved_overlay = stuck_overlay
+	stuck_to = user
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
+	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
 ///causes fire tiles underneath target when stuck_to
 /obj/item/explosive/grenade/sticky/cloaker/proc/make_smoke(datum/source, old_loc, movement_dir, forced, old_locs)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -86,17 +86,6 @@
 	///if this specific grenade should be allowed to self sticky
 	var/self_sticky = FALSE
 
-///handles sticky overlay and attaching the grenade itself to the target
-/obj/item/explosive/grenade/sticky/proc/stuck_to(atom/hit_atom)
-	var/image/stuck_overlay = image(icon, hit_atom, initial(icon_state) + "_stuck")
-	stuck_overlay.pixel_x = rand(-5, 5)
-	stuck_overlay.pixel_y = rand(-7, 7)
-	hit_atom.add_overlay(stuck_overlay)
-	forceMove(hit_atom)
-	saved_overlay = stuck_overlay
-	stuck_to = hit_atom
-	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
-
 /obj/item/explosive/grenade/sticky/throw_impact(atom/hit_atom, speed)
 	. = ..()
 	if(!.)
@@ -130,6 +119,17 @@
 	UnregisterSignal(stuck_to, COMSIG_QDELETING)
 	stuck_to = null
 	saved_overlay = null
+
+///handles sticky overlay and attaching the grenade itself to the target
+/obj/item/explosive/grenade/sticky/proc/stuck_to(atom/hit_atom)
+	var/image/stuck_overlay = image(icon, hit_atom, initial(icon_state) + "_stuck")
+	stuck_overlay.pixel_x = rand(-5, 5)
+	stuck_overlay.pixel_y = rand(-7, 7)
+	hit_atom.add_overlay(stuck_overlay)
+	forceMove(hit_atom)
+	saved_overlay = stuck_overlay
+	stuck_to = hit_atom
+	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
 /obj/item/explosive/grenade/sticky/trailblazer
 	name = "\improper M45 Trailblazer grenade"

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -99,6 +99,21 @@
 	stuck_to = hit_atom
 	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
 
+/obj/item/explosive/grenade/sticky/afterattack(atom/target, mob/user)
+	. = ..()
+	if(target != user)
+		return
+	user.drop_held_item()
+	activate()
+	var/image/stuck_overlay = image(icon, user, initial(icon_state) + "_stuck")
+	stuck_overlay.pixel_x = rand(-5, 5)
+	stuck_overlay.pixel_y = rand(-7, 7)
+	user.add_overlay(stuck_overlay)
+	forceMove(user)
+	saved_overlay = stuck_overlay
+	stuck_to = user
+	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
+
 /obj/item/explosive/grenade/sticky/prime()
 	if(stuck_to)
 		clean_refs()
@@ -132,6 +147,14 @@
 /obj/item/explosive/grenade/sticky/trailblazer/throw_impact(atom/hit_atom, speed)
 	. = ..()
 	if(!.)
+		return
+	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
+	var/turf/T = get_turf(src)
+	T.ignite(25, 25)
+
+/obj/item/explosive/grenade/sticky/trailblazer/afterattack(atom/target, mob/user)
+	. = ..()
+	if(target != user)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
@@ -174,6 +197,12 @@
 /obj/item/explosive/grenade/sticky/cloaker/throw_impact(atom/hit_atom, speed)
 	. = ..()
 	if(!.)
+		return
+	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
+
+/obj/item/explosive/grenade/sticky/cloaker/afterattack(atom/target, mob/user)
+	. = ..()
+	if(target != user)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -86,6 +86,7 @@
 	///if this specific grenade should be allowed to self sticky
 	var/self_sticky = FALSE
 
+///handles sticky overlay and attaching the grenade itself to the target
 /obj/item/explosive/grenade/sticky/proc/stuck_to(atom/hit_atom)
 	var/image/stuck_overlay = image(icon, hit_atom, initial(icon_state) + "_stuck")
 	stuck_overlay.pixel_x = rand(-5, 5)
@@ -109,11 +110,10 @@
 	if(target != user)
 		return
 	if(!self_sticky)
-		return FALSE
+		return
 	user.drop_held_item()
 	activate()
-	var/hit_atom = target
-	stuck_to(hit_atom)
+	stuck_to(target)
 
 /obj/item/explosive/grenade/sticky/prime()
 	if(stuck_to)
@@ -156,7 +156,7 @@
 
 /obj/item/explosive/grenade/sticky/trailblazer/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!.)
+	if(!self_sticky || target != user)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
@@ -205,7 +205,7 @@
 
 /obj/item/explosive/grenade/sticky/cloaker/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!.)
+	if(!self_sticky || target != user)
 		return
 	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
 


### PR DESCRIPTION

## About The Pull Request

allows stickies to be applied to the user, and only the user, from in hand
## Why It's Good For The Game

Quality of life and makes the stickies such as cloaker much more usable, and trailblazer to be used offensively by a marine who may be wearing fire armor and such. 
## Changelog
:cl:
qol: Allows grenades to be self stickied, instead of having to be applies by others
balance: Self-applied stickies allowing one to use them directly
/:cl:
