### PR TITLE
Evolution Changes

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -114,6 +114,8 @@ GLOBAL_LIST_INIT(all_xeno_types, list(
 GLOBAL_LIST_INIT(xeno_types_tier_one, list(/mob/living/carbon/xenomorph/runner, /mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/sentinel, /mob/living/carbon/xenomorph/defender, /mob/living/carbon/xenomorph/baneling))
 GLOBAL_LIST_INIT(xeno_types_tier_two, list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/spitter, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/bull, /mob/living/carbon/xenomorph/wraith, /mob/living/carbon/xenomorph/puppeteer))
 GLOBAL_LIST_INIT(xeno_types_tier_three, list(/mob/living/carbon/xenomorph/gorger, /mob/living/carbon/xenomorph/widow, /mob/living/carbon/xenomorph/ravager, /mob/living/carbon/xenomorph/praetorian, /mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/defiler, /mob/living/carbon/xenomorph/crusher, /mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/behemoth))
+GLOBAL_LIST_INIT(xeno_types_tier_four, list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king))
+GLOBAL_LIST_INIT(xeno_types_tier_shrike, list(/mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king))
 
 GLOBAL_LIST_INIT_TYPED(hive_datums, /datum/hive_status, init_hive_datum_list()) // init by make_datum_references_lists()
 

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -115,7 +115,6 @@ GLOBAL_LIST_INIT(xeno_types_tier_one, list(/mob/living/carbon/xenomorph/runner, 
 GLOBAL_LIST_INIT(xeno_types_tier_two, list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/spitter, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/bull, /mob/living/carbon/xenomorph/wraith, /mob/living/carbon/xenomorph/puppeteer))
 GLOBAL_LIST_INIT(xeno_types_tier_three, list(/mob/living/carbon/xenomorph/gorger, /mob/living/carbon/xenomorph/widow, /mob/living/carbon/xenomorph/ravager, /mob/living/carbon/xenomorph/praetorian, /mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/defiler, /mob/living/carbon/xenomorph/crusher, /mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/behemoth))
 GLOBAL_LIST_INIT(xeno_types_tier_four, list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king))
-GLOBAL_LIST_INIT(xeno_types_tier_shrike, list(/mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king))
 
 GLOBAL_LIST_INIT_TYPED(hive_datums, /datum/hive_status, init_hive_datum_list()) // init by make_datum_references_lists()
 

--- a/code/modules/codex/entries/mobs_codex.dm
+++ b/code/modules/codex/entries/mobs_codex.dm
@@ -40,7 +40,7 @@
 
 	if(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED)
 		xeno_strings += "<br><U>This can evolve to</U>:"
-		for(var/type in xeno_caste.evolves_to)
+		for(var/type in get_evolution_options())
 			xeno_strings += "[GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE].caste_name]"
 
 	if(length(actions))

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
@@ -26,11 +26,6 @@
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/spitter,
-		/mob/living/carbon/xenomorph/bull,
-	)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -25,10 +25,6 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/crusher,
-		/mob/living/carbon/xenomorph/behemoth,
-	)
 	deevolves_to = list(
 		/mob/living/carbon/xenomorph/runner,
 		/mob/living/carbon/xenomorph/baneling,

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -29,8 +29,6 @@
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
-	evolves_to = list(/mob/living/carbon/xenomorph/defiler, /mob/living/carbon/xenomorph/widow)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
 	can_hold_eggs = CAN_HOLD_ONE_HAND

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -27,12 +27,6 @@
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/warrior,
-		/mob/living/carbon/xenomorph/bull,
-		/mob/living/carbon/xenomorph/puppeteer,
-	)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -29,15 +29,6 @@
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/shrike,
-		/mob/living/carbon/xenomorph/queen,
-		/mob/living/carbon/xenomorph/king,
-		/mob/living/carbon/xenomorph/carrier,
-		/mob/living/carbon/xenomorph/hivelord,
-		/mob/living/carbon/xenomorph/hivemind,
-	)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_IS_BUILDER
 	can_hold_eggs = CAN_HOLD_TWO_HANDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -30,8 +30,6 @@
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
-	evolves_to = list(/mob/living/carbon/xenomorph/defiler, /mob/living/carbon/xenomorph/gorger)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_IS_BUILDER
 	can_hold_eggs = CAN_HOLD_TWO_HANDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -31,7 +31,6 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(/mob/living/carbon/xenomorph/ravager, /mob/living/carbon/xenomorph/widow)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
@@ -26,13 +26,6 @@
 
 	// *** Evolution *** //
 	evolution_threshold = 50
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/drone,
-		/mob/living/carbon/xenomorph/runner,
-		/mob/living/carbon/xenomorph/sentinel,
-		/mob/living/carbon/xenomorph/defender,
-		/mob/living/carbon/xenomorph/baneling,
-	)
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_INNATE_HEALING

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -19,7 +19,6 @@
 	upgrade_threshold = TIER_TWO_THRESHOLD
 	evolution_threshold = 225
 
-	evolves_to = list(/mob/living/carbon/xenomorph/widow, /mob/living/carbon/xenomorph/warlock)
 	deevolves_to = list(/mob/living/carbon/xenomorph/defender)
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -29,12 +29,6 @@
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/hunter,
-		/mob/living/carbon/xenomorph/bull,
-		/mob/living/carbon/xenomorph/wraith,
-	)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_RIDE_CRUSHER

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -27,8 +27,6 @@
 	evolution_threshold = 100
 	upgrade_threshold = TIER_ONE_THRESHOLD
 
-	evolves_to = list(/mob/living/carbon/xenomorph/spitter)
-
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_RIDE_CRUSHER

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -29,7 +29,6 @@
 	maximum_active_caste = 1
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(/mob/living/carbon/xenomorph/queen)
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -25,10 +25,6 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/boiler,
-		/mob/living/carbon/xenomorph/praetorian,
-	)
 	deevolves_to = list(
 		/mob/living/carbon/xenomorph/sentinel,
 		/mob/living/carbon/xenomorph/baneling,

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -25,7 +25,6 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(/mob/living/carbon/xenomorph/crusher, /mob/living/carbon/xenomorph/behemoth, /mob/living/carbon/xenomorph/gorger, /mob/living/carbon/xenomorph/warlock)
 	deevolves_to = /mob/living/carbon/xenomorph/defender
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -25,11 +25,6 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	evolves_to = list(
-		/mob/living/carbon/xenomorph/defiler,
-		/mob/living/carbon/xenomorph/ravager,
-		/mob/living/carbon/xenomorph/warlock,
-	)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -33,7 +33,7 @@
 			"cooldown" = (initial(xeno_ability.cooldown_duration) / 10)
 		)
 	.["evolves_to"] = list()
-	for(var/evolves_into in xeno.xeno_caste.evolves_to)
+	for(var/evolves_into in xeno.get_evolution_options())
 		var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[evolves_into][XENO_UPGRADE_BASETYPE]
 		var/list/caste_data = list(
 			"type_path" = caste.caste_type_path,

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -2,9 +2,6 @@
 
 //Recoded and consolidated by Abby -- ALL evolutions come from here now. It should work with any caste, anywhere
 // refactored by spookydonut because the above two were shitcoders and i'm sure in time my code too will be considered shit.
-//All castes need an evolves_to() list in their defines
-//Such as evolves_to = list("Warrior", "Sentinel", "Runner", "Badass") etc
-// except use typepaths now so you dont have to have an entry for literally every evolve path
 
 /mob/living/carbon/xenomorph/verb/Evolve()
 	set name = "Evolve"
@@ -53,6 +50,22 @@
 
 	do_evolve(castetype, castepick, TRUE)
 
+/mob/living/carbon/xenomorph/proc/get_evolution_options()
+	switch(tier)
+		if(XENO_TIER_ZERO)
+			return GLOB.xeno_types_tier_one
+		if(XENO_TIER_ONE)
+			return GLOB.xeno_types_tier_two + GLOB.xeno_types_tier_four
+		if(XENO_TIER_TWO)
+			return GLOB.xeno_types_tier_three + GLOB.xeno_types_tier_four
+		if(XENO_TIER_THREE)
+			return GLOB.xeno_types_tier_four
+		if(XENO_TIER_FOUR)
+			if(isxenoshrike(src))
+				return GLOB.xeno_types_tier_shrike
+			else
+				return list()
+
 ///Handles the evolution or devolution of the xenomorph
 /mob/living/carbon/xenomorph/proc/do_evolve(caste_type, forced_caste_name, regression = FALSE)
 	if(!generic_evolution_checks())
@@ -68,14 +81,14 @@
 		castepick = forced_caste_name
 	else
 		var/list/castes_to_pick = list()
-		for(var/type in xeno_caste.evolves_to)
+		for(var/type in get_evolution_options())
 			var/datum/xeno_caste/Z = GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE]
 			castes_to_pick += Z.caste_name
 		castepick = tgui_input_list(src, "We are growing into a beautiful alien! It is time to choose a caste.", null, castes_to_pick)
 		if(!castepick) //Changed my mind
 			return
 
-		for(var/type in xeno_caste.evolves_to)
+		for(var/type in get_evolution_options())
 			var/datum/xeno_caste/XC = GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE]
 			if(castepick == XC.caste_name)
 				new_mob_type = type
@@ -213,7 +226,7 @@
 		balloon_alert(src, "The restraints are too restricting to allow us to evolve")
 		return FALSE
 
-	if(isnull(xeno_caste.evolves_to) || !(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
+	if(isnull(get_evolution_options()) || !(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		balloon_alert(src, "We are already the apex of form and function. Let's go forth and spread the hive!")
 		return FALSE
 
@@ -241,7 +254,7 @@
 
 ///Check if the xeno can currently evolve into a specific caste
 /mob/living/carbon/xenomorph/proc/caste_evolution_checks(new_mob_type, castepick, regression = FALSE)
-	if(!regression && !(new_mob_type in xeno_caste.evolves_to))
+	if(!regression && !(new_mob_type in get_evolution_options()))
 		balloon_alert(src, "We can't evolve to that caste from our current one")
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -50,7 +50,9 @@
 
 	do_evolve(castetype, castepick, TRUE)
 
+///Creates a list of possible evolution options for a caste based on their tier.
 /mob/living/carbon/xenomorph/proc/get_evolution_options()
+	. = list()
 	switch(tier)
 		if(XENO_TIER_ZERO)
 			return GLOB.xeno_types_tier_one
@@ -61,10 +63,9 @@
 		if(XENO_TIER_THREE)
 			return GLOB.xeno_types_tier_four
 		if(XENO_TIER_FOUR)
-			if(isxenoshrike(src))
-				return GLOB.xeno_types_tier_shrike
-			else
-				return list()
+			if(istype(xeno_caste, /datum/xeno_caste/shrike))
+				return list(/mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king)
+
 
 ///Handles the evolution or devolution of the xenomorph
 /mob/living/carbon/xenomorph/proc/do_evolve(caste_type, forced_caste_name, regression = FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -61,8 +61,6 @@
 	///Threshold amount of upgrade points to next maturity
 	var/upgrade_threshold = 0
 
-	///Type paths to the castes that this xenomorph can evolve to
-	var/list/evolves_to = list()
 	///Singular type path for the caste to deevolve to when forced to by the queen.
 	var/deevolves_to
 


### PR DESCRIPTION

## About The Pull Request
Xenomorphs can now evolve to any xenomorph in the next tier, and to T4. For example, Runner can now evolve to Spitter or even Queen if there is a slot open. Queen and King still cannot evo, and Shrike can only evo to queen and king. Plus, larva can only evolve T1's.
## Why It's Good For The Game
This is a relic of trying to associate castes with eachother, like the Runner is red and Ravager is red too, so they should be in the same tree. Even for xenos that aren't really related at all (see: warrior and warlock). This allows for more flexibility in Xenomorph play, especially roundstart when Xenos go drone; they can now evo to whatever they want after quickbuild.
## Changelog
:cl:
balance: Xenomorphs can now evolve to any caste above their tier and T4, with exceptions made for the T4's and larva
/:cl:
