### PR TITLE
Action visual fix

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -140,6 +140,7 @@
 		return
 	cooldown_timer = addtimer(CALLBACK(src, PROC_REF(on_cooldown_finish)), cooldown_length, TIMER_STOPPABLE)
 	button.add_overlay(visual_references[VREF_IMAGE_XENO_CLOCK])
+	update_button_icon()
 
 ///Time remaining on cooldown
 /datum/action/ability/proc/cooldown_remaining()


### PR DESCRIPTION

## About The Pull Request
Abilities weren't updating their icons by default on use (xenos separately just update all icons when they use plasma), leading to cooldown clocks etc not appearing.
## Why It's Good For The Game
Working visual good.
## Changelog
:cl:
fix: fixed abilities not updating their icon correctly on use in some cases
/:cl:
