### PR TITLE
Reduces The Cost Of The Minion Spawner

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -235,7 +235,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/building/spawner
 	name = "Spawner"
 	desc = "Constructs a spawner that generates ai xenos over time"
-	psypoint_cost = 600
+	psypoint_cost = 400
 	icon = "spawner"
 	flags_gamemode = ABILITY_NUCLEARWAR
 	flags_upgrade = UPGRADE_FLAG_USES_TACTICAL


### PR DESCRIPTION

## About The Pull Request
Reduces the cost of the minion spawner from 600 tac points to 400.
## Why It's Good For The Game
Right now this thing is incredibly expensive, especially compared to other tac buildings. This will hopefully make it more in-line with the cost of other tac purchase. I wasn't sure how to price this, so I set it to 400 so if it's bought round-start, there wouldn't be points for other tac structures. If it's still too expensive or too cheap, let me know
## Changelog
:cl:
balance: Reduced the price of the minion spawner from 600 to 400 tac points
/:cl:
