### PR TITLE
Hud fix

### DIFF
--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -996,7 +996,7 @@ directive is properly returned.
 				hud_list[hud] = list()
 			else
 				var/image/I = image('icons/mob/hud.dmi', src, "")
-				I.appearance_flags = RESET_COLOR|RESET_TRANSFORM
+				I.appearance_flags = RESET_COLOR|RESET_TRANSFORM|KEEP_APART
 				hud_list[hud] = I
 
 /**


### PR DESCRIPTION

## About The Pull Request
Fixed huds have appearance modifiers applied to them (like xeno buffs/shield module etc). The flag was removed in the appearance update accidentally.
## Why It's Good For The Game
Fix.
## Changelog
:cl:
fix: fixed some visuals with hud icons
/:cl:
