### PR TITLE
Removes hatchling rank, adds prime

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -30,17 +30,17 @@
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	switch(playtime_mins)
 		if(0 to 600)
-			name = prefix + "Hatchling King ([nicknumber])"
-		if(601 to 1500)
 			name = prefix + "Young King ([nicknumber])"
+		if(601 to 1500)
+			name = prefix + "Mature King ([nicknumber])"
 		if(1501 to 4200)
-			name = prefix + "Mature Emperor ([nicknumber])"
-		if(4201 to 10500)
 			name = prefix + "Elder Emperor ([nicknumber])"
-		if(10501 to INFINITY)
+		if(4201 to 10500)
 			name = prefix + "Ancient Emperor ([nicknumber])"
+		if(10501 to INFINITY)
+			name = prefix + "Prime Emperor ([nicknumber])"
 		else
-			name = prefix + "Hatchling King ([nicknumber])"
+			name = prefix + "Young King ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -76,17 +76,17 @@
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	switch(playtime_mins)
 		if(0 to 600)
-			name = prefix + "Hatchling Queen ([nicknumber])"
-		if(601 to 1500)
 			name = prefix + "Young Queen ([nicknumber])"
+		if(601 to 1500)
+			name = prefix + "Mature Queen ([nicknumber])"
 		if(1501 to 4200)
-			name = prefix + "Mature Empress ([nicknumber])"
-		if(4201 to 10500)
 			name = prefix + "Elder Empress ([nicknumber])"
-		if(10501 to INFINITY)
+		if(4201 to 10500)
 			name = prefix + "Ancient Empress ([nicknumber])"
+		if(10501 to INFINITY)
+			name = prefix + "Prime Empress ([nicknumber])"
 		else
-			name = prefix + "Hatchling Queen ([nicknumber])"
+			name = prefix + "Young Queen ([nicknumber])"
 
 	real_name = name
 	if(mind)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -156,17 +156,17 @@
 	var/rank_name
 	switch(playtime_mins)
 		if(0 to 600)
-			rank_name = "Hatchling"
-		if(601 to 1500) //10 hours
 			rank_name = "Young"
-		if(1501 to 4200) //25 hours
+		if(601 to 1500) //10 hours
 			rank_name = "Mature"
-		if(4201 to 10500) //70 hours
+		if(1501 to 4200) //25 hours
 			rank_name = "Elder"
-		if(10501 to INFINITY) //175 hours
+		if(4201 to 10500) //70 hours
 			rank_name = "Ancient"
+		if(10501 to INFINITY) //175 hours
+			rank_name = "Prime"
 		else
-			rank_name = "Hatchling"
+			rank_name = "Young"
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	name = prefix + "[rank_name ? "[rank_name] " : ""][xeno_caste.display_name] ([nicknumber])"
 


### PR DESCRIPTION

## About The Pull Request
Hatchling rank is no more. It now goes Young > Mature > Elder > Ancient > Prime
## Why It's Good For The Game
The amount of mental anguish I received when I saw an ancient titled xeno with a prime rank icon was very immense. In addition, this will make it so the rank icons line up with how they were before maturity removal.
This should be the last change I have to make to the system. I can live with "Primordial Prime".
## Changelog
:cl:
spellcheck: Hatchling xeno rank is replaced with young, prime is now the top xeno rank
/:cl:
