### PR TITLE
Fix AI runtimes

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -529,7 +529,7 @@ SUBSYSTEM_DEF(minimaps)
 		if(owner)
 			RegisterSignal(new_track, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))
 			var/turf/old_turf = get_turf(tracking)
-			if(old_turf.z != new_track.z)
+			if(!old_turf.z || old_turf.z != new_track.z)
 				on_owner_z_change(new_track, old_turf.z, new_track.z)
 		return
 	locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -390,9 +390,9 @@
 		. += "Railgun status: Railgun is ready to fire."
 
 		if(last_ai_bioscan + COOLDOWN_AI_BIOSCAN > world.time)
-			stat("AI bioscan status:", "Instruments recalibrating, next scan in [(last_ai_bioscan  + COOLDOWN_AI_BIOSCAN - world.time)/10] seconds.") //about 10 minutes
+			. += "AI bioscan status:", "Instruments recalibrating, next scan in [(last_ai_bioscan  + COOLDOWN_AI_BIOSCAN - world.time)/10] seconds." //about 10 minutes
 		else
-			stat("AI bioscan status:", "Instruments are ready to scan the planet.")
+			. += "AI bioscan status:", "Instruments are ready to scan the planet."
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -390,9 +390,9 @@
 		. += "Railgun status: Railgun is ready to fire."
 
 		if(last_ai_bioscan + COOLDOWN_AI_BIOSCAN > world.time)
-			. += "AI bioscan status:", "Instruments recalibrating, next scan in [(last_ai_bioscan  + COOLDOWN_AI_BIOSCAN - world.time)/10] seconds." //about 10 minutes
+			. += "AI bioscan status: Instruments recalibrating, next scan in [(last_ai_bioscan  + COOLDOWN_AI_BIOSCAN - world.time)/10] seconds." //about 10 minutes
 		else
-			. += "AI bioscan status:", "Instruments are ready to scan the planet."
+			. += "AI bioscan status: Instruments are ready to scan the planet."
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

One happens when AI first spawns in, so obviously `old_turf` is gonna be null, in this case we should update ofc.

Other is just the tgui stat panel forgor to remove one of the `stat()s`
## Why It's Good For The Game

Runtime bad!
## Changelog
:cl:
fix: Fixed some AI runtimes
/:cl:
