### PR TITLE
Kills BR's indoor APC's that controlled outside areas, splits up LZ 2 engi into two areas.

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -21,7 +21,6 @@
 /obj/machinery/door/airlock/mainship/research/glass/free_access{
 	name = "\improper Eta Lab Secure Storage"
 	},
-/obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "abb" = (
@@ -335,12 +334,10 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "afd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor,
-/area/bigredv2/outside/n)
+/area/bigredv2/outside/hydroponics)
 "afg" = (
 /obj/machinery/power/apc,
 /obj/structure/cable,
@@ -4581,6 +4578,7 @@
 	dir = 1;
 	name = "\improper Crew Habitation Complex"
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
 "aOV" = (
@@ -4716,7 +4714,6 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "aRj" = (
 /obj/structure/barricade/wooden,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
 "aRk" = (
@@ -5912,18 +5909,18 @@
 "bmv" = (
 /obj/structure/filingcabinet,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bmw" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bmx" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bmA" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/marking/asteroidwarning{
@@ -5951,7 +5948,7 @@
 "bmY" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bnb" = (
 /obj/machinery/door_control{
 	dir = 4;
@@ -6003,7 +6000,7 @@
 /obj/item/tool/lighter/zippo,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bnA" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	name = "\improper Atmospherics Condenser"
@@ -6214,7 +6211,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/filtration_plant)
 "bqp" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -6341,7 +6338,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bsY" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Atmospherics Condenser"
@@ -6377,12 +6374,12 @@
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "btu" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "btv" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -6400,7 +6397,7 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/filtration_plant)
 "btN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6427,7 +6424,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/filtration_plant)
 "bud" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
@@ -8258,6 +8255,10 @@
 	dir = 4
 	},
 /area/bigredv2/outside/space_port/two)
+"deg" = (
+/obj/structure/cable,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/ne)
 "dev" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 1
@@ -8380,7 +8381,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dun" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -8922,6 +8923,12 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"eGO" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "eHC" = (
 /obj/effect/turf_decal/sandedge/corner2{
 	dir = 8
@@ -9007,12 +9014,9 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
 "ePH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/e)
 "ePI" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/caves/west)
@@ -9648,6 +9652,9 @@
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"gnk" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering/east)
 "gpg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -9861,7 +9868,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "gLv" = (
 /obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
@@ -10191,9 +10198,10 @@
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
 "htK" = (
+/obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
+/area/bigredv2/outside/hydroponics)
 "hvP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -10560,7 +10568,7 @@
 "iup" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "iwo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -10922,10 +10930,9 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "jfc" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
+/area/bigredv2/outside/filtration_plant)
 "jfy" = (
 /obj/machinery/light{
 	dir = 1
@@ -11487,11 +11494,12 @@
 /turf/open/floor,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "kjl" = (
-/obj/effect/spawner/random/misc/structure/supplycrate,
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/marking/bot,
-/area/bigredv2/outside/s)
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/e)
 "kkj" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -11603,6 +11611,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"kzT" = (
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "kAz" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -12065,6 +12076,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
+"lLa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "lLi" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -12682,7 +12698,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "niU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -12736,7 +12752,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/filtration_plant)
 "nnD" = (
 /obj/machinery/door_control{
 	id = "Marshal Offices";
@@ -12823,10 +12839,12 @@
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
 "nux" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/dorms)
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/ne)
 "nuy" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -13178,7 +13196,7 @@
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "olw" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -13230,7 +13248,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "orX" = (
 /obj/machinery/light{
 	dir = 4
@@ -13409,6 +13427,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
+"oJW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/n)
 "oKE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -13750,7 +13776,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "pJP" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -13804,6 +13830,10 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"pPI" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "pPJ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -14479,6 +14509,11 @@
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/dorms)
+"rqt" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/ne)
 "rrc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14724,11 +14759,14 @@
 	},
 /area/bigredv2/outside/nw)
 "rSn" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
-	dir = 1
+	crash_break_probability = 100
 	},
-/turf/open/floor/wood,
+/turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
 "rSL" = (
 /obj/structure/girder/reinforced,
@@ -14894,7 +14932,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "sqr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -14980,6 +15018,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"sBN" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "sDV" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
@@ -15171,7 +15214,6 @@
 "tdx" = (
 /obj/item/trash/candy,
 /obj/effect/landmark/weed_node,
-/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "tdC" = (
@@ -15252,6 +15294,9 @@
 	dir = 9
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
+"tpg" = (
+/turf/closed/wall,
+/area/bigredv2/outside/engineering/east)
 "tpG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -15796,7 +15841,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "uwD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -16010,6 +16055,12 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
+"uVx" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "\improper Engineering Complex"
+	},
+/turf/open/floor,
+/area/bigredv2/outside/filtration_plant)
 "uWz" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor,
@@ -16468,7 +16519,7 @@
 /obj/item/trash/kepler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "vSH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17087,7 +17138,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xrC" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 1
@@ -17104,7 +17155,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xsS" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -17120,11 +17171,11 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "xuc" = (
 /obj/machinery/power/apc/drained{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/ne)
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/s)
 "xue" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning,
@@ -34431,11 +34482,11 @@ sGO
 lKw
 wzM
 aMc
-blJ
+gnk
 btu
-uNS
+pPI
 dst
-fRt
+sBN
 aaa
 aaa
 aaa
@@ -34648,11 +34699,11 @@ wzM
 lKw
 wzM
 aMc
-blJ
+gnk
 btr
-uNS
-tOJ
-tOJ
+pPI
+lLa
+lLa
 aaa
 aaa
 aaa
@@ -34865,7 +34916,7 @@ wzM
 lKw
 wzM
 vYw
-blJ
+gnk
 bmv
 xsz
 uwr
@@ -35082,7 +35133,7 @@ wzM
 lKw
 wzM
 tCk
-blJ
+gnk
 bmw
 gKZ
 vSs
@@ -35299,11 +35350,11 @@ sGO
 lKw
 wzM
 vYw
-blJ
+gnk
 bmx
 iup
 bnz
-bob
+eGO
 aaa
 aaa
 aaa
@@ -35516,11 +35567,11 @@ oxP
 wzM
 oxP
 vYw
-blJ
-bmk
+gnk
+tpg
 bmY
 bmY
-bmk
+tpg
 aaa
 aaa
 aaa
@@ -35734,9 +35785,9 @@ aFM
 qDk
 fHv
 bsX
-hwc
-hwc
-hwc
+kzT
+kzT
+kzT
 orP
 aaa
 aaa
@@ -36167,11 +36218,11 @@ xsS
 vBu
 vBu
 gaV
-blJ
-blJ
-blJ
-blJ
-blJ
+gnk
+gnk
+gnk
+gnk
+gnk
 aaa
 aaa
 aaa
@@ -37266,12 +37317,12 @@ wzM
 oxP
 oxP
 oxP
-bmk
-bmq
-bmq
-hwc
-ePH
-bmk
+bkt
+bmK
+bmK
+bkE
+bnC
+bkt
 wMP
 vJR
 hLG
@@ -37483,12 +37534,12 @@ yhc
 wzM
 oxP
 djb
-bmk
-bmq
+bkt
+bmK
 bqo
-hwc
+bkE
 btJ
-bmk
+bkt
 xOD
 kCz
 hLG
@@ -37700,10 +37751,10 @@ wzM
 oxP
 oxP
 vNZ
-bsX
-hwc
-udg
-xzw
+uVx
+bkE
+jfc
+wOA
 nmV
 bua
 nrC
@@ -37917,12 +37968,12 @@ oxP
 oxP
 oxP
 aMc
-hwc
-hwc
-hwc
-hwc
-ePH
-uNS
+bkE
+bkE
+bkE
+bkE
+bnC
+bqp
 dQy
 btv
 btv
@@ -38269,7 +38320,7 @@ acp
 acp
 acp
 acp
-aqJ
+oJW
 waY
 waY
 asH
@@ -38285,7 +38336,7 @@ asH
 gfD
 iPs
 asH
-afd
+boy
 aCP
 asH
 aEK
@@ -38371,7 +38422,7 @@ hLG
 bvp
 jNI
 jNI
-jNI
+xuc
 dQy
 jNI
 mRs
@@ -38502,7 +38553,7 @@ asH
 uUl
 atY
 asH
-nux
+dur
 aCO
 asH
 aCO
@@ -38806,7 +38857,7 @@ xuH
 jNI
 mRs
 kEl
-htK
+uFI
 uFI
 elE
 mRs
@@ -38936,7 +38987,7 @@ aaa
 waj
 asJ
 asJ
-nux
+dur
 asJ
 jaB
 dur
@@ -39023,7 +39074,7 @@ bvp
 jNI
 mRs
 kEl
-jfc
+jgh
 pXY
 abX
 mRs
@@ -39239,8 +39290,8 @@ vJR
 bvp
 eOX
 mRs
-kjl
-htK
+kEl
+uFI
 uFI
 foK
 mRs
@@ -43943,7 +43994,7 @@ aKx
 aKx
 aEO
 aEO
-rSn
+aEO
 azb
 aTh
 fXC
@@ -44379,7 +44430,7 @@ aKx
 aEO
 xjO
 azb
-aTh
+rSn
 oxP
 aMc
 eBA
@@ -45241,7 +45292,7 @@ arD
 aKB
 aCc
 ulB
-apo
+nux
 apo
 aBv
 sEz
@@ -45458,11 +45509,11 @@ arD
 aKB
 gsc
 ulB
-apo
-jdG
+deg
+rqt
 aOU
-xMA
-vDA
+afd
+htK
 aOU
 aTk
 tWT
@@ -46101,7 +46152,7 @@ aaa
 aaa
 sEz
 aCf
-xuc
+sEz
 aCf
 aBv
 aIw
@@ -52846,9 +52897,9 @@ aTq
 onZ
 aOl
 xHO
-xHO
-xHO
-xHO
+kjl
+ePH
+ePH
 uXp
 aaa
 aaa

--- a/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
@@ -1,4 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ae" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"ai" = (
+/obj/structure/table,
+/obj/item/tool/lighter/random,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "aN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -13,7 +22,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bJ" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -36,35 +45,52 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"cL" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "cO" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
 "cT" = (
 /obj/machinery/vending/snack,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "da" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "db" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"ds" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "rad_door";
+	name = "\improper Radiation Shielding"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
 "dB" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -87,7 +113,11 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"fW" = (
+/obj/structure/closet/radiation,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -97,6 +127,13 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"hr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "hx" = (
 /obj/machinery/shower{
 	dir = 8
@@ -107,7 +144,7 @@
 "hG" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ik" = (
 /obj/structure/sign/safety/hazard,
 /turf/open/floor,
@@ -116,11 +153,11 @@
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "iV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -128,7 +165,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jc" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/s)
@@ -139,7 +176,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jn" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -161,7 +198,7 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -190,20 +227,20 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "kZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "lc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "lr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
@@ -211,7 +248,7 @@
 "lE" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "mo" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -227,7 +264,7 @@
 "nf" = (
 /obj/machinery/computer/area_atmos,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "nl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/breath,
@@ -249,6 +286,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"pu" = (
+/turf/closed/wall,
+/area/bigredv2/outside/engineering/east)
 "pC" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -258,23 +298,27 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qe" = (
 /obj/structure/table,
 /obj/item/tool/lighter/random,
 /obj/item/lightreplacer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qg" = (
 /obj/structure/closet/radiation,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"qi" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "qq" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -285,7 +329,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -304,7 +348,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "rq" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
@@ -319,7 +363,7 @@
 "sk" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "sH" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/sw)
@@ -327,7 +371,15 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"td" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/electronics{
@@ -338,7 +390,7 @@
 "tQ" = (
 /obj/item/tool/multitool,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tW" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /obj/machinery/door/poddoor/mainship{
@@ -352,7 +404,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"uA" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "uJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -391,18 +448,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "wL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "wT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "wW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
@@ -413,6 +470,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"xh" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "xm" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor,
@@ -422,7 +484,7 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xG" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
@@ -435,20 +497,28 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yi" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"yk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "yn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -457,7 +527,7 @@
 "zl" = (
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "zn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -479,13 +549,13 @@
 "zR" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Aa" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "At" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -496,13 +566,13 @@
 /area/bigredv2/outside/engineering)
 "AJ" = (
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "BG" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "BH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -516,18 +586,18 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Cn" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "CU" = (
 /obj/machinery/light{
 	dir = 1
@@ -537,11 +607,18 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Em" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
 "Ev" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
 	},
 /area/bigredv2/outside/sw)
+"Ft" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering/east)
 "Fz" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -566,7 +643,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "FJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -610,12 +687,18 @@
 	},
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"GA" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "GD" = (
 /obj/structure/table,
 /obj/item/tool/analyzer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "GE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -640,23 +723,29 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Iu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "IK" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "IS" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/earmuffs,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Jb" = (
 /obj/machinery/vending/cola,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "JM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -671,7 +760,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "JS" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor,
@@ -689,17 +778,17 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ko" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "KI" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal{
@@ -722,7 +811,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ln" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/sw)
@@ -735,7 +824,7 @@
 /obj/machinery/computer/atmos_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "LO" = (
 /obj/effect/landmark/corpsespawner/engineer{
 	corpseback = /obj/item/storage/backpack;
@@ -745,7 +834,11 @@
 	name = "Colonist Ted Jarka"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"Ma" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Md" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -757,10 +850,10 @@
 	name = "\improper Engine Reactor Control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Mq" = (
 /turf/open/liquid/water/river,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Nb" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor,
@@ -791,7 +884,7 @@
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ol" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/machinery/machine_frame,
@@ -802,7 +895,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "OB" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
@@ -825,7 +918,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ql" = (
 /obj/machinery/bot/mulebot,
 /turf/open/floor,
@@ -833,24 +926,31 @@
 "Qo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"QE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "QY" = (
 /turf/closed/wall/mineral/gold,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ro" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "SC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -863,7 +963,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "TD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -886,7 +986,7 @@
 "Ud" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Uf" = (
 /turf/closed/wall,
 /area/bigredv2/outside/engineering)
@@ -898,14 +998,14 @@
 	name = "Reactor Radiation Shielding control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "UJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "UO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
@@ -917,7 +1017,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Va" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -931,7 +1031,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "VC" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
@@ -949,7 +1049,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Wq" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -961,7 +1061,12 @@
 	name = "Storm Shutters"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"WK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Xa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/weldpack,
@@ -980,7 +1085,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"YN" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"YP" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Zc" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -988,12 +1104,12 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Zn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/hazard,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Zp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1010,6 +1126,13 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Zs" = (
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"Zx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ZJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1020,13 +1143,17 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"ZM" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ZV" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 
 (1,1,1) = {"
 hx
@@ -1157,19 +1284,19 @@ bJ
 xG
 xG
 xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
 nP
 nP
 "}
@@ -1198,7 +1325,7 @@ IK
 Qo
 Qo
 AJ
-xG
+Ft
 nP
 nP
 "}
@@ -1227,8 +1354,8 @@ dW
 Qo
 Qo
 Ko
-xG
-xG
+Ft
+Ft
 nP
 "}
 (8,1,1) = {"
@@ -1257,7 +1384,7 @@ Qo
 Qo
 AJ
 AJ
-xG
+Ft
 nP
 "}
 (9,1,1) = {"
@@ -1286,8 +1413,8 @@ Mq
 Mq
 Mq
 AJ
-xG
-xG
+Ft
+Ft
 "}
 (10,1,1) = {"
 vr
@@ -1316,7 +1443,7 @@ QY
 Mq
 wT
 zR
-xG
+Ft
 "}
 (11,1,1) = {"
 lr
@@ -1345,7 +1472,7 @@ Mq
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (12,1,1) = {"
 UO
@@ -1374,7 +1501,7 @@ QY
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (13,1,1) = {"
 wZ
@@ -1382,14 +1509,14 @@ jR
 bJ
 Gu
 UO
-Uf
-Uf
-Uf
+pu
+pu
+pu
 Ml
-Uf
-Uf
-xG
-xG
+pu
+pu
+Ft
+Ft
 Mq
 Mq
 Mq
@@ -1403,7 +1530,7 @@ Mq
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (14,1,1) = {"
 vr
@@ -1411,14 +1538,14 @@ Pz
 Uf
 JM
 Nb
-Uf
+pu
 Gy
-Pz
-vr
-vr
-Nb
+uA
+Zs
+Zs
+ae
 iS
-tW
+ds
 Mq
 QY
 Mq
@@ -1432,7 +1559,7 @@ QY
 Mq
 wT
 AJ
-xG
+Ft
 "}
 (15,1,1) = {"
 vr
@@ -1440,14 +1567,14 @@ Nn
 bJ
 Gu
 qF
-Uf
-vr
+pu
+Zs
 PK
-vr
-UO
+Zs
+Zx
 Ud
-Pz
-tW
+uA
+ds
 Mq
 Mq
 Mq
@@ -1461,7 +1588,7 @@ Mq
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (16,1,1) = {"
 Pz
@@ -1474,9 +1601,9 @@ pZ
 pZ
 Sl
 wF
-Wq
+qi
 JO
-tW
+ds
 Mq
 QY
 Mq
@@ -1490,7 +1617,7 @@ QY
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (17,1,1) = {"
 Uf
@@ -1498,14 +1625,14 @@ Uf
 Uf
 CU
 Ib
-Uf
-UO
-UO
-vr
-UO
+pu
+Zx
+Zx
+Zs
+Zx
 Ud
 GD
-tW
+ds
 Mq
 Mq
 Mq
@@ -1519,22 +1646,22 @@ Mq
 Mq
 AJ
 hG
-xG
+Ft
 "}
 (18,1,1) = {"
 zl
-bJ
+Em
 Kn
-GE
-UO
-Uf
-vr
+hr
+Zx
+pu
+Zs
 Um
-vr
-vr
-vr
+Zs
+Zs
+Zs
 Lz
-tW
+ds
 Mq
 QY
 Mq
@@ -1548,22 +1675,22 @@ QY
 Mq
 wT
 AJ
-xG
+Ft
 "}
 (19,1,1) = {"
-Wq
+qi
 jy
 LO
-ZJ
+Iu
 WA
-Uf
-Uf
-Uf
+pu
+pu
+pu
 Ml
-Uf
-Uf
-xG
-xG
+pu
+pu
+Ft
+Ft
 Mq
 Mq
 Mq
@@ -1577,21 +1704,21 @@ Mq
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (20,1,1) = {"
-pC
-bJ
-vr
-ZJ
-UO
-vr
-vr
+xh
+Em
+Zs
+Iu
+Zx
+Zs
+Zs
 Kn
-ZL
-UO
-vr
-tW
+Ma
+Zx
+Zs
+ds
 Mq
 Mq
 QY
@@ -1606,21 +1733,21 @@ QY
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (21,1,1) = {"
-jF
+YP
 Ll
-jF
+YP
 qq
 ZV
 NN
 NN
-UO
-xm
-UO
-vr
-tW
+Zx
+ZM
+Zx
+Zs
+ds
 Mq
 Mq
 Mq
@@ -1635,21 +1762,21 @@ Mq
 Mq
 AJ
 AJ
-xG
+Ft
 "}
 (22,1,1) = {"
-vr
-bJ
-vr
-JM
+Zs
+Em
+Zs
+td
 BG
-ks
+GA
 qe
-Ht
-vr
-vr
-ZL
-tW
+WK
+Zs
+Zs
+Ma
+ds
 Mq
 Mq
 QY
@@ -1664,21 +1791,21 @@ QY
 Mq
 wT
 zR
-xG
+Ft
 "}
 (23,1,1) = {"
-Uf
-Uf
+pu
+pu
 lE
 YK
 sS
 IS
-jR
-vr
-vr
-vr
+ai
+Zs
+Zs
+Zs
 nf
-xG
+Ft
 Mq
 Mq
 Mq
@@ -1692,22 +1819,22 @@ Mq
 Mq
 Mq
 AJ
-xG
-xG
+Ft
+Ft
 "}
 (24,1,1) = {"
-UO
+Zx
 lc
-vr
+Zs
 YK
 db
 db
 db
-UO
+Zx
 up
-xG
-xG
-xG
+Ft
+Ft
+Ft
 wT
 AJ
 AJ
@@ -1729,8 +1856,8 @@ wL
 Op
 kx
 Zc
-jF
-jF
+cL
+YP
 CA
 UV
 kZ
@@ -1749,23 +1876,23 @@ qy
 AJ
 AJ
 wT
-xG
+Ft
 xG
 ek
 "}
 (26,1,1) = {"
-xG
-xG
-xG
-xG
-xG
+Ft
+Ft
+Ft
+Ft
+Ft
 sk
 yn
 Vq
 Zn
-xG
-qg
-xG
+Ft
+fW
+Ft
 AJ
 Ko
 Aa
@@ -1778,7 +1905,7 @@ Aa
 wT
 AJ
 AJ
-xG
+Ft
 ek
 uN
 "}
@@ -1787,27 +1914,27 @@ Nr
 Nr
 Nr
 Nr
-xG
-xG
+Ft
+Ft
 Cn
-Zp
+yk
 bp
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
 uN
 uN
 "}
@@ -1817,16 +1944,16 @@ OB
 OB
 OB
 OB
-xG
+Ft
 cT
 Ro
-Md
-jF
-jF
-jF
-jF
+YN
+YP
+YP
+YP
+YP
 jb
-xG
+Ft
 TK
 Xp
 Xp
@@ -1846,16 +1973,16 @@ OB
 kf
 OB
 OB
-xG
+Ft
 Jb
-vr
+Zs
 re
-TO
-UO
-vr
-ZL
+QE
+Zx
+Zs
+Ma
 UJ
-xG
+Ft
 Xp
 Xp
 Xp
@@ -1875,16 +2002,16 @@ OB
 OB
 OB
 OB
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-vr
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Zs
 FH
-xG
+Ft
 Xp
 Xp
 HL

--- a/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /obj/machinery/vending/snack,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ax" = (
 /obj/machinery/door_control{
 	dir = 1;
@@ -10,7 +10,7 @@
 	name = "Storm Shutters"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bb" = (
 /obj/structure/rack,
 /obj/item/camera_film,
@@ -35,6 +35,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/engineering)
+"ck" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "cD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
@@ -64,7 +72,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dY" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -75,7 +83,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "en" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -99,18 +107,22 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "eC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "fr" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"gb" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/electronics{
@@ -151,15 +163,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "hV" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ib" = (
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "iu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -176,7 +188,7 @@
 	name = "\improper Engine Reactor Control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/machinery/machine_frame,
@@ -230,12 +242,15 @@
 /obj/item/tool/pen,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"mV" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering/east)
 "nC" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "oq" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -259,6 +274,13 @@
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"pX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "pZ" = (
 /obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /obj/effect/decal/cleanable/dirt,
@@ -299,29 +321,38 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "su" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"sw" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"sL" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/earmuffs,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -336,6 +367,12 @@
 "tV" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/s)
+"ua" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "uk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
@@ -378,7 +415,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"wr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "wt" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -409,7 +452,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yb" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -418,15 +461,23 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yf" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/sw)
+"yz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "yB" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "zj" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -442,6 +493,9 @@
 	dir = 1
 	},
 /area/bigredv2/caves/southwest)
+"Ao" = (
+/turf/closed/wall,
+/area/bigredv2/outside/engineering/east)
 "At" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for opening the engines blast doors.";
@@ -450,13 +504,13 @@
 	name = "Reactor Radiation Shielding control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ax" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Az" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -473,7 +527,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "AS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -490,6 +544,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"BF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Ca" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -504,7 +562,7 @@
 /obj/item/tool/lighter/random,
 /obj/item/lightreplacer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "CS" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 5
@@ -519,7 +577,7 @@
 "Dx" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "DH" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor,
@@ -558,11 +616,16 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Fy" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/caves/southwest)
+"Gc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Ge" = (
 /obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
@@ -574,18 +637,25 @@
 "Gp" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Gv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Gw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "GE" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "GH" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
@@ -610,7 +680,7 @@
 	name = "Colonist Ted Jarka"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Jb" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 9
@@ -659,12 +729,12 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "KV" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "LF" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
@@ -676,6 +746,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/s)
+"LU" = (
+/obj/structure/table,
+/obj/item/tool/lighter/random,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "MD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -700,7 +775,7 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "NQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/electronics{
@@ -727,15 +802,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ow" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "OF" = (
 /obj/machinery/computer/area_atmos,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "OH" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 8
@@ -744,21 +819,21 @@
 "OK" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ON" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Pc" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Pp" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 4
@@ -773,7 +848,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Qn" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -789,13 +864,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Qv" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"QC" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -815,7 +895,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "SP" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -836,14 +916,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "TL" = (
 /obj/machinery/power/monitor{
 	name = "Main Power Grid Monitoring"
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "UB" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -851,7 +931,7 @@
 	},
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "US" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -860,7 +940,7 @@
 /obj/structure/table,
 /obj/item/tool/analyzer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -883,13 +963,21 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "VL" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/rock)
+"Wi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Wo" = (
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Ww" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "WD" = (
 /obj/machinery/light{
 	dir = 1
@@ -909,20 +997,37 @@
 	dir = 1
 	},
 /area/bigredv2/caves/southwest)
+"XN" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Yq" = (
 /obj/machinery/vending/cola,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Yy" = (
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"YE" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "YG" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 4
 	},
 /area/bigredv2/caves/southwest)
+"Zq" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
 "Zt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -936,7 +1041,13 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"ZK" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ZV" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -1300,13 +1411,13 @@ bN
 wt
 Ie
 Jv
-Pt
-Pt
-Pt
+Ao
+Ao
+Ao
 jf
-Pt
-Pt
-GH
+Ao
+Ao
+mV
 LF
 LF
 Gh
@@ -1329,13 +1440,13 @@ wW
 Pt
 Oa
 DH
-Pt
+Ao
 UB
-wW
-Wo
-DH
+YE
+ib
+sw
 yB
-GH
+mV
 LF
 LF
 LF
@@ -1358,13 +1469,13 @@ zj
 wt
 Ie
 qO
-Pt
-Wo
+Ao
+ib
 Qv
-Jv
+Wi
 Ow
-wW
-GH
+YE
+mV
 LF
 LF
 LF
@@ -1391,9 +1502,9 @@ yb
 eC
 eC
 wo
-Jq
+gb
 TL
-GH
+mV
 LF
 LF
 LF
@@ -1416,13 +1527,13 @@ Pt
 Pt
 WD
 cD
-Pt
-Jv
-Jv
-Jv
+Ao
+Wi
+Wi
+Wi
 Ow
 Vj
-GH
+mV
 LF
 LF
 LF
@@ -1441,17 +1552,17 @@ su
 "}
 (18,1,1) = {"
 Yy
-wt
+Zq
 Sv
-tK
-Jv
-Pt
+pX
+Wi
+Ao
 ib
 At
-Wo
-Wo
+ib
+ib
 hV
-GH
+mV
 LF
 LF
 LF
@@ -1469,18 +1580,18 @@ qm
 su
 "}
 (19,1,1) = {"
-Jq
+gb
 GE
 Ih
-Ds
+ua
 ax
-Pt
-Pt
-Pt
+Ao
+Ao
+Ao
 jf
-Pt
-Pt
-GH
+Ao
+Ao
+mV
 LF
 LF
 Gh
@@ -1498,18 +1609,18 @@ Bi
 su
 "}
 (20,1,1) = {"
-SP
-wt
-Wo
-Ds
-Jv
-Wo
-Wo
+QC
+Zq
+ib
+ua
+Wi
+ib
+ib
 Sv
-Vv
-Jv
-Wo
-GH
+BF
+Wi
+ib
+mV
 LF
 Gh
 Gh
@@ -1527,18 +1638,18 @@ su
 su
 "}
 (21,1,1) = {"
-JU
+sL
 eu
-JU
+sL
 sZ
 TD
 fr
 fr
-Jv
-dv
-Jv
-Wo
-GH
+Wi
+Ww
+Wi
+ib
+mV
 LF
 ox
 Gh
@@ -1556,18 +1667,18 @@ Bn
 su
 "}
 (22,1,1) = {"
-Wo
-wt
-Wo
-Oa
+ib
+Zq
+ib
+XN
 nC
-jG
+ZK
 CN
-DO
-Wo
-Wo
-Vv
-GH
+Gc
+ib
+ib
+BF
+mV
 LF
 Gh
 Tg
@@ -1585,18 +1696,18 @@ Al
 su
 "}
 (23,1,1) = {"
-Pt
-Pt
+Ao
+Ao
 Gp
 Of
 KV
 tt
-bN
-Wo
-Wo
-Wo
+LU
+ib
+ib
+ib
 OF
-GH
+mV
 LF
 Gh
 Gh
@@ -1614,18 +1725,18 @@ Al
 su
 "}
 (24,1,1) = {"
-Jv
+Wi
 Px
-Wo
+ib
 Of
 eh
 eh
 eh
-Jv
-Jv
-Wo
-Wo
-GH
+Wi
+Wi
+ib
+ib
+mV
 LF
 LF
 Gh
@@ -1647,14 +1758,14 @@ ZJ
 Ax
 xP
 KS
-JU
-JU
+yz
+sL
 Pc
 Qt
 NA
-Jq
-Jq
-GH
+gb
+gb
+mV
 VL
 LF
 LF
@@ -1672,18 +1783,18 @@ su
 qm
 "}
 (26,1,1) = {"
-GH
-GH
-GH
-GH
-GH
+mV
+mV
+mV
+mV
+mV
 Dx
 ON
 Fq
-Jv
-Wo
-Wo
-GH
+Wi
+ib
+ib
+mV
 VL
 VL
 LF
@@ -1706,16 +1817,16 @@ cL
 cL
 cL
 GH
-GH
+mV
 OK
-en
+ck
 AQ
-Wo
-Wo
-GH
-GH
-GH
-GH
+ib
+ib
+mV
+mV
+mV
+mV
 LF
 LF
 LF
@@ -1735,16 +1846,16 @@ xH
 xH
 xH
 xH
-GH
+mV
 aa
 hL
-Sg
-JU
-JU
-JU
-JU
+wr
+sL
+sL
+sL
+sL
 dw
-GH
+mV
 LF
 LF
 wm
@@ -1764,16 +1875,16 @@ xH
 Ca
 xH
 xH
-GH
+mV
 Yq
-Wo
+ib
 VI
-bq
-Jv
-Wo
-Vv
+Gw
+Wi
+ib
+BF
 tv
-GH
+mV
 wm
 wm
 wm
@@ -1793,16 +1904,16 @@ xH
 xH
 xH
 xH
-GH
-GH
-GH
-GH
-GH
-GH
-GH
-Wo
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+ib
 sg
-GH
+mV
 wm
 lo
 Jb

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -5,13 +5,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "aU" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -31,7 +31,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
@@ -56,7 +56,7 @@
 "cQ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "de" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -72,7 +72,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dp" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
@@ -81,7 +81,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dY" = (
 /obj/machinery/light{
 	dir = 8
@@ -89,13 +89,13 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ea" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/liquid/water/river,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -104,30 +104,46 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "eQ" = (
 /obj/structure/table,
 /obj/item/tool/lighter/random,
 /obj/item/lightreplacer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"eR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"fe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "fK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "gx" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "gy" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -139,7 +155,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "gH" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
@@ -148,7 +164,11 @@
 "hj" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"ho" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "hJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -166,10 +186,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ix" = (
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "iT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
@@ -196,7 +216,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jR" = (
 /obj/machinery/light{
 	dir = 1
@@ -242,7 +262,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/hazard,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ma" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -250,13 +270,21 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "nz" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "nR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/electronics{
@@ -264,6 +292,9 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"nV" = (
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "nZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
@@ -274,7 +305,7 @@
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "op" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
@@ -288,13 +319,17 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "oP" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"oX" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
 "pa" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -303,7 +338,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "pE" = (
 /obj/structure/sign/safety/hazard,
 /turf/open/floor,
@@ -316,7 +351,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qg" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -330,7 +365,7 @@
 "qi" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -343,7 +378,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -354,7 +389,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "qT" = (
 /obj/structure/closet/radiation,
 /turf/open/floor,
@@ -367,11 +402,16 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"rG" = (
+/obj/structure/table,
+/obj/item/tool/lighter/random,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "rK" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "rM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -396,6 +436,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"sK" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "tc" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -409,7 +454,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -446,13 +491,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "uP" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/liquid/water/river,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "uU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor,
@@ -468,7 +513,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "vv" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -478,14 +523,14 @@
 "vw" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "vR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "we" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -512,7 +557,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "wY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal{
@@ -528,13 +573,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xk" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xu" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/s)
@@ -543,7 +588,7 @@
 	name = "\improper Engine Reactor Control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yi" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/outside/s)
@@ -553,20 +598,24 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"yD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "yN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yQ" = (
 /obj/item/tool/multitool,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yR" = (
 /obj/machinery/computer/area_atmos,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yS" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
@@ -581,7 +630,7 @@
 "zt" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "zx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
@@ -599,16 +648,30 @@
 "zN" = (
 /obj/machinery/vending/snack,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Am" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Ay" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "AT" = (
 /obj/structure/sign/safety/high_radiation,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Bc" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"Bg" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "BK" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor,
@@ -621,7 +684,7 @@
 /obj/effect/spawner/random/misc/earmuffs,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Cx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -646,11 +709,31 @@
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"DO" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"DZ" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "rad_door";
+	name = "\improper Radiation Shielding"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
+"Eq" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Ex" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "EV" = (
 /turf/closed/wall,
 /area/bigredv2/outside/engineering)
@@ -669,13 +752,13 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "FY" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Gl" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/sw)
@@ -686,12 +769,12 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "GE" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "GG" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -702,10 +785,10 @@
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Hk" = (
 /turf/open/liquid/water/river,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Hz" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 9
@@ -717,13 +800,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "HK" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "HO" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -736,30 +819,41 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "HX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ib" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
 "Ic" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Jk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Ke" = (
+/obj/structure/closet/radiation,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Kv" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"KP" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Lm" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -768,16 +862,19 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"Lx" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering/east)
 "Ly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Mk" = (
 /turf/closed/wall/mineral/gold,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Mr" = (
 /obj/effect/landmark/corpsespawner/engineer{
 	corpseback = /obj/item/storage/backpack;
@@ -787,17 +884,17 @@
 	name = "Colonist Ted Jarka"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "MJ" = (
 /obj/structure/table,
 /obj/item/tool/analyzer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Nh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Np" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -821,7 +918,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Os" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -844,6 +941,13 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"OS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Pk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/machinery/machine_frame,
@@ -860,7 +964,7 @@
 	name = "Storm Shutters"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "PB" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -878,7 +982,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "QH" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor,
@@ -886,7 +996,7 @@
 "QO" = (
 /obj/machinery/vending/cola,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "QT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -917,15 +1027,15 @@
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "RD" = (
 /obj/machinery/power/geothermal/bigred,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "RW" = (
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Si" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
@@ -944,7 +1054,7 @@
 	},
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Tt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -964,6 +1074,13 @@
 /obj/item/tool/analyzer,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"UM" = (
+/turf/closed/wall,
+/area/bigredv2/outside/engineering/east)
+"Vk" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Vy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/weldpack,
@@ -980,30 +1097,40 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Ww" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "WA" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Xe" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "XF" = (
 /obj/machinery/power/monitor{
 	name = "Main Power Grid Monitoring"
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "XS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"XZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Yk" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for opening the engines blast doors.";
@@ -1012,7 +1139,7 @@
 	name = "Reactor Radiation Shielding control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "YJ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1036,7 +1163,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ZE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/powercell,
@@ -1180,19 +1307,19 @@ GG
 Ib
 Ib
 Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
 op
 op
 "}
@@ -1221,7 +1348,7 @@ WA
 yN
 yN
 ix
-Ib
+Lx
 op
 op
 "}
@@ -1250,8 +1377,8 @@ XS
 yN
 yN
 Od
-Ib
-Ib
+Lx
+Lx
 op
 "}
 (8,1,1) = {"
@@ -1280,7 +1407,7 @@ yN
 yN
 ix
 ix
-Ib
+Lx
 op
 "}
 (9,1,1) = {"
@@ -1309,8 +1436,8 @@ Hk
 Hk
 Hk
 ix
-Ib
-Ib
+Lx
+Lx
 "}
 (10,1,1) = {"
 lU
@@ -1339,7 +1466,7 @@ Mk
 Hk
 hj
 Xe
-Ib
+Lx
 "}
 (11,1,1) = {"
 Nz
@@ -1368,7 +1495,7 @@ Hk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (12,1,1) = {"
 nZ
@@ -1397,7 +1524,7 @@ Mk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (13,1,1) = {"
 wv
@@ -1405,14 +1532,14 @@ CS
 GG
 Ri
 nZ
-EV
-EV
-EV
+UM
+UM
+UM
 xT
-EV
-EV
-Ib
-Ib
+UM
+UM
+Lx
+Lx
 Hk
 Hk
 Hk
@@ -1426,7 +1553,7 @@ Hk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (14,1,1) = {"
 lU
@@ -1434,20 +1561,20 @@ HO
 EV
 kV
 BK
-EV
+UM
 ST
-HO
-lU
-lU
-BK
+sK
+nV
+nV
+Vk
 Rl
-wL
+DZ
 Hk
 Mk
 Hk
 Ex
 ix
-Ib
+Lx
 ix
 ix
 Hk
@@ -1455,7 +1582,7 @@ Mk
 Hk
 hj
 ix
-Ib
+Lx
 "}
 (15,1,1) = {"
 lU
@@ -1463,14 +1590,14 @@ Wq
 GG
 Ri
 iT
-EV
-lU
+UM
+nV
 dI
-lU
-nZ
+nV
+ho
 Ic
-HO
-wL
+sK
+DZ
 Hk
 Hk
 Hk
@@ -1484,7 +1611,7 @@ Hk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (16,1,1) = {"
 HO
@@ -1497,9 +1624,9 @@ vj
 vj
 jG
 ee
-SK
+Bc
 XF
-wL
+DZ
 Hk
 Mk
 Hk
@@ -1513,7 +1640,7 @@ Mk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (17,1,1) = {"
 EV
@@ -1521,14 +1648,14 @@ EV
 EV
 jR
 bB
-EV
-nZ
-nZ
-lU
-nZ
+UM
+ho
+ho
+nV
+ho
 Ic
 MJ
-wL
+DZ
 Hk
 Hk
 Hk
@@ -1542,28 +1669,28 @@ Hk
 Hk
 ix
 HX
-Ib
+Lx
 "}
 (18,1,1) = {"
 RW
-GG
+oX
 HK
-vi
-nZ
-EV
-lU
+KP
+ho
+UM
+nV
 Yk
-lU
-lU
-lU
+nV
+nV
+nV
 rK
-wL
+DZ
 Hk
 Mk
 Hk
 Ex
 ix
-Ib
+Lx
 ix
 ix
 Hk
@@ -1571,22 +1698,22 @@ Mk
 Hk
 hj
 ix
-Ib
+Lx
 "}
 (19,1,1) = {"
-SK
+Bc
 xk
 Mr
-Jk
+Qe
 Pz
-EV
-EV
-EV
+UM
+UM
+UM
 xT
-EV
-EV
-Ib
-Ib
+UM
+UM
+Lx
+Lx
 Hk
 Hk
 Hk
@@ -1600,21 +1727,21 @@ Hk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (20,1,1) = {"
-CL
-GG
-lU
-Jk
-nZ
-lU
-lU
+DO
+oX
+nV
+Qe
+ho
+nV
+nV
 HK
-Am
-nZ
-lU
-wL
+yD
+ho
+nV
+DZ
 Hk
 Hk
 Mk
@@ -1629,21 +1756,21 @@ Mk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (21,1,1) = {"
-hQ
+Ww
 xc
-hQ
+Ww
 FY
 HF
 nz
 nz
-nZ
-kS
-nZ
-lU
-wL
+ho
+Ay
+ho
+nV
+DZ
 Hk
 Hk
 Hk
@@ -1658,21 +1785,21 @@ Hk
 Hk
 ix
 ix
-Ib
+Lx
 "}
 (22,1,1) = {"
-lU
-GG
-lU
-kV
+nV
+oX
+nV
+fe
 hU
-Cx
+Eq
 eQ
-EX
-lU
-lU
-Am
-wL
+XZ
+nV
+nV
+yD
+DZ
 Hk
 Hk
 Mk
@@ -1687,21 +1814,21 @@ Mk
 Hk
 hj
 Xe
-Ib
+Lx
 "}
 (23,1,1) = {"
-EV
-EV
+UM
+UM
 vw
 uv
 bA
 Cr
-CS
-lU
-lU
-lU
+rG
+nV
+nV
+nV
 yR
-Ib
+Lx
 Hk
 Hk
 Hk
@@ -1715,22 +1842,22 @@ Hk
 Hk
 Hk
 ix
-Ib
-Ib
+Lx
+Lx
 "}
 (24,1,1) = {"
-nZ
+ho
 vR
-lU
+nV
 uv
 tJ
 tJ
 tJ
-nZ
+ho
 pe
-Ib
-Ib
-Ib
+Lx
+Lx
+Lx
 hj
 ix
 ix
@@ -1744,7 +1871,7 @@ ix
 ix
 ix
 ix
-Ib
+Lx
 jq
 "}
 (25,1,1) = {"
@@ -1752,8 +1879,8 @@ yk
 gE
 fM
 Gr
-hQ
-hQ
+eR
+Ww
 wN
 ma
 Ly
@@ -1772,23 +1899,23 @@ PZ
 ix
 ix
 hj
-Ib
-Ib
+Lx
+Lx
 yi
 "}
 (26,1,1) = {"
-Ib
-Ib
-Ib
-Ib
-Ib
+Lx
+Lx
+Lx
+Lx
+Lx
 zt
 ok
 pH
 lX
-Ib
-qT
-Ib
+Lx
+Ke
+Lx
 ix
 Od
 oI
@@ -1801,7 +1928,7 @@ oI
 hj
 ix
 ix
-Ib
+Lx
 yi
 jq
 "}
@@ -1810,27 +1937,27 @@ PB
 PB
 PB
 PB
-Ib
-Ib
+Lx
+Lx
 qi
-tS
+nx
 Nh
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
 jq
 jq
 "}
@@ -1840,16 +1967,16 @@ Si
 Si
 Si
 Si
-Ib
+Lx
 zN
 aA
-rM
-hQ
-hQ
-hQ
-hQ
+Bg
+Ww
+Ww
+Ww
+Ww
 HP
-Ib
+Lx
 Pu
 xu
 xu
@@ -1869,16 +1996,16 @@ Si
 pa
 Si
 Si
-Ib
+Lx
 QO
-lU
+nV
 fK
-kT
-nZ
-lU
-Am
+OS
+ho
+nV
+yD
 Ha
-Ib
+Lx
 xu
 xu
 xu
@@ -1898,16 +2025,16 @@ Si
 Si
 Si
 Si
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-Ib
-lU
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+Lx
+nV
 qP
-Ib
+Lx
 xu
 xu
 Hz

--- a/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
@@ -5,7 +5,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -24,7 +24,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "bK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/powercell,
@@ -33,14 +33,14 @@
 "bO" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "cD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -62,7 +62,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "dz" = (
 /obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /obj/effect/decal/cleanable/dirt,
@@ -76,7 +76,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"dQ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "dZ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -120,11 +125,23 @@
 	dir = 4
 	},
 /area/bigredv2/caves/southwest)
+"gY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "ha" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 1
 	},
 /area/bigredv2/caves/southwest)
+"hx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "hH" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 5
@@ -138,7 +155,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "jb" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -159,7 +176,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ko" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor,
@@ -182,24 +199,38 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "lx" = (
 /obj/machinery/power/monitor{
 	name = "Main Power Grid Monitoring"
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"mi" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "mN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "nu" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"oH" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "oX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -232,13 +263,20 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "pX" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"pY" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "qd" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -251,9 +289,19 @@
 /obj/structure/closet/radiation,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"qN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "qS" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/s)
+"ro" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering/east)
 "rt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -264,18 +312,18 @@
 /obj/machinery/computer/atmos_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "rN" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "se" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "sl" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -290,7 +338,7 @@
 "sV" = (
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "ta" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/weldpack,
@@ -306,7 +354,7 @@
 	name = "\improper Engineering Complex"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tF" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 4
@@ -318,7 +366,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "tN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -333,6 +381,10 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"ug" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "uD" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -348,7 +400,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "vP" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
@@ -358,6 +410,10 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"wd" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "wG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
@@ -370,7 +426,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "xo" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -393,7 +449,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
@@ -406,7 +462,7 @@
 	name = "\improper Engine Reactor Control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "yH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal{
@@ -443,7 +499,7 @@
 "Aq" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Au" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -451,22 +507,27 @@
 "AW" = (
 /obj/machinery/computer/area_atmos,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Bb" = (
 /obj/machinery/vending/snack,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Be" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Bx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "BC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "BO" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -475,7 +536,7 @@
 "BS" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Cu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -485,6 +546,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Cx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "CC" = (
 /obj/structure/rack,
 /obj/item/camera_film,
@@ -502,7 +569,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "De" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -523,6 +590,19 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Ed" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
+"Ef" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Ej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -539,6 +619,11 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"EY" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Fs" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -562,7 +647,7 @@
 /area/bigredv2/outside/engineering)
 "GK" = (
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Hz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -572,7 +657,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "HQ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -595,7 +680,7 @@
 "IN" = (
 /obj/machinery/vending/cola,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "IZ" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
@@ -604,7 +689,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Jx" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -635,7 +720,7 @@
 /obj/item/tool/lighter/random,
 /obj/item/lightreplacer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "KR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
@@ -645,7 +730,7 @@
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Mw" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -655,7 +740,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "MU" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -669,7 +754,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Nr" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 9
@@ -692,6 +777,9 @@
 "NS" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/sw)
+"Oo" = (
+/turf/closed/wall,
+/area/bigredv2/outside/engineering/east)
 "OA" = (
 /obj/structure/table,
 /obj/item/tool/lighter/random,
@@ -713,7 +801,7 @@
 /obj/effect/spawner/random/misc/earmuffs,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Pi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/excavation_site_spawner,
@@ -724,7 +812,7 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Pw" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for opening the engines blast doors.";
@@ -733,7 +821,11 @@
 	name = "Reactor Radiation Shielding control"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
+"Pz" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "PH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -750,7 +842,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "PW" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 8
@@ -768,12 +860,16 @@
 	name = "Colonist Ted Jarka"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Qv" = (
 /obj/structure/rack,
 /obj/item/tool/analyzer,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Rb" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Rp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -789,11 +885,21 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"RM" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "RR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/breath,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Sv" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering/east)
 "Sw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor,
@@ -815,7 +921,7 @@
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Ta" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -827,7 +933,7 @@
 	dir = 8
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "TQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -866,14 +972,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Xh" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Xz" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -887,12 +993,12 @@
 	name = "Storm Shutters"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "XU" = (
 /obj/structure/table,
 /obj/item/tool/analyzer,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Yb" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 5
@@ -906,6 +1012,11 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"Yo" = (
+/obj/structure/table,
+/obj/item/tool/lighter/random,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "Yq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -924,7 +1035,7 @@
 	dir = 4
 	},
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Zj" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -932,7 +1043,7 @@
 	},
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/engineering/east)
 "Zv" = (
 /obj/item/stack/sheet/glass/glass,
 /obj/structure/cable,
@@ -1296,13 +1407,13 @@ OA
 Mw
 ky
 jg
-Qe
-Qe
-Qe
+Oo
+Oo
+Oo
 yu
-Qe
-Qe
-vP
+Oo
+Oo
+ro
 ZD
 ZD
 fd
@@ -1325,13 +1436,13 @@ DP
 Qe
 PH
 eH
-Qe
+Oo
 Zj
-DP
-OK
-eH
+EY
+GK
+Rb
 LP
-vP
+ro
 ZD
 ZD
 ZD
@@ -1354,13 +1465,13 @@ xo
 Mw
 ky
 KR
-Qe
-OK
+Oo
+GK
 vN
-jg
+ug
 bO
-DP
-vP
+EY
+ro
 ZD
 ZD
 ZD
@@ -1387,9 +1498,9 @@ if
 BC
 BC
 PT
-Fs
+Pz
 lx
-vP
+ro
 ZD
 ZD
 ZD
@@ -1412,13 +1523,13 @@ Qe
 Qe
 fe
 yc
-Qe
-jg
-jg
-jg
+Oo
+ug
+ug
+ug
 bO
 XU
-vP
+ro
 ZD
 ZD
 ZD
@@ -1437,17 +1548,17 @@ RB
 "}
 (18,1,1) = {"
 sV
-Mw
+Sv
 TA
-cD
-jg
-Qe
+pY
+ug
+Oo
 GK
 Pw
-OK
-OK
+GK
+GK
 rL
-vP
+ro
 ZD
 ZD
 ZD
@@ -1465,18 +1576,18 @@ zc
 RB
 "}
 (19,1,1) = {"
-Fs
+Pz
 Pp
 Qo
-EF
+RM
 XI
-Qe
-Qe
-Qe
+Oo
+Oo
+Oo
 yu
-Qe
-Qe
-vP
+Oo
+Oo
+ro
 ZD
 ZD
 fd
@@ -1494,18 +1605,18 @@ fm
 RB
 "}
 (20,1,1) = {"
-jb
-Mw
-OK
-EF
-jg
-OK
-OK
+dQ
+Sv
+GK
+RM
+ug
+GK
+GK
 TA
-Ek
-jg
-OK
-vP
+gY
+ug
+GK
+ro
 ZD
 fd
 fd
@@ -1523,18 +1634,18 @@ RB
 RB
 "}
 (21,1,1) = {"
-Hz
+Ed
 dI
-Hz
+Ed
 Ne
 Xh
 pX
 pX
-jg
-nu
-jg
-OK
-vP
+ug
+wd
+ug
+GK
+ro
 ZD
 Au
 fd
@@ -1552,18 +1663,18 @@ vs
 RB
 "}
 (22,1,1) = {"
-OK
-Mw
-OK
-PH
+GK
+Sv
+GK
+Ef
 Mx
-Xz
+oH
 Kz
-Ns
-OK
-OK
-Ek
-vP
+Bx
+GK
+GK
+gY
+ro
 ZD
 fd
 Yr
@@ -1581,18 +1692,18 @@ Dw
 RB
 "}
 (23,1,1) = {"
-Qe
-Qe
+Oo
+Oo
 Aq
 km
 HC
 Pd
-OA
-OK
-OK
-OK
+Yo
+GK
+GK
+GK
 AW
-vP
+ro
 ZD
 fd
 fd
@@ -1610,18 +1721,18 @@ Dw
 RB
 "}
 (24,1,1) = {"
-jg
+ug
 ax
-OK
+GK
 km
 yb
 yb
 yb
-jg
-jg
-OK
-OK
-vP
+ug
+ug
+GK
+GK
+ro
 ZD
 ZD
 fd
@@ -1643,14 +1754,14 @@ se
 kC
 Jq
 dk
-Hz
-Hz
+mi
+Ed
 tG
 bo
 mN
-Fs
-Fs
-vP
+Pz
+Pz
+ro
 bf
 ZD
 ZD
@@ -1668,18 +1779,18 @@ RB
 zc
 "}
 (26,1,1) = {"
-vP
-vP
-vP
-vP
-vP
+ro
+ro
+ro
+ro
+ro
 BS
 SZ
 Db
-jg
-OK
-OK
-vP
+ug
+GK
+GK
+ro
 bf
 bf
 ZD
@@ -1701,17 +1812,17 @@ pe
 pe
 pe
 pe
-vP
-vP
+ro
+ro
 rN
-OZ
+hx
 Wy
-OK
-OK
-vP
-vP
-vP
-vP
+GK
+GK
+ro
+ro
+ro
+ro
 ZD
 ZD
 ZD
@@ -1731,16 +1842,16 @@ xM
 xM
 xM
 xM
-vP
+ro
 Bb
 cx
-vS
-Hz
-Hz
-Hz
-Hz
+Cx
+Ed
+Ed
+Ed
+Ed
 wK
-vP
+ro
 ZD
 ZD
 ZD
@@ -1760,16 +1871,16 @@ xM
 ff
 xM
 xM
-vP
+ro
 IN
-OK
+GK
 pV
-cI
-jg
-OK
-Ek
+qN
+ug
+GK
+gY
 YW
-vP
+ro
 ZD
 ZD
 ZD
@@ -1789,16 +1900,16 @@ xM
 xM
 xM
 xM
-vP
-vP
-vP
-vP
-vP
-vP
-vP
-OK
+ro
+ro
+ro
+ro
+ro
+ro
+ro
+GK
 tr
-vP
+ro
 qS
 dZ
 Nr

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -99,13 +99,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white/warningstripe,
 /area/bigredv2/outside/office_complex)
-"fQ" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 4
-	},
-/area/bigredv2/outside/office_complex)
 "fW" = (
 /obj/structure/table,
 /obj/machinery/computer3/laptop/secure_data,
@@ -198,7 +191,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "jz" = (
@@ -270,7 +262,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
@@ -396,11 +387,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/office_complex)
-"qF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "qU" = (
 /obj/structure/closet/jcloset,
 /obj/item/clothing/head/beret/jan,
@@ -452,10 +438,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
-"ua" = (
-/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "um" = (
@@ -651,13 +633,6 @@
 "BM" = (
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/office_complex)
-"Cr" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/redtaupecorner,
-/area/bigredv2/outside/office_complex)
 "Cz" = (
 /obj/machinery/light{
 	dir = 8
@@ -683,7 +658,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
@@ -901,11 +875,9 @@
 /area/bigredv2/outside/office_complex)
 "Np" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/office_complex)
 "Nq" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
@@ -1563,7 +1535,7 @@ ov
 ov
 ov
 VI
-Cr
+ei
 ov
 kz
 tt
@@ -1588,7 +1560,7 @@ Hm
 zI
 ov
 VI
-Cr
+ei
 ov
 ov
 ov
@@ -1634,10 +1606,10 @@ ov
 ov
 ov
 Np
-ua
-qF
+As
+JI
 We
-fQ
+qB
 jl
 LH
 mq

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -4,30 +4,22 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile,
 /area/bigredv2/outside/office_complex)
-"aB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "aC" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "aT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/obj/machinery/power/apc/drained,
 /turf/open/floor,
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/office_complex)
 "aU" = (
 /obj/machinery/light{
 	dir = 4
@@ -488,7 +480,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "pC" = (
@@ -1015,7 +1006,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/icefloor,
@@ -1043,10 +1033,6 @@
 "Fp" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/se)
-"Fs" = (
-/obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "Ft" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4
@@ -1223,13 +1209,6 @@
 	},
 /obj/item/ammo_casing,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
-"LC" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 4
-	},
 /area/bigredv2/outside/office_complex)
 "LE" = (
 /obj/item/stack/sheet/metal,
@@ -1531,14 +1510,6 @@
 "Vc" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
-"Vv" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	name = "\improper Private Office"
-	},
-/turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "VH" = (
 /obj/machinery/light{
@@ -2200,10 +2171,10 @@ Tx
 Tx
 Tx
 aT
-Fs
-aB
-Vv
-LC
+mv
+Am
+Cj
+Xu
 aC
 yn
 eK

--- a/_maps/modularmaps/big_red/bigredofficevar3.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar3.dmm
@@ -215,13 +215,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
-"lo" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 4
-	},
-/area/bigredv2/outside/office_complex)
 "lt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -315,7 +308,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
@@ -407,7 +399,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "to" = (
@@ -435,27 +426,12 @@
 /obj/item/folder/red,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
-"uG" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	name = "\improper Private Office"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "uH" = (
 /obj/structure/table,
 /obj/machinery/computer/pod/old{
 	name = "Personal Computer"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/office_complex)
-"uK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
 "vl" = (
 /obj/machinery/light{
@@ -543,7 +519,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
@@ -789,7 +764,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
@@ -842,10 +816,6 @@
 	name = "\improper Office Complex Shutters"
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
-"Ne" = (
-/obj/structure/cable,
-/turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "NA" = (
 /obj/structure/table,
@@ -962,11 +932,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
-"TA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "TN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -993,11 +958,9 @@
 /area/bigredv2/outside/office_complex)
 "Vi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor,
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/office_complex)
 "Vp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -1534,7 +1497,7 @@ EO
 EX
 eB
 Yj
-uK
+Bl
 eB
 eB
 eB
@@ -1580,10 +1543,10 @@ eB
 eB
 eB
 Vi
-Ne
-TA
-uG
-lo
+VB
+kj
+aL
+Cl
 sL
 Za
 TN

--- a/code/game/area/bigred.dm
+++ b/code/game/area/bigred.dm
@@ -248,11 +248,14 @@
 	outside = FALSE
 
 /area/bigredv2/outside/engineering
-	name = "Engineering Complex"
+	name = "West Engineering Complex"
 	icon_state = "engine"
 	ceiling = CEILING_METAL
 	minimap_color = MINIMAP_AREA_ENGI
 	outside = FALSE
+
+/area/bigredv2/outside/engineering/east
+	name = "East Engineering Complex"
 
 /area/bigredv2/outside/storage
 	name = "Storage"


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. The reason for the area split was to allow Xenos to build somewhat into LZ 2 Engineering.
## Why It's Good For The Game
Indoor APC's having weather effects on them was, for lack of a better word, wack. Outdoor APC's look fine. In addition, Tadpole could land in some highly contested spots for free; now Xenos can build there roundstart.
## Changelog
:cl:
balance: Xenos can build further into LZ 2 Engineering roundstart on Big Red, APCs for the outdoor areas on Big Red are now outside instead of inside.
/:cl:
