### PR TITLE
SOM light armour fix

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -1,10 +1,10 @@
-/datum/loadout_item/suit_slot/som_som_light_shield
+/datum/loadout_item/suit_slot/som_light_shield
 	name = "Light Aegis armor"
 	desc = "M-11 scout armor with a Aegis shield module. Provides excellent mobility but lower protection."
 	item_typepath = /obj/item/clothing/suit/modular/som/light/shield
 	jobs_supported = list(SOM_SQUAD_MARINE)
 
-/datum/loadout_item/suit_slot/som_som_light_shield
+/datum/loadout_item/suit_slot/som_light_shield/veteran
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	req_desc = "Requires a blink drive."
 	item_whitelist = list(/obj/item/blink_drive = ITEM_SLOT_BACK)


### PR DESCRIPTION

## About The Pull Request
MFW no one asks why SOM squaddies don't have light armour, but have weapons that are only available with light armour.
## Why It's Good For The Game
Missing equipment bad
## Changelog
:cl:
fix: fixed missing light armour for SOM squaddies in campaign
/:cl:
