### PR TITLE
Fixes health analyzer SSD display

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -262,12 +262,13 @@ REAGENT SCANNER
 			)
 			damaged_organs += list(current_organ)
 		data["damaged_organs"] = damaged_organs
-
+	var/ssd = null
 	if(patient.has_brain() && patient.stat != DEAD && ishuman(patient))
 		if(!patient.key)
-			data["ssd"] = "No soul detected." // they ghosted
+			ssd = "No soul detected." // they ghosted
 		else if(!patient.client)
-			data["ssd"] = "SSD detected." // SSD
+			ssd = "SSD detected." // SSD
+	data["ssd"] = ssd
 
 	return data
 


### PR DESCRIPTION

## About The Pull Request
Currently, health analyzers behave incorrectly once an ssd individual is scanned, and will display every scanned human as ssd thereafter. This is because the ssd data is never updated except if the target is ssd, thus never overwriting this information if it no longer applies.
This fixes that.
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: Health analyzer SSD information is no longer wrong.
/:cl:
