### PR TITLE
Engineer teleporter rebalance

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -4,14 +4,9 @@
 	max_integrity = 200
 	resistance_flags = XENO_DAMAGEABLE
 	idle_power_usage = 50
-	///List of all teleportable types
-	var/static/list/teleportable_types = list(
-		/obj/structure/closet,
-		/mob/living/carbon/human,
-		/obj/machinery,
-	)
 	///List of banned teleportable types
 	var/static/list/blacklisted_types = list(
+		/mob/living/carbon/human,
 		/obj/machinery/nuclearbomb
 	)
 
@@ -67,10 +62,17 @@
 
 	var/list/atom/movable/teleporting = list()
 	for(var/atom/movable/thing in loc)
-		if(is_type_in_list(thing, blacklisted_types))
+		if(is_type_in_list(thing, blacklisted_types) || thing.anchored)
 			continue
-		if(is_type_in_list(thing, teleportable_types) && !thing.anchored)
-			teleporting += thing
+		var/can_teleport = TRUE
+		if(thing.contents && length(thing.contents))
+			for(var/atom/movable/thing_inside in thing.contents)
+				if(is_type_in_list(thing_inside, blacklisted_types))
+					can_teleport = FALSE
+		if(!can_teleport)
+			to_chat(user, span_warning("Unable to teleport [thing] due to safety protocols."))
+			continue
+		teleporting += thing
 
 	if(!length(teleporting))
 		to_chat(user, span_warning("No teleportable content was detected on [src]!"))

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -6,7 +6,7 @@
 	idle_power_usage = 50
 	///List of banned teleportable types
 	var/static/list/blacklisted_types = list(
-		/mob/living/carbon/human,
+		/mob/living/carbon,
 		/obj/machinery/nuclearbomb
 	)
 


### PR DESCRIPTION
## About The Pull Request
The engineer's teleporter is no longer able to teleport carbon mobs, such as marines and xenos.
To compensate, the teleporter is now able to teleport just about anything besides mobs (marines and xenos) and the nuke itself.

## Why It's Good For The Game
Removes a largely exploitable aspect of the teleporter, while giving it a much more varied and accessible niche in compensation.

## Changelog
:cl: Lewdcifer
balance: Engineer teleporter can now teleport anything with the exception of human mobs (marines) and the nuke.
/:cl: