### PR TITLE
SG-29 Fire delay .2->.25

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1227,7 +1227,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/sgstock, /obj/item/attachable/sgbarrel)
 	gun_skill_category = SKILL_SMARTGUN //Uses SG skill for the penalties.
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.25 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.1


### PR DESCRIPTION
## About The Pull Request
Moves T-29's fire delay from .2 to .25.
## Why It's Good For The Game
I first tested moving T-29 from heavy rifle fire rate to rifle fire rate in https://github.com/tgstation/TerraGov-Marine-Corps/pull/9912, eventually after closing that PR Arctrooper made https://github.com/tgstation/TerraGov-Marine-Corps/pull/10151 which was a continuation of my PR and included the SG-29 buffs as a side effect.

This was a mistake.

T-29 should not have had its fire rate increased, it should have lesser DPS to compensate for its IFF, higher penetration and mesonnods, overall I tried the swap to see how the gun felt and personally I think it lead to powercreep as people said it 'Felt better' due to being stronger overall and being useable as a mere rifle with IFF rather than as a fire support gun so the powercreep was allowed to go through, generally speaking T-29 should move back down a level of fire rate and be back to its original state instead of having the ability and incentives to be used as just a rifle with IFF instead as of pure fire support.
I feel like if you want rate of fire you should move to the SG minigun, and if you want an all rounder move to the SG-29, if you want long range with a funny side gun, move to the SG DMR.
## Changelog
:cl:
balance: SG-29 now has 0.25 fire rate rather than 0.2.
/:cl:
