### PR TITLE
Changed the armour threshold for getting gibbed by a devastating explosion

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -468,7 +468,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SLOWDOWN_REGEN 0.4
 
 #define XENO_DEADHUMAN_DRAG_SLOWDOWN 2
-#define XENO_EXPLOSION_GIB_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will gib xenos
+#define XENO_EXPLOSION_GIB_THRESHOLD 0.1 //if your effective bomb armour is less than 90, devestating explosions will gib xenos
 
 #define KING_SUMMON_TIMER_DURATION 5 MINUTES
 


### PR DESCRIPTION

## About The Pull Request
Changed the armour threshold for getting gibbed by a devastating explosion.
Previously you needed more than 5 bomb armour (i.e. have any warding pheromone). You now need 90 bomb armour (be an explosion resistant caste at minimum)
## Why It's Good For The Game
Gibbing is cool.

(It really isn't but neither is having weapons take your teammates out of the round unrecoverably when they have fairly survivable effects on their intended targets.)
## Changelog
:cl:
balance: Xenomorphs are now gibbed by dev explosions unless they have 90+ bomb armour
/:cl:
