### PR TITLE
Plasma guns no longer spawn in crash, valhalla

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -248,8 +248,6 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
 			/obj/item/cell/lasgun/plasma_powerpack = -1,
 			/obj/item/cell/lasgun/volkite/powerpack/plasma_chargepack = -1,
-			/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/rifle = 5,
-			/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/cannon = 5,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,
@@ -448,6 +446,8 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = -1,
 			/obj/item/cell/lasgun/plasma_powerpack = -1,
 			/obj/item/cell/lasgun/volkite/powerpack/plasma_chargepack = -1,
+			/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/rifle = -1,
+			/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/cannon = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,


### PR DESCRIPTION

## About The Pull Request
i forget these are both mechanics that exist in our game
## Why It's Good For The Game
There probably shouldn't be plasma guns in crash, I'll leave the ammo incase someone does an event or something.
## Changelog
:cl:
fix: You can no longer get plasma guns on crash.
fix: You can find plasma guns in valhalla.
/:cl:
