### PR TITLE
Baneling death rework (only on intentional death)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -16,6 +16,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BANELING_EXPLODE,
 	)
+	var/died_due_to_ability = FALSE
 
 /datum/action/xeno_action/baneling_explode/handle_button_status_visuals()
 	var/mob/living/carbon/xenomorph/baneling = owner
@@ -72,6 +73,9 @@
 	var/smoke_range = X.plasma_stored/60
 	/// Use up all plasma so that we dont smoke twice because we die.
 	X.use_plasma(X.plasma_stored)
+	// If the smoke was triggered via ability, flag that
+	if (ability)
+		died_due_to_ability = TRUE
 	/// If this proc is triggered by signal, we want to divide range by 4
 	if(!ability)
 		smoke_range = smoke_range*0.25

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/abilities_baneling.dm
@@ -48,18 +48,26 @@
 
 /datum/action/xeno_action/baneling_explode/can_use_action()
 	. = ..()
-	var/mob/living/carbon/xenomorph/X = owner
-	var/datum/action/xeno_action/spawn_pod/pod_action = X.actions_by_path[/datum/action/xeno_action/spawn_pod]
-	if(SSmonitor.gamestate == SHUTTERS_CLOSED && isnull(pod_action.the_pod))
-		X.balloon_alert(owner, span_notice("Can't explode before shutters without a pod!"))
+	if(!can_currently_explode())
 		return FALSE
 
 /datum/action/xeno_action/baneling_explode/action_activate()
 	. = ..()
 	var/mob/living/carbon/xenomorph/X = owner
+	if(!can_currently_explode())
+		X.balloon_alert(owner, span_notice("Can't explode before shutters without a pod!"))
+		return FALSE
 	handle_smoke(ability = TRUE)
 	X.record_tactical_unalive()
 	X.death(FALSE)
+
+/datum/action/xeno_action/baneling_explode/proc/can_currently_explode()
+	. = TRUE
+	if (SSmonitor.gamestate == SHUTTERS_CLOSED) // Split for faster exit
+		var/mob/living/carbon/xenomorph/X = owner
+		var/datum/action/xeno_action/spawn_pod/pod_action = X.actions_by_path[/datum/action/xeno_action/spawn_pod]
+		if (isnull(pod_action.the_pod))
+			return FALSE
 
 /// This proc defines, and sets up and then lastly starts the smoke, if ability is false we divide range by 4.
 /datum/action/xeno_action/baneling_explode/proc/handle_smoke(datum/source, ability = FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
@@ -71,8 +71,13 @@
 	if(isnull(source))
 		return
 	var/mob/living/carbon/xenomorph/xeno_ref = source
+	var/datum/action/xeno_action/baneling_explode/explode_action = xeno_ref.actions_by_path[/datum/action/xeno_action/baneling_explode]
+	if (!explode_action.died_due_to_ability) // Did we die in a manner other than using our explode ability?
+		to_chat(xeno_ref.client, span_xenohighdanger("We have died without successfully detonating. We will not reform in our pod."))
+		return 0 // Don't cancel the death
 	cleanup_baneling(xeno_ref)
 	xeno_ref.forceMove(src)
+	explode_action.died_due_to_ability = FALSE // Reset the dying method flag
 	ADD_TRAIT(xeno_ref, TRAIT_STASIS, BANELING_STASIS_TRAIT)
 	if(xeno_ref.stored_charge >= BANELING_CHARGE_MAX)
 		addtimer(CALLBACK(src, PROC_REF(increase_charge), xeno_ref), BANELING_CHARGE_GAIN_TIME)


### PR DESCRIPTION
## About The Pull Request

People keep screaming about how baneling is shit and needs to be outright removed, see: #14415 
More context can probably be found on the discord.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/4741640/72c3cb2f-8440-426a-bbcb-805e9b261d6b)

I didn't make the change where it no longer releases gas on permadeath, since that seems at least a good way to go out.
Marines still accomplish killing a xeno for good. Gas radius is still smaller, ofc.

uhh i tested it locally and it seemed to work lol
did a small bugfix and cleanup while i was here (it was showing the 'cant explode' message every few secs)

## Why It's Good For The Game

I honestly would rather banelings be nerfed less than this PR, but if this is the alternative to them getting removed entirely then I can stomach it.

## Changelog

unsure how to mark this more majorly lol
:cl:
balance: Banelings no longer respawn in their pod if they are killed, except for if they use their explode abilities.
/:cl:

