### PR TITLE
Gives DBs a 0.7 damage multiplier

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -172,6 +172,7 @@
 	recoil = 2
 	recoil_unwielded = 4
 	aim_slowdown = 0.6
+	damage_mult = 0.7
 
 /obj/item/weapon/gun/shotgun/double/sawn
 	name = "sawn-off shotgun"
@@ -499,6 +500,7 @@
 	movement_acc_penalty_mult = 5
 
 	placed_overlay_iconstate = "wood"
+	damage_mult = 1
 
 //***********************************************************
 // Derringer
@@ -529,6 +531,7 @@
 	recoil_unwielded = 0
 	aim_slowdown = 0
 	wield_delay = 0.1 SECONDS
+	damage_mult = 1
 
 /obj/item/weapon/gun/shotgun/double/derringer/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Title. The edits to make it 1 are because martini and derringer are subtypes of the DB.
## Why It's Good For The Game

Seems [barnets nerf](https://github.com/tgstation/TerraGov-Marine-Corps/pull/13588) didn't really do much to curb the fact the DB is just flat out the best shotgun if you learn the reload and therefore overperforms. This aims to bring it more in line with the others. You can still fire it fast but you don't chunk as hard as a full powered shotgun. 

By the way this applies to the sawn off and the map spawned DBs too

## Changelog
:cl:
balance: Gave DBs a 0.7 damage multiplier, like the SH-39
/:cl:
