### PR TITLE
Chemrette invis fix

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -171,8 +171,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 2
 	flags_equip_slot = ITEM_SLOT_BELT
-	max_storage_space = 25
-	storage_slots = 25
+	max_storage_space = 18
+	storage_slots = 18
 	can_hold = list(
 		/obj/item/clothing/mask/cigarette,
 		/obj/item/tool/lighter,


### PR DESCRIPTION

## About The Pull Request

Changes the slots from 25 to 18

## Why It's Good For The Game

Because someone made the chemrette package larger than the cig one but it uses the same sprite changes, when you go over 18 things inside it goes invisible. Theres no real reason that its larger so this pushes it back down.

I havent tested this, beyond failed every time I tried to run it and I dont know what the vscode version of how to host and run the game is, but the change is so minor there is no way its going to break something. Its literally changing slot sizes. Id appreciate if someone told me the updated method of testing things since the warnings that refused to allow it to run were about how I need to use vscode to do it and I have zero idea where to do that. That or open and run it while testing something else.

## Changelog
:cl:
fix: fixed a few things
/:cl:
