### PR TITLE
Show statpanel scroll bar only when needed

### DIFF
--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -4,7 +4,7 @@ body {
 	margin: 0 !important;
 	padding: 0 !important;
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 
 body.dark {


### PR DESCRIPTION

## About The Pull Request

Simple one line change that hides the scroll bar on the stat panel if there is no need for it. I haven't actually tested it on base TGMC, only on my ~2 week old branch but it's just a CSS variable so should work.

## Why It's Good For The Game

One line change that fixes something I found annoying.

## Changelog
:cl:
fix: Hide statpanel scroll bar when not needed.
/:cl:
