### PR TITLE
Campaign BSOD fix

### DIFF
--- a/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
@@ -21,9 +21,9 @@ const CampaignTabs = [
 export type MissionData = {
   faction_rewards_data;
   typepath?: string;
-  name: string;
+  name?: string;
 
-  map_name: string;
+  map_name?: string;
   starting_faction?: string;
   hostile_faction?: string;
   winning_faction?: string;


### PR DESCRIPTION

## About The Pull Request
(Probably) fixes the BSOD that seems to occasionally pop up in the campaign status panel.
I can't reproduce it to verify however.
## Why It's Good For The Game
BSOD essentially bricks the mode.
## Changelog
:cl:
fix: Fixes an uncommon BSOD on the campaign status screen
/:cl:
