### PR TITLE
Campaign VP target reduced to 7

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -1,5 +1,5 @@
 ///Number of victory points before a faction wins a campaign
-#define CAMPAIGN_MAX_VICTORY_POINTS 12
+#define CAMPAIGN_MAX_VICTORY_POINTS 7
 
 ///Respawn time in campaign mode
 #define CAMPAIGN_RESPAWN_TIME 2 MINUTES


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. 12 was basically a placeholder, and VP victory was only intended as a fallback win condition in case a game dragged on for ages... but since the mode isn't entirely finished (i.e. the game ending missions don't exist yet), the VP limit might as well be reasonably obtainable for current gameplay.
## Why It's Good For The Game
Winnable games is good.
## Changelog
:cl:
balance: Campaign VP target reduced to 7 from 12 until round ending missions are added
/:cl:
