### PR TITLE
Follow up mission end QOL

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -277,6 +277,8 @@
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
 		outfit.quantity = initial(outfit.quantity)
 	for(var/mob/living/carbon/human/corpse AS in GLOB.dead_human_list) //clean up all the bodies and refund normal roles if required
+		if(corpse.z != mission_z_level)
+			continue
 		if(!HAS_TRAIT(corpse, TRAIT_UNDEFIBBABLE) && corpse.job.job_cost)
 			corpse.job.add_job_positions(1)
 		qdel(corpse)

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -197,12 +197,20 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 	generate_new_mission()
 	update_static_data_for_all_viewers()
-	addtimer(CALLBACK(src, PROC_REF(return_to_base)), AFTER_MISSION_TELEPORT_DELAY)
+	addtimer(CALLBACK(src, PROC_REF(return_to_base), completed_mission), AFTER_MISSION_TELEPORT_DELAY)
 	addtimer(CALLBACK(src, PROC_REF(get_selector)), AFTER_MISSION_LEADER_DELAY) //if the leader died, we load a new one after a bit to give respawns some time
 
 ///Returns all faction members back to base after the mission is completed
-/datum/faction_stats/proc/return_to_base()
+/datum/faction_stats/proc/return_to_base(datum/campaign_mission/completed_mission)
 	for(var/mob/living/carbon/human/human_mob AS in GLOB.alive_human_list_faction[faction])
+		if(human_mob.z != completed_mission.mission_z_level && human_mob.job.job_cost)
+			human_mob.revive(TRUE)
+			human_mob.overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
+			human_mob.overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
+			human_mob.forceMove(pick(GLOB.spawns_by_job[human_mob.job.type]))
+			human_mob.Stun(1 SECONDS) //so you don't accidentally shoot your team etc
+			continue
+
 		var/mob/dead/observer/ghost = human_mob.ghostize()
 		if(human_mob.job.job_cost) //We don't refund ally roles
 			human_mob.job.add_job_positions(1)


### PR DESCRIPTION

## About The Pull Request
Returned the 'teleport to base' feature at mission end for anyone not on the mission z-level (i.e any shipside roles or people that didn't have a chance to deploy).

Also added a z-level check on cleaning up bodies. Mainly to avoid badmins accidentally messing with job slots if they have dead bodies on an admin z-level or something.
## Why It's Good For The Game
It was somewhat redundant to ghost them, let you dupe binos, and caused some minor bugs with overwatch.
## Changelog
:cl:
qol: Campaign: Players still on their home z-level will be teleported to spawn instead of ghosted at mission end
/:cl:
