### PR TITLE
Defiler egg injecting qol + bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -324,6 +324,11 @@
 			span_xenodanger("Our stinger retracts, leaving the egg and little one alive."))
 		return fail_activate()
 
+	if(alien_egg.maturity_stage != alien_egg.stage_ready_to_burst)
+		alien_egg.balloon_alert(X, "Egg not mature")
+		return fail_activate()
+
+	alien_egg.balloon_alert_to_viewers("Injected")
 	succeed_activate()
 	add_cooldown()
 


### PR DESCRIPTION

## About The Pull Request

Feedback when you successfully inject the egg + you can no longer open the egg mid do_after to get a free hugger
## Why It's Good For The Game
qol good bug bad
## Changelog
:cl:
qol: Defiler egg injection has more feedback now
fix: Opening the defiler egg mid progress bar makes the injection fail
/:cl:
