### PR TITLE
Research Outpost is no longer votable if the gamemode is Nuclear War.

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -14,6 +14,9 @@
 #define MAP_GELIDA_IV "Gelida IV"
 #define MAP_DELTA_STATION "Delta Station"
 #define MAP_OSCAR_OUTPOST "Oscar Outpost"
+#define MAP_DESPARITY "Desparity"
+#define MAP_LAWANKA_OUTPOST "Lawanka Outpost"
+#define MAP_DAEDALUS_PRISON "Daedalus Prison"
 
 #define MAP_PILLAR_OF_SPRING "Pillar of Spring"
 #define MAP_SULACO "Sulaco"

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///If the gamemode has a whitelist of valid ground maps. Whitelist overrides the blacklist
 	var/list/whitelist_ground_maps
 	///If the gamemode has a blacklist of disallowed ground maps
-	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
+	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_RESEARCH_OUTPOST, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
 	///if fun tads are enabled by default
 	var/enable_fun_tads = FALSE
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. If the gamemode selected at the time (or in vote) is Crash, it can still be played. The only way it can be played is if someone votes Nuclear War in the lobby; which shouldn't usually happen, as pop drops most of the time after a vote.
## Why It's Good For The Game
This map is the worst of the worst when it comes to Nuclear War. The other crash maps (Icy Caves, Orion, Desparity) aren't great either, but somewhat(?) work for lowpop NW.
## Changelog
:cl:
del: Research Outpost is no longer votable when Nuclear War is selected.
/:cl:
