### PR TITLE
Nanites purge healing meds but can't be purged (+ a buff to their healing)

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -310,7 +310,7 @@
 	icon_state = "autoinjector-6"
 	amount_per_transfer_from_this = 1
 	volume = 1
-	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1)
+	list_reagents = list(/datum/reagent/medicalnanites = 1)
 	free_refills = FALSE
 
 /obj/item/reagent_containers/hypospray/autoinjector/pain //made for debugging

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -215,9 +215,9 @@
 
 /datum/chemical_reaction/medicalnanites
 	name = "Medical Nanites"
-	results = list(/datum/reagent/medicine/research/medicalnanites = 9)
+	results = list(/datum/reagent/medicalnanites = 9)
 	required_reagents = list(/datum/reagent/iron = 10, /datum/reagent/medicine/lemoline = 1)
-	required_catalysts = list(/datum/reagent/medicine/research/medicalnanites = 1)
+	required_catalysts = list(/datum/reagent/medicalnanites = 1)
 
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1275,7 +1275,7 @@
 /datum/reagent/medicine/research/somolent/overdose_process(mob/living/L, metabolism)
 	holder.remove_reagent(/datum/reagent/medicine/research/somolent, 1)
 
-/datum/reagent/medicine/research/medicalnanites
+/datum/reagent/medicalnanites
 	name = "Medical nanites"
 	description = "These are a batch of construction nanites altered for in-vivo replication. They can heal wounds using the iron present in the bloodstream. Medical care is recommended during injection."
 	color = COLOR_REAGENT_MEDICALNANITES
@@ -1283,49 +1283,63 @@
 	scannable = TRUE
 	taste_description = "metal, followed by mild burning"
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
+	purge_list = list(
+		/datum/reagent/medicine/bicaridine,
+		/datum/reagent/medicine/kelotane,
+		/datum/reagent/medicine/tramadol,
+		/datum/reagent/medicine/tricordrazine,
+		/datum/reagent/medicine/meralyne,
+		/datum/reagent/medicine/dermaline,
+		/datum/reagent/medicine/paracetamol,
+		/datum/reagent/medicine/russian_red,
+		/datum/reagent/consumable/drink/doctor_delight,
+	)
+	purge_rate = 5
 
-/datum/reagent/medicine/research/medicalnanites/on_mob_add(mob/living/L, metabolism)
+/datum/reagent/medicalnanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("You feel like you should stay near medical help until this shot settles in."))
 
-/datum/reagent/medicine/research/medicalnanites/on_mob_life(mob/living/L, metabolism)
+/datum/reagent/medicalnanites/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
 		if(1 to 75)
-			L.take_limb_damage(0.015*current_cycle*effect_str, 0.015*current_cycle*effect_str)
-			L.adjustToxLoss(1*effect_str)
-			L.adjustStaminaLoss((1.5)*effect_str)
-			L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.40)
+			L.take_limb_damage(0.015 * current_cycle * effect_str, 0.015 * current_cycle * effect_str)
+			L.adjustToxLoss(1 * effect_str)
+			L.adjustStaminaLoss(1.5 * effect_str)
+			L.reagents.add_reagent(/datum/reagent/medicalnanites, 0.4)
 			if(prob(5))
 				to_chat(L, span_notice("You feel intense itching!"))
 		if(76)
 			to_chat(L, span_warning("The pain rapidly subsides. Looks like they've adapted to you."))
 		if(77 to INFINITY)
 			if(volume < 30) //smol injection will self-replicate up to 30u using 240u of blood.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.15)
+				L.reagents.add_reagent(/datum/reagent/medicalnanites, 0.15)
 				L.blood_volume -= 2
 
 			if(volume < 35) //allows 10 ticks of healing for 20 points of free heal to lower scratch damage bloodloss amounts.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.1)
+				L.reagents.add_reagent(/datum/reagent/medicalnanites, 0.1)
 
-			if (volume > 5 && L.getBruteLoss(organic_only = TRUE))
-				L.heal_overall_damage(2*effect_str, 0)
-				L.adjustToxLoss(0.1*effect_str)
-				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)
-				if(prob(40))
+			if(volume > 5)
+				L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
+				L.adjustToxLoss(-0.15 * effect_str)
+
+			if(volume > 5 && L.getBruteLoss(organic_only = TRUE))
+				L.heal_overall_damage(3 * effect_str, 0)
+				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
+				if(prob(10))
 					to_chat(L, span_notice("Your cuts and bruises begin to scab over rapidly!"))
 
-			if (volume > 5 && L.getFireLoss(organic_only = TRUE))
-				L.heal_overall_damage(0, 2*effect_str)
-				L.adjustToxLoss(0.1*effect_str)
-				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)
-				if(prob(40))
+			if(volume > 5 && L.getFireLoss(organic_only = TRUE))
+				L.heal_overall_damage(0, 3 * effect_str)
+				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
+				if(prob(10))
 					to_chat(L, span_notice("Your burns begin to slough off, revealing healthy tissue!"))
 	return ..()
 
-/datum/reagent/medicine/research/medicalnanites/overdose_process(mob/living/L, metabolism)
+/datum/reagent/medicalnanites/overdose_process(mob/living/L, metabolism)
 	L.adjustToxLoss(effect_str) //softcap VS injecting massive amounts of medical nanites for the healing factor with no downsides. Still doable if you're clever about it.
-	holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.25)
+	holder.remove_reagent(/datum/reagent/medicalnanites, 0.25)
 
-/datum/reagent/medicine/research/medicalnanites/on_mob_delete(mob/living/L, metabolism)
+/datum/reagent/medicalnanites/on_mob_delete(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your nanites have been fully purged! They no longer affect you."))
 
 /datum/reagent/medicine/research/stimulon

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1287,6 +1287,7 @@
 		/datum/reagent/medicine/bicaridine,
 		/datum/reagent/medicine/kelotane,
 		/datum/reagent/medicine/tramadol,
+		/datum/reagent/medicine/oxycodone,
 		/datum/reagent/medicine/tricordrazine,
 		/datum/reagent/medicine/meralyne,
 		/datum/reagent/medicine/dermaline,


### PR DESCRIPTION

## About The Pull Request
- Repaths nanites so they don't get purged by hypervene or ozeo (or water)
- Makes nanites purge chemicals that heal brute or burn (also tramadol because I made nanites give its effects)
- Makes nanites HEAL a small amount of toxin damage (you can still take dylo with them by the way)
## Why It's Good For The Game

The goal of these changes is to make nanites more of a sidegrade to the classic BKTT, with some upsides as well as downsides.

Upsides being 
- You get a little more healing overall 
- You only have to carry blood restoring chemicals instead of pill bottles of BKTT

Downsides being

- You may find it hard to keep blood up if you're constantly taking damage
- You can't inject more on the fly, and if you get defiled (should be the only way to get your nanites purged) you have to get a new injector which will take time to make your nanites work again
## Changelog
:cl:
balance: Nanites have been rebalanced to be a sidegrade to BKTT, check the PR for more details
/:cl:
