### PR TITLE
Reduces spray flamer nozzle's cone range

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -77,7 +77,7 @@
 	///Damage multiplier for mobs caught in the initial stream of fire.
 	var/mob_flame_damage_mod = 2
 	///how wide of a cone the flamethrower produces on wide mode.
-	var/cone_angle = 55
+	var/cone_angle = 50
 
 /obj/item/weapon/gun/flamer/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Per title. Before and after shown below:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59634950/fd25b5cd-bd82-4a68-b696-c10403914fe1)

## Why It's Good For The Game
This thing's range is way too oppressive and covers a lot for what it can do. I believe this is a reasonable way of nerfing it.

## Changelog
:cl: Lewdcifer
balance: Spray flamer nozzle's cone range reduced.
/:cl: