### PR TITLE
Runner evasion can be cancelled early

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -50,6 +50,7 @@
 #define COOLDOWN_RAVAGER_FLAMER_ACT "cooldown_ravager_flamer_act"
 #define COOLDOWN_DROPPOD_TARGETTING "cooldown_droppod_targetting"
 #define COOLDOWN_TRY_TTS "cooldown_try_tts"
+#define COOLDOWN_EVASION_ACTIVATION "cooldown_evasion_activation"
 
 //Mecha cooldowns
 #define COOLDOWN_MECHA "mecha"

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -120,6 +120,9 @@
 	 * When called by the evasion extension, deactivate will be FALSE so the ability won't turn off by itself
 	 */
 	if(deactivate && evade_active)
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EVASION_ACTIVATION))
+			owner.balloon_alert(owner, "Accidental deactivation guard!")	//Little message to let the player know and not think it is a bug that their evasion didn't turn off
+			return
 		evasion_deactivate()
 		return
 
@@ -148,6 +151,7 @@
 	RegisterSignal(owner, COMSIG_LIVING_PRE_THROW_IMPACT, PROC_REF(evasion_throw_dodge))
 	GLOB.round_statistics.runner_evasions++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_evasions")
+	TIMER_COOLDOWN_START(src, COOLDOWN_EVASION_ACTIVATION, 1 SECONDS)
 
 /datum/action/ability/xeno_action/evasion/process()
 	var/mob/living/carbon/xenomorph/runner/runner_owner = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -118,7 +118,6 @@
 	//The evasion extension removes the cooldown before calling this proc again, so use that to differentiate if it was the player trying to cancel
 	if(evade_active && cooldown_timer)
 		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EVASION_ACTIVATION))
-			owner.balloon_alert(owner, "Accidental deactivation guard!")	//Little message to let the player know and not think it is a bug that their evasion didn't turn off
 			return
 		evasion_deactivate()
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -113,13 +113,10 @@
 	action_icon_state = "evasion_[auto_evasion? "on" : "off"]"
 	update_button_icon()
 
-/datum/action/ability/xeno_action/evasion/action_activate(deactivate = TRUE)
-	/* Since both the button and the evasion extension call this proc directly, making a toggle for the ability
-	 * Deactivate will default to TRUE when called by a button click, but this should not be a problem
-	 * on the first activation since the evade_active will be false
-	 * When called by the evasion extension, deactivate will be FALSE so the ability won't turn off by itself
-	 */
-	if(deactivate && evade_active)
+/datum/action/ability/xeno_action/evasion/action_activate()
+	//Since both the button and the evasion extension call this proc directly, check if the cooldown timer exists
+	//The evasion extension removes the cooldown before calling this proc again, so use that to differentiate if it was the player trying to cancel
+	if(evade_active && cooldown_timer)
 		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EVASION_ACTIVATION))
 			owner.balloon_alert(owner, "Accidental deactivation guard!")	//Little message to let the player know and not think it is a bug that their evasion didn't turn off
 			return
@@ -254,7 +251,7 @@
 	if(evasion_stacks >= RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD && cooldown_remaining()) //We have more evasion stacks than needed to refresh our cooldown, while being on cooldown.
 		clear_cooldown()
 		if(auto_evasion && xeno_owner.plasma_stored >= ability_cost)
-			action_activate(FALSE)
+			action_activate()
 	var/turf/current_turf = get_turf(xeno_owner) //location of after image SFX
 	playsound(current_turf, pick('sound/effects/throw.ogg','sound/effects/alien_tail_swipe1.ogg', 'sound/effects/alien_tail_swipe2.ogg'), 25, 1) //sound effects
 	var/obj/effect/temp_visual/xenomorph/afterimage/after_image


### PR DESCRIPTION
## About The Pull Request

Couple of lines of code that accommodate for cancelling evasion if active. Ability still goes on cooldown on activation regardless of if cancelled or not.

Has a 1 second cooldown before it can be deactivated to prevent accidental deactivations when trying to spam press it in the heat of combat. Could probably be 0.5 seconds if players feel it is too long ingame.

## Why It's Good For The Game

Yes it's a minor buff, but more importantly quality of life feature since evasion disarms the rounies and they must wait out the entire duration.

## Changelog
:cl:
qol: Runners can manually cancel evasion.
balance: Runners no longer disarmed for the entire duration of evasion if they cancel it.
/:cl:
