### PR TITLE
Gives gorger plasma on attack

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -60,6 +60,14 @@
 		/datum/action/xeno_action/activable/devour,
 	)
 
+/datum/xeno_caste/gorger/on_caste_applied(mob/xenomorph)
+	. = ..()
+	xenomorph.AddElement(/datum/element/plasma_on_attack, 1.5)
+
+/datum/xeno_caste/gorger/on_caste_removed(mob/xenomorph)
+	. = ..()
+	xenomorph.RemoveElement(/datum/element/plasma_on_attack, 1.5)
+
 /datum/xeno_caste/gorger/normal
 	upgrade = XENO_UPGRADE_NORMAL
 


### PR DESCRIPTION

## About The Pull Request
Gives gorger plasma on attack
## Why It's Good For The Game
Gorger struggles with gaining blood after using carnage and feast.
This buff aims to allow Gorger to take longer engagements and have some source of blood that doesn't stun himself.
## Changelog
:cl:
balance: Gorger gains blood on hit
/:cl:
