### PR TITLE
Halves the cost of HEDP grenade boxes in Req.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -822,7 +822,7 @@ EXPLOSIVES
 	name = "M40 HEDP high explosive grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/frag)
-	cost = 500
+	cost = 250
 
 /datum/supply_packs/explosives/explosives_hidp
 	name = "M40 HIDP incendiary explosive grenade box crate"


### PR DESCRIPTION
## About The Pull Request
The current price of a box of HEDP grenades which contains 25 grenades has a supply point cost of 500.
For that same cost, you can buy a brand new mortar and 25 HE shells without reqtorio.
If you were to reqtorio shells outright, you'd have to purchase 100 points worth of machinery and then you could purchase 3 resupplies of HE (For the cost of 360) for 90 HE shells, more than triple the amount with points to spare.
What I'm trying to say is, that the cost of 500 is wayy too big for what it gives. Currently you can also just buy 15 WP nades for 700 which are miles better than HEDP.
## Why It's Good For The Game
As good as grenade launcher meta is, convincing Req to buy you an extremely expensive box of only 25 nades (Which go by REALLY fast) is not only wasteful of money, but also extremely hard. This should make the purchase more desirable and less of a drain on req wallet.

### TLDR: Make nades cheaper because the price is too high

(All of this is said by a Req main, I don't really know about the per-point-cost vs Performance of each grenade, but it's definitely more worth it to buy modules or WP nades rather than 25 nades for **20 points each**)
## Changelog
:cl:
balance: halved the cost of HEDP boxes in req. (500 >> 250)
/:cl:
