### PR TITLE
Evasion no longer lets you slash marines

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -28,6 +28,14 @@
 	if(. == CONSCIOUS && layer != initial(layer))
 		layer = MOB_LAYER
 
+/mob/living/carbon/xenomorph/runner/UnarmedAttack(atom/A, has_proximity, modifiers)
+	/// Runner should not be able to slash while evading.
+	var/datum/action/ability/xeno_action/evasion/evasion_action = actions_by_path[/datum/action/ability/xeno_action/evasion]
+	if(evasion_action.evade_active)
+		balloon_alert(src, "Cannot slash while evading")
+		return
+	return ..()
+
 /mob/living/carbon/xenomorph/runner/med_hud_set_status()
 	. = ..()
 	hud_set_evasion()


### PR DESCRIPTION

## About The Pull Request
https://i.imgur.com/LmHmI2l.png

Title basically.
## Why It's Good For The Game
Makes runner evasion a pretty dedicated escape tool from group rather than just god mode.
<!-- Argue for thhe merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
balance: Runner can no longer slash in invasion.
/:cl:
