### PR TITLE
Makes the two tile pod door (namely used on big red) acidable

### DIFF
--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -104,7 +104,6 @@
 	icon = 'icons/obj/doors/1x2blast_hor.dmi'
 	dir = EAST
 	width = 2
-	resistance_flags = UNACIDABLE
 
 /obj/machinery/door/poddoor/two_tile_hor/execution
 	icon_state = "pdoor0"
@@ -135,7 +134,6 @@
 	icon = 'icons/obj/doors/1x2blast_vert.dmi'
 	dir = NORTH
 	width = 2
-	resistance_flags = UNACIDABLE
 
 /obj/machinery/door/poddoor/two_tile_ver/riotarmory
 	icon_state = "pdoor0"


### PR DESCRIPTION

## About The Pull Request

![StrongDMM_vXPgcOpisc](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/c448c022-5c27-4787-ad6f-7134c171095f)

Talking about these and the ones up in lambda
## Why It's Good For The Game

Marines can break these comically easily, meanwhile xenos need a crusher, bit guh. You have to walk all the way around half the map if you happen to get a modular combo up in lambda, which I'm really not a fan of.
## Changelog
:cl:
balance: Makes the two tile pod door (namely used on big red) acidable
/:cl:
