### PR TITLE
Removes the delay from mantis swipe + they can be given plasma now

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/mantis/abilities_mantis.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/mantis/abilities_mantis.dm
@@ -1,3 +1,4 @@
 /datum/action/ability/activable/xeno/ravage/slow
 	///How long is the windup before ravaging
 	cooldown_duration = 30 SECONDS
+	ability_cost = 250

--- a/code/modules/mob/living/carbon/xenomorph/castes/mantis/abilities_mantis.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/mantis/abilities_mantis.dm
@@ -1,21 +1,3 @@
 /datum/action/ability/activable/xeno/ravage/slow
 	///How long is the windup before ravaging
-	var/windup_time = 0.5 SECONDS
 	cooldown_duration = 30 SECONDS
-
-/datum/action/ability/activable/xeno/ravage/slow/use_ability(atom/A)
-	if(!do_after(owner, windup_time, IGNORE_HELD_ITEM, owner, BUSY_ICON_GENERIC, extra_checks = CALLBACK(src, PROC_REF(can_use_action), FALSE, ABILITY_USE_BUSY)))
-		return fail_activate()
-	return ..()
-
-/datum/action/ability/activable/xeno/ravage/slow/ai_should_use(atom/target)
-	. = ..()
-	if(!.)
-		return
-	action_activate()
-	LAZYINCREMENT(owner.do_actions, target)
-	addtimer(CALLBACK(src, PROC_REF(decrease_do_action), target), windup_time)
-
-///Decrease the do_actions of the owner
-/datum/action/ability/activable/xeno/ravage/slow/proc/decrease_do_action(atom/target)
-	LAZYDECREMENT(owner.do_actions, target)

--- a/code/modules/mob/living/carbon/xenomorph/castes/mantis/castedatum_mantis.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/mantis/castedatum_mantis.dm
@@ -17,7 +17,7 @@
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 250 //1 ravage
+	plasma_max = 500 //2 ravages
 	plasma_gain = 20
 
 	// *** Health *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/mantis/castedatum_mantis.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/mantis/castedatum_mantis.dm
@@ -17,7 +17,7 @@
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 600 //3 ravage
+	plasma_max = 250 //1 ravage
 	plasma_gain = 20
 
 	// *** Health *** //
@@ -25,7 +25,7 @@
 
 	// *** Flags *** //
 	caste_flags = CASTE_DO_NOT_ALERT_LOW_LIFE|CASTE_IS_A_MINION
-	can_flags = CASTE_CAN_BE_QUEEN_HEALED
+	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA
 	caste_traits = null
 
 	// *** Defense *** //


### PR DESCRIPTION
## About The Pull Request

pt 4/4

This swipe does literally 25 damage to unarmored humans. all this swipe did was make it near impossible for non-AI mantis can actually manage to use it

mantis swipe now takes 250 plasma, and mantis now has 500 plasma total but can be given plasma by teammates

## Why It's Good For The Game

I think this one is pretty obvious. Mantis is by far the worst minion caste in the game right now for a player to use. While AI tend to hit a majority of their swipes, players struggle to hit anything at all even with proper positioning and getting the jump on marines due to the nature of the ability. If you've ever played mantis, you know what I'm talking about. The swipe is a 25 damage move to unarmored opponents (with basic mantis slashes already being 20), but its nearly impossible to hit cause of the windup. This makes mantis easier to use and a viable choice for player minions 

## Changelog

:cl:
balance: mantis swipe no longer has a huge delay, mantis has slightly less plasma
qol: mantis can now be given plasma by teammtes
/:cl:

