### PR TITLE
sg-29 aim slowdown change from .95 to .85

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1268,7 +1268,7 @@
 	caliber = CALIBER_10x26_CASELESS //codex
 	max_shells = 300 //codex
 	force = 30
-	aim_slowdown = 0.95
+	aim_slowdown = 0.85
 	wield_delay = 1.3 SECONDS
 	fire_sound = "gun_smartgun"
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'


### PR DESCRIPTION
## About The Pull Request

MJP said that sg-29 should get a slowdown of "0.85 rather than 0.95" that is not from v-grip

https://github.com/tgstation/TerraGov-Marine-Corps/pull/14842

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/95c42ca5-5dfb-4597-89bf-e0cb172e4bf1)


## Why It's Good For The Game

as promised by other PR

## Changelog

:cl:
balance: sg-29 aim slowdown change from .95 to .85
/:cl:

