### PR TITLE
Evolution tower buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -374,6 +374,12 @@
 	for(var/obj/structure/xeno/evotower/tower AS in evotowers)
 		. += tower.boost_amount
 
+///fetches number of bonus maturity points given to the hive
+/datum/hive_status/proc/get_upgrade_boost()
+	. = 0
+	for(var/obj/structure/xeno/evotower/tower AS in evotowers)
+		. += tower.maturty_boost_amount
+
 // ***************************************
 // *********** Adding xenos
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 
 /datum/hive_upgrade/building/evotower
 	name = "Evolution Tower"
-	desc = "Constructs a tower that increases the rate of evolution point and maturity point generation by 1.2 times per tower."
+	desc = "Constructs a tower that increases the rate of evolution point generation by 0.2 and maturity point generation by 0.8 times per tower."
 	psypoint_cost = 300
 	icon = "evotower"
 	flags_gamemode = ABILITY_NUCLEARWAR

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -217,7 +217,7 @@
 	// Upgrade is increased based on marine to xeno population taking stored_larva as a modifier.
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
-	upgrade_stored += 1 + (stored_larva/6) + hive.get_evolution_boost() //Do this regardless of whether we can upgrade so age accrues at primo
+	upgrade_stored += 1 + (stored_larva/6) + hive.get_upgrade_boost() //Do this regardless of whether we can upgrade so age accrues at primo
 	if(!upgrade_possible())
 		return
 	if(upgrade_stored < xeno_caste.upgrade_threshold)

--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -11,6 +11,8 @@
 	xeno_structure_flags = CRITICAL_STRUCTURE
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
+	///maturity boost amt to be added per tower per cycle
+	var/maturty_boost_amount = 0.8
 
 /obj/structure/xeno/evotower/Initialize(mapload, _hivenumber)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Increases maturity gain from evolution tower to 0.8, basically the same as old 4 maturity towers
## Why It's Good For The Game
Evolution tower was in a terrible spot due to maturity only existing for primo, an extra 0.8 should be fine given maturity only spikes at primo now instead of young to ancient
## Changelog
:cl:
balance: Evolution now gives an extra 0.8 maturity instead of 0.2
/:cl:
