### PR TITLE
Makes Chameleon Badge, Cape, Kama, and Reflective Belt Easier to Equip

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/cape.dm
+++ b/code/modules/clothing/modular_armor/attachments/cape.dm
@@ -9,7 +9,7 @@
 	attachment_layer = CAPE_LAYER
 	prefered_slot = SLOT_W_UNIFORM
 	greyscale_config = /datum/greyscale_config/cape
-	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB|ATTACH_ACTIVATION
+	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB|ATTACH_ACTIVATION|ATTACH_NO_HANDS
 	attach_delay = 0 SECONDS
 	detach_delay = 0 SECONDS
 	secondary_color = TRUE
@@ -225,7 +225,7 @@
 	desc = "A chromatic kama to improve on the design of the 7E badge, this kama is capable of two colors, for all your fashion needs. Hanged from the belt, it serves to flourish the lower extremities.  \n Interact with facepaint to color. Attaches onto a uniform."
 	slot = ATTACHMENT_SLOT_KAMA
 	attachment_layer = KAMA_LAYER
-	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB
+	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB|ATTACH_NO_HANDS
 	starting_attachments = list(/obj/item/armor_module/armor/cape_highlight/kama)
 	greyscale_config = /datum/greyscale_config/cape
 	icon_state_variants = list(
@@ -256,7 +256,7 @@
 	desc = "A cape to improve on the design of the 7E badge, this cape is capable of six colors, for all your fashion needs. This variation of the cape functions more as a scarf. \n Interact with facepaint to color. Attaches onto a uniform. Activate it to toggle the hood."
 	icon_state = "highlight"
 	slot = ATTACHMENT_SLOT_CAPE_HIGHLIGHT
-	flags_attach_features = ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB
+	flags_attach_features = ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB|ATTACH_NO_HANDS
 	colorable_allowed = PRESET_COLORS_ALLOWED|ICON_STATE_VARIANTS_ALLOWED|COLOR_WHEEL_ALLOWED
 	greyscale_config = /datum/greyscale_config/cape_highlight
 	secondary_color = TRUE

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -18,6 +18,7 @@
 	icon_state = "pt_belt"
 	item_state = "pt_belt_a"
 	slot = ATTACHMENT_SLOT_BELT
+	flags_attach_features = ATTACH_NO_HANDS
 
 /**
  * Shoulder lamp strength module


### PR DESCRIPTION

## About The Pull Request
Makes it so that the chameleon cape, badge, kama, and reflective belt doesn't require holding your uniform in hand to attach.
## Why It's Good For The Game
Considering all of these are cosmetic, there's not much reason to not let them be attached to uniform you are currently wearing except that it makes it tedious. This makes it so you can play dress up without having to constantly drop everything on the floor from taking your uniform off.
## Changelog
:cl:
qol: The chameleon badge, cape, kama, and reflective belt can be attached to uniforms that are being worn.
/:cl:
