### PR TITLE
Some small beacon fixes

### DIFF
--- a/code/datums/components/beacon.dm
+++ b/code/datums/components/beacon.dm
@@ -32,6 +32,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON_STATE, PROC_REF(on_update_icon_state))
+	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
 
 /datum/component/beacon/UnregisterFromParent()
 	UnregisterSignal(parent, list(
@@ -40,6 +41,7 @@
 		COMSIG_ATOM_ATTACK_HAND,
 		COMSIG_ATOM_EXAMINE,
 		COMSIG_ATOM_UPDATE_ICON_STATE,
+		COMSIG_MOVABLE_Z_CHANGED,
 		))
 	QDEL_NULL(beacon_datum)
 	QDEL_NULL(beacon_cam)
@@ -127,7 +129,7 @@
 
 	message_admins("[ADMIN_TPMONTY(user)] set up a supply beacon.") //do something with this
 	playsound(source, 'sound/machines/twobeep.ogg', 15, 1)
-	user.visible_message("[user] activates [source]'s signal'.")
+	user.visible_message("[user] activates [source]'s signal.")
 	user.show_message(span_notice("The [source] beeps and states, \"Your current coordinates were registered by the supply console. LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(source)]\""), EMOTE_AUDIBLE, span_notice("The [source] vibrates but you can not hear it!"))
 	beacon_datum = new /datum/supply_beacon("[user.name] + [A]", get_turf(source), user.faction)
 	RegisterSignal(beacon_datum, COMSIG_QDELETING, PROC_REF(clean_beacon_datum))
@@ -135,30 +137,31 @@
 
 ///Deactivates the beacon
 /datum/component/beacon/proc/deactivate(atom/movable/source, mob/user)
-	if(length(user.do_actions))
+	if(length(user?.do_actions))
 		user.balloon_alert(user, "Busy!")
 		active = TRUE
 		return
 	if(source.anchored)
-		var/delay = max(1 SECONDS, anchor_time * 0.5 - 2 SECONDS * user.skills.getRating(SKILL_LEADERSHIP)) //Half as long as setting it up.
-		user.visible_message(span_notice("[user] starts removing [source] from the ground."),
-		span_notice("You start removing [source] from the ground, deactivating it."))
-		if(!do_after(user, delay, NONE, source, BUSY_ICON_GENERIC))
-			user.balloon_alert(user, "Keep still!")
-			active = TRUE
-			return
+		if(user)
+			var/delay = max(1 SECONDS, anchor_time * 0.5 - 2 SECONDS * user.skills.getRating(SKILL_LEADERSHIP)) //Half as long as setting it up.
+			user.visible_message(span_notice("[user] starts removing [source] from the ground."),
+			span_notice("You start removing [source] from the ground, deactivating it."))
+			if(!do_after(user, delay, NONE, source, BUSY_ICON_GENERIC))
+				user.balloon_alert(user, "Keep still!")
+				active = TRUE
+				return
+			user.put_in_active_hand(source)
+			user.show_message(span_warning("The [source] beeps and states, \"Your last position is no longer accessible by the supply console"), EMOTE_AUDIBLE, span_notice("The [source] vibrates but you can not hear it!"))
 		source.anchored = FALSE
 		source.layer = initial(source.layer)
 		source.set_light(0)
-		user.put_in_active_hand(source)
 		SSminimaps.remove_marker(source)
 
+	source.visible_message(span_warning("[source] stops emitting a signal."))
 	QDEL_NULL(beacon_cam)
 	QDEL_NULL(beacon_datum)
 	activator = null
 	playsound(source, 'sound/machines/twobeep.ogg', 15, 1)
-	user.visible_message("[user] deactivates [source]'s signal.")
-	user.show_message(span_warning("The [source] beeps and states, \"Your last position is no longer accessible by the supply console"), EMOTE_AUDIBLE, span_notice("The [source] vibrates but you can not hear it!"))
 	active = FALSE //this is here because of attack hand
 	source.update_appearance()
 
@@ -183,7 +186,18 @@
 ///Updates the icon state of the object to an active state, if it has one
 /datum/component/beacon/proc/on_update_icon_state(atom/source, updates)
 	SIGNAL_HANDLER
-	source.icon = icon(source.icon, active_icon_state)
+	if(active)
+		source.icon = icon(source.icon, active_icon_state)
+	else
+		source.icon = initial(source.icon)
+
+///What happens when we change Z level
+/datum/component/beacon/proc/on_z_change(atom/source, old_z, new_z)
+	SIGNAL_HANDLER
+	var/turf/source_turf = get_turf(source)
+	if(!is_ground_level(source_turf.z) && active)
+		INVOKE_ASYNC(src, PROC_REF(deactivate), source)
+		return
 
 /datum/component/beacon/ai_droid/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_UNMANNED_COORDINATES, PROC_REF(toggle_activation))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes icon not going back from its activated icon state once the beacon was undeployed
- Fixes the beacon not reacting to it's Z level changed, it now deactivates if it changes Z level to a level that isn't groundside

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs b

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Beacons now go back to their inactive icon state when undeployed
fix: Beacons now deactivate themselves when they change Z level to a Z level that isn't groundside (instead of leaving the beacon datum on the tile they were at just before they changed Z level)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
