### PR TITLE
AMR lase slows down again on hit, flak slowdown removed.

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -139,6 +139,7 @@
 //Define sniper laser multipliers
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
+#define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1158,7 +1158,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	airburst_multiplier = 0.5
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
-	staggerstun(victim, proj,  max_range = 30, slowdown = 2)
+	staggerstun(victim, proj,  max_range = 30)
 	airburst(victim, proj)
 
 /datum/ammo/bullet/sniper/svd

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -875,6 +875,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	if(proj.shot_from && src == proj.shot_from.sniper_target(src))
 		damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
+		add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
 
 	if(iscarbon(proj.firer))
 		var/mob/living/carbon/shooter_carbon = proj.firer


### PR DESCRIPTION

## About The Pull Request
Readds AMR lase slowdown on hit.
Removes flak ammo slowdown as lase slowdown is back in entirety.
## Why It's Good For The Game
AMR lase slowdown was not an issue, the gun was heavily reliant on it to be competieve as a sniper support weapon as it has subpar damage compared to something like an autosniper for much higher cost, considering the lase already serves as some sort of warning this was just an unnecessary nerf, the penetration nerf was enough.
## Changelog
:cl:
balance: Readds AMR lase hit slowdown.
/:cl:
