### PR TITLE
Reduces xeno rank playtime requirements

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -31,13 +31,13 @@
 	switch(playtime_mins)
 		if(0 to 600)
 			name = prefix + "Hatchling King ([nicknumber])"
-		if(601 to 3000)
+		if(601 to 1500)
 			name = prefix + "Young King ([nicknumber])"
-		if(3001 to 9000)
+		if(1501 to 4200)
 			name = prefix + "Mature Emperor ([nicknumber])"
-		if(9001 to 18000)
+		if(4201 to 10500)
 			name = prefix + "Elder Emperor ([nicknumber])"
-		if(18001 to INFINITY)
+		if(10501 to INFINITY)
 			name = prefix + "Ancient Emperor ([nicknumber])"
 		else
 			name = prefix + "Hatchling King ([nicknumber])"

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -77,13 +77,13 @@
 	switch(playtime_mins)
 		if(0 to 600)
 			name = prefix + "Hatchling Queen ([nicknumber])"
-		if(601 to 3000)
+		if(601 to 1500)
 			name = prefix + "Young Queen ([nicknumber])"
-		if(3001 to 9000)
+		if(1501 to 4200)
 			name = prefix + "Mature Empress ([nicknumber])"
-		if(9001 to 18000)
+		if(4201 to 10500)
 			name = prefix + "Elder Empress ([nicknumber])"
-		if(18001 to INFINITY)
+		if(10501 to INFINITY)
 			name = prefix + "Ancient Empress ([nicknumber])"
 		else
 			name = prefix + "Hatchling Queen ([nicknumber])"

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -154,13 +154,13 @@
 	switch(playtime_mins)
 		if(0 to 600)
 			rank_name = "Hatchling"
-		if(601 to 3000)
+		if(601 to 1500) //10 hours
 			rank_name = "Young"
-		if(3001 to 9000)
+		if(1501 to 4200) //25 hours
 			rank_name = "Mature"
-		if(9001 to 18000)
+		if(4201 to 10500) //70 hours
 			rank_name = "Elder"
-		if(18001 to INFINITY)
+		if(10501 to INFINITY) //175 hours
 			rank_name = "Ancient"
 		else
 			rank_name = "Hatchling"
@@ -187,13 +187,13 @@
 	switch(playtime_mins)
 		if(0 to 600)
 			return 0
-		if(601 to 3000)
+		if(601 to 1500)
 			return 1
-		if(3001 to 9000)
+		if(1501 to 4200)
 			return 2
-		if(9001 to 18000)
+		if(4201 to 10500)
 			return 3
-		if(18001 to INFINITY)
+		if(10501 to INFINITY)
 			return 4
 		else
 			return 0


### PR DESCRIPTION

## About The Pull Request
Young - 10 hours (the same)
Mature - 25 hours (instead of 50)
Elder - 70 hours (instead of 100)
Ancient - 175+ (instead of 300)
## Why It's Good For The Game
Apparently they were too long, and the people nagging at me for it were probably right since it is a per caste thing, and people change caste around alot during a game. This is a copy from CM's xeno ranks outside of name.
## Changelog
:cl:
qol: Reduced xeno rank playtime requirements
/:cl:
