### PR TITLE
Medicine now doesnt heal you for 4 seconds if you get slashed/shot

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -122,6 +122,8 @@
 	var/damage_done = apply_damage(damage, BRUTE, affecting, armor_block, TRUE, TRUE, TRUE, armor_pen) //This should slicey dicey
 	SEND_SIGNAL(X, COMSIG_XENOMORPH_POSTATTACK_LIVING, src, damage_done, damage_mod)
 
+	last_recieved_attack = world.time
+
 	return TRUE
 
 /mob/living/silicon/attack_alien_disarm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -152,3 +152,6 @@
 	var/time_entered_stasis = 0
 	///The world.time of when this mob entered a cryo tube
 	var/time_entered_cryo = 0
+
+	///last time this mob was attacked by something, manually tracked
+	var/last_recieved_attack = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -912,6 +912,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	else
 		bullet_message(proj, feedback_flags)
 
+	last_recieved_attack = world.time
+
 	GLOB.round_statistics.total_projectile_hits[faction]++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_projectile_hits[faction]")
 

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -304,6 +304,10 @@
 						var/datum/reagent/A = addiction
 						if(istype(R, A))
 							A.addiction_stage = -15 //you're satisfied for a good while
+
+			if(istype(R, /datum/reagent/medicine) && ((L.last_recieved_attack + 4 SECONDS) > world.time))
+				continue
+
 			need_mob_update += R.on_mob_life(L, quirks)
 
 	if(can_overdose)


### PR DESCRIPTION
## About The Pull Request

Tittle

## Why It's Good For The Game

Xenos struggle to deal with marines that armor stack and use heal chems, so instead of trying to deal with 5600 different chem mixes and endlessly nerfing them, this pr removes the problem completely

## Changelog
:cl:
balance: Medicine now doesnt heal you for 4 seconds if you get slashed/shot
/:cl:
