### PR TITLE
Port string list config type from tg, fix tts voice blacklist config

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -118,6 +118,22 @@
 	config_entry_value = text2num(trim(str_val)) != 0
 	return TRUE
 
+/// List config entry, used for configuring a list of strings
+/datum/config_entry/str_list
+	abstract_type = /datum/config_entry/str_list
+	default = list()
+	dupes_allowed = TRUE
+	/// whether the string elements will be lowercased on ValidateAndSet or not.
+	var/lowercase = FALSE
+
+/datum/config_entry/str_list/ValidateAndSet(str_val)
+	if (!VASProcCallGuard(str_val))
+		return FALSE
+	str_val = trim(str_val)
+	if (str_val != "")
+		config_entry_value += lowercase ? lowertext(str_val) : str_val
+	return TRUE
+
 /datum/config_entry/number_list
 	abstract_type = /datum/config_entry/number_list
 	config_entry_value = list()


### PR DESCRIPTION
This ports the str_list config subtype that was added as a part of tgstation/tgstation#54465

The tts voice blacklist config uses this subtype.