### PR TITLE
Repeater adjustments (balance)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -697,6 +697,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 70
 	penetration = 20
 	sundering = 1.25
+	handful_amount = 7
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1 SECONDS)

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -588,7 +588,7 @@
 	reload_sound = 'sound/weapons/guns/interact/mosin_reload.ogg'
 	caliber = CALIBER_4570 //codex
 	load_method = SINGLE_CASING //codex
-	max_chamber_items = 13 //codex
+	max_chamber_items = 6 //codex
 	default_ammo_type = /datum/ammo/bullet/rifle/repeater
 	gun_skill_category = SKILL_RIFLES
 	cocked_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'//good enough for now.

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -204,8 +204,8 @@
 	icon_state_mini = "ammo_packet_blue"
 	default_ammo = /datum/ammo/bullet/rifle/repeater
 	w_class = WEIGHT_CLASS_SMALL
-	current_rounds = 50
-	max_rounds = 50
+	current_rounds = 49
+	max_rounds = 49
 
 /obj/item/ammo_magazine/packet/pthreeightyacp
 	name = "packet of .380 ACP"


### PR DESCRIPTION

## About The Pull Request
Repeater is limited to 7 rounds.
Repeater handfuls are now 7 rounds
Repeater packets are now 49 rounds
## Why It's Good For The Game
Who the fuck made this gun without going in and adjusting handful amounts. 
14 doesn't divide gracefully into 8
50 doesn't divide gracefully into 8 OR 14

Repeater ammo limit is just a balance thing. 14 shots of 70 damage + stagger induces xope
## Changelog
:cl:
qol: repeater ammo packets and handfuls now contain sensible amounts of ammo which divide equally now
balance: Repeater magazine size decreased (14 -> 7)
/:cl:
