### PR TITLE
Increased chance to gib humans with explosions

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -794,7 +794,7 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define GRAB_PIXEL_SHIFT_NECK 16
 
 #define HUMAN_CARRY_SLOWDOWN 0.35
-#define HUMAN_EXPLOSION_GIB_THRESHOLD 0.95
+#define HUMAN_EXPLOSION_GIB_THRESHOLD 0.1
 
 
 // =============================


### PR DESCRIPTION

## About The Pull Request
Changed the armour threshold for getting gibbed by a devastating explosion.
Previously you needed more than 5 bomb armour (i.e. not be naked). You now need 90 bomb armour (hiln on medium at minimum)
## Why It's Good For The Game
Gibbing is cool.
## Changelog
:cl:
balance: Humans are now gibbed by dev explosions unless they have 90+ bomb armour
/:cl:
