### PR TITLE
Detpack fixes

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -136,8 +136,9 @@
 	if(!signal || !on)
 		return
 
-	var/turf/location = get_turf(signal.source)
-	if(location.z != z)
+	var/turf/source_location = get_turf(signal.source)
+	var/turf/det_location = get_turf(src)
+	if(source_location.z != det_location.z)
 		return
 
 	if(signal.data["code"] != code)
@@ -340,15 +341,13 @@
 	//Time to go boom
 	playsound(src.loc, 'sound/weapons/ring.ogg', 200, FALSE)
 	boom = TRUE
+	var/turf/det_location = get_turf(plant_target)
+	plant_target.ex_act(EXPLODE_DEVASTATE)
+	plant_target = null
 	if(det_mode == TRUE) //If we're on demolition mode, big boom.
-		explosion(plant_target, 3, 5, 6, 0, 6)
+		explosion(det_location, 3, 5, 6, 0, 6)
 	else //if we're not, focused boom.
-		explosion(plant_target, 2, 2, 3, 0, 3, throw_range = FALSE)
-	if(plant_target)
-		if(isobj(plant_target))
-			plant_target = null
-			if(!istype(plant_target,/obj/vehicle/multitile/root/cm_armored))
-				qdel(plant_target)
+		explosion(det_location, 2, 2, 3, 0, 3, throw_range = FALSE)
 	qdel(src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Detpack code is gross, someone refactor it please.

Fixed detpacks being attachable to structures (i.e tables/airlocks/etc) but being unable to receive a det signal
Fixed detpack explosions being severely weaker than intended when placed on solid turfs,
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed detpacks not working on structures, and being weaker than expected on solid turfs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
