### PR TITLE
C4 (Plastique Explosives) No Longer Require A Multitool To Disarm

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -136,6 +136,7 @@
 		alarm_sounded = FALSE
 		plant_target = null
 		update_icon()
+	return ..()
 
 ///Handles the actual explosion effects
 /obj/item/explosive/plastique/proc/detonate()

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -111,12 +111,6 @@
 
 /obj/item/explosive/plastique/attack_hand(mob/living/user)
 	if(armed)
-		to_chat(user, "<font color='warning'>Disarm [src] first to remove it!</font>")
-		return
-	return ..()
-
-/obj/item/explosive/plastique/attackby(obj/item/I, mob/user, params)
-	if(ismultitool(I) && armed)
 		if(!do_after(user, 2 SECONDS, NONE, plant_target, BUSY_ICON_HOSTILE))
 			return
 


### PR DESCRIPTION

## About The Pull Request
C4, or plastique explosives, no longer require a multitool to disarm, instead only requiring to click on the C4 to remove it.
## Why It's Good For The Game
Currently, C4 requires a multitool to disarm, meaning the only job that can reliably disarm the C4 are engies. Considering that both FC and SLs can acquire C4, this means that most of the time if a C4 is misplaced, it is just gonna destroy whatever (or whoever) it was planted on. This at least makes it easier to avoid accidents with C4.
## Changelog
:cl:
balance: C4 (Plastique explosives) no longer requires a multitool to disarm.
/:cl:
