### PR TITLE
Fix flamer back tank disconnecting with magharness

### DIFF
--- a/code/datums/components/reequip.dm
+++ b/code/datums/components/reequip.dm
@@ -5,10 +5,8 @@
 
 	///list of SLOT_* defines for equip_in_one_of_slots
 	var/list/slots_to_try
-	///Ticks between the object being dropped and reequipped
-	var/reequip_delay = 0.3 SECONDS
 
-/datum/component/reequip/Initialize(slots, _reequip_delay, ...)
+/datum/component/reequip/Initialize(slots, ...)
 	if(!slots)
 		return COMPONENT_INCOMPATIBLE
 	if(!isitem(parent))
@@ -16,8 +14,6 @@
 	if(!islist(slots))
 		slots = list(slots)
 	slots_to_try = slots
-	if(_reequip_delay)
-		reequip_delay = _reequip_delay
 	RegisterSignal(parent, COMSIG_ITEM_REMOVED_INVENTORY, PROC_REF(begin_reequip))
 	RegisterSignal(parent, COMSIG_MOVABLE_PRE_THROW, PROC_REF(cancel_throw))
 
@@ -29,7 +25,7 @@
 ///Just holds a delay for the reequip attempt
 /datum/component/reequip/proc/begin_reequip(source, mob/user)
 	SIGNAL_HANDLER
-	addtimer(CALLBACK(src, PROC_REF(catch_wrapper), source, user), reequip_delay)
+	INVOKE_ASYNC(src, PROC_REF(catch_wrapper), source, user)
 
 ///Wrapper to ensure signals only come from One Spot
 /datum/component/reequip/proc/catch_wrapper(source, mob/user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -458,7 +458,8 @@
 	. = ..()
 	set_gun_user(null)
 	active_attachable?.removed_from_inventory(user)
-	drop_connected_mag(null, user)
+	if(loc != user) // reequip component caught it with the signal
+		drop_connected_mag(null, user)
 
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)


### PR DESCRIPTION

## About The Pull Request

Note: also removes .3 second delay for magharness. Since you get stunned anyway this shouldn't do anything?

## Why It's Good For The Game
Best case yay back tank worst case we find out why the delay is there and I redo this

## Changelog
:cl:
del: Removed split second delay on magharness
fix: Fix flamer back tank disconnecting with magharness
/:cl:
