### PR TITLE
Silo time scaling

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -1,3 +1,8 @@
+///Scaling multiplier for larva respawn rate based on round time
+#define XENO_SPAWN_TIME_SCALING_MAX_AMOUNT 2
+///Time at which scaling multiplier hits its max
+#define XENO_SPAWN_TIME_SCALING_MAX_TIME 2.5 HOURS
+
 SUBSYSTEM_DEF(silo)
 	name = "Silo"
 	wait = 1 MINUTES
@@ -28,6 +33,8 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
 	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
+
+	current_larva_spawn_rate *= LERP(1, XENO_SPAWN_TIME_SCALING_MAX_AMOUNT, min((world.time - SSticker?.round_start_time) / XENO_SPAWN_TIME_SCALING_MAX_TIME, 1))
 
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -1,7 +1,7 @@
 ///Scaling multiplier for larva respawn rate based on round time
 #define XENO_SPAWN_TIME_SCALING_MAX_AMOUNT 2
 ///Time at which scaling multiplier hits its max
-#define XENO_SPAWN_TIME_SCALING_MAX_TIME 2.5 HOURS
+#define XENO_SPAWN_TIME_SCALING_MAX_TIME 3 HOURS
 
 SUBSYSTEM_DEF(silo)
 	name = "Silo"

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -33,7 +33,8 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
 	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
-	current_larva_spawn_rate *= LERP(1, XENO_SPAWN_TIME_SCALING_MAX_AMOUNT, min((world.time - SSticker?.round_start_time - SSticker?.mode.shutters_drop_time) / XENO_SPAWN_TIME_SCALING_MAX_TIME, 1))
+	//Scales with time after shutter lifting time
+	current_larva_spawn_rate *= LERP(1, XENO_SPAWN_TIME_SCALING_MAX_AMOUNT, clamp((world.time - SSticker?.round_start_time - SSticker?.mode.shutters_drop_time) / XENO_SPAWN_TIME_SCALING_MAX_TIME, 0, 1))
 
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -33,8 +33,7 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
 	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
-
-	current_larva_spawn_rate *= LERP(1, XENO_SPAWN_TIME_SCALING_MAX_AMOUNT, min((world.time - SSticker?.round_start_time) / XENO_SPAWN_TIME_SCALING_MAX_TIME, 1))
+	current_larva_spawn_rate *= LERP(1, XENO_SPAWN_TIME_SCALING_MAX_AMOUNT, min((world.time - SSticker?.round_start_time - SSticker?.mode.shutters_drop_time) / XENO_SPAWN_TIME_SCALING_MAX_TIME, 1))
 
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. Aka: It only gets worse.

Larva spawn rate now scales with round duration, up to a max of x2 larva rate after 3 hours.
## Why It's Good For The Game
Marines are nominally the attacking faction in HvX, yet they tend to benefit more from prolonged rounds due to req and other factors. This is somewhat compounded by our modern high pop, where rounds can easily be prolonged to allow for large marine respawn waves.

This change creates a level of time pressure on marines, which encourages them to actually be aggressive, and disincentivises prolonged seiges or stalemates.
## Changelog
:cl:
balance: Larva generation slowly scales up over time, to a maximum of x2 speed after 3 hours
/:cl:
