### PR TITLE
Campaign: drop pod refresh fixes

### DIFF
--- a/_maps/map_files/Iteron/Iteron.dmm
+++ b/_maps/map_files/Iteron/Iteron.dmm
@@ -95,7 +95,7 @@
 /turf/closed/wall/mainship/outer/reinforced,
 /area/mainship/patrol_base)
 "bG" = (
-/obj/structure/drop_pod_launcher,
+/obj/structure/drop_pod_launcher/supply,
 /obj/structure/droppod/nonmob/supply_pod,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)
@@ -793,10 +793,10 @@
 	},
 /area/mainship/patrol_base)
 "js" = (
-/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/structure/drop_pod_launcher/mech,
 /obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)
@@ -817,15 +817,15 @@
 	},
 /area/mainship/patrol_base)
 "jL" = (
-/obj/structure/drop_pod_launcher,
+/obj/structure/drop_pod_launcher/sentry,
 /obj/structure/droppod/nonmob/turret_pod,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)
 "jU" = (
-/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/structure/drop_pod_launcher/mech,
 /obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)
@@ -1064,7 +1064,7 @@
 	},
 /area/mainship/patrol_base)
 "nz" = (
-/obj/structure/drop_pod_launcher,
+/obj/structure/drop_pod_launcher/mech,
 /obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/prison/cleanmarked,
 /area/mainship/patrol_base/hanger)

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -620,3 +620,12 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 
 /obj/structure/drop_pod_launcher/leader
 	pod_type = /obj/structure/droppod/leader
+
+/obj/structure/drop_pod_launcher/mech
+	pod_type = /obj/structure/droppod/nonmob/mech_pod
+
+/obj/structure/drop_pod_launcher/supply
+	pod_type = /obj/structure/droppod/nonmob/supply_pod
+
+/obj/structure/drop_pod_launcher/sentry
+	pod_type = /obj/structure/droppod/nonmob/turret_pod


### PR DESCRIPTION

## About The Pull Request
The drop pod refresh asset will actually refresh mech, supply and sentry pods as expected.
## Why It's Good For The Game
Working thing good.
## Changelog
:cl:
fix: Campaign: Fixes the drop pod refresh asset not correctly replacing the specialty pods
/:cl:
