### PR TITLE
Campaign autobalance tweaks

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -12,6 +12,8 @@
 #define AFTER_MISSION_LEADER_DELAY 1 MINUTES
 ///How long after a mission is selected that team balance is checked
 #define CAMPAIGN_AUTOBALANCE_DELAY 1 MINUTES
+///How long players get to choose to autobalance or not
+#define CAMPAIGN_AUTOBALANCE_DECISION_TIME 30 SECONDS
 ///Standard amount of missions for a faction to have
 #define CAMPAIGN_STANDARD_MISSION_QUANTITY 3
 ///Attrition bonus for losing

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -143,6 +143,8 @@
 			continue
 		swap_player_team(faction_member, autobalance_faction_list[2])
 
+	addtimer(CALLBACK(src, PROC_REF(autobalance_bonus)), CAMPAIGN_AUTOBALANCE_DECISION_TIME + 1 SECONDS)
+
 /** Checks team balance
  * Returns null if teams are nominally balanced
  * Returns a list with the stronger team first if they are inbalanced
@@ -158,7 +160,7 @@
 
 ///Actually swaps the player to the other team, unless balance has been restored
 /datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction)
-	if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), 30 SECONDS) != "Change team")
+	if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), CAMPAIGN_AUTOBALANCE_DECISION_TIME, FALSE) != "Change team")
 		return
 	var/list/current_ratio = autobalance_check(1)
 	if(!current_ratio || current_ratio[2] == user.faction)
@@ -169,8 +171,18 @@
 	var/mob/dead/observer/ghost = user.ghostize()
 	user.job.add_job_positions(1)
 	qdel(user)
-	var/datum/game_mode/mode = SSticker.mode
-	mode.player_respawn(ghost) //auto open the respawn screen
+	var/datum/individual_stats/new_stats = stat_list[new_faction].get_player_stats(ghost)
+	new_stats.give_funds(max(stat_list[new_faction].accumulated_mission_reward * 0.5, 200)) //Added credits for swapping team
+	player_respawn(ghost) //auto open the respawn screen
+
+///buffs the weaker team if players don't voluntarily switch
+/datum/game_mode/hvh/campaign/proc/autobalance_bonus()
+	var/list/autobalance_faction_list = autobalance_check()
+	if(!autobalance_faction_list)
+		return
+
+	var/autobal_num = ROUND_UP(length(GLOB.alive_human_list_faction[autobalance_faction_list[1]]) - length(GLOB.alive_human_list_faction[autobalance_faction_list[2]]) * 0.2)
+	current_mission.spawn_mech(autobalance_faction_list[2], 0, 0, autobal_num, "[autobal_num] additional mechs granted for autobalance")
 
 //respawn stuff
 

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -460,7 +460,7 @@
 	GLOB.campaign_structures -= mission_obj
 
 ///spawns mechs for a faction
-/datum/campaign_mission/proc/spawn_mech(mech_faction, heavy_mech, medium_mech, light_mech)
+/datum/campaign_mission/proc/spawn_mech(mech_faction, heavy_mech, medium_mech, light_mech, override_message)
 	if(!mech_faction)
 		return
 	var/total_count = (heavy_mech + medium_mech + light_mech)
@@ -480,4 +480,4 @@
 		GLOB.campaign_structures += new_mech
 		RegisterSignal(new_mech, COMSIG_QDELETING, TYPE_PROC_REF(/datum/campaign_mission, remove_mission_object))
 
-	map_text_broadcast(mech_faction, "[total_count] mechs have been deployed for this mission.", "Mechs available")
+	map_text_broadcast(mech_faction, override_message ? override_message : "[total_count] mechs have been deployed for this mission.", "Mechs available")


### PR DESCRIPTION

## About The Pull Request
Changing team via autobalance now gives you an extra 50% credit bonus (or 200, if its at the start of the game).
If the sides are STILL not balanced after any team swaps (i.e. not enough people swapped) then the weaker team is given a light mech for every 5 people they're outnumbered by.
## Why It's Good For The Game
Incentivised actually swapping team for balance.
Helps the weaker team with mechs if the other team is full of smellies that don't want to swap.
## Changelog
:cl:
balance: Campaign: Switching team for autobalance rewards you with addition credits
balance: Campaign: If teams are still not balanced, the weaker team is given light mechs based on how outnumbered they are
/:cl:
