### PR TITLE
Bike nerf

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -11,7 +11,7 @@
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
 	key_type = null
 	integrity_failure = 0.5
-	allow_pass_flags = PASSABLE
+	allow_pass_flags = PASSABLE|PASS_LOW_STRUCTURE
 	coverage = 30	//It's just a bike, not hard to shoot over
 	buckle_flags = CAN_BUCKLE|BUCKLE_PREVENTS_PULL|BUCKLE_NEEDS_HAND
 	///Internal motorbick storage object

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -24,7 +24,7 @@
 	var/fuel_max = 1000
 	///reference to the attached sidecar, if present
 	var/obj/item/sidecar/attached_sidecar
-
+	///If the bike is knocked over
 	var/tipped = FALSE
 	COOLDOWN_DECLARE(enginesound_cooldown)
 


### PR DESCRIPTION

## About The Pull Request
Two changes to bikes to make them less cheesy in terms of their abusable game mechanics.

You can now jump over bikes (a mob bucked to it will still block you however)

Xenos and explosions can knock bikes over, making them nondense and briefly stunning any occupants.
Humans can flip the bike back so it can be ridden again.

Its only a 10% chance on xeno melee attacks (and you do need to hit the actual bike) but it means xenos aren't just completely ggnore'd if they get trapped behind a bike.
## Why It's Good For The Game
The ability to hard trap xenos isn't great gameplay for xenos.
## Changelog
:cl:
balance: Bikes can be jumped over
balance: Bikes can be knocked over by xeno melee attacks or explosions
/:cl:
