### PR TITLE
Adds a prompt to the reload admins verb

### DIFF
--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -444,6 +444,9 @@
 	if(!check_rights(R_SERVER))
 		return
 
+	if(tgui_alert(usr, "Are you sure you want to reload admins?", "Reload admins", list("Yes", "No")) != "Yes")
+		return
+
 	load_admins()
 
 	log_admin("[key_name(src)] manually reloaded admins.")


### PR DESCRIPTION

## About The Pull Request

Title. Yes/no prompt
## Why It's Good For The Game

I keep pressing this on accident while trying to start the round on local and it has no prompt so it basically just de-admins you if you're on localhost. This sucks
## Changelog
:cl:
admin: Added a prompt to the reload admins verb
/:cl:
