### PR TITLE
Removes Psychic Summon from Xenomorph King

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -53,7 +53,6 @@
 		/datum/action/ability/xeno_action/petrify,
 		/datum/action/ability/activable/xeno/off_guard,
 		/datum/action/ability/activable/xeno/shattering_roar,
-		/datum/action/ability/xeno_action/psychic_summon,
 		/datum/action/ability/xeno_action/pheromones,
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,


### PR DESCRIPTION
## About The Pull Request
Removes the Summon ability from King.
## Why It's Good For The Game
Repeatedly rounds are ruined by king summons, and a lot of xenos dislike being taken away from combat, or worse, getting suddenly killed by a king summon. A single player should not have this much control over player locations.

There has been talk about letting xenos "opt out" of being summoned, effectively ruining what the ability is meant to do. Instead, removing it is better in my opinion. 

King can still rally the hive.

Perhaps it can be replaced with another ability in the future, but right now I can't think of anything, and giving them spit seems a little too powercreep.
## Changelog
:cl:
del: Xenomorph King can no longer summon
/:cl:
