### PR TITLE
Defensive mission cas disablers

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -106,7 +106,8 @@
 #define COMSIG_GLOB_CAMPAIGN_DROPBLOCKER_DISABLED "!campaign_dropblocker_disabled"
 ///Override code for NT base rescue mission
 #define COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE "!campaign_nt_override_code"
-
+///Campaign asset obtained for the first time
+#define COMSIG_CAMPAIGN_NEW_ASSET "campaign_new_asset"
 ///Campaign asset activation successful
 #define COMSIG_CAMPAIGN_ASSET_ACTIVATION "campaign_asset_activation"
 ///Campaign asset disabler activated

--- a/code/datums/gamemodes/campaign/campaign_assets.dm
+++ b/code/datums/gamemodes/campaign/campaign_assets.dm
@@ -45,9 +45,12 @@
 	///Feedback message if this asset is unusable during this mission
 	var/blacklist_message = "Unavailable during this mission."
 
-/datum/campaign_asset/New(datum/faction_stats/winning_faction)
+/datum/campaign_asset/New(datum/faction_stats/new_faction)
 	. = ..()
-	faction = winning_faction
+	if(!istype(new_faction))
+		return qdel(src)
+	SEND_SIGNAL(new_faction, COMSIG_CAMPAIGN_NEW_ASSET, src)
+	faction = new_faction
 	if(asset_flags & ASSET_IMMEDIATE_EFFECT)
 		immediate_effect()
 	if(asset_flags & ASSET_PASSIVE_EFFECT)

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -44,8 +44,11 @@
 
 /datum/campaign_mission/capture_mission/asat/load_pre_mission_bonuses()
 	. = ..()
-	spawn_mech(hostile_faction, 0, 0, 3)
-	spawn_mech(starting_faction, 0, 2)
+	spawn_mech(hostile_faction, 0, 0, 4)
+	spawn_mech(starting_faction, 0, 1, 1)
+
+	var/datum/faction_stats/attacking_team = mode.stat_list[starting_faction]
+	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/som_cas/instant)
 
 /datum/campaign_mission/capture_mission/asat/load_objective_description()
 	starting_faction_objective_description = "Major Victory:Capture all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Capture at least [min_capture_amount] ASAT systems." : ""]"

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -43,6 +43,12 @@
 	for(var/i = 1 to objectives_total)
 		new /obj/item/storage/box/explosive_mines(get_turf(pick(GLOB.campaign_reward_spawners[defending_faction])))
 
+	var/datum/faction_stats/attacking_team = mode.stat_list[starting_faction]
+	if(starting_faction == FACTION_TERRAGOV)
+		attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
+	else if(starting_faction == FACTION_SOM)
+		attacking_team.add_asset(/datum/campaign_asset/asset_disabler/som_cas/instant)
+
 /datum/campaign_mission/destroy_mission/fire_support_raid/load_mission_brief()
 	starting_faction_mission_brief = "A [hostile_faction] fire support position has been identified in this area. This key location provides fire support to [hostile_faction] forces across the region. \
 		By destroying this outpost we can silence their guns and greatly weaken the enemy's forces. \

--- a/code/datums/gamemodes/campaign/missions/supply_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/supply_raid.dm
@@ -45,6 +45,11 @@
 /datum/campaign_mission/destroy_mission/supply_raid/load_pre_mission_bonuses()
 	. = ..()
 	spawn_mech(defending_faction, 0, 1)
+	var/datum/faction_stats/attacking_team = mode.stat_list[starting_faction]
+	if(starting_faction == FACTION_TERRAGOV)
+		attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
+	else if(starting_faction == FACTION_SOM)
+		attacking_team.add_asset(/datum/campaign_asset/asset_disabler/som_cas/instant)
 
 /datum/campaign_mission/destroy_mission/supply_raid/apply_major_victory()
 	winning_faction = starting_faction


### PR DESCRIPTION

## About The Pull Request
Defensive missions now disable CAS for the attacking team (mortar support, if you have it, is still available).

Defense missions generally suffer from being extremely difficult for a number of reasons. CAS is not the sole or main cause for this, but it is a significant factor, as well used CAS absolutely crushes defensive positions.
## Why It's Good For The Game
Slightly more balanced defensive missions.
## Changelog
:cl:
balance: Campaign: Attacking teams on defensive missions can no longer call in CAS
/:cl:
