### PR TITLE
Removes the context menu toggle

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -17,8 +17,6 @@
 	//Preferences related
 	var/datum/preferences/prefs = null
 	var/inprefs = FALSE
-	///remembers what our context menu setting is currently set to
-	var/shift_to_open_context_menu = TRUE
 
 
 	//Mob related

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -314,24 +314,6 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 	to_chat(usr, span_notice("You will [(usr.client.prefs.toggles_sound & SOUND_NOENDOFROUND) ? "no longer" : "now"] hear round end sounds."))
 
-///Toggles whether or not you need to hold shift to access the right click menu
-/client/verb/toggle_right_click()
-	set name = "Toggle Right Click"
-	set category = "Preferences"
-
-	if(shift_to_open_context_menu)
-		winset(src, "mapwindow.map", "right-click=false")
-		winset(src, "default.Shift", "is-disabled=true")
-		winset(src, "default.ShiftUp", "is-disabled=true")
-		shift_to_open_context_menu = FALSE
-		to_chat(usr, span_notice("You will no longer need to hold the Shift key to access the right click menu"))
-	else
-		winset(src, "mapwindow.map", "right-click=true")
-		winset(src, "ShiftUp", "is-disabled=false")
-		winset(src, "Shift", "is-disabled=false")
-		shift_to_open_context_menu = TRUE
-		to_chat(usr, span_notice("You will now need to hold the Shift key to access the right click menu"))
-
 ///Same thing as the character creator preference, but as a byond verb, because not everyone can reach it in tgui preference menu
 /client/verb/toggle_tgui_fancy()
 	set name = "Toggle TGUI Window Compability Mode"


### PR DESCRIPTION

## Why It's Good For The Game

Intended as a temp thing during the transition like 3 years ago so this is a bit overdue

## Changelog
:cl:
del: Removes the context menu toggle
/:cl:
