### PR TITLE
Maptable accessibility

### DIFF
--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -145,16 +145,15 @@
 	. = ..()
 	if(.)
 		return
-	if(user.skills.getRating(SKILL_LEADERSHIP) < SKILL_LEAD_EXPERT)
-		user.balloon_alert(user, "Can't use that!")
-		return TRUE
-	if(is_banned_from(user.client.ckey, GLOB.roles_allowed_minimap_draw))
-		to_chat(user, span_boldwarning("You have been banned from a command role. You may not use [src] until the ban has been lifted."))
-		return TRUE
 
 /obj/machinery/cic_maptable/drawable/interact(mob/user)
 	. = ..()
 	if(.)
+		return
+	if(user.skills.getRating(SKILL_LEADERSHIP) < SKILL_LEAD_EXPERT)
+		return
+	if(is_banned_from(user.client.ckey, GLOB.roles_allowed_minimap_draw))
+		to_chat(user, span_boldwarning("You have been banned from a command role. You may not use access draw functions until the ban has been lifted."))
 		return
 	user.client.screen += drawing_tools
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Maptables that have drawing functions are now accessible by anyone.
Instead, the draw features are what's leadership locked. (i.e. for normal ungas its just a normal maptable).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets normal ungas use maptables for map, without letting them get their sticky fingers on the drawtools.

Notably this is nice for SOM in campaign since the public map table wasn't accessible for 90% of the SOM players. Aylmao.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Maptables with draw functionality are accessible to all users, but the draw features remain leadership locked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
