### PR TITLE
The Antenna module now improves comms in caves, loses req beacon

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -225,4 +225,4 @@
 #define CAVE_MINOR_INTERFERENCE 1 //! Scrambles outgoing messages, no impact on outgoing.
 #define CAVE_FULL_INTERFERENCE 2 //! Prevents incoming and outgoing messages.
 
-#define ANTENNA_SYNCING_TIME 15 SECONDS //! Time needed to initially configure an antenna module after equipping.
+#define ANTENNA_SYNCING_TIME 30 SECONDS //! Time needed to initially configure an antenna module after equipping.

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -219,3 +219,10 @@
 #define X_FIRE_LAYER 1
 #define X_TOTAL_LAYERS 9
 /////////////////////////////////
+
+//Cave comms defines
+#define CAVE_NO_INTERFERENCE 0 //! No impact on comms.
+#define CAVE_MINOR_INTERFERENCE 1 //! Scrambles outgoing messages, no impact on outgoing.
+#define CAVE_FULL_INTERFERENCE 2 //! Prevents incoming and outgoing messages.
+
+#define ANTENNA_SYNCING_TIME 15 SECONDS //! Time needed to initially configure an antenna module after equipping.

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -222,7 +222,7 @@
 
 //Cave comms defines
 #define CAVE_NO_INTERFERENCE 0 //! No impact on comms.
-#define CAVE_MINOR_INTERFERENCE 1 //! Scrambles outgoing messages, no impact on outgoing.
+#define CAVE_MINOR_INTERFERENCE 1 //! Scrambles outgoing messages, no impact on incoming.
 #define CAVE_FULL_INTERFERENCE 2 //! Prevents incoming and outgoing messages.
 
 #define ANTENNA_SYNCING_TIME 30 SECONDS //! Time needed to initially configure an antenna module after equipping.

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1054,3 +1054,4 @@
 #define COMSIG_PUPPET_CHANGE_ORDER "puppetchangeorder"
 #define COMSIG_PUPPET_CHANGE_ALL_ORDER "puppetglobalorder"
 
+#define COMSIG_CAVE_INTERFERENCE_CHECK "cave_interference_check" //! Cave comms interference check signal.

--- a/code/game/objects/items/radio/radio.dm
+++ b/code/game/objects/items/radio/radio.dm
@@ -307,7 +307,6 @@
 			signal.data["compression"] += rand(20, 40)
 		if(CAVE_FULL_INTERFERENCE)
 			return
-		else
 
 	// All non-independent radios make an attempt to use the subspace system first
 	signal.send_to_receivers()

--- a/code/game/objects/items/radio/radio.dm
+++ b/code/game/objects/items/radio/radio.dm
@@ -292,10 +292,22 @@
 		return
 
 	var/area/A = get_area(src)
+	var/radio_disruption = CAVE_NO_INTERFERENCE
 	if(!isnull(A) && (A.ceiling >= CEILING_UNDERGROUND) && !(A.flags_area & ALWAYS_RADIO))
+		radio_disruption = CAVE_MINOR_INTERFERENCE
 		if(A.ceiling >= CEILING_DEEP_UNDERGROUND)
+			radio_disruption = CAVE_FULL_INTERFERENCE
+
+	var/list/inplace_interference = list(radio_disruption)
+	SEND_SIGNAL(talking_movable, COMSIG_CAVE_INTERFERENCE_CHECK, inplace_interference)
+	radio_disruption = inplace_interference[1]
+
+	switch(radio_disruption)
+		if(CAVE_MINOR_INTERFERENCE)
+			signal.data["compression"] += rand(20, 40)
+		if(CAVE_FULL_INTERFERENCE)
 			return
-		signal.data["compression"] += rand(20, 40)
+		else
 
 	// All non-independent radios make an attempt to use the subspace system first
 	signal.send_to_receivers()
@@ -345,8 +357,23 @@
 		var/turf/position = get_turf(src)
 		if(!position || !(position.z in levels))
 			return FALSE
+		var/radio_disruption = CAVE_NO_INTERFERENCE
 		var/area/A = get_area(src)
-		if(A?.ceiling >= CEILING_DEEP_UNDERGROUND)
+		if(A?.ceiling >= CEILING_UNDERGROUND && !(A.flags_area & ALWAYS_RADIO))
+			radio_disruption = CAVE_MINOR_INTERFERENCE //Unused for this case but may aswell create parity on what the value of the var is.
+			if(A.ceiling >= CEILING_DEEP_UNDERGROUND)
+				radio_disruption = CAVE_FULL_INTERFERENCE
+		var/list/potential_owners = get_nested_locs(src) //Sometimes not equipped, sometimes not even equippable, sometimes in storage, this feels like it's an okay way to do it.
+		var/mob/living/found_owner
+		for(var/mob/living/candidate in potential_owners)
+			found_owner = candidate
+			break
+
+		if(found_owner)
+			var/inplace_interference = list(radio_disruption)
+			SEND_SIGNAL(found_owner, COMSIG_CAVE_INTERFERENCE_CHECK, inplace_interference)
+			radio_disruption = inplace_interference[1]
+		if(radio_disruption == CAVE_FULL_INTERFERENCE)
 			return FALSE
 
 	// allow checks: are we listening on that frequency?

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -662,7 +662,7 @@
 		return
 	to_chat(user, span_notice("Setting up Antenna communication relay. Please wait."))
 	comms_setup = COMMS_SETTING
-	addtimer(CALLBACK(src, PROC_REF(finish_startup), user), ANTENNA_SYNCING_TIME, TIMER_STOPPABLE)
+	startup_timer_id = addtimer(CALLBACK(src, PROC_REF(finish_startup), user), ANTENNA_SYNCING_TIME, TIMER_STOPPABLE)
 
 ///Finishes startup, rendering the module effective.
 /obj/item/armor_module/module/antenna/proc/finish_startup(mob/living/user)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -637,6 +637,7 @@
 			startup_timer_id = null
 	else
 		RegisterSignal(user, COMSIG_CAVE_INTERFERENCE_CHECK, PROC_REF(on_interference_check))
+		start_sync(user)
 	return ..()
 
 ///Handles interacting with caves checking for if anything is reducing (or increasing) interference.
@@ -648,17 +649,22 @@
 
 /obj/item/armor_module/module/antenna/activate(mob/living/user)
 	if(comms_setup == COMMS_SETTING)
-		to_chat(user, span_notice("Your Antenna module is already in the process of setting up!"))
+		to_chat(user, span_notice("Your Antenna module is still configuring!"))
 		return
 	if(comms_setup == COMMS_SETUP)
 		var/turf/location = get_turf(user)
 		user.show_message(span_notice("The [src] beeps and states, \"Uplink data: LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(src)]\""), EMOTE_AUDIBLE, span_notice("The [src] vibrates but you can not hear it!"))
 		return
+
+///Begins the starup sequence.
+/obj/item/armor/antenna/proc/start_sync(mob/living/user)
+	if(comms_setup != COMMS_OFF) //Guh?
+		return
 	to_chat(user, span_notice("Configuring Antenna communication relay. Please wait."))
 	comms_setup = COMMS_SETTING
 	addtimer(CALLBACK(src, PROC_REF(finish_startup), user), ANTENNA_SYNCING_TIME, TIMER_STOPPABLE)
 
-
+///Finishes startupm, rendering the module effective.
 /obj/item/armor_module/module/antenna/proc/finish_startup(mob/living/user)
 	comms_setup = COMMS_SETUP
 	user.show_message(span_notice("[src] beeps twice and states: \"Antenna configuration complete. Relay system active.\""), EMOTE_AUDIBLE, span_notice("[src] vibrates twice."))

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -624,12 +624,12 @@
 	prefered_slot = SLOT_HEAD
 	toggle_signal = COMSIG_KB_HELMETMODULE
 	///If the comms system is configured.
-	var/comms_setup = FALSEW
+	var/comms_setup = FALSE
 
 /obj/item/armor_module/module/antenna/handle_actions(datum/source, mob/user, slot)
 	if(slot != prefered_slot)
 		UnregisterSignal(user, COMSIG_CAVE_INTERFERENCE_CHECK)
-		comms_active = COMMS_OFF
+		comms_setup = COMMS_OFF
 	else
 		RegisterSignal(user, COMSIG_CAVE_INTERFERENCE_CHECK, PROC_REF(on_interference_check))
 	return ..()
@@ -646,6 +646,7 @@
 		to_chat(user, span_notice("Your Antenna module is already in the process of setting up!"))
 		return
 	if(comms_setup == COMMS_SETUP)
+		var/turf/location = get_turf(user)
 		user.show_message(span_notice("The [src] beeps and states, \"Uplink data: LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(src)]\""), EMOTE_AUDIBLE, span_notice("The [src] vibrates but you can not hear it!"))
 		return
 	to_chat(user, span_notice("Configuring Antenna communication relay. Hold still while aligning."))
@@ -655,11 +656,6 @@
 		comms_setup = COMMS_OFF
 		return
 	comms_setup = COMMS_SETUP
-
-/// Signal handler to nullify beacon datum
-/obj/item/armor_module/module/antenna/proc/clean_beacon_datum()
-	SIGNAL_HANDLER
-	beacon_datum = null
 
 #undef COMMS_OFF
 #undef COMMS_SETTING

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -656,7 +656,7 @@
 		user.show_message(span_notice("The [src] beeps and states, \"Uplink data: LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(src)]\""), EMOTE_AUDIBLE, span_notice("The [src] vibrates but you can not hear it!"))
 		return
 
-///Begins the starup sequence.
+///Begins the startup sequence.
 /obj/item/armor_module/module/antenna/proc/start_sync(mob/living/user)
 	if(comms_setup != COMMS_OFF) //Guh?
 		return
@@ -664,7 +664,7 @@
 	comms_setup = COMMS_SETTING
 	addtimer(CALLBACK(src, PROC_REF(finish_startup), user), ANTENNA_SYNCING_TIME, TIMER_STOPPABLE)
 
-///Finishes startupm, rendering the module effective.
+///Finishes startup, rendering the module effective.
 /obj/item/armor_module/module/antenna/proc/finish_startup(mob/living/user)
 	comms_setup = COMMS_SETUP
 	user.show_message(span_notice("[src] beeps twice and states: \"Antenna configuration complete. Relay system active.\""), EMOTE_AUDIBLE, span_notice("[src] vibrates twice."))

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -657,7 +657,7 @@
 		return
 
 ///Begins the starup sequence.
-/obj/item/armor/antenna/proc/start_sync(mob/living/user)
+/obj/item/armor_module/module/antenna/proc/start_sync(mob/living/user)
 	if(comms_setup != COMMS_OFF) //Guh?
 		return
 	to_chat(user, span_notice("Setting up Antenna communication relay. Please wait."))

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -649,7 +649,7 @@
 
 /obj/item/armor_module/module/antenna/activate(mob/living/user)
 	if(comms_setup == COMMS_SETTING)
-		to_chat(user, span_notice("Your Antenna module is still configuring!"))
+		to_chat(user, span_notice("Your Antenna module is still in the process of starting up!"))
 		return
 	if(comms_setup == COMMS_SETUP)
 		var/turf/location = get_turf(user)
@@ -660,7 +660,7 @@
 /obj/item/armor/antenna/proc/start_sync(mob/living/user)
 	if(comms_setup != COMMS_OFF) //Guh?
 		return
-	to_chat(user, span_notice("Configuring Antenna communication relay. Please wait."))
+	to_chat(user, span_notice("Setting up Antenna communication relay. Please wait."))
 	comms_setup = COMMS_SETTING
 	addtimer(CALLBACK(src, PROC_REF(finish_startup), user), ANTENNA_SYNCING_TIME, TIMER_STOPPABLE)
 

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -634,6 +634,7 @@
 		comms_setup = COMMS_OFF
 		if(startup_timer_id)
 			deltimer(startup_timer_id)
+			startup_timer_id = null
 	else
 		RegisterSignal(user, COMSIG_CAVE_INTERFERENCE_CHECK, PROC_REF(on_interference_check))
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Alternate PR to #14594 

The antenna module loses its access to req beacons like in the referenced PR, but in exchange can reduce the interference of caves by one stage.
To do this, it first needs to be configured with a 30 second sync timer (which **does not** require you to stand in place), after which it will remain on indefinitely (barring unequipping it).
Reason for this channel is to avoid people "oceloting" an Antenna helmet to wear it when talking then take it back off. This makes it more of a commitment, and is a one-time thing as you very rarely have any reason to take your helmet off (never, in fact).

This means that in shallow caves, you will talk / hear like outside, and in deep caves you will hear like outside, but talk with some interference.
You also still have access to your location data, once your system is configured.

The implementation for receiving is a bit uhh because radios do not have a consistent place they are, and I wanted to include all radios that are anywhere on you in case you are carrying some special radio and not a headset, but should work.
Thanks to mandatory 515 I cannot test this PR because 515 would be detrimental to me, so I'll be using the CI to debug if I typod.
## Why It's Good For The Game
This is a much cooler solution for antenna modules instead of making them obsolete, while still requiring commitment due to a delay between equipping & enabling, and actually being to use it.

### (**Note:** I do not have any personal opinion on if the antenna beacon should stay or get removed. This PR only exists as an alternate PR to completely rendering antenna modules obsolete, should maintainers decide they really want the beacon part gone)
## Changelog
:cl:
balance: Antenna helmet modules have exchanged their ability to project a req drop beacon for improving caves communications (once configured)
/:cl:
