### PR TITLE
Updates The Bottle of Docter's Delight's Description And Moves It To The Valhalla Tab

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -245,6 +245,6 @@
 
 /obj/item/reagent_containers/glass/bottle/doctor_delight
 	name = "\improper Doctor's Delight bottle"
-	desc = "A small bottle. Contains Doctor's Delight."
+	desc = "A small bottle. Contains Doctor's Delight - functions similar to tricordrazine, but makes the patient hungry."
 	icon_state = "bottle3"
 	list_reagents = list(/datum/reagent/consumable/drink/doctor_delight = 60)

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -245,6 +245,6 @@
 
 /obj/item/reagent_containers/glass/bottle/doctor_delight
 	name = "\improper Doctor's Delight bottle"
-	desc = "A small bottle. Contains Doctor's Delight - functions similar to tricordrazine, but makes the patient hungry."
+	desc = "A small bottle. Contains Doctor's Delight - functions similar to tricordrazine, but is weaker and makes the patient hungry."
 	icon_state = "bottle3"
 	list_reagents = list(/datum/reagent/consumable/drink/doctor_delight = 60)

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -264,7 +264,6 @@
 			/obj/item/reagent_containers/glass/bottle/adminordrazine = -1,
 			/obj/item/reagent_containers/glass/bottle/lemoline = -1,
 			/obj/item/reagent_containers/glass/bottle/nanoblood = -1,
-			/obj/item/reagent_containers/glass/bottle/doctor_delight = -1,
 		),
 		"Pill Bottle" = list(
 			/obj/item/storage/pill_bottle/bicaridine = -1,
@@ -321,6 +320,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/virilyth = -1,
 			/obj/item/reagent_containers/hypospray/autoinjector/roulettium = -1,
 			/obj/item/reagent_containers/glass/bottle/toxin = -1,
+			/obj/item/reagent_containers/glass/bottle/doctor_delight = -1,
 		),
 	)
 


### PR DESCRIPTION
## About The Pull Request
Updates the description of the bottle of Doctor's Delight to describe it's effect and side-effect Also moves it to the Valhalla tab of the vendor.
## Why It's Good For The Game
Let's new players know what the chem does if they grab it from the Nanotrasen MedPlus. Also It's not available from the normal vendor, only Valhalla vendor, meaning it would fit better in the Valhalla tab.
## Changelog
:cl:
spellcheck: Updated the description of Doctor's Delight in the Nanotrasen Medplus to describe it's effects.
balance: Moves the Doctor's Delight reagent bottle to the Valhalla tab of the vendor
/:cl:
