### PR TITLE
Fix acid pool wrong flags

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -246,7 +246,8 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Constructs a pool that allows xenos to regenerate sunder in it while resting. Requires open space and time to place."
 	psypoint_cost = 200
 	icon = "pool"
-	flags_upgrade = ABILITY_NUCLEARWAR|UPGRADE_FLAG_USES_TACTICAL
+	flags_gamemode = ABILITY_NUCLEARWAR
+	flags_upgrade = UPGRADE_FLAG_USES_TACTICAL
 	building_type = /obj/structure/xeno/acid_pool
 
 /datum/hive_upgrade/building/acid_pool/can_buy(mob/living/carbon/xenomorph/buyer, silent = TRUE)


### PR DESCRIPTION

## About The Pull Request

ABILITY_NUCLEARWAR was put in the wrong place, this means it was a one time buy for some reason like its a primo
## Why It's Good For The Game

Bug bad
## Changelog
:cl:
fix: Fix acid pools having bad flags
/:cl:
