### PR TITLE
Flares can now be dragged way faster

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -441,6 +441,8 @@
 	desc = "A TGMC standard issue flare utilizing the standard DP canister chassis. Capable of being loaded in any grenade launcher, or thrown by hand."
 	icon_state = "flare_grenade"
 	item_state = "flare_grenade"
+	drag_delay = 1
+	drag_windup = 0
 	det_time = 0
 	throwforce = 1
 	dangerous = FALSE


### PR DESCRIPTION

## About The Pull Request
See title. Flares now have 1 drag delay (down from 3) and 0 drag windup (down from 1.5)

untested pr
## Why It's Good For The Game
Flares are very potent as a map control tool and are incredibly comically easy for marines to shit out en masse, on top of being functionally unlimited. Forcing xenos to wait 1.5 seconds to drag each flare is really :/
## Changelog
:cl:
balance: Xenos may now drag flares without windup. Flares may be dragged much faster overall.
/:cl:
