### PR TITLE
Skirmish Rifle buff, 30->40 mag cap

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1686,7 +1686,7 @@
 	unload_sound = 'sound/weapons/guns/interact/t21_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/t21_reload.ogg'
 	caliber = CALIBER_10X25_CASELESS //codex
-	max_shells = 30 //codex
+	max_shells = 40 //codex
 	force = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/standard_skirmishrifle
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/standard_skirmishrifle)

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -424,7 +424,7 @@
 	icon_state = "t21"
 	icon_state_mini = "mag_rifle"
 	default_ammo = /datum/ammo/bullet/rifle/heavy
-	max_rounds = 30
+	max_rounds = 40
 
 //ALF-51B
 


### PR DESCRIPTION

## About The Pull Request
Skirmisher now has 40 magazine capacity.
## Why It's Good For The Game
Makes the skirmirsher a more enticing choice, it currently suffers from terrible ammo economy overall as it has significantly worse magazine capacity compared to other weapons in the same overall class (BR, StormR, AK, etc) so this should help it stand out more.
## Changelog
:cl:
balance: Skirmish Rifle has been buffed to 40 magazine capacity instead of 30.
/:cl:
