### PR TITLE
Base rescue mission tweaks

### DIFF
--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -60,8 +60,8 @@
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_pre_mission_bonuses()
 	. = ..()
-	for(var/i = 1 to objectives_total)
-		new /obj/item/storage/box/explosive_mines(get_turf(pick(GLOB.campaign_reward_spawners[defending_faction])))
+	spawn_mech(attacking_faction, 0, 0, 5)
+	spawn_mech(defending_faction, 0, 0, 2)
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission_brief()
 	starting_faction_mission_brief = "NanoTrasen has issues an emergency request for assistance at an isolated medical facility located in the Western Ayolan Ranges. \
@@ -70,6 +70,7 @@
 	hostile_faction_mission_brief = "Recon forces have led us to this secure Nanotrasen facility in the Western Ayolan Ranges. Sympathetic native elements suggest NT have been conducting secret research here to the detriment of the local ecosystem and human settlements. \
 		Find the security override terminals to override the facility's emergency lockdown. \
 		Once the lockdown is lifted, destroy what they're working on inside."
+	hostile_faction_mission_parameters = "Teleportation is unavailable in this area due to unknown interference from beneath the NT compound."
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_objective_description()
 	starting_faction_objective_description = "Major Victory:Protect the NT base from SOM attack. Do not allow them to override the security lockdown and destroy NT's sensitive equipment"


### PR DESCRIPTION

## About The Pull Request
Added light mechs to NT base rescue.
5 for SOM, 2 for TGMC.

Also added some extra text to clarify that SOM cannot deploy via teleporter at all during this mission.
## Why It's Good For The Game
This is quite hard for SOM, and even though they're attacking, marines are the ones choosing it. Some mech muscle should make it more interesting for them. Light mechs are weak enough that infantry can take them down quite easily without dedicated AT weapons.
## Changelog
:cl:
balance: Campaign: Made NT base rescue a bit easier for SOM
/:cl:
