### PR TITLE
Campaign mission end ghostize

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -276,9 +276,10 @@
 	for(var/i in GLOB.quick_loadouts)
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
 		outfit.quantity = initial(outfit.quantity)
-	for(var/mob/living/carbon/human/corpse AS in GLOB.dead_human_list)
-		corpse.set_undefibbable(TRUE)
-		qdel(corpse) //clean up all the corpses
+	for(var/mob/living/carbon/human/corpse AS in GLOB.dead_human_list) //clean up all the bodies and refund normal roles if required
+		if(!HAS_TRAIT(corpse, TRAIT_UNDEFIBBABLE) && corpse.job.job_cost)
+			corpse.job.add_job_positions(1)
+		qdel(corpse)
 
 ///Unregisters all signals when the mission finishes
 /datum/campaign_mission/proc/unregister_mission_signals()

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -276,6 +276,9 @@
 	for(var/i in GLOB.quick_loadouts)
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
 		outfit.quantity = initial(outfit.quantity)
+	for(var/mob/living/carbon/human/corpse AS in GLOB.dead_human_list)
+		corpse.set_undefibbable(TRUE)
+		qdel(corpse) //clean up all the corpses
 
 ///Unregisters all signals when the mission finishes
 /datum/campaign_mission/proc/unregister_mission_signals()

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -203,15 +203,10 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 ///Returns all faction members back to base after the mission is completed
 /datum/faction_stats/proc/return_to_base()
 	for(var/mob/living/carbon/human/human_mob AS in GLOB.alive_human_list_faction[faction])
-		if(!human_mob.job.job_cost) //asset based roles are one use
-			human_mob.ghostize()
-			qdel(human_mob)
-			continue
-		human_mob.revive(TRUE)
-		human_mob.overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
-		human_mob.overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
-		human_mob.forceMove(pick(GLOB.spawns_by_job[human_mob.job.type]))
-		human_mob.Stun(1 SECONDS) //so you don't accidentally shoot your team etc
+		var/mob/dead/observer/ghost = human_mob.ghostize()
+		qdel(human_mob)
+		var/datum/game_mode/mode = SSticker.mode
+		mode.player_respawn(ghost) //auto open the respawn screen
 
 ///Generates status tab info for the mission
 /datum/faction_stats/proc/get_status_tab_items(mob/source, list/items)

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -204,6 +204,8 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 /datum/faction_stats/proc/return_to_base()
 	for(var/mob/living/carbon/human/human_mob AS in GLOB.alive_human_list_faction[faction])
 		var/mob/dead/observer/ghost = human_mob.ghostize()
+		if(human_mob.job.job_cost) //We don't refund ally roles
+			human_mob.job.add_job_positions(1)
 		qdel(human_mob)
 		var/datum/game_mode/mode = SSticker.mode
 		mode.player_respawn(ghost) //auto open the respawn screen

--- a/code/game/objects/machinery/computer/nt_access.dm
+++ b/code/game/objects/machinery/computer/nt_access.dm
@@ -1,4 +1,5 @@
 // -- generate override code computer
+//TODO: Make a parent computer to remove all the nuke disk copy paste
 /obj/item/circuitboard/computer/nt_access
 	name = "circuit board (nuke disk generator)"
 	build_path = /obj/machinery/computer/nt_access


### PR DESCRIPTION
## About The Pull Request
Currently, ally jobs are ghosted at mission end, and everyone else is sent to spawn.
Changed to now have ALL players ghosted at mission end.

Additionally, all dead humans are qdel'd at mission end. Maybe good for perf when you no longer have 500 dead bodies with radios etc, but mainly QOL so overwatch isn't flooded with an ever growing list of KIA's.
## Why It's Good For The Game
Aims to fix two problems:
Players having half their kit missing after a mission etc
Players looting lots of good shit, letting winning teams snowball significantly in some cases
## Changelog
:cl:
balance: Campaign: All players are ghosted at the end of a mission
/:cl:
