### PR TITLE
Radiopack and AI drone beacon don't work in deep caves anymore

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -633,6 +633,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	if(!is_ground_level(user.z))
 		to_chat(user, span_warning("You have to be on the planet to use this or it won't transmit."))
 		return FALSE
+	var/area/A = get_area(user)
+	if(A && istype(A) && A.ceiling >= CEILING_DEEP_UNDERGROUND)
+		to_chat(user, span_warning("This won't work if you're standing deep underground."))
+		return FALSE
 	var/turf/location = get_turf(src)
 	beacon_datum = new /datum/supply_beacon(user.name, user.loc, user.faction, 4 MINUTES)
 	RegisterSignal(beacon_datum, COMSIG_QDELETING, PROC_REF(clean_beacon_datum))

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -131,6 +131,10 @@
 	if(!is_ground_level(z))
 		to_chat(source, span_warning("You have to be on the planet to use this or it won't transmit."))
 		return FALSE
+	var/area/A = get_area(user)
+	if(A && istype(A) && A.ceiling >= CEILING_DEEP_UNDERGROUND)
+		to_chat(user, span_warning("This won't work if you're standing deep underground."))
+		return FALSE
 	beacon_datum = new /datum/supply_beacon(user.name, src.loc, user.faction, 4 MINUTES)
 	RegisterSignal(beacon_datum, COMSIG_QDELETING, PROC_REF(clean_beacon_datum))
 	user.show_message(span_notice("The [src] beeps and states, \"Your current coordinates were registered by the supply console. LONGITUDE [loc.x]. LATITUDE [loc.y]. Area ID: [get_area(src)]\""))


### PR DESCRIPTION

## About The Pull Request

I thought this was done in the same PR we made antenna have this behavior. Apparently not.
## Why It's Good For The Game

See https://github.com/tgstation/TerraGov-Marine-Corps/pull/14594 and https://github.com/tgstation/TerraGov-Marine-Corps/pull/14596

I'd also like to add that depending on map plat holds can be near impenetrable by a relatively large portion of the hive. This gets even more apparent if the pop is low (the xenos either have to choose to give up the whole map to deal with a plat or just let the plat mine for free). This is pretty sub par from a design perspective in my opinion and is more an issue with the mode admittedly. The xenos should be able to attrition the miner at least.

Plat mining should probably not be something that can be done indefinitely and the marine who does it should have to risk themselves to get additional supplies at least.
## Changelog
:cl:
balance: Radiopack and AI drone beacon don't work in deep caves anymore
/:cl:
