### PR TITLE
Changes The Minion Spawner To Require Tactical Points Instead of Strategic Points

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -238,6 +238,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	psypoint_cost = 600
 	icon = "spawner"
 	flags_gamemode = ABILITY_NUCLEARWAR
+	flags_upgrade = UPGRADE_FLAG_USES_TACTICAL
 	building_type = /obj/structure/xeno/spawner
 
 /datum/hive_upgrade/defence


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Currently the minion spawner requires 600 strategic points. This makes it incredibly unappealing to purchase, especially when a silo is only 200 points more, and provides larva and minions instead of only minions. While making it cheaper could make it purchased more, it competing for points with the silo means it would have to be incredibly cheap in order for it to be worth buying.
## Changelog
:cl:
balance: The Minion Spawner now uses tactical points instead of strategic.
/:cl:
