### PR TITLE
Removes Tyr 2 modules from HvX, keeping Tyr 1

### DIFF
--- a/code/game/objects/items/loot_box.dm
+++ b/code/game/objects/items/loot_box.dm
@@ -668,8 +668,6 @@
 	new /obj/item/weapon/gun/minigun(src)
 	new /obj/item/ammo_magazine/minigun_powerpack(src)
 	new /obj/item/ammo_magazine/minigun_powerpack(src)
-	new /obj/item/armor_module/module/tyr_extra_armor(src)
-	new /obj/item/armor_module/module/tyr_extra_armor(src)
 
 /obj/item/storage/box/crate/loot/sadarclassic_pack/Initialize(mapload)
 	. = ..()

--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -453,11 +453,6 @@ GLOBAL_LIST_INIT(module, list(
 	. = ..()
 	recipe = GLOB.module
 
-/obj/item/factory_part/module_tyr2
-	name = "\improper Mark 2 Tyr armor reinforcement"
-	desc = "An unfinished Mark 2 Tyr armor reinforcement module."
-	result = /obj/item/armor_module/module/tyr_extra_armor
-
 /obj/item/factory_part/module_tyr2/Initialize(mapload)
 	. = ..()
 	recipe = GLOB.module

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1039,7 +1039,6 @@ ARMOR
 		/obj/item/armor_module/module/valkyrie_autodoc,
 		/obj/item/armor_module/module/fire_proof,
 		/obj/item/armor_module/module/fire_proof_helmet,
-		/obj/item/armor_module/module/tyr_extra_armor,
 		/obj/item/armor_module/module/mimir_environment_protection,
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/better_shoulder_lamp,
@@ -1060,13 +1059,6 @@ ARMOR
 	contains = list(
 		/obj/item/armor_module/module/fire_proof,
 		/obj/item/armor_module/module/fire_proof_helmet,
-	)
-	cost = 120
-
-/datum/supply_packs/armor/modular/attachments/tyr_extra_armor
-	name = "Tyr mark 2 armor module"
-	contains = list(
-		/obj/item/armor_module/module/tyr_extra_armor,
 	)
 	cost = 120
 


### PR DESCRIPTION
## About The Pull Request
Per title, alternative to #14873 so maintainers can choose whichever of the two they prefer.

## Why It's Good For The Game
See #14873.

## Changelog
:cl: Lewdcifer
del: Tyr 2 module is no longer available in HvX game modes.
/:cl: