### PR TITLE
Buffs tweezer removal time

### DIFF
--- a/code/game/objects/items/devices/tweezers.dm
+++ b/code/game/objects/items/devices/tweezers.dm
@@ -9,7 +9,7 @@
 
 /obj/item/tweezers/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/shrapnel_removal, 10 SECONDS)
+	AddElement(/datum/element/shrapnel_removal, 4 SECONDS, 10 SECONDS)
 
 /obj/item/tweezers_advanced
 	name = "\improper ESR-12"


### PR DESCRIPTION

## About The Pull Request
Changes removal of each shrap from 10 seconds to 4, keeps 10 second fumble if you have no med skill
## Why It's Good For The Game
Shrap is a pretty guh mechanic, and barring adding CM shrap removal (unga can do it himself), having to wait 10 seconds in the middle of combat per mistake a teammate made is not ideal. Hopefully this makes it way less agonizing after the MG guns you down.
## Changelog
:cl:
balance: Tweezer takes 4 seconds to remove shrap instead of 10
/:cl:
