### PR TITLE
ASL order fix

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -21,7 +21,7 @@
 	///What skill is needed to have this action
 	var/skill_name = SKILL_LEADERSHIP
 	///What minimum level in that skill is needed to have that action
-	var/skill_min = SKILL_LEAD_EXPERT
+	var/skill_min = SKILL_LEAD_TRAINED
 
 /datum/action/innate/message_squad/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min


### PR DESCRIPTION

## About The Pull Request

decreases the skill required to send squad orders from 3 to 2 allowing asl to send orders

## Why It's Good For The Game

after prs #13810 nerf on leadership the ability to send squad orders was lost since the skill requirment remained the same.
Asl being able to act as Asl good.

## Changelog
:cl:
balance: squad order skill require from 3 to 2
/:cl:
