### PR TITLE
Fix Toggle Ambience verb and delete CHANNEL_AMBIENT

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -1,6 +1,5 @@
 //max channel is 1024. Only go lower from here, because byond tends to pick the first availiable channel to play sounds on
 #define CHANNEL_LOBBYMUSIC 1024
-#define CHANNEL_AMBIENT 1023
 #define CHANNEL_NOTIFY 1022 // observer, new player, vote notifications
 #define CHANNEL_VOX 1021 //vox announcements from AI
 #define CHANNEL_ANNOUNCEMENTS 1020 // IC priority announcements, hivemind messages etc

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -157,7 +157,7 @@
 		to_chat(src, span_notice("You will now hear ambient sounds."))
 	else
 		to_chat(src, span_notice("You will no longer hear ambient sounds."))
-		mob.stop_sound_channel(CHANNEL_AMBIENT)
+		mob.stop_sound_channel(CHANNEL_AMBIENCE)
 	usr.client.update_ambience_pref()
 
 


### PR DESCRIPTION

## About The Pull Request

The Toggle Ambience verb didn't actually stop ambience that was already running because it used the wrong channel. CHANNEL_AMBIENT is not used anywhere in the code except the define and this verb.

## Why It's Good For The Game

Bug fix. I don't know why CHANNEL_AMBIENT exists, CHANNEL_AMBIENCE is right there.

## Changelog
:cl:
fix: Toggle Ambience verb stops ambience that is currently playing.
/:cl:
