### PR TITLE
Widowmaker Impact Time 3s>6s, Widowmaker Cost 225>175

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -391,11 +391,11 @@
 //this one is air-to-air only
 /obj/structure/ship_ammo/cas/rocket/widowmaker
 	name = "\improper AIM-224 'Widowmaker'"
-	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly. Moving this will require some sort of lifter."
+	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment. Moving this will require some sort of lifter."
 	icon_state = "single"
-	travelling_time = 3 SECONDS //not powerful, but reaches target fast
+	travelling_time = 6 SECONDS
 	ammo_id = ""
-	point_cost = 225
+	point_cost = 175
 	devastating_explosion_range = 2
 	heavy_explosion_range = 4
 	light_explosion_range = 7


### PR DESCRIPTION

## About The Pull Request
As in title.

## Why It's Good For The Game
On low orbit, a widowmaker is not reasonably human-reactable. While you can consistently avoid the worst of it, you are practically guaranteed to take at least some incidental damage and knockback due to the large range boasted. To make things worse, widowmakers have a devastation range, meaning a sufficiently unaware (or trapped) xeno can be gibbed outright. High velocity 30mm, HE minirockets, and lasers all do much less damage in a much smaller and more dodgable area, and while yes, rockets SHOULD have a bigger boom, the combination of speed and power boasted by a widowmaker has been universally problematic. 

## Changelog
:cl:
balance: widowmaker now has a default time of 6 seconds, and its cost has been decreased to 175.
/:cl:
