### PR TITLE
Add wheelchair-mounted minigun for the elderly

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -113,6 +113,7 @@
 #define WEIGHTBENCH_TRAIT "weightbench"
 #define BOILER_ROOTED_TRAIT "boiler_rooted"
 #define STRAPPABLE_ITEM_TRAIT "strappable_item"
+#define WHEELCHAIR_TRAIT "wheelchair"
 #define VALI_TRAIT "vali"
 #define HELDGLOVE_TRAIT "heldglove"
 #define SECTOID_TRAIT "sectoid"

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -123,6 +123,9 @@
 	set_vehicle_dir_layer(EAST, OBJ_LAYER)
 	set_vehicle_dir_layer(WEST, OBJ_LAYER)
 
+/datum/component/riding/vehicle/wheelchair/weaponized
+	vehicle_move_delay = 2.5
+
 /datum/component/riding/vehicle/motorbike
 	vehicle_move_delay = 2
 	ride_check_flags = RIDER_NEEDS_LEGS | RIDER_NEEDS_ARMS | UNBUCKLE_DISABLED_RIDER

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -477,6 +477,10 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	//A reference to whatever this gun is mounted to for dropped()
 	var/mount
 
+/obj/item/weapon/gun/minigun_wheelchair/Destroy()
+	mount = null
+	return ..()
+
 //This will account for cases like if the user's hand is cut off, return it to the object it was mounted on
 /obj/item/weapon/gun/minigun_wheelchair/dropped(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -440,6 +440,52 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 /obj/item/weapon/gun/minigun/valhalla
 	obj_flags = NONE
 
+//Mounted version of the minigun for the wheelchair
+/obj/item/weapon/gun/minigun_wheelchair
+	name = "\improper Modified MG-100 Vindicator Minigun"
+	desc = "A minigun that's been modified to be mounted on a wheelchair. As a result, it is more controllable and fed externally by an ammo reservoir."
+
+	icon = 'icons/Marine/gun64.dmi'
+	icon_state = "minigun"
+	item_state = "minigun"
+	fire_animation = "minigun_fire"
+	max_shells = 1000 //codex
+	caliber = CALIBER_762X51 //codex
+	load_method = MAGAZINE //codex
+	fire_sound = 'sound/weapons/guns/fire/minigun.ogg'
+	unload_sound = 'sound/weapons/guns/interact/minigun_unload.ogg'
+	reload_sound = 'sound/weapons/guns/interact/working_the_bolt.ogg'
+	cocked_sound = 'sound/weapons/guns/interact/minigun_cocked.ogg'
+	default_ammo_type = /obj/item/ammo_magazine/minigun_wheelchair
+	allowed_ammo_types = list(/obj/item/ammo_magazine/minigun_wheelchair)
+	w_class = WEIGHT_CLASS_HUGE
+	force = 20
+	wield_delay = 12
+	gun_skill_category = SKILL_FIREARMS
+	flags_item = 0	//To remove wielding
+	flags_gun_features = GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
+	reciever_flags = AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE|AMMO_RECIEVER_MAGAZINES
+	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
+
+	fire_delay = 0.15 SECONDS
+	windup_delay = 0.7 SECONDS
+	windup_sound = 'sound/weapons/guns/fire/tank_minigun_start.ogg'
+	scatter = 5
+	damage_falloff_mult = 0.5
+	movement_acc_penalty_mult = 0
+
+	//A reference to whatever this gun is mounted to for dropped()
+	var/mount
+
+//This will account for cases like if the user's hand is cut off, return it to the object it was mounted on
+/obj/item/weapon/gun/minigun_wheelchair/dropped(mob/user)
+	. = ..()
+	forceMove(mount)
+
+//So that it displays the minigun on the mob as if always wielded
+/obj/item/weapon/gun/minigun_wheelchair/update_item_state()
+	item_state = "[base_gun_icon]_w"
+
 // SG minigun
 
 /obj/item/weapon/gun/minigun/smart_minigun

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -441,53 +441,42 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	obj_flags = NONE
 
 //Mounted version of the minigun for the wheelchair
-/obj/item/weapon/gun/minigun_wheelchair
+/obj/item/weapon/gun/minigun/wheelchair
 	name = "\improper Modified MG-100 Vindicator Minigun"
 	desc = "A minigun that's been modified to be mounted on a wheelchair. As a result, it is more controllable and fed externally by an ammo reservoir."
 
-	icon = 'icons/Marine/gun64.dmi'
-	icon_state = "minigun"
-	item_state = "minigun"
-	fire_animation = "minigun_fire"
 	max_shells = 1000 //codex
-	caliber = CALIBER_762X51 //codex
-	load_method = MAGAZINE //codex
-	fire_sound = 'sound/weapons/guns/fire/minigun.ogg'
-	unload_sound = 'sound/weapons/guns/interact/minigun_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/working_the_bolt.ogg'
-	cocked_sound = 'sound/weapons/guns/interact/minigun_cocked.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/minigun_wheelchair
 	allowed_ammo_types = list(/obj/item/ammo_magazine/minigun_wheelchair)
-	w_class = WEIGHT_CLASS_HUGE
-	force = 20
-	wield_delay = 12
-	gun_skill_category = SKILL_FIREARMS
-	flags_item = 0	//To remove wielding
+	obj_flags = NONE	//Do not affect autobalance
+	flags_item = NONE	//To remove wielding
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
 	reciever_flags = AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE|AMMO_RECIEVER_MAGAZINES
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
+	actions_types = list()
+	attachable_allowed = list()
 
-	fire_delay = 0.15 SECONDS
+	recoil = 0
+	recoil_unwielded = 0
+
 	windup_delay = 0.7 SECONDS
-	windup_sound = 'sound/weapons/guns/fire/tank_minigun_start.ogg'
-	scatter = 5
-	damage_falloff_mult = 0.5
 	movement_acc_penalty_mult = 0
 
 	//A reference to whatever this gun is mounted to for dropped()
 	var/mount
 
-/obj/item/weapon/gun/minigun_wheelchair/Destroy()
+/obj/item/weapon/gun/minigun/wheelchair/Destroy()
 	mount = null
 	return ..()
 
 //This will account for cases like if the user's hand is cut off, return it to the object it was mounted on
-/obj/item/weapon/gun/minigun_wheelchair/dropped(mob/user)
+/obj/item/weapon/gun/minigun/wheelchair/dropped(mob/user)
 	. = ..()
 	forceMove(mount)
 
 //So that it displays the minigun on the mob as if always wielded
-/obj/item/weapon/gun/minigun_wheelchair/update_item_state()
+/obj/item/weapon/gun/minigun/wheelchair/update_item_state()
 	item_state = "[base_gun_icon]_w"
 
 // SG minigun

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -426,6 +426,19 @@
 	caliber = CALIBER_10x26_CASELESS
 	flags_item_map_variant = null
 
+//"External magazine" for the wheelchair-mounted minigun
+/obj/item/ammo_magazine/minigun_wheelchair
+	name = "\improper Mounted MG-100 Vindicator ammo rack"
+	desc = "A case filled to the brim with ammunition. Appears custom made to be slotted into a feeding system."
+	icon = 'icons/obj/items/ammo.dmi'
+	icon_state = "minigun"
+	flags_atom = CONDUCT
+	flags_magazine = MAGAZINE_REFILLABLE
+	w_class = WEIGHT_CLASS_HUGE
+	default_ammo = /datum/ammo/bullet/minigun
+	current_rounds = 1000
+	max_rounds = 1000
+	reload_delay = 0.75 SECONDS
 
 // ICC coilgun
 

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -88,6 +88,10 @@
 	weapon = new /obj/item/weapon/gun/minigun_wheelchair
 	weapon.mount = src
 
+/obj/vehicle/ridden/wheelchair/weaponized/obj_destruction(damage_flag)
+	weapon.Destroy()
+	. = ..()
+
 //The wheelchair speed is actually on the component, delay_multiplier does nothing
 /obj/vehicle/ridden/wheelchair/weaponized/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/wheelchair/weaponized)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -67,3 +67,70 @@
 /obj/vehicle/ridden/wheelchair/proc/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/wheelchair)
 
+
+
+/* Battlechair - A wheelchair with a mounted minigun */
+/obj/vehicle/ridden/wheelchair/weaponized
+	name = "\improper Battlechair"
+	desc = "A sturdy wheelchair fitted with a minigun. Your legs may have failed you, but your weapon won't."
+	max_integrity = 400
+
+	///Reference to the mounted weapon
+	var/obj/item/weapon/gun/minigun_wheelchair/weapon
+
+/obj/vehicle/ridden/wheelchair/weaponized/examine(mob/user)
+	. = ..()
+	. += span_notice("Drag to yourself to unload the mounted weapon.")
+	. += "Ammo: [span_bold("[weapon.rounds]/[weapon.max_rounds]")]"
+
+/obj/vehicle/ridden/wheelchair/weaponized/Initialize(mapload)
+	. = ..()
+	weapon = new /obj/item/weapon/gun/minigun_wheelchair
+	weapon.mount = src
+
+//The wheelchair speed is actually on the component, delay_multiplier does nothing
+/obj/vehicle/ridden/wheelchair/weaponized/make_ridable()
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/wheelchair/weaponized)
+
+//Set the rider as the gun's wielder
+/obj/vehicle/ridden/wheelchair/weaponized/after_add_occupant(mob/M)
+	. = ..()
+	if(istype(M))
+		if(!M.put_in_active_hand(weapon) && !M.put_in_inactive_hand(weapon))
+			to_chat(M, span_warning("Could not equip weapon! Click [src] with a free hand to equip."))
+		//NODROP is so that you can't just drop the gun or have someone take it off your hands
+		ADD_TRAIT(weapon, TRAIT_NODROP, WHEELCHAIR_TRAIT)
+
+//The ex-rider no longer wields the gun
+/obj/vehicle/ridden/wheelchair/weaponized/after_remove_occupant(mob/M)
+	. = ..()
+	if(istype(M))
+		REMOVE_TRAIT(weapon, TRAIT_NODROP, WHEELCHAIR_TRAIT)
+		/*
+		doUnEquip doesn't work so
+		Also the gun's dropped() has the code that returns it to the chair
+		It was necessary to do this to account for edge cases like the user's arm being cut off; no need for an extra forceMove() here
+		*/
+		M.dropItemToGround(weapon)
+
+//If the rider doesn't have the weapon equipped and clicks the wheelchair, equip them with it instead of unbuckling
+/obj/vehicle/ridden/wheelchair/weaponized/attack_hand(mob/living/user)
+	if(is_occupant(user) && !user.is_holding(weapon))
+		user.put_in_active_hand(weapon)
+	else
+		. = ..()
+
+//If the user drags the wheelchair to themselves, unload the gun
+/obj/vehicle/ridden/wheelchair/weaponized/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	if(!istype(usr, /mob/living) || over != usr || !in_range(src, usr))
+		return
+
+	var/mob/living/user = usr
+	weapon.unload(user)
+
+//Users can reload the gun without entering the chair by clicking the chair with the magazine
+/obj/vehicle/ridden/wheelchair/weaponized/attackby(obj/item/I, mob/living/user, def_zone)
+	. = ..()
+	if(istype(I, /obj/item/ammo_magazine))
+		weapon.reload(I, user)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -90,7 +90,7 @@
 
 /obj/vehicle/ridden/wheelchair/weaponized/obj_destruction(damage_flag)
 	weapon.Destroy()
-	. = ..()
+	return ..()
 
 //The wheelchair speed is actually on the component, delay_multiplier does nothing
 /obj/vehicle/ridden/wheelchair/weaponized/make_ridable()
@@ -122,7 +122,7 @@
 	if(is_occupant(user) && !user.is_holding(weapon))
 		user.put_in_active_hand(weapon)
 	else
-		. = ..()
+		..()
 
 //If the user drags the wheelchair to themselves, unload the gun
 /obj/vehicle/ridden/wheelchair/weaponized/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -88,7 +88,7 @@
 	weapon = new /obj/item/weapon/gun/minigun/wheelchair
 	weapon.mount = src
 
-/obj/vehicle/ridden/wheelchair/weaponized/obj_destruction(damage_flag)
+/obj/vehicle/ridden/wheelchair/weaponized/Destroy()
 	QDEL_NULL(weapon)
 	return ..()
 

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -76,7 +76,7 @@
 	max_integrity = 400
 
 	///Reference to the mounted weapon
-	var/obj/item/weapon/gun/minigun_wheelchair/weapon
+	var/obj/item/weapon/gun/minigun/wheelchair/weapon
 
 /obj/vehicle/ridden/wheelchair/weaponized/examine(mob/user)
 	. = ..()
@@ -85,11 +85,11 @@
 
 /obj/vehicle/ridden/wheelchair/weaponized/Initialize(mapload)
 	. = ..()
-	weapon = new /obj/item/weapon/gun/minigun_wheelchair
+	weapon = new /obj/item/weapon/gun/minigun/wheelchair
 	weapon.mount = src
 
 /obj/vehicle/ridden/wheelchair/weaponized/obj_destruction(damage_flag)
-	weapon.Destroy()
+	QDEL_NULL(weapon)
 	return ..()
 
 //The wheelchair speed is actually on the component, delay_multiplier does nothing
@@ -122,7 +122,7 @@
 	if(is_occupant(user) && !user.is_holding(weapon))
 		user.put_in_active_hand(weapon)
 	else
-		..()
+		return ..()
 
 //If the user drags the wheelchair to themselves, unload the gun
 /obj/vehicle/ridden/wheelchair/weaponized/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)


### PR DESCRIPTION

## About The Pull Request

Adds a wheelchair modified for combat. Comes with a minigun strapped to it. For use with the old man ERT.

https://github.com/tgstation/TerraGov-Marine-Corps/assets/30136710/29396220-52da-4f38-b915-3586bb602ae0

Differences from the standard minigun:
- 1000 rounds
- No recoil
- Operated with one hand
- Must be seated in the wheelchair to operate, cannot detach

## Why It's Good For The Game

It's a wheelchair-mounted minigun. The elderly have just as much a right to heavy weapons.

## Changelog
:cl:
add: Wheelchair-mounted minigun.
/:cl:
