### PR TITLE
ASAT mission fixes

### DIFF
--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -55,6 +55,30 @@
 	starting_faction_objective_description = "Major Victory:Capture all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Capture at least [min_capture_amount] ASAT systems." : ""]"
 	hostile_faction_objective_description = "Major Victory:Prevent the capture of all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Prevent the capture of atleast [min_capture_amount] ASAT systems." : ""]"
 
+/datum/campaign_mission/capture_mission/asat/check_mission_progress()
+	if(outcome)
+		return TRUE
+
+	if(!game_timer)
+		return FALSE
+
+	if(!max_time_reached && objectives_remaining)
+		return FALSE
+
+	if(capture_count[MISSION_STARTING_FACTION] >= objectives_total)
+		message_admins("Mission finished: [MISSION_OUTCOME_MAJOR_VICTORY]")
+		outcome = MISSION_OUTCOME_MAJOR_VICTORY
+	else if(min_capture_amount && (capture_count[MISSION_STARTING_FACTION] >= min_capture_amount))
+		message_admins("Mission finished: [MISSION_OUTCOME_MINOR_VICTORY]")
+		outcome = MISSION_OUTCOME_MINOR_VICTORY
+	else if(capture_count[MISSION_STARTING_FACTION] > 0)
+		message_admins("Mission finished: [MISSION_OUTCOME_MINOR_LOSS]")
+		outcome = MISSION_OUTCOME_MINOR_LOSS
+	else
+		message_admins("Mission finished: [MISSION_OUTCOME_MAJOR_LOSS]")
+		outcome = MISSION_OUTCOME_MAJOR_LOSS
+	return TRUE
+
 /datum/campaign_mission/capture_mission/asat/apply_major_victory()
 	. = ..()
 	var/datum/faction_stats/som_team = mode.stat_list[starting_faction]

--- a/code/game/objects/structures/campaign_structures/capture_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/capture_objectives.dm
@@ -227,12 +227,17 @@
 	icon_state = "asat"
 	desc = "A sophisticated surface to space missile system designed for attacking orbiting satellites or spacecraft."
 	capture_flags = CAPTURE_OBJECTIVE_RECAPTURABLE
-	///owning faction
-	var/faction = FACTION_TERRAGOV
+	owning_faction = FACTION_TERRAGOV
 
 /obj/structure/campaign_objective/capture_objective/fultonable/asat_system/capture_check(mob/living/user)
 	//This is a 'defend' objective. The defending faction can't actually claim it for themselves, just decap it.
-	if((user.faction == faction) && !capturing_faction && !owning_faction)
+	if((user.faction == owning_faction) && !capturing_faction)
 		user.balloon_alert(user, "Defend this objective!")
 		return FALSE
 	return ..()
+
+/obj/structure/campaign_objective/capture_objective/fultonable/asat_system/do_capture(mob/living/user)
+	capturing_faction = null
+	capture_timer = null
+	countdown.stop()
+	finish_capture(user)


### PR DESCRIPTION
## About The Pull Request
Marines can no longer cap their own objective if it was in the process of being captured by SOM.
Instead it will simply cancel the hostile capture timer as intended.

Fixed up the win condition checks as marines don't cap any objectives.
## Why It's Good For The Game
Funny bug bad.
## Changelog
:cl:
fix: Campaign: Marines will no longer be able to steal their own ASAT objectives
fix: Campaign: Fixed some errors in the ASAT mission win conditions
/:cl:
