### PR TITLE
Auto job tab select for campaign

### DIFF
--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -135,7 +135,8 @@
 		CRASH("campaign_mission loaded without campaign game mode")
 
 	var/list/data = list()
-
+	var/mob/living/living_user = user
+	data["current_job"] = istype(living_user) ? living_user.job.title : null
 	data["currency"] = currency
 
 	//perk stuff

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
@@ -24,7 +24,7 @@ export const IndividualLoadouts = (props) => {
     useLocalState<LoadoutItemData | null>('unlockPotentialItem', null);
   const [selectedJob, setSelectedJob] = useLocalState(
     'selectedJob',
-    data.jobs[0],
+    data.current_job ? data.current_job : data.jobs[0],
   );
   const [selectedLoadoutItem, setselectedLoadoutItem] = useLocalState(
     'selectedLoadoutItem',

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
@@ -20,7 +20,7 @@ export const IndividualPerks = (props) => {
   );
   const [selectedJob, setSelectedJob] = useLocalState(
     'selectedJob',
-    data.jobs[0],
+    data.current_job ? data.current_job : data.jobs[0],
   );
   const [selectedPerk, setSelectedPerk] = useLocalState(
     'selectedPerk',

--- a/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
@@ -32,6 +32,7 @@ export type IndividualData = {
   ui_theme: string;
   perks_data: PerkData[];
   currency: number;
+  current_job?: string;
   faction: string;
   jobs: string[];
   perk_icons?: string[];
@@ -77,7 +78,7 @@ export const IndividualStats = (props) => {
   );
   const [selectedJob, setSelectedJob] = useLocalState(
     'selectedJob',
-    data.jobs[0],
+    data.current_job ? data.current_job : data.jobs[0],
   );
 
   const [unlockedPerk, setPurchasedPerk] = useLocalState<PerkData | null>(


### PR DESCRIPTION

## About The Pull Request
When you open the loadout screen, it will now automatically default to your current role, since that's what you're going to interact with 95% of the time.
## Why It's Good For The Game
Better QOL
## Changelog
:cl:
qol: Campaign loadout UI defaults to the job tab for your current job
/:cl:
