### PR TITLE
CAS ordnance travelling times are no longer affected by spaceship orbit

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -683,7 +683,7 @@
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
 	var/obj/structure/ship_ammo/SA = ammo_equipped //necessary because we nullify ammo_equipped when firing big rockets
-	var/ammo_travelling_time = SA.travelling_time * ((GLOB.current_orbit+3)/6) //how long the rockets/bullets take to reach the ground target.
+	var/ammo_travelling_time = SA.travelling_time //how long the rockets/bullets take to reach the ground target.
 	var/ammo_warn_sound = SA.warning_sound
 	deplete_ammo()
 	COOLDOWN_START(src, last_fired, firing_delay)


### PR DESCRIPTION
## About The Pull Request
Per title. Maintainers agreed that this was a better alternative than #14551.

## Why It's Good For The Game
If you check the PRs that I made before this one, you'll get a better image, but tl;dr is CAS ordnance shouldn't be fast enough to require inhuman reactions from xenos.

## Changelog
:cl: Lewdcifer
balance: CAS ordnance travelling times are no longer affected by spaceship orbit
/:cl: