### PR TITLE
Reduces roundstart grenades from 600->200

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -110,7 +110,7 @@
 			/obj/item/ammo_magazine/rifle/tx54/incendiary = 4,
 			/obj/item/ammo_magazine/rifle/tx54/smoke = 4,
 			/obj/item/ammo_magazine/rifle/tx54/smoke/tangle = 2,
-			/obj/item/explosive/grenade = 600,
+			/obj/item/explosive/grenade = 200,
 			/obj/item/explosive/grenade/m15 = 30,
 			/obj/item/explosive/grenade/sticky = 125,
 			/obj/item/explosive/grenade/sticky/trailblazer = 75,
@@ -322,7 +322,7 @@
 		"Grenades" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = -1,
 			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = -1,
-			/obj/item/explosive/grenade = 600,
+			/obj/item/explosive/grenade = 200,
 			/obj/item/explosive/grenade/m15 = 30,
 			/obj/item/explosive/grenade/sticky = 125,
 			/obj/item/explosive/grenade/incendiary = 50,


### PR DESCRIPTION

## About The Pull Request
600->200 HEDPs.
## Why It's Good For The Game
600 grenades is enough for the entire game, encourages incredible amounts of spam, reduces logistical need for anyone to actually properly manage grenades RO wise, and generally was just an old overreaction to making grenades much more accessible.
At 200, it should still ideally be highly accessible alongside support grenades, but not quite overbearing to use if the force isn't properly longterm supplied.
## Changelog
:cl:
balance: Amount of free roundstart HEDPs reduced to 200 from 600.
/:cl:
