### PR TITLE
Locks tadpole to leader access, reduces PO slot by one.

### DIFF
--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -8,7 +8,7 @@
 		/datum/job/terragov/command/captain = 1,
 		/datum/job/terragov/command/fieldcommander = 1,
 		/datum/job/terragov/command/staffofficer = 4,
-		/datum/job/terragov/command/pilot = 2,
+		/datum/job/terragov/command/pilot = 1,
 		/datum/job/terragov/engineering/chief = 1,
 		/datum/job/terragov/engineering/tech = 2,
 		/datum/job/terragov/requisitions/officer = 1,

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -296,7 +296,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	title = PILOT_OFFICER
 	paygrade = "WO"
 	comm_title = "PO"
-	total_positions = 2
+	total_positions = 1
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	minimal_access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_MEDBAY)
 	skills_type = /datum/skills/pilot
@@ -316,7 +316,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 		<b>You answer to the</b> acting Command Staff<br /><br />
 		<b>Unlock Requirement</b>: Starting Role<br /><br />
 		<b>Gamemode Availability</b>: Nuclear War<br /><br /><br />
-		<b>Duty</b>: Choose between the Condor, a modular attack aircraft that provides close air support with a variety of weapons ranging from the inbuilt gatling to wing mounted rockets; or the Tadpole, a versatile dropship capable of fulfilling roles ranging from ambulance to mobile bunker.
+		<b>Duty</b>: Pilot the Condor, a modular attack aircraft that provides close air support with a variety of weapons ranging from the inbuilt gatling to wing mounted rockets.
 	"}
 	minimap_icon = "pilot"
 

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -17,7 +17,7 @@
 	desc = "Used to designate a precise transit location for the Tadpole."
 	icon_state = "shuttlecomputer"
 	screen_overlay = "shuttlecomputer_screen"
-	req_one_access = list(ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LEADER)
+	req_access = list(ACCESS_MARINE_LEADER)
 	density = FALSE
 	interaction_flags = INTERACT_OBJ_UI
 	resistance_flags = RESIST_ALL


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. Leader access includes squad leaders and FC, and leader access can be given to ID's in CIC.
## Why It's Good For The Game
This aims to remedy two issues:
1. Picking PO when there is already one, gambling what job you are actually doing.
2. Hopefully less Tadpole grief.
Number 1 is fairly self explanatory, if there is only 1 PO slot they are expected to be doing CAS. If someone else steals CAS (which is ALOT rarer than someone taking Tadpole), that is already an admin issue. This fixes one admin issue as well.
Number 2 is a bit more complicated. Tadpole throwing an entire round is inherent to it's flawed design, there is no fixing that. However, PO anecdotally is a hotspot for new players, SL and FC much less so. This hopes to reduce the amount of people with sub 100 hours trying out the tadpole without any relevant game knowledge. If you want a non-leader to pilot the Tadpole, you have to very willingly give them access in CIC which has a degree of trust to it, unlike PO being selected from the get-go. On 30 pop there should be atleast one leader, and if there is none the players already have to be given a captain ID for req and such by the admins which is a separate issue.
## Changelog
:cl:
balance: Removes one Pilot Officer slot, makes the Tadpole only be able to be piloted by those with Leader access (SL, aSL, FC's)
/:cl:
