### PR TITLE
Defensive mission walance

### DIFF
--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -773,10 +773,6 @@
 	},
 /turf/closed/wall,
 /area/campaign/jungle_outpost/outpost/living)
-"di" = (
-/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
-/turf/open/floor/plating/ground/dirt2,
-/area/campaign/jungle_outpost/ground/jungle/south_west)
 "dj" = (
 /obj/structure/morgue{
 	dir = 8
@@ -4044,12 +4040,6 @@
 /obj/effect/spawner/random/misc/folder,
 /turf/open/floor/tile/blue/taupeblue,
 /area/campaign/jungle_outpost/outpost/command)
-"qZ" = (
-/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
-/turf/open/floor/plating/ground/dirtgrassborder2{
-	dir = 4
-	},
-/area/campaign/jungle_outpost/ground/jungle)
 "ra" = (
 /obj/structure/platform{
 	dir = 4
@@ -6684,7 +6674,6 @@
 /obj/effect/landmark/campaign_structure/barricade/sandbags{
 	dir = 8
 	},
-/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/landing)
 "BP" = (
@@ -17322,7 +17311,7 @@ eU
 vZ
 vZ
 vZ
-di
+vZ
 vZ
 vZ
 vZ
@@ -23332,7 +23321,7 @@ cX
 fQ
 uB
 oM
-qZ
+oM
 oM
 oM
 oM

--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -101,6 +101,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/campaign/jungle_outpost/outpost/engineering)
+"at" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "au" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/liquid/water/river,
@@ -292,6 +301,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/campaign/jungle_outpost/outpost/science)
+"bn" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/autosmooth,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "bo" = (
 /turf/open/floor/plating/ground/dirtgrassborder2/corner,
 /area/campaign/jungle_outpost/ground/jungle/east)
@@ -333,6 +349,14 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/campaign/jungle_outpost/ground/jungle)
+"bx" = (
+/obj/structure/platform,
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "by" = (
 /obj/structure/rock/variable/jungle,
 /turf/open/ground/grass/weedable,
@@ -382,6 +406,15 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/outpost/living)
+"bI" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "bJ" = (
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 4
@@ -740,6 +773,10 @@
 	},
 /turf/closed/wall,
 /area/campaign/jungle_outpost/outpost/living)
+"di" = (
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
+/turf/open/floor/plating/ground/dirt2,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "dj" = (
 /obj/structure/morgue{
 	dir = 8
@@ -1309,6 +1346,12 @@
 /obj/structure/prop/mainship/research/destructive_analyzer,
 /turf/open/floor/tile/white,
 /area/campaign/jungle_outpost/outpost/science)
+"fE" = (
+/obj/effect/landmark/campaign_structure/howitzer_objective{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt2,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "fF" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/ground/grass/weedable,
@@ -1400,6 +1443,15 @@
 /obj/machinery/door/airlock/mainship/command/free_access,
 /turf/open/floor,
 /area/campaign/jungle_outpost/outpost/command)
+"fY" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "fZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -2048,6 +2100,12 @@
 	dir = 5
 	},
 /area/campaign/jungle_outpost/outpost/command)
+"iB" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "iC" = (
 /obj/machinery/light{
 	dir = 8
@@ -2366,6 +2424,14 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
+"kc" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 1
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "kd" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/powercell,
@@ -2475,6 +2541,12 @@
 	dir = 6
 	},
 /area/campaign/jungle_outpost/outpost/security)
+"kA" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "kB" = (
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt,
@@ -2869,6 +2941,12 @@
 /obj/structure/flora/jungle/grass,
 /turf/open/ground/grass/weedable,
 /area/campaign/jungle_outpost/ground/jungle/north_west)
+"md" = (
+/obj/effect/landmark/campaign_structure/howitzer_objective{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2,
+/area/campaign/jungle_outpost/ground/jungle)
 "me" = (
 /obj/structure/rock/variable/jungle_large,
 /turf/open/liquid/water/river/autosmooth,
@@ -3001,6 +3079,15 @@
 /obj/structure/platform,
 /turf/closed/wall,
 /area/campaign/jungle_outpost/outpost/medbay/chemistry)
+"mM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner2,
+/area/campaign/jungle_outpost/ground/jungle)
 "mO" = (
 /obj/structure/flora/jungle/bush,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
@@ -3081,6 +3168,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/campaign/jungle_outpost/ground/jungle/south_east)
+"nh" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/turf/open/floor/plating/ground/dirt2,
+/area/campaign/jungle_outpost/ground/jungle)
 "nj" = (
 /obj/structure/catwalk,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
@@ -3201,6 +3295,14 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
+"nL" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/ground/grass/beach/corner{
+	dir = 1
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "nM" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -3559,6 +3661,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
+"po" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/campaign/jungle_outpost/outpost/landing)
 "pp" = (
 /obj/structure/flora/grass/tallgrass/autosmooth,
 /turf/open/ground/grass/beach/corner2,
@@ -3601,6 +3714,13 @@
 /obj/structure/flora/jungle/grass/thin,
 /turf/open/ground/grass/beach,
 /area/campaign/jungle_outpost/ground/jungle/north_east)
+"py" = (
+/obj/structure/flora/jungle/grass/thin,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle)
 "pA" = (
 /obj/structure/rock/variable/jungle,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
@@ -3924,6 +4044,12 @@
 /obj/effect/spawner/random/misc/folder,
 /turf/open/floor/tile/blue/taupeblue,
 /area/campaign/jungle_outpost/outpost/command)
+"qZ" = (
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
+/turf/open/floor/plating/ground/dirtgrassborder2{
+	dir = 4
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "ra" = (
 /obj/structure/platform{
 	dir = 4
@@ -4109,6 +4235,11 @@
 /obj/machinery/light,
 /turf/open/floor/tile/blue/taupeblue,
 /area/campaign/jungle_outpost/outpost/command)
+"rF" = (
+/obj/structure/platform,
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "rG" = (
 /obj/structure/flora/jungle/grass/thin,
 /turf/open/floor/plating/ground/dirtgrassborder2{
@@ -4597,6 +4728,18 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/outpost/medbay/lobby)
+"tB" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "tC" = (
 /obj/structure/flora/jungle/bush,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
@@ -4709,6 +4852,12 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/ground/jungle/west)
+"ue" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "uf" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -4767,10 +4916,6 @@
 /obj/structure/rock/variable/jungle,
 /turf/open/ground/grass/weedable,
 /area/campaign/jungle_outpost/ground/jungle/south)
-"uq" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/north_west)
 "ur" = (
 /obj/structure/table/reinforced,
 /obj/item/radio,
@@ -4820,6 +4965,14 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/campaign/jungle_outpost/outpost/living)
+"uB" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner2{
+	dir = 8
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "uC" = (
 /obj/structure/platform_decoration{
 	dir = 5
@@ -5035,6 +5188,12 @@
 /obj/structure/platform{
 	dir = 9
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
 /turf/open/floor,
 /area/campaign/jungle_outpost/outpost/landing/storage)
 "vE" = (
@@ -5082,10 +5241,6 @@
 /turf/open/floor/plating/ground/dirtgrassborder2/corner2{
 	dir = 8
 	},
-/area/campaign/jungle_outpost/ground/jungle/east)
-"vO" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
 /area/campaign/jungle_outpost/ground/jungle/east)
 "vP" = (
 /obj/structure/flora/jungle/grass/thin,
@@ -5241,10 +5396,6 @@
 	dir = 8
 	},
 /area/campaign/jungle_outpost/ground/jungle)
-"wB" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle)
 "wC" = (
 /obj/structure/platform_decoration,
 /turf/open/liquid/water,
@@ -5367,6 +5518,11 @@
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor,
 /area/campaign/jungle_outpost/outpost/outer/west)
+"xe" = (
+/obj/structure/platform,
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "xf" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/security,
@@ -5636,6 +5792,13 @@
 	},
 /turf/closed/wall,
 /area/campaign/jungle_outpost/outpost/req)
+"yd" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/autosmooth,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "ye" = (
 /obj/structure/flora/grass/tallgrass/autosmooth,
 /turf/open/floor/plating/ground/dirtgrassborder2/autosmooth,
@@ -5672,6 +5835,10 @@
 /obj/structure/platform{
 	dir = 10
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
 /turf/open/floor,
 /area/campaign/jungle_outpost/outpost/landing/storage)
 "yp" = (
@@ -5837,6 +6004,12 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
+"yW" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "za" = (
 /obj/structure/platform{
 	dir = 9
@@ -5853,6 +6026,12 @@
 /obj/structure/flora/jungle/large_bush,
 /obj/structure/platform_decoration{
 	dir = 9
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle)
+"zd" = (
+/obj/effect/landmark/campaign_structure/howitzer_objective{
+	dir = 4
 	},
 /turf/open/ground/grass/weedable,
 /area/campaign/jungle_outpost/ground/jungle)
@@ -6138,6 +6317,10 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/ground/jungle/north_east)
+"An" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/turf/open/floor/plating/ground/dirtgrassborder2/autosmooth,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "Ap" = (
 /obj/structure/closet/crate/mass_produced_crate/construction,
 /turf/open/floor/tile/purple/whitepurple,
@@ -6497,6 +6680,11 @@
 /obj/structure/platform{
 	dir = 10
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/landing)
 "BP" = (
@@ -6591,6 +6779,9 @@
 /area/campaign/jungle_outpost/ground/jungle/south_east)
 "Cf" = (
 /obj/structure/flora/jungle/grass/thin,
+/obj/effect/landmark/campaign_structure/howitzer_objective{
+	dir = 4
+	},
 /turf/open/ground/grass/beach/corner{
 	dir = 4
 	},
@@ -6710,6 +6901,15 @@
 "CG" = (
 /turf/open/floor/plating/ground/dirtgrassborder2,
 /area/campaign/jungle_outpost/ground/jungle/south_west)
+"CI" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor,
+/area/campaign/jungle_outpost/outpost/landing/storage)
 "CJ" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -7546,6 +7746,12 @@
 	dir = 8
 	},
 /area/campaign/jungle_outpost/outpost/medbay/chemistry)
+"Gr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "Gs" = (
 /turf/open/floor/plating/dmg2,
 /area/campaign/jungle_outpost/outpost/outer/southwest)
@@ -7694,6 +7900,12 @@
 	},
 /turf/open/floor/plating/ground/dirtgrassborder2,
 /area/campaign/jungle_outpost/ground/jungle/east)
+"GY" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/autosmooth,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "GZ" = (
 /obj/structure/catwalk,
 /obj/effect/turf_decal/riverdecal,
@@ -7782,10 +7994,6 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
-"Hw" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/floor/plating/ground/dirtgrassborder2/corner,
-/area/campaign/jungle_outpost/ground/jungle)
 "Hy" = (
 /obj/structure/stairs/seamless/edge_vert{
 	dir = 8
@@ -7958,11 +8166,6 @@
 /obj/structure/flora/grass/tallgrass/autosmooth,
 /turf/open/liquid/water/river/autosmooth,
 /area/campaign/jungle_outpost/ground/river/north)
-"Il" = (
-/obj/structure/flora/jungle/grass/thin,
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/east)
 "Im" = (
 /obj/structure/flora/grass/tallgrass/autosmooth,
 /obj/structure/platform_decoration{
@@ -8254,6 +8457,14 @@
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/tile/white,
 /area/campaign/jungle_outpost/outpost/medbay/chemistry)
+"JF" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner2{
+	dir = 4
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "JG" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/freezer,
@@ -8271,10 +8482,6 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
-"JK" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/south_west)
 "JL" = (
 /turf/open/floor/plating/ground/dirtgrassborder2/corner2,
 /area/campaign/jungle_outpost/ground/jungle/south_west)
@@ -8428,6 +8635,9 @@
 /area/campaign/jungle_outpost/ground/jungle/north_east)
 "Kv" = (
 /obj/effect/landmark/mob_spawner/farwa,
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
 /turf/open/ground/grass/beach/corner2{
 	dir = 4
 	},
@@ -8451,6 +8661,13 @@
 /obj/machinery/shower,
 /turf/open/floor/freezer,
 /area/campaign/jungle_outpost/outpost/command)
+"KB" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags,
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "KC" = (
 /obj/structure/bed/roller,
 /obj/machinery/power/apc/drained,
@@ -8478,10 +8695,6 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/campaign/jungle_outpost/ground/jungle/east)
-"KF" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/north)
 "KG" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 8
@@ -9070,6 +9283,15 @@
 "Nk" = (
 /turf/open/floor/plating/ground/dirt2,
 /area/campaign/jungle_outpost/ground/jungle/east)
+"Nl" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "Nm" = (
 /obj/structure/flora/jungle/grass,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner,
@@ -9637,10 +9859,6 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/ground/jungle/east)
-"PE" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/south)
 "PF" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/engibelt,
@@ -9904,6 +10122,15 @@
 /obj/machinery/light,
 /turf/open/floor/tile/purple/whitepurple,
 /area/campaign/jungle_outpost/outpost/science/south)
+"QQ" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "QR" = (
 /turf/closed/wall,
 /area/campaign/jungle_outpost/outpost/living)
@@ -10448,6 +10675,14 @@
 	dir = 8
 	},
 /area/campaign/jungle_outpost/outpost/medbay)
+"Tj" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2{
+	dir = 8
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "Tk" = (
 /turf/closed/wall/r_wall,
 /area/campaign/jungle_outpost/outpost/security)
@@ -10528,6 +10763,14 @@
 /obj/machinery/prop/computer/PC,
 /turf/open/floor/wood/alt_seven,
 /area/campaign/jungle_outpost/outpost/science/office)
+"TD" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/turf/open/ground/grass/beach{
+	dir = 4
+	},
+/area/campaign/jungle_outpost/ground/jungle)
 "TE" = (
 /obj/structure/cable,
 /turf/open/floor/tile/blue/whitebluecorner{
@@ -11100,6 +11343,18 @@
 /obj/machinery/botany/editor,
 /turf/open/floor/tile/hydro,
 /area/campaign/jungle_outpost/outpost/living/hydro)
+"VX" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/campaign/jungle_outpost/outpost/landing)
 "VY" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -11383,6 +11638,12 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/landing)
+"Xa" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/campaign/jungle_outpost/ground/jungle/south_west)
 "Xb" = (
 /turf/open/floor/tile/neutral/full,
 /area/campaign/jungle_outpost/outpost/living/canteen)
@@ -11761,10 +12022,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/alt_four,
 /area/campaign/jungle_outpost/outpost/command/captain)
-"YF" = (
-/obj/effect/landmark/campaign_structure/howitzer_objective,
-/turf/open/ground/grass/weedable,
-/area/campaign/jungle_outpost/ground/jungle/west)
 "YG" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/random/medical/pillbottle,
@@ -14284,7 +14541,7 @@ ZS
 ZS
 ZS
 Fd
-YF
+bE
 ct
 Hq
 rQ
@@ -14713,7 +14970,7 @@ BV
 BV
 BV
 Fe
-uq
+Fe
 Fe
 Fe
 BV
@@ -16303,9 +16560,9 @@ PQ
 Xz
 Xz
 Xz
-Xz
-Xz
-Xz
+bI
+iB
+KB
 Uj
 Gd
 Gd
@@ -16767,7 +17024,7 @@ vZ
 vZ
 vZ
 eU
-eU
+yd
 Xz
 Xz
 Xz
@@ -16910,7 +17167,7 @@ Xz
 Xz
 Xz
 eU
-vZ
+fE
 vZ
 vZ
 vZ
@@ -16919,7 +17176,7 @@ sN
 vZ
 vZ
 vZ
-eU
+An
 Xz
 Xz
 Xz
@@ -17065,13 +17322,13 @@ eU
 vZ
 vZ
 vZ
+di
 vZ
 vZ
 vZ
+fE
 vZ
-vZ
-vZ
-eU
+An
 Xz
 Xz
 Xz
@@ -17211,7 +17468,7 @@ QL
 Dp
 fa
 CV
-Xz
+Xa
 eU
 vZ
 vZ
@@ -17223,7 +17480,7 @@ vZ
 eU
 eU
 eU
-eU
+bn
 Xz
 Xz
 cm
@@ -17363,7 +17620,7 @@ TJ
 Xz
 Xz
 Xz
-Xz
+Xa
 eU
 vZ
 vZ
@@ -17515,14 +17772,14 @@ Dp
 Xz
 Xz
 Xz
-Xz
+Xa
 eU
+fE
 vZ
 vZ
-vZ
 eU
-eU
-Xz
+GY
+Gr
 Gd
 Gd
 Gd
@@ -17667,7 +17924,7 @@ Xz
 Ft
 Uj
 Ft
-Xz
+Nl
 eU
 eU
 eU
@@ -20404,7 +20661,7 @@ cm
 cm
 Uj
 Xz
-JK
+Xz
 Gd
 Gd
 Gd
@@ -22012,10 +22269,10 @@ YC
 YC
 YC
 mL
-ZH
+TD
 MA
-XC
-fQ
+kc
+JF
 DE
 Ga
 yp
@@ -22614,7 +22871,7 @@ kH
 mD
 mD
 mD
-KY
+py
 mD
 PP
 KX
@@ -22642,7 +22899,7 @@ mD
 KY
 mD
 mD
-Hw
+wO
 oM
 MD
 kH
@@ -22921,7 +23178,7 @@ fQ
 ld
 oM
 oM
-HF
+nL
 DN
 DN
 jV
@@ -23070,12 +23327,12 @@ mD
 mD
 mD
 Wo
-cX
+Tj
 cX
 fQ
-ld
+uB
 oM
-oM
+qZ
 oM
 oM
 oM
@@ -23377,9 +23634,9 @@ gn
 Fg
 ND
 mD
-wB
+mD
 Qc
-NK
+md
 xw
 kH
 dV
@@ -23534,7 +23791,7 @@ mD
 NK
 xw
 kH
-mD
+zd
 mD
 tp
 QR
@@ -23683,8 +23940,8 @@ qG
 mD
 mD
 wO
-MD
-xw
+mM
+nh
 kH
 mD
 mD
@@ -24503,7 +24760,7 @@ sk
 nI
 nI
 LG
-PE
+EX
 EX
 Gb
 cJ
@@ -24863,7 +25120,7 @@ bA
 nO
 bA
 bA
-KF
+bA
 nO
 xK
 HV
@@ -28562,7 +28819,7 @@ mD
 mD
 lA
 kH
-wB
+mD
 dn
 dn
 qs
@@ -28831,18 +29088,18 @@ Jh
 Jh
 Jh
 Jh
+tB
+at
+at
+at
 Jh
 Jh
 Jh
-Jh
-Jh
-Jh
-Jh
-Jh
-Jh
-Jh
-Jh
-Jh
+at
+at
+at
+at
+at
 yn
 Ct
 yD
@@ -28975,7 +29232,15 @@ Ex
 Ex
 Ho
 EU
-IZ
+CI
+jt
+jt
+jt
+jt
+jt
+jt
+jt
+yW
 jt
 jt
 jt
@@ -28987,15 +29252,7 @@ jt
 jt
 jt
 jt
-jt
-jt
-jt
-jt
-jt
-jt
-jt
-jt
-wY
+rF
 Ct
 yD
 CT
@@ -29127,7 +29384,7 @@ he
 uY
 EU
 EU
-IZ
+CI
 jt
 jt
 jt
@@ -29147,7 +29404,7 @@ jt
 nU
 jt
 jt
-wY
+rF
 Ct
 vN
 CT
@@ -29279,7 +29536,7 @@ EU
 EU
 EU
 EU
-IZ
+CI
 jt
 jt
 jt
@@ -29290,7 +29547,7 @@ jt
 jt
 jt
 jt
-jt
+fM
 jt
 Mh
 Mh
@@ -29299,7 +29556,7 @@ jt
 MM
 jt
 jt
-wY
+rF
 Ct
 Nk
 vN
@@ -29597,7 +29854,7 @@ jt
 jt
 jt
 jt
-jt
+fM
 jt
 jt
 Ds
@@ -29742,10 +29999,10 @@ BT
 hV
 hV
 ZR
-tX
-tX
-tX
-tX
+VX
+QQ
+QQ
+QQ
 BO
 jt
 jt
@@ -29755,7 +30012,7 @@ jt
 jt
 jt
 jt
-wY
+rF
 qz
 nP
 br
@@ -29898,7 +30155,7 @@ jf
 jf
 jf
 jf
-HO
+xe
 Pd
 jt
 jt
@@ -29907,7 +30164,7 @@ jt
 jt
 jt
 jt
-wY
+rF
 If
 Mp
 XV
@@ -30050,16 +30307,16 @@ jf
 jf
 jf
 jf
-HO
+xe
 Pd
 jt
-fM
+jt
 jt
 jt
 Yh
 jt
 jt
-wY
+rF
 TF
 zu
 TF
@@ -30198,11 +30455,11 @@ jf
 jf
 jf
 jf
+kA
 jf
 jf
 jf
-jf
-HO
+xe
 jt
 jt
 jt
@@ -30211,7 +30468,7 @@ jt
 GF
 jt
 jt
-wY
+rF
 TF
 TF
 TF
@@ -30350,11 +30607,11 @@ FM
 FM
 FM
 FM
-FM
+po
+ue
 jf
 jf
-jf
-HO
+bx
 jt
 jt
 jt
@@ -30363,7 +30620,7 @@ jt
 GF
 jt
 jt
-wY
+rF
 TF
 TF
 IJ
@@ -30510,12 +30767,12 @@ JW
 hv
 jt
 jt
-jt
+fM
 jt
 mP
 jt
 jt
-wY
+rF
 eJ
 TF
 TF
@@ -31268,10 +31525,10 @@ jf
 jf
 HO
 jt
-YP
-YP
-YP
-YP
+fY
+fY
+fY
+fY
 YP
 YP
 YP
@@ -32082,7 +32339,7 @@ Nk
 Nk
 yD
 TF
-Il
+XV
 TF
 TF
 TF
@@ -33123,7 +33380,7 @@ TF
 TF
 CT
 CT
-vO
+TF
 nw
 nw
 OE

--- a/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
+++ b/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
@@ -203,6 +203,12 @@
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/science)
+"aW" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines,
+/area/patricks_rest/ground/colonyse)
 "aY" = (
 /turf/closed/mineral/smooth/indestructible,
 /area/patricks_rest/ground/colonysw)
@@ -328,6 +334,13 @@
 /obj/effect/landmark/patrol_point/som/som_22,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/ground/colonynw)
+"bC" = (
+/obj/structure/flora/desert/grass/heavy,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "bD" = (
 /obj/structure/platform/metalplatform{
 	dir = 9
@@ -499,6 +512,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/landing_pad)
+"co" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonys)
 "cp" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/freezer,
@@ -670,12 +687,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/hydro)
+"db" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonycent)
 "dc" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/patricks_rest/surface/building/storage_depot_south)
+"dd" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyse)
 "de" = (
 /obj/structure/platform/metalplatform{
 	dir = 1
@@ -857,6 +884,11 @@
 	},
 /turf/closed/wall/mainship,
 /area/patricks_rest/surface/building/hydro)
+"dZ" = (
+/obj/structure/cable,
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyse)
 "eb" = (
 /obj/structure/desertdam/decals/road/line{
 	dir = 4
@@ -889,6 +921,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/residential_w)
+"ej" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "el" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -1245,6 +1284,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/landing_pad)
+"fM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonynw)
 "fN" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -1504,6 +1547,11 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/colonyne)
+"gV" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyse)
 "gW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete,
@@ -1753,6 +1801,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/offices)
+"ie" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonyse)
 "if" = (
 /obj/structure/largecrate,
 /obj/structure/cable,
@@ -1944,6 +2001,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/storage_depot_research)
+"iU" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonycent)
 "iV" = (
 /obj/machinery/conveyor,
 /obj/item/storage/briefcase,
@@ -2062,6 +2125,14 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/atc)
+"jx" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonycent)
 "jy" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
@@ -2203,6 +2274,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/patricks_rest/ground/underground/cave)
+"kc" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonyse)
 "ke" = (
 /obj/effect/ai_node,
 /obj/machinery/light{
@@ -2252,6 +2332,12 @@
 	dir = 8
 	},
 /area/patricks_rest/ground/colonycent)
+"kr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyn)
 "ks" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/mainship/mono,
@@ -2609,6 +2695,18 @@
 /obj/item/reagent_containers/food/snacks/soup/meatballsoup,
 /turf/open/floor/prison/sterilewhite,
 /area/patricks_rest/surface/building/residential_cent)
+"lZ" = (
+/obj/structure/largecrate,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/patricks_rest/ground/colonyn)
 "ma" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow/full,
@@ -2625,6 +2723,14 @@
 /obj/effect/turf_decal/warning_stripes/stripedsquare,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/security_post_cargo)
+"me" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/patricks_rest/ground/colonyn)
 "mf" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/prison/blue/plate{
@@ -2884,6 +2990,12 @@
 	},
 /turf/open/floor/prison/yellow/full,
 /area/patricks_rest/surface/building/residential_w)
+"ni" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonye)
 "nj" = (
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/landing_pad)
@@ -3009,12 +3121,6 @@
 "nH" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/surface/building/residential_w)
-"nI" = (
-/obj/structure/cargo_container{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete,
-/area/patricks_rest/ground/colonyn)
 "nK" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/mainship/mono,
@@ -3024,6 +3130,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/patricks_rest/surface/building/residential_cent)
+"nM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/surface/building/medbay)
 "nN" = (
 /obj/structure/desertdam/decals/road/line{
 	dir = 4
@@ -3363,6 +3473,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/ore)
+"po" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonye)
 "pp" = (
 /obj/machinery/light{
 	dir = 1
@@ -3435,6 +3549,12 @@
 /obj/item/stack/sheet/metal,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/ground/colonyn)
+"pD" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonyse)
 "pE" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/surface/building/storage_depot_south)
@@ -3582,6 +3702,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/hydro)
+"ql" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonye)
 "qm" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
@@ -3619,6 +3745,15 @@
 /obj/machinery/griddle,
 /turf/open/floor/grayscale/black,
 /area/patricks_rest/surface/building/residential_cent)
+"qw" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyn)
 "qx" = (
 /obj/structure/rack,
 /obj/item/newspaper,
@@ -3768,9 +3903,25 @@
 /obj/structure/desertdam/decals/road/line{
 	dir = 1
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
 	},
+/area/patricks_rest/ground/colonynw)
+"rn" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines,
+/area/patricks_rest/ground/colonys)
+"ro" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/ground/colonynw)
 "rp" = (
 /obj/structure/rack,
@@ -3779,6 +3930,13 @@
 "rs" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/patricks_rest/surface/building/residential_cent)
+"rt" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "ru" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/tool/kitchen/tray,
@@ -3946,6 +4104,7 @@
 /area/patricks_rest/ground/colonye)
 "sn" = (
 /obj/structure/desertdam/decals/road/line,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
 	},
@@ -3957,6 +4116,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/science)
+"sp" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 10
+	},
+/area/patricks_rest/ground/colonyn)
 "sq" = (
 /obj/machinery/door/airlock/multi_tile/mainship/personalglass{
 	dir = 2
@@ -4026,6 +4193,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/residential_w)
+"sK" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "sL" = (
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
@@ -4407,6 +4581,11 @@
 "uB" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/science)
+"uC" = (
+/obj/structure/flora/desert/grass/heavy,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonye)
 "uD" = (
 /obj/structure/table/reinforced,
 /obj/structure/window{
@@ -4485,6 +4664,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/surface/building/atc)
+"uS" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines,
+/area/patricks_rest/ground/underground/cave)
 "uT" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -4623,6 +4808,12 @@
 	dir = 5
 	},
 /area/patricks_rest/ground/colonye)
+"vC" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "vD" = (
 /obj/structure/largecrate,
 /obj/machinery/light{
@@ -4792,6 +4983,14 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
 /area/patricks_rest/surface/building/residential_w)
+"ww" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyse)
 "wx" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/prison/yellow/full,
@@ -4831,6 +5030,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/ore_storage)
+"wH" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonys)
 "wJ" = (
 /obj/structure/desertdam/decals/road/line,
 /turf/open/floor/plating/ground/concrete,
@@ -5111,6 +5318,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/red/full,
 /area/patricks_rest/surface/building/security_post_cargo)
+"yh" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonye)
 "yj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/emails,
@@ -5232,6 +5443,10 @@
 /obj/machinery/mineral/processing_unit,
 /turf/open/floor/prison/darkbrown/full,
 /area/patricks_rest/surface/building/ore)
+"yW" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyn)
 "yY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -5259,6 +5474,12 @@
 /obj/structure/prop/mainship/sensor_computer1,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/offices)
+"zg" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/patricks_rest/ground/underground/cave)
 "zh" = (
 /obj/structure/table/mainship,
 /obj/machinery/light,
@@ -5272,10 +5493,6 @@
 	},
 /turf/open/floor/prison/red/full,
 /area/patricks_rest/surface/building/security_post_cargo)
-"zj" = (
-/obj/effect/landmark/campaign_structure/mlrs,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/patricks_rest/ground/colonyw)
 "zl" = (
 /obj/structure/dropship_piece/two/cockpit/right{
 	dir = 1
@@ -5428,6 +5645,17 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/darkyellow/full,
 /area/patricks_rest/surface/building/hydro)
+"Af" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/patricks_rest/surface/building/security_post_cargo)
 "Ah" = (
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/engineering)
@@ -5556,6 +5784,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/residential_cent)
+"AP" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/underground/cave)
 "AQ" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
@@ -5611,6 +5845,14 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/residential_w)
+"Bg" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/underground/cave)
 "Bi" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -5806,6 +6048,15 @@
 /obj/machinery/light,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/surface/building/engineering)
+"Ci" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/patricks_rest/ground/colonyn)
 "Cj" = (
 /obj/structure/table/mainship,
 /obj/machinery/light{
@@ -5826,6 +6077,13 @@
 /obj/machinery/computer3/laptop,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/residential_engi)
+"Cr" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyse)
 "Cs" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/surface/building/medbay)
@@ -5915,6 +6173,9 @@
 /area/patricks_rest/surface/building/science)
 "CN" = (
 /obj/machinery/floodlight/colony,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/patricks_rest/surface/building/command)
 "CO" = (
@@ -5939,6 +6200,12 @@
 	dir = 1
 	},
 /area/patricks_rest/ground/colonyw)
+"CU" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/surface/building/storage_depot_south)
 "CV" = (
 /obj/structure/rock/variable/basalt,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -5953,6 +6220,12 @@
 	dir = 1
 	},
 /area/patricks_rest/ground/colonye)
+"CZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyn)
 "Da" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -6086,6 +6359,11 @@
 	dir = 1
 	},
 /area/patricks_rest/surface/building/command)
+"DG" = (
+/obj/structure/flora/desert/grass/heavy,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonyse)
 "DH" = (
 /obj/structure/largecrate,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -6114,10 +6392,26 @@
 	},
 /turf/open/liquid/water/river,
 /area/patricks_rest/surface/building/residential_w)
+"DQ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonyse)
 "DR" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/residential_cent)
+"DS" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonye)
 "DT" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
@@ -6185,10 +6479,21 @@
 "Ek" = (
 /turf/open/floor/plating/ground/concrete/edge,
 /area/patricks_rest/ground/colonynw)
+"Em" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "En" = (
 /obj/item/shard,
 /turf/open/floor/mainship/sterile/dark,
 /area/patricks_rest/surface/building/medbay)
+"Eo" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "Ep" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -6227,6 +6532,15 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/prison/darkyellow/full,
 /area/patricks_rest/surface/building/hydro)
+"Ey" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonys)
 "Ez" = (
 /obj/machinery/door/airlock/mainship/generic/glass,
 /obj/structure/cable,
@@ -6399,6 +6713,12 @@
 /obj/structure/largecrate,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/hydro)
+"Fr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/patricks_rest/ground/underground/cave)
 "Fs" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering,
 /turf/open/floor/prison/darkyellow/full,
@@ -6437,10 +6757,6 @@
 "FA" = (
 /turf/open/floor/prison/whitegreenfull2,
 /area/patricks_rest/surface/building/residential_w)
-"FB" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/mineral/smooth,
-/area/patricks_rest/ground/colonye)
 "FC" = (
 /obj/effect/ai_node,
 /obj/structure/bed/chair/office/dark{
@@ -6489,6 +6805,10 @@
 /area/patricks_rest/surface/building/baggage)
 "FP" = (
 /obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
 /turf/open/floor/plating/ground/concrete/edge,
 /area/patricks_rest/ground/colonyn)
 "FR" = (
@@ -6567,6 +6887,16 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/underground/cave)
+"Gi" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "Gk" = (
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/barracks)
@@ -6616,6 +6946,14 @@
 "Gs" = (
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/security_post_cargo)
+"Gu" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/patricks_rest/ground/underground/cave)
 "Gv" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -6822,6 +7160,13 @@
 /obj/structure/rack,
 /turf/open/floor/freezer,
 /area/patricks_rest/surface/building/residential_cent)
+"Ht" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonye)
 "Hu" = (
 /obj/machinery/computer/body_scanconsole,
 /turf/open/floor/mainship/sterile/dark,
@@ -6944,12 +7289,26 @@
 "HY" = (
 /turf/open/floor/prison/yellow/full,
 /area/patricks_rest/surface/building/residential_w)
+"HZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonynw)
 "Ia" = (
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/patricks_rest/ground/underground/cave)
+"Ic" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/patricks_rest/ground/colonyn)
 "Id" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/mainship,
@@ -6982,6 +7341,12 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/whitegreenfull2,
 /area/patricks_rest/surface/building/offices)
+"Im" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonys)
 "Iq" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -7425,6 +7790,10 @@
 	},
 /turf/open/floor/prison/red/full,
 /area/patricks_rest/surface/building/residential_cent)
+"Ky" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonye)
 "Kz" = (
 /obj/machinery/photocopier,
 /turf/open/floor/prison/blue/plate{
@@ -7681,6 +8050,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/ground/colonycent)
+"LJ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonys)
 "LN" = (
 /obj/machinery/light,
 /obj/structure/cable,
@@ -7739,6 +8117,20 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/ground/colonynw)
+"Mb" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/patricks_rest/ground/colonyn)
+"Mc" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "Md" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -7790,6 +8182,10 @@
 	},
 /turf/open/shuttle/dropship/three,
 /area/patricks_rest/surface/landing_pad)
+"Mm" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonycent)
 "Mn" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
@@ -7820,6 +8216,13 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/storage_depot_south)
+"Mt" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyn)
 "Mu" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -7939,6 +8342,12 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/science)
+"MV" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonycent)
 "MX" = (
 /obj/effect/landmark/campaign_structure/tele_blocker,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -7949,6 +8358,15 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/colonyn)
+"Na" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonycent)
 "Nb" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 1
@@ -8010,6 +8428,12 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/patricks_rest/surface/building/residential_cent)
+"Nr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/patricks_rest/ground/colonys)
 "Ns" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /obj/machinery/light{
@@ -8023,6 +8447,12 @@
 	dir = 8
 	},
 /area/patricks_rest/ground/colonyn)
+"Nu" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyse)
 "Nx" = (
 /turf/closed/wall/mainship,
 /area/patricks_rest/surface/building/residential_cent)
@@ -8036,6 +8466,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/security_post_cargo)
+"NA" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "NB" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/prison/darkbrown/full,
@@ -8057,6 +8493,10 @@
 "NH" = (
 /turf/closed/mineral/smooth,
 /area/patricks_rest/surface/building/hydro)
+"NI" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "NJ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -8144,6 +8584,14 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/ground/colonyw)
+"Oa" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/edge{
+	dir = 8
+	},
+/area/patricks_rest/ground/colonyn)
 "Ob" = (
 /turf/open/floor/mainship/tcomms,
 /area/patricks_rest/surface/building/science)
@@ -8241,6 +8689,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/patricks_rest/ground/colonyn)
+"OD" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "OE" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
@@ -8482,6 +8938,12 @@
 "PL" = (
 /turf/closed/mineral/smooth,
 /area/patricks_rest/ground/colonycent)
+"PM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonys)
 "PN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/science/pathogenic_Isolator,
@@ -8746,6 +9208,10 @@
 /obj/structure/stairs/seamless/edge_vert,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/ground/colonye)
+"QZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "Ra" = (
 /turf/closed/shuttle/dropship2/singlewindow{
 	dir = 1
@@ -8797,10 +9263,6 @@
 /obj/structure/prop/brokenvendor/brokenuniformvendor,
 /turf/open/floor/mainship/green/full,
 /area/patricks_rest/surface/building/barracks)
-"Rq" = (
-/obj/effect/landmark/campaign_structure/mlrs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/patricks_rest/ground/colonys)
 "Rr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete,
@@ -9163,6 +9625,13 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/ground/colonycent)
+"SZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonyn)
 "Ta" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/mainship/mono,
@@ -9264,10 +9733,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/atc)
-"TG" = (
-/obj/effect/landmark/campaign_structure/mlrs,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/patricks_rest/ground/colonycent)
 "TJ" = (
 /obj/effect/ai_node,
 /obj/machinery/door/airlock/multi_tile/mainship/personalglass{
@@ -9326,6 +9791,16 @@
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/patricks_rest/surface/building/engineering)
+"Ua" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines,
+/area/patricks_rest/ground/colonys)
+"Ub" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/patricks_rest/ground/colonyse)
 "Uc" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/prison/red/full,
@@ -9357,6 +9832,12 @@
 /turf/open/floor/prison/darkyellow/full,
 /area/patricks_rest/surface/building/engineering)
 "Uj" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
 	},
@@ -9385,6 +9866,13 @@
 /obj/effect/landmark/campaign_structure/mlrs,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/patricks_rest/ground/colonycent)
+"Uo" = (
+/obj/structure/flora/desert/grass/heavy,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonys)
 "Up" = (
 /turf/closed/mineral/smooth,
 /area/patricks_rest/ground/colonys)
@@ -9550,6 +10038,12 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/ground/colonyn)
+"Ve" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/patricks_rest/ground/colonyn)
 "Vf" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -9577,6 +10071,15 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/patricks_rest/surface/building/offices)
+"Vn" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/patricks_rest/ground/colonys)
 "Vp" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -9652,6 +10155,15 @@
 /area/patricks_rest/ground/colonynw)
 "VG" = (
 /turf/closed/wall/mainship,
+/area/patricks_rest/ground/colonys)
+"VH" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/patricks_rest/ground/colonys)
 "VI" = (
 /turf/open/floor/plating/ground/concrete/lines{
@@ -9756,6 +10268,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/transformer_barracks)
+"Wj" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 5
+	},
+/area/patricks_rest/ground/colonyn)
 "Wk" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
@@ -9988,6 +10509,13 @@
 	dir = 4
 	},
 /area/patricks_rest/ground/colonyn)
+"Xl" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/patricks_rest/ground/underground/cave)
 "Xm" = (
 /obj/machinery/light{
 	dir = 4
@@ -10293,6 +10821,10 @@
 /obj/machinery/microwave,
 /turf/open/floor/prison/whitegreenfull2,
 /area/patricks_rest/surface/building/residential_engi)
+"YU" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/patricks_rest/ground/colonyse)
 "YV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -10337,6 +10869,9 @@
 	dir = 8
 	},
 /obj/structure/flora/desert/grass,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/patricks_rest/surface/building/residential_w)
 "Zd" = (
@@ -10423,6 +10958,14 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/building/ore_storage)
+"Zx" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/patricks_rest/ground/colonyn)
 "Zy" = (
 /obj/machinery/light{
 	dir = 8
@@ -16831,7 +17374,7 @@ gk
 wj
 Yq
 Yq
-zj
+Yq
 Yq
 iy
 bH
@@ -18650,12 +19193,12 @@ Ev
 Ev
 Ev
 AD
-AD
-KP
-KP
+ro
+HZ
+HZ
 tf
 tf
-KP
+HZ
 Ev
 Ev
 Ev
@@ -19056,12 +19599,12 @@ tf
 tf
 tf
 tf
+fM
 tf
 tf
 tf
 tf
-tf
-tf
+fM
 up
 up
 up
@@ -19445,9 +19988,9 @@ fN
 fN
 fN
 cc
-va
+Mt
 FP
-qB
+Ci
 qB
 qB
 qB
@@ -19573,9 +20116,9 @@ QG
 Ow
 QG
 fN
-yZ
-wA
-pW
+lZ
+Ic
+sp
 cc
 va
 RW
@@ -19652,7 +20195,7 @@ ud
 tz
 Km
 Lr
-Rq
+wz
 wz
 wz
 wz
@@ -19705,7 +20248,7 @@ zB
 Ow
 Ow
 fN
-cc
+Zx
 JD
 fY
 cc
@@ -19837,7 +20380,7 @@ zB
 Ow
 Ow
 fN
-kO
+Wj
 BA
 Bu
 cc
@@ -19969,7 +20512,7 @@ zB
 zB
 Ow
 fN
-MA
+me
 DH
 MS
 XU
@@ -20458,8 +21001,8 @@ NG
 Jx
 Ad
 Ad
-ES
-tz
+CU
+wH
 Km
 Lr
 wz
@@ -20571,12 +21114,12 @@ ND
 ht
 hy
 ff
-UR
-wz
+bC
+ej
 tz
 Km
-Lr
-ES
+rn
+CU
 Ad
 ey
 ey
@@ -20856,9 +21399,9 @@ NG
 Ad
 ES
 tz
-Km
-Lr
-wz
+Im
+Ua
+Eo
 bm
 "}
 (79,1,1) = {"
@@ -21034,9 +21577,9 @@ XG
 AZ
 AZ
 AZ
-AZ
-fk
-AZ
+qw
+CZ
+Ve
 AZ
 sN
 sN
@@ -21166,7 +21709,7 @@ XG
 AC
 AC
 AZ
-AZ
+kr
 fk
 AZ
 AZ
@@ -21298,7 +21841,7 @@ XG
 WI
 WI
 AZ
-nI
+AZ
 fk
 AZ
 AZ
@@ -22085,11 +22628,11 @@ wA
 wA
 wA
 Uj
-va
-iO
-wA
-pW
-fk
+Mt
+Oa
+Ic
+sp
+SZ
 Ow
 fk
 AZ
@@ -22221,7 +22764,7 @@ va
 AZ
 AZ
 XG
-fk
+yW
 fk
 fk
 fk
@@ -22285,17 +22828,17 @@ nH
 SO
 Ni
 UR
-SO
-Ni
-Ni
-wz
+rt
+NA
+NA
+ej
 tz
 Km
 Lr
-Py
-wz
-wz
-wz
+Gi
+Eo
+Eo
+ej
 wz
 wz
 vr
@@ -22366,7 +22909,7 @@ xV
 dR
 Ol
 dR
-xV
+Af
 kp
 kp
 zX
@@ -22412,7 +22955,7 @@ bQ
 Lr
 wz
 wz
-wz
+VH
 wz
 wz
 vr
@@ -22420,14 +22963,14 @@ wz
 wz
 wz
 wz
-wz
+NI
 tz
 Km
 Lr
-Py
+sK
 Ni
 SO
-Ni
+QZ
 Ni
 SO
 SO
@@ -22493,12 +23036,12 @@ AZ
 AZ
 AZ
 AZ
-AZ
+kr
 Qz
 wO
 tX
 Qz
-Qz
+MV
 Qz
 wO
 wk
@@ -22559,7 +23102,7 @@ Lr
 Py
 Ni
 lX
-QT
+nM
 QT
 QT
 Cs
@@ -22625,7 +23168,7 @@ cW
 cW
 cW
 cW
-cW
+Mb
 uK
 jE
 cd
@@ -22940,7 +23483,7 @@ Km
 Lr
 wz
 wz
-wz
+Vn
 wz
 Lq
 GW
@@ -23072,7 +23615,7 @@ Km
 Lr
 wz
 Ni
-UR
+Uo
 wz
 tz
 Km
@@ -23304,7 +23847,7 @@ ME
 ME
 ME
 NW
-TG
+GX
 GX
 cC
 ME
@@ -23340,7 +23883,7 @@ UR
 wz
 tz
 Km
-Km
+co
 Km
 Km
 Km
@@ -23729,8 +24272,8 @@ VG
 mx
 ob
 Km
-Lr
-mx
+Ua
+Nr
 VG
 Ni
 wz
@@ -23819,10 +24362,10 @@ XQ
 Tn
 Wd
 Tt
-HK
+jx
 Qz
 wk
-Pg
+iU
 fw
 PL
 PL
@@ -23955,7 +24498,7 @@ HK
 Qz
 wk
 Pg
-GX
+Mm
 ME
 PL
 PL
@@ -24218,9 +24761,9 @@ Tt
 HK
 Qz
 wk
-Pg
-Pg
-Pg
+Na
+iU
+iU
 Pg
 PL
 PL
@@ -24343,14 +24886,14 @@ wW
 Ie
 tP
 Pg
-Pg
+db
 EQ
 kp
 kp
 nA
 Qz
 wk
-Pg
+db
 Pg
 Un
 Pg
@@ -24396,9 +24939,9 @@ ao
 wz
 wz
 wz
-wz
-wz
-tz
+Mc
+Mc
+LJ
 Km
 Lr
 Py
@@ -24475,7 +25018,7 @@ Go
 Vc
 cA
 UK
-Pg
+db
 HK
 Qz
 jT
@@ -24607,7 +25150,7 @@ Wd
 Tt
 EC
 UK
-Pg
+db
 HK
 Qz
 Qz
@@ -24650,8 +25193,8 @@ lX
 ao
 ao
 VG
-mx
-ob
+Nr
+Ey
 Km
 Lr
 mx
@@ -24930,12 +25473,12 @@ tz
 Km
 Lr
 Py
-Ni
-Ni
-Ni
-Ni
-lX
-lX
+vC
+vC
+vC
+vC
+PM
+PM
 mS
 qj
 GE
@@ -25142,9 +25685,9 @@ Qz
 wJ
 wO
 wk
-Pg
-Pg
-Pg
+iU
+iU
+iU
 UK
 Mq
 cJ
@@ -25838,7 +26381,7 @@ Up
 Si
 UR
 Ni
-Py
+OD
 tz
 Km
 Lr
@@ -25964,13 +26507,13 @@ eY
 eY
 Ni
 Ni
+QZ
 Ni
 Ni
 Ni
 Ni
 Ni
-Ni
-Py
+Em
 tz
 Km
 Lr
@@ -26096,13 +26639,13 @@ eY
 eY
 Ni
 UR
+QZ
 Ni
 Ni
 Ni
 Ni
 Ni
-Ni
-Py
+Em
 tz
 Km
 Lr
@@ -26219,13 +26762,13 @@ eY
 eY
 eY
 eY
-eY
+zg
 eY
 LF
 eY
 eY
 eY
-eY
+zg
 Jq
 Jq
 bs
@@ -26234,7 +26777,7 @@ bs
 hW
 bs
 Jq
-le
+gV
 iX
 Rr
 MO
@@ -26357,7 +26900,7 @@ eY
 eY
 eY
 eY
-eY
+zg
 Jq
 Jq
 Jq
@@ -26366,7 +26909,7 @@ HI
 bs
 HI
 Jq
-le
+gV
 iX
 HE
 MO
@@ -26498,7 +27041,7 @@ zC
 zC
 zC
 zC
-le
+ww
 iX
 HE
 MO
@@ -26615,7 +27158,7 @@ eY
 eY
 eY
 eY
-eY
+zg
 eY
 LF
 eY
@@ -26747,7 +27290,7 @@ eY
 eY
 eY
 eY
-eY
+zg
 Vv
 Vv
 Vv
@@ -27818,14 +28361,14 @@ to
 to
 to
 to
-le
-iX
+Cr
+ie
 Rr
 MO
 we
-Jq
-Jq
-Jq
+kc
+pD
+DQ
 bs
 ao
 ao
@@ -27911,10 +28454,10 @@ uc
 uc
 uc
 uc
-UC
-Bb
-Wx
-vW
+Bg
+AP
+uS
+Gu
 eY
 eY
 eY
@@ -27957,7 +28500,7 @@ MO
 we
 Jq
 Jq
-Jq
+Ub
 bs
 ao
 ao
@@ -28089,7 +28632,7 @@ MO
 we
 Jq
 BV
-bs
+YU
 bs
 ao
 ao
@@ -28221,7 +28764,7 @@ MO
 we
 HI
 bs
-TR
+DG
 HI
 bs
 ao
@@ -28479,7 +29022,7 @@ uJ
 uJ
 uJ
 Au
-HE
+dd
 HE
 MO
 we
@@ -28611,7 +29154,7 @@ uJ
 uJ
 uJ
 Au
-HE
+dd
 HE
 MO
 we
@@ -28744,8 +29287,8 @@ uJ
 uJ
 Au
 HE
-HE
-MO
+Nu
+aW
 CN
 bG
 bG
@@ -29007,7 +29550,7 @@ wG
 wG
 wG
 Ax
-nP
+dZ
 nP
 DN
 dD
@@ -29755,14 +30298,14 @@ mC
 mC
 mC
 mC
-eY
-eY
-eY
-eY
+Fr
+Fr
+Fr
+Xl
 GM
 hA
 VN
-ae
+DS
 ae
 ae
 ae
@@ -30700,7 +31243,7 @@ Vv
 Vv
 Vv
 Vv
-FB
+Vv
 Vv
 Vv
 Vv
@@ -30962,7 +31505,7 @@ SA
 IX
 IX
 Jz
-Jz
+ni
 Jz
 Jz
 zV
@@ -30972,7 +31515,7 @@ mL
 Jz
 Jz
 Jz
-IX
+yh
 IX
 IX
 QW
@@ -31094,7 +31637,7 @@ IX
 IX
 IX
 Jz
-Jz
+ni
 Jz
 Jz
 Vp
@@ -31104,7 +31647,7 @@ Jz
 Jz
 Jz
 Jz
-IX
+yh
 SA
 IX
 sf
@@ -31226,17 +31769,17 @@ IX
 IX
 IX
 IX
+ql
 IX
 IX
 IX
-IX
 Jz
 Jz
 Jz
 Jz
 Jz
 Jz
-IX
+yh
 IX
 IX
 fx
@@ -31358,7 +31901,7 @@ IX
 SA
 SA
 IX
-IX
+ql
 IX
 IX
 IX
@@ -31625,14 +32168,14 @@ Jz
 Jz
 Jz
 IX
+Ky
 IX
 IX
 IX
 IX
 IX
 IX
-IX
-IX
+yh
 IX
 IX
 IX
@@ -31764,7 +32307,7 @@ Jz
 Jz
 Jz
 IX
-IX
+yh
 IX
 IX
 fx
@@ -31896,7 +32439,7 @@ Jz
 Jz
 Jz
 Jc
-SA
+uC
 SA
 IX
 lg
@@ -32028,7 +32571,7 @@ Jz
 Jz
 Jz
 IX
-IX
+yh
 SA
 IX
 kz
@@ -32160,7 +32703,7 @@ Jz
 Jz
 Jz
 IX
-IX
+yh
 IX
 IX
 IX
@@ -32279,7 +32822,7 @@ VN
 Cu
 IX
 Jz
-Jz
+ni
 Jz
 IX
 IX
@@ -32411,10 +32954,10 @@ ST
 Cu
 IX
 IX
+ql
 IX
 IX
-IX
-IX
+ql
 IX
 bq
 IX
@@ -32546,7 +33089,7 @@ SA
 IX
 IX
 IX
-ZM
+Ht
 IX
 IX
 Jz
@@ -32556,7 +33099,7 @@ Jz
 Jz
 Jz
 Jz
-Jz
+po
 SA
 IX
 kz
@@ -32678,7 +33221,7 @@ IX
 IX
 IX
 IX
-Jz
+ni
 Jz
 Jz
 Jz
@@ -32688,7 +33231,7 @@ jG
 rZ
 Ko
 Jz
-Jz
+po
 Jz
 IX
 IX
@@ -32807,7 +33350,7 @@ ae
 ae
 IX
 IX
-IX
+ql
 Jz
 Jz
 Jz
@@ -32820,7 +33363,7 @@ rU
 rU
 rU
 Ko
-Jz
+po
 Jz
 Jz
 IX

--- a/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
+++ b/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
@@ -512,10 +512,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/patricks_rest/surface/landing_pad)
-"co" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor/plating/ground/concrete,
-/area/patricks_rest/ground/colonys)
 "cp" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/freezer,
@@ -884,11 +880,6 @@
 	},
 /turf/closed/wall/mainship,
 /area/patricks_rest/surface/building/hydro)
-"dZ" = (
-/obj/structure/cable,
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor/plating/ground/concrete,
-/area/patricks_rest/ground/colonyse)
 "eb" = (
 /obj/structure/desertdam/decals/road/line{
 	dir = 4
@@ -6808,7 +6799,6 @@
 /obj/effect/landmark/campaign_structure/barricade/sandbags/som{
 	dir = 8
 	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
 /turf/open/floor/plating/ground/concrete/edge,
 /area/patricks_rest/ground/colonyn)
 "FR" = (
@@ -7790,10 +7780,6 @@
 	},
 /turf/open/floor/prison/red/full,
 /area/patricks_rest/surface/building/residential_cent)
-"Ky" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/patricks_rest/ground/colonye)
 "Kz" = (
 /obj/machinery/photocopier,
 /turf/open/floor/prison/blue/plate{
@@ -8182,10 +8168,6 @@
 	},
 /turf/open/shuttle/dropship/three,
 /area/patricks_rest/surface/landing_pad)
-"Mm" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/patricks_rest/ground/colonycent)
 "Mn" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
@@ -23883,7 +23865,7 @@ UR
 wz
 tz
 Km
-co
+Km
 Km
 Km
 Km
@@ -24498,7 +24480,7 @@ HK
 Qz
 wk
 Pg
-Mm
+GX
 ME
 PL
 PL
@@ -29550,7 +29532,7 @@ wG
 wG
 wG
 Ax
-dZ
+nP
 nP
 DN
 dD
@@ -32168,7 +32150,7 @@ Jz
 Jz
 Jz
 IX
-Ky
+IX
 IX
 IX
 IX

--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -707,10 +707,6 @@
 	dir = 10
 	},
 /area/lawankaoutpost/colony/biologics)
-"aCd" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/ground/grass/weedable,
-/area/lawankaoutpost/outside/northwest)
 "aCh" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/ground/grass/weedable,
@@ -6707,13 +6703,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
-"fzN" = (
-/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
-	dir = 8
-	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor/tile/white,
-/area/lawankaoutpost/colony/operations_hall)
 "fAa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7223,13 +7212,6 @@
 	dir = 10
 	},
 /area/lawankaoutpost/colony/mining)
-"fTF" = (
-/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
-	dir = 1
-	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor,
-/area/lawankaoutpost/colony/landingzonetwo)
 "fTL" = (
 /obj/machinery/disposal,
 /turf/open/floor/freezer,
@@ -21177,13 +21159,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/taupeblue,
 /area/lawankaoutpost/colony/northdorms)
-"rro" = (
-/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
-	dir = 4
-	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor/tile/white,
-/area/lawankaoutpost/colony/operations_hall)
 "rrz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -21587,7 +21562,6 @@
 /obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
 	dir = 4
 	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/lawankaoutpost/outside/northwest)
 "rGI" = (
@@ -25874,13 +25848,6 @@
 "vjm" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/southeast)
-"vjx" = (
-/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
-	dir = 8
-	},
-/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
-/turf/open/floor,
-/area/lawankaoutpost/colony/landingzonetwo)
 "vjE" = (
 /turf/open/floor/grayscale/black,
 /area/lawankaoutpost/colony/operations_kitchen)
@@ -47370,7 +47337,7 @@ prY
 xQt
 xQt
 xQt
-aCd
+xQt
 qjr
 nTr
 xQt
@@ -55009,7 +54976,7 @@ oya
 tBQ
 ktu
 eWC
-fzN
+eWC
 eWC
 ktu
 xdJ
@@ -63255,7 +63222,7 @@ cgK
 xdJ
 gKu
 sOi
-rro
+sOi
 sOi
 gKu
 tBQ
@@ -72242,7 +72209,7 @@ wEk
 wEk
 uWt
 xvl
-vjx
+cEu
 puk
 cvN
 sDW
@@ -73306,7 +73273,7 @@ qDC
 sXl
 wEk
 wEk
-fTF
+tLE
 wEk
 wEk
 wEk

--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -131,6 +131,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"aeA" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "aeT" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_y = -3
@@ -267,6 +276,11 @@
 /obj/item/clothing/head/helmet/riot,
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/caves/nukestorage)
+"alq" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "alw" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -520,6 +534,18 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/medbay)
+"awR" = (
+/obj/machinery/landinglight/lz2{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "awT" = (
 /obj/structure/sign/botany{
 	dir = 1
@@ -681,6 +707,10 @@
 	dir = 10
 	},
 /area/lawankaoutpost/colony/biologics)
+"aCd" = (
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "aCh" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/ground/grass/weedable,
@@ -1098,6 +1128,7 @@
 	dir = 2
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
 "aVd" = (
@@ -1588,6 +1619,9 @@
 /area/lawankaoutpost/colony/northdorms)
 "bso" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
 /turf/open/floor/tile/red/whitered,
 /area/lawankaoutpost/colony/operations_hall)
 "bsK" = (
@@ -1636,6 +1670,12 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/colony/hydroponics)
+"buU" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "bvM" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -1917,6 +1957,16 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/operations_storage)
+"bFq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "bFS" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_x = -8
@@ -1946,6 +1996,17 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/lawankaoutpost/colony/biologics)
+"bGQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "bGR" = (
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/dropship_start_location,
@@ -2185,6 +2246,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"bTr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered,
+/area/lawankaoutpost/colony/operations_hall)
 "bTI" = (
 /obj/machinery/light{
 	light_color = "#da2f1b"
@@ -2909,6 +2974,10 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
 /turf/open/floor,
 /area/lawankaoutpost/colony/landingzonetwo)
 "cvR" = (
@@ -2936,6 +3005,16 @@
 /obj/item/trash/pistachios,
 /turf/open/floor/tile/blue/taupeblue,
 /area/lawankaoutpost/colony/robotics)
+"cyp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/northwest)
 "cyC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/tile/dark/brown2{
@@ -3085,6 +3164,12 @@
 /obj/item/tool/minihoe,
 /turf/open/floor/tile/green/full,
 /area/lawankaoutpost/colony/hydroponics)
+"cEu" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "cEA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/landmark/weed_node,
@@ -3149,6 +3234,12 @@
 "cGs" = (
 /turf/open/floor/mainship/tcomms,
 /area/lawankaoutpost/colony/biologics)
+"cGD" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "cGJ" = (
 /obj/structure/flora/grass/tallgrass/hideable{
 	color = "#7a8c54"
@@ -3333,6 +3424,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lawankaoutpost/colony/biologics_storage)
+"cQO" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "cRx" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /turf/open/floor,
@@ -3477,10 +3572,6 @@
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
 /area/lawankaoutpost/colony/marshalls)
-"cXI" = (
-/obj/effect/landmark/campaign_structure/asat_system,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/lawankaoutpost/outside/west)
 "cXS" = (
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/tile/dark2,
@@ -3561,6 +3652,14 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
+"daw" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "daB" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
@@ -3651,6 +3750,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/south)
+"ddW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "dea" = (
 /obj/machinery/light{
 	dir = 8
@@ -3750,6 +3856,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
+"dhZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 9
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "dir" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue/taupeblue,
@@ -4017,6 +4131,12 @@
 "dun" = (
 /turf/closed/wall/cult,
 /area/lawankaoutpost/caves/southwest)
+"duo" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "duN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4298,6 +4418,13 @@
 "dJH" = (
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_kitchen)
+"dJO" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/southeast)
 "dJU" = (
 /turf/open/floor/tile/red/whitered{
 	dir = 9
@@ -4520,6 +4647,14 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/mining)
+"dTG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "dUh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -4632,6 +4767,14 @@
 	dir = 5
 	},
 /area/lawankaoutpost/colony/operations_administration)
+"eag" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 10
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "eaq" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5091,6 +5234,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
 "esN" = (
@@ -5396,6 +5542,7 @@
 /area/lawankaoutpost/colony/medbay)
 "eHv" = (
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/landmark/campaign_structure/asat_system,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/colony/operations_hall)
 "eHy" = (
@@ -5835,6 +5982,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lawankaoutpost/colony/recdorms)
+"eWC" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "eWO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -6019,6 +6172,15 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/southwest)
+"fhA" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/northwest)
 "fhC" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -6291,6 +6453,15 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/operations_meeting)
+"fsi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "fst" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark2,
@@ -6338,6 +6509,16 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"ftP" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "ftR" = (
 /obj/structure/cargo_container/ch_red{
 	dir = 1
@@ -6526,6 +6707,13 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"fzN" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "fAa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6694,6 +6882,14 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/southdorms)
+"fHH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "fHP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -6782,6 +6978,18 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/caves/west/garbledradio)
+"fKB" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 1
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "fKE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6796,6 +7004,13 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/cargo)
+"fKM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "fKR" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/sandstone,
@@ -7008,6 +7223,13 @@
 	dir = 10
 	},
 /area/lawankaoutpost/colony/mining)
+"fTF" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "fTL" = (
 /obj/machinery/disposal,
 /turf/open/floor/freezer,
@@ -7704,6 +7926,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/lawankaoutpost/colony/recdorms)
+"gtR" = (
+/obj/item/stool,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "gtS" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_x = -11;
@@ -7847,6 +8076,9 @@
 /area/lawankaoutpost/caves/southwest)
 "gCQ" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
 /turf/open/floor/tile/red/whitered{
 	dir = 5
 	},
@@ -8465,6 +8697,9 @@
 "hhr" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/northwest)
 "hhw" = (
@@ -8904,6 +9139,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/colony/engineering)
+"hGO" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered,
+/area/lawankaoutpost/colony/operations_hall)
 "hHa" = (
 /obj/structure/table,
 /obj/item/circuitboard/computer/powermonitor,
@@ -9207,6 +9449,15 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/west)
+"hSj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 4
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "hSl" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/ground/grass/weedable,
@@ -9263,6 +9514,12 @@
 	},
 /turf/open/floor,
 /area/lawankaoutpost/colony/recdorms)
+"hTE" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/southeast)
 "hTN" = (
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/tile/dark2,
@@ -9294,10 +9551,23 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/robotics)
+"hUA" = (
+/obj/effect/landmark/campaign_structure/asat_system,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "hUT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/lawankaoutpost/colony/operations_kitchen)
+"hVu" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "hVC" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
@@ -9330,6 +9600,16 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/cargo)
+"hXl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "hXN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -9437,6 +9717,12 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northeast)
+"icW" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "idb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -9800,6 +10086,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/southeast)
+"ivi" = (
+/obj/item/stool,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "ivx" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_x = -6;
@@ -9862,6 +10155,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"ixS" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "iya" = (
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/tile/green/greentaupe,
@@ -10512,6 +10810,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/green/full,
 /area/lawankaoutpost/colony/hydroponics)
+"iYK" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "iZd" = (
 /obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 1;
@@ -10716,6 +11021,12 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/engineering)
+"jfZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/southeast)
 "jgh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing,
@@ -10826,12 +11137,18 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
 /turf/open/floor/tile/red/whitered{
 	dir = 4
 	},
 /area/lawankaoutpost/colony/operations_hall)
 "jjF" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
 "jjG" = (
@@ -10941,6 +11258,12 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"jnP" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "jnU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/weed_node,
@@ -11165,6 +11488,9 @@
 /area/lawankaoutpost/colony/recdorms)
 "jAe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
 	dir = 1
 	},
 /turf/open/floor/tile/white,
@@ -11432,6 +11758,12 @@
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /turf/open/floor/tile/dark/red2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"jLe" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "jLu" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
@@ -11822,6 +12154,12 @@
 	},
 /turf/open/floor/freezer,
 /area/lawankaoutpost/colony/northdorms)
+"khx" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "khB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -12123,6 +12461,15 @@
 /obj/effect/turf_decal/warning_stripes/box,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"kwA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 4
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "kwI" = (
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/atmos)
@@ -12194,6 +12541,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/blue/taupeblue,
 /area/lawankaoutpost/colony/biologics)
+"kyD" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 1
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "kyJ" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/wood,
@@ -12386,6 +12741,15 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/mining)
+"kHg" = (
+/obj/machinery/landinglight/lz2{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "kHz" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -12931,6 +13295,12 @@
 	},
 /turf/open/floor/wood,
 /area/lawankaoutpost/colony/bar)
+"ldp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "ldt" = (
 /obj/structure/table/reinforced,
 /obj/structure/paper_bin{
@@ -12945,6 +13315,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lawankaoutpost/colony/recdorms)
+"leg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 4
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "lej" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -12959,6 +13338,17 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northeast)
+"lfp" = (
+/obj/effect/spawner/random/misc/trash,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "lfv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/white,
@@ -13975,6 +14365,13 @@
 "lTQ" = (
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/caves/nukestorage)
+"lTX" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/southeast)
 "lUk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14323,6 +14720,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northeast)
+"mnp" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "mnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -14469,6 +14872,12 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor,
 /area/lawankaoutpost/colony/mining)
+"msB" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/southeast)
 "msI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15092,6 +15501,10 @@
 /obj/machinery/landinglight/lz2{
 	dir = 4
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/drop2/lz2)
 "mUm" = (
@@ -15443,6 +15856,13 @@
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/mining)
+"niT" = (
+/obj/item/stool,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered,
+/area/lawankaoutpost/colony/operations_hall)
 "njc" = (
 /obj/effect/ai_node,
 /turf/open/floor,
@@ -16050,6 +16470,12 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
+"nFO" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 6
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "nFU" = (
 /turf/open/floor,
 /area/lawankaoutpost/colony/landingzoneone)
@@ -16178,6 +16604,19 @@
 /obj/structure/cargo_container/ch_green,
 /turf/open/floor,
 /area/lawankaoutpost/colony/landingzonetwo)
+"nKe" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
+"nKi" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "nKl" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -16378,6 +16817,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
+"nTK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "nTQ" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -16385,6 +16832,11 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/southwest)
+"nUc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "nUh" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/tile/green/greentaupe,
@@ -17016,6 +17468,13 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/biologics)
+"otm" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "otD" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -17093,6 +17552,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/lawankaoutpost/outside/west)
+"oxk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 1
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "oxl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -17741,6 +18211,15 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/operations_hall)
+"oXp" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "oXI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/blue/whitebluecorner{
@@ -17798,10 +18277,6 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/northdorms)
-"pbK" = (
-/obj/effect/landmark/campaign_structure/asat_system,
-/turf/open/floor/plating/ground/dirt,
-/area/lawankaoutpost/outside/central)
 "pcm" = (
 /turf/open/floor/mainship/blue,
 /area/lawankaoutpost/colony/biologics)
@@ -17959,6 +18434,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/northeast)
+"pia" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "pic" = (
 /obj/structure/table,
 /obj/item/laptop,
@@ -18116,6 +18598,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/lawankaoutpost/colony/northdorms)
+"poD" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "poI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	name = "\improper Operations Kitchen"
@@ -18266,6 +18755,13 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/atmos)
+"puk" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "puu" = (
 /obj/structure/closet/coffin,
 /obj/item/grown/sunflower,
@@ -18491,6 +18987,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/marshalls)
+"pCE" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "pCN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -18704,6 +19209,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/corpsespawner/colonist,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
 /turf/open/floor/tile/red/whitered{
 	dir = 4
 	},
@@ -18881,6 +19389,9 @@
 	pixel_y = -3
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
 "pUx" = (
@@ -19225,6 +19736,10 @@
 /obj/structure/cargo_container/ch_green,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/cargo)
+"qjr" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "qju" = (
 /obj/machinery/computer3/powermonitor,
 /turf/open/floor/tile/dark2,
@@ -20070,6 +20585,13 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/recdorms)
+"qWr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/tile/red/whitered{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "qWK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20092,6 +20614,14 @@
 	},
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_kitchen)
+"qXJ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "qXU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20207,6 +20737,15 @@
 	},
 /turf/open/floor/freezer,
 /area/lawankaoutpost/colony/southdorms)
+"rcl" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "rcG" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/packagedbar,
@@ -20638,6 +21177,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/taupeblue,
 /area/lawankaoutpost/colony/northdorms)
+"rro" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "rrz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -21036,6 +21582,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/lawankaoutpost/colony/bar)
+"rGl" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/northwest)
 "rGI" = (
 /obj/machinery/optable,
 /obj/effect/landmark/corpsespawner/colonist/burst,
@@ -21086,6 +21640,15 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor,
 /area/lawankaoutpost/colony/biologics)
+"rJx" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "rJM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -21246,6 +21809,7 @@
 /area/lawankaoutpost/colony/cargo)
 "rSS" = (
 /obj/machinery/camera/autoname/lz_camera,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
@@ -21979,6 +22543,10 @@
 	pixel_x = -6;
 	pixel_y = -5
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/northwest)
 "szb" = (
@@ -22096,6 +22664,13 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/operations_storage)
+"sDp" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "sDx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
@@ -22335,10 +22910,23 @@
 	},
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
+"sNv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "sNB" = (
 /obj/machinery/computer/telecomms/monitor,
 /turf/open/floor/bcircuit/anim,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"sOi" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "sOu" = (
 /obj/structure/cargo_container,
 /turf/open/floor,
@@ -22375,6 +22963,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/central)
+"sPq" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "sPu" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -22425,6 +23017,14 @@
 	dir = 10
 	},
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"sSO" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "sSV" = (
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
@@ -22737,6 +23337,12 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/marshalls)
+"tdZ" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "ten" = (
 /turf/open/floor/tile/dark/brown2,
 /area/lawankaoutpost/colony/mining)
@@ -23572,6 +24178,14 @@
 	dir = 10
 	},
 /area/lawankaoutpost/colony/operations_hall)
+"tLs" = (
+/obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/red/whitered,
+/area/lawankaoutpost/colony/operations_hall)
 "tLu" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/yellow2{
@@ -23585,6 +24199,12 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/marshalls)
+"tLE" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "tMc" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/tcomms,
@@ -24450,6 +25070,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
 "uBn" = (
@@ -24474,6 +25097,12 @@
 	},
 /turf/open/floor/tile/green/full,
 /area/lawankaoutpost/colony/hydroponics)
+"uCo" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/floor/tile/red/whitered,
+/area/lawankaoutpost/colony/operations_hall)
 "uCz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
@@ -24979,6 +25608,17 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/medbay)
+"uXH" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 1
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "uYc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -25234,6 +25874,13 @@
 "vjm" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/southeast)
+"vjx" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/item/weapon/gun/sentry/big_sentry/premade/radial,
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "vjE" = (
 /turf/open/floor/grayscale/black,
 /area/lawankaoutpost/colony/operations_kitchen)
@@ -26241,7 +26888,6 @@
 /area/lawankaoutpost/colony/medbay)
 "wca" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/landmark/campaign_structure/asat_system,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/colony/operations_hall)
 "wce" = (
@@ -26488,6 +27134,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/atmos)
+"wiv" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/outside/southeast)
 "wiz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -26624,6 +27276,15 @@
 /obj/mecha_wreckage/phazon,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/lawankaoutpost/colony/robotics)
+"wnK" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/southeast)
 "wnM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -26657,6 +27318,16 @@
 	},
 /turf/open/floor,
 /area/lawankaoutpost/colony/northdorms)
+"woK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/tile/red/whitered{
+	dir = 5
+	},
+/area/lawankaoutpost/colony/operations_hall)
 "wpg" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -26751,6 +27422,7 @@
 /area/lawankaoutpost/colony/bar)
 "wuH" = (
 /obj/structure/cable,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
 /turf/open/floor/tile/red/whitered{
 	dir = 10
 	},
@@ -26844,6 +27516,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/lawankaoutpost/colony/bar)
+"wxM" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "wxY" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/fence,
@@ -27312,6 +27991,15 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/lawankaoutpost/outside/south)
+"wVg" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lawankaoutpost/caves/northwest/garbledradio)
 "wVs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -27335,6 +28023,7 @@
 /area/lawankaoutpost/caves/west/garbledradio)
 "wXb" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
 "wXh" = (
@@ -27413,6 +28102,15 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/lawankaoutpost/colony/bar)
+"xal" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_hall)
 "xap" = (
 /obj/structure/rack,
 /obj/machinery/light,
@@ -27974,6 +28672,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/northwest)
+"xvl" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "xvx" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/tile/red/whitered{
@@ -28028,6 +28735,12 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/south)
+"xxD" = (
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/lawankaoutpost/outside/southeast)
 "xxH" = (
 /obj/mecha_wreckage/seraph,
 /turf/open/floor/tile/dark/yellow2{
@@ -28284,6 +28997,13 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/marshalls)
+"xIg" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/outside/northwest)
 "xIh" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_x = 2;
@@ -28692,6 +29412,13 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/engineering)
+"xYP" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lawankaoutpost/colony/landingzonetwo)
 "xYV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -45749,14 +46476,14 @@ ruO
 vyl
 qQS
 fVT
+tdZ
+tdZ
+tdZ
 knt
 knt
-knt
-knt
-knt
-knt
-knt
-knt
+tdZ
+tdZ
+tdZ
 xGW
 xGW
 oqq
@@ -45779,7 +46506,7 @@ xQt
 xQt
 hSX
 xQt
-hSX
+ixS
 xQt
 hSX
 xQt
@@ -45996,7 +46723,7 @@ nQk
 kGD
 xQt
 tyS
-nTr
+nUc
 xQt
 xQt
 amB
@@ -46210,10 +46937,10 @@ nTr
 hSX
 xQt
 xQt
-nQk
+alq
 xQt
 xQt
-xQt
+fKM
 xQt
 tJa
 qyn
@@ -46403,9 +47130,9 @@ fVT
 knt
 knt
 knt
-knt
-rOj
-knt
+wVg
+otm
+wxM
 knt
 rrz
 xGW
@@ -46427,7 +47154,7 @@ xQt
 xQt
 xQt
 noY
-xQt
+qjr
 xQt
 hSX
 xQt
@@ -46620,9 +47347,9 @@ fVT
 knt
 knt
 knt
+nKe
 knt
-knt
-knt
+cQO
 knt
 knt
 knt
@@ -46643,8 +47370,8 @@ prY
 xQt
 xQt
 xQt
-xQt
-xQt
+aCd
+qjr
 nTr
 xQt
 xQt
@@ -46837,9 +47564,9 @@ tbi
 aFw
 ybI
 fyS
+dTG
 ybI
-ybI
-ybI
+ldp
 ybI
 ybI
 kfY
@@ -46861,7 +47588,7 @@ hSX
 nTr
 nTr
 xQt
-xQt
+qjr
 xQt
 xQt
 xQt
@@ -47078,7 +47805,7 @@ xQt
 xQt
 xQt
 hSX
-xQt
+qjr
 xQt
 xQt
 syL
@@ -47298,7 +48025,7 @@ xQt
 nQk
 xQt
 bzx
-xQt
+qjr
 dgc
 hSX
 xQt
@@ -47515,7 +48242,7 @@ xQt
 kGD
 xQt
 xQt
-xQt
+qjr
 xQt
 xQt
 nTr
@@ -47538,7 +48265,7 @@ vuj
 ewf
 qyR
 lNL
-cXI
+vuj
 oxj
 iJs
 ulZ
@@ -47940,8 +48667,8 @@ xQt
 xQt
 xQt
 dhy
-nTr
-xQt
+sNv
+buU
 vXr
 wAJ
 xzM
@@ -48156,7 +48883,7 @@ xQt
 nTr
 hSX
 xQt
-xQt
+pEo
 xQt
 xQt
 mHu
@@ -49021,7 +49748,7 @@ oRz
 oRz
 xQt
 vrF
-xQt
+jLe
 xQt
 xQt
 hSX
@@ -49235,10 +49962,10 @@ mdJ
 oRz
 oRz
 xQt
-xQt
+pEo
 hSX
 xQt
-xQt
+jLe
 amB
 qUy
 xQt
@@ -49455,10 +50182,10 @@ xQt
 xQt
 hSX
 nTr
-xQt
-xQt
-hSX
-xQt
+rcl
+mnp
+xIg
+mnp
 xQt
 xQt
 vXr
@@ -49885,7 +50612,7 @@ hhr
 mdJ
 oRz
 xQt
-xQt
+qjr
 xQt
 xQt
 xQt
@@ -50095,14 +50822,14 @@ sBa
 xQt
 xQt
 qUy
-xQt
+jLe
 oRz
 oRz
-pXs
-mdJ
-sqp
-xQt
-nQk
+fhA
+cyp
+rGl
+mnp
+sSO
 nTr
 xQt
 vXr
@@ -50312,7 +51039,7 @@ nTr
 xQt
 hSX
 xQt
-xQt
+jLe
 oRz
 pXs
 pXs
@@ -50746,7 +51473,7 @@ nQk
 amB
 uPN
 xQt
-pEo
+xQt
 oRz
 xuZ
 sdr
@@ -50963,16 +51690,16 @@ amB
 gRP
 nTr
 xQt
-xQt
+jLe
 oRz
 qlY
 tnv
 oRz
 oRz
 xQt
-xQt
-bzx
-xQt
+mnp
+fHH
+mnp
 vXr
 rYL
 uaK
@@ -51180,7 +51907,7 @@ xQt
 nTr
 xQt
 xQt
-hSX
+sDp
 oRz
 qlY
 xiN
@@ -52053,11 +52780,11 @@ iGM
 cey
 jUl
 aym
-xQt
+mnp
 pUp
 uOd
 xQt
-amB
+pia
 vXr
 wbB
 uaK
@@ -54281,9 +55008,9 @@ oya
 oya
 tBQ
 ktu
-tBQ
-tBQ
-tBQ
+eWC
+fzN
+eWC
 ktu
 xdJ
 hlD
@@ -54930,12 +55657,12 @@ hvT
 mtb
 cLk
 dwP
-tBQ
-sNn
+eWC
+xal
 wIu
 xGz
 rVp
-eiK
+poD
 bso
 ooU
 vcg
@@ -57751,13 +58478,13 @@ wOY
 ppQ
 tBQ
 pUE
-tle
+uXH
 uBf
-qPW
+ivi
 tBQ
 qPW
 uBf
-tib
+tLs
 pUE
 tBQ
 ppQ
@@ -57965,10 +58692,10 @@ wmd
 bpN
 lTO
 fOq
-lkZ
+daw
 mwR
 lkZ
-dJU
+dhZ
 taI
 bpN
 lkZ
@@ -57977,7 +58704,7 @@ taI
 wuH
 lkZ
 lkZ
-cDj
+qWr
 lkZ
 lkZ
 fOq
@@ -57989,7 +58716,7 @@ pnt
 tBQ
 ktu
 lkZ
-cDj
+qWr
 oQm
 poI
 wQV
@@ -58182,7 +58909,7 @@ rPe
 oXj
 qKz
 rPe
-rPe
+hXl
 iXv
 hTU
 ykB
@@ -58191,10 +58918,10 @@ pjG
 exi
 oQM
 giX
-kif
+niT
 xRS
 etk
-rPe
+nTK
 rPe
 rPe
 xmK
@@ -58206,7 +58933,7 @@ rPe
 xmK
 soj
 rPe
-iXv
+eag
 hTU
 hTU
 ykk
@@ -58388,7 +59115,7 @@ sDx
 wQV
 nXK
 tBQ
-tle
+kyD
 agr
 tBQ
 bws
@@ -58399,7 +59126,7 @@ tBQ
 nsa
 jAe
 gfa
-tBQ
+khx
 cNE
 xka
 tle
@@ -58423,7 +59150,7 @@ iTw
 tBQ
 agr
 xdJ
-qUw
+bTr
 tBQ
 nXK
 wQV
@@ -58605,7 +59332,7 @@ wyD
 npJ
 smi
 qRW
-qsb
+woK
 aUq
 hNN
 avG
@@ -58619,7 +59346,7 @@ pYj
 avG
 qnp
 hTU
-ykB
+oxk
 sVw
 uSr
 ifp
@@ -58631,7 +59358,7 @@ qsb
 avG
 avG
 pLX
-aUq
+leg
 idR
 avG
 avG
@@ -58822,7 +59549,7 @@ wQV
 wQV
 tBQ
 chf
-pgp
+hSj
 eXn
 xdJ
 bKO
@@ -58842,13 +59569,13 @@ rIU
 rIU
 alw
 jgC
-cvR
+nFO
 bKO
 pgp
 bKO
 bKO
 bKO
-kai
+kwA
 bKO
 bKO
 bKO
@@ -59053,13 +59780,13 @@ ach
 aaP
 pZK
 fom
-atp
-djN
+fKB
+bGQ
 tBQ
 tBQ
-qPW
+gtR
 esE
-qUw
+hGO
 eZL
 tBQ
 tpG
@@ -62091,13 +62818,13 @@ ioK
 mAS
 fGC
 dJH
-tBQ
-oRu
+sOi
+lfp
 tle
 tBQ
 qUw
-gKu
-qUw
+bFq
+uCo
 pMi
 sWy
 hdr
@@ -62527,9 +63254,9 @@ cgK
 cgK
 xdJ
 gKu
-tBQ
-tBQ
-tBQ
+sOi
+rro
+sOi
 gKu
 tBQ
 wgw
@@ -63426,7 +64153,7 @@ uJt
 dxV
 sUR
 hoS
-pbK
+wQV
 iBn
 wQV
 pCP
@@ -69559,16 +70286,16 @@ sKP
 sKP
 sKP
 sKP
-lYq
-vjm
-vjm
+aeA
+msB
+lTX
 pdy
 vjm
 vjm
-lYq
-sKP
-sKP
-sKP
+aeA
+jfZ
+jfZ
+jfZ
 xGW
 oqq
 oqq
@@ -69776,7 +70503,7 @@ sKP
 sKP
 tSX
 sSV
-lYq
+jnP
 vjm
 vjm
 gWW
@@ -69993,7 +70720,7 @@ sKP
 sKP
 sKP
 sKP
-ssU
+iYK
 vjm
 eXA
 pdy
@@ -70210,7 +70937,7 @@ xGW
 xGW
 sKP
 sKP
-lYq
+jnP
 vjm
 vjm
 vjm
@@ -70427,7 +71154,7 @@ llj
 llj
 llj
 mhj
-tWa
+ddW
 cop
 cop
 cop
@@ -71514,9 +72241,9 @@ lJa
 wEk
 wEk
 uWt
-wEk
-wEk
-xHR
+xvl
+vjx
+puk
 cvN
 sDW
 mSj
@@ -71731,10 +72458,10 @@ wEk
 wEk
 wEk
 hYh
-wEk
+tLE
 wEk
 xHR
-qip
+hVu
 hYh
 ciA
 wEk
@@ -71921,10 +72648,10 @@ vjm
 vjm
 lYq
 tZX
-ssU
-lYq
-ssU
-jlK
+ftP
+xxD
+nKi
+fsi
 uaC
 nuL
 cWF
@@ -72138,15 +72865,15 @@ vjm
 vjm
 vjm
 vjm
-vjm
+wiv
 vjm
 vjm
 qDC
 vCz
 wEk
 wEk
-wEk
-wEk
+pCE
+cEu
 wEk
 wEk
 cDI
@@ -72355,14 +73082,14 @@ eyS
 vjm
 vjm
 vjm
-eyS
+dJO
 vjm
 vjm
 qDC
 wEk
 wEk
 wEk
-hYh
+xYP
 wEk
 wEk
 wEk
@@ -72579,7 +73306,7 @@ qDC
 sXl
 wEk
 wEk
-wEk
+fTF
 wEk
 wEk
 wEk
@@ -72796,17 +73523,17 @@ qDC
 vCz
 wEk
 wEk
-wEk
+tLE
 wEk
 lTw
 fsf
 fsf
 fsf
 fsf
-fsf
-fsf
-fsf
-fsf
+awR
+kHg
+kHg
+kHg
 fsf
 fsf
 mTD
@@ -73006,23 +73733,23 @@ lYq
 lYq
 lYq
 vjm
-vjm
+wiv
 vjm
 vjm
 qDC
 wEk
 wEk
 wEk
-wEk
-wEk
+rJx
+icW
 xiR
 apz
 rxQ
 rxQ
 rxQ
+qXJ
 rxQ
-rxQ
-rxQ
+hUA
 rxQ
 rxQ
 rxQ
@@ -73223,7 +73950,7 @@ tSX
 sKP
 tZX
 lYq
-lYq
+jnP
 lYq
 lYq
 jlK
@@ -73237,13 +73964,13 @@ ojM
 jsZ
 prl
 bhj
+cGD
 jsZ
 jsZ
 jsZ
 jsZ
 jsZ
-jsZ
-jsZ
+sPq
 jsZ
 jsZ
 jsZ
@@ -73440,8 +74167,8 @@ sKP
 sKP
 sKP
 cDD
-sKP
-sKP
+wnK
+hTE
 sKP
 oHS
 uaC
@@ -73460,7 +74187,7 @@ jsZ
 jsZ
 jsZ
 jsZ
-jsZ
+sPq
 jsZ
 jsZ
 jsZ
@@ -73677,7 +74404,7 @@ jsZ
 jsZ
 jsZ
 jsZ
-jsZ
+sPq
 jsZ
 jsZ
 jsZ
@@ -73888,7 +74615,7 @@ ojM
 jsZ
 jsZ
 jsZ
-jsZ
+cGD
 jsZ
 jsZ
 jsZ
@@ -74105,12 +74832,12 @@ ojM
 jsZ
 jsZ
 jsZ
+oXp
 jsZ
 jsZ
-jsZ
-jsZ
-jsZ
-jsZ
+duo
+duo
+duo
 jjF
 jsZ
 jsZ

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -39,8 +39,8 @@
 	starting_faction_additional_rewards = "Additional ICC support, ability to counteract TGMC drop pod usage"
 	hostile_faction_additional_rewards = "Preserve the ability to use drop pods uncontested"
 
-	objectives_total = 5
-	min_capture_amount = 3
+	objectives_total = 6
+	min_capture_amount = 4
 
 /datum/campaign_mission/capture_mission/asat/load_pre_mission_bonuses()
 	. = ..()

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -7,8 +7,8 @@
 	map_file = '_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
-	objectives_total = 10
-	min_destruction_amount = 7
+	objectives_total = 9
+	min_destruction_amount = 6
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 90 SECONDS,
 		MISSION_HOSTILE_FACTION = 0,

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -95,6 +95,6 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_light_levels = list(225, 150, 100, 75)
-	objectives_total = 8
-	min_destruction_amount = 6
+	objectives_total = 5
+	min_destruction_amount = 3
 	hostile_faction_additional_rewards = "Protect our fire support options to ensure continued access to mortar support. Combat robots and fire support is available if you successfully defend this outpost."

--- a/code/game/objects/structures/campaign_structures/misc_structures.dm
+++ b/code/game/objects/structures/campaign_structures/misc_structures.dm
@@ -16,6 +16,7 @@
 	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid/som)
 
 /obj/effect/landmark/campaign_structure/barricade/sandbags/asat
+	name = "ASAT_capture_sandbags"
 	mission_types = list(/datum/campaign_mission/capture_mission/asat)
 
 /obj/effect/landmark/campaign_structure/barricade/concrete

--- a/code/game/objects/structures/campaign_structures/misc_structures.dm
+++ b/code/game/objects/structures/campaign_structures/misc_structures.dm
@@ -1,0 +1,19 @@
+//misc campaign structures/landmark spawners. Make sure mission types are set correctly, with child types made as required to avoid conflicts
+/obj/effect/landmark/campaign_structure/barricade
+	name = "fire_support_raid_barricade"
+	icon = 'icons/Marine/barricades.dmi'
+	icon_state = "metal_0"
+	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid)
+	spawn_object = /obj/structure/barricade/metal
+
+/obj/effect/landmark/campaign_structure/barricade/sandbags
+	name = "fire_support_raid_sandbags"
+	icon_state = "sandbag_0"
+	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid)
+	spawn_object = /obj/structure/barricade/sandbags
+
+/obj/effect/landmark/campaign_structure/barricade/concrete
+	name = "fire_support_raid_concrete"
+	icon_state = "concrete_0"
+	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid)
+	spawn_object = /obj/structure/barricade/concrete

--- a/code/game/objects/structures/campaign_structures/misc_structures.dm
+++ b/code/game/objects/structures/campaign_structures/misc_structures.dm
@@ -12,6 +12,9 @@
 	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid)
 	spawn_object = /obj/structure/barricade/sandbags
 
+/obj/effect/landmark/campaign_structure/barricade/sandbags/som
+	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid/som)
+
 /obj/effect/landmark/campaign_structure/barricade/concrete
 	name = "fire_support_raid_concrete"
 	icon_state = "concrete_0"

--- a/code/game/objects/structures/campaign_structures/misc_structures.dm
+++ b/code/game/objects/structures/campaign_structures/misc_structures.dm
@@ -15,6 +15,9 @@
 /obj/effect/landmark/campaign_structure/barricade/sandbags/som
 	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid/som)
 
+/obj/effect/landmark/campaign_structure/barricade/sandbags/asat
+	mission_types = list(/datum/campaign_mission/capture_mission/asat)
+
 /obj/effect/landmark/campaign_structure/barricade/concrete
 	name = "fire_support_raid_concrete"
 	icon_state = "concrete_0"

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1091,6 +1091,7 @@
 #include "code\game\objects\structures\campaign_structures\capture_objectives.dm"
 #include "code\game\objects\structures\campaign_structures\deploy_blockers.dm"
 #include "code\game\objects\structures\campaign_structures\destroy_objectives.dm"
+#include "code\game\objects\structures\campaign_structures\misc_structures.dm"
 #include "code\game\objects\structures\crates_lockers\closets.dm"
 #include "code\game\objects\structures\crates_lockers\crates.dm"
 #include "code\game\objects\structures\crates_lockers\largecrate.dm"


### PR DESCRIPTION

## About The Pull Request
Changes to both factions firesupport missions as well as ASAT capture for SOM.

Consolidates objectives into clusters to make them actually practical to defend, and added barricades (via landmark) to these clusters to help the defending team a bit more.

The SOM firesupport mission (i.e. marines defending) isn't clustered due to how the map is more linear in its design, so its instead two 'paths' of objectives for SOM to follow.
## Why It's Good For The Game
These missions were absurdly difficult for the defending team, this should make them a bit less wack.
## Changelog
:cl:
balance: Made fire support and ASAT capture missions in campaign easier for the defending team
/:cl:
