### PR TITLE
Fixes spiderlings not continuing their attack

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -144,7 +144,7 @@
 /// Check if escorted_atom moves away from the spiderling while it's attacking something, this is to always keep them close to escorted_atom
 /datum/ai_behavior/spiderling/look_for_new_state()
 	if(current_action == MOVING_TO_ATOM)
-		if(escorted_atom)
+		if(escorted_atom && !(mob_parent.Adjacent(escorted_atom)))
 			change_action(ESCORTING_ATOM, escorted_atom)
 
 /// Check so that we dont keep attacking our target beyond it's death


### PR DESCRIPTION

## About The Pull Request
This fixes spiderlings stopping their attack after one slash, now they'll only stop if the widow is not adjacent to them
## Why It's Good For The Game
TerraGov-Marine-Corps/pull/13713 had broken it by removing a check, without this it's much harder to have them dealing damage
## Changelog
:cl:
fix: Widow's spiderlings will no longer just constantly stop attacking their target, now the widow will have to move away from the spiderlings and only then they will stop
/:cl:
