### PR TITLE
Rebinds unique action to C by default (instead of space)

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -36,7 +36,7 @@
 	quick_equip_slot = 5
 
 /datum/keybinding/human/unique_action
-	hotkey_keys = list("Space")
+	hotkey_keys = list("C")
 	name = "unique_action"
 	full_name = "Perform unique action"
 	keybind_signal = COMSIG_KB_UNIQUEACTION


### PR DESCRIPTION

## About The Pull Request

Why C? Because it's unused on humans. Also space to jump is more intuitive for newer people I feel like.

Keep in mind if you aren't connecting for the first time your keybinds won't be affected by this!!!
## Why It's Good For The Game

2 different things on the same key by default is a bit questionable.
## Changelog
:cl:
qol: Rebound unique action to C by default (instead of space)
/:cl:
