### PR TITLE
Action fixes

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -189,9 +189,8 @@
 		return
 	if(!owner)
 		return
-	SEND_SIGNAL(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, owner)
-
 	if(toggled)
+		SEND_SIGNAL(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, owner)
 		RegisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, PROC_REF(deselect))
 	else
 		UnregisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE)

--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -183,6 +183,19 @@
 		deselect()
 	return ..()
 
+/datum/action/ability/activable/set_toggle(value)
+	. = ..()
+	if(!.)
+		return
+	if(!owner)
+		return
+	SEND_SIGNAL(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, owner)
+
+	if(toggled)
+		RegisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, PROC_REF(deselect))
+	else
+		UnregisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE)
+
 /datum/action/ability/activable/alternate_action_activate()
 	INVOKE_ASYNC(src, PROC_REF(action_activate))
 

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -26,8 +26,6 @@ KEYBINDINGS
 	var/action_type = ACTION_CLICK
 	///Used for keeping track of the addition of the selected/active frames
 	var/toggled = FALSE
-	///Flags for action behavior
-	var/action_flags = NONE
 
 /datum/action/New(Target)
 	target = Target

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -26,6 +26,8 @@ KEYBINDINGS
 	var/action_type = ACTION_CLICK
 	///Used for keeping track of the addition of the selected/active frames
 	var/toggled = FALSE
+	///Flags for action behavior
+	var/action_flags = NONE
 
 /datum/action/New(Target)
 	target = Target
@@ -71,26 +73,10 @@ KEYBINDINGS
 ///Depending on the action type , toggles the selected/active frame to show without allowing stacking multiple overlays
 /datum/action/proc/set_toggle(value)
 	if(value == toggled)
-		return
-	if(value)
-		if(owner)
-			SEND_SIGNAL(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, owner)
-		RegisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE, PROC_REF(deselect))
-		switch(action_type)
-			if(ACTION_SELECT)
-				button.add_overlay(visual_references[VREF_MUTABLE_SELECTED_FRAME])
-			if(ACTION_TOGGLE)
-				button.add_overlay(visual_references[VREF_MUTABLE_ACTIVE_FRAME])
-		toggled = TRUE
-		return
-	if(owner)
-		UnregisterSignal(owner, COMSIG_ACTION_EXCLUSIVE_TOGGLE)
-	switch(action_type)
-		if(ACTION_SELECT)
-			button.cut_overlay(visual_references[VREF_MUTABLE_SELECTED_FRAME])
-		if(ACTION_TOGGLE)
-			button.cut_overlay(visual_references[VREF_MUTABLE_ACTIVE_FRAME])
-	toggled = FALSE
+		return FALSE
+	toggled = value
+	update_button_icon()
+	return TRUE
 
 ///Setting this action as the active action
 /datum/action/proc/select()
@@ -134,6 +120,17 @@ KEYBINDINGS
 			button.add_overlay(action_appearence)
 	if(background_icon_state != button.icon_state)
 		button.icon_state = background_icon_state
+	switch(action_type)
+		if(ACTION_SELECT)
+			button.cut_overlay(visual_references[VREF_MUTABLE_SELECTED_FRAME])
+		if(ACTION_TOGGLE)
+			button.cut_overlay(visual_references[VREF_MUTABLE_ACTIVE_FRAME])
+	if(toggled)
+		switch(action_type)
+			if(ACTION_SELECT)
+				button.add_overlay(visual_references[VREF_MUTABLE_SELECTED_FRAME])
+			if(ACTION_TOGGLE)
+				button.add_overlay(visual_references[VREF_MUTABLE_ACTIVE_FRAME])
 	handle_button_status_visuals()
 	return TRUE
 

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -55,12 +55,12 @@
 	name = "Toggle [target]"
 	button.name = name
 
+/datum/action/item_action/toggle/action_activate()
+	. = ..()
+	set_toggle(!toggled)
+
 /datum/action/item_action/toggle/suit_toggle
 	keybinding_signals = list(KEYBINDING_NORMAL = COMSIG_KB_SUITLIGHT)
-
-/datum/action/item_action/toggle/suit_toggle/update_button_icon()
-	set_toggle(holder_item.light_on)
-	return ..()
 
 /datum/action/item_action/toggle/motion_detector/action_activate()
 	. = ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -188,7 +188,6 @@
 	flags_armor_features ^= ARMOR_LAMP_ON
 	playsound(src, 'sound/items/flashlight.ogg', 15, TRUE)
 	update_icon()
-	update_action_button_icons()
 
 /obj/item/clothing/suit/update_clothing_icon()
 	if(ismob(loc))

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -121,7 +121,6 @@
 
 /obj/item/armor_module/ui_action_click(mob/user, datum/action/item_action/toggle/action)
 	action.set_toggle(activate(user))
-	action.update_button_icon()
 
 ///Called on ui_action_click. Used for activating the module.
 /obj/item/armor_module/proc/activate(mob/living/user)

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -145,7 +145,6 @@
 			return FALSE
 	return ..()
 
-
 /obj/item/clothing/suit/modular/attack_self(mob/user)
 	. = ..()
 	if(.)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1546,7 +1546,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		. = TRUE
 	for(var/datum/action/item_action/toggle/action_to_update AS in actions)
 		action_to_update.set_toggle(.)
-		action_to_update.update_button_icon()
 
 ///Handles the gun attaching to the armor.
 /obj/item/attachable/shoulder_mount/proc/handle_armor_attach(datum/source, attaching_item, mob/user)
@@ -1755,7 +1754,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	attached_to:gunattachment = src
 	activate(user)
 	new_action.set_toggle(TRUE)
-	new_action.update_button_icon()
 	update_icon()
 	RegisterSignal(master_gun, COMSIG_ITEM_REMOVED_INVENTORY, TYPE_PROC_REF(/obj/item/weapon/gun, drop_connected_mag))
 
@@ -1791,11 +1789,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		set_gun_user(null)
 		set_gun_user(master_gun.gun_user)
 		to_chat(user, span_notice("You start using [src]."))
-	for(var/datum/action/item_action/toggle/action AS in master_gun.actions)
-		if(action.target != src )
-			continue
-		action.set_toggle(master_gun.active_attachable == src)
-		action.update_button_icon()
 	return TRUE
 
 ///Called when the attachment is trying to be attached. If the attachment is allowed to go through, return TRUE.


### PR DESCRIPTION
## About The Pull Request
Some fixes/code improvements.
Fixes #14831

Fixes certain toggle action (like underbarrels etc) interacting with ability toggles like jetpack.
The exclusive toggle stuff is now at the ability/activable level, since I realised thats actually the only place needed.

Unfucked various action code, mainly around suit lights and gun attachments that were just doing dumb/unneeded stuff.

Setting toggled overlays is now handled by update_button_icon() instead of set_toggle() directly.
## Why It's Good For The Game
Bug fix, cleaner code
## Changelog
:cl:
fix: fixed some actions interacting with other actions incorrectly
code: cleaned up some more action code
/:cl:
