### PR TITLE
Defibbing a dead marine turns on their camera.

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -307,6 +307,13 @@
 	H.handle_regular_hud_updates()
 	H.updatehealth() //One more time, so it doesn't show the target as dead on HUDs
 	H.dead_ticks = 0 //We reset the DNR time
+
+	//Checks if our "patient" is wearing a camera. Then it turns it on if it's off.
+	if(istype(H.wear_ear, /obj/item/radio/headset/mainship))
+		var/obj/item/radio/headset/mainship/cam_headset = H.wear_ear
+		if(!(cam_headset.camera.status))
+			cam_headset.camera.toggle_cam(null, FALSE)
+
 	REMOVE_TRAIT(H, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
 	if(user.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -311,7 +311,7 @@
 	//Checks if our "patient" is wearing a camera. Then it turns it on if it's off.
 	if(istype(H.wear_ear, /obj/item/radio/headset/mainship))
 		var/obj/item/radio/headset/mainship/cam_headset = H.wear_ear
-		if(!(cam_headset.camera.status))
+		if(!(cam_headset?.camera?.status))
 			cam_headset.camera.toggle_cam(null, FALSE)
 
 	REMOVE_TRAIT(H, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -166,7 +166,7 @@
 	if(stat == DEAD)
 		if(istype(wear_ear, /obj/item/radio/headset/mainship))
 			var/obj/item/radio/headset/mainship/cam_headset = wear_ear
-			if(cam_headset.camera.status)
+			if(cam_headset?.camera?.status)
 				cam_headset.camera.toggle_cam(null, FALSE)
 				playsound(loc, "alien_claw_metal", 25, 1)
 				X.do_attack_animation(src, ATTACK_EFFECT_CLAW)


### PR DESCRIPTION

## About The Pull Request
Defibbing a dead marine turns on their camera.
## Why It's Good For The Game
This currently just exists as a knowledge check, which does nothing but harm CIC/AI players.
It's dumb and should not exist.
## Changelog
:cl:
qol: Defibbing a dead marine will turn on their camera
/:cl:
