### PR TITLE
Gas mask TTS filter changes

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -13,7 +13,6 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	siemens_coefficient = 0.9
-	voice_filter = "lowpass=f=750,volume=2"
 	var/gas_filter_strength = 1			//For gas mask filters
 	var/list/filtered_gases = list(/datum/reagent/toxin/phoron, "sleeping_agent", "carbon_dioxide")
 	///Does this particular mask have breath noises
@@ -40,6 +39,7 @@
 /obj/item/clothing/mask/gas/tactical
 	name = "Tactical gas mask"
 	icon_state = "gas_alt_tactical"
+	voice_filter = "lowpass=f=750,volume=2"
 
 /obj/item/clothing/mask/gas/tactical/coif
 	name = "Tactical coifed gas mask"
@@ -56,7 +56,7 @@
 	flags_inventory = COVERMOUTH|BLOCKGASEFFECT
 	flags_inv_hide = HIDEEARS|HIDEFACE|HIDEALLHAIR
 	breathy = FALSE
-	voice_filter = null
+	voice_filter = "lowpass=f=750,volume=2"
 
 /obj/item/clothing/mask/gas/pmc/damaged
 	name = "damaged M8 pattern armored balaclava"
@@ -77,7 +77,6 @@
 	icon_state = "wolf_mask"
 	anti_hug = 2
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/icc
 	name = "\improper Modelle/60 gas mask"
@@ -100,6 +99,7 @@
 	anti_hug = 1
 	siemens_coefficient = 0.7
 	flags_armor_protection = FACE|EYES
+	voice_filter = "lowpass=f=750,volume=2"
 
 /obj/item/clothing/mask/gas/specops
 	name = "Special Operations gasmask"
@@ -111,6 +111,7 @@
 	icon_state = "specop"
 	item_state = "specop"
 	siemens_coefficient = 0.7
+	voice_filter = "lowpass=f=750,volume=2"
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "syndicate mask"
@@ -139,7 +140,6 @@
 	icon_state = "clown"
 	item_state = "clown_hat"
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/sexyclown
 	name = "sexy-clown wig and mask"
@@ -147,7 +147,6 @@
 	icon_state = "sexyclown"
 	item_state = "sexyclown"
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/mime
 	name = "mime mask"
@@ -155,7 +154,6 @@
 	icon_state = "mime"
 	item_state = "mime"
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/monkeymask
 	name = "monkey mask"
@@ -164,7 +162,6 @@
 	item_state = "monkeymask"
 	flags_armor_protection = HEAD|FACE|EYES
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/sexymime
 	name = "sexy mime mask"
@@ -172,7 +169,6 @@
 	icon_state = "sexymime"
 	item_state = "sexymime"
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/death_commando
 	name = "Death Commando Mask"
@@ -185,7 +181,6 @@
 	desc = "Beep boop"
 	icon_state = "death"
 	breathy = FALSE
-	voice_filter = null
 
 /obj/item/clothing/mask/gas/owl_mask
 	name = "owl mask"

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -355,7 +355,6 @@
 	name = "style mask"
 	desc = "A cool sylish mask that through some arcane magic blocks gas attacks. How? Who knows. How did you even get this?"
 	breathy = FALSE
-	voice_filter = null
 	icon_state = "gas_alt"
 	item_state = "gas_alt"
 	item_icons = list(slot_wear_mask_str)


### PR DESCRIPTION

## About The Pull Request
With TTS back, I am reminded of how bad the gas mask filters are.
Removed the filter from the default gas mask. It now specifically only applies to a few gas masks like the tactical, swat etc.
## Why It's Good For The Game
Gas masks are a mandatory item and it makes people genuinely hard to understand, defeating the point of TTS to begin with.
Now you can specifically choose the hard to understand mask if you really want it.
## Changelog
:cl:
qol: Only some gas masks such as the tactical or swat masks have TTS filters
/:cl:
