### PR TITLE
Magmoor Disk Sets

### DIFF
--- a/_maps/magmoor_digsite_iv.json
+++ b/_maps/magmoor_digsite_iv.json
@@ -3,7 +3,9 @@
     "map_path": "map_files/Magmoor_Digsite_IV",
     "map_file": "Magmoor_Digsite_IV.dmm",
 	"disk_sets": {
-		"basic": 1
+		"set1": 1,
+		"set2": 1,
+		"set3": 1
 	},
 	"quickbuilds": 1800,
     "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a mining and archaeological site, known as Magmoor Digsite IV. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!"

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -2673,7 +2673,9 @@
 	},
 /area/magmoor/compound/southwest)
 "bOI" = (
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	set_associations = list("set2")
+	},
 /turf/open/floor/mainship/purple{
 	dir = 9
 	},
@@ -7285,7 +7287,9 @@
 /turf/closed/wall/r_wall,
 /area/magmoor/research/containment)
 "feR" = (
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	set_associations = list("set1", "set3")
+	},
 /turf/open/floor/carpet,
 /area/magmoor/command/office/main)
 "ffk" = (
@@ -8711,7 +8715,9 @@
 	},
 /area/magmoor/civilian/clean/shower)
 "ght" = (
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	set_associations = list("set2", "set3")
+	},
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
@@ -16027,7 +16033,9 @@
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound)
 "lGP" = (
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	set_associations = list("set1", "set3")
+	},
 /turf/open/floor/mainship/cargo,
 /area/magmoor/mining/storage)
 "lGS" = (
@@ -20381,7 +20389,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/nuke_disk_candidate,
+/obj/structure/nuke_disk_candidate{
+	set_associations = list("set1", "set2")
+	},
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
Instead of disks being fully random out of 5 locations on Magmoor (this can lead to 2 cave disks or all disks being outside, leading to very different results of walance), adds 3 disk sets to Magmoor.
Dorms > Admin > Mining
Dorms > Engineering > Research
Engineering > Admin > Mining
Each of these disk sets has two outside disks and one caves (the cave being mining and research).
## Why It's Good For The Game
Makes the map less balanced on RNG, but still keeps the variety that disk sets give.
## Changelog
:cl:
balance: Magmoor disks are now sorted into 3 preset sets.
/:cl:
