### PR TITLE
Kill most RR in campaign

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
@@ -19,20 +19,12 @@
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
-/datum/loadout_item/helmet/som_veteran/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)
-
 /datum/loadout_item/helmet/gorgon
 	name = "Gorgon pattern helmet"
 	desc = "Made for use with Gorgon pattern assault armor, providing superior protection. Typically seen on SOM leaders or their most elite combat units."
 	item_typepath = /obj/item/clothing/head/modular/som/leader
 	jobs_supported = list(SOM_SQUAD_LEADER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
-
-/datum/loadout_item/helmet/gorgon/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)
 
 /datum/loadout_item/helmet/gorgon/fc
 	name = "Gorgon pattern helmet"
@@ -57,10 +49,6 @@
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/suit/modular/som/heavy/lorica = ITEM_SLOT_OCLOTHING)
 
-/datum/loadout_item/helmet/som_tyr/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)
-
 /datum/loadout_item/helmet/som_mimir
 	name = "Biohazard helmet"
 	desc = "A standard combat helmet with a Mithridatius 'Mith' environmental protection module."
@@ -68,10 +56,6 @@
 	item_typepath = /obj/item/clothing/head/modular/som/bio
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/suit/modular/som/heavy/mithridatius = ITEM_SLOT_OCLOTHING)
-
-/datum/loadout_item/helmet/som_mimir/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
-	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)
 
 /datum/loadout_item/helmet/som_engineer
 	name = "Engineering helmet"


### PR DESCRIPTION

## About The Pull Request
Some SOM roles no longer get RR in their hats.

SOM medics still get some RR (compared to tgmc corpsmen with neuraline), as well as some melee roles.
## Why It's Good For The Game
More level playing field.
## Changelog
:cl:
balance: Removed some RR from campaign
/:cl:
