### PR TITLE
t21 tweak v2 

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1687,7 +1687,7 @@
 	unload_sound = 'sound/weapons/guns/interact/t21_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/t21_reload.ogg'
 	caliber = CALIBER_10X25_CASELESS //codex
-	max_shells = 30 //codex
+	max_shells = 40 //codex
 	force = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/standard_skirmishrifle
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/standard_skirmishrifle)
@@ -1729,6 +1729,7 @@
 	aim_speed_modifier = 2.5
 
 	fire_delay = 0.25 SECONDS
+	damage_mult = 1.1
 	burst_amount = 1
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -424,7 +424,7 @@
 	icon_state = "t21"
 	icon_state_mini = "mag_rifle"
 	default_ammo = /datum/ammo/bullet/rifle/heavy
-	max_rounds = 30
+	max_rounds = 40
 
 //ALF-51B
 


### PR DESCRIPTION

## About The Pull Request

Redone version of toki's take on tweaking the t21, slightly better version than what toki made with a .5 damage increase from what they had. ammo increased to 40 and damage to 33.

## Why It's Good For The Game

"This PR of mine enables the AR21 be able compete with other guns within TGMC. It increases its magazine capacity from 30 to 40, while also boosting its bullet damage from 30 to ~~32.5~~ 33. by giving it its own ammo type and also gave it its own box of ammo!!!" -toki

## Changelog
:cl:
balance: Increases t21 mag capacity from 30 to 40
balance: Increases damage from 30 to 33
:cl:
