### PR TITLE
Warlock Psycrush nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -268,6 +268,7 @@
 	ability_cost = 40
 	cooldown_duration = 12 SECONDS
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY
+	target_flags = ABILITY_TURF_TARGET
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_CRUSH,
 	)


### PR DESCRIPTION

## About The Pull Request
Psycrush now targets turfs specifically.
## Why It's Good For The Game
Although instant casting/triggering is fine and intended, tracking mobs isn't really intended for this ability.
Should make it harder to bully a lone guy with a rapid cast.
## Changelog
:cl:
balance: Psycrush now only targets turfs
/:cl:
