### PR TITLE
Glass turf fix

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -17,6 +17,7 @@
 	layer = ABOVE_OBJ_LAYER
 	dir = NORTH
 	density = TRUE
+	coverage = 0
 	var/base_category //what kind of equipment this base accepts.
 	var/ship_tag //used to associate the base to a dropship.
 	/// offset in pixels when equipment is attached

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -509,6 +509,7 @@
 
 /turf/closed/shuttle/dropship1/panel
 	icon_state = "shuttle_interior_panel"
+	density = FALSE
 
 /turf/closed/shuttle/dropship1/engineone
 	icon_state = "shuttle_interior_backengine"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -587,7 +587,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return FALSE //No hits ...yet!
 
 /obj/projectile/proc/scan_a_turf(turf/turf_to_scan, cardinal_move)
-	if(turf_to_scan.density) //Handle wall hit.
+	if(turf_to_scan.density && ((turf_to_scan == original_target) || !((turf_to_scan.allow_pass_flags & PASS_GLASS) && (ammo.flags_ammo_behavior & AMMO_ENERGY))))
 		ammo.on_hit_turf(turf_to_scan, src)
 		turf_to_scan.bullet_act(src)
 		return !(ammo.flags_ammo_behavior & AMMO_PASS_THROUGH_TURF)

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -875,6 +875,7 @@
 
 /obj/structure/dropship_piece/one/weapon
 	opacity = FALSE
+	coverage = 0
 
 /obj/structure/dropship_piece/one/weapon/leftleft
 	icon_state = "brown_weapon_ll"


### PR DESCRIPTION
## About The Pull Request
Fixes all types of glass turfs not actually respecting the pass_glass flag.
This means lasers will actually go through them as expected now.

Also fixed a couple other minor related alamo bugs.
The invisible dense turfs under the alamo computer consoles are no longer dense (so you can actually shoot through the front window)
The invisible attach points on alamo and tad (and the object they are linked to) no longer have 50% coverage (so your bullets aren't blocked by invisible funny effect)
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed glass turfs not being passable by lasers and such when they should have been
/:cl:
