### PR TITLE
Halves Psychic Drain's plasma cost

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1131,6 +1131,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HEADBITE,
 	)
+	ability_cost = 50
 	gamemode_flags = ABILITY_NUCLEARWAR
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1127,11 +1127,11 @@
 	name = "Psy drain"
 	action_icon_state = "headbite"
 	desc = "Drain the victim of its life force to gain larva and psych points"
+	ability_cost = 50
 	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_FORTIFIED|ABILITY_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HEADBITE,
 	)
-	ability_cost = 50
 	gamemode_flags = ABILITY_NUCLEARWAR
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1132,7 +1132,6 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HEADBITE,
 	)
 	gamemode_flags = ABILITY_NUCLEARWAR
-	ability_cost = 100
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1
 


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
So you killed a guy and secured the body somehow. Now you have to pay a flat plasma cost. Don't forget that your drain can be interrupted by damage, and that this hits certain castes with lower plasma maximums (looking at you, woyer) much harder. There's not much point to it and all it does is punish caste choices for unholy reasons.

## Changelog
:cl: Lewdcifer
balance: Psydrain plasma cost reduced from 100 to 50.
/:cl: