### PR TITLE
nukes these two portaflashers from slumbridge prison

### DIFF
--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -4671,7 +4671,6 @@
 /area/slumbridge/sombase/west)
 "dyt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher/portable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -15957,16 +15956,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside2)
-"lRh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher/portable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred{
-	dir = 1
-	},
-/area/slumbridge/prison/outerringnorth)
 "lRi" = (
 /turf/open/floor/plating/ground/snow/layer2{
 	dir = 10
@@ -49668,7 +49657,7 @@ fCq
 iAS
 iAS
 fCq
-lRh
+qFT
 nHy
 fCq
 gZN


### PR DESCRIPTION

## About The Pull Request
100% certified xalt pr
## Why It's Good For The Game
STOP PUTTING TINY, UNSLASHABLE, DENSE, MOVABLE PROPS ON YOUR GODDAMN MAPS
## Changelog
:cl:
balance: removes slumbridge's portaflashers
/:cl:
