### PR TITLE
Hud icon and overlays cleanup

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -122,47 +122,47 @@
 	var/atom/movable/screen/using
 
 //AI core
-	using = new /atom/movable/screen/ai/aicore()
+	using = new /atom/movable/screen/ai/aicore(null, src)
 	using.screen_loc = ui_ai_core
 	static_inventory += using
 
 //Camera list
-	using = new /atom/movable/screen/ai/camera_list()
+	using = new /atom/movable/screen/ai/camera_list(null, src)
 	using.screen_loc = ui_ai_camera_list
 	static_inventory += using
 
 //Track
-	using = new /atom/movable/screen/ai/camera_track()
+	using = new /atom/movable/screen/ai/camera_track(null, src)
 	using.screen_loc = ui_ai_track_with_camera
 	static_inventory += using
 
 //VOX
-	using = new /atom/movable/screen/ai/announcement()
+	using = new /atom/movable/screen/ai/announcement(null, src)
 	using.screen_loc = ui_ai_announcement
 	static_inventory += using
 
 //VOX Help
-	using = new /atom/movable/screen/ai/announcement_help()
+	using = new /atom/movable/screen/ai/announcement_help(null, src)
 	using.screen_loc = ui_ai_announcement_help
 	static_inventory += using
 
 //Camera light
-	using = new /atom/movable/screen/ai/camera_light()
+	using = new /atom/movable/screen/ai/camera_light(null, src)
 	using.screen_loc = ui_ai_camera_light
 	static_inventory += using
 
 //Multicamera mode
-	using = new /atom/movable/screen/ai/multicam()
+	using = new /atom/movable/screen/ai/multicam(null, src)
 	using.screen_loc = ui_ai_multicam
 	static_inventory += using
 
 //Add multicamera camera
-	using = new /atom/movable/screen/ai/add_multicam()
+	using = new /atom/movable/screen/ai/add_multicam(null, src)
 	using.screen_loc = ui_ai_add_multicam
 	static_inventory += using
 
 //bioscan
-	using = new /atom/movable/screen/ai/bioscan()
+	using = new /atom/movable/screen/ai/bioscan(null, src)
 	using.screen_loc = ui_ai_bioscan
 	static_inventory += using
 

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -46,11 +46,11 @@
 	. = ..()
 	var/atom/movable/screen/using
 
-	using = new /atom/movable/screen/ghost/follow_ghosts()
+	using = new /atom/movable/screen/ghost/follow_ghosts(null, src)
 	using.screen_loc = ui_ghost_slot2
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/reenter_corpse()
+	using = new /atom/movable/screen/ghost/reenter_corpse(null, src)
 	using.screen_loc = ui_ghost_slot3
 	static_inventory += using
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -32,7 +32,7 @@
 	var/atom/movable/screen/toggle_firemode
 	var/atom/movable/screen/unique_action
 
-	var/atom/movable/screen/zone_sel
+	var/atom/movable/screen/zone_sel/zone_sel
 	var/atom/movable/screen/pull_icon
 	var/atom/movable/screen/throw_icon
 	var/atom/movable/screen/rest_icon

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -30,7 +30,7 @@
 	var/has_hidden_gear
 	for(var/gear_slot in hud_data.gear)
 
-		inv_box = new /atom/movable/screen/inventory()
+		inv_box = new /atom/movable/screen/inventory(null, src)
 		inv_box.icon = ui_style
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
@@ -48,7 +48,7 @@
 			static_inventory += inv_box
 
 	if(has_hidden_gear)
-		using = new /atom/movable/screen/toggle_inv()
+		using = new /atom/movable/screen/toggle_inv(null, src)
 		using.icon = ui_style
 		using.color = ui_color
 		using.alpha = ui_alpha
@@ -57,7 +57,7 @@
 	// Draw the attack intent dialogue.
 	if(hud_data.has_a_intent)
 
-		using = new /atom/movable/screen/act_intent/corner()
+		using = new /atom/movable/screen/act_intent/corner(null, src)
 		using.icon_state = owner.a_intent
 		using.alpha = ui_alpha
 		static_inventory += using
@@ -66,7 +66,7 @@
 
 
 	if(hud_data.has_m_intent)
-		using = new /atom/movable/screen/mov_intent()
+		using = new /atom/movable/screen/mov_intent(null, src)
 		using.icon = ui_style
 		using.icon_state = (owner.m_intent == MOVE_INTENT_RUN ? "running" : "walking")
 		using.color = ui_color
@@ -75,7 +75,7 @@
 		move_intent = using
 
 	if(hud_data.has_drop)
-		using = new /atom/movable/screen/drop()
+		using = new /atom/movable/screen/drop(null, src)
 		using.icon = ui_style
 		using.color = ui_color
 		using.alpha = ui_alpha
@@ -83,119 +83,108 @@
 
 	if(hud_data.has_hands)
 
-		using = new /atom/movable/screen/human/equip
+		using = new /atom/movable/screen/human/equip(null, src)
 		using.icon = ui_style
 		using.plane = ABOVE_HUD_PLANE
 		using.color = ui_color
 		using.alpha = ui_alpha
 		static_inventory += using
 
-		inv_box = new /atom/movable/screen/inventory/hand/right()
+		inv_box = new /atom/movable/screen/inventory/hand/right(null, src)
 		inv_box.icon = ui_style
-		if(owner && !owner.hand)	//This being 0 or null means the right hand is in use
-			inv_box.add_overlay("hand_active")
 		inv_box.slot_id = SLOT_R_HAND
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
+		inv_box.update_icon()
 		r_hand_hud_object = inv_box
 		static_inventory += inv_box
 
-		inv_box = new /atom/movable/screen/inventory/hand()
+		inv_box = new /atom/movable/screen/inventory/hand/left(null, src)
 		inv_box.setDir(EAST)
 		inv_box.icon = ui_style
-		if(owner?.hand)	//This being 1 means the left hand is in use
-			inv_box.add_overlay("hand_active")
 		inv_box.slot_id = SLOT_L_HAND
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
+		inv_box.update_icon()
 		l_hand_hud_object = inv_box
 		static_inventory += inv_box
 
-		using = new /atom/movable/screen/swap_hand/human()
+		using = new /atom/movable/screen/swap_hand/human(null, src)
 		using.icon = ui_style
 		using.color = ui_color
 		using.alpha = ui_alpha
 		static_inventory += using
 
-		using = new /atom/movable/screen/swap_hand/right()
+		using = new /atom/movable/screen/swap_hand/right(null, src)
 		using.icon = ui_style
 		using.color = ui_color
 		using.alpha = ui_alpha
 		static_inventory += using
 
 	if(hud_data.has_resist)
-		using = new /atom/movable/screen/resist()
+		using = new /atom/movable/screen/resist(null, src)
 		using.icon = ui_style
 		using.color = ui_color
 		using.alpha = ui_alpha
 		hotkeybuttons += using
 
 	if(hud_data.has_throw)
-		throw_icon = new /atom/movable/screen/throw_catch()
+		throw_icon = new /atom/movable/screen/throw_catch(null, src)
 		throw_icon.icon = ui_style
 		throw_icon.color = ui_color
 		throw_icon.alpha = ui_alpha
 		hotkeybuttons += throw_icon
 
-		pull_icon = new /atom/movable/screen/pull()
+		pull_icon = new /atom/movable/screen/pull(null, src)
 		pull_icon.icon = ui_style
 		pull_icon.update_icon(owner)
 		hotkeybuttons += pull_icon
 
 	if(hud_data.has_warnings)
-		oxygen_icon = new /atom/movable/screen/oxygen()
+		oxygen_icon = new /atom/movable/screen/oxygen(null, src)
 		infodisplay += oxygen_icon
 
-		toxin_icon = new /atom/movable/screen()
-		toxin_icon.icon_state = "tox0"
-		toxin_icon.name = "toxin"
-		toxin_icon.screen_loc = ui_toxin
+		toxin_icon = new /atom/movable/screen/toxin(null, src)
 		infodisplay += toxin_icon
 
-		fire_icon = new /atom/movable/screen/fire()
+		fire_icon = new /atom/movable/screen/fire(null, src)
 		infodisplay += fire_icon
 
-		healths = new /atom/movable/screen/healths()
+		healths = new /atom/movable/screen/healths(null, src)
 		infodisplay += healths
 
-		staminas = new
+		staminas = new /atom/movable/screen/stamina_hud(null, src)
 		infodisplay += staminas
 
 	if(hud_data.has_pressure)
-		pressure_icon = new /atom/movable/screen()
-		pressure_icon.icon_state = "pressure0"
-		pressure_icon.name = "pressure"
-		pressure_icon.screen_loc = ui_pressure
+		pressure_icon = new /atom/movable/screen/pressure(null, src)
 		infodisplay += pressure_icon
 
 	if(hud_data.has_bodytemp)
-		bodytemp_icon = new /atom/movable/screen/bodytemp()
+		bodytemp_icon = new /atom/movable/screen/bodytemp(null, src)
 		infodisplay += bodytemp_icon
 
 
 	if(hud_data.has_nutrition)
-		nutrition_icon = new /atom/movable/screen()
-		nutrition_icon.icon_state = "nutrition0"
-		nutrition_icon.name = "nutrition"
-		nutrition_icon.screen_loc = ui_nutrition
+		nutrition_icon = new /atom/movable/screen/nutrition(null, src)
 		infodisplay += nutrition_icon
 
-	rest_icon = new /atom/movable/screen/rest()
+	rest_icon = new /atom/movable/screen/rest(null, src)
 	rest_icon.icon = ui_style
 	rest_icon.color = ui_color
 	rest_icon.alpha = ui_alpha
-	rest_icon.update_icon(owner)
+	rest_icon.update_icon()
 	static_inventory += rest_icon
 
 	//squad leader locator
-	SL_locator = new /atom/movable/screen/SL_locator
+	SL_locator = new /atom/movable/screen/SL_locator(null, src)
 	infodisplay += SL_locator
 
-	zone_sel = new /atom/movable/screen/zone_sel()
+	zone_sel = new /atom/movable/screen/zone_sel(null, src)
 	zone_sel.icon = ui_style
 	zone_sel.color = ui_color
 	zone_sel.alpha = ui_alpha
-	zone_sel.update_icon(owner)
+	zone_sel.set_selected_zone(BODY_ZONE_CHEST, owner)
 	static_inventory += zone_sel
 
 

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -7,12 +7,12 @@
 
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, C.view)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, C.view)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, src, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, src, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, src, C.view)
 		if(SSparallax.random_layer)
-			C.parallax_layers_cached += new SSparallax.random_layer
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, C.view)
+			C.parallax_layers_cached += new SSparallax.random_layer(null, src, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, src, C.view)
 
 	C.parallax_layers = C.parallax_layers_cached.Copy()
 
@@ -238,7 +238,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 
-/atom/movable/screen/parallax_layer/Initialize(mapload, view)
+/atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner, view)
 	. = ..()
 	if (!view)
 		view = world.view
@@ -289,7 +289,7 @@
 /atom/movable/screen/parallax_layer/random/space_gas
 	icon_state = "space_gas"
 
-/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, view)
+/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, datum/hud/hud_owner, view)
 	. = ..()
 	src.add_atom_colour(SSparallax.random_parallax_color, ADMIN_COLOUR_PRIORITY)
 

--- a/code/_onclick/hud/picture_in_picture.dm
+++ b/code/_onclick/hud/picture_in_picture.dm
@@ -15,7 +15,7 @@
 	var/const/max_dimensions = 10
 
 
-/atom/movable/screen/movable/pic_in_pic/Initialize(mapload)
+/atom/movable/screen/movable/pic_in_pic/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	make_backgrounds()
 
@@ -60,7 +60,7 @@
 	add_overlay(move_tab)
 
 	if(!button_x)
-		button_x = new /atom/movable/screen/component_button(null, src)
+		button_x = new /atom/movable/screen/component_button(null, null, src)
 		var/mutable_appearance/MA = new /mutable_appearance()
 		MA.name = "close"
 		MA.icon = 'icons/misc/pic_in_pic.dmi'
@@ -73,7 +73,7 @@
 	vis_contents += button_x
 
 	if(!button_expand)
-		button_expand = new /atom/movable/screen/component_button(null, src)
+		button_expand = new /atom/movable/screen/component_button(null, null, src)
 		var/mutable_appearance/MA = new /mutable_appearance()
 		MA.name = "expand"
 		MA.icon = 'icons/misc/pic_in_pic.dmi'
@@ -86,7 +86,7 @@
 	vis_contents += button_expand
 
 	if(!button_shrink)
-		button_shrink = new /atom/movable/screen/component_button(null, src)
+		button_shrink = new /atom/movable/screen/component_button(null, null, src)
 		var/mutable_appearance/MA = new /mutable_appearance()
 		MA.name = "shrink"
 		MA.icon = 'icons/misc/pic_in_pic.dmi'

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(length(elements) < max_elements)
 		var/elements_to_add = max_elements - length(elements)
 		for(var/i in 1 to elements_to_add) //Create all elements
-			var/atom/movable/screen/radial/slice/new_element = new /atom/movable/screen/radial/slice
+			var/atom/movable/screen/radial/slice/new_element = new /atom/movable/screen/radial/slice()
 			new_element.tooltips = use_tooltips
 			new_element.parent = src
 			elements += new_element

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -45,7 +45,7 @@
 	appearance_flags = PLANE_MASTER
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/openspace/Initialize(mapload)
+/atom/movable/screen/plane_master/openspace/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("first_stage_openspace", 1, drop_shadow_filter(color = "#04080FAA", size = -10))
 	add_filter("second_stage_openspace", 2, drop_shadow_filter(color = "#04080FAA", size = -15))
@@ -118,7 +118,7 @@
 	mymob.overlay_fullscreen("lighting_backdrop", /atom/movable/screen/fullscreen/lighting_backdrop/backplane)
 	mymob.overlay_fullscreen("lighting_backdrop_lit_secondary", /atom/movable/screen/fullscreen/lighting_backdrop/lit_secondary)
 
-/atom/movable/screen/plane_master/lighting/Initialize(mapload)
+/atom/movable/screen/plane_master/lighting/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("emissives", 1, alpha_mask_filter(render_source = EMISSIVE_RENDER_TARGET, flags = MASK_INVERSE))
 	add_filter("object_lighting", 2, alpha_mask_filter(render_source = O_LIGHTING_VISUAL_RENDER_TARGET, flags = MASK_INVERSE))
@@ -133,7 +133,7 @@
 	render_target = EMISSIVE_RENDER_TARGET
 	render_relay_plane = null
 
-/atom/movable/screen/plane_master/emissive/Initialize(mapload)
+/atom/movable/screen/plane_master/emissive/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("em_block_masking", 1, color_matrix_filter(GLOB.em_mask_matrix))
 

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -40,7 +40,7 @@
 	plane = RENDER_PLANE_GAME
 	render_relay_plane = RENDER_PLANE_MASTER
 
-/atom/movable/screen/plane_master/rendering_plate/game_world/Initialize(mapload)
+/atom/movable/screen/plane_master/rendering_plate/game_world/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = GRAVITY_PULSE_RENDER_TARGET, size = 10))
 

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -23,6 +23,11 @@
 	 */
 	var/del_on_map_removal = TRUE
 
+/atom/movable/screen/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(hud_owner && istype(hud_owner))
+		hud = hud_owner
+
 /atom/movable/screen/Destroy()
 	master = null
 	hud = null
@@ -94,15 +99,20 @@
 		return TRUE
 
 /atom/movable/screen/inventory/hand
+	///The tag used by this hand, used for activate_hand()
+	var/hand_tag = ""
+
+/atom/movable/screen/inventory/hand/left
 	name = "l_hand"
 	icon_state = "hand_l"
 	screen_loc = ui_lhand
-	var/hand_tag = "l"
+	hand_tag = "l"
 
-/atom/movable/screen/inventory/hand/update_icon(active = FALSE)
-	cut_overlays()
-	if(active)
-		add_overlay("hand_active")
+/atom/movable/screen/inventory/hand/left/update_overlays()
+	. = ..()
+	if(!hud?.mymob?.hand)
+		return
+	. += "hand_active"
 
 /atom/movable/screen/inventory/hand/Click(location, control, params)
 	. = ..()
@@ -115,6 +125,12 @@
 	icon_state = "hand_r"
 	screen_loc = ui_rhand
 	hand_tag = "r"
+
+/atom/movable/screen/inventory/hand/right/update_overlays()
+	. = ..()
+	if(!hud?.mymob || hud.mymob.hand)
+		return
+	. += "hand_active"
 
 /atom/movable/screen/close
 	name = "close"
@@ -168,11 +184,11 @@
 	usr.toggle_move_intent()
 
 
-/atom/movable/screen/mov_intent/update_icon(mob/user)
-	if(!user)
+/atom/movable/screen/mov_intent/update_icon_state()
+	if(!hud?.mymob)
 		return
 
-	switch(user.m_intent)
+	switch(hud.mymob.m_intent)
 		if(MOVE_INTENT_RUN)
 			icon_state = "running"
 		if(MOVE_INTENT_WALK)
@@ -193,10 +209,10 @@
 	var/mob/living/L = usr
 	L.lay_down()
 
-/atom/movable/screen/rest/update_icon(mob/mymob)
-	if(!isliving(mymob))
+/atom/movable/screen/rest/update_icon_state()
+	if(!isliving(hud?.mymob))
 		return
-	var/mob/living/L = mymob
+	var/mob/living/L = hud?.mymob
 	icon_state = "act_rest[L.resting ? "0" : ""]"
 
 /atom/movable/screen/pull
@@ -212,10 +228,10 @@
 	usr.stop_pulling()
 
 
-/atom/movable/screen/pull/update_icon(mob/user)
-	if(!user)
+/atom/movable/screen/pull/update_icon_state()
+	if(!hud?.mymob)
 		return
-	if(user.pulling)
+	if(hud.mymob.pulling)
 		icon_state = "pull"
 	else
 		icon_state = "pull0"
@@ -370,19 +386,19 @@
 							return BODY_ZONE_PRECISE_EYES
 				return BODY_ZONE_HEAD
 
-/atom/movable/screen/zone_sel/proc/set_selected_zone(choice, mob/user)
+/atom/movable/screen/zone_sel/proc/set_selected_zone(choice = BODY_ZONE_CHEST, mob/user)
 	if(isobserver(user))
 		return
 
 	if(choice != selecting)
 		selecting = choice
-		update_icon(user)
+		user.zone_selected = selecting
+	update_icon()
 	return TRUE
 
-/atom/movable/screen/zone_sel/update_icon(mob/user)
-	cut_overlays()
-	add_overlay(mutable_appearance('icons/mob/screen/zone_sel.dmi', "[z_prefix][selecting]"))
-	user.zone_selected = selecting
+/atom/movable/screen/zone_sel/update_overlays()
+	. = ..()
+	. += mutable_appearance('icons/mob/screen/zone_sel.dmi', "[z_prefix][selecting]")
 
 /atom/movable/screen/zone_sel/alien
 	icon = 'icons/mob/screen/alien.dmi'
@@ -401,9 +417,23 @@
 /atom/movable/screen/stamina_hud
 	icon = 'icons/mob/screen/health.dmi'
 	name = "stamina"
-	icon_state = "staminaloss0"
+	icon_state = "stamloss-14"
 	screen_loc = UI_STAMINA
 	mouse_opacity = MOUSE_OPACITY_ICON
+
+/atom/movable/screen/stamina_hud/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/mymob_human = hud.mymob
+	if(mymob_human.stat == DEAD)
+		icon_state = "stamloss200"
+		return
+	var/relative_stamloss = mymob_human.getStaminaLoss()
+	if(relative_stamloss < 0 && mymob_human.max_stamina)
+		relative_stamloss = round(((relative_stamloss * 14) / mymob_human.max_stamina), 1)
+	else
+		relative_stamloss = round(((relative_stamloss * 7) / (mymob_human.maxHealth * 2)), 1)
+	icon_state = "stamloss[relative_stamloss]"
 
 /atom/movable/screen/stamina_hud/Click(location, control, params)
 	if(!isliving(usr))
@@ -418,7 +448,7 @@
 /atom/movable/screen/component_button
 	var/atom/movable/screen/parent
 
-/atom/movable/screen/component_button/Initialize(mapload, atom/movable/screen/parent)
+/atom/movable/screen/component_button/Initialize(mapload, datum/hud/hud_owner, atom/movable/screen/parent)
 	. = ..()
 	src.parent = parent
 
@@ -498,18 +528,131 @@
 	icon_state = "temp0"
 	screen_loc = ui_temp
 
+/atom/movable/screen/bodytemp/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	if(!human_mymob.species)
+		switch(human_mymob.bodytemperature) //310.055 optimal body temp
+			if(370 to INFINITY)
+				icon_state = "temp4"
+			if(350 to 370)
+				icon_state = "temp3"
+			if(335 to 350)
+				icon_state = "temp2"
+			if(320 to 335)
+				icon_state = "temp1"
+			if(300 to 320)
+				icon_state = "temp0"
+			if(295 to 300)
+				icon_state = "temp-1"
+			if(280 to 295)
+				icon_state = "temp-2"
+			if(260 to 280)
+				icon_state = "temp-3"
+			else
+				icon_state = "temp-4"
+	else
+		var/temp_step
+		if(human_mymob.bodytemperature >= human_mymob.species.body_temperature)
+			temp_step = (human_mymob.species.heat_level_1 - human_mymob.species.body_temperature) / 4
+
+			if(human_mymob.bodytemperature >= human_mymob.species.heat_level_1)
+				icon_state = "temp4"
+			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 3)
+				icon_state = "temp3"
+			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 2)
+				icon_state = "temp2"
+			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 1)
+				icon_state = "temp1"
+			else
+				icon_state = "temp0"
+
+		else if(human_mymob.bodytemperature < human_mymob.species.body_temperature)
+			temp_step = (human_mymob.species.body_temperature - human_mymob.species.cold_level_1)/4
+
+			if(human_mymob.bodytemperature <= human_mymob.species.cold_level_1)
+				icon_state = "temp-4"
+			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 3)
+				icon_state = "temp-3"
+			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 2)
+				icon_state = "temp-2"
+			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 1)
+				icon_state = "temp-1"
+			else
+				icon_state = "temp0"
 
 /atom/movable/screen/oxygen
 	name = "oxygen"
 	icon_state = "oxy0"
 	screen_loc = ui_oxygen
 
+/atom/movable/screen/oxygen/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	if(human_mymob.hal_screwyhud == 3 || human_mymob.oxygen_alert)
+		icon_state = "oxy1"
+	else
+		icon_state = "oxy0"
+
+/atom/movable/screen/toxin
+	name = "toxin"
+	icon_state = "tox0"
+	screen_loc = ui_toxin
+
+/atom/movable/screen/toxin/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	if(human_mymob.hal_screwyhud == 4)
+		icon_state = "tox1"
+	else
+		icon_state = "tox0"
+
+/atom/movable/screen/pressure
+	name = "pressure"
+	icon_state = "pressure0"
+	screen_loc = ui_pressure
+
+/atom/movable/screen/pressure/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	icon_state = "pressure[human_mymob.pressure_alert]"
+
+/atom/movable/screen/nutrition
+	name = "nutrition"
+	icon_state = "nutrition1"
+	screen_loc = ui_nutrition
+
+/atom/movable/screen/nutrition/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	switch(human_mymob.nutrition)
+		if(NUTRITION_OVERFED to INFINITY)
+			icon_state = "nutrition0"
+		if(NUTRITION_HUNGRY to NUTRITION_OVERFED) //Not-hungry.
+			icon_state = "nutrition1" //Empty icon.
+		if(NUTRITION_STARVING to NUTRITION_HUNGRY)
+			icon_state = "nutrition3"
+		else
+			icon_state = "nutrition4"
 
 /atom/movable/screen/fire
-	name = "fire"
+	name = "body temperature"
 	icon_state = "fire0"
 	screen_loc = ui_fire
 
+/atom/movable/screen/fire/update_icon_state()
+	if(!ishuman(hud?.mymob))
+		return
+	var/mob/living/carbon/human/human_mymob = hud.mymob
+	if(human_mymob.fire_alert)
+		icon_state = "fire[human_mymob.fire_alert]" //fire_alert is either 0 if no alert, 1 for cold and 2 for heat.
+	else
+		icon_state = "fire0"
 
 /atom/movable/screen/toggle_inv
 	name = "toggle"
@@ -547,7 +690,7 @@
 	///List of possible screen locs
 	var/static/list/ammo_screen_loc_list = list(ui_ammo1, ui_ammo2, ui_ammo3, ui_ammo4)
 
-/atom/movable/screen/ammo/Initialize(mapload)
+/atom/movable/screen/ammo/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	flash_holder = new
 	flash_holder.icon_state = "frame"
@@ -643,7 +786,7 @@
 	deltimer(del_timer)
 	qdel(src)
 
-/atom/movable/screen/arrow/Initialize(mapload) //Self-deletes
+/atom/movable/screen/arrow/Initialize(mapload, datum/hud/hud_owner) //Self-deletes
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	del_timer = addtimer(CALLBACK(src, PROC_REF(kill_arrow)), duration, TIMER_STOPPABLE)

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -552,35 +552,37 @@
 				icon_state = "temp-3"
 			else
 				icon_state = "temp-4"
-	else
-		var/temp_step
-		if(human_mymob.bodytemperature >= human_mymob.species.body_temperature)
-			temp_step = (human_mymob.species.heat_level_1 - human_mymob.species.body_temperature) / 4
+		return
 
-			if(human_mymob.bodytemperature >= human_mymob.species.heat_level_1)
-				icon_state = "temp4"
-			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 3)
-				icon_state = "temp3"
-			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 2)
-				icon_state = "temp2"
-			else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 1)
-				icon_state = "temp1"
-			else
-				icon_state = "temp0"
+	var/temp_step
+	if(human_mymob.bodytemperature >= human_mymob.species.body_temperature)
+		temp_step = (human_mymob.species.heat_level_1 - human_mymob.species.body_temperature) / 4
 
-		else if(human_mymob.bodytemperature < human_mymob.species.body_temperature)
-			temp_step = (human_mymob.species.body_temperature - human_mymob.species.cold_level_1)/4
+		if(human_mymob.bodytemperature >= human_mymob.species.heat_level_1)
+			icon_state = "temp4"
+		else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 3)
+			icon_state = "temp3"
+		else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 2)
+			icon_state = "temp2"
+		else if(human_mymob.bodytemperature >= human_mymob.species.body_temperature + temp_step * 1)
+			icon_state = "temp1"
+		else
+			icon_state = "temp0"
+		return
 
-			if(human_mymob.bodytemperature <= human_mymob.species.cold_level_1)
-				icon_state = "temp-4"
-			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 3)
-				icon_state = "temp-3"
-			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 2)
-				icon_state = "temp-2"
-			else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 1)
-				icon_state = "temp-1"
-			else
-				icon_state = "temp0"
+	if(human_mymob.bodytemperature < human_mymob.species.body_temperature)
+		temp_step = (human_mymob.species.body_temperature - human_mymob.species.cold_level_1)/4
+
+		if(human_mymob.bodytemperature <= human_mymob.species.cold_level_1)
+			icon_state = "temp-4"
+		else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 3)
+			icon_state = "temp-3"
+		else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 2)
+			icon_state = "temp-2"
+		else if(human_mymob.bodytemperature <= human_mymob.species.body_temperature - temp_step * 1)
+			icon_state = "temp-1"
+		else
+			icon_state = "temp0"
 
 /atom/movable/screen/oxygen
 	name = "oxygen"

--- a/code/_onclick/hud/screen_objects/text_objects.dm
+++ b/code/_onclick/hud/screen_objects/text_objects.dm
@@ -25,6 +25,7 @@
 
 /atom/movable/screen/text/screen_timer/Initialize(
 		mapload,
+		datum/hud/hud_owner,
 		list/mobs,
 		timer,
 		text,

--- a/code/_onclick/hud/xeno/hivemind.dm
+++ b/code/_onclick/hud/xeno/hivemind.dm
@@ -2,18 +2,18 @@
 	..()
 	var/atom/movable/screen/using
 
-	using = new /atom/movable/screen/alien/nightvision()
+	using = new /atom/movable/screen/alien/nightvision(null, src)
 	using.alpha = ui_alpha
 	infodisplay += using
 
-	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay()
+	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay(null, src)
 	alien_plasma_display.alpha = ui_alpha
 	infodisplay += alien_plasma_display
 
-	healths = new /atom/movable/screen/healths/alien()
+	healths = new /atom/movable/screen/healths/alien(null, src)
 	healths.alpha = ui_alpha
 	infodisplay += healths
 
-	locate_leader = new /atom/movable/screen/alien/queen_locator()
+	locate_leader = new /atom/movable/screen/alien/queen_locator(null, src)
 	locate_leader.alpha = ui_alpha
 	infodisplay += locate_leader

--- a/code/_onclick/hud/xeno/larva.dm
+++ b/code/_onclick/hud/xeno/larva.dm
@@ -2,20 +2,20 @@
 	..()
 	var/atom/movable/screen/using
 
-	using = new /atom/movable/screen/mov_intent/alien()
+	using = new /atom/movable/screen/mov_intent/alien(null, src)
 	using.alpha = ui_alpha
 	using.icon_state = (owner.m_intent == MOVE_INTENT_RUN ? "running" : "walking")
 	static_inventory += using
 	move_intent = using
 
-	using = new /atom/movable/screen/alien/nightvision()
+	using = new /atom/movable/screen/alien/nightvision(null, src)
 	using.alpha = ui_alpha
 	infodisplay += using
 
-	healths = new /atom/movable/screen/healths/alien()
+	healths = new /atom/movable/screen/healths/alien(null, src)
 	healths.alpha = ui_alpha
 	infodisplay += healths
 
-	locate_leader = new /atom/movable/screen/alien/queen_locator()
+	locate_leader = new /atom/movable/screen/alien/queen_locator(null, src)
 	locate_leader.alpha = ui_alpha
 	infodisplay += locate_leader

--- a/code/_onclick/hud/xeno/xeno.dm
+++ b/code/_onclick/hud/xeno/xeno.dm
@@ -50,87 +50,85 @@
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 
-	using = new /atom/movable/screen/act_intent/corner()
+	using = new /atom/movable/screen/act_intent/corner(null, src)
 	using.alpha = ui_alpha
 	using.icon_state = owner.a_intent
 	static_inventory += using
 	action_intent = using
 
 
-	using = new /atom/movable/screen/mov_intent/alien()
+	using = new /atom/movable/screen/mov_intent/alien(null, src)
 	using.alpha = ui_alpha
 	using.icon_state = (owner.m_intent == MOVE_INTENT_RUN ? "running" : "walking")
 	static_inventory += using
 	move_intent = using
 
-	using = new /atom/movable/screen/drop()
+	using = new /atom/movable/screen/drop(null, src)
 	using.icon = 'icons/mob/screen/alien.dmi'
 	using.alpha = ui_alpha
 	static_inventory += using
 
-	inv_box = new /atom/movable/screen/inventory/hand/right()
+	inv_box = new /atom/movable/screen/inventory/hand/right(null, src)
 	inv_box.icon = 'icons/mob/screen/alien.dmi'
 	using.alpha = ui_alpha
-	if(owner && !owner.hand)	//This being 0 or null means the right hand is in use
-		using.add_overlay("hand_active")
 	inv_box.slot_id = SLOT_R_HAND
+	inv_box.update_icon()
 	r_hand_hud_object = inv_box
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory/hand()
+	inv_box = new /atom/movable/screen/inventory/hand/left(null, src)
 	inv_box.icon = 'icons/mob/screen/alien.dmi'
 	using.alpha = ui_alpha
-	if(owner?.hand)	//This being 1 means the left hand is in use
-		inv_box.add_overlay("hand_active")
 	inv_box.slot_id = SLOT_L_HAND
+	inv_box.update_icon()
 	l_hand_hud_object = inv_box
 	static_inventory += inv_box
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = 'icons/mob/screen/alien.dmi'
 	using.alpha = ui_alpha
 	static_inventory += using
 
-	using = new /atom/movable/screen/swap_hand/right()
+	using = new /atom/movable/screen/swap_hand/right(null, src)
 	using.icon = 'icons/mob/screen/alien.dmi'
 	using.alpha = ui_alpha
 	static_inventory += using
 
-	using = new /atom/movable/screen/resist()
+	using = new /atom/movable/screen/resist(null, src)
 	using.icon = 'icons/mob/screen/alien.dmi'
 	using.screen_loc = ui_above_movement
 	using.alpha = ui_alpha
 	hotkeybuttons += using
 
-	throw_icon = new /atom/movable/screen/throw_catch()
+	throw_icon = new /atom/movable/screen/throw_catch(null, src)
 	throw_icon.icon = 'icons/mob/screen/alien.dmi'
 	throw_icon.alpha = ui_alpha
 	hotkeybuttons += throw_icon
 
-	healths = new /atom/movable/screen/healths/alien()
+	healths = new /atom/movable/screen/healths/alien(null, src)
 	healths.alpha = ui_alpha
 	infodisplay += healths
 
-	using = new /atom/movable/screen/alien/nightvision()
+	using = new /atom/movable/screen/alien/nightvision(null, src)
 	using.alpha = ui_alpha
 	infodisplay += using
 
-	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay()
+	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay(null, src)
 	alien_plasma_display.alpha = ui_alpha
 	infodisplay += alien_plasma_display
 
-	locate_leader = new /atom/movable/screen/alien/queen_locator()
+	locate_leader = new /atom/movable/screen/alien/queen_locator(null, src)
 	locate_leader.alpha = ui_alpha
 	infodisplay += locate_leader
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = 'icons/mob/screen/alien.dmi'
 	pull_icon.screen_loc = ui_above_movement
 	pull_icon.alpha = ui_alpha
-	pull_icon.update_icon(owner)
+	pull_icon.update_icon()
 	hotkeybuttons += pull_icon
 
-	zone_sel = new /atom/movable/screen/zone_sel/alien()
+	zone_sel = new /atom/movable/screen/zone_sel/alien(null, src)
 	zone_sel.update_icon(owner)
 	static_inventory += zone_sel
 

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -353,7 +353,7 @@ SUBSYSTEM_DEF(minimaps)
 	var/hash = "[zlevel]-[flags]"
 	if(hashed_minimaps[hash])
 		return hashed_minimaps[hash]
-	var/atom/movable/screen/minimap/map = new(null, zlevel, flags)
+	var/atom/movable/screen/minimap/map = new(null, null, zlevel, flags)
 	if (!map.icon) //Don't wanna save an unusable minimap for a z-level.
 		CRASH("Empty and unusable minimap generated for '[zlevel]-[flags]'") //Can be caused by atoms calling this proc before minimap subsystem initializing.
 	hashed_minimaps[hash] = map
@@ -381,7 +381,7 @@ SUBSYSTEM_DEF(minimaps)
 	///assoc list of mob choices by clicking on coords. only exists fleetingly for the wait loop in [/proc/get_coords_from_click]
 	var/list/mob/choices_by_mob
 
-/atom/movable/screen/minimap/Initialize(mapload, target, flags)
+/atom/movable/screen/minimap/Initialize(mapload, datum/hud/hud_owner, target, flags)
 	. = ..()
 	if(!SSminimaps.minimaps_by_z["[target]"])
 		return

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -426,6 +426,7 @@
 	return ..()
 
 /datum/status_effect/spacefreeze
+	alert_type = /atom/movable/screen/alert/status_effect/spacefreeze
 	id = "spacefreeze"
 
 /datum/status_effect/spacefreeze/on_creation(mob/living/new_owner)
@@ -820,3 +821,8 @@
 	scale = generator(GEN_VECTOR, list(0.6, 0.6), list(1, 1), NORMAL_RAND)
 	friction = -0.05
 	color = "#818181"
+
+/atom/movable/screen/alert/status_effect/spacefreeze
+	name = "Freezing"
+	desc = "Space is very very cold, who would've thought?"
+	icon_state = "cold3"

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -671,7 +671,7 @@
 	if(!allow_drawing_method)
 		verbs -= /obj/item/storage/verb/toggle_draw_mode
 
-	boxes = new
+	boxes = new()
 	boxes.name = "storage"
 	boxes.master = src
 	boxes.icon_state = "block"
@@ -679,21 +679,21 @@
 	boxes.layer = HUD_LAYER
 	boxes.plane = HUD_PLANE
 
-	storage_start = new /atom/movable/screen/storage(  )
+	storage_start = new /atom/movable/screen/storage()
 	storage_start.name = "storage"
 	storage_start.master = src
 	storage_start.icon_state = "storage_start"
 	storage_start.screen_loc = "7,7 to 10,8"
 	storage_start.layer = HUD_LAYER
 	storage_start.plane = HUD_PLANE
-	storage_continue = new /atom/movable/screen/storage(  )
+	storage_continue = new /atom/movable/screen/storage()
 	storage_continue.name = "storage"
 	storage_continue.master = src
 	storage_continue.icon_state = "storage_continue"
 	storage_continue.screen_loc = "7,7 to 10,8"
 	storage_continue.layer = HUD_LAYER
 	storage_continue.plane = HUD_PLANE
-	storage_end = new /atom/movable/screen/storage(  )
+	storage_end = new /atom/movable/screen/storage()
 	storage_end.name = "storage"
 	storage_end.master = src
 	storage_end.icon_state = "storage_end"
@@ -701,20 +701,20 @@
 	storage_end.layer = HUD_LAYER
 	storage_end.plane = HUD_PLANE
 
-	stored_start = new /obj //we just need these to hold the icon
+	stored_start = new /obj() //we just need these to hold the icon
 	stored_start.icon_state = "stored_start"
 	stored_start.layer = HUD_LAYER
 	stored_start.plane = HUD_PLANE
-	stored_continue = new /obj
+	stored_continue = new /obj()
 	stored_continue.icon_state = "stored_continue"
 	stored_continue.layer = HUD_LAYER
 	stored_continue.plane = HUD_PLANE
-	stored_end = new /obj
+	stored_end = new /obj()
 	stored_end.icon_state = "stored_end"
 	stored_end.layer = HUD_LAYER
 	stored_end.plane = HUD_PLANE
 
-	closer = new
+	closer = new()
 	closer.master = src
 
 /obj/item/storage/Destroy()

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -153,7 +153,7 @@
 /datum/buildmode/proc/change_dir(newdir)
 	build_dir = newdir
 	close_dirswitch()
-	dirbutton.update_icon()
+	dirbutton.update_dir()
 	return TRUE
 
 

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -38,7 +38,7 @@
 	return TRUE
 
 
-/atom/movable/screen/buildmode/mode/update_icon()
+/atom/movable/screen/buildmode/mode/update_icon_state()
 	icon_state = bd.mode.get_button_iconstate()
 
 
@@ -58,10 +58,9 @@
 	screen_loc = "NORTH,WEST+2"
 	name = "Change Dir"
 
-
-/atom/movable/screen/buildmode/bdir/update_icon()
+///Updates the direction of the buildmode
+/atom/movable/screen/buildmode/bdir/proc/update_dir()
 	dir = bd.build_dir
-
 
 
 /atom/movable/screen/buildmode/bdir/Click()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -12,19 +12,6 @@
 		clear_fullscreen("brute")
 		clear_fullscreen("oxy")
 		clear_fullscreen("crit")
-
-		if(!hud_used)
-			return
-		if(hud_used.nutrition_icon)
-			hud_used.nutrition_icon.icon_state = "nutrition1"
-		if(hud_used.toxin_icon)
-			hud_used.toxin_icon.icon_state = "tox0"
-		if(hud_used.oxygen_icon)
-			hud_used.oxygen_icon.icon_state = "oxy0"
-		if(hud_used.fire_icon)
-			hud_used.fire_icon.icon_state = "fire0"
-		if(hud_used.bodytemp_icon)
-			hud_used.bodytemp_icon.icon_state = "temp0"
 		return
 
 	if(stat == UNCONSCIOUS && health <= get_crit_threshold())
@@ -102,86 +89,17 @@
 	if(!hud_used)
 		return
 
-	if(hud_used.nutrition_icon)
-		switch(nutrition)
-			if(NUTRITION_OVERFED to INFINITY)
-				hud_used.nutrition_icon.icon_state = "nutrition0"
-			if(NUTRITION_HUNGRY to NUTRITION_OVERFED) //Not-hungry.
-				hud_used.nutrition_icon.icon_state = "nutrition1" //Empty icon.
-			if(NUTRITION_STARVING to NUTRITION_HUNGRY)
-				hud_used.nutrition_icon.icon_state = "nutrition3"
-			else
-				hud_used.nutrition_icon.icon_state = "nutrition4"
+	hud_used?.nutrition_icon?.update_icon()
 
-	if(hud_used.pressure_icon)
-		hud_used.pressure_icon.icon_state = "pressure[pressure_alert]"
+	hud_used?.pressure_icon?.update_icon()
 
-	if(hud_used.toxin_icon)
-		if(hal_screwyhud == 4)
-			hud_used.toxin_icon.icon_state = "tox1"
-		else
-			hud_used.toxin_icon.icon_state = "tox0"
-	if(hud_used.oxygen_icon)
-		if(hal_screwyhud == 3 || oxygen_alert)
-			hud_used.oxygen_icon.icon_state = "oxy1"
-		else
-			hud_used.oxygen_icon.icon_state = "oxy0"
-	if(hud_used.fire_icon)
-		if(fire_alert)
-			hud_used.fire_icon.icon_state = "fire[fire_alert]" //fire_alert is either 0 if no alert, 1 for cold and 2 for heat.
-		else
-			hud_used.fire_icon.icon_state = "fire0"
+	hud_used?.toxin_icon?.update_icon()
 
-	if(hud_used.bodytemp_icon)
-		if(!species)
-			switch(bodytemperature) //310.055 optimal body temp
-				if(370 to INFINITY)
-					hud_used.bodytemp_icon.icon_state = "temp4"
-				if(350 to 370)
-					hud_used.bodytemp_icon.icon_state = "temp3"
-				if(335 to 350)
-					hud_used.bodytemp_icon.icon_state = "temp2"
-				if(320 to 335)
-					hud_used.bodytemp_icon.icon_state = "temp1"
-				if(300 to 320)
-					hud_used.bodytemp_icon.icon_state = "temp0"
-				if(295 to 300)
-					hud_used.bodytemp_icon.icon_state = "temp-1"
-				if(280 to 295)
-					hud_used.bodytemp_icon.icon_state = "temp-2"
-				if(260 to 280)
-					hud_used.bodytemp_icon.icon_state = "temp-3"
-				else
-					hud_used.bodytemp_icon.icon_state = "temp-4"
-		else
-			var/temp_step
-			if(bodytemperature >= species.body_temperature)
-				temp_step = (species.heat_level_1 - species.body_temperature) / 4
+	hud_used?.oxygen_icon?.update_icon()
 
-				if(bodytemperature >= species.heat_level_1)
-					hud_used.bodytemp_icon.icon_state = "temp4"
-				else if(bodytemperature >= species.body_temperature + temp_step * 3)
-					hud_used.bodytemp_icon.icon_state = "temp3"
-				else if(bodytemperature >= species.body_temperature + temp_step * 2)
-					hud_used.bodytemp_icon.icon_state = "temp2"
-				else if(bodytemperature >= species.body_temperature + temp_step * 1)
-					hud_used.bodytemp_icon.icon_state = "temp1"
-				else
-					hud_used.bodytemp_icon.icon_state = "temp0"
+	hud_used?.fire_icon?.update_icon()
 
-			else if(bodytemperature < species.body_temperature)
-				temp_step = (species.body_temperature - species.cold_level_1)/4
-
-				if(bodytemperature <= species.cold_level_1)
-					hud_used.bodytemp_icon.icon_state = "temp-4"
-				else if(bodytemperature <= species.body_temperature - temp_step * 3)
-					hud_used.bodytemp_icon.icon_state = "temp-3"
-				else if(bodytemperature <= species.body_temperature - temp_step * 2)
-					hud_used.bodytemp_icon.icon_state = "temp-2"
-				else if(bodytemperature <= species.body_temperature - temp_step * 1)
-					hud_used.bodytemp_icon.icon_state = "temp-1"
-				else
-					hud_used.bodytemp_icon.icon_state = "temp0"
+	hud_used?.bodytemp_icon?.update_icon()
 
 
 /mob/living/carbon/human/handle_healths_hud_updates()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -543,7 +543,7 @@
 	var/obj/machinery/nuclearbomb/nuke = thing
 	if(!nuke.timer)
 		CRASH("hive_status's setup_nuke_hud_timer called with invalid nuke object")
-	nuke_hud_timer = new(null, get_all_xenos() , nuke.timer, "Nuke ACTIVE: ${timer}")
+	nuke_hud_timer = new(null, null, get_all_xenos() , nuke.timer, "Nuke ACTIVE: ${timer}")
 
 /datum/hive_status/Destroy(force, ...)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -803,12 +803,8 @@ below 100 is not dizzy
 	hand = !hand
 	SEND_SIGNAL(src, COMSIG_CARBON_SWAPPED_HANDS)
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
-		hud_used.l_hand_hud_object.update_icon(hand)
-		hud_used.r_hand_hud_object.update_icon(!hand)
-		if(hand)	//This being 1 means the left hand is in use
-			hud_used.l_hand_hud_object.add_overlay("hand_active")
-		else
-			hud_used.r_hand_hud_object.add_overlay("hand_active")
+		hud_used.l_hand_hud_object.update_icon()
+		hud_used.r_hand_hud_object.update_icon()
 	return
 
 ///Swap to the hand clicked on the hud

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -92,6 +92,7 @@
 		updateStamina(feedback)
 
 /mob/living/proc/updateStamina(feedback = TRUE)
+	hud_used?.staminas?.update_icon()
 	if(staminaloss < max(health * 1.5,0) || !(COOLDOWN_CHECK(src, last_stamina_exhaustion))) //If we're on cooldown for stamina exhaustion, don't bother
 		return
 
@@ -104,21 +105,6 @@
 	add_slowdown(STAMINA_EXHAUSTION_DEBUFF_STACKS)
 	adjust_blurriness(STAMINA_EXHAUSTION_DEBUFF_STACKS)
 	COOLDOWN_START(src, last_stamina_exhaustion, LIVING_STAMINA_EXHAUSTION_COOLDOWN - (skills.getRating(SKILL_STAMINA) * STAMINA_SKILL_COOLDOWN_MOD)) //set the cooldown.
-
-
-/mob/living/carbon/human/updateStamina(feedback = TRUE)
-	. = ..()
-	if(!hud_used?.staminas)
-		return
-	if(stat == DEAD)
-		hud_used.staminas.icon_state = "stamloss200"
-		return
-	var/relative_stamloss = getStaminaLoss()
-	if(relative_stamloss < 0 && max_stamina)
-		relative_stamloss = round(((relative_stamloss * 14) / max_stamina), 1)
-	else
-		relative_stamloss = round(((relative_stamloss * 7) / (maxHealth * 2)), 1)
-	hud_used.staminas.icon_state = "stamloss[relative_stamloss]"
 
 /// Adds an entry to our stamina_regen_modifiers and updates stamina_regen_multiplier
 /mob/living/proc/add_stamina_regen_modifier(mod_name, mod_value)

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -45,11 +45,7 @@
 		if(!silent)
 			to_chat(src, span_notice("You get up."))
 		SEND_SIGNAL(src, COMSIG_XENOMORPH_UNREST)
-	update_resting()
-
-
-/mob/living/proc/update_resting()
-	hud_used?.rest_icon?.update_icon(src)
+	hud_used?.rest_icon?.update_icon()
 
 
 /mob/living/verb/ghost()

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -222,7 +222,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 		if(!silent)
 			to_chat(src, span_warning("Cannot place more than [max_multicams] multicamera windows."))
 		return
-	var/atom/movable/screen/movable/pic_in_pic/ai/C = new /atom/movable/screen/movable/pic_in_pic/ai()
+	var/atom/movable/screen/movable/pic_in_pic/ai/C = new()
 	C.set_view_size(3, 3, FALSE)
 	C.set_view_center(get_turf(eyeobj))
 	C.set_ai(src)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -357,7 +357,7 @@
 
 	if(hud_used?.static_inventory)
 		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
-			selector.update_icon(src)
+			selector.update_icon()
 
 	return TRUE
 

--- a/code/modules/screen_alert/misc_alert.dm
+++ b/code/modules/screen_alert/misc_alert.dm
@@ -17,7 +17,7 @@
 	///x offset of image
 	var/image_to_play_offset_x = 0
 
-/atom/movable/screen/text/screen_text/picture/Initialize(mapload)
+/atom/movable/screen/text/screen_text/picture/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	overlays += image('icons/UI_Icons/screen_alert_images.dmi', icon_state = image_to_play, pixel_y = image_to_play_offset_y, pixel_x = image_to_play_offset_x)
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -196,7 +196,7 @@
 
 /obj/vehicle/sealed/mecha/Initialize(mapload)
 	. = ..()
-	ui_view = new(null, src)
+	ui_view = new(null, null, src)
 	if(enclosed)
 		internal_tank = new (src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(play_stepsound))

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	///list of plane masters to apply to owners
 	var/list/plane_masters = list()
 
-/atom/movable/screen/mech_builder_view/Initialize(mapload)
+/atom/movable/screen/mech_builder_view/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	assigned_map = "mech_preview_[REF(src)]"
 	set_position(1, 1)

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -10,7 +10,7 @@
 	///list of plane masters to apply to owners
 	var/list/plane_masters = list()
 
-/atom/movable/screen/mech_view/Initialize(mapload, obj/vehicle/sealed/mecha/newowner)
+/atom/movable/screen/mech_view/Initialize(mapload, datum/hud/hud_owner, obj/vehicle/sealed/mecha/newowner)
 	. = ..()
 	owner = newowner
 	assigned_map = "mech_view_[REF(owner)]"


### PR DESCRIPTION

## About The Pull Request

Title. A bunch of this was shitcode and icon states/overlays were handled outside of the relevant procs.

This should fix stamina being invisible when you first spawn in (non existent icon state as the default lol), also some alerts being named weirdly.
## Why It's Good For The Game

This is less shitcode. 
## Changelog
:cl:
refactor: Cleaned up hud icons and overlays
/:cl:
