### PR TITLE
Fix items being weird with layers if equipped is overriden the wrong way

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -55,12 +55,12 @@
 	if(!l_hand)
 		W.forceMove(src)
 		l_hand = W
-		W.equipped(src,SLOT_L_HAND)
 		W.layer = ABOVE_HUD_LAYER
 		W.plane = ABOVE_HUD_PLANE
 		update_inv_l_hand()
 		W.pixel_x = initial(W.pixel_x)
 		W.pixel_y = initial(W.pixel_y)
+		W.equipped(src,SLOT_L_HAND)
 		return TRUE
 	return FALSE
 
@@ -83,12 +83,12 @@
 	if(!r_hand)
 		W.forceMove(src)
 		r_hand = W
-		W.equipped(src,SLOT_R_HAND)
 		W.layer = ABOVE_HUD_LAYER
 		W.plane = ABOVE_HUD_PLANE
 		update_inv_r_hand()
 		W.pixel_x = initial(W.pixel_x)
 		W.pixel_y = initial(W.pixel_y)
+		W.equipped(src,SLOT_R_HAND)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Prime example is baton staying in the hud layer despite being dropped
## Why It's Good For The Game

Bug bad
## Changelog
:cl:
fix: Stun batons should not ominously float above everything in the game after someone without access tries to pick it up anymore
/:cl:
