### PR TITLE
Fix glass being able to be merged into any other glass type

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -11689,7 +11689,7 @@
 /area/bigredv2/outside/marshal_office)
 "kOk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "kPA" = (
@@ -12839,7 +12839,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/smes_coil,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor,

--- a/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
+++ b/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
@@ -9348,7 +9348,7 @@
 /area/patricks_rest/surface/building/residential_cent)
 "RL" = (
 /obj/structure/closet/crate/mass_produced_crate/supply,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /turf/open/floor/prison/darkbrown/full,
 /area/patricks_rest/surface/building/ore_storage)
 "RN" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -5812,7 +5812,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "eSp" = (
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /obj/structure/rack,
@@ -10802,7 +10802,7 @@
 /area/lv624/lazarus/atmos)
 "kyP" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor/plating/platebot,

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -13278,7 +13278,7 @@
 /area/mainship/squads/req)
 "qHv" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -2943,7 +2943,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science/research)

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -14025,7 +14025,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3
@@ -14557,7 +14557,7 @@
 /obj/machinery/light/mainship/small{
 	dir = 1
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -6914,7 +6914,7 @@
 	amount = 25
 	},
 /obj/item/storage/briefcase/inflatable,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/repair_bay)
 "bVF" = (
@@ -17174,7 +17174,7 @@
 /area/mainship/hull/starboard_hull)
 "rYA" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/effect/spawner/random/misc/gnome,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -3928,10 +3928,10 @@
 /area/whiskey_outpost/outside/east)
 "tP" = (
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor/marking/bot,

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -629,7 +629,7 @@
 "acX" = (
 /obj/item/storage/box/crate/sentry,
 /obj/structure/rack,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -6132,7 +6132,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /obj/effect/turf_decal/warning_stripes/thick,
@@ -7498,7 +7498,7 @@
 "jXn" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/item/stack/rods,
 /obj/item/cell/high,
 /obj/item/cell/high,
@@ -10520,8 +10520,8 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/item/stack/sheet/plasteel/large_stack,
 /obj/item/tool/crowbar,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -11988,7 +11988,7 @@
 /area/centcom/valhalla)
 "qcP" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/item/stack/rods,
 /obj/machinery/air_alarm,
 /obj/effect/turf_decal/tile/yellow{
@@ -12305,7 +12305,7 @@
 /area/tdome/tdomeadmin)
 "qBl" = (
 /obj/item/tool/wrench,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /obj/item/stack/sheet/metal{
@@ -13519,7 +13519,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor/tile/dark/gray,
@@ -14650,8 +14650,8 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
+/obj/item/stack/sheet/glass/glass,
 /turf/open/floor/wood,
 /area/centcom/valhalla)
 "tuC" = (

--- a/_maps/map_files/oscar_outpost/oscar_outpost.dmm
+++ b/_maps/map_files/oscar_outpost/oscar_outpost.dmm
@@ -2903,10 +2903,10 @@
 /area/oscar_outpost/outside/west)
 "tM" = (
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/glass/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
-/obj/item/stack/sheet/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
+/obj/item/stack/sheet/glass/glass/large_stack,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -8512,10 +8512,10 @@
 /area/oscar_outpost)
 "Tv" = (
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor/tile/dark,

--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -4781,7 +4781,7 @@
 /area/slumbridge/outside/southeast)
 "dDF" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /turf/open/floor/tile/dark,

--- a/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
@@ -366,7 +366,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "wg" = (
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)

--- a/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
@@ -564,7 +564,7 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/caves/southwest)
 "Ge" = (
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -428,7 +428,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "uj" = (
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)

--- a/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
@@ -934,7 +934,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "Zv" = (
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -271,7 +271,7 @@
 "hw" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/weaponry/gun,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3

--- a/_maps/modularmaps/lv624/robotics.dmm
+++ b/_maps/modularmaps/lv624/robotics.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ar" = (
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 30
 	},
 /obj/structure/rack,

--- a/_maps/shuttles/big_ert.dmm
+++ b/_maps/shuttles/big_ert.dmm
@@ -588,10 +588,10 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 30
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50
 	},
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50
 	},
 /obj/item/stack/cable_coil,

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -360,7 +360,7 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/facepaint/black,
-/obj/item/stack/sheet/glass{
+/obj/item/stack/sheet/glass/glass{
 	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3

--- a/code/game/objects/effects/spawners/random/engineering.dm
+++ b/code/game/objects/effects/spawners/random/engineering.dm
@@ -204,8 +204,8 @@
 	icon_state = "random_glass"
 	spawn_loot_chance = 90
 	loot = list(
-		/obj/item/stack/sheet/glass = 25,
-		/obj/item/stack/sheet/glass/large_stack = 1,
+		/obj/item/stack/sheet/glass/glass = 25,
+		/obj/item/stack/sheet/glass/glass/large_stack = 1,
 	)
 
 /obj/effect/spawner/random/engineering/insulatedgloves

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -16,7 +16,7 @@
 	)
 	item_state = "shard-glass"
 	attack_verb = list("stabbed", "slashed", "sliced", "cut")
-	var/source_sheet_type = /obj/item/stack/sheet/glass
+	var/source_sheet_type = /obj/item/stack/sheet/glass/glass
 	var/shardsize
 
 /obj/item/shard/suicide_act(mob/user)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -15,7 +15,6 @@
 	singular_name = "glass sheet"
 	icon_state = "sheet-glass"
 	item_state = "sheet-glass"
-	merge_type = /obj/item/stack/sheet/glass
 	var/created_window = /obj/structure/window
 	var/reinforced_type = /obj/item/stack/sheet/glass/reinforced
 	var/is_reinforced = FALSE
@@ -74,8 +73,9 @@ GLOBAL_LIST_INIT(glass_radial_images, list(
 		V.use(1)
 		if(!src && !RG)
 			user.put_in_hands(RG)
-
-/obj/item/stack/sheet/glass/large_stack
+/obj/item/stack/sheet/glass/glass //this exists because otherwise glass can be merger into any ofthe other glass types.
+	merge_type = /obj/item/stack/sheet/glass/glass
+/obj/item/stack/sheet/glass/glass/large_stack
 	amount = 50
 
 
@@ -88,6 +88,7 @@ GLOBAL_LIST_INIT(glass_radial_images, list(
 	singular_name = "reinforced glass sheet"
 	icon_state = "sheet-rglass"
 	item_state = "sheet-rglass"
+	merge_type = /obj/item/stack/sheet/glass/reinforced
 
 	created_window = /obj/structure/window/reinforced
 	is_reinforced = TRUE
@@ -101,8 +102,10 @@ GLOBAL_LIST_INIT(glass_radial_images, list(
 	desc = "Phoron glass is a silicate-phoron alloy turned into a non-crystalline solid. It is transparent just like glass, even if visibly tainted pink, and very resistant to damage and heat."
 	singular_name = "phoron glass sheet"
 	icon_state = "sheet-phoronglass"
+	merge_type = /obj/item/stack/sheet/glass/phoronglass
 	created_window = /obj/structure/window/phoronbasic
 	reinforced_type = /obj/item/stack/sheet/glass/phoronrglass
+
 
 /*
 * Reinforced phoron glass sheets
@@ -112,5 +115,6 @@ GLOBAL_LIST_INIT(glass_radial_images, list(
 	desc = "Reinforced phoron glass is made out of squares of silicate-phoron alloy glass layered on a metallic rod matrice. It is insanely resistant to both physical shock and heat."
 	singular_name = "reinforced phoron glass sheet"
 	icon_state = "sheet-phoronrglass"
+	merge_type = /obj/item/stack/sheet/glass/phoronrglass
 	created_window = /obj/structure/window/phoronreinforced
 	is_reinforced = TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -195,7 +195,7 @@
 		if(reinf)
 			new /obj/item/stack/sheet/glass/reinforced(loc, 2)
 		else
-			new /obj/item/stack/sheet/glass(loc, 2)
+			new /obj/item/stack/sheet/glass/glass(loc, 2)
 	else
 		new shardtype(loc)
 		if(is_full_window())

--- a/code/modules/codex/entries/stacks_codex.dm
+++ b/code/modules/codex/entries/stacks_codex.dm
@@ -5,7 +5,7 @@
 	Clicking on a floor without any tiles will reinforce the floor.  You can make reinforced glass by combining rods and normal glass sheets."
 
 /datum/codex_entry/glass
-	associated_paths = list(/obj/item/stack/sheet/glass)
+	associated_paths = list(/obj/item/stack/sheet/glass/glass)
 	mechanics_text = "Use in your hand to build a window.  Can be upgraded to reinforced glass by adding metal rods, which are made from metal sheets."
 
 /datum/codex_entry/glass_reinf

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1343,7 +1343,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/glass50
 	name = "50 glass sheets"
-	contains = list(/obj/item/stack/sheet/glass/large_stack)
+	contains = list(/obj/item/stack/sheet/glass/glass/large_stack)
 	cost = 100
 
 /datum/supply_packs/engineering/wood50


### PR DESCRIPTION
## About The Pull Request
Fixes #14638 

there was possibly a fix i could do without editing map but it would change more stuff so i just did this and it wanst any much big change.
basically since merging stacks is done by the stack attackby() any glass that was of the subtype of ../sheet/glass ( all glass stacks) would be able to merge the glass sheet into it, this solves it because the only subtype of ../sheet/glass/glass is ../glass/large_stack as far as i found
## Why It's Good For The Game
Fixes bug yay
## Changelog
:cl:
fix: glass can't turn into other glass types by merging it into a reinforced/phoron glass stack
/:cl:
