### PR TITLE
Vents Now Damage Mobs Inside of Them

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -10,6 +10,9 @@
 
 	handle_fire() //Check if we're on fire
 
+	if(is_ventcrawling) //Damage mobs inside of vents
+		apply_damage(1, BRUTE)
+
 /mob/living/carbon/handle_regular_hud_updates()
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Title, mobs will now take 1 brute damage per life tick while inside of a vent.
## Why It's Good For The Game
Currently, xenos can camp vents indefinitely. This means that a xeno could just stall by hiding inside of a vent, or if all the vents are welded, the xeno is just stuck until a vent is unwelded. This will help prevent stalling xenos inside of vents, or help free xenos stuck in purgatory by killing them.
## Changelog
:cl:
balance: Mobs will now take 1 brute damage per life tick while inside of vents.
/:cl:
