### PR TITLE
Clarifies AI Bioscan Corruption Is Affected By Ship Elevation

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -124,10 +124,10 @@
 				to_chat(usr, span_warning("Signal analysis reveals excellent detail about hostile movements and numbers."))
 				return
 			if(3)
-				to_chat(usr, span_warning("Minor corruption detected in our bioscan instruments, some information about hostile activity may be incorrect."))
+				to_chat(usr, span_warning("Minor corruption detected in our bioscan instruments due to ship elevation, some information about hostile activity may be incorrect."))
 				return
 			if(5)
-				to_chat(usr, span_warning("Major corruption detected in our bioscan readings, information heavily corrupted."))
+				to_chat(usr, span_warning("Major corruption detected in our bioscan readings due to ship elevation, information heavily corrupted."))
 		return
 
 	if(announce_humans)


### PR DESCRIPTION
## About The Pull Request
This pr clarifies in the corruption text of AI bioscans that the cause of said corruption is caused by the current elevation of the ship.
## Why It's Good For The Game
Let's new players know that they could get a clearer scan if they were on a lower elevation.
## Changelog
:cl:
spellcheck: Adds clarification to the AI's bioscan that corruption is caused by the elevation of the ship.
/:cl:
