### PR TITLE
puppeteers organic bomb base timer reduced, now has the windup

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -274,7 +274,7 @@
 		return fail_activate()
 	RegisterSignal(victim, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(start_exploding))
 	RegisterSignal(victim, COMSIG_MOB_DEATH, PROC_REF(detonate))
-	addtimer(CALLBACK(src, PROC_REF(detonate), victim), 15 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_exploding), victim), 5 SECONDS)
 	add_cooldown()
 
 ///asynchronous signal handler for start_exploding_async


### PR DESCRIPTION
## About The Pull Request

organic bomb base timer before automatically detonating reduced from 15 secs to 5, now has the 1.5sec windup instead of an instant explosion
## Why It's Good For The Game

Very underused ability, at times worse because 3 puppets with fury blessing will almost always be a better option (and reducing your puppets for this ability feels weak). The acid itself isn't that strong either. Couple this with a base 15 sec timer before it explodes by itself without reaching a target (and with minion fuckery) makes this abillity very weak as the puppets will likely just die by the time it reaches its target.. In practice the total time before the puppets explode (without slashing anything) will be 6.5s (5 + 1.5s windup)

## Changelog

:cl:
balance: Puppeteers organic bombs base timer reduced, now uses a windup
/:cl:

