### PR TITLE
Changes Hypo Hypervene Acronym to Hy

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -483,7 +483,7 @@
 	list_reagents = list(
 		/datum/reagent/hypervene = 60,
 	)
-	description_overlay = "Ht"
+	description_overlay = "Hy"
 
 /obj/item/reagent_containers/hypospray/advanced/nanoblood
 	name = "nanoblood hypospray"


### PR DESCRIPTION

## About The Pull Request
Changes the current acronym for hypervene in a hypo from Ht to Hy.
## Why It's Good For The Game
No other hypervene container uses Ht, so making the hypo use Hy makes it consistent with other hypervene bottles/injectors.
## Changelog
:cl:
spellcheck: Changed the acronym for the hypervene hypo to Hy
/:cl:
