### PR TITLE
Possibly fixes some situations that would incorrectly DNR you.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -34,8 +34,9 @@
 		else //Dead
 			dead_ticks ++
 			var/mob/dead/observer/related_ghost = get_ghost()
+			var/datum/limb/headcheck = get_limb("head")
 			// boolean, determines if the body's ghost can reenter the body
-			var/ghost_left = !client && !related_ghost?.can_reenter_corpse
+			var/ghost_left = !mind && (!(!headcheck || (headcheck.limb_status & LIMB_DESTROYED)) || (!(species.species_flags & DETACHABLE_HEAD))) && !related_ghost?.can_reenter_corpse
 			if(dead_ticks > TIME_BEFORE_DNR || ghost_left)
 				set_undefibbable(ghost_left)
 			else


### PR DESCRIPTION

## About The Pull Request
Aims to resolve the two cases explained in the linked issue.
For the disconnect, client was replaced with mind as that is more reliable (and should also get removed if you take a body.
For decaps, an additional check was added that either requires the head to be present, or for the target to not have a reattachable head.
Was done there instead of removing the trait on reattach as that would cause potential issues with other cases of DNRing.

Fixes #14745 
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: It should be less likely for you to go DNR in cases where you shouldn't be DNR.
/:cl:
