### PR TITLE
Daedalus Changes (#1)

### DIFF
--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -1962,6 +1962,11 @@
 	dir = 1
 	},
 /area/daedalusprison/inside/security/warden)
+"bHC" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/south)
 "bIA" = (
 /turf/open/floor/prison/red/corner,
 /area/daedalusprison/inside/habitationsouth)
@@ -2527,7 +2532,7 @@
 "chJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/darkfrostwall,
+/turf/closed/mineral/smooth/darkfrostwall/cuttable,
 /area/daedalusprison/caves/rock)
 "chS" = (
 /obj/structure/table,
@@ -6722,6 +6727,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/purple/taupepurple,
 /area/daedalusprison/inside/hydroponicstesting)
+"fBv" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/daedalusprison/outside/south)
 "fBx" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
@@ -7394,6 +7403,11 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/daedalusprison/inside/prisonshower)
+"ghP" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/northeast)
 "giM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7494,9 +7508,9 @@
 	},
 /area/daedalusprison/inside/colonydorms)
 "gmu" = (
-/obj/machinery/miner/damaged,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/daedalusprison/outside/north)
+/area/daedalusprison/outside/south)
 "gmx" = (
 /obj/machinery/light{
 	dir = 1
@@ -8670,7 +8684,7 @@
 /area/daedalusprison/inside/mechanicshop)
 "hoO" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/darkfrostwall,
+/turf/closed/mineral/smooth/darkfrostwall/cuttable,
 /area/daedalusprison/caves/rock)
 "hoW" = (
 /obj/structure/table/reinforced,
@@ -9019,6 +9033,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/daedalusprison/inside/engineering)
+"hEM" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/daedalusprison/outside/north)
 "hFj" = (
 /obj/item/ammo_casing,
 /turf/open/floor/prison,
@@ -13489,7 +13507,7 @@
 	},
 /area/daedalusprison/inside/centralhalls)
 "liI" = (
-/turf/closed/mineral/smooth/darkfrostwall,
+/turf/closed/mineral/smooth/darkfrostwall/cuttable,
 /area/daedalusprison/caves/rock)
 "lja" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14090,6 +14108,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red,
 /area/daedalusprison/inside/habitationsouth)
+"lHH" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/northeast)
 "lHO" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -17189,6 +17211,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
+"ojR" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/north)
 "ojY" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
@@ -17285,7 +17311,7 @@
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/colonydorms)
 "opr" = (
-/turf/closed/mineral/smooth/darkfrostwall,
+/turf/closed/mineral/smooth/darkfrostwall/cuttable,
 /area/daedalusprison/caves/northwest)
 "opN" = (
 /turf/open/floor/tile/green/greentaupe{
@@ -17982,6 +18008,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
+"oPp" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/daedalusprison/outside/northeast)
 "oPy" = (
 /obj/structure/table/mainship,
 /obj/effect/landmark/weed_node,
@@ -20866,6 +20896,10 @@
 	dir = 6
 	},
 /area/daedalusprison/inside/northmeetingroom)
+"rin" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/daedalusprison/outside/northeast)
 "rit" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/prison,
@@ -31699,7 +31733,7 @@ wTh
 ira
 ira
 ira
-ira
+wTh
 liI
 liI
 liI
@@ -31912,8 +31946,8 @@ wTh
 miz
 kzq
 ira
-ira
 wTh
+miz
 liI
 sLx
 sLx
@@ -32125,7 +32159,7 @@ miz
 miz
 ira
 ira
-ira
+miz
 liI
 sLx
 sLx
@@ -32337,7 +32371,7 @@ ira
 ira
 ira
 ira
-ira
+miz
 liI
 liI
 liI
@@ -32549,9 +32583,9 @@ ira
 mEN
 ira
 ira
-ira
-mEN
-ira
+miz
+kzq
+miz
 liI
 sLx
 sLx
@@ -32763,7 +32797,7 @@ ira
 ira
 ira
 ira
-ira
+miz
 liI
 liI
 sLx
@@ -32972,11 +33006,11 @@ sLx
 sLx
 liI
 ira
-mEN
+vbd
 ira
 ira
-ira
-ira
+miz
+miz
 liI
 liI
 sLx
@@ -33164,13 +33198,13 @@ sLx
 liI
 kzq
 miz
-ira
-ira
-ira
-ira
-ira
-ira
-ira
+miz
+wTf
+wTf
+miz
+miz
+wTf
+wTf
 liI
 sLx
 sLx
@@ -33188,8 +33222,8 @@ ira
 wTh
 ira
 ira
-mEN
-ira
+kzq
+miz
 liI
 liI
 sLx
@@ -33379,8 +33413,8 @@ ira
 ira
 ira
 ira
-ira
-ira
+miz
+miz
 ira
 ira
 liI
@@ -33401,8 +33435,8 @@ ira
 wTh
 ira
 ira
-ira
-ira
+miz
+miz
 liI
 liI
 sLx
@@ -33609,13 +33643,13 @@ liI
 mEN
 ira
 ira
-mEN
+vbd
 ira
 ira
 ira
 ira
-mEN
-ira
+kzq
+miz
 liI
 liI
 sLx
@@ -33827,8 +33861,8 @@ miz
 ira
 ira
 ira
-ira
-ira
+miz
+miz
 liI
 sLx
 sLx
@@ -34040,7 +34074,7 @@ ira
 mEN
 ira
 ira
-mEN
+kzq
 liI
 sLx
 sLx
@@ -34230,10 +34264,10 @@ liI
 liI
 liI
 liI
+miz
 wTf
 wTf
-wTf
-wTf
+miz
 liI
 liI
 sLx
@@ -34252,7 +34286,7 @@ ira
 ira
 ira
 ira
-ira
+miz
 liI
 liI
 sLx
@@ -34434,10 +34468,10 @@ sLx
 sLx
 liI
 kzq
-ira
-ira
-ira
-mEN
+wTf
+miz
+miz
+uAB
 liI
 sLx
 sLx
@@ -35093,7 +35127,7 @@ sLx
 sLx
 sLx
 liI
-ira
+wTh
 ira
 miz
 kzq
@@ -35740,8 +35774,8 @@ miz
 miz
 ira
 ira
-ira
-ira
+miz
+miz
 ira
 ira
 miz
@@ -35952,8 +35986,8 @@ ira
 ira
 ira
 ngx
-ira
-ira
+miz
+miz
 ira
 ira
 ira
@@ -36364,7 +36398,7 @@ sLx
 sLx
 liI
 liI
-ira
+miz
 ira
 ira
 miz
@@ -36561,12 +36595,12 @@ ira
 ira
 liI
 liI
+miz
 wTf
+miz
+miz
 wTf
-wTf
-wTf
-wTf
-wTf
+miz
 liI
 liI
 sLx
@@ -36575,8 +36609,8 @@ sLx
 sLx
 sLx
 liI
-ira
-ira
+miz
+miz
 ira
 ira
 wTf
@@ -36787,7 +36821,7 @@ sLx
 sLx
 sLx
 liI
-ira
+miz
 ira
 ira
 ira
@@ -36908,13 +36942,13 @@ sLx
 liI
 liI
 dVz
+vBS
 dVz
 dVz
 dVz
 dVz
 dVz
-dVz
-dVz
+dLg
 dVz
 dVz
 dVz
@@ -36999,7 +37033,7 @@ sLx
 sLx
 sLx
 liI
-mEN
+kzq
 ira
 ira
 vbd
@@ -37121,7 +37155,7 @@ sLx
 liI
 liI
 dLg
-dVz
+vBS
 dVz
 dVz
 dLg
@@ -37130,7 +37164,7 @@ dVz
 dVz
 dVz
 dVz
-dVz
+vBS
 dVz
 sLx
 sLx
@@ -37198,7 +37232,7 @@ ira
 ira
 ira
 ira
-ira
+wTh
 ira
 liI
 liI
@@ -37211,7 +37245,7 @@ sLx
 sLx
 sLx
 liI
-ira
+miz
 ira
 ira
 ira
@@ -37340,7 +37374,7 @@ dVz
 dVz
 dVz
 dVz
-dVz
+dLg
 dVz
 dVz
 dVz
@@ -37407,8 +37441,8 @@ liI
 ira
 ira
 ira
-mEN
-ira
+kzq
+miz
 ira
 ira
 liI
@@ -37423,7 +37457,7 @@ sLx
 sLx
 sLx
 liI
-ira
+miz
 ira
 ira
 ira
@@ -37619,8 +37653,8 @@ liI
 ira
 ira
 ira
-ira
-ira
+miz
+miz
 ira
 mEN
 liI
@@ -37635,7 +37669,7 @@ sLx
 sLx
 sLx
 liI
-ira
+miz
 ira
 ira
 ira
@@ -37766,8 +37800,8 @@ sLx
 sLx
 dVz
 dVz
-dVz
-dVz
+vBS
+dLg
 dVz
 sLx
 sLx
@@ -37847,7 +37881,7 @@ sLx
 sLx
 liI
 liI
-mEN
+kzq
 ira
 ira
 mEN
@@ -37979,7 +38013,7 @@ sLx
 sLx
 dVz
 dVz
-dVz
+vBS
 dVz
 sLx
 sLx
@@ -38058,8 +38092,8 @@ sLx
 sLx
 liI
 liI
-ira
-ira
+miz
+miz
 ira
 ira
 ngx
@@ -38269,7 +38303,7 @@ liI
 liI
 liI
 liI
-wTh
+kwE
 ira
 ira
 ira
@@ -38403,7 +38437,7 @@ sLx
 sLx
 sLx
 dVz
-dVz
+dLg
 dVz
 sLx
 sLx
@@ -38682,7 +38716,7 @@ ira
 ira
 miz
 miz
-ira
+wTh
 ira
 miz
 miz
@@ -39251,7 +39285,7 @@ kIn
 kIn
 nmO
 dmP
-dVz
+dLg
 dVz
 sLx
 prV
@@ -39463,7 +39497,7 @@ kIn
 sEf
 nmO
 dmP
-dmP
+nmg
 dVz
 sLx
 prV
@@ -40194,8 +40228,8 @@ ira
 ira
 ira
 ira
-ira
-ira
+miz
+miz
 liI
 liI
 vXd
@@ -40405,8 +40439,8 @@ liI
 ira
 ira
 ira
-ira
-ira
+miz
+miz
 liI
 liI
 liI
@@ -40617,7 +40651,7 @@ ira
 mEN
 ira
 ira
-mEN
+kzq
 liI
 liI
 sLx
@@ -40829,7 +40863,7 @@ ira
 ira
 ira
 ira
-ira
+miz
 liI
 sLx
 sLx
@@ -47402,8 +47436,8 @@ fvb
 hch
 fvb
 fvb
-fvb
-fvb
+eHi
+eHi
 fvb
 fvb
 liI
@@ -47614,8 +47648,8 @@ fvb
 fvb
 fvb
 fvb
-fvb
-fvb
+eHi
+eHi
 fvb
 liI
 liI
@@ -48187,14 +48221,14 @@ bOo
 cXA
 sNf
 maf
+gmu
+gmu
 qqi
+gmu
+gmu
 qqi
-qqi
-qqi
-qqi
-qqi
-qqi
-qqi
+gmu
+gmu
 sLx
 sLx
 sLx
@@ -48246,8 +48280,8 @@ fvb
 fvb
 fvb
 fvb
-fvb
-fvb
+eHi
+eHi
 fvb
 fvb
 fvb
@@ -48399,14 +48433,14 @@ pbo
 bOo
 sNf
 maf
-qqi
-qqi
+gmu
+gmu
 kaT
+gmu
+gmu
 qqi
-qqi
-qqi
-kaT
-qqi
+bHC
+gmu
 sLx
 sLx
 sLx
@@ -48458,8 +48492,8 @@ eHi
 eHi
 eHi
 fvb
-fvb
-fvb
+eHi
+eHi
 fvb
 fvb
 fvb
@@ -48823,12 +48857,12 @@ lJM
 lJM
 sNf
 aok
+bUI
+gmu
+gmu
 qqi
-qqi
-qqi
-qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 sLx
 sLx
@@ -49036,10 +49070,10 @@ maf
 aok
 aok
 qqi
+gmu
+gmu
 qqi
-qqi
-qqi
-qqi
+gmu
 qqi
 qqi
 sLx
@@ -49243,11 +49277,11 @@ jpF
 aok
 kaT
 qqi
-qqi
+bUI
 qqi
 kaT
 qqi
-qqi
+bUI
 qqi
 kaT
 qqi
@@ -49303,8 +49337,8 @@ sLx
 sLx
 sLx
 liI
-fvb
-fvb
+eHi
+eHi
 fvb
 inc
 fvb
@@ -49459,8 +49493,8 @@ qqi
 qqi
 qqi
 qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 qqi
 qqi
@@ -49515,7 +49549,7 @@ sLx
 sLx
 sLx
 liI
-fvb
+eHi
 fvb
 inc
 hch
@@ -49667,15 +49701,15 @@ aXz
 cdG
 qqi
 qqi
-bUI
 qqi
+gmu
+gmu
 qqi
+gmu
+gmu
 qqi
-qqi
-bUI
-qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 sLx
 sLx
@@ -49727,7 +49761,7 @@ sLx
 sLx
 liI
 liI
-oFt
+gdW
 fvb
 fvb
 oFt
@@ -49880,14 +49914,14 @@ cdG
 qqi
 qqi
 qqi
+gmu
+gmu
 qqi
 qqi
 qqi
 qqi
-qqi
-qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 tCL
 sLx
@@ -49938,8 +49972,8 @@ sLx
 sLx
 liI
 liI
-fvb
-fvb
+eHi
+eHi
 fvb
 fvb
 fvb
@@ -49988,7 +50022,7 @@ liI
 uSn
 uSn
 riX
-riX
+uSn
 uSn
 liI
 sLx
@@ -50095,11 +50129,11 @@ qqi
 qqi
 kaT
 qqi
+gmu
+gmu
+syf
 qqi
-qqi
-kaT
-qqi
-qqi
+bUI
 qqi
 aiF
 tCL
@@ -50148,9 +50182,9 @@ sLx
 sLx
 liI
 liI
-fvb
-fvb
-fvb
+eHi
+eHi
+eHi
 fvb
 fvb
 fvb
@@ -50303,15 +50337,15 @@ aXz
 cdG
 qqi
 qqi
-bUI
 qqi
+gmu
+gmu
 qqi
+gmu
+gmu
 qqi
-qqi
-bUI
-qqi
-qqi
-tCL
+gmu
+fBv
 bUI
 tCL
 tCL
@@ -50359,8 +50393,8 @@ sLx
 sLx
 liI
 liI
-fvb
-fvb
+eHi
+eHi
 fvb
 fvb
 fvb
@@ -50516,14 +50550,14 @@ cdG
 qqi
 qqi
 qqi
+gmu
+gmu
 qqi
 qqi
 qqi
 qqi
-qqi
-qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 tCL
 nls
@@ -50731,8 +50765,8 @@ qqi
 qqi
 qqi
 qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 qqi
 qqi
@@ -50940,14 +50974,14 @@ aok
 kaT
 qqi
 qqi
+gmu
+bHC
 qqi
+gmu
+gmu
 kaT
-qqi
-qqi
-qqi
-kaT
-qqi
-qqi
+gmu
+gmu
 qqi
 nHn
 nls
@@ -51151,14 +51185,14 @@ aok
 qqi
 qqi
 qqi
-bUI
+qqi
+gmu
+gmu
 qqi
 qqi
 qqi
 qqi
-bUI
-qqi
-qqi
+gmu
 qqi
 bUI
 liI
@@ -51367,8 +51401,8 @@ qqi
 qqi
 qqi
 qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 qqi
 qqi
@@ -51576,11 +51610,11 @@ qqi
 qqi
 qqi
 qqi
+gmu
+gmu
 qqi
-qqi
-qqi
-qqi
-qqi
+gmu
+gmu
 qqi
 qqi
 liI
@@ -51788,12 +51822,12 @@ qqi
 kaT
 qqi
 qqi
+gmu
+bHC
+bUI
 qqi
-kaT
 qqi
-qqi
-qqi
-kaT
+syf
 liI
 liI
 sLx
@@ -51999,9 +52033,9 @@ qqi
 qqi
 qqi
 qqi
+bUI
 qqi
-qqi
-qqi
+bUI
 qqi
 qqi
 liI
@@ -58270,8 +58304,8 @@ tOL
 dXL
 dXL
 dXL
-dXL
-dXL
+ojR
+ojR
 mqf
 dXL
 dXL
@@ -58482,8 +58516,8 @@ jXr
 dXL
 dXL
 dXL
-dXL
-dXL
+ojR
+ojR
 dXL
 dXL
 dXL
@@ -58906,7 +58940,7 @@ dXL
 dXL
 spn
 dXL
-gmu
+dXL
 dXL
 spn
 dXL
@@ -59120,8 +59154,8 @@ dXL
 dXL
 dXL
 dXL
-dXL
-dXL
+ojR
+ojR
 dXL
 jxY
 mUr
@@ -59326,14 +59360,14 @@ jXr
 dXL
 dXL
 dXL
+ojR
+ojR
 dXL
 dXL
 dXL
 dXL
-dXL
-dXL
-kEG
-dXL
+ojR
+ojR
 dXL
 qgt
 mUr
@@ -59538,8 +59572,8 @@ jts
 dXL
 dXL
 oJZ
-dXL
-dXL
+ojR
+ojR
 dXL
 dXL
 dXL
@@ -60808,8 +60842,8 @@ sWn
 bKc
 lpZ
 dXL
-dXL
-dXL
+ojR
+ojR
 dXL
 dXL
 eJo
@@ -61020,8 +61054,8 @@ oUJ
 xIF
 tOL
 dXL
-dXL
-dXL
+ojR
+ojR
 dXL
 dXL
 eJo
@@ -61869,8 +61903,8 @@ dXL
 dXL
 dXL
 dXL
-dXL
-dXL
+ojR
+ojR
 dXL
 eJo
 dNI
@@ -62081,8 +62115,8 @@ dXL
 dXL
 dXL
 mqf
-dXL
-dXL
+ojR
+ojR
 dXL
 eJo
 iGv
@@ -62925,12 +62959,12 @@ qFB
 xIF
 jXr
 dXL
+ojR
+ojR
 dXL
 dXL
 dXL
-dXL
-dXL
-dXL
+ojR
 dXL
 dXL
 dXL
@@ -63137,13 +63171,13 @@ jEN
 xIF
 jXr
 spn
-dXL
-dXL
+ojR
+ojR
 dXL
 spn
 dXL
-dXL
-dXL
+ojR
+ojR
 spn
 dXL
 dXL
@@ -63357,8 +63391,8 @@ ewM
 dXL
 ewM
 dXL
-ewM
-dXL
+hEM
+ojR
 kEG
 dXL
 dXL
@@ -63569,8 +63603,8 @@ maY
 kAD
 maY
 loZ
-kAD
-kAD
+rin
+rin
 maY
 maY
 maY
@@ -63757,8 +63791,8 @@ dbI
 wOa
 maY
 maY
-maY
-maY
+lHH
+lHH
 lNW
 maY
 maY
@@ -63969,8 +64003,8 @@ kAD
 maY
 kAD
 luQ
-maY
-maY
+lHH
+lHH
 maY
 luQ
 kAD
@@ -64207,8 +64241,8 @@ loZ
 loZ
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 fjx
 bDH
@@ -64413,14 +64447,14 @@ lZm
 dpB
 maY
 maY
-kAD
+rin
+oPp
 loZ
-loZ
 kAD
 kAD
 maY
-maY
-maY
+lHH
+lHH
 maY
 fjx
 vvJ
@@ -64625,8 +64659,8 @@ bqD
 bOX
 loZ
 maY
-maY
-loZ
+lHH
+oPp
 kAD
 maY
 maY
@@ -65266,8 +65300,8 @@ maY
 lNW
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 maY
 fjx
@@ -65478,8 +65512,8 @@ maY
 maY
 maY
 kAD
-maY
-maY
+lHH
+lHH
 kAD
 maY
 cTb
@@ -66733,12 +66767,12 @@ maY
 jEO
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 vJy
-maY
-gOC
+lHH
+ghP
 maY
 tsN
 maY
@@ -66945,19 +66979,19 @@ maY
 maY
 maY
 maY
+lHH
+lHH
+maY
+maY
+lHH
+lHH
 maY
 maY
 maY
 maY
 maY
-maY
-maY
-maY
-maY
-maY
-maY
-kAD
-loZ
+rin
+oPp
 nHX
 hUa
 vQh
@@ -67168,8 +67202,8 @@ maY
 maY
 maY
 kAD
-kAD
-loZ
+rin
+oPp
 nHX
 hUa
 uMQ
@@ -67587,8 +67621,8 @@ eeZ
 eeZ
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 kAD
 loZ
@@ -67799,8 +67833,8 @@ rsg
 eeZ
 vJy
 maY
-maY
-kAD
+lHH
+rin
 kAD
 kAD
 loZ
@@ -68437,8 +68471,8 @@ maY
 asY
 kAD
 loZ
-loZ
-kAD
+oPp
+rin
 kAD
 kAD
 kAD
@@ -68649,8 +68683,8 @@ maY
 lMW
 kAD
 loZ
-kAD
-kAD
+rin
+rin
 maY
 maY
 maY
@@ -68810,7 +68844,7 @@ mkY
 mkY
 bce
 jxu
-aoX
+jxu
 mkY
 bce
 mkY
@@ -69495,8 +69529,8 @@ mHI
 uaa
 bLV
 hgg
-loZ
-kAD
+oPp
+rin
 kAD
 maY
 maY
@@ -69707,8 +69741,8 @@ eeZ
 eeZ
 nBd
 kAD
-kAD
-maY
+rin
+lHH
 maY
 maY
 maY
@@ -70558,8 +70592,8 @@ maY
 maY
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 maY
 uRA
@@ -70770,8 +70804,8 @@ maY
 maY
 luQ
 maY
-maY
-maY
+lHH
+lHH
 luQ
 sLx
 uRA
@@ -71190,8 +71224,8 @@ eeZ
 eeZ
 eeZ
 vJy
-maY
-maY
+lHH
+lHH
 maY
 maY
 maY
@@ -71402,8 +71436,8 @@ maY
 maY
 maY
 maY
-maY
-maY
+lHH
+lHH
 maY
 maY
 maY

--- a/code/game/area/daedalusprison.dm
+++ b/code/game/area/daedalusprison.dm
@@ -351,11 +351,13 @@
 
 /area/daedalusprison/inside/security/medsec
 	name = "Prison Medbay Security"
+	ceiling = CEILING_OBSTRUCTED
 
 /area/daedalusprison/inside/medical
 	name = "Prison Infirmary"
 	icon_state = "medbay"
 	minimap_color = MINIMAP_AREA_MEDBAY
+	ceiling = CEILING_OBSTRUCTED
 
 /area/daedalusprison/inside/medical/chemistry
 	name = "Prison Chemistry"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -113,7 +113,11 @@
 	base_icon_state = "darkfrostwall"
 	resistance_flags = PLASMACUTTER_IMMUNE|UNACIDABLE
 
+/turf/closed/mineral/smooth/darkfrostwall/cuttable
+	resistance_flags = UNACIDABLE
+
 /turf/closed/mineral/smooth/darkfrostwall/indestructible
+	name = "tough rock"
 	resistance_flags = RESIST_ALL
 	icon_state = "wall-invincible"
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -80,5 +80,5 @@ endmap
 
 
 map daedalusprison
-	minplayers 35
+	minplayers 50
 endmap


### PR DESCRIPTION

## About The Pull Request
Outskirt cave walls are actually cuttable now, the hull cave walls are now named "tough rock"
Removed two miners
Added more premaze
Medical is open to CAS, but cannot be landed in by tadpole
## Why It's Good For The Game
Hopefully makes the map a little better for Xenos, and makes the caves work more as intended.
## Changelog
:cl:
balance: Daedalus Prison: Removed two miners, more preweed, medical cannot be landed in by tad, and outskirt cave walls are actually pcable
spellcheck: Darkfrost hull walls are now named "tough rock"

/:cl:
