### PR TITLE
MBX can't be one handed

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -668,6 +668,7 @@
 
 	flags_item_map_variant = NONE
 
+	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_SMOKE_PARTICLES
 	fire_delay = 0.6 SECONDS
 	accuracy_mult = 1.2
 	cock_delay = 0.2 SECONDS


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
I don't think this gun really needs it to be good, it already has solid damage and this just makes it melt just about any xeno in a few seconds


https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/ccb6ab07-1ea4-44d1-967c-2528dc7504a6

(you could probably do it faster than this clip im not really trying to time it)
## Changelog
:cl:
balance: MBX is now two handed only
/:cl:
