### PR TITLE
Xenos/Weeds can no longer hide under Rear Attach Points

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -108,6 +108,7 @@
 	base_category = DROPSHIP_CREW_WEAPON
 	density = FALSE
 	layer = HOLOPAD_LAYER //Keeps xenos from hiding under them
+	plane = FLOOR_PLANE //Doesn't layer under weeds unless it has this
 
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = SHUTTLE_ALAMO

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -107,7 +107,7 @@
 	name = "rear attach point"
 	base_category = DROPSHIP_CREW_WEAPON
 	density = FALSE
-	layer = BELOW_OBJ_LAYER
+	layer = HOLOPAD_LAYER //Keeps xenos from hiding under them
 
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = SHUTTLE_ALAMO


### PR DESCRIPTION

## About The Pull Request
This pr changes the layer of rear attach points so that weeds, weed nodes, and xenos such as larvas and runners can no longer hide under them.
## Why It's Good For The Game
Doesn't make much sense considering it's supposed to be a panel attached to the floor why xenos can hide under them, which usually means marines aren't gonna check under the panel for xenos. Plus the only way you can tell a larva is under it is right clicking it, due to larvas being completetly covered by the rear attach point. Weeds weeds are for a similar reason.
## Changelog
:cl:
balance: Weeds and xenos can no longer hide under rear attach points
/:cl:
