### PR TITLE
Russian Red rework

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -256,7 +256,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/russian_red
 	name = "emergency autoinjector"
-	desc = "An autoinjector loaded with a single use of Russian Red. Restores a significant amount of stamina and heals a large amount of damage, but causes slight permanent damage."
+	desc = "An autoinjector loaded with a single use of Russian Red. Restores a significant amount of stamina and heals a large amount of damage, but causes slight permanent damage and unconciousness durning the process."
 	icon_state = "Redwood"
 	amount_per_transfer_from_this = 15
 	volume = 30

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -455,7 +455,7 @@
 
 /obj/item/storage/pill_bottle/russian_red
 	name = "\improper Russian Red pill bottle"
-	desc = "Contains pills that heal all damage rapidly at the cost of small amounts of unhealable damage."
+	desc = "Contains pills that heal damage rapidly at the cost of small amounts of unhealable damage and the requirement of being asleep durning the process."
 	icon_state = "pill_canister"
 	pill_type_to_fill = /obj/item/reagent_containers/pill/russian_red
 	greyscale_colors = "#3d0000#ffffff"

--- a/code/game/objects/items/storage/pill_packets.dm
+++ b/code/game/objects/items/storage/pill_packets.dm
@@ -84,7 +84,7 @@
 
 /obj/item/storage/pill_bottle/packet/russian_red
 	name = "russian red pill packet"
-	desc = "This packet contains Russian Red pills. Used for field treatment of critical cases without a medic. Once you take them out they don't go back in.."
+	desc = "This packet contains Russian Red pills. Used for field treatment of critical cases without a medic, causes unconciousness durning the process. Once you take them out they don't go back in.."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/russian_red
 	pip_color = COLOR_PACKET_RUSSIAN_RED
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -593,8 +593,8 @@
 		if(1 to 9) // Extremely strong painkiller effect, could technically be used to escape high pain, but you'll pass out soon.. So..
 			L.reagent_pain_modifier += PAIN_REDUCTION_SUPER_HEAVY
 		if(10 to 40)
-			L.heal_overall_damage(7*effect_str, 7*effect_str)
-			L.adjustToxLoss(-2.5*effect_str)
+			L.heal_overall_damage(8*effect_str, 8*effect_str)
+			L.adjustToxLoss(-3.5*effect_str)
 			L.Sleeping(2 SECONDS)
 			L.adjustCloneLoss(0.2*effect_str)
 		if(41 to INFINITY)


### PR DESCRIPTION

## About The Pull Request
Russian red rework
- Now knocks you out durning the process of healing, with a slight delay.
- Heals slightly more (8 per tick)
- Clone loss is way less. Also offset by the fact you're sleeping.
- The windup before the heal has incredibly high pain resist, you could technically use this as a super inaprov if you time it well on downed teammates.
## Why It's Good For The Game
Makes Russian Red less of an emergency combat chem and more of an emergency out of combat chemical, you could still use it in combat for the super high pain resist, however such a manuever is ill advised.
## Changelog
:cl:
balance: Russian red has been entirely reworked, it now knocks you out durning the process of healing, has slightly higher healing, has high pain resist before the windup, the emergency healing on crit marines has been unchanged.
/:cl:
