### PR TITLE
Campaign: Various small tweaks loadout/perk tweaks

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -194,7 +194,7 @@
 	if(carbon_owner.selected_ability == src)
 		return
 	if(carbon_owner.selected_ability)
-		carbon_owner.selected_ability.deselect() //todo: make jetpack/blinkdrive etc activatables
+		carbon_owner.selected_ability.deselect()
 	select()
 
 /datum/action/ability/activable/keybind_activation()

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -41,7 +41,7 @@
 	. = ..()
 	for(var/faction in factions)
 		stat_list[faction] = new /datum/faction_stats(faction)
-	RegisterSignal(SSdcs, COMSIG_LIVING_JOB_SET, PROC_REF(register_faction_member))
+	RegisterSignals(SSdcs, list(COMSIG_GLOB_PLAYER_ROUNDSTART_SPAWNED, COMSIG_GLOB_PLAYER_LATE_SPAWNED), PROC_REF(register_faction_member))
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_MOB_DEATH, COMSIG_MOB_GHOSTIZE), PROC_REF(set_death_time))
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, PROC_REF(cut_death_list_timer))
 	addtimer(CALLBACK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode/hvh/campaign, intro_sequence)), SSticker.round_start_time + 1 MINUTES)

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -68,11 +68,11 @@
 	)
 	///cash rewards for the mission type
 	var/list/cash_rewards = list(
-		MISSION_OUTCOME_MAJOR_VICTORY = list(1500, 1000),
-		MISSION_OUTCOME_MINOR_VICTORY = list(1200, 1000),
-		MISSION_OUTCOME_DRAW = list(1000, 1000),
-		MISSION_OUTCOME_MINOR_LOSS = list(1000, 1200),
-		MISSION_OUTCOME_MAJOR_LOSS = list(1000, 1500),
+		MISSION_OUTCOME_MAJOR_VICTORY = list(800, 600),
+		MISSION_OUTCOME_MINOR_VICTORY = list(700, 600),
+		MISSION_OUTCOME_DRAW = list(600, 600),
+		MISSION_OUTCOME_MINOR_LOSS = list(600, 700),
+		MISSION_OUTCOME_MAJOR_LOSS = list(600, 800),
 	)
 	/// Timer used to calculate how long till mission ends
 	var/game_timer

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -68,11 +68,11 @@
 	)
 	///cash rewards for the mission type
 	var/list/cash_rewards = list(
-		MISSION_OUTCOME_MAJOR_VICTORY = list(2000, 1000),
-		MISSION_OUTCOME_MINOR_VICTORY = list(1500, 1000),
+		MISSION_OUTCOME_MAJOR_VICTORY = list(1500, 1000),
+		MISSION_OUTCOME_MINOR_VICTORY = list(1200, 1000),
 		MISSION_OUTCOME_DRAW = list(1000, 1000),
-		MISSION_OUTCOME_MINOR_LOSS = list(1000, 1500),
-		MISSION_OUTCOME_MAJOR_LOSS = list(1000, 2000),
+		MISSION_OUTCOME_MINOR_LOSS = list(1000, 1200),
+		MISSION_OUTCOME_MAJOR_LOSS = list(1000, 1500),
 	)
 	/// Timer used to calculate how long till mission ends
 	var/game_timer

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -137,14 +137,21 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		return
 	if(new_member.faction != faction)
 		return
-	if(!individual_stat_list[new_member.key])
-		individual_stat_list[new_member.key] = new /datum/individual_stats(new_member, faction, accumulated_mission_reward)
-	else
+	if(individual_stat_list[new_member.key])
 		individual_stat_list[new_member.key].current_mob = new_member
 		individual_stat_list[new_member.key].apply_perks()
-
+	else
+		get_player_stats(new_member)
 	var/datum/action/campaign_loadout/loadouts = new
 	loadouts.give_action(new_member)
+
+///Returns a users individual stat datum, generating a new one if required
+/datum/faction_stats/proc/get_player_stats(mob/user)
+	if(!user.key)
+		return
+	if(!individual_stat_list[user.key])
+		individual_stat_list[user.key] = new /datum/individual_stats(user, faction, accumulated_mission_reward)
+	return individual_stat_list[user.key]
 
 ///Randomly adds a new mission to the available pool
 /datum/faction_stats/proc/generate_new_mission()

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -82,6 +82,8 @@
 
 	if(!istype(user)) //we immediately apply the perk where possible
 		return
+	if(!(user.job.title in new_perk.jobs_supported))
+		return
 	new_perk.apply_perk(user)
 
 ///Unlocks a loadout item for use
@@ -335,7 +337,7 @@
 	if(!your_faction)
 		return
 
-	var/datum/individual_stats/stats = get_player_stats(owner)
+	var/datum/individual_stats/stats = your_faction.get_player_stats(owner)
 	if(!stats)
 		return
 	stats.current_mob = M
@@ -344,7 +346,7 @@
 	var/datum/faction_stats/your_faction = GLOB.faction_stats_datums[owner.faction]
 	if(!your_faction)
 		return
-	var/datum/individual_stats/stats = get_player_stats(owner)
+	var/datum/individual_stats/stats = your_faction.get_player_stats(owner)
 	if(!stats)
 		return
 	stats.current_mob = owner //taking over ssd's creates a mismatch

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -3,7 +3,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 1000
+	var/currency = 300
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -335,17 +335,17 @@
 	if(!your_faction)
 		return
 
-	var/datum/individual_stats/stats = your_faction.individual_stat_list[owner.key]
+	var/datum/individual_stats/stats = get_player_stats(owner)
 	if(!stats)
-		CRASH("Attempted to load Individual stat datum without one existing for [owner] key [owner.key]")
+		return
 	stats.current_mob = M
 
 /datum/action/campaign_loadout/action_activate()
 	var/datum/faction_stats/your_faction = GLOB.faction_stats_datums[owner.faction]
 	if(!your_faction)
 		return
-
-	var/datum/individual_stats/stats = your_faction.individual_stat_list[owner.key]
+	var/datum/individual_stats/stats = get_player_stats(owner)
 	if(!stats)
-		CRASH("Attempted to load Individual stat datum without one existing for [owner] key [owner.key]")
+		return
+	stats.current_mob = owner //taking over ssd's creates a mismatch
 	stats.interact(owner)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
@@ -7,7 +7,7 @@
 /datum/loadout_item/back/som_combat_pack
 	name = "Mining rucksack"
 	desc = "A rucksack with origins dating back to the mining colonies. Has the storage capacity of a backpack but no draw delay."
-	purchase_cost = 80
+	purchase_cost = 50
 	item_typepath = /obj/item/storage/backpack/lightpack/som
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN)
 

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -73,7 +73,7 @@
 	item_typepath = /obj/item/clothing/suit/modular/som/heavy/mithridatius
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/head/modular/som/bio = ITEM_SLOT_HEAD)
-	quantity = 3
+	quantity = 2
 
 //engineer
 /datum/loadout_item/suit_slot/som_engineer

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
@@ -21,7 +21,7 @@
 /datum/loadout_item/back/combat_pack
 	name = "Combat pack"
 	desc = "A small lightweight pack for expeditions and short-range operations. Has the storage capacity of a backpack but no draw delay."
-	purchase_cost = 80
+	purchase_cost = 50
 	item_typepath = /obj/item/storage/backpack/lightpack
 	jobs_supported = list(SQUAD_MARINE, SQUAD_SMARTGUNNER)
 

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -37,7 +37,6 @@
 	req_desc = "Requires a FL-84 flamethrower."
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/surt
 	jobs_supported = list(SQUAD_MARINE)
-	item_whitelist = list(/obj/item/weapon/gun/flamer/big_flamer/marinestandard/wide = ITEM_SLOT_SUITSTORE)
 
 /datum/loadout_item/suit_slot/heavy_tyr
 	name = "Heavy Tyr armor"

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -2,7 +2,7 @@
 /datum/campaign_mission/capture_mission/asat
 	name = "ASAT capture"
 	mission_icon = "asat_capture"
-	map_name = "Lawanka outpost"
+	map_name = "Lawanka Outpost"
 	map_file = '_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -3,7 +3,7 @@
 	name = "NT base rescue"
 	mission_icon = "nt_rescue"
 	mission_flags = MISSION_DISALLOW_TELEPORT
-	map_name = "NT site B-403"
+	map_name = "NT Site B-403"
 	map_file = '_maps/map_files/Campaign maps/nt_base/nt_base.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SNOWSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE)

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -3,7 +3,7 @@
 	name = "Fire support raid"
 	mission_icon = "mortar_raid"
 	mission_flags = MISSION_DISALLOW_DROPPODS
-	map_name = "Jungle outpost SR-422"
+	map_name = "Jungle Outpost SR-422"
 	map_file = '_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -217,14 +217,14 @@
 ///test missions
 /datum/campaign_mission/tdm/lv624
 	name = "Combat patrol 2"
-	map_name = "Orion outpost"
+	map_name = "Orion Outpost"
 	map_file = '_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm'
 	map_light_colours = list(COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW)
 	map_light_levels = list(225, 150, 100, 75)
 
 /datum/campaign_mission/tdm/first_mission
 	name = "First Contact"
-	map_name = "Jungle outpost SR-422"
+	map_name = "Jungle Outpost SR-422"
 	map_file = '_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)

--- a/code/datums/gamemodes/campaign/missions/phoron_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/phoron_capture.dm
@@ -2,7 +2,7 @@
 /datum/campaign_mission/capture_mission/phoron_capture
 	name = "Phoron retrieval"
 	mission_icon = "phoron_raid"
-	map_name = "Jungle outpost SR-422"
+	map_name = "Jungle Outpost SR-422"
 	map_file = '_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)

--- a/code/datums/gamemodes/campaign/missions/supply_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/supply_raid.dm
@@ -3,7 +3,7 @@
 	name = "Supply Depot raid"
 	mission_icon = "supply_depot"
 	mission_flags = MISSION_DISALLOW_DROPPODS
-	map_name = "Rocinante base"
+	map_name = "Rocinante Base"
 	map_file = '_maps/map_files/Campaign maps/som_base/sombase.dmm'
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SNOWSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE)
@@ -76,7 +76,7 @@
 
 /datum/campaign_mission/destroy_mission/supply_raid/som
 	mission_flags = MISSION_DISALLOW_TELEPORT
-	map_name = "Orion outpost"
+	map_name = "Orion Outpost"
 	map_file = '_maps/map_files/Campaign maps/orion_2/orionoutpost_2.dmm'
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_traits = list(ZTRAIT_AWAY = TRUE)

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -107,7 +107,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	ui_icon = "soft_footed"
 	traits = list(TRAIT_AXE_EXPERT)
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
-	unlock_cost = 400
+	unlock_cost = 450
 	prereq_perks = list(/datum/perk/skill_mod/melee/two)
 
 /datum/perk/trait/axe_master/unlock_bonus(mob/living/carbon/owner, datum/individual_stats/owner_stats)
@@ -124,7 +124,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	ui_icon = "soft_footed"
 	traits = list(TRAIT_SWORD_EXPERT)
 	jobs_supported = list(SQUAD_MARINE, SQUAD_LEADER, FIELD_COMMANDER)
-	unlock_cost = 400
+	unlock_cost = 450
 	prereq_perks = list(/datum/perk/skill_mod/melee/two)
 
 /datum/perk/trait/sword_master/unlock_bonus(mob/living/carbon/owner, datum/individual_stats/owner_stats)
@@ -172,14 +172,14 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	ui_icon = "cqc_1"
 	cqc = 1
 	all_jobs = TRUE
-	unlock_cost = 300
+	unlock_cost = 250
 
 /datum/perk/skill_mod/cqc/two
 	name = "Hand to hand specialisation"
 	desc = "Greatly improved unarmed damage and stun chance."
 	req_desc = "Requires Hand to hand expertise."
 	ui_icon = "cqc_2"
-	unlock_cost = 400
+	unlock_cost = 350
 	prereq_perks = list(/datum/perk/skill_mod/cqc)
 
 /datum/perk/skill_mod/melee
@@ -188,7 +188,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	ui_icon = "melee_1"
 	melee_weapons = 1
 	all_jobs = TRUE
-	unlock_cost = 200
+	unlock_cost = 300
 
 /datum/perk/skill_mod/melee/two
 	name = "Melee specialisation"
@@ -196,7 +196,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	req_desc = "Requires Melee expertise."
 	ui_icon = "melee_2"
 	prereq_perks = list(/datum/perk/skill_mod/melee)
-	unlock_cost = 250
+	unlock_cost = 400
 
 /datum/perk/skill_mod/firearms
 	name = "Advanced firearm training"
@@ -239,7 +239,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	rifles = 1
 	all_jobs = TRUE
 	prereq_perks = list(/datum/perk/skill_mod/firearms)
-	unlock_cost = 800
+	unlock_cost = 1000
 
 /datum/perk/skill_mod/smgs
 	name = "Advanced SMG training"

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -218,7 +218,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 
 /datum/perk/skill_mod/shotguns
 	name = "Advanced shotgun training"
-	desc = "Improved damage with pistol type firearms. Unlocks access to a shotgun secondary weapon in the backslot."
+	desc = "Improved damage with shotgun type firearms. Unlocks access to a shotgun secondary weapon in the backslot."
 	req_desc = "Requires Advanced firearm training."
 	ui_icon = "shotguns"
 	shotguns = 1
@@ -284,7 +284,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	desc = "Improved bonuses when issuing orders."
 	ui_icon = "leadership"
 	leadership = 1
-	jobs_supported = list(SQUAD_LEADER, FIELD_COMMANDER, STAFF_OFFICER, CAPTAIN)
+	jobs_supported = list(SQUAD_LEADER, FIELD_COMMANDER, STAFF_OFFICER, CAPTAIN, SOM_SQUAD_LEADER, SOM_STAFF_OFFICER, SOM_FIELD_COMMANDER, SOM_COMMANDER)
 	unlock_cost = 1100
 
 /datum/perk/skill_mod/medical

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
@@ -90,9 +90,9 @@ export const IndividualLoadouts = (props) => {
                         selectedLoadoutItem.item_type.name ===
                         equippeditem.item_type.name
                           ? 'orange'
-                          : equippeditem.item_type.valid_choice === 0
-                            ? 'red'
-                            : equippeditem.item_type.quantity === 0
+                          : equippeditem.item_type.quantity === 0
+                            ? 'grey'
+                            : equippeditem.item_type.valid_choice === 0
                               ? 'red'
                               : 'blue'
                       }
@@ -107,9 +107,9 @@ export const IndividualLoadouts = (props) => {
                               selectedLoadoutItem.item_type.name ===
                               equippeditem.item_type.name
                                 ? equippeditem.item_type.icon + '_orange'
-                                : equippeditem.item_type.valid_choice === 0
-                                  ? equippeditem.item_type.icon + '_red'
-                                  : equippeditem.item_type.quantity === 0
+                                : equippeditem.item_type.quantity === 0
+                                  ? equippeditem.item_type.icon + '_grey'
+                                  : equippeditem.item_type.valid_choice === 0
                                     ? equippeditem.item_type.icon + '_red'
                                     : equippeditem.item_type.icon + '_blue',
                             ])}
@@ -160,13 +160,12 @@ export const IndividualLoadouts = (props) => {
                     color={
                       selectedPossibleItem.name === potentialitem.name
                         ? 'orange'
-                        : !potentialitem.unlocked
+                        : !potentialitem.unlocked ||
+                            potentialitem.quantity === 0
                           ? 'grey'
                           : !potentialitem.valid_choice
                             ? 'red'
-                            : potentialitem.quantity === 0
-                              ? 'red'
-                              : 'blue'
+                            : 'blue'
                     }
                   >
                     <Flex align="center">
@@ -177,13 +176,12 @@ export const IndividualLoadouts = (props) => {
                             'campaign_loadout_items18x18',
                             selectedPossibleItem.name === potentialitem.name
                               ? potentialitem.icon + '_orange'
-                              : !potentialitem.unlocked
+                              : !potentialitem.unlocked ||
+                                  potentialitem.quantity === 0
                                 ? potentialitem.icon + '_grey'
                                 : !potentialitem.valid_choice
                                   ? potentialitem.icon + '_red'
-                                  : potentialitem.quantity === 0
-                                    ? potentialitem.icon + '_red'
-                                    : potentialitem.icon + '_blue',
+                                  : potentialitem.icon + '_blue',
                           ])}
                         />
                       )}
@@ -200,7 +198,9 @@ export const IndividualLoadouts = (props) => {
           vertical
           title={selectedJob + ' loadout'}
           textColor={
-            selectedOutfitCostData.outfit_cost < data.currency ? 'white' : 'red'
+            selectedOutfitCostData.outfit_cost <= data.currency
+              ? 'white'
+              : 'red'
           }
         >
           Equip cost: {selectedOutfitCostData.outfit_cost}
@@ -250,7 +250,9 @@ export const IndividualLoadouts = (props) => {
             </LabeledList.Item>
             {selectedPossibleItem.quantity !== -1 && (
               <LabeledList.Item label="Quantity">
-                {selectedPossibleItem.quantity}
+                {selectedPossibleItem.quantity === 0
+                  ? 'None currently available'
+                  : selectedPossibleItem.quantity}
               </LabeledList.Item>
             )}
             {selectedPossibleItem.requirements && (


### PR DESCRIPTION
## About The Pull Request
Some minor tweaks after the test we had.
Items that are out of stock will now be more clearly marked, showing as grey instead of red (which is easily confused for being invalid), and explicitly saying 'none currently available'.

Reduced winning team credit rewards.
Reduced the starting amount to 300 from 1000.

Mith armour for SOM correctly has a limit of 2 instead of 3 (so probably less rad spam!)

Increased the cost of a few perks.

Fixes some minor bugs.

Fixed some grammar mistakes.
## Why It's Good For The Game
Minor balance/UI tweaks for the better.
## Changelog
:cl:
balance: adjusted a few campaign loadout and perk things
/:cl:
