### PR TITLE
delete specialclick

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -692,7 +692,6 @@
 #define COMSIG_KB_CARBON_SELECTDISARMINTENT_DOWN "keybinding_carbon_selectdisarmintent_down"
 #define COMSIG_KB_CARBON_SELECTGRABINTENT_DOWN "keybinding_carbon_selectgrabintent_down"
 #define COMSIG_KB_CARBON_SELECTHARMINTENT_DOWN "keybinding_carbon_selectharmintent_down"
-#define COMSIG_KB_CARBON_SPECIALCLICK_DOWN "keybinding_carbon_specialclick_down"
 #define COMSIG_KB_CLIENT_GETHELP_DOWN "keybinding_client_gethelp_down"
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -116,32 +116,3 @@
 		return
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
-
-/datum/keybinding/carbon/specialclick
-	hotkey_keys = list("Ctrl")
-	name = "specialclick"
-	full_name = "Special Click"
-	description = "Hold this hotkey_keys and click to trigger special object interactions."
-	keybind_signal = COMSIG_KB_CARBON_SPECIALCLICK_DOWN
-
-
-/datum/keybinding/carbon/specialclick/down(client/user)
-	. = ..()
-	if(.)
-		return
-	RegisterSignals(user.mob, list(COMSIG_MOB_CLICKON), PROC_REF(specialclicky))
-	RegisterSignals(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), TYPE_PROC_REF(/datum/keybinding, intercept_mouse_special))
-	return TRUE
-
-
-/datum/keybinding/carbon/specialclick/up(client/user)
-	UnregisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_CLICKON))
-	return TRUE
-
-/datum/keybinding/carbon/specialclick/proc/specialclicky(datum/source, atom/A, params)
-	SIGNAL_HANDLER
-	var/mob/living/carbon/user = source
-	if(!user.client || !(user.client.eye == user || user.client.eye == user.loc))
-		UnregisterSignal(user, (COMSIG_MOB_CLICKON))
-		return
-	A.specialclick(user)

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -982,11 +982,6 @@ directive is properly returned.
 
 	return TRUE
 
-
-// For special click interactions (take first item out of container, quick-climb, etc.)
-/atom/proc/specialclick(mob/living/carbon/user)
-	return
-
 /atom/proc/prepare_huds()
 	hud_list = new
 	for(var/hud in hud_possible) //Providing huds.

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -50,7 +50,7 @@
 		use_wall_hole(user)
 
 
-/obj/effect/acid_hole/specialclick(mob/living/carbon/user)
+/obj/effect/acid_hole/CtrlClick(mob/living/carbon/user)
 	if(!isxeno(user))
 		return
 	if(!user.CanReach(src))

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -218,11 +218,11 @@
 		return ..()
 	return window.MouseDrop_T(dropping, user)
 
-/obj/alien/weeds/weedwall/window/specialclick(mob/living/carbon/user)
+/obj/alien/weeds/weedwall/window/CtrlClick(mob/living/carbon/user)
 	var/obj/structure/window = locate(window_type) in loc
 	if(!window)
 		return ..()
-	return window.specialclick(user)
+	return window.CtrlClick(user)
 
 /obj/alien/weeds/weedwall/window/attackby(obj/item/I, mob/user, params) //yes, this blocks attacking the weed itself, but if you destroy the frame you destroy the weed!
 	var/obj/structure/window = locate(window_type) in loc

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -49,7 +49,7 @@
 
 	do_climb(usr)
 
-/obj/structure/specialclick(mob/living/carbon/user)
+/obj/structure/CtrlClick(mob/living/carbon/user)
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(do_climb), user)
 

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -43,7 +43,7 @@ Blue weeds and purple sticky resin slow you down. Get rid of them!
 During Self Destruct, green control rods are armed control rods. Each rods take 3 minutes to rise, forcing marines to hold Self Destruct for a total of 20 minutes. Collect all six!
 A fit marine can carry many weapons: in their armor, belt, even hanging from their back.
 Requisitions has many supplies to enhance the combat power of marine units, such as attachments, ammunition, and other toys; ask their crew what's in store and you may be pleasantly surprised. DISCLAIMER: Extra gears' availability is dependent on supply.
-As a marine, you can climb over waist-high obstacles like sandbags, window frames or tables by CTRL+click on them or drag-clicking yourself onto them.
+As a marine, you can climb over waist-high obstacles like sandbags, window frames or tables by CTRL+clicking them or drag-clicking yourself onto them.
 You can jump over waist-high obstacles like platforms, tables, and window frames, for a small stamina cost (Default: Spacebar).
 The Terra Experimental laser rifles have a mode selector that can be switched using the Unique Action command (Default: Spacebar). Some modes are better than other modes in specific circumstances.
 You can remove armor pieces (leg pieces, arm pieces and chest pieces) and armor modules (Valkyrie, Baldur, etc.) from the XM-02 Combat Exoskeleton by Alt+clicking the exoskeleton.

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -43,7 +43,7 @@ Blue weeds and purple sticky resin slow you down. Get rid of them!
 During Self Destruct, green control rods are armed control rods. Each rods take 3 minutes to rise, forcing marines to hold Self Destruct for a total of 20 minutes. Collect all six!
 A fit marine can carry many weapons: in their armor, belt, even hanging from their back.
 Requisitions has many supplies to enhance the combat power of marine units, such as attachments, ammunition, and other toys; ask their crew what's in store and you may be pleasantly surprised. DISCLAIMER: Extra gears' availability is dependent on supply.
-As a marine, you can climb over waist-high obstacles like sandbags, window frames or tables by "SpecialClicking" (Default: CTRL+click) on them or drag-clicking yourself onto them.
+As a marine, you can climb over waist-high obstacles like sandbags, window frames or tables by CTRL+click on them or drag-clicking yourself onto them.
 You can jump over waist-high obstacles like platforms, tables, and window frames, for a small stamina cost (Default: Spacebar).
 The Terra Experimental laser rifles have a mode selector that can be switched using the Unique Action command (Default: Spacebar). Some modes are better than other modes in specific circumstances.
 You can remove armor pieces (leg pieces, arm pieces and chest pieces) and armor modules (Valkyrie, Baldur, etc.) from the XM-02 Combat Exoskeleton by Alt+clicking the exoskeleton.


### PR DESCRIPTION

## About The Pull Request
delete specialclick
## Why It's Good For The Game
This was dumb.
We had some things coded onto CTRL click
And then we had other things coded onto specialclick (Which is defaulted to CTRL)
???
I'm deleting specialclick in favor of keeping our click code.
## Changelog
:cl:
del: Deletes "specialclick" keybind
/:cl:
