### PR TITLE
Disables tadpole, makes hijacking have the same people check as capturing, reduces PO slots to 1

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -296,7 +296,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	title = PILOT_OFFICER
 	paygrade = "WO"
 	comm_title = "PO"
-	total_positions = 2
+	total_positions = 1
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	minimal_access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_MEDBAY)
 	skills_type = /datum/skills/pilot

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -124,7 +124,7 @@
 	description = "The plain and simple old Tadpole-03 model."
 	///shuttle switch console name
 	var/display_name = "Tadpole Standard Model"
-	var/admin_enable = TRUE
+	var/admin_enable = FALSE
 
 /datum/map_template/shuttle/minidropship/old
 	suffix = "_big"
@@ -135,7 +135,6 @@
 	suffix = "_food"
 	description = "A Tadpole modified to provide foods and services. Who the hell let this on the military catalogue? Bounty on that guy."
 	display_name = "Tadpole Food-truck Model"
-	admin_enable = FALSE
 
 /datum/map_template/shuttle/minidropship/factorio
 	suffix = "_factorio"
@@ -146,7 +145,6 @@
 	suffix = "_mobile_bar"
 	description =	"A Tadpole modified to provide drinks and disservices. God dammit it's him again, I thought we got rid of him."
 	display_name =	"Tadpole Mobile-Bar Model"
-	admin_enable = FALSE
 
 /datum/map_template/shuttle/minidropship/umbilical
 	suffix = "_umbilical"
@@ -169,7 +167,7 @@
 	shuttle_id = SHUTTLE_DISTRESS_UPP
 	name = "Distress UPP"
 
-/datum/map_template/shuttle/small_ert/ufo 
+/datum/map_template/shuttle/small_ert/ufo
 	shuttle_id = SHUTTLE_DISTRESS_UFO
 	name = "Small UFO"
 

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -681,6 +681,17 @@
 	var/mob/living/carbon/xenomorph/X = usr
 
 	if(href_list["hijack"])
+		var/groundside_humans
+		for(var/N in GLOB.alive_human_list)
+			var/mob/H = N
+			if(H.z != X.z)
+				continue
+			groundside_humans++
+
+		if(groundside_humans > 5)
+			to_chat(X, span_xenowarning("There is still prey left to hunt!"))
+			return
+
 		if(!(X.hive.hive_flags & HIVE_CAN_HIJACK))
 			to_chat(X, span_warning("Our hive lacks the psychic prowess to hijack the bird."))
 			return


### PR DESCRIPTION
## About The Pull Request
See title. Kills stealthjacking.
Reduces PO slots to 1.
## Why It's Good For The Game
Tadpole is terrible for gameflow, and removing it is would fix a lot of the game flow problems we usually encounter with logistics and such. Also stealthjacking is kinda cringe with summon making it so easy.
## Changelog
:cl:
del: Disables tadpole in nuclear war.
balance: You can no longer hijack as long as there are 6~ marines groundside.
/:cl:
