### PR TITLE
Base rescue mission time tweaks

### DIFF
--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -10,6 +10,7 @@
 	map_light_levels = list(225, 150, 100, 75)
 	objectives_total = 1
 	min_destruction_amount = 1
+	max_game_time = 15 MINUTES
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 60 SECONDS,
 		MISSION_HOSTILE_FACTION = 0,

--- a/code/game/objects/machinery/computer/nt_access.dm
+++ b/code/game/objects/machinery/computer/nt_access.dm
@@ -15,11 +15,9 @@
 	resistance_flags = INDESTRUCTIBLE|UNACIDABLE
 	layer = ABOVE_MOB_LAYER
 	///Time needed for the machine to generate the disc
-	var/segment_time = 1.5 MINUTES
+	var/segment_time = 1 MINUTES
 	///Time to start a segment
-	var/start_time = 15 SECONDS
-	///Time to print a disk
-	var/printing_time = 15 SECONDS
+	var/start_time = 5 SECONDS
 	///Total number of times the hack is required
 	var/total_segments = 5
 	///What segment we are on, (once this hits total, disk is printed)
@@ -128,7 +126,7 @@
 				busy = TRUE
 
 				usr.visible_message("[usr] started a program to send the [code_color] security override command.", "You started a program to send the [code_color] security override command.")
-				if(!do_after(usr, printing_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
+				if(!do_after(usr, start_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
 					busy = FALSE
 					return
 


### PR DESCRIPTION

## About The Pull Request
Time for each segment is changed from 1.5 minutes to 1 minute.
Time to activate each segment is changed from 15 seconds to 5 seconds.
Total round time increased from 12 minutes to 15 minutes (this is still in addition to the period before the timer starts, I forget what it is).

Also just removed a basically unneeded var.
## Why It's Good For The Game
This mission is very difficult for the SOM, hopefully this makes it a little less guh.
## Changelog
:cl:
balance: Made the timings for the base rescue mission easier for SOM
/:cl:
