### PR TITLE
Slightly reduces the cheese level of Wraiths

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -296,6 +296,16 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/turf/return_turf = get_turf(portal)
 	if(!return_turf)
 		return_turf = locate(backup_coordinates[1], backup_coordinates[2], backup_coordinates[3])
+	if(banishment_target.density)
+		var/list/cards = GLOB.cardinals.Copy()
+		for(var/mob/living/displacing in return_turf)
+			if(displacing.stat == DEAD) //no.
+				continue
+			shuffle(cards) //direction should vary.
+			for(var/card AS in cards)
+				if(step(displacing, card))
+					to_chat(displacing, span_warning("A sudden force pushes you away from [return_turf]!"))
+					break
 	banishment_target.resistance_flags = initial(banishment_target.resistance_flags)
 	banishment_target.status_flags = initial(banishment_target.status_flags) //Remove stasis and temp invulerability
 	banishment_target.forceMove(return_turf)


### PR DESCRIPTION
## About The Pull Request 
Banished objects that are solid (have density) will now push out any living beings on their tile before returning, if possible. This can potentially be used offensively (to force targets off a tile), but less to cheese like the previous state allowed.
## Why It's Good For The Game
Aims to counteract a specific technique relying on ending up on the same tile as certain solid objects. You shouldn't be on that tile, and telegibbing would be very rude to anyone, so this it is.
## Changelog
:cl:
balance: Banished solid objects now push out any living beings on their return tile (if possible) before returning.
/:cl:
