### PR TITLE
Euclide range on projectile stuns

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		CRASH("staggerstun called without a mob target")
 	if(!isliving(victim))
 		return
-	if(proj.distance_travelled > max_range)
+	if(get_dist_euclide(proj.starting_turf, victim) > max_range)
 		return
 	var/impact_message = ""
 	if(isxeno(victim))


### PR DESCRIPTION

## About The Pull Request
Uses get_dist_euclide instead of get_dist, for checking stun range.

Like throw range, stun range was wonky when it came to diagonal. Unlike throws which had worse range than they should, diagonal stuns go further then expected.

This is particularly noticable on the slug shotgun for example.

The player facing change is that instead of a square of turfs around you in stun range, its now (roughly) a circle, so something like a slug shotgun will in many diagonal cases now need to be one turf closer to the target than how it is currently.
## Why It's Good For The Game
Less wonky stuns at long range on diagonals
## Changelog
:cl:
balance: Projectile stuns no longer work at a greater distance then expected when fired at diagonal angles
/:cl:
