### PR TITLE
Ravager and Gorger are now pepperball immune

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -4082,8 +4082,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/pepperball/on_hit_mob(mob/living/victim, obj/projectile/proj)
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/X = victim
-		X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
-		X.use_plasma(plasma_drain)
+		if(!x.HAS_TRAIT(CASTE_PLASMADRAIN_IMMUNE))
+			X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
+			X.use_plasma(plasma_drain)
 
 /datum/ammo/bullet/pepperball/pepperball_mini
 	damage = 40

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -4082,7 +4082,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/pepperball/on_hit_mob(mob/living/victim, obj/projectile/proj)
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/X = victim
-		if(!x.HAS_TRAIT(CASTE_PLASMADRAIN_IMMUNE))
+		if(!(X.xeno_caste.caste_flags & CASTE_PLASMADRAIN_IMMUNE))
 			X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
 			X.use_plasma(plasma_drain)
 


### PR DESCRIPTION
## About The Pull Request
See title.
Saltpr? Maybe.
## Why It's Good For The Game
These guys have special slowflake plasma types that they either can't generate innately, or only generate up to a certain point. Going up against a pepperball user as rav means losing your ability to charge, which you have to generate yourself by slashing marines, which is a bit unfair.
This problem goes double for gorger, who doesn't generate ANY plasma by herself and requires standing still in order to generate blood. In addition, she's slow as hell which means any retard can basically completely drain her plasma gauge if they even barely try. Not fun.
## Changelog
:cl:
balance: Ravager, Gorger, and puppeteer will no longer be affected by pepperball
/:cl:
