### PR TITLE
Xenos once again block marines diagonally

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -330,7 +330,7 @@
 			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
 			 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us
 			*/
-			if(moving_diagonally && (get_dir(src, L) in GLOB.cardinals) && (L.faction == faction || L.move_force <= move_resist) && get_step(src, dir).Enter(src, loc))
+			if(moving_diagonally && (get_dir(src, L) in GLOB.cardinals) && (L.faction == faction || L.move_resist <= move_force) && get_step(src, dir).Enter(src, loc))
 				mob_swap_mode = PHASING
 			if(mob_swap_mode)
 				//switch our position with L

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -327,8 +327,10 @@
 				mob_swap_mode = PHASING
 			else if((move_resist >= MOVE_FORCE_VERY_STRONG || move_resist > L.move_force) && a_intent == INTENT_HELP) //Larger mobs can shove aside smaller ones. Xenos can always shove xenos
 				mob_swap_mode = SWAPPING
-			///if we're moving diagonally, but the mob isn't on the diagonal destination turf we have no reason to shuffle/push them
-			if(moving_diagonally && (get_dir(src, L) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc))
+			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
+			 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us
+			*/
+			if(moving_diagonally && (get_dir(src, L) in GLOB.cardinals) && (L.faction == faction || L.move_force <= move_resist) && get_step(src, dir).Enter(src, loc))
 				mob_swap_mode = PHASING
 			if(mob_swap_mode)
 				//switch our position with L


### PR DESCRIPTION

## About The Pull Request


https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/e7257b5d-2a1b-4d21-9a9a-b1151371ec46
## Why It's Good For The Game

Marines can kinda do some still escapes currenly and it can be pretty hard for xenos to do something to stop it in certain cases.

![NVIDIA_Share_Z7Em4zZomG](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/239ffc74-2f12-4e47-b1ea-ded29538111d)
For example the marine can just walk like this which isn't ideal.

This also restores behavior to the old one from before my diagonal PRs.
## Changelog
:cl:
balance: Marines cannot skip past xenos diagonally if there's an obstacle between them, check the PR for a more clear explanation
/:cl:
