### PR TITLE
Nerfs the Vali module's ability availability

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -24,7 +24,9 @@
 	var/resource_storage_max = 200
 	///Amount of substance stored currently
 	var/resource_storage_current = 0
-	///Amount required for operation
+	/// Amount of substance required to start operating.
+	var/resource_storage_required = 150
+	/// Amount of substance to drain while operating.
 	var/resource_drain_amount = 10
 	///Actions that the component provides
 	var/list/datum/action/component_actions = list(
@@ -243,7 +245,7 @@
 		if(!COOLDOWN_CHECK(src, chemboost_activation_cooldown))
 			wearer.balloon_alert(wearer, "You need to wait another [COOLDOWN_TIMELEFT(src, chemboost_activation_cooldown)/10] seconds")
 			return
-		if(resource_storage_current < resource_drain_amount)
+		if(resource_storage_current < resource_storage_required)
 			wearer.balloon_alert(wearer, "Insufficient green blood to begin operation")
 			return
 		if(wearer.stat)
@@ -284,7 +286,7 @@
 /datum/component/chem_booster/proc/update_boost(amount)
 	boost_amount = amount
 	wearer?.balloon_alert(wearer, "Enhancement level set to [boost_amount]")
-	resource_drain_amount = boost_amount*(3 + boost_amount)
+	resource_drain_amount *= amount
 
 ///Handles Vali stat boosts and any other potential buffs on activation/deactivation
 /datum/component/chem_booster/proc/setup_bonus_effects()
@@ -378,7 +380,7 @@
 		return
 	if(resource_storage_current >= resource_storage_max)
 		return
-	update_resource(round(20*connected_weapon.attack_speed/11))
+	update_resource(round(10 + connected_weapon.attack_speed * 0.5))
 
 ///Adds or removes resource from the suit. Signal gets sent at every 25% of stored resource
 /datum/component/chem_booster/proc/update_resource(amount)


### PR DESCRIPTION
## About The Pull Request
Per title. Changes are as follows;
- Amount of substance required to use the suit's ability increased from 10 > 150.
- Amount of substance drained while the ability is active changed.
  - The previous formula was: `Boost level * (3 + boost level)`, resulting in 4 at x1, and 10 at x2 _(very inconsistent, mind you)_.
  - The new formula is: `10 * boost level`, resulting in 10 at x1 and 20 at x2.
- Amount of substance acquisition changed.
  - The previous formula was: `20 * (weapon attack speed / 11)`, which had varying results depending on your weapon of choice;
    - 14 units per Knife attack.
    - 21 units per Harvester attack. 
    - 43 units per Claymore attack.
  - The new formula is: `10 + (weapon attack speed * 0.5)`, which has varying results depending on your weapon of choice;
    - 14 units per Knife attack _(note it remains unchanged, this is intentional for the knife)_.
    - 16 units per Harvester attack.
    - 22 units per Claymore attack.

## Why It's Good For The Game
We're trying to cut down on just how tanky marines can be, and Vali is a major offender in this party. This PR makes it so that vali users have to put in more work to use their boost, and forces them to actually think about when and where to use it as its availability is reduced.

## Changelog
:cl: Lewdcifer
balance: Vali: amount of substance required to use the suit's ability increased from 10 > 150.
balance: Vali: amount of substance drained while the ability is active changed. Previously, it was 4 at x1 and 10 at x2. This was changed to 10 at x1 and 20 at x2.
balance: Vali: amount of substance acquisition changed. Previously, it was 21 for harvester, and 43 for claymore. This was changed to 16 for harvester, and 22 for claymore. Knife unaffected.
/:cl: