### PR TITLE
Fixes slumbridge enclosed area not being underground

### DIFF
--- a/code/game/area/slumbridge.dm
+++ b/code/game/area/slumbridge.dm
@@ -4,6 +4,9 @@
 	name = "Enclosed Area"
 	icon_state = "transparent"
 	always_unpowered = TRUE
+	ceiling = CEILING_DEEP_UNDERGROUND
+	outside = FALSE
+	always_unpowered = TRUE
 
 /area/slumbridge/rock/nearlz
 	icon_state = "blue"


### PR DESCRIPTION

## About The Pull Request
Whats on the tin. CAS won't work in PC'd cave tiles on Slum anymore, hopefully.
p.s SOMEONE RE-ORGANIZE SLUMBRIDGE AREA FILE IT IS GIVING ME A STROKE, THIS IS A CRY FOR HELP
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: Slumbridge rock turfs now have an underground ceiling
/:cl:
