### PR TITLE
Fixes Xenomorph pounce bypassing shields & improves it a bit.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -327,17 +327,22 @@
 	if(living_target.stat)
 		return
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	if(ishuman(living_target) && (living_target.dir in reverse_nearby_direction(living_target.dir)))
+	if(ishuman(living_target) && (angle_to_dir(Get_Angle(xeno_owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
 		var/mob/living/carbon/human/human_target = living_target
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
 			xeno_owner.Paralyze(XENO_POUNCE_SHIELD_STUN_DURATION)
 			xeno_owner.set_throwing(FALSE)
 			return COMPONENT_KEEP_THROWING
-	playsound(living_target.loc, 'sound/voice/alien_pounce.ogg', 25, TRUE)
+	trigger_pounce_effect(living_target)
+	pounce_complete()
+
+///Triggers the effect of a successful pounce on the target.
+/datum/action/ability/activable/xeno/pounce/proc/trigger_pounce_effect(mob/living/living_target)
+	playsound(get_turf(living_target), 'sound/voice/alien_pounce.ogg', 25, TRUE)
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.Immobilize(XENO_POUNCE_STANDBY_DURATION)
 	xeno_owner.forceMove(get_turf(living_target))
 	living_target.Knockdown(XENO_POUNCE_STUN_DURATION)
-	pounce_complete()
 
 /datum/action/ability/activable/xeno/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -32,7 +32,7 @@
 	action_icon_state = "pounce_savage_[savage_activated? "on" : "off"]"
 	update_button_icon()
 
-/datum/action/ability/activable/xeno/pounce/runner/mob_hit(datum/source, mob/living/living_target)
+/datum/action/ability/activable/xeno/pounce/runner/trigger_pounce_effect(mob/living/living_target)
 	. = ..()
 	if(!savage_activated)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -597,6 +597,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	for(var/mob/rider AS in crosser.buckled_mobs)
 		if(ishuman(rider))
 			crosser.unbuckle_mob(rider)
+	if(crosser.throwing)
+		crosser.throw_source = get_turf(linked_portal)
 	crosser.Move(get_turf(linked_portal), crosser.dir)
 	UnregisterSignal(crosser, COMSIG_MOVABLE_MOVED)
 


### PR DESCRIPTION
## About The Pull Request
#14099 broke the shield dir check by checking for the target twice instead of xeno vs. target.
Not only does this fix it, it also improves the direction check to be more versatile instead of relying strictly on the xeno's dir, using angle relative to origin turf. Furthermore, also fixes some proc stuff so Savage no longer triggers if the pounce itself failed (which is the correct behavior).

Additionally, somewhat related, makes portals teleporting a thrown object adjust the throw origin turf to the portal target's turf.
Portals currently mess up anything that uses the throw origin turf for calculations (such as bounces), which may lead to issues with thrown objects. This should make them behave more reasonable.
## Why It's Good For The Game
Fix man good.

Portals not updating throw origin, while a minor issue, can be annoying, and should not break anything if it is updated (the throw itself uses a seperate var).
## Changelog
:cl:
fix: Xenomorph pounce abilities no longer bypass shields.
fix: Runner Savage only triggers if the pounce didn't fail.
fix: Thrown objects should now behave more reasonable after passing a portal, for cases such as bouncing.
/:cl:
