### PR TITLE
Xenomorph resting rework

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -479,6 +479,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SILO_DETECTION_RANGE 10//How far silos can detect hostiles
 #define XENO_GARGOYLE_DETECTION_COOLDOWN 30 SECONDS
 #define XENO_GARGOYLE_DETECTION_RANGE 10//How far gargoyles can detect hostiles
+#define XENO_RESTING_COOLDOWN 2 SECONDS
 
 #define XENO_HIVEMIND_DETECTION_RANGE 10 //How far out (in tiles) can the hivemind detect hostiles
 #define XENO_HIVEMIND_DETECTION_COOLDOWN 1 MINUTES

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -208,7 +208,7 @@
 	if(!isliving(usr))
 		return
 	var/mob/living/L = usr
-	L.lay_down()
+	L.toggle_resting()
 
 /atom/movable/screen/rest/update_icon_state()
 	. = ..()

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -55,7 +55,7 @@
 	if(.)
 		return
 	var/mob/living/carbon/C = user.mob
-	C.lay_down()
+	C.toggle_resting()
 	return TRUE
 
 /datum/keybinding/carbon/select_help_intent

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/Initialize(mapload)
-	add_verb(src, /mob/living/proc/lay_down)
+	add_verb(src, /mob/living/proc/toggle_resting)
 	b_type = pick(7;"O-", 38;"O+", 6;"A-", 34;"A+", 2;"B-", 9;"B+", 1;"AB-", 3;"AB+")
 	blood_type = b_type
 
@@ -1130,5 +1130,10 @@
 
 /mob/living/carbon/human/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
 	if(buckled)
+		return
+	return ..()
+
+/mob/living/carbon/human/get_up()
+	if(!do_after(src, 2 SECONDS, IGNORE_LOC_CHANGE|IGNORE_HELD_ITEM, src))
 		return
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -15,7 +15,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	if(!istype(X))
 		return
-	X.lay_down()
+	X.toggle_resting()
 	return succeed_activate()
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -421,3 +421,6 @@
 	var/footstep_type = FOOTSTEP_XENO_MEDIUM
 
 	COOLDOWN_DECLARE(xeno_health_alert_cooldown)
+
+	///The resting cooldown
+	COOLDOWN_DECLARE(xeno_resting_cooldown)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -464,11 +464,20 @@ Returns TRUE when loc_weeds_type changes. Returns FALSE when it doesn’t change
 		return
 	update_icon()
 
-/mob/living/carbon/xenomorph/lay_down()
+/mob/living/carbon/xenomorph/toggle_resting()
 	var/datum/action/ability/xeno_action/xeno_resting/resting_action = actions_by_path[/datum/action/ability/xeno_action/xeno_resting]
 	if(!resting_action || !resting_action.can_use_action())
 		return
+
+	if(!COOLDOWN_CHECK(src, xeno_resting_cooldown))
+		balloon_alert(src, "Cannot get up so soon after resting!")
+		return
 	return ..()
+
+/mob/living/carbon/xenomorph/set_resting()
+	. = ..()
+	if(resting)
+		COOLDOWN_START(src, xeno_resting_cooldown, XENO_RESTING_COOLDOWN)
 
 /mob/living/carbon/xenomorph/set_jump_component(duration = 0.5 SECONDS, cooldown = 2 SECONDS, cost = 0, height = 16, sound = null, flags = JUMP_SHADOW, flags_pass = PASS_LOW_STRUCTURE|PASS_FIRE)
 	var/gravity = get_gravity()

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -476,7 +476,7 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/proc/setup_verbs()
-	add_verb(src, /mob/living/proc/lay_down)
+	add_verb(src, /mob/living/proc/toggle_resting)
 
 /mob/living/carbon/xenomorph/hivemind/setup_verbs()
 	return

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -4,8 +4,8 @@
 
 	do_resist()
 
-
-/mob/living/proc/lay_down()
+///Handles trying to toggle resting state
+/mob/living/proc/toggle_resting()
 	set name = "Rest"
 	set category = "IC"
 
@@ -16,18 +16,20 @@
 		if(is_ventcrawling)
 			return FALSE
 		set_resting(TRUE, FALSE)
-	else if(do_actions)
-		to_chat(src, span_warning("You are still in the process of standing up."))
 		return
-	else if(do_after(src, 2 SECONDS, IGNORE_LOC_CHANGE|IGNORE_HELD_ITEM, src))
-		get_up()
+	if(do_actions)
+		balloon_alert(src, "Busy!")
+		return
+	get_up()
 
+///Handles getting up, doing a basic check before relaying it to the actual proc that does it
 /mob/living/proc/get_up()
 	if(!incapacitated(TRUE))
 		set_resting(FALSE, FALSE)
 	else
 		to_chat(src, span_notice("You fail to get up."))
 
+///Actually handles toggling the resting state
 /mob/living/proc/set_resting(rest, silent = TRUE)
 	if(status_flags & INCORPOREAL)
 		return


### PR DESCRIPTION

## About The Pull Request

This is essentially a shameless ripoff of CM's resting. You can lay down instantly, but then cannot get up for 2 seconds after. In exchange you get up instantly after the 2 seconds have passed.

I also renamed the proc to be more clear about what it does and put in docs
## Why It's Good For The Game

As it stands right now xenos get punished for not mashing the hell out of their resting key because it is objectively better to do so as it makes you safer from being jumped. This should help make all xenos equal, lazy resting or not
## Changelog
:cl:
balance: Xenomorph resting now blocks you from unresting for 2 seconds, instead of it being a 2 second progress bar to get up
/:cl:
