### PR TITLE
New Gorger Primordial Ability: Oppose

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -802,7 +802,7 @@
 #define COMSIG_XENOABILITY_DEVOUR "xenoability_devour"
 #define COMSIG_XENOABILITY_DRAIN "xenoability_drain"
 #define COMSIG_XENOABILITY_TRANSFUSION "xenoability_transfusion"
-#define COMSIG_XENOABILITY_ASSIZE "xenoability_oppose"
+#define COMSIG_XENOABILITY_OPPOSE "xenoability_oppose"
 #define COMSIG_XENOABILITY_PSYCHIC_LINK "xenoability_psychic_link"
 #define COMSIG_XENOABILITY_CARNAGE "xenoability_carnage"
 #define COMSIG_XENOABILITY_FEAST "xenoability_feast"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -802,7 +802,7 @@
 #define COMSIG_XENOABILITY_DEVOUR "xenoability_devour"
 #define COMSIG_XENOABILITY_DRAIN "xenoability_drain"
 #define COMSIG_XENOABILITY_TRANSFUSION "xenoability_transfusion"
-#define COMSIG_XENOABILITY_ASSIZE "xenoability_assize"
+#define COMSIG_XENOABILITY_ASSIZE "xenoability_oppose"
 #define COMSIG_XENOABILITY_PSYCHIC_LINK "xenoability_psychic_link"
 #define COMSIG_XENOABILITY_CARNAGE "xenoability_carnage"
 #define COMSIG_XENOABILITY_FEAST "xenoability_feast"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -802,7 +802,7 @@
 #define COMSIG_XENOABILITY_DEVOUR "xenoability_devour"
 #define COMSIG_XENOABILITY_DRAIN "xenoability_drain"
 #define COMSIG_XENOABILITY_TRANSFUSION "xenoability_transfusion"
-#define COMSIG_XENOABILITY_REJUVENATE "xenoability_rejuvenate"
+#define COMSIG_XENOABILITY_ASSIZE "xenoability_assize"
 #define COMSIG_XENOABILITY_PSYCHIC_LINK "xenoability_psychic_link"
 #define COMSIG_XENOABILITY_CARNAGE "xenoability_carnage"
 #define COMSIG_XENOABILITY_FEAST "xenoability_feast"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -601,8 +601,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define GORGER_DRAIN_HEAL 40 // overheal gained each time the target is drained
 #define GORGER_DRAIN_BLOOD_DRAIN 20 // amount of plasma drained when feeding on something
 #define GORGER_TRANSFUSION_HEAL 0.3 // in %
-#define GORGER_ASSIZE_COST 100
-#define GORGER_ASSIZE_HEAL 0.2 // in %
+#define GORGER_OPPOSE_COST 100
+#define GORGER_OPPOSE_HEAL 0.2 // in %
 #define GORGER_PSYCHIC_LINK_CHANNEL 10 SECONDS
 #define GORGER_PSYCHIC_LINK_RANGE 15
 #define GORGER_PSYCHIC_LINK_REDIRECT 0.5 //in %

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -601,11 +601,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define GORGER_DRAIN_HEAL 40 // overheal gained each time the target is drained
 #define GORGER_DRAIN_BLOOD_DRAIN 20 // amount of plasma drained when feeding on something
 #define GORGER_TRANSFUSION_HEAL 0.3 // in %
-#define GORGER_REJUVENATE_DURATION -1
-#define GORGER_REJUVENATE_COST 20
-#define GORGER_REJUVENATE_SLOWDOWN 6
-#define GORGER_REJUVENATE_HEAL 0.05 //in %
-#define GORGER_REJUVENATE_THRESHOLD 0.10 //in %
+#define GORGER_ASSIZE_COST 100
+#define GORGER_ASSIZE_HEAL 0.2 // in %
 #define GORGER_PSYCHIC_LINK_CHANNEL 10 SECONDS
 #define GORGER_PSYCHIC_LINK_RANGE 15
 #define GORGER_PSYCHIC_LINK_REDIRECT 0.5 //in %

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -503,11 +503,11 @@
 	keybind_signal = COMSIG_XENOABILITY_TRANSFUSION
 	hotkey_keys = list("H")
 
-/datum/keybinding/xeno/assize
-	name = "assize"
-	full_name = "Gorger: Assize"
+/datum/keybinding/xeno/oppose
+	name = "oppose"
+	full_name = "Gorger: Oppose"
 	description = "Violently suffuse the nearby ground with stored blood, staggering nearby marines and healing nearby xenomorphs."
-	keybind_signal = COMSIG_XENOABILITY_ASSIZE
+	keybind_signal = COMSIG_XENOABILITY_OPPOSE
 	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/psychic_link

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -503,11 +503,11 @@
 	keybind_signal = COMSIG_XENOABILITY_TRANSFUSION
 	hotkey_keys = list("H")
 
-/datum/keybinding/xeno/rejuvenate
-	name = "rejuvenate"
-	full_name = "Gorger: Rejuvenate"
-	description = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
-	keybind_signal = COMSIG_XENOABILITY_REJUVENATE
+/datum/keybinding/xeno/assize
+	name = "assize"
+	full_name = "Gorger: Assize"
+	description = "Violently suffuse the nearby ground with stored blood, staggering nearby marines and healing nearby xenomorphs."
+	keybind_signal = COMSIG_XENOABILITY_ASSIZE
 	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/psychic_link

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -331,64 +331,8 @@
 	enhancement_action.end_ability()
 
 // ***************************************
-// *********** Rejuvenate
+// *********** Psychic Link
 // ***************************************
-/atom/movable/screen/alert/status_effect/xeno_rejuvenate
-	name = "Rejuvenation"
-	desc = "Your health is being restored."
-	icon_state = "xeno_rejuvenate"
-
-/datum/status_effect/xeno_rejuvenate
-	id = "xeno_rejuvenate"
-	tick_interval = 2 SECONDS
-	alert_type = /atom/movable/screen/alert/status_effect/xeno_rejuvenate
-	///Amount of damage taken before reduction kicks in
-	var/tick_damage_limit
-	///Amount of damage taken this tick
-	var/tick_damage
-
-/datum/status_effect/xeno_rejuvenate/on_creation(mob/living/new_owner, set_duration, tick_damage_limit)
-	owner = new_owner
-	duration = set_duration
-	src.tick_damage_limit = tick_damage_limit
-	RegisterSignals(owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE), PROC_REF(handle_damage_taken))
-	owner.add_movespeed_modifier(MOVESPEED_ID_GORGER_REJUVENATE, TRUE, 0, NONE, TRUE, GORGER_REJUVENATE_SLOWDOWN)
-	owner.add_filter("[id]m", 0, outline_filter(2, "#455d5762"))
-	return ..()
-
-/datum/status_effect/xeno_rejuvenate/on_remove()
-	. = ..()
-	UnregisterSignal(owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
-	owner.remove_movespeed_modifier(MOVESPEED_ID_GORGER_REJUVENATE)
-	owner.remove_filter("[id]m")
-
-/datum/status_effect/xeno_rejuvenate/tick()
-	var/mob/living/carbon/xenomorph/owner_xeno = owner
-	if(owner_xeno.plasma_stored < GORGER_REJUVENATE_COST)
-		to_chat(owner_xeno, span_notice("Not enough substance to sustain ourselves..."))
-		owner_xeno.remove_status_effect(STATUS_EFFECT_XENO_REJUVENATE)
-		return
-
-	owner_xeno.plasma_stored -= GORGER_REJUVENATE_COST
-	new /obj/effect/temp_visual/telekinesis(get_turf(owner_xeno))
-	to_chat(owner_xeno, span_notice("We feel our wounds close up."))
-
-	var/amount = owner_xeno.maxHealth * GORGER_REJUVENATE_HEAL
-	HEAL_XENO_DAMAGE(owner_xeno, amount, FALSE)
-	tick_damage = 0
-
-///Handles damage received when the status effect is active
-/datum/status_effect/xeno_rejuvenate/proc/handle_damage_taken(datum/source, amount, list/amount_mod)
-	SIGNAL_HANDLER
-	if(amount <= 0)
-		return
-
-	tick_damage += amount
-	if(tick_damage < tick_damage_limit)
-		return
-
-	amount_mod += min(amount * 0.75, 40)
-
 #define PSYCHIC_LINK_COLOR "#2a888360"
 #define CALC_DAMAGE_REDUCTION(amount, amount_mod) \
 	if(amount <= 0) { \
@@ -398,9 +342,6 @@
 	amount = min(amount * redirect_mod, remaining_health); \
 	amount_mod += amount
 
-// ***************************************
-// *********** Psychic Link
-// ***************************************
 /datum/status_effect/xeno_psychic_link
 	id = "xeno_psychic_link"
 	tick_interval = 2 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -269,16 +269,22 @@
 		if(M.stat == DEAD)
 			continue
 		var/distance = get_dist(M, owner_xeno)
-		if(distance==0 && !owner_xeno.issamexenohive(M)) //if we're right on top of them, they take actual damage
-			M.take_overall_damage(12, BRUTE, MELEE, updating_health = TRUE, max_limbs = 3)
-		else if(distance <= 1 && !owner_xeno.issamexenohive(M)) //marines will only be staggerslowed if they're one tile away from you
-			M.adjust_stagger(2)
-			M.adjust_slowdown(2)
-		else if(owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
+		if(owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
 			var/mob/living/carbon/xenomorph/target_xeno = M
 			var/heal_amount = M.maxHealth * GORGER_ASSIZE_HEAL
 			HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
 			adjustOverheal(target_xeno, heal_amount)
+			continue
+		else if(distance == 0) //if we're right on top of them, they take actual damage
+			M.take_overall_damage(12, BRUTE, MELEE, updating_health = TRUE, max_limbs = 3)
+			to_chat(M, span_highdanger("[X] slams her fists into you, crushing you to the ground!"))
+			M.Paralyze(2 SECONDS)
+			shake_camera(M, 3, 3)
+		else if(distance <= 1) //marines will only be staggerslowed if they're one tile away from you
+			shake_camera(M, 2, 2)
+			M.adjust_stagger(2)
+			M.adjust_slowdown(3)
+
 
 /datum/action/ability/activable/xeno/assize/ai_should_use(atom/target)
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -263,7 +263,7 @@
 	succeed_activate()
 
 	playsound(owner_xeno.loc, 'sound/effects/bang.ogg', 25, 0)
-	owner_xeno.visible_message(span_xenodanger("[X] smashes into the ground!"), \
+	owner_xeno.visible_message(span_xenodanger("[owner_xeno] smashes into the ground!"), \
 	span_xenodanger("We smash into the ground!"))
 	owner_xeno.create_stomp() //Adds the visual effect. Wom wom wom
 	for(var/mob/living/M in range(3, get_turf(owner_xeno)))
@@ -275,7 +275,7 @@
 		else if(distance <= 1 && !owner_xeno.issamexenohive(M)) //marines will only be staggerslowed if they're one tile away from you
 			M.adjust_stagger(2)
 			M.adjust_slowdown(2)
-		if(distance <= 3 && owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
+		else if(owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
 			var/heal_amount = M.maxHealth * GORGER_ASSIZE_HEAL
 			HEAL_XENO_DAMAGE(M, heal_amount, FALSE)
 			adjustOverheal(M, heal_amount)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -245,7 +245,7 @@
 // ***************************************
 
 /datum/action/ability/activable/xeno/oppose
-	name = "oppose"
+	name = "Oppose"
 	action_icon_state = "rejuvenation"
 	desc = "Violently suffuse the nearby ground with stored blood, staggering nearby marines and healing nearby xenomorphs."
 	cooldown_duration = 30 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -281,7 +281,7 @@
 		else if(distance <= 1) //marines will only be staggerslowed if they're one tile away from you
 			shake_camera(M, 2, 2)
 			to_chat(M, span_highdanger("Blood swells up from the ground around you!"))
-			M.adjust_stagger(20)
+			M.adjust_stagger(2 SECONDS)
 			M.adjust_slowdown(3)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -277,11 +277,12 @@
 			continue
 		else if(distance == 0) //if we're right on top of them, they take actual damage
 			M.take_overall_damage(12, BRUTE, MELEE, updating_health = TRUE, max_limbs = 3)
-			to_chat(M, span_highdanger("[X] slams her fists into you, crushing you to the ground!"))
+			to_chat(M, span_highdanger("[owner_xeno] slams her fists into you, crushing you to the ground!"))
 			M.Paralyze(2 SECONDS)
 			shake_camera(M, 3, 3)
 		else if(distance <= 1) //marines will only be staggerslowed if they're one tile away from you
 			shake_camera(M, 2, 2)
+			to_chat(M, span_highdanger("Blood swells up from the ground around you!"))
 			M.adjust_stagger(2)
 			M.adjust_slowdown(3)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -262,12 +262,12 @@
 	add_cooldown()
 	succeed_activate()
 
-	playsound(X.loc, 'sound/effects/bang.ogg', 25, 0)
-	X.visible_message(span_xenodanger("[X] smashes into the ground!"), \
+	playsound(owner_xeno.loc, 'sound/effects/bang.ogg', 25, 0)
+	owner_xeno.visible_message(span_xenodanger("[X] smashes into the ground!"), \
 	span_xenodanger("We smash into the ground!"))
-	X.create_stomp() //Adds the visual effect. Wom wom wom
-	for(var/mob/living/M in range(3, get_turf(X)))
-		if(M.stat = DEAD)
+	owner_xeno.create_stomp() //Adds the visual effect. Wom wom wom
+	for(var/mob/living/M in range(3, get_turf(owner_xeno)))
+		if(M.stat == DEAD)
 			continue
 		var/distance = get_dist(M, owner_xeno)
 		if(distance==0 && !owner_xeno.issamexenohive(M)) //if we're right on top of them, they take actual damage
@@ -275,7 +275,7 @@
 		else if(distance <= 1 && !owner_xeno.issamexenohive(M)) //marines will only be staggerslowed if they're one tile away from you
 			M.adjust_stagger(2)
 			M.adjust_slowdown(2)
-		if(distance <= 3 && X.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
+		if(distance <= 3 && owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
 			var/heal_amount = M.maxHealth * GORGER_ASSIZE_HEAL
 			HEAL_XENO_DAMAGE(M, heal_amount, FALSE)
 			adjustOverheal(M, heal_amount)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -276,9 +276,10 @@
 			M.adjust_stagger(2)
 			M.adjust_slowdown(2)
 		else if(owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
+			var/mob/living/carbon/xenomorph/target_xeno = M
 			var/heal_amount = M.maxHealth * GORGER_ASSIZE_HEAL
-			HEAL_XENO_DAMAGE(M, heal_amount, FALSE)
-			adjustOverheal(M, heal_amount)
+			HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
+			adjustOverheal(target_xeno, heal_amount)
 
 /datum/action/ability/activable/xeno/assize/ai_should_use(atom/target)
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -254,9 +254,8 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ASSIZE,
 	)
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY
-	use_state_flags = ABILITY_USE_STAGGERED
 
-/datum/action/ability/activable/xeno/rejuvenate/use_ability(atom/A)
+/datum/action/ability/activable/xeno/assize/use_ability(atom/A)
 	. = ..()
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -262,10 +262,10 @@
 	succeed_activate()
 
 	playsound(owner_xeno.loc, 'sound/effects/bang.ogg', 25, 0)
-	owner_xeno.visible_message(span_xenodanger("[owner_xeno] smashes into the ground!"), \
-	span_xenodanger("We smash into the ground!"))
+	owner_xeno.visible_message(span_xenodanger("[owner_xeno] smashes her fists into the ground into the ground!"), \
+	span_xenodanger("We smash our fists into the ground!"))
 	owner_xeno.create_stomp() //Adds the visual effect. Wom wom wom
-	for(var/mob/living/M in range(3, get_turf(owner_xeno)))
+	for(var/mob/living/M in range(3))
 		if(M.stat == DEAD)
 			continue
 		var/distance = get_dist(M, owner_xeno)
@@ -274,16 +274,14 @@
 			var/heal_amount = M.maxHealth * GORGER_OPPOSE_HEAL
 			HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
 			adjustOverheal(target_xeno, heal_amount)
-			continue
 		else if(distance == 0) //if we're right on top of them, they take actual damage
 			M.take_overall_damage(12, BRUTE, MELEE, updating_health = TRUE, max_limbs = 3)
 			to_chat(M, span_highdanger("[owner_xeno] slams her fists into you, crushing you to the ground!"))
-			M.Paralyze(2 SECONDS)
 			shake_camera(M, 3, 3)
 		else if(distance <= 1) //marines will only be staggerslowed if they're one tile away from you
 			shake_camera(M, 2, 2)
 			to_chat(M, span_highdanger("Blood swells up from the ground around you!"))
-			M.adjust_stagger(2)
+			M.adjust_stagger(20)
 			M.adjust_slowdown(3)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -241,21 +241,21 @@
 	return can_use_ability(target, TRUE)
 
 // ***************************************
-// *********** Assize
+// *********** oppose
 // ***************************************
 
-/datum/action/ability/activable/xeno/assize
-	name = "Assize"
+/datum/action/ability/activable/xeno/oppose
+	name = "oppose"
 	action_icon_state = "rejuvenation"
 	desc = "Violently suffuse the nearby ground with stored blood, staggering nearby marines and healing nearby xenomorphs."
 	cooldown_duration = 30 SECONDS
-	ability_cost = GORGER_ASSIZE_COST
+	ability_cost = GORGER_OPPOSE_COST
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ASSIZE,
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_OPPOSE,
 	)
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY
 
-/datum/action/ability/activable/xeno/assize/use_ability(atom/A)
+/datum/action/ability/activable/xeno/oppose/use_ability(atom/A)
 	. = ..()
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	add_cooldown()
@@ -271,7 +271,7 @@
 		var/distance = get_dist(M, owner_xeno)
 		if(owner_xeno.issamexenohive(M))  //Xenos can be healed up to three tiles away from you
 			var/mob/living/carbon/xenomorph/target_xeno = M
-			var/heal_amount = M.maxHealth * GORGER_ASSIZE_HEAL
+			var/heal_amount = M.maxHealth * GORGER_OPPOSE_HEAL
 			HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
 			adjustOverheal(target_xeno, heal_amount)
 			continue
@@ -287,7 +287,7 @@
 			M.adjust_slowdown(3)
 
 
-/datum/action/ability/activable/xeno/assize/ai_should_use(atom/target)
+/datum/action/ability/activable/xeno/oppose/ai_should_use(atom/target)
 	return FALSE
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -75,7 +75,7 @@
 		/datum/action/ability/activable/xeno/psychic_link,
 		/datum/action/ability/activable/xeno/drain,
 		/datum/action/ability/activable/xeno/transfusion,
-		/datum/action/ability/activable/xeno/assize,
+		/datum/action/ability/activable/xeno/oppose,
 		/datum/action/ability/activable/xeno/carnage,
 		/datum/action/ability/activable/xeno/feast,
 		/datum/action/ability/activable/xeno/devour,

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -75,7 +75,7 @@
 		/datum/action/ability/activable/xeno/psychic_link,
 		/datum/action/ability/activable/xeno/drain,
 		/datum/action/ability/activable/xeno/transfusion,
-		/datum/action/ability/activable/xeno/rejuvenate,
+		/datum/action/ability/activable/xeno/assize,
 		/datum/action/ability/activable/xeno/carnage,
 		/datum/action/ability/activable/xeno/feast,
 		/datum/action/ability/activable/xeno/devour,


### PR DESCRIPTION
## About The Pull Request
Title. Oppose is an ability with a 30 second cooldown that costs 100 blood. When activated, it heals every xeno in a radius of 3 tiles (the heal amount is less than a transfuse), as well as staggering and slowing marines in a radius of one tile.
If the Gorger manages to activate this ability from right on top of you, you take a bit of damage and get stunned.
inb4 "Knockoff crusher" comments or something
## Why It's Good For The Game
Rejuvenate functions as a good heal that has less startup cost, but one that also makes you slow as hell. For a primordial ability, its stats are terrible and it isn't very unique in general (Gorger already has feast). Oppose replaces this with an ability that isn't bad to use and also offers the Gorger more team-play.
## Changelog
:cl:
add: New Gorger primordial: Oppose. Staggers and slows nearby marines while healing nearby xenomorphs, at a cost. Replaces current primordial ability, Rejuvenate
del: Rejuvenate
/:cl:
