### PR TITLE
Tfoot OB inaccuracy penalty

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -13,13 +13,19 @@
 	pass_flags = PASS_AIR
 	resistance_flags = UNACIDABLE|PLASMACUTTER_IMMUNE|PROJECTILE_IMMUNE|CRUSHER_IMMUNE
 	var/amount = 3
+	///Duration in 2 second ticks
 	var/lifetime = 5
 	///time in decisecond for a smoke to spread one tile.
 	var/expansion_speed = 1
+	///Special effect traits
 	var/smoke_traits = NONE
-	var/strength = 1 // Effects scale with the emitter's bomb_strength upgrades.
-	var/bio_protection = 1 // how unefficient its effects are against protected target from 0 to 1.
-	var/datum/effect_system/smoke_spread/cloud // for associated chemical smokes.
+	///Smoke effect strength mult
+	var/strength = 1
+	///Effect strength mult against bio protection
+	var/bio_protection = 1
+	///for associated chemical smoke
+	var/datum/effect_system/smoke_spread/cloud
+	///Fraction used for chem touch effects
 	var/fraction = 0.2
 	///Delay in ticks before this smoke can affect a given mob again, applied in living's effect_smoke
 	var/minimum_effect_delay = 1 SECONDS
@@ -189,8 +195,11 @@
 /////////////////////////////////////////////
 
 /datum/effect_system/smoke_spread
+	///Smoke range
 	var/range = 3
+	///Type of smoke
 	var/smoke_type = /obj/effect/particle_effect/smoke
+	///Smoke duration in 2 sec ticks
 	var/lifetime
 	var/list/smokes
 	var/list/smoked_mobs

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -399,7 +399,7 @@
 /obj/structure/ob_ammo/warhead/plasmaloss/warhead_impact(turf/target, inaccuracy_amt = 0)
 	. = ..()
 	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
-	smoke.set_up(25, target, 3 SECONDS)//Vape nation
+	smoke.set_up(25, target, 30 - (inaccuracy_amt * 2))//Vape nation
 	smoke.start()
 
 /obj/structure/ob_ammo/ob_fuel


### PR DESCRIPTION

## About The Pull Request
Tfoot OB duration (60 seconds) is now reduced by 4 seconds per level of fuel inaccuracy.
## Why It's Good For The Game
Tfoot OB is currently the only OB that has no downside for fuel inaccuracy outside of actual target accuracy (which doesn't matter as long as you don't fire it into a wall).

This means its less beneficial to spam 1 fuel tangle OB's.

Also added some missing autodoc as some shit is missing/unclear (like OB duration being labelled as 3 SECONDS when its actually a duration in 2 second ticks).
## Changelog
:cl:
balance: Tfoot OB's duration is reduced by 4 seconds per level of fuel inaccuracy
/:cl:
