### PR TITLE
Throw signal fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -617,13 +617,13 @@
 		flags_atom &= ~DIRLOCK
 	if(isobj(src) && throwing)
 		throw_impact(get_turf(src), speed)
-	if(loc)
-		stop_throw(flying, original_layer)
-		SEND_SIGNAL(loc, COMSIG_TURF_THROW_ENDED_HERE, src)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
+	stop_throw(flying, original_layer)
 
-/// Annul all throw var to ensure a clean exit out of throw state
+///Clean up all throw vars
 /atom/movable/proc/stop_throw(flying = FALSE, original_layer)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
+	if(loc)
+		SEND_SIGNAL(loc, COMSIG_TURF_THROW_ENDED_HERE, src)
 	set_throwing(FALSE)
 	if(flying)
 		set_flying(FALSE, original_layer)
@@ -1201,10 +1201,7 @@
 	grab_state = newstate
 
 ///Toggles AM between throwing states
-/atom/movable/proc/set_throwing(new_throwing, flying)
-	if(new_throwing == throwing)
-		return
-	. = throwing
+/atom/movable/proc/set_throwing(new_throwing)
 	throwing = new_throwing
 	if(throwing)
 		pass_flags |= PASS_THROW

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -105,8 +105,8 @@
 	human_user.update_inv_back()
 	update_icon()
 	new /obj/effect/temp_visual/smoke(get_turf(human_user))
-	human_user.fly_at(A, calculate_range(human_user), speed)
 	RegisterSignal(human_user, COMSIG_MOVABLE_POST_THROW, PROC_REF(reset_flame))
+	human_user.fly_at(A, calculate_range(human_user), speed)
 	return TRUE
 
 ///Calculate the max range of the jetpack, changed by some item slowdown


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts where a couple of throw ending signals are sent. This seems to be the cause of a uncommon throw bugs.
Adjusted jetpacks to register for this signal BEFORE the throw, as this was the only one positioned incorrectly.

Also cleaned up the set_throwing proc, as it was just doing some pointless stuff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a couple of uncommon throw bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
