### PR TITLE
Bunch of weird runtimes that broke one round then never happened again

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -33,11 +33,11 @@
 	var/postfix = "[sobject][saddition][hp]"
 
 	var/message = "[what_done] [starget][postfix]"
-	user.log_message(message, LOG_ATTACK, color="red")
+	user?.log_message(message, LOG_ATTACK, color="red")
 
 	if(user != target)
 		var/reverse_message = "was [what_done] by [ssource][postfix]"
-		target.log_message(reverse_message, LOG_VICTIM, color="orange", log_globally=FALSE)
+		target?.log_message(reverse_message, LOG_VICTIM, color="orange", log_globally=FALSE)
 
 /// Logging for bombs detonating
 /proc/log_bomber(atom/user, details, atom/bomb, additional_details, message_admins = FALSE)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -156,9 +156,11 @@
 /proc/deadchat_broadcast(message, source = null, mob/follow_target = null, turf/turf_target = null, speaker_key = null, message_type = DEADCHAT_REGULAR)
 	message = span_deadsay("[source][span_linkify("[message]")]")
 	for(var/mob/M in GLOB.player_list)
+		if(!M.client)
+			continue
 		var/chat_toggles = TOGGLES_CHAT_DEFAULT
 		var/deadchat_toggles = TOGGLES_DEADCHAT_DEFAULT
-		if(M.client.prefs)
+		if(M?.client?.prefs)
 			var/datum/preferences/prefs = M.client.prefs
 			chat_toggles = prefs.toggles_chat
 			deadchat_toggles = prefs.toggles_deadchat

--- a/code/game/objects/machinery/telecomms/broadcasting.dm
+++ b/code/game/objects/machinery/telecomms/broadcasting.dm
@@ -186,7 +186,7 @@
 
 	// Add observers who have ghost radio enabled.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
-		if(ghost.client.prefs.toggles_chat & CHAT_GHOSTRADIO)
+		if(ghost?.client?.prefs?.toggles_chat & CHAT_GHOSTRADIO)
 			receive |= ghost
 
 	// Render the message and have everybody hear it.

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -1,18 +1,18 @@
 // You might be wondering why this isn't client level. If focus is null, we don't want you to move.
 // Only way to do that is to tie the behavior into the focus's keyLoop().
 /atom/movable/keyLoop(client/user)
-	if(user.keys_held["Ctrl"])
+	if(user?.keys_held["Ctrl"])
 		return
 	var/movement_dir = NONE
 	for(var/_key in user.keys_held)
 		movement_dir = movement_dir | user.movement_keys[_key]
-	if(user.next_move_dir_add)
+	if(user?.next_move_dir_add)
 		movement_dir |= user.next_move_dir_add
-	if(user.next_move_dir_sub)
+	if(user?.next_move_dir_sub)
 		movement_dir &= ~user.next_move_dir_sub
 	// Sanity checks in case you hold left and right and up to make sure you only go up
 	if((movement_dir & NORTH) && (movement_dir & SOUTH))
 		movement_dir &= ~(NORTH|SOUTH)
 	if((movement_dir & EAST) && (movement_dir & WEST))
 		movement_dir &= ~(EAST|WEST)
-	user.Move(get_step(src, movement_dir), movement_dir)
+	user?.Move(get_step(src, movement_dir), movement_dir)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -910,7 +910,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	D.orphan_hive_timer = addtimer(CALLBACK(D, TYPE_PROC_REF(/datum/game_mode, orphan_hivemind_collapse)), NUCLEAR_WAR_ORPHAN_HIVEMIND, TIMER_STOPPABLE)
 
-	orphan_hud_timer = new(null, get_all_xenos(), D.orphan_hive_timer, "Orphan Hivemind Collapse: ${timer}", 150, -80)
+	orphan_hud_timer = new(null, null, get_all_xenos(), D.orphan_hive_timer, "Orphan Hivemind Collapse: ${timer}", 150, -80)
 
 /datum/hive_status/normal/burrow_larva(mob/living/carbon/xenomorph/larva/L)
 	if(!is_ground_level(L.z))

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -200,6 +200,6 @@
 	UnregisterSignal(user, list(COMSIG_KB_MOB_FACENORTH_DOWN, COMSIG_KB_MOB_FACEEAST_DOWN, COMSIG_KB_MOB_FACESOUTH_DOWN, COMSIG_KB_MOB_FACEWEST_DOWN))
 
 /mob/camera/aiEye/playsound_local(turf/turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, sound/S, distance_multiplier, mob/sound_reciever)
-	if(!parent_cameranet.checkTurfVis(get_turf(src)))
+	if(istype(parent_cameranet) && !parent_cameranet.checkTurfVis(get_turf(src)))
 		return
 	return ..(turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, S, distance_multiplier, ai)


### PR DESCRIPTION

## About The Pull Request

- Runtime related to target missing in the attack log message

- Runtime related to trying to display messages to clientless ghosts, causing dchat to not work
- Another runtime related to trying to display comms messages to ghosts, causing radio to not work
- Runtime related to a mob somehow calling `keyLoop` without a client being passed in as user
- An arg I forgot in the orphan hivemind onscreen countdown
- Some remote eyes not playing nice with the logic in the sound transferring to the user (because their `parent_cameranet` var gets set to a non `/datum/cameranet` for whatever reason, I've opted to just not let them hear at all until this code is refactored to have one unified var that determines the hud user)
## Why It's Good For The Game
runtime dad
## Changelog
:cl:
fix: Various runtime fixes, see the PR
/:cl:
