### PR TITLE
Increase explosive pouch max size to fit recoiless rifle rockets

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -371,7 +371,7 @@
 	icon_state = "explosive"
 	sprite_slots = 2
 	storage_slots = 4
-	max_w_class = WEIGHT_CLASS_NORMAL
+	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(
 		/obj/item/explosive/plastique,
 		/obj/item/explosive/mine,


### PR DESCRIPTION

## About The Pull Request

This increases the explosives pouch max weight so it can fit all rocket types. Right now it fits SADAR rockets but not recoiless rifle rockets

## Why It's Good For The Game

Its strange a smaller caliber rocket does not fit in this pouch because its a different size, I dont want to change the RR rockets size directly because then it fits in backpacks and that may have more implications since the pouch only fits certain things anyhow

## Changelog
:cl:
balance: RR rockets now fit in explosive pouch
/:cl:
