### PR TITLE
Adds Marine Food Vendors to all ship requisition areas + makes sure all ships have cig vendors

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -28242,21 +28242,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "xIn" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/facepaint/green{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/tool/hand_labeler{
-	pixel_x = 7;
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/green{
 	dir = 2
 	},

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -9616,9 +9616,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mgE" = (
-/obj/structure/rack,
-/obj/item/pizzabox/meat,
-/obj/item/facepaint/green,
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -11743,6 +11741,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "oSs" = (
+/obj/structure/rack,
+/obj/item/pizzabox/meat,
+/obj/item/facepaint/green,
 /obj/machinery/light/mainship{
 	dir = 4
 	},

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1446,8 +1446,8 @@
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "bNe" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted,
 /obj/item/coin/iron,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "bNh" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -16623,9 +16623,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint3)
 "ktu" = (
-/obj/machinery/air_alarm{
-	dir = 4
-	},
+/obj/machinery/vending/marineFood,
 /turf/open/floor/prison,
 /area/sulaco/cargo)
 "ktX" = (
@@ -17572,6 +17570,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"lFQ" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo)
 "lGM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/warning{
@@ -51125,7 +51129,7 @@ rvC
 vvG
 qZW
 nPU
-wsa
+lFQ
 hCz
 uDh
 whV

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -17267,7 +17267,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "lpg" = (
-/obj/machinery/vending/sovietsoda,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "lpw" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -10041,10 +10041,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "ggn" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "ggr" = (
@@ -18964,10 +18964,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "vao" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_port)
 "vaF" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -18247,6 +18247,10 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"tOe" = (
+/obj/machinery/vending/marineFood,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "tPb" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -63864,7 +63868,7 @@ bnF
 bpx
 pqU
 iWe
-iWe
+gaR
 jMY
 iWe
 gzg
@@ -65151,7 +65155,7 @@ bro
 sic
 bGk
 avZ
-gaR
+tOe
 byh
 otD
 bKU

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -736,6 +736,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"rb" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "su" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
@@ -1221,7 +1225,7 @@ Uo
 Uo
 al
 Mj
-ac
+rb
 ab
 bU
 bU


### PR DESCRIPTION
## About The Pull Request
What it says on the tin; the food vendor in question being the one you always eat at from prep. In addition, some ships were RNG on whether you would have a cigarette vendor at all (or in the bigbury's case, no cig vendor) which could jeopardize if you had chemrettes or not. This remedies that, too.
## Why It's Good For The Game
Convenience for the RO/Marine that wants to grab food quickly and send it down without the hassle of a long walk to a special vendor.
## Changelog
:cl:
add: Marine Food Vendors are now present in all requisition areas.
qol: All ships now have cigarette vendors guaranteed to spawn in
/:cl:
