### PR TITLE
Sets reagent pouch draw_mode to default on

### DIFF
--- a/code/game/objects/items/storage/reagent_pouch.dm
+++ b/code/game/objects/items/storage/reagent_pouch.dm
@@ -54,7 +54,7 @@
 	can_hold = list(/obj/item/reagent_containers/hypospray)
 	cant_hold = list(/obj/item/reagent_containers/glass/reagent_canister) //To prevent chat spam when you try to put the container in
 	flags_item = NOBLUDGEON
-	draw_mode = 1
+	draw_mode = TRUE
 	///The internal container of the pouch. Holds the reagent that you use to refill the connected injector
 	var/obj/item/reagent_containers/glass/reagent_canister/inner
 	///List of chemicals we fill up our pouch with on Initialize()

--- a/code/game/objects/items/storage/reagent_pouch.dm
+++ b/code/game/objects/items/storage/reagent_pouch.dm
@@ -54,6 +54,7 @@
 	can_hold = list(/obj/item/reagent_containers/hypospray)
 	cant_hold = list(/obj/item/reagent_containers/glass/reagent_canister) //To prevent chat spam when you try to put the container in
 	flags_item = NOBLUDGEON
+	draw_mode = 1
 	///The internal container of the pouch. Holds the reagent that you use to refill the connected injector
 	var/obj/item/reagent_containers/glass/reagent_canister/inner
 	///List of chemicals we fill up our pouch with on Initialize()


### PR DESCRIPTION

## About The Pull Request
draw_mode = 1
so it defaults to drawing on left click
## Why It's Good For The Game
TBH this thing only holds 1 item, it makes sense to pull out the item when you click the pouch.
I just forgot this existed when I added it.
## Changelog
:cl:
qol: reagent pouch defaults to draw mode enabled (left click to draw)
/:cl:
