### PR TITLE
CQC skill tweaks

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -115,6 +115,8 @@
 #define SKILL_CQC_MP 2 //no risk of accidental weapon discharge upon disarming (MP)
 #define SKILL_CQC_MASTER 5
 
+///unarmed damage mod from CQC skill
+#define CQC_SKILL_DAMAGE_MOD 5
 ///disarm chance mod from CQC skill
 #define CQC_SKILL_DISARM_MOD 5
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -107,7 +107,7 @@
 				return FALSE
 
 			H.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
-			var/max_dmg = H.melee_damage + H.skills.getRating(SKILL_CQC)
+			var/max_dmg = H.melee_damage + (H.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD)
 			var/damage = rand(1, max_dmg)
 
 			var/target_zone = ran_zone(H.zone_selected)
@@ -116,7 +116,7 @@
 
 			visible_message(span_danger("[H] [pick(attack.attack_verb)]ed [src]!"), null, null, 5)
 			var/list/hit_report = list()
-			if(damage >= 5 && prob(50))
+			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[H] has weakened [src]!"), null, null, 5)
 				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				hit_report += "(KO)"

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -107,7 +107,7 @@
 				return FALSE
 
 			H.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
-			var/max_dmg = H.melee_damage + (H.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD)
+			var/max_dmg = max(H.melee_damage + (H.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD), 3)
 			var/damage = rand(1, max_dmg)
 
 			var/target_zone = ran_zone(H.zone_selected)


### PR DESCRIPTION

## About The Pull Request
CQC skill now adds a tremendous 5 (five) extra damage instead of 1 (note punch damage is still an rng number, so this only increases the max damage).

Adds a max damage floor, so negative cqc won't make you do literally nothing.

Adjusted the punch stun chance so it won't be quite so comically high with good CQC. (unchanced odds with normal CQC)
For reference
## Why It's Good For The Game
Needed for upcoming campaign changes.
## Changelog
:cl:
balance: CQC skill now does +5 max damage instead of +1
/:cl:
