### PR TITLE
Campaign autobalance

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -10,6 +10,8 @@
 #define AFTER_MISSION_TELEPORT_DELAY 10 SECONDS
 ///How long after a mission ends a new leader is picked
 #define AFTER_MISSION_LEADER_DELAY 1 MINUTES
+///How long after a mission is selected that team balance is checked
+#define CAMPAIGN_AUTOBALANCE_DELAY 1 MINUTES
 ///Standard amount of missions for a faction to have
 #define CAMPAIGN_STANDARD_MISSION_QUANTITY 3
 ///Attrition bonus for losing

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -151,17 +151,10 @@
 	var/team_one_count = length(GLOB.alive_human_list_faction[factions[1]])
 	var/team_two_count = length(GLOB.alive_human_list_faction[factions[2]])
 
-	var/stronger_faction
-	var/weaker_faction
-
 	if(team_one_count > team_two_count * ratio)
-		stronger_faction = factions[1]
-		weaker_faction = factions[2]
+		return list(factions[1], factions[2])
 	else if(team_one_count < team_two_count * ratio)
-		stronger_faction = factions[2]
-		weaker_faction = factions[1]
-
-	return list(stronger_faction, weaker_faction)
+		return list(factions[2], factions[1])
 
 ///Actually swaps the player to the other team, unless balance has been restored
 /datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction)

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -129,7 +129,7 @@
 /datum/game_mode/hvh/campaign/proc/load_new_mission(datum/campaign_mission/new_mission)
 	current_mission = new_mission
 	current_mission.load_mission()
-	addtimer(CALLBACK(src, PROC_REF(autobalance_cycle)), 1 MINUTES) //we autobalance teams after a short delay to account for slow respawners
+	addtimer(CALLBACK(src, PROC_REF(autobalance_cycle)), CAMPAIGN_AUTOBALANCE_DELAY) //we autobalance teams after a short delay to account for slow respawners
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, bioscan_interval)
 
 ///Checks team balance and tries to correct if possible

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -129,7 +129,55 @@
 /datum/game_mode/hvh/campaign/proc/load_new_mission(datum/campaign_mission/new_mission)
 	current_mission = new_mission
 	current_mission.load_mission()
+	addtimer(CALLBACK(src, PROC_REF(autobalance_cycle)), 1 MINUTES) //we autobalance teams after a short delay to account for slow respawners
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, bioscan_interval)
+
+///Checks team balance and tries to correct if possible
+/datum/game_mode/hvh/campaign/proc/autobalance_cycle()
+	var/list/autobalance_faction_list = autobalance_check()
+	if(!autobalance_faction_list)
+		return
+
+	for(var/mob/living/carbon/human/faction_member AS in GLOB.alive_human_list_faction[autobalance_faction_list[1]])
+		if(stat_list[faction_member.faction].faction_leader == faction_member)
+			continue
+		swap_player_team(faction_member, autobalance_faction_list[2])
+
+/** Checks team balance
+ * Returns null if teams are nominally balanced
+ * Returns a list with the stronger team first if they are inbalanced
+ */
+/datum/game_mode/hvh/campaign/proc/autobalance_check(ratio = MAX_UNBALANCED_RATIO_TWO_HUMAN_FACTIONS)
+	var/team_one_count = length(GLOB.alive_human_list_faction[factions[1]])
+	var/team_two_count = length(GLOB.alive_human_list_faction[factions[2]])
+
+	var/stronger_faction
+	var/weaker_faction
+
+	if(team_one_count > team_two_count * ratio)
+		stronger_faction = factions[1]
+		weaker_faction = factions[2]
+	else if(team_one_count < team_two_count * ratio)
+		stronger_faction = factions[2]
+		weaker_faction = factions[1]
+
+	return list(stronger_faction, weaker_faction)
+
+///Actually swaps the player to the other team, unless balance has been restored
+/datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction)
+	if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), 30 SECONDS) != "Change team")
+		return
+	var/list/current_ratio = autobalance_check(1)
+	if(!current_ratio || current_ratio[2] == user.faction)
+		to_chat(user, span_warning("Team balance already corrected."))
+		return
+	LAZYREMOVE(GLOB.alive_human_list_faction[user.faction], user)
+	user.faction = new_faction //we set this first so the ghost's faction and subsequent job screen is correct, but it means we have to remove from the faction list above first.
+	var/mob/dead/observer/ghost = user.ghostize()
+	user.job.add_job_positions(1)
+	qdel(user)
+	var/datum/game_mode/mode = SSticker.mode
+	mode.player_respawn(ghost) //auto open the respawn screen
 
 //respawn stuff
 


### PR DESCRIPTION

## About The Pull Request
Adds a basic autobalance system.

After a new mission is selected, if one team notably outnumbers the other, all members of that team will get a prompt asking if they'd like to be swapped to the other team.

Of course this is voluntary, but there's really no point in forcing people into teams tbh, since people just refuse to play half the time if its not on the team they want.
## Why It's Good For The Game
Less skewed rounds when a bunch of people dc/leave/ragequit.
## Changelog
:cl:
balance: Campaign has an autobalance check at the start of every mission to try balance team numbers
/:cl:
