### PR TITLE
Emplacements may be hopped over

### DIFF
--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -7,7 +7,7 @@
 	layer = TANK_BARREL_LAYER
 	use_power = FALSE
 	hud_possible = list(MACHINE_HEALTH_HUD, MACHINE_AMMO_HUD)
-	allow_pass_flags = PASSABLE
+	allow_pass_flags = PASSABLE|PASS_LOW_STRUCTURE
 	///Store user old pixel x
 	var/user_old_x = 0
 	///Store user old pixel y

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -4,6 +4,7 @@
 	use_power = 0
 	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_ENGPREP, ACCESS_MARINE_LEADER)
 	hud_possible = list(MACHINE_HEALTH_HUD, MACHINE_AMMO_HUD)
+	allow_pass_flags = PASSABLE
 
 	///Spark system for making sparks
 	var/datum/effect_system/spark_spread/spark_system


### PR DESCRIPTION

## About The Pull Request
Salt pr? Maybe.
## Why It's Good For The Game
Seriously this thing is like, a gun laid on the ground. I can walk over a crate of these things just lying around but I can't jump over one when they set it upright?

This also allows xenos to counter emplacements when they get right into melee range by just shoving the marine off or by just standing on the gun; you can't shoot right on your tile when wielding an emplacement. Granteed, that first thing might keep the second thing from being a factor, but whatever.
## Changelog
:cl:
balance: Emplaced guns (such as the mg27) may now be jumped over.
/:cl:
