### PR TITLE
Fixes the lobby button runtimes

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -7,6 +7,7 @@
 	for(var/button in buttons)
 		var/atom/movable/screen/text/lobby/screen = new button()
 		screen.hud = src
+		screen.update_text()
 		static_inventory += screen
 		screen.set_position(2, ycoord--)
 


### PR DESCRIPTION

## About The Pull Request

Fixes the many runtimes related to lobby buttons, namely everything related to it screwing up for players who join before everything is finished initialized. Basically we prevent the `MouseEntered` proc from firing if it's not initialized because it can happen before the sound subsystem is even initialized and `Click` because god do I not want to risk it. 

Would test merge this just in case it doesn't work.
## Why It's Good For The Game

Runtimes bad, lobby buttons not being broken good.
## Changelog
:cl:
fix: Fixed lobby button runtimes and bugs (you shouldn't get 'Unknown Character' anymore)
/:cl:
