### PR TITLE
Fixes the sg-85 ammo bin missing from req and adds it's powerpack to req

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -643,6 +643,11 @@ WEAPONS
 	contains = list(/obj/item/ammo_magazine/packet/smart_minigun)
 	cost = 50
 
+/datum/supply_packs/weapons/smart_minigun_powerpack
+	name = "SG-85 powerpack"
+	contains = list(/obj/item/ammo_magazine/minigun_powerpack/smartgun)
+	cost = 150
+
 /datum/supply_packs/weapons/smarttarget_rifle
 	name = "SG-62 Smart Target Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smarttargetrifle)
@@ -653,7 +658,7 @@ WEAPONS
 	contains = list(/obj/item/ammo_magazine/rifle/standard_smarttargetrifle)
 	cost = 35
 
-/datum/supply_packs/weapons/smart_minigun_ammo
+/datum/supply_packs/weapons/smarttarget_rifle_ammo_bin
 	name = "SG-62 smart target rifle ammo bin"
 	contains = list(/obj/item/ammo_magazine/packet/smart_targetrifle)
 	cost = 50


### PR DESCRIPTION

## About The Pull Request

Title
## Why It's Good For The Game

This was unintended in the mjp pr + I see no reason why the backpack shouldn't be in req in case you lose it
## Changelog
:cl:
add: Added the SG-85 powerpack to req
fix: Fixes SG-85 ammo bins not being in req
/:cl:
