### PR TITLE
Boiler globules now visible in stat panel

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -40,6 +40,15 @@
 	set_light_range_power_color(glow, 4, color)
 
 // ***************************************
+// *********** Life overrides
+// ***************************************
+/mob/living/carbon/xenomorph/boiler/get_status_tab_items()
+	. = ..()
+	. += "Stored corrosive acid globules: [corrosive_ammo]"
+	. += "Stored neurotoxic globules: [neuro_ammo]"
+
+
+// ***************************************
 // *********** Init
 // ***************************************
 /mob/living/carbon/xenomorph/boiler/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
Uses carrier's hugger count code in ``carrier.dm`` as seen here:
![bild](https://github.com/tgstation/TerraGov-Marine-Corps/assets/17747087/41351c04-7ec7-4f84-b1cd-273661173397)
and repurposes it for globules and adds it to boiler's ``boiler.dm`` file as seen here:
![bild](https://github.com/tgstation/TerraGov-Marine-Corps/assets/17747087/f7743e42-8c89-40b9-9294-8795ad226188)

This PR has been fully tested on a local build with zero (0) noticeable runtimes or errors.
![dreamseeker_2023-12-22_12-53-20](https://github.com/tgstation/TerraGov-Marine-Corps/assets/17747087/6fda6abf-e0d7-4f1c-a72e-ae3bec946f21)

## Why It's Good For The Game
From what i can tell the only way to see the amount of globules a boiler is carrying is via either how luminous they are which isn't especially exact or noticing the globlue creation icon has changed ever so slightly (to the point where i only noticed it while testing this PR and never before)

This provides another layer of information the boiler can see for the exact amount of globules they are carrying both corrosive and neurotoxin which is displayed alongside the rest of the exact information most xenos get in their stat panel (like how carriers can see the exact amount of huggers they have stored in *their* stat panel).
## Changelog
:cl: Vondiech
qol: Boilers can now see the exact amount of acid/neuro globules they are carrying in their "Status" panel on the right-hand side of the screen alongside with the rest of their xeno stats.
/:cl:
