### PR TITLE
Radiation nerf

### DIFF
--- a/code/datums/fire_support.dm
+++ b/code/datums/fire_support.dm
@@ -417,7 +417,7 @@
 	start_visual = /obj/effect/temp_visual/dropship_flyby/som
 	uses = 2
 	///Base strength of the rad effects
-	var/rad_strength = 30
+	var/rad_strength = 25
 	///Range for the maximum rad effects
 	var/inner_range = 3
 	///Range for the moderate rad effects

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -125,7 +125,7 @@
 	///The range range for the grenade's weak effect
 	var/outer_range = 7
 	///The potency of the grenade
-	var/rad_strength = 20
+	var/rad_strength = 16
 
 /obj/item/explosive/grenade/rad/prime()
 	var/turf/impact_turf = get_turf(src)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2415,7 +2415,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 50
 	penetration = 10
 	///Base strength of the rad effects
-	var/rad_strength = 25
+	var/rad_strength = 20
 	///Range for the maximum rad effects
 	var/inner_range = 3
 	///Range for the moderate rad effects


### PR DESCRIPTION

## About The Pull Request
Reduce rad strength across the board for rad grenades, rockets and missiles.
## Why It's Good For The Game
Radiation weapons were a little bit too strong, especially as in campaign you can tweak your loadout to get a bit more of them.
## Changelog
:cl:
balance: Reduced the power of radiation weaponry
/:cl:
