### PR TITLE
Renames The Rear Attach Point

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -104,7 +104,7 @@
 	pixel_y = 32
 
 /obj/effect/attach_point/crew_weapon
-	name = "rear attach point"
+	name = "interior attach point"
 	base_category = DROPSHIP_CREW_WEAPON
 	density = FALSE
 	layer = BELOW_OBJ_LAYER


### PR DESCRIPTION

## About The Pull Request
Renames the rear attach point to interior attach point.
## Why It's Good For The Game
Why it makes some sense for the alamo, the current name isn't that good when it's in places like the middle of the tad. This has it make more sense, name-wise
## Changelog
:cl:
spellcheck: Renamed rear attach points to interior attach points
/:cl:
