### PR TITLE
Fixes pouches not updating icon on spawn.

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -16,6 +16,7 @@
 	if(fill_number && fill_type)
 		for(var/i in 1 to fill_number)
 			new fill_type(src)
+	return INITIALIZE_HINT_LATELOAD
 
 /obj/item/storage/pouch/LateInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I forgot that `LateInitialize` should be said to activate, in result icon just didn't update and for the moment of last pr I assumed it did the work. :Clueless:
I tested it properly this time, and unless some artifacts occure or occured, it should work fine. Stuff is still in needed pouches, it's empty when empty on spawn, full when full on spawn.
## Changelog
:cl:
fix: pouches now properly update, for real this time.
/:cl: