### PR TITLE
increases the range of sg153 bullets to 40 from 20

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1299,6 +1299,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 50
+	max_range = 40
 	penetration = 25
 	sundering = 5
 	shell_speed = 4


### PR DESCRIPTION
## About The Pull Request

adds max_range to sg153 bullets; this increases range of spotting rifle from 20 to 40, which matches the main sg62 and the DMR

## Why It's Good For The Game

the underbarrel spotting rifle doesn't shoot as far as the main sg62 rifle after i increased sg62 range. it actually just has the normal base bullet max_range without this PR. you can, while using the sg62, currently, hit things that are at the edge tiles of your scope, but if you try to dual-fire with the spotting rifle, your second bullet won't hit things that far out.

versatility thing, i guess. people dont take the sg62 for Reasons and often compare it to just a DMR; hopefully this can help lean a bit more into the niche of the unique spotting rifle ammos setting this gun apart from the DMR. im also not that into the practice of having to manage two different range statistics on what is (in mechanics) used as one gun. it seems silly and counterintuitive, especially since they _used to_ actually be properly synced for range, and since they share other stats like wield delay and whatnot (again from them being the Same Mechanical Item). i'm happy enough seeing how the sg62 has played since range was increased to think that this parity balance for sg153 wouldn't be wicked over-the-top.

**TLDR;** the underbarrel rifle shares the range with something like an AR, but the primary gun functions as something more like a DMR. this makes the underbarrel rifle more aligned with the main sg62 in that sense.

i'd also be down to limit the range to something more like 30 on BOTH guns if this seems scope-creep-y and we don't want to promote offscreen IFFing more

## Changelog

:cl:
balance: the SG153 spotting rifle's maximum bullet range has been increased to match the range of the SG62 it's attached to
/:cl: