### PR TITLE
Campaign individual performance rewards

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -27,7 +27,7 @@
 	var/datum/campaign_mission/current_mission
 	///campaign stats organised by faction
 	var/list/datum/faction_stats/stat_list = list()
-	///List of death times by key. Used for respawn time
+	///List of death times by ckey. Used for respawn time
 	var/list/player_death_times = list()
 
 /datum/game_mode/hvh/campaign/announce()
@@ -64,8 +64,8 @@
 		return respawnee.respawn()
 
 	var/respawn_delay = CAMPAIGN_RESPAWN_TIME + stat_list[respawnee.faction]?.respawn_delay_modifier
-	if((player_death_times[respawnee.key] + respawn_delay) > world.time)
-		to_chat(respawnee, "<span class='warning'>Respawn timer has [round((player_death_times[respawnee.key] + respawn_delay - world.time) / 10)] seconds remaining.<spawn>")
+	if((player_death_times[respawnee.ckey] + respawn_delay) > world.time)
+		to_chat(respawnee, "<span class='warning'>Respawn timer has [round((player_death_times[respawnee.ckey] + respawn_delay - world.time) / 10)] seconds remaining.<spawn>")
 		return
 
 	attempt_attrition_respawn(respawnee)
@@ -183,7 +183,7 @@
 		return
 	if(!(player.faction in factions))
 		return
-	player_death_times[player.key] = world.time
+	player_death_times[player.ckey] = world.time
 
 ///Wrapper for cutting the deathlist via timer due to the players not immediately returning to base
 /datum/game_mode/hvh/campaign/proc/cut_death_list_timer(datum/source)

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -68,11 +68,11 @@
 	)
 	///cash rewards for the mission type
 	var/list/cash_rewards = list(
-		MISSION_OUTCOME_MAJOR_VICTORY = list(800, 600),
-		MISSION_OUTCOME_MINOR_VICTORY = list(700, 600),
-		MISSION_OUTCOME_DRAW = list(600, 600),
-		MISSION_OUTCOME_MINOR_LOSS = list(600, 700),
-		MISSION_OUTCOME_MAJOR_LOSS = list(600, 800),
+		MISSION_OUTCOME_MAJOR_VICTORY = list(650, 450),
+		MISSION_OUTCOME_MINOR_VICTORY = list(550, 450),
+		MISSION_OUTCOME_DRAW = list(450, 450),
+		MISSION_OUTCOME_MINOR_LOSS = list(450, 550),
+		MISSION_OUTCOME_MAJOR_LOSS = list(450, 650),
 	)
 	/// Timer used to calculate how long till mission ends
 	var/game_timer

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	var/respawn_delay_modifier = 0
 	///records how much currency has been earned from missions, for late join players
 	var/accumulated_mission_reward = 0
-	///list of individual stats by key
+	///list of individual stats by ckey
 	var/list/datum/individual_stats/individual_stat_list = list()
 
 /datum/faction_stats/New(new_faction)
@@ -137,9 +137,9 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		return
 	if(new_member.faction != faction)
 		return
-	if(individual_stat_list[new_member.key])
-		individual_stat_list[new_member.key].current_mob = new_member
-		individual_stat_list[new_member.key].apply_perks()
+	if(individual_stat_list[new_member.ckey])
+		individual_stat_list[new_member.ckey].current_mob = new_member
+		individual_stat_list[new_member.ckey].apply_perks()
 	else
 		get_player_stats(new_member)
 	var/datum/action/campaign_loadout/loadouts = new
@@ -147,11 +147,11 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 ///Returns a users individual stat datum, generating a new one if required
 /datum/faction_stats/proc/get_player_stats(mob/user)
-	if(!user.key)
+	if(!user.ckey)
 		return
-	if(!individual_stat_list[user.key])
-		individual_stat_list[user.key] = new /datum/individual_stats(user, faction, accumulated_mission_reward)
-	return individual_stat_list[user.key]
+	if(!individual_stat_list[user.ckey])
+		individual_stat_list[user.ckey] = new /datum/individual_stats(user, faction, accumulated_mission_reward)
+	return individual_stat_list[user.ckey]
 
 ///Randomly adds a new mission to the available pool
 /datum/faction_stats/proc/generate_new_mission()

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -47,7 +47,9 @@
 	credit_bonus += personal_statistics.mission_projectile_damage * 0.03
 	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.06
 	credit_bonus += mission_melee_damage * 0.06
+	credit_bonus += mission_delimbs * 3
 	credit_bonus += mission_revives * 10
+	credit_bonus += mission_times_revived * 5 //purple heart
 	credit_bonus += mission_structures_built * 2
 
 	give_funds(max(floor(credit_bonus), 0))

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -1,5 +1,6 @@
 /datum/individual_stats
 	interaction_flags = INTERACT_UI_INTERACT
+	var/owner_ckey
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
@@ -19,6 +20,8 @@
 
 /datum/individual_stats/New(mob/living/carbon/new_mob, new_faction, new_currency)
 	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, PROC_REF(post_mission_credits))
+	owner_ckey = new_mob.ckey
 	current_mob = new_mob
 	faction = new_faction
 	currency += new_currency
@@ -36,6 +39,15 @@
 	perks_by_job = null
 	unlocked_items = null
 	return ..()
+
+///Pay each player additional credits based on individual performance during the mission
+/datum/individual_stats/proc/post_mission_credits()
+	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner_ckey]
+	var/credit_bonus = 0
+	credit_bonus += personal_statistics.mission_projectile_damage * 0.01
+	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.02
+
+	give_funds(max(floor(credit_bonus), 0))
 
 ///Applies cash
 /datum/individual_stats/proc/give_funds(amount)

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -44,8 +44,11 @@
 /datum/individual_stats/proc/post_mission_credits()
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner_ckey]
 	var/credit_bonus = 0
-	credit_bonus += personal_statistics.mission_projectile_damage * 0.01
-	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.02
+	credit_bonus += personal_statistics.mission_projectile_damage * 0.03
+	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.06
+	credit_bonus += mission_melee_damage * 0.06
+	credit_bonus += mission_revives * 10
+	credit_bonus += mission_structures_built * 2
 
 	give_funds(max(floor(credit_bonus), 0))
 

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -41,7 +41,8 @@
 	return ..()
 
 ///Pay each player additional credits based on individual performance during the mission
-/datum/individual_stats/proc/post_mission_credits()
+/datum/individual_stats/proc/post_mission_credits(datum/source)
+	SIGNAL_HANDLER
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner_ckey]
 	give_funds(personal_statistics.get_mission_reward())
 

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -44,9 +44,9 @@
 /datum/individual_stats/proc/post_mission_credits()
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner_ckey]
 	var/credit_bonus = 0
-	credit_bonus += personal_statistics.mission_projectile_damage * 0.03
-	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.06
-	credit_bonus += mission_melee_damage * 0.06
+	credit_bonus += personal_statistics.mission_projectile_damage * 0.1
+	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.2
+	credit_bonus += mission_melee_damage * 0.2
 	credit_bonus += mission_delimbs * 3
 	credit_bonus += mission_revives * 10
 	credit_bonus += mission_times_revived * 5 //purple heart

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -43,16 +43,7 @@
 ///Pay each player additional credits based on individual performance during the mission
 /datum/individual_stats/proc/post_mission_credits()
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner_ckey]
-	var/credit_bonus = 0
-	credit_bonus += personal_statistics.mission_projectile_damage * 0.1
-	credit_bonus -= personal_statistics.mission_friendly_fire_damage * 0.2
-	credit_bonus += mission_melee_damage * 0.2
-	credit_bonus += mission_delimbs * 3
-	credit_bonus += mission_revives * 10
-	credit_bonus += mission_times_revived * 5 //purple heart
-	credit_bonus += mission_structures_built * 2
-
-	give_funds(max(floor(credit_bonus), 0))
+	give_funds(personal_statistics.get_mission_reward())
 
 ///Applies cash
 /datum/individual_stats/proc/give_funds(amount)

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -239,7 +239,7 @@ GLOBAL_PROTECT(exp_specialmap)
 
 /datum/job/proc/add_job_positions(amount)
 	if(!(job_flags & (JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE)))
-		CRASH("add_job_positions called for a non-joinable job")
+		return
 	if(total_positions == -1)
 		return TRUE
 	var/previous_amount = total_positions

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -38,10 +38,6 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/projectile_damage = 0
 	var/melee_damage = 0
 
-	var/mission_projectile_damage = 0
-
-	var/mission_friendly_fire_damage = 0
-
 	//We are watching
 	var/friendly_fire_damage = 0
 
@@ -108,6 +104,14 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/sippies = 0
 	var/war_crimes = 0
 	var/tactical_unalives = 0	//Someone should add a way to determine if you died to a grenade in your hand and add it to this
+
+	//campaign specific vars
+	var/mission_projectile_damage = 0
+	var/mission_friendly_fire_damage = 0
+
+	var/mission_melee_damage = 0
+	var/mission_revives = 0
+	var/mission_structures_built = 0
 
 /datum/personal_statistics/New()
 	. = ..()
@@ -279,6 +283,9 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 /datum/personal_statistics/proc/reset_mission_stats()
 	mission_projectile_damage = 0
 	mission_friendly_fire_damage = 0
+	mission_revives = 0
+	mission_structures_built = 0
+	mission_melee_damage = 0
 
 /* Not sure what folder to put a file of just record keeping procs, so just leaving them here
 The alternative is scattering them everywhere under their respective objects which is a bit messy */
@@ -290,6 +297,9 @@ The alternative is scattering them everywhere under their respective objects whi
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
 	personal_statistics.melee_hits++
 	personal_statistics.melee_damage += damage
+	personal_statistics.mission_melee_damage += damage
+	if(faction == user.faction)
+		personal_statistics.mission_friendly_fire_damage += damage
 	return TRUE
 
 /mob/living/carbon/human/record_melee_damage(mob/living/user, damage, delimbed)
@@ -557,6 +567,7 @@ The alternative is scattering them everywhere under their respective objects whi
 		return FALSE
 	var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[ckey]
 	personal_statistics.structures_built++
+	personal_statistics.mission_structures_built++
 	return TRUE
 
 /mob/proc/record_war_crime()

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -282,6 +282,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
  * Used for Campaign
  */
 /datum/personal_statistics/proc/reset_mission_stats()
+	SIGNAL_HANDLER
 	mission_projectile_damage = 0
 	mission_friendly_fire_damage = 0
 	mission_revives = 0

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -108,9 +108,10 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	//campaign specific vars
 	var/mission_projectile_damage = 0
 	var/mission_friendly_fire_damage = 0
-
 	var/mission_melee_damage = 0
+	var/mission_delimbs = 0
 	var/mission_revives = 0
+	var/mission_times_revived = 0
 	var/mission_structures_built = 0
 
 /datum/personal_statistics/New()
@@ -284,8 +285,10 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_projectile_damage = 0
 	mission_friendly_fire_damage = 0
 	mission_revives = 0
+	mission_times_revived = 0
 	mission_structures_built = 0
 	mission_melee_damage = 0
+	mission_delimbs = 0
 
 /* Not sure what folder to put a file of just record keeping procs, so just leaving them here
 The alternative is scattering them everywhere under their respective objects which is a bit messy */
@@ -313,6 +316,7 @@ The alternative is scattering them everywhere under their respective objects whi
 		personal_statistics.limbs_lost++
 	personal_statistics = GLOB.personal_statistics_list[user.ckey]
 	personal_statistics.delimbs++
+	personal_statistics.mission_delimbs++
 	return TRUE
 
 ///Record whenever a player shoots things, taking into account bonus projectiles without running these checks multiple times

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -290,6 +290,19 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_melee_damage = 0
 	mission_delimbs = 0
 
+///Returns the credit bonus based on stats from the current mission
+/datum/personal_statistics/proc/get_mission_reward()
+	var/credit_bonus = 0
+	credit_bonus += mission_projectile_damage * 0.1
+	credit_bonus -= mission_friendly_fire_damage * 0.2
+	credit_bonus += mission_melee_damage * 0.2
+	credit_bonus += mission_delimbs * 3
+	credit_bonus += mission_revives * 10
+	credit_bonus += mission_times_revived * 5 //purple heart
+	credit_bonus += mission_structures_built * 2
+
+	return max(floor(credit_bonus), 0)
+
 /* Not sure what folder to put a file of just record keeping procs, so just leaving them here
 The alternative is scattering them everywhere under their respective objects which is a bit messy */
 

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -115,6 +115,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/mission_structures_built = 0
 	var/mission_objective_destroyed = 0
 	var/mission_blocker_destroyed = 0
+	var/mission_objective_captured = 0
+	var/mission_objective_decaptured = 0
 
 /datum/personal_statistics/New()
 	. = ..()
@@ -294,6 +296,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_delimbs = 0
 	mission_objective_destroyed = 0
 	mission_blocker_destroyed = 0
+	mission_objective_captured = 0
+	mission_objective_decaptured = 0
 
 ///Returns the credit bonus based on stats from the current mission
 /datum/personal_statistics/proc/get_mission_reward()
@@ -307,6 +311,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	credit_bonus += mission_structures_built * 2
 	credit_bonus += mission_objective_destroyed * 15
 	credit_bonus += mission_blocker_destroyed * 10
+	credit_bonus += mission_objective_captured * 5
+	credit_bonus += mission_objective_decaptured * 3
 
 	return max(floor(credit_bonus), 0)
 

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -113,6 +113,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/mission_revives = 0
 	var/mission_times_revived = 0
 	var/mission_structures_built = 0
+	var/mission_objective_destroyed = 0
+	var/mission_blocker_destroyed = 0
 
 /datum/personal_statistics/New()
 	. = ..()
@@ -290,6 +292,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_structures_built = 0
 	mission_melee_damage = 0
 	mission_delimbs = 0
+	mission_objective_destroyed = 0
+	mission_blocker_destroyed = 0
 
 ///Returns the credit bonus based on stats from the current mission
 /datum/personal_statistics/proc/get_mission_reward()
@@ -301,6 +305,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	credit_bonus += mission_revives * 10
 	credit_bonus += mission_times_revived * 5 //purple heart
 	credit_bonus += mission_structures_built * 2
+	credit_bonus += mission_objective_destroyed * 15
+	credit_bonus += mission_blocker_destroyed * 10
 
 	return max(floor(credit_bonus), 0)
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -321,6 +321,7 @@
 	if(user.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
 		personal_statistics.revives++
+		personal_statistics.mission_revives++
 	GLOB.round_statistics.total_human_revives[H.faction]++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_human_revives[H.faction]")
 	to_chat(H, span_notice("You suddenly feel a spark and your consciousness returns, dragging you back to the mortal plane."))

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -21,9 +21,12 @@
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
 	/// radius this smoke will encompass
 	var/smokeradius = 1
+	///Current/last user of the c4
+	var/mob/living/last_user
 
 /obj/item/explosive/plastique/Destroy()
 	plant_target = null
+	last_user = null
 	return ..()
 
 /obj/item/explosive/plastique/update_icon_state()
@@ -94,6 +97,7 @@
 			forceMove(location)
 		armed = TRUE
 		timer = target.plastique_time_mod(timer)
+		last_user = user
 
 		log_bomber(user, "planted", src, "on [target] with a [timer] second fuse", message_admins = TRUE)
 
@@ -136,6 +140,7 @@
 		armed = FALSE
 		alarm_sounded = FALSE
 		plant_target = null
+		last_user = null
 		update_icon()
 	return ..()
 
@@ -151,7 +156,7 @@
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	smoke.set_up(smokeradius, plant_target, 2)
 	smoke.start()
-	plant_target.plastique_act()
+	plant_target.plastique_act(last_user)
 	qdel(src)
 
 ///Triggers a warning beep prior to the actual detonation, while also setting the actual detonation timer
@@ -163,7 +168,7 @@
 		update_icon()
 
 ///Handles the effect of c4 on the atom - overridden as needed
-/atom/proc/plastique_act()
+/atom/proc/plastique_act(mob/living/plastique_user)
 	ex_act(EXPLODE_DEVASTATE)
 
 /obj/item/explosive/plastique/genghis_charge

--- a/code/game/objects/structures/campaign_structures/capture_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/capture_objectives.dm
@@ -112,6 +112,9 @@
 		owning_faction = null
 		update_icon()
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_DECAPTURED, src, user)
+		if(user.ckey)
+			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
+			personal_statistics.mission_objective_decaptured ++
 		return
 	finish_capture(user)
 
@@ -120,6 +123,9 @@
 	SHOULD_CALL_PARENT(TRUE)
 	owning_faction = user.faction
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAPTURED, src, user)
+	if(user.ckey)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
+		personal_statistics.mission_objective_captured ++
 	update_icon()
 
 ///Returns time left on the nuke in seconds

--- a/code/game/objects/structures/campaign_structures/deploy_blockers.dm
+++ b/code/game/objects/structures/campaign_structures/deploy_blockers.dm
@@ -43,7 +43,10 @@
 /obj/structure/campaign_deployblocker/ex_act()
 	return
 
-/obj/structure/campaign_deployblocker/plastique_act()
+/obj/structure/campaign_deployblocker/plastique_act(mob/living/plastique_user)
+	if(plastique_user && plastique_user.ckey)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
+		personal_statistics.mission_blocker_destroyed += (faction != plastique_user.faction ? 1 : -1)
 	qdel(src)
 
 ///Signals its destruction, enabling the use of the teleporter asset

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -10,7 +10,10 @@
 	QDEL_NULL(explosion_smoke)
 	return ..()
 
-/obj/structure/campaign_objective/destruction_objective/plastique_act()
+/obj/structure/campaign_objective/destruction_objective/plastique_act(mob/living/plastique_user)
+	if(plastique_user && plastique_user.ckey)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
+		personal_statistics.mission_objective_destroyed ++
 	qdel(src)
 
 /obj/structure/campaign_objective/destruction_objective/plastique_time_mod(time)
@@ -70,7 +73,10 @@
 	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_MOB_LAYER, dir)
 	. += new_overlay
 
-/obj/structure/campaign_objective/destruction_objective/mlrs/plastique_act()
+/obj/structure/campaign_objective/destruction_objective/mlrs/plastique_act(mob/living/plastique_user)
+	if(plastique_user && plastique_user.ckey)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
+		personal_statistics.mission_objective_destroyed ++
 	disable()
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/disable()
@@ -115,8 +121,8 @@
 	spawn_object = /obj/structure/campaign_objective/destruction_objective/mlrs/tank
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/tank
-	name = "\improper tank"
-	desc = "A massive multi launch rocket system on a tracked chassis. Can unleash a tremendous amount of firepower in a short amount of time."
+	name = "\improper M34A2 Longstreet Light Tank"
+	desc = "A giant piece of armor with a big gun, good for blowing stuff up."
 	icon_state = "tank"
 
 /obj/effect/landmark/campaign_structure/apc
@@ -129,7 +135,7 @@
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/apc
 	name = "\improper APC"
-	desc = "A massive multi launch rocket system on a tracked chassis. Can unleash a tremendous amount of firepower in a short amount of time."
+	desc = "A giant piece of armor for carrying troops in relative safety. Still has a pretty big gun."
 	icon_state = "apc"
 	smoke_type = /particles/tank_wreck_smoke/apc
 
@@ -276,10 +282,13 @@
 	if(status == BLUESPACE_CORE_BROKEN)
 		disable()
 
-/obj/structure/campaign_objective/destruction_objective/bluespace_core/plastique_act()
+/obj/structure/campaign_objective/destruction_objective/bluespace_core/plastique_act(mob/living/plastique_user)
 	if(status == BLUESPACE_CORE_OK)
 		change_status(BLUESPACE_CORE_UNSTABLE)
 	else if(status == BLUESPACE_CORE_UNSTABLE)
+		if(plastique_user && plastique_user.ckey)
+			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
+			personal_statistics.mission_objective_destroyed ++
 		change_status(BLUESPACE_CORE_BROKEN)
 
 //airbase

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -5,6 +5,8 @@
 	soft_armor = list(MELEE = 200, BULLET = 200, LASER = 200, ENERGY = 200, BOMB = 200, BIO = 200, FIRE = 200, ACID = 200) //require c4 normally
 	///explosion smoke particle holder
 	var/obj/effect/abstract/particle_holder/explosion_smoke
+	///The faction this belongs to
+	var/faction = FACTION_TERRAGOV
 
 /obj/structure/campaign_objective/destruction_objective/Destroy()
 	QDEL_NULL(explosion_smoke)
@@ -13,7 +15,7 @@
 /obj/structure/campaign_objective/destruction_objective/plastique_act(mob/living/plastique_user)
 	if(plastique_user && plastique_user.ckey)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
-		personal_statistics.mission_objective_destroyed ++
+		personal_statistics.mission_objective_destroyed += (faction != plastique_user.faction ? 1 : -1)
 	qdel(src)
 
 /obj/structure/campaign_objective/destruction_objective/plastique_time_mod(time)
@@ -33,6 +35,7 @@
 	icon = 'icons/Marine/howitzer.dmi'
 	icon_state = "howitzer_deployed"
 	pixel_x = -16
+	faction = FACTION_SOM
 
 //MLRS
 /obj/effect/landmark/campaign_structure/mlrs
@@ -76,7 +79,7 @@
 /obj/structure/campaign_objective/destruction_objective/mlrs/plastique_act(mob/living/plastique_user)
 	if(plastique_user && plastique_user.ckey)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
-		personal_statistics.mission_objective_destroyed ++
+		personal_statistics.mission_objective_destroyed += (faction != plastique_user.faction ? 1 : -1)
 	disable()
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/disable()
@@ -143,13 +146,6 @@
 	position = list(87, 60, 0)
 
 //Supply depot objectives
-/obj/effect/landmark/campaign_structure/supply_objective
-	name = "howitzer objective"
-	icon = 'icons/Marine/howitzer.dmi'
-	icon_state = "howitzer_deployed"
-	mission_types = list(/datum/campaign_mission/destroy_mission/fire_support_raid)
-	spawn_object = /obj/structure/campaign_objective/destruction_objective/howitzer
-
 /obj/structure/campaign_objective/destruction_objective/supply_objective
 	name = "SUPPLY_OBJECTIVE"
 	icon = 'icons/Marine/howitzer.dmi'
@@ -196,6 +192,7 @@
 	icon_state = "phoron_stack"
 	bound_height = 32
 	bound_width = 64
+	faction = FACTION_SOM
 
 /obj/structure/campaign_objective/destruction_objective/supply_objective/phoron_stack/Initialize(mapload)
 	. = ..()
@@ -248,6 +245,7 @@
 	bound_width = 64
 	pixel_y = -18
 	pixel_x = -16
+	faction = FACTION_SOM
 	var/status = BLUESPACE_CORE_OK
 
 /obj/structure/campaign_objective/destruction_objective/bluespace_core/Initialize(mapload)
@@ -288,12 +286,12 @@
 	else if(status == BLUESPACE_CORE_UNSTABLE)
 		if(plastique_user && plastique_user.ckey)
 			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[plastique_user.ckey]
-			personal_statistics.mission_objective_destroyed ++
+			personal_statistics.mission_objective_destroyed += (faction != plastique_user.faction ? 1 : -1)
 		change_status(BLUESPACE_CORE_BROKEN)
 
 //airbase
 /obj/structure/prop/som_fighter
-	name = "\improper Harbinger"
+	name = "harbinger"
 	desc = "A state of the art Harbinger class fighter. The premier fighter for SOM forces in space and atmosphere, bristling with high tech systems and weapons."
 	icon = 'icons/Marine/mainship_props96.dmi'
 	icon_state = "SOM_fighter"
@@ -303,7 +301,7 @@
 	allow_pass_flags = PASS_AIR
 
 /obj/effect/landmark/campaign_structure/harbinger
-	name = "\improper Harbinger"
+	name = "harbinger"
 	icon = 'icons/Marine/mainship_props96.dmi'
 	icon_state = "SOM_fighter"
 	pixel_x = -33
@@ -312,7 +310,7 @@
 	spawn_object = /obj/structure/campaign_objective/destruction_objective/harbinger
 
 /obj/structure/campaign_objective/destruction_objective/harbinger
-	name = "\improper Harbinger"
+	name = "harbinger"
 	desc = "A state of the art harbinger class fighter. The premier fighter for SOM forces in space and atmosphere, bristling with high tech systems and weapons."
 	icon = 'icons/Marine/mainship_props96.dmi'
 	icon_state = "SOM_fighter"
@@ -322,6 +320,7 @@
 	bound_width = 3
 	bound_x = -32
 	layer = ABOVE_MOB_LAYER
+	faction = FACTION_SOM
 
 /obj/effect/landmark/campaign_structure/viper
 	name = "\improper Viper"

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -134,7 +134,7 @@
 	spawn_object = /obj/structure/campaign_objective/destruction_objective/mlrs/apc
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/apc
-	name = "\improper APC"
+	name = "\improper M577 armored personnel carrier"
 	desc = "A giant piece of armor for carrying troops in relative safety. Still has a pretty big gun."
 	icon_state = "apc"
 	smoke_type = /particles/tank_wreck_smoke/apc

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -811,6 +811,7 @@
 		//This would go on on_revive() but that is a mob/living proc
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[ckey]
 		personal_statistics.times_revived++
+		personal_statistics.mission_times_revived++
 	SEND_SIGNAL(src, COMSIG_MOB_STAT_CHANGED, ., new_stat)
 
 /// Cleanup proc that's called when a mob loses a client, either through client destroy or logout

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -897,8 +897,9 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)
 		adjust_sunder(proj.sundering)
 
-	if(stat != DEAD && ismob(proj.firer))
-		record_projectile_damage(proj.firer, damage)	//Tally up whoever the shooter was
+	if(stat != DEAD && isliving(proj.firer))
+		var/mob/living/living_firer = proj.firer
+		living_firer.record_projectile_damage(damage, src)	//Tally up whoever the shooter was
 
 	if(damage)
 		if(do_shrapnel_roll(proj, damage))


### PR DESCRIPTION
## About The Pull Request
The end of mission credit reward is now supplemented by an amount determined by your individual performance.
Using the personal stats datum, the following stats are recorded each mission, and you receive a reward for them.
**Projectile damage: 0.1 credits** per damage dealt. This is after armour.
**Melee damage: 0.2 credits** per damage dealt.
**Friendly fire damage** (both projectile and melee): **-0.2 credits** per damage dealt.
**Delimbs: 3 credits** per delimb
**Revives: 10 credits** per revive
**Being revived: 5 credits** per revive. Stay in the fight marine!
**Structure built: 3 credits** per structure
**Objective destroyed: 15 credits** per objective (-15 if you are a moron and blow up your own)
**Deploy blocker destroyed: 10 credits** per objective (-10 if you are a moron and blow up your own)
**Objective captured: 5 credits** per objective
**Objective decaptured** (i.e. turn a hostile one neutral): **3 credits** per objective

The base reward from winning/losing a mission has been tweaked down across the board by 150 to compensate. This means however that if you lose a mission but do well individually, you could still get quite a lot of credits.

Also changed some key stuff in campaign to use ckey.
## Why It's Good For The Game
Reward individual performance.
## Changelog
:cl:
balance: Campaign: credits are additionally awarded at the end of a mission based on individual performance
balance: Campaign: Base credit reward for ending a mission reduced by 150
/:cl:
