### PR TITLE
shortens hivemind plasma transfer delay from 2 seconds to 0.5 seconds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -65,6 +65,7 @@
 
 /datum/action/ability/activable/xeno/transfer_plasma/hivemind
 	plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT * 2
+	transfer_delay = 0.5 SECONDS
 
 /datum/action/ability/activable/xeno/transfer_plasma/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
 	if (owner.status_flags & INCORPOREAL)


### PR DESCRIPTION
## About The Pull Request

changes the plasma transfer delay from 2 seconds to .5 seconds for hivemind

## Why It's Good For The Game

base transfer delay on the ability is 2 seconds for all castes; hivelord has an override of .5 seconds for that. people move away from hiveminds rather fast and they only have a 2 tile range (from the base ability) for the transfer to work, so maybe being able to do it a bit quicker would help stop interruptions and keep everybody moving

maybe okay since hivemind plasma pool is much more limited than hivelord's and so it bottlenecks easier, leading one to be selective about who and when they transfer plasma

## Changelog

:cl:
balance: Hivemind's "Transfer Plasma" ability now takes half a second to channel instead of two seconds.
/:cl: