### PR TITLE
Throw bounce improvements

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -137,6 +137,7 @@
 	else if(. >= 360)
 		. -= 360
 
+///Returns one of the 8 directions based on an angle
 /proc/angle_to_dir(angle)
 	switch(angle)
 		if(338 to 360, 0 to 22)
@@ -155,6 +156,18 @@
 			return WEST
 		if(293 to 337)
 			return NORTHWEST
+
+///Returns one of the 4 cardinal directions based on an angle
+/proc/angle_to_cardinal_dir(angle)
+	switch(angle)
+		if(316 to 360, 0 to 45)
+			return NORTH
+		if(46 to 135)
+			return EAST
+		if(136 to 225)
+			return SOUTH
+		if(226 to 315)
+			return WEST
 
 ///returns degrees between two angles
 /proc/get_between_angles(degree_one, degree_two)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -488,7 +488,7 @@
 		return
 	if(!isturf(loc))
 		return
-	var/dir_to_proj = get_dir(hit_atom, old_throw_source)
+	var/dir_to_proj = angle_to_cardinal_dir(Get_Angle(hit_atom, old_throw_source))
 	if(ISDIAGONALDIR(dir_to_proj))
 		var/list/cardinals = list(turn(dir_to_proj, 45), turn(dir_to_proj, -45))
 		for(var/direction in cardinals)
@@ -497,8 +497,8 @@
 				cardinals -= direction
 		dir_to_proj = pick(cardinals)
 
-	var/perpendicular_angle = Get_Angle(hit_atom, get_step(hit_atom, dir_to_proj))
-	var/new_angle = (perpendicular_angle + (perpendicular_angle - Get_Angle(old_throw_source, src) - 180) + rand(-10, 10))
+	var/perpendicular_angle = Get_Angle(hit_atom, get_step(hit_atom, ISDIAGONALDIR(dir_to_proj) ? get_dir(hit_atom, old_throw_source) - dir_to_proj : dir_to_proj))
+	var/new_angle = (perpendicular_angle + (perpendicular_angle - Get_Angle(old_throw_source, (loc == old_throw_source ? hit_atom : src)) - 180) + rand(-10, 10))
 
 	if(new_angle < -360)
 		new_angle += 720 //north is 0 instead of 360


### PR DESCRIPTION

## About The Pull Request
Changed how throw bounces are calculated to work more consistantly.

Namely, throws that instantly collide (throwing something at a wall next to you) or certain unusual angles making things bounce towards you.

Its kind of guh since we're using exact angles, but its a tile based game with walls facing the 4 cardinal directions, so there were a few edge cases where bounces would still go in weird directions.

They should now always behave as you'd expect.
## Why It's Good For The Game
Realistic bounces or something.
## Changelog
:cl:
fix: Fixed some instances where throw bounces would behave funnily
/:cl:
