### PR TITLE
Changes Layer of Rear Attach Points.

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -107,6 +107,7 @@
 	name = "rear attach point"
 	base_category = DROPSHIP_CREW_WEAPON
 	density = FALSE
+	layer = BELOW_OBJ_LAYER
 
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = SHUTTLE_ALAMO


### PR DESCRIPTION

## About The Pull Request
Changes the layer of rear attach points to be below objects, rather than above them. Note this does not affect larva hiding under them.
## Why It's Good For The Game
Items that are dropped on the same tile as rear attach points tend to be lost, due to being completely obscured by the attach point. This makes it less likely to lose items due to the layering. Also makes it look a bit less ugly by preventing items from sticking out from under the attach point.
## Changelog
:cl:
qol: The rear attach points will now layer under items, rather than over them.
/:cl:
