### PR TITLE
Shifts SG prep door on Cantabury so they may leave without breaking glass

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -530,13 +530,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cc" = (
-/obj/machinery/door/window/right{
+/obj/effect/landmark/start/job/crash/squadsmartgunner,
+/obj/structure/window/reinforced/toughened{
 	dir = 1
 	},
-/obj/structure/window/reinforced/toughened{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/crash/squadsmartgunner,
+/obj/machinery/door/window/right,
 /turf/open/floor/mainship/red,
 /area/shuttle/canterbury)
 "cd" = (


### PR DESCRIPTION

## About The Pull Request
moves around the windoor in the SG prep on the cantabury since it is now blocked by a synth vendor.
## Why It's Good For The Game
its nice to not break windows or to be trapped in a glass box.
Before:
![CantBefore](https://github.com/tgstation/TerraGov-Marine-Corps/assets/12964904/6fda4fe3-80ff-46be-8397-25b4e38c6fa5)
After:
![CantAfter](https://github.com/tgstation/TerraGov-Marine-Corps/assets/12964904/481d5abb-411a-43aa-82d8-b67a2b968239)
## Changelog
:cl:
fix: SG prep on cantabury no longer has its only door blocked
/:cl:
