### PR TITLE
lets scorpion be given plasma + can now weak acid items

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/scorpion/castedatum_scorpion.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/scorpion/castedatum_scorpion.dm
@@ -41,5 +41,5 @@
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
 		/datum/action/ability/activable/xeno/xeno_spit,
-		/datum/action/ability/activable/xeno/corrosive_acid/drone
+		/datum/action/ability/activable/xeno/corrosive_acid/drone,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/scorpion/castedatum_scorpion.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/scorpion/castedatum_scorpion.dm
@@ -25,7 +25,7 @@
 
 	// *** Flags *** //
 	caste_flags = CASTE_DO_NOT_ALERT_LOW_LIFE|CASTE_IS_A_MINION
-	can_flags = CASTE_CAN_BE_QUEEN_HEALED
+	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA
 	caste_traits = null
 
 	// *** Defense *** //
@@ -41,4 +41,5 @@
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
 		/datum/action/ability/activable/xeno/xeno_spit,
+		/datum/action/ability/activable/xeno/corrosive_acid/drone
 	)


### PR DESCRIPTION
## About The Pull Request

pt 2/4 minyun changes, scorpion can now spit weak acid on items and can be given plasma 

## Why It's Good For The Game

scorpion was a class that desperately could use plasma prior but couldnt be given plasma for ??? reasons. it was annoying af to anyone playing and anti-teamwork 4 no raisin

Scorpions being allowed to melt items means they can flares and other items, letting actual castes to do important things and leaving melting to a minion. Right now a main niche of minions is being used exclusively for the boring task of slowly dragging flares because no one wants to actually deal with them. This will assist with game monotony (AI can't acid btw)

## Changelog

:cl:
qol: Scorpions can now be given plasma
add: Scorpions can put weak acid on obj's
/:cl:

