### PR TITLE
No lobby wait time by default

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -158,7 +158,7 @@ Administrative related.
 /datum/config_entry/flag/looc_enabled
 
 /datum/config_entry/number/lobby_countdown
-	config_entry_value = 180
+	config_entry_value = 0
 
 /datum/config_entry/number/mission_end_countdown
 	config_entry_value = 120


### PR DESCRIPTION

## About The Pull Request

Simply makes the lobby wait time 0 by default. Should have no effect on any live server since the config overrides the default entries.

## Why It's Good For The Game

A giant thorn in my side, and probably other developers. No more having to type out the starting early command.

## Changelog
:cl:
config: The lobby wait time is 0 by default
/:cl:
