### PR TITLE
Xenos that die on crash refund 1 larva

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -23,6 +23,7 @@
 #define COMSIG_GLOB_NUKE_EXPLODED "!nuke_exploded"
 #define COMSIG_GLOB_NUKE_DIFFUSED "!nuke_diffused"
 #define COMSIG_GLOB_DISK_GENERATED "!disk_produced"
+#define COMSIG_GLOBAL_XENO_DEATH "!xeno_death"
 
 #define COMSIG_GLOB_SHIP_SELF_DESTRUCT_ACTIVATED "!ship_self_destruct_activated"
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -95,6 +95,7 @@
 		computer_to_disable.update_icon()
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH)
+	RegisterSignal(SSdcs, COMSIG_GLOBAL_XENO_DEATH, PROC_REF(regain_larva))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_EXPLODED, PROC_REF(on_nuclear_explosion))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
@@ -208,3 +209,10 @@
 			continue
 		. += H.job.jobworth[/datum/job/xenomorph]
 
+///Refunds 1 larva whenever any xeno dies
+/datum/game_mode/infestation/crash/proc/regain_larva()
+	SIGNAL_HANDLER
+	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	xeno_job.add_job_positions(1)
+	xeno_hive.update_tier_limits()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -689,6 +689,7 @@
 	dead_xenos += X
 
 	SEND_SIGNAL(X, COMSIG_HIVE_XENO_DEATH)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_XENO_DEATH, X)
 
 	if(X == living_xeno_ruler)
 		on_ruler_death(X)


### PR DESCRIPTION

## About The Pull Request
Xenos that die on crash refund 1 larva
## Why It's Good For The Game
Currently Crash suffers from low xeno spawn rate.
Already they are locked behind the 3 minute xeno respawn time, so sitting in larva queue because balance_scales() decided that you don't deserve any larva is not a good experience.
Crash should have either 0 xeno respawn timer, or they should have some sensical larva generation so people aren't permanently stuck in larva queue.
## Changelog
:cl:
balance: Xenos get 1 larva refunded when they die on crash
/:cl:
