### PR TITLE
PMC standard armour tweak

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -221,7 +221,7 @@
 	name = "\improper M4 pattern PMC armor"
 	desc = "A common armor vest that is designed for high-profile security operators and corporate mercenaries in mind."
 	icon_state = "pmc_armor"
-	soft_armor = list(MELEE = 55, BULLET = 70, LASER = 60, ENERGY = 38, BOMB = 50, BIO = 15, FIRE = 38, ACID = 45)
+	soft_armor = list(MELEE = 55, BULLET = 70, LASER = 60, ENERGY = 55, BOMB = 50, BIO = 15, FIRE = 38, ACID = 45)
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	allowed = list(
 		/obj/item/weapon/gun,


### PR DESCRIPTION

## About The Pull Request
PMC standards specifically had a huge energy armour hole for no apparent reason.
## Why It's Good For The Game
Absolutely jobbing to volkite is bad.
## Changelog
:cl:
balance: PMC standard armour has improved energy armour in line with other pmc suits
/:cl:
