### PR TITLE
Nerfs Laser MG melting mode

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -970,9 +970,9 @@
 /datum/lasrifle/energy_mg_mode/standard/melting
 	rounds_per_shot = 20
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/autolaser/melting
-	fire_delay = 0.4 SECONDS
+	fire_delay = 0.5 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser_rifle_2.ogg'
-	windup_delay = 0.3 SECONDS
+	windup_delay = 0.4 SECONDS
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 	message_to_user = "You set the machine laser's charge mode to melting."
 	radial_icon_state = "laser_heat"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -970,9 +970,9 @@
 /datum/lasrifle/energy_mg_mode/standard/melting
 	rounds_per_shot = 20
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/autolaser/melting
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.4 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser_rifle_2.ogg'
-	windup_delay = 0.4 SECONDS
+	windup_delay = 0.3 SECONDS
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 	message_to_user = "You set the machine laser's charge mode to melting."
 	radial_icon_state = "laser_heat"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -970,7 +970,7 @@
 /datum/lasrifle/energy_mg_mode/standard/melting
 	rounds_per_shot = 20
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/autolaser/melting
-	fire_delay = 0.7 SECONDS
+	fire_delay = 0.4 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser_rifle_2.ogg'
 	windup_delay = 0.3 SECONDS
 	fire_mode = GUN_FIREMODE_SEMIAUTO

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -968,10 +968,12 @@
 	description = "Fires a powerful laser pulse after a brief charge up."
 
 /datum/lasrifle/energy_mg_mode/standard/melting
-	rounds_per_shot = 18
+	rounds_per_shot = 20
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/autolaser/melting
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.7 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser_rifle_2.ogg'
+	windup_delay = 0.3 SECONDS
+	fire_mode = GUN_FIREMODE_SEMIAUTO
 	message_to_user = "You set the machine laser's charge mode to melting."
 	radial_icon_state = "laser_heat"
 	description = "Fires an unusual laser pulse that applies a melting effect which severely sunders xenomorph armor over time, as well as applying further damage."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Laser MG now has 0.4 seconds of fire delay with a 0.3 second windup, as well as being semiauto
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Each stack of melting does 3 sunder. The laser MG applies two stacks of melting per shot, which translates to 6 sunder per shot, or 18 sunder per second pre nerf, which is pretty nutty for a free gun with free ammo. This PR makes the sunder still be good while nerfing the sunder per shot.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Increases laser MG melting mode firedelay and makes it require windup on every shot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
