### PR TITLE
Removes the magnum from the crash weapons vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -306,7 +306,6 @@
 			/obj/item/ammo_magazine/pistol/standard_heavypistol = -1,
 			/obj/item/weapon/gun/revolver/standard_revolver = -1,
 			/obj/item/ammo_magazine/revolver/standard_revolver = -1,
-			/obj/item/weapon/gun/revolver/standard_magnum = -1,
 			/obj/item/ammo_magazine/revolver/standard_magnum = -1,
 			/obj/item/weapon/gun/pistol/standard_pocketpistol = -1,
 			/obj/item/ammo_magazine/pistol/standard_pocketpistol = -1,


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
When moving the magnum to the SL vendor during it's release, MJP forgot to take it away from the special crash weapons vendor. This seems like an oversight, lest maintainers have their reason for letting it stay in.
## Changelog
:cl:
fix: Fixes the Magnum being available in Crash outside of the SL vendor.
/:cl:
