### PR TITLE
Fixes a typo related to paracetamol pill packets.

### DIFF
--- a/code/game/objects/items/storage/pill_packets.dm
+++ b/code/game/objects/items/storage/pill_packets.dm
@@ -65,7 +65,7 @@
 	pip_color = COLOR_PACKET_DYLOVENE
 
 /obj/item/storage/pill_bottle/packet/paracetamol
-	name = "paracematol pill packet"
+	name = "paracetamol pill packet"
 	desc = "This packet contains paracetamol pills, also known as tylenol. A long lasting but minor painkiller. Once you take them out they don't go back in. No more than 4 pills in a long period."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/paracetamol
 	pip_color = COLOR_PACKET_PARACETAMOL


### PR DESCRIPTION
## About The Pull Request
Per title. It was written as paracematol, instead of paracetamol.

## Why It's Good For The Game
Good spelling, good grammar, good life.

## Changelog
:cl: Lewdcifer
spellcheck: Fixed a typo related to paracetamol pill packets.
/:cl: