### PR TITLE
Reduce time dilation from chat window messages

### DIFF
--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -20,16 +20,15 @@ SUBSYSTEM_DEF(chat)
 	var/list/client_to_sequence_number = list()
 
 /datum/controller/subsystem/chat/proc/generate_payload(client/target, message_data)
-	var/sequence = client_to_sequence_number[target.ckey]
-	client_to_sequence_number[target.ckey] += 1
+	var/sequence = client_to_sequence_number[target.ckey]++
 
 	var/datum/chat_payload/payload = new
 	payload.sequence = sequence
 	payload.content = message_data
 
-	if(!(target.ckey in client_to_reliability_history))
-		client_to_reliability_history[target.ckey] = list()
 	var/list/client_history = client_to_reliability_history[target.ckey]
+	if(!islist(client_history))
+		client_history = (client_to_reliability_history[target.ckey] = list())
 	client_history["[sequence]"] = payload
 
 	if(length(client_history) > CHAT_RELIABILITY_HISTORY_SIZE)


### PR DESCRIPTION
This proc is the top of the list for overhead and cost during high lag moments.

This reduces the amount of associated list scans from 3 `logn` scans and 1 `n` scan to 2 `logn` scans.

`in` is a major code smell because it does everything the harder way.

the final solution to speeding up this proc would be to move all of this to the client datum or the player_info datum if we need it to persist between reconnections (assuming tgmc has the player_info datum)