### PR TITLE
ASL rally arrows fix

### DIFF
--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -9,7 +9,7 @@
 	///What skill is needed to have this action
 	var/skill_name = SKILL_LEADERSHIP
 	///What minimum level in that skill is needed to have that action
-	var/skill_min = SKILL_LEAD_EXPERT
+	var/skill_min = SKILL_LEAD_TRAINED
 
 /datum/action/innate/order/give_action(mob/M)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

decreases the skill required to send squad rallys from 3 to 2 allowing asl to send rally arrows once again

## Why It's Good For The Game

after prs #13810 nerf on leadership the ability to send squad rallys was lost since the skill requirment remained the same.
Asl being able to act as Asl good.

## Changelog
:cl:
fix: squad rally skill requirement from 3 to 2
/:cl:
