### PR TITLE
Replaces the HE rockets in the seasonal operations recoilless rocket bag with LE rockets

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -39,8 +39,8 @@ SUBSYSTEM_DEF(persistence)
 		),
 		SEASONAL_HEAVY = list(
 		/datum/season_datum/weapons/guns/heavy_defualt,
-		//datum/season_datum/weapons/guns/heavy_ff,
-		//datum/season_datum/weapons/guns/heavy_autorail,
+		/datum/season_datum/weapons/guns/heavy_ff,
+		/datum/season_datum/weapons/guns/heavy_autorail,
 		/datum/season_datum/weapons/guns/heavy_shock,
 		),
 	)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -39,8 +39,8 @@ SUBSYSTEM_DEF(persistence)
 		),
 		SEASONAL_HEAVY = list(
 		/datum/season_datum/weapons/guns/heavy_defualt,
-		/datum/season_datum/weapons/guns/heavy_ff,
-		/datum/season_datum/weapons/guns/heavy_autorail,
+		//datum/season_datum/weapons/guns/heavy_ff,
+		//datum/season_datum/weapons/guns/heavy_autorail,
 		/datum/season_datum/weapons/guns/heavy_shock,
 		),
 	)
@@ -314,7 +314,7 @@ SUBSYSTEM_DEF(persistence)
 	description = "The generic set of roundstart TGMC heavy weapons, TAT and RR."
 	item_list = list(
 		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
-		/obj/item/storage/holster/backholster/rpg/full = 2,
+		/obj/item/storage/holster/backholster/rpg/low_impact = 2,
 		/obj/item/ammo_magazine/rocket/recoilless = 4,
 		/obj/item/ammo_magazine/rocket/recoilless/light = 4,
 		/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
@@ -347,7 +347,7 @@ SUBSYSTEM_DEF(persistence)
 	name = "Shock Weapons"
 	description = "RR and MLRS for roundstart vendors."
 	item_list = list(
-		/obj/item/storage/holster/backholster/rpg/full = 2,
+		/obj/item/storage/holster/backholster/rpg/low_impact = 2,
 		/obj/item/ammo_magazine/rocket/recoilless = 4,
 		/obj/item/ammo_magazine/rocket/recoilless/light = 4,
 		/obj/item/ammo_magazine/rocket/recoilless/heat = 16,


### PR DESCRIPTION

## About The Pull Request
Replaces the HE shells in the seasonal recoilless rifle bag with LE shells.
## Why It's Good For The Game
Currently, the seasonals give the recoilless rifle 10 HE shells. Considering this can easily take down a queen in 2 shots, this seems rather excessive, especially for free. This effectively reduces the total amount of HE shells to 4, and the LE shells to 10 for the seasonals.
## Changelog
:cl:
balance: Replaced the HE shells in the seasonal recoilless rifle bag with LE shells. Non-seasonal variants untouched.
/:cl:
