### PR TITLE
Prevents Hypo Injecting Synths And Combat Robots.

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -70,6 +70,9 @@
 	if(!reagents.total_volume)
 		balloon_alert(user, "Hypospray is Empty.")
 		return
+	if(is_species(A, /datum/species/robot) || is_species(A, /datum/species/synthetic) || is_species(A, /datum/species/early_synthetic))
+		A.balloon_alert(user, "Can't inject (robot)")
+		return
 	if(!A.is_injectable() && !ismob(A))
 		A.balloon_alert(user, "Can't fill.")
 		return

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -70,8 +70,9 @@
 	if(!reagents.total_volume)
 		balloon_alert(user, "Hypospray is Empty.")
 		return
-	if(is_species(A, /datum/species/robot) || is_species(A, /datum/species/synthetic) || is_species(A, /datum/species/early_synthetic))
-		A.balloon_alert(user, "Can't inject (robot)")
+	var/mob/living/carbon/C = A
+	if((C.species.species_flags & NO_CHEM_METABOLIZATION) || (C.species.species_flags & IS_SYNTHETIC))
+		C.balloon_alert(user, "Can't inject (robot)")
 		return
 	if(!A.is_injectable() && !ismob(A))
 		A.balloon_alert(user, "Can't fill.")


### PR DESCRIPTION

## About The Pull Request
Prevents injecting synths and combat robots with hypos.
## Why It's Good For The Game
Attempting to inject synths/robots currently causes the hypo to "inject" 0 units. This makes it clearer to new players that robots can't use chems, and is overall less confusing.
## Changelog
:cl:
fix: Synths/Robots no longer can be injected with hypos.
/:cl:
