### PR TITLE
Remove HSG nest from canter + some canter maintenance

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -116,11 +116,6 @@
 /obj/machinery/computer/cryopod,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"aG" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
 "aH" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile,
@@ -275,6 +270,12 @@
 /area/shuttle/canterbury/medical)
 "bg" = (
 /obj/machinery/vending/uniform_supply,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bh" = (
@@ -300,6 +301,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "bk" = (
@@ -349,8 +357,6 @@
 /area/shuttle/canterbury)
 "br" = (
 /obj/structure/table/mainship,
-/obj/item/fuel_cell/full,
-/obj/item/fuel_cell/full,
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
 /obj/effect/spawner/random/engineering/extinguisher/regularweighted,
 /obj/item/t_scanner,
@@ -504,6 +510,9 @@
 	},
 /area/shuttle/canterbury/cic)
 "bS" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
 /turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bT" = (
@@ -559,12 +568,6 @@
 "cR" = (
 /turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
-"ds" = (
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
 "fL" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -616,12 +619,6 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
-"lX" = (
-/obj/structure/cable,
-/obj/effect/attach_point/crew_weapon/dropship1,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
 "ma" = (
 /obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
@@ -696,12 +693,6 @@
 /obj/machinery/vending/weapon/crash,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"pT" = (
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
 "pY" = (
 /obj/structure/barricade/plasteel{
 	dir = 8
@@ -710,9 +701,6 @@
 /area/shuttle/canterbury)
 "qh" = (
 /obj/structure/rack,
-/obj/machinery/air_alarm{
-	dir = 8
-	},
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/plasteel/medium_stack,
@@ -853,6 +841,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/armor_supply,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "zc" = (
@@ -865,12 +856,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"zk" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/shuttle/canterbury/cic)
 "zy" = (
 /obj/machinery/door/poddoor/mainship{
 	dir = 2;
@@ -881,10 +866,10 @@
 /area/shuttle/canterbury)
 "AS" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/tl102/hsg_nest,
-/obj/item/ammo_magazine/tl102/hsg_nest,
-/obj/item/ammo_magazine/tl102/hsg_nest,
-/obj/item/ammo_magazine/tl102/hsg_nest,
+/obj/item/storage/belt/utility/full,
+/obj/item/t_scanner,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "BZ" = (
@@ -900,6 +885,12 @@
 /area/shuttle/canterbury)
 "DF" = (
 /obj/machinery/vending/armor_supply,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "DI" = (
@@ -962,11 +953,17 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Kk" = (
-/obj/machinery/air_alarm{
+/obj/machinery/vending/uniform_supply,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "KD" = (
 /obj/machinery/marine_selector/clothes,
@@ -976,11 +973,11 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "Mj" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
+/obj/machinery/air_alarm{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
+/obj/structure/bed/chair/dropship/passenger,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "MY" = (
 /turf/open/floor/mainship/blue/full,
@@ -1073,15 +1070,11 @@
 /turf/open/floor/mainship/blue,
 /area/shuttle/canterbury/cic)
 "Ui" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/bed/chair/dropship/passenger,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Ul" = (
 /obj/machinery/vending/nanomed,
@@ -1158,11 +1151,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
-"Xp" = (
-/obj/machinery/door/window,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
 "XO" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
@@ -1233,7 +1221,7 @@ Uo
 Uo
 al
 Mj
-Kk
+ac
 ab
 bU
 bU
@@ -1266,7 +1254,7 @@ Uo
 Uo
 al
 Ui
-Xp
+ac
 ab
 bi
 pY
@@ -1299,7 +1287,7 @@ ad
 ad
 al
 UE
-as
+ac
 ab
 CA
 an
@@ -1328,11 +1316,11 @@ Uo
 Uo
 al
 al
-zk
+uu
 bL
 al
 Rd
-aG
+jq
 ab
 iy
 an
@@ -1365,7 +1353,7 @@ MY
 bM
 al
 AS
-as
+ac
 ab
 YN
 an
@@ -1398,7 +1386,7 @@ uu
 bN
 al
 FZ
-as
+ac
 ab
 uZ
 an
@@ -1431,7 +1419,7 @@ MY
 bS
 al
 qh
-as
+ac
 ab
 Wk
 an
@@ -1464,11 +1452,11 @@ bK
 Ul
 ad
 ac
-as
+ac
 ki
 ac
 an
-pT
+ac
 ac
 ac
 ac
@@ -1501,7 +1489,7 @@ as
 nM
 as
 as
-lX
+as
 as
 as
 aa
@@ -1534,7 +1522,7 @@ ac
 zy
 ac
 an
-ds
+ac
 ac
 ac
 ac
@@ -1713,7 +1701,7 @@ bA
 aT
 UO
 aX
-bg
+Kk
 bA
 bg
 ab
@@ -1779,7 +1767,7 @@ bA
 cF
 DI
 aQ
-aM
+cF
 DI
 aQ
 ab

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -80,12 +80,6 @@
 /obj/machinery/firealarm{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28
-	},
 /turf/open/floor/mainship/blue{
 	dir = 10
 	},
@@ -146,9 +140,6 @@
 /obj/item/tool/wrench,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/tool/screwdriver,
-/obj/item/ammo_magazine/tl102/hsg_nest,
-/obj/item/ammo_magazine/tl102/hsg_nest,
-/obj/item/ammo_magazine/tl102/hsg_nest,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aw" = (
@@ -163,8 +154,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/mech_bay_recharge_port,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/wrench,
+/obj/item/tool/screwdriver,
+/obj/item/tool/crowbar,
+/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "ay" = (
@@ -174,7 +169,14 @@
 	id = "starboard_umbilical_outer";
 	name = "outer door-control"
 	},
-/obj/vehicle/ridden/powerloader,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel"
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aA" = (
@@ -222,14 +224,20 @@
 /area/shuttle/canterbury)
 "aL" = (
 /obj/effect/landmark/start/job/crash/squadmarine,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 1
-	},
+/obj/structure/bed/chair/dropship/passenger,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aN" = (
-/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
-/turf/open/floor/mainship/cargo,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "aO" = (
 /obj/machinery/loadout_vendor/crash,
@@ -242,7 +250,7 @@
 /area/shuttle/canterbury)
 "aQ" = (
 /obj/machinery/fuelcell_recycler,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "aR" = (
 /obj/structure/window/framed/mainship/canterbury,
@@ -275,12 +283,16 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
+/obj/item/fuel_cell/random,
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "bb" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bd" = (
 /obj/structure/window/reinforced/toughened{
@@ -290,7 +302,8 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "be" = (
-/turf/open/floor/mainship,
+/obj/machinery/marine_selector/clothes/synth,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bg" = (
 /obj/structure/cable,
@@ -310,7 +323,7 @@
 	name = "Core Power Monitoring"
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bk" = (
 /obj/structure/window/reinforced/toughened{
@@ -326,11 +339,11 @@
 /obj/machinery/cell_charger,
 /obj/item/radio,
 /obj/item/tool/crowbar,
-/obj/structure/table/reinforced,
 /obj/item/storage/box/crate/sentry,
 /obj/item/storage/box/crate/sentry,
 /obj/item/storage/box/crate/sentry,
-/turf/open/floor/mainship/mono,
+/obj/structure/rack,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bn" = (
 /obj/machinery/cryopod,
@@ -412,10 +425,7 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "bC" = (
-/obj/item/fuel_cell/full,
-/obj/item/fuel_cell/random,
-/obj/item/fuel_cell/random,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bD" = (
 /obj/effect/landmark/start/job/crash/squadsmartgunner,
@@ -552,24 +562,6 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
-"ci" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/start/job/crash/squadsmartgunner,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
-"ck" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28
-	},
-/obj/structure/barricade/plasteel{
-	dir = 8
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/shuttle/canterbury)
 "cl" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /turf/open/floor/podhatch/floor,
@@ -723,18 +715,6 @@
 /obj/effect/landmark/start/job/crash/medicalofficer,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"cW" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28
-	},
-/obj/structure/barricade/plasteel{
-	dir = 4
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/shuttle/canterbury)
 "cY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -773,13 +753,15 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "vY" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/orange/full,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "zE" = (
 /obj/structure/window/framed/mainship/canterbury,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "zN" = (
 /obj/machinery/vending/engivend,
@@ -816,13 +798,14 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "RS" = (
-/obj/structure/cable,
-/obj/effect/attach_point/crew_weapon/dropship1,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/window/framed/mainship/canterbury,
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "UG" = (
-/obj/machinery/marine_selector/clothes/synth,
-/turf/open/floor/mainship/cargo,
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "YI" = (
 /obj/machinery/iv_drip,
@@ -883,7 +866,7 @@ an
 au
 aA
 aA
-ck
+aA
 an
 aQ
 bC
@@ -908,7 +891,7 @@ aB
 aJ
 Bu
 an
-aR
+RS
 bb
 zE
 bo
@@ -929,7 +912,7 @@ ab
 ab
 cV
 aJ
-aD
+vY
 aN
 zN
 cv
@@ -954,7 +937,7 @@ cF
 aJ
 cR
 UG
-vY
+bC
 bg
 bl
 bo
@@ -998,7 +981,7 @@ ar
 aw
 bO
 bO
-RS
+bO
 bO
 ao
 bO
@@ -1020,10 +1003,10 @@ aj
 as
 ab
 aL
-bO
+aJ
 aD
 aD
-be
+aD
 aD
 aJ
 aD
@@ -1043,7 +1026,7 @@ am
 at
 ab
 cP
-bO
+aJ
 cS
 aO
 Hv
@@ -1066,17 +1049,17 @@ ac
 ab
 ab
 cQ
-bO
+aJ
 cT
 an
 aV
 aD
-aD
+aJ
 bt
 br
 br
 aJ
-aD
+be
 cc
 cE
 an
@@ -1088,8 +1071,8 @@ aa
 aa
 an
 ax
-ci
-bO
+cQ
+aJ
 cU
 an
 aW
@@ -1113,7 +1096,7 @@ an
 ay
 aF
 aF
-cW
+aF
 an
 bp
 bq


### PR DESCRIPTION

## About The Pull Request

Title

Maintenance changes include making the tiles more consistent, moving some vendors, adding some glass panels around vendors where they were inconsistent, fixing some chairs facing the wrong way, fixing a duplicate air alarm, fixing floating intercoms.
## Why It's Good For The Game

The HSG is way overkill for crash, you really don't need it to hold canter considering the marine access to vendors. It makes canter even more comically holdable. 
## Changelog
:cl:
qol: Misc fixes to both crash ships
balance: The HSG nest has been removed from crash ships
/:cl:
