### PR TITLE
Adds BKTT Pills and Bottle to MarineMed

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -242,6 +242,11 @@
 	list_reagents = list(/datum/reagent/hypervene = 3)
 	pill_id = 14
 
+/obj/item/reagent_containers/pill/bktt
+	pill_desc = "A BKTT pill. A combination of medications used to treat multiple types of damage at once."
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5, /datum/reagent/medicine/tramadol = 5, /datum/reagent/medicine/tricordrazine = 5)
+	pill_id = 22
+
 /obj/item/reagent_containers/pill/ultrazine
 	//pill_desc = "An ultrazine pill. A highly-potent, long-lasting combination CNS and muscle stimulant. Extremely addictive."
 	list_reagents = list(/datum/reagent/medicine/ultrazine = 5)

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -244,7 +244,7 @@
 
 /obj/item/reagent_containers/pill/bktt
 	pill_desc = "A BKTT pill. A combination of medications used to treat multiple types of damage at once."
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5, /datum/reagent/medicine/tramadol = 5, /datum/reagent/medicine/	tricordrazine = 5)
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5, /datum/reagent/medicine/tramadol = 5, /datum/reagent/medicine/tricordrazine = 5)
 	pill_id = 21
 
 /obj/item/reagent_containers/pill/ultrazine

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -244,8 +244,8 @@
 
 /obj/item/reagent_containers/pill/bktt
 	pill_desc = "A BKTT pill. A combination of medications used to treat multiple types of damage at once."
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5, /datum/reagent/medicine/tramadol = 5, /datum/reagent/medicine/tricordrazine = 5)
-	pill_id = 22
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5, /datum/reagent/medicine/tramadol = 5, /datum/reagent/medicine/	tricordrazine = 5)
+	pill_id = 21
 
 /obj/item/reagent_containers/pill/ultrazine
 	//pill_desc = "An ultrazine pill. A highly-potent, long-lasting combination CNS and muscle stimulant. Extremely addictive."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -453,6 +453,14 @@
 	greyscale_colors = "#F7A151#ffffff" //orange like carrots
 	description_overlay = "Im"
 
+/obj/item/storage/pill_bottle/bktt
+	name = "\improper BKTT pill bottle"
+	desc = "Contains pills that heal multiple damage types at once."
+	icon_state = "pill_canister"
+	pill_type_to_fill = /obj/item/reagent_containers/pill/bktt
+	greyscale_colors = "#8d634d#ffffff"
+	description_overlay = "Bk"
+
 /obj/item/storage/pill_bottle/russian_red
 	name = "\improper Russian Red pill bottle"
 	desc = "Contains pills that heal all damage rapidly at the cost of small amounts of unhealable damage."

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -896,6 +896,7 @@
 			/obj/item/storage/pill_bottle/kelotane = -1,
 			/obj/item/storage/pill_bottle/tramadol = -1,
 			/obj/item/storage/pill_bottle/tricordrazine = -1,
+			/obj/item/storage/pill_bottle/bktt = -1
 			/obj/item/storage/pill_bottle/dylovene = -1,
 			/obj/item/storage/pill_bottle/paracetamol = -1,
 			/obj/item/storage/pill_bottle/isotonic = -1,
@@ -941,6 +942,7 @@
 			/obj/item/storage/pill_bottle/kelotane = -1,
 			/obj/item/storage/pill_bottle/tramadol = -1,
 			/obj/item/storage/pill_bottle/tricordrazine = -1,
+			/obj/item/storage/pill_bottle/bktt = -1
 			/obj/item/storage/pill_bottle/dylovene = -1,
 			/obj/item/storage/pill_bottle/paracetamol = -1,
 			/obj/item/storage/pill_bottle/isotonic = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -896,7 +896,7 @@
 			/obj/item/storage/pill_bottle/kelotane = -1,
 			/obj/item/storage/pill_bottle/tramadol = -1,
 			/obj/item/storage/pill_bottle/tricordrazine = -1,
-			/obj/item/storage/pill_bottle/bktt = -1
+			/obj/item/storage/pill_bottle/bktt = -1,
 			/obj/item/storage/pill_bottle/dylovene = -1,
 			/obj/item/storage/pill_bottle/paracetamol = -1,
 			/obj/item/storage/pill_bottle/isotonic = -1,
@@ -942,7 +942,7 @@
 			/obj/item/storage/pill_bottle/kelotane = -1,
 			/obj/item/storage/pill_bottle/tramadol = -1,
 			/obj/item/storage/pill_bottle/tricordrazine = -1,
-			/obj/item/storage/pill_bottle/bktt = -1
+			/obj/item/storage/pill_bottle/bktt = -1,
 			/obj/item/storage/pill_bottle/dylovene = -1,
 			/obj/item/storage/pill_bottle/paracetamol = -1,
 			/obj/item/storage/pill_bottle/isotonic = -1,


### PR DESCRIPTION

## About The Pull Request

Creates BKTT Pills and respective Pill Bottles for Marines in the MarineMed.

## Why It's Good For The Game

We already have a pouch that holds well more than enough BKTT for one round. (That can easily be replaced anyways if TAD loads like 50 onto it.) And upon that, this should save *some* of the pain for MD's and Marines alike that is the inevitable chem break in to make all their mixes. This just makes it possible without having to go through chem pain.

There are only 5u of each med (20u total) in each pill, which still makes it slightly more inefficient (because you now need to hit about 6 pills to reach 30u) than the option of taking up your whole pouch slot with a reagent container. I made the med dosage this low because i KNOW people will game this and wind up with 4 pill bottles in any storage slot they can find.

## Changelog
:cl:
add: Marines now have access to BKTT pill bottles in the MarineMed.
/:cl:
