### PR TITLE
Removes jetpacks from marine vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -129,7 +129,6 @@
 			/obj/item/ammo_magazine/flamer_tank/large = 16,
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/water = -1,
-			/obj/item/jetpack_marine = 3,
 			/obj/item/bodybag/tarp = 10,
 		),
 		"Heavy Weapons" = list(
@@ -337,7 +336,6 @@
 			/obj/item/ammo_magazine/flamer_tank/large = 30,
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/water = -1,
-			/obj/item/jetpack_marine = 3,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,


### PR DESCRIPTION

## About The Pull Request
Removes jetpacks from Marine vendors entirely. They are no longer free.
## Why It's Good For The Game
Something like this should've never been free, considering its effectively a get out of jail free card for most situations and is a huge boost to mobility in others, in my opinion it should cost you cash money to get as a Marine.
## Changelog
:cl:
balance: Marine vendors no longer contain three free jetpacks.
/:cl:
