### PR TITLE
Removes Mimir 2 modules from HvX

### DIFF
--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -441,18 +441,6 @@ GLOBAL_LIST_INIT(module, list(
 	. = ..()
 	recipe = GLOB.module
 
-/obj/item/factory_part/module_mimir2
-	name = "\improper Mark 2 Mimir environmental resistance system"
-	desc = "An unfinished Mark 2 Mimir environmental resistance system module."
-	result = list(
-		/obj/item/armor_module/module/mimir_environment_protection,
-		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
-	)
-
-/obj/item/factory_part/module_mimir2/Initialize(mapload)
-	. = ..()
-	recipe = GLOB.module
-
 /obj/item/factory_part/module_tyr2
 	name = "\improper Mark 2 Tyr armor reinforcement"
 	desc = "An unfinished Mark 2 Tyr armor reinforcement module."

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -299,12 +299,6 @@
 	refill_type = /obj/item/factory_part/module_valk
 	refill_amount = 10
 
-/obj/item/factory_refill/module_mimir2_refill
-	name = "box of rounded metal plates"
-	desc = "A box of round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/module_mimir2
-	refill_amount = 10
-
 /obj/item/factory_refill/module_tyr2_refill
 	name = "box of rounded metal plates"
 	desc = "A box of round metal plates inside. Used to refill Unboxers."

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1040,8 +1040,6 @@ ARMOR
 		/obj/item/armor_module/module/fire_proof,
 		/obj/item/armor_module/module/fire_proof_helmet,
 		/obj/item/armor_module/module/tyr_extra_armor,
-		/obj/item/armor_module/module/mimir_environment_protection,
-		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/better_shoulder_lamp,
 		/obj/item/armor_module/module/hlin_explosive_armor,
 		/obj/item/armor_module/module/binoculars/artemis_mark_two,
@@ -1069,14 +1067,6 @@ ARMOR
 		/obj/item/armor_module/module/tyr_extra_armor,
 	)
 	cost = 120
-
-/datum/supply_packs/armor/modular/attachments/mimir_environment_protection
-	name = "Mimir Mark 2 module set"
-	contains = list(
-		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
-		/obj/item/armor_module/module/mimir_environment_protection,
-	)
-	cost = 150
 
 /datum/supply_packs/armor/modular/attachments/hlin_bombimmune
 	name = "Hlin armor module"
@@ -2201,11 +2191,6 @@ FACTORY
 /datum/supply_packs/factory/module_valk_refill
 	name = "Valkyrie Automedical Armor System assembly refill"
 	contains = list(/obj/item/factory_refill/module_valk_refill)
-	cost = 600
-
-/datum/supply_packs/factory/module_mimir2_refill
-	name = "Mark 2 Mimir Environmental Resistance System assembly refill"
-	contains = list(/obj/item/factory_refill/module_mimir2_refill)
 	cost = 600
 
 /datum/supply_packs/factory/module_tyr2_refill


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Hard counters acid, very stinky in my eyes. Mimir 1 can stay since it isn't a straight counter.

## Changelog
:cl: Lewdcifer
del: Removes Mimir 2 modules from HvX game modes.
/:cl: