### PR TITLE
Fixes various strip related bugs (+ an extra runtime)

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -565,7 +565,7 @@
 /atom/movable/screen/ammo/proc/add_hud(mob/living/user, datum/ammo_owner)
 	if(isnull(ammo_owner))
 		CRASH("/atom/movable/screen/ammo/proc/add_hud() has been called from [src] without the required param of ammo_owner")
-	user?.client.screen += src
+	user?.client?.screen += src
 
 ///wrapper to removing this ammo hud from the users screen
 /atom/movable/screen/ammo/proc/remove_hud(mob/living/user)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -173,7 +173,9 @@
 	return FALSE					//nonliving mobs don't have hands
 
 /mob/living/put_in_hand_check(obj/item/I, hand_index)
-	if((I.flags_item & ITEM_ABSTRACT))
+	if((I.flags_item & ITEM_ABSTRACT) || !istype(I))
+		return FALSE
+	if(incapacitated() || lying_angle || (status_flags & INCORPOREAL))
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -33,7 +33,7 @@
 		else
 			return get_limb(BODY_ZONE_PRECISE_R_HAND)
 
-/mob/Living/carbon/put_in_hand_check(obj/item/I, hand_index)
+/mob/living/carbon/put_in_hand_check(obj/item/I, hand_index)
 	if(!index_to_hand(hand_index))
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -48,7 +48,7 @@
 	var/mob/mob_source = source
 
 	if(!mob_source.can_put_in_hand(equipping, hand_index))
-		to_chat(src, "<span class='warning'>\The [equipping] doesn't fit in that place!</span>")
+		to_chat(user, "<span class='warning'>[mob_source] can't hold [equipping] right now!</span>")
 		return FALSE
 
 	return TRUE
@@ -105,6 +105,9 @@
 	hand_index = 1
 
 /datum/strippable_item/hand/left/get_alternate_action(atom/source, mob/user)
+	var/obj/item/source_item = get_item(source)
+	if(!HAS_TRAIT(source_item, TRAIT_STRAPPABLE))
+		return null
 	return get_strippable_alternate_action_strap(get_item(source), source)
 
 /datum/strippable_item/hand/left/alternate_action(atom/source, mob/user)
@@ -115,6 +118,9 @@
 	hand_index = 2
 
 /datum/strippable_item/hand/right/get_alternate_action(atom/source, mob/user)
+	var/obj/item/source_item = get_item(source)
+	if(!HAS_TRAIT(source_item, TRAIT_STRAPPABLE))
+		return null
 	return get_strippable_alternate_action_strap(get_item(source), source)
 
 /datum/strippable_item/hand/right/alternate_action(atom/source, mob/user)
@@ -130,6 +136,10 @@
 /// The proc that actually does the alternate action
 /datum/strippable_item/proc/strippable_alternate_action_strap(obj/item/item, atom/source, mob/user)
 	if(!HAS_TRAIT(item, TRAIT_STRAPPABLE))
+		return
+	
+	if(length(user.do_actions))
+		user.balloon_alert(user, "Busy!")
 		return
 
 	var/strapped = HAS_TRAIT_FROM(item, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14473

Fixes items disappearing if you try to equip them in the hands of someone who's lying down
Fixes the strap button appearing on items without straps
Fixes the strap button do_after being stackable
Fixes the warning message not being sent to the user when an item fails to equip
Fixes a misc runtime related to the gun ammo counter trying to put itself on the screen of a mob without a clien
## Why It's Good For The Game

Bug bad
## Changelog
:cl:
fix: Various fixes to the strip menu, check the PR
/:cl:
