### PR TITLE
Allows ai to ping alert the baneling pod.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -248,6 +248,9 @@
 /obj/structure/xeno/trap/AIMiddleClick(mob/living/silicon/ai/user)
 	user.ai_ping(src, COOLDOWN_AI_PING_NORMAL)
 
+/obj/structure/xeno/baneling_pod/AIMiddleClick(mob/living/silicon/ai/user)
+	user.ai_ping(src, COOLDOWN_AI_PING_LOW)
+
 /* acid */
 
 /obj/effect/xenomorph/acid/AIMiddleClick(mob/living/silicon/ai/user)


### PR DESCRIPTION

## About The Pull Request
What is says on the tin. You will be able to ping the baneling's pod as AI.
## Why It's Good For The Game
Consistency?
## Changelog
:cl:
add: You can now ping the baneling pod as AI.
/:cl:
