### PR TITLE
Adds a proximity check for sentries to prevent stacking, part 2: electric boogaloo

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -146,6 +146,9 @@
 #define ENERGY_OVERCHARGE_AMMO_COST 80
 #define ENERGY_OVERCHARGE_FIRE_DELAY 10
 
+//Define sentry
+#define SENTRY_DEPLOY_RANGE_LIMIT 1 // SQUARE range within which another sentry cannot be deployed.
+
 //Define stagger damage multipliers
 #define STAGGER_DAMAGE_MULTIPLIER 0.5 //-50% damage dealt by the staggered target after all other mods.
 

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -82,6 +82,12 @@
 		if(user.do_actions)
 			user.balloon_alert(user, "You are already doing something!")
 			return
+		if(istype(item_to_deploy, /obj/item/weapon/gun/sentry))
+			for(var/turf/turf_to_check AS in RANGE_TURFS(SENTRY_DEPLOY_RANGE_LIMIT, location))
+				for(var/obj/machinery/deployable/mounted/sentry/deployable_sentry in turf_to_check)
+					if(get_dist_euclide(deployable_sentry, item_to_deploy) >= SENTRY_DEPLOY_RANGE_LIMIT)
+						user.balloon_alert(user, "Another sentry is too close")
+						return
 		user.balloon_alert(user, "You start deploying...")
 		user.setDir(newdir) //Face towards deploy location for ease of deploy.
 		if(!do_after(user, deploy_time, NONE, item_to_deploy, BUSY_ICON_BUILD))

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -399,9 +399,14 @@
 	if(deployed_turret.loc == src) //not deployed
 		if(is_reserved_level(z))
 			to_chat(user, span_warning("[src] can't deploy mid-flight."))
-		else
-			to_chat(user, span_notice("You deploy [src]."))
-			deploy_sentry()
+			return
+		for(var/turf/turf_to_check AS in RANGE_TURFS(SENTRY_DEPLOY_RANGE_LIMIT, get_step(src, ship_base.dir)))
+			for(var/obj/machinery/deployable/mounted/sentry/deployable_sentry in turf_to_check)
+				if(get_dist_euclide(deployable_sentry, src) >= SENTRY_DEPLOY_RANGE_LIMIT)
+					to_chat(user, span_warning("Another sentry is too close."))
+					return
+		to_chat(user, span_notice("You deploy [src]."))
+		deploy_sentry()
 	else
 		to_chat(user, span_notice("You retract [src]."))
 		undeploy_sentry()


### PR DESCRIPTION
## About The Pull Request
Per title. Revival of #12756.
Sentries cannot be deployed adjacent to one another.

## Why It's Good For The Game
Refer to #12756.

## Changelog
:cl: Lewdcifer
balance: Proximity check for sentries added to prevent stacking. Sentries can no longer be deployed adjacent to one another.
/:cl: