### PR TITLE
Fix middle click pref for humans

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -408,8 +408,13 @@ if(selected_ability.target_flags & flagname && !istype(A, typepath)){\
 /mob/living/carbon/human/ShiftClickOn(atom/A)
 	if(client.prefs.toggles_gameplay & MIDDLESHIFTCLICKING)
 		return ..()
-	var/obj/item/held_thing = get_active_held_item()
+	if(selected_ability)
+		A = ability_target(A)
+		if(selected_ability.can_use_ability(A))
+			selected_ability.use_ability(A)
+		return TRUE
 
+	var/obj/item/held_thing = get_active_held_item()
 	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_SHIFTCLICKON, A, src) & COMPONENT_ITEM_CLICKON_BYPASS)
 		return FALSE
 	return ..()


### PR DESCRIPTION

## About The Pull Request
Abilities (like jetpack/blink/sectoid powers/etc) for humans will now work with shift click if you have your middle click pref toggled to shift click.
I forgot middle click pref is even a thing, so never added the code for humans.

If anyone has trouble with this before the pr is merged, you can change the pref to mmb and that will work fine.
## Why It's Good For The Game
Pref working is good.
## Changelog
:cl:
fix: shift click will work for human abilities such as jetpack, if you have toggled your pref from middle mouse button
/:cl:
