### PR TITLE
Fix earlyadd minimap icons not showing up on minimap

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -41,11 +41,9 @@ SUBSYSTEM_DEF(minimaps)
 	var/list/hashed_minimaps = list()
 
 /datum/controller/subsystem/minimaps/Initialize()
+	initialized = TRUE
 	for(var/datum/space_level/z_level AS in SSmapping.z_list)
 		load_new_z(null, z_level)
-	//RegisterSignal(SSdcs, COMSIG_GLOB_NEW_Z, PROC_REF(load_new_z))
-
-	initialized = TRUE
 
 	return SS_INIT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

This means miners, gens and other stuff shows up on the minimap 
## Why It's Good For The Game

bug bad
## Changelog
:cl:
fix: Miners, gens and other stuff should actually show up on minimap now
/:cl:
