### PR TITLE
Makes Praetorian, Gorger, and Crusher resistant to projectile stagger.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -31,6 +31,7 @@
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
+	caste_flags = CASTE_STAGGER_RESISTANT
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -32,7 +32,7 @@
 	deevolves_to = list(/mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/hivelord)
 
 	// *** Flags *** //
-	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED
+	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED|CASTE_STAGGER_RESISTANT
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_LEADER
 	caste_traits = null
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -29,6 +29,7 @@
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
+	caste_flags = CASTE_STAGGER_RESISTANT
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 45, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 50, ACID = 40)


### PR DESCRIPTION
## About The Pull Request

This PR adds the stagger resistant flag to a few tier 3s, Praetorian, Crusher, and Gorger.

## Why It's Good For The Game

None of these T3's are able to be knockdowned by projectiles, it makes 0 sense for them to be staggered by projectiles and unable to use basic abilities. Especially for a caste such as Praetorian, which can be blocked from using something as menial as Acid Spit while being a T3. I did not add stagger resistance to castes such as warlock and defiler as stagger is a relevant counter for them and they can be knockdowned. However, for crusher, gorger, and praetorian I don't believe being able to stagger them with projectiles should be a thing at all and would make these castes a lot more fun to play.

## Changelog

:cl:
balance: Praetorian, Crusher, and Gorger are now resistant to projectile stagger
/:cl:

