### PR TITLE
Adds proc attack_self_alternate()

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -349,6 +349,7 @@
 #define COMSIG_ITEM_ATTACK_ALTERNATE "item_attack_alt"			//from base of obj/item/attack_alternate(): (/mob/living/target, /mob/living/user)
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
 	#define COMPONENT_NO_INTERACT (1<<0)
+#define COMSIG_ITEM_ATTACK_SELF_ALTERNATE "item_attack_self_alternate" //from base of obj/item/attack_self_alternate(): (/mob)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_EQUIPPED_TO_SLOT "item_equip_to_slot"			//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT "item_equip_not_in_slot"	//from base of obj/item/equipped(): (/mob/equipper, slot)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -120,7 +120,11 @@
 	var/obj/item/W = get_active_held_item()
 
 	if(W == A)
-		W.attack_self(src)
+		if(modifiers["right"])
+			W.attack_self_alternate(src)
+		else
+			W.attack_self(src)
+
 		update_inv_l_hand()
 		update_inv_r_hand()
 		return

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -49,7 +49,7 @@
 ///Called when the item is in the active hand, and RIGHT clicked;
 /obj/item/proc/attack_self_alternate(mob/user)
 	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_ALTERNATE, user)
-	add_fingerprint(user, "attack_self")
+	add_fingerprint(user, "attack_selfLalternate")
 	if(!can_interact(user))
 		return
 	interact(user)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,6 +46,14 @@
 		return
 	interact(user)
 
+///Called when the item is in the active hand, and RIGHT clicked;
+/obj/item/proc/attack_self_alternate(mob/user)
+	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_ALTERNATE, user)
+	add_fingerprint(user, "attack_self")
+	if(!can_interact(user))
+		return
+	interact(user)
+
 /atom/proc/attackby(obj/item/I, mob/user, params)
 	SIGNAL_HANDLER_DOES_SLEEP
 	add_fingerprint(user, "attackby", I)


### PR DESCRIPTION

## About The Pull Request
Adds proc attack_self_alternate()
When you are holding an item in-hand and you right-click it.
## Why It's Good For The Game
This was dumb, it was basically impossible to right click an item if it was in your selected hand.
## Changelog
:cl:
code: add proc attack_self_alternate()
/:cl:
