### PR TITLE
You can buy pair of neuraline injectors in req.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1179,6 +1179,14 @@ MEDICAL
 	)
 	cost = 300
 
+/datum/supply_packs/medical/neuraline_injector
+	name = "Neuraline Injector (x2)"
+	contains = list(
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+	)
+	cost = 200
+
 /datum/supply_packs/medical/biomass
 	name = "biomass crate"
 	contains = list(


### PR DESCRIPTION

## About The Pull Request
x2 for 200 points.
## Why It's Good For The Game
Adds more stuff for marines to buy for points, technically you can buy 1 for 300 in advanced med, but that's very inefficent.
## Changelog
:cl:
add: Neuraline injector crate to requisitions.
/:cl:
