### PR TITLE
Orders Show Job Title of Order Sender

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -56,9 +56,9 @@
 	if(human_owner.assigned_squad)
 		for(var/mob/living/carbon/human/marine AS in human_owner.assigned_squad.marines_list)
 			marine.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>SQUAD ORDERS UPDATED:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
-			to_chat(marine, "<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>")
+			to_chat(marine, "<h2 class='alert'>You have received orders from the [human_owner.job.title]:</h2><br>[span_alert(text)]<br><br>")
 		return
 	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list)
 		if(human.faction == human_owner.faction)
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>ORDERS UPDATED:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
-			to_chat(human, "<h2 class='alert'>You have received orders to...</h2><br>[span_alert(text)]<br><br>")
+			to_chat(human, "<h2 class='alert'>You have received orders from the [human_owner.job.title]:</h2><br>[span_alert(text)]<br><br>")


### PR DESCRIPTION

## About The Pull Request
Orders will now show what job sent the order, rather than being ambiguous.
![Change Me - Debugdalus 12_8_2023 6_48_20 PM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/acd1e4c9-7936-4f1e-8fa1-8cbf04dad7b5)
## Why It's Good For The Game
Knowing who sent the orders can influence whether or not you would want to follow em. This makes it clearer, especially in the case of conflicting orders.
## Changelog
:cl:
add: Orders will now show what job sent them in the orders' header.
/:cl:
