### PR TITLE
Mine alpha fix

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -237,7 +237,7 @@ Stepping directly on the mine will also blow it up
 	icon_state = "m92"
 	target_mode = MINE_VEHICLE_ONLY
 
-/obj/item/explosive/mine/update_icon(updates=ALL)
+/obj/item/explosive/mine/anti_tank/update_icon(updates=ALL)
 	. = ..()
 	alpha = armed ? 50 : 255
 


### PR DESCRIPTION

## About The Pull Request
Normal claymores had the lower alpha meant only for AT mines.
I am dum and messed up the typepath.
## Why It's Good For The Game
After playing against sneaky claymores in HvH, I actually like them, so would be happy for them to stay. It was an unintended HvX balance change though, so would like thoughts on this.
## Changelog
:cl:
fix: fixed normal claymores being sneakier than intended
/:cl:
