### PR TITLE
Crash railgun removal

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -48,6 +48,7 @@
 #define MODE_NO_PERMANENT_WOUNDS (1<<12)
 #define MODE_SILOS_SPAWN_MINIONS (1<<13)
 #define MODE_ALLOW_XENO_QUICKBUILD (1<<14)
+#define MODE_DISALLOW_RAILGUN (1<<15)
 
 #define MODE_INFESTATION_X_MAJOR "Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR "Marine Major Victory"

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/crash
 	name = "Crash"
 	config_tag = "Crash"
-	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT|MODE_DEAD_GRAB_FORBIDDEN
+	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT|MODE_DEAD_GRAB_FORBIDDEN|MODE_DISALLOW_RAILGUN
 	flags_xeno_abilities = ABILITY_CRASH
 	valid_job_types = list(
 		/datum/job/terragov/squad/standard = -1,

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -250,6 +250,9 @@
 			mortar.recieve_target(TU,user)
 			return
 		if(MODE_RAILGUN)
+			if(SSticker?.mode?.flags_round_type & MODE_DISALLOW_RAILGUN)
+				to_chat(user, span_notice("ERROR. NO LINKED RAILGUN DETECTED. UNABLE TO FIRE."))
+				return
 			to_chat(user, span_notice("ACQUIRING TARGET. RAILGUN TRIANGULATING. DON'T MOVE."))
 			if((GLOB.marine_main_ship?.rail_gun?.last_firing + COOLDOWN_RAILGUN_FIRE) > world.time)
 				to_chat(user, "[icon2html(src, user)] [span_warning("The Rail Gun hasn't cooled down yet!")]")


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

Railgun isn't even supposed to be in crash. IC wise there is no ship in orbit to actually give railgun support at all, and its jsut a coder thing why the ship actually exists (this could be fixed however).

Railguns can also be used to blowup silos which is a hassle for admins.
## Why It's Good For The Game
Unintended feature.
## Changelog
:cl:
balance: Ship railgun is no longer available in Crash
/:cl:
