### PR TITLE
Nerfs scout rifle sunder, buffs penetration

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -734,7 +734,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
 	damage = 40
-	penetration = 40
+	penetration = 30
 	sundering = 5
 	bullet_color = COLOR_SOFT_RED
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -734,8 +734,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
 	damage = 40
-	penetration = 20
-	sundering = 10
+	penetration = 40
+	sundering = 5
 	bullet_color = COLOR_SOFT_RED
 
 /datum/ammo/bullet/rifle/tx8/incendiary
@@ -751,8 +751,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
 	damage = 30
-	penetration = 10
-	sundering = 12.5
+	penetration = 20
+	sundering = 6.5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)


### PR DESCRIPTION
## About The Pull Request

Halves (roughly) the sunder on penetration/impact, but doubles the penetration.
## Why It's Good For The Game

Currently the scout rifle does 25 sunder (on non impact, it has more) a second, which isn't fightable unless you want to sacrifice all your armor for one guy. Even a req weapon should be something you can fight. Top it off with the fact this weapon is IFF and you can stack it very well with your fellow marines to delete the armor off any xeno that enters your screen, which just isn't fun or fair to fight, even if the ammo is paid. 

Doubling it's armor penetration means this gun is basically built to take down high armor xenos, which means it shouldn't be useless with the sunder cut in half and will still be able to do it's job of taking down large xenos.
## Changelog
:cl:
balance: The basic scout rifle ammo now deals 5 sunder down from 12, but has double the armor penetration (30, up from 20)
balance: The impact scout rifle ammo now deals 6.5 sunder (down from 12.5), but has double the armor penetration (20, up from 10)
/:cl:
