### PR TITLE
Deletes some garbage on big red.

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -2724,11 +2724,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
-"axF" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/n)
 "axP" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -36982,7 +36977,7 @@ gzM
 gzM
 gzM
 gzM
-axF
+aqO
 aqO
 gzM
 gQv

--- a/_maps/modularmaps/big_red/bigredsouthwestetavar4.dmm
+++ b/_maps/modularmaps/big_red/bigredsouthwestetavar4.dmm
@@ -11,12 +11,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"aF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/south)
 "bp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -3022,7 +3016,7 @@ dO
 IX
 vo
 IX
-aF
+IX
 dO
 dO
 Jd


### PR DESCRIPTION

## About The Pull Request
Deleted duplicate wooden barricade.
Also deleted the light tube which is floating in nowhere.
## Why It's Good For The Game
Consistency.
## Changelog
:cl:
fix: deleted some garbage on Big Red.
/:cl:
