### PR TITLE
More OB cinematics for shipside

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -171,6 +171,11 @@
 /// Handles the playing of the Orbital Bombardment incoming sound and other visual and auditory effects of the cannon, usually a spiraling whistle noise but can be overridden.
 /obj/structure/orbital_cannon/proc/handle_ob_firing_effects(target, ob_sound = 'sound/effects/OB_incoming.ogg')
 	flick("OBC_firing",src)
+	for(var/mob/living/current_mob AS in GLOB.mob_living_list)
+		if(!current_mob || !is_mainship_level(current_mob.z))
+			continue
+		shake_camera(current_mob, 0.7 SECONDS)
+		to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as it's orbital cannon opens fire."))
 	playsound(loc, 'sound/effects/obfire.ogg', 100, FALSE, 20, 4)
 	for(var/mob/M AS in hearers(WARHEAD_FALLING_SOUND_RANGE, target))
 		M.playsound_local(target, ob_sound, falloff = 2)

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -174,8 +174,10 @@
 	for(var/mob/living/current_mob AS in GLOB.mob_living_list)
 		if(!current_mob || !is_mainship_level(current_mob.z))
 			continue
+		if(get_dist(src, current_mob) > 20)
+			current_mob.playsound_local(current_mob, 'sound/effects/obalarm.ogg', 25)
 		shake_camera(current_mob, 0.7 SECONDS)
-		to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as it's orbital cannon opens fire."))
+		to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as her orbital cannon opens fire."))
 	playsound(loc, 'sound/effects/obfire.ogg', 100, FALSE, 20, 4)
 	for(var/mob/M AS in hearers(WARHEAD_FALLING_SOUND_RANGE, target))
 		M.playsound_local(target, ob_sound, falloff = 2)


### PR DESCRIPTION
## About The Pull Request
When the OB is fired, an alarm for those not near the OB will play, their screen will shake, and a flavor message will be sent to their chatbox for even more Flavor™
## Why It's Good For The Game
Cinematics are cool.
## Changelog
:cl:
add: Firing the OB will play an alarm for those outside of hearing distance of the cannon and on ship, shake the ship, and send out a flavor message.
/:cl:
