### PR TITLE
Adjust psylance stagger

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3415,7 +3415,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
 	if(isxeno(M))
 		return
-	staggerstun(M, P, 9, stagger = 4 SECONDS, slowdown = 2, knockback = 1)
+	staggerstun(M, P, 9, stagger = 1 SECONDS, slowdown = 2, knockback = 1)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/T, obj/projectile/P)
 	return


### PR DESCRIPTION

## About The Pull Request
Psylance only staggers for 1 second instead of 4.
## Why It's Good For The Game
4 seconds was never intended, it was a left over from before stagger was refactored to actually count duration accurately.
## Changelog
:cl:
balance: Psylance stagger reduced to 1 second
/:cl:
