### PR TITLE
Fixes flat door icons

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -117,24 +117,28 @@
 	name = "silver door"
 	material_type = /obj/item/stack/sheet/mineral/silver
 	base_icon_state = "silver"
+	icon_state = "silver"
 	max_integrity = 500
 
 /obj/structure/mineral_door/gold
 	name = "gold door"
 	material_type = /obj/item/stack/sheet/mineral/gold
 	base_icon_state = "gold"
+	icon_state = "gold"
 	max_integrity = 250
 
 /obj/structure/mineral_door/uranium
 	name = "uranium door"
 	material_type = /obj/item/stack/sheet/mineral/uranium
 	base_icon_state = "uranium"
+	icon_state = "uranium"
 	max_integrity = 500
 
 /obj/structure/mineral_door/sandstone
 	name = "sandstone door"
 	material_type = /obj/item/stack/sheet/mineral/sandstone
 	base_icon_state = "sandstone"
+	icon_state = "sandstone"
 	max_integrity = 100
 
 /obj/structure/mineral_door/transparent
@@ -150,6 +154,7 @@
 	name = "phoron door"
 	material_type = /obj/item/stack/sheet/mineral/phoron
 	base_icon_state = "phoron"
+	icon_state = "phoron"
 	max_integrity = 250
 
 /obj/structure/mineral_door/transparent/phoron/attackby(obj/item/W as obj, mob/user as mob)
@@ -172,6 +177,7 @@
 	name = "diamond door"
 	material_type = /obj/item/stack/sheet/mineral/diamond
 	base_icon_state = "diamond"
+	icon_state = "diamond"
 	max_integrity = 1000
 
 
@@ -179,6 +185,7 @@
 	name = "wooden door"
 	material_type = /obj/item/stack/sheet/wood
 	base_icon_state = "wood"
+	icon_state = "wood"
 	trigger_sound = 'sound/effects/doorcreaky.ogg'
 	max_integrity = 100
 


### PR DESCRIPTION

## About The Pull Request

Title.
They weren't showing correct color in map preview, this fixes it.

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: Fixed mineral doors not showing correct coloring in map preview
/:cl:
