### PR TITLE
Fixes injections when targeting non-carbon targets

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -70,10 +70,11 @@
 	if(!reagents.total_volume)
 		balloon_alert(user, "Hypospray is Empty.")
 		return
-	var/mob/living/carbon/C = A
-	if((C.species.species_flags & NO_CHEM_METABOLIZATION) || (C.species.species_flags & IS_SYNTHETIC))
-		C.balloon_alert(user, "Can't inject (robot)")
-		return
+	if(iscarbon(A))
+		var/mob/living/carbon/C = A
+		if((C.species.species_flags & NO_CHEM_METABOLIZATION) || (C.species.species_flags & IS_SYNTHETIC))
+			C.balloon_alert(user, "Can't inject (robot)")
+			return
 	if(!A.is_injectable() && !ismob(A))
 		A.balloon_alert(user, "Can't fill.")
 		return


### PR DESCRIPTION

## About The Pull Request
The recent PR that made robots / synths uninjectable as a whole instead of catching the case later post-change-requests assumed all injected targets would be carbons, which led to invalid var accesses on anything that was not a carbon.
This fixes that by only checking for carbon things if the target is actually a carbon.
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: Injectors can inject (valid) non-carbon things again.
/:cl:
