### PR TITLE
Partial reversion of MG-27 buffs

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -437,7 +437,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.05 SECONDS
+	aim_fire_delay = 0.1 SECONDS
 	aim_speed_modifier = 5
 	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
@@ -450,7 +450,7 @@
 	fire_delay = 0.15 SECONDS
 	burst_amount = 1
 	deploy_time = 1 SECONDS
-	damage_falloff_mult = 0.25
+	damage_falloff_mult = 0.5
 	undeploy_time = 0.5 SECONDS
 	max_integrity = 200
 

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -450,7 +450,7 @@
 	fire_delay = 0.15 SECONDS
 	burst_amount = 1
 	deploy_time = 1 SECONDS
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.4
 	undeploy_time = 0.5 SECONDS
 	max_integrity = 200
 


### PR DESCRIPTION

## About The Pull Request
Partially reverts the latest buffs to the MG-27 as per #13478.
Aim mode fire delay increased from 0.05s to 0.1s.
Damage falloff increased from 0.25s to 0.4s.
Magazine size kept intact.

## Why It's Good For The Game
The MG-27 is capable of holding down a position entirely by itself, making any given area effectively suicide to challenge. Xenos have a huge problem related to being incapable of contesting any held position, making said holds a breeze, and the MG-27 is a huge culprit. This was discussed a while ago in #dev-general and I believe this was the general agreement that was reached with maintainers (particularly Lumi and Ivan).

## Changelog
:cl: Lewdcifer
balance: Partial reversion of MG-27 buffs. Aim mode fire delay increased from 0.05s > 0.1s, damage falloff increased from 0.25s > 0.4s.
/:cl: