### PR TITLE
Fix smartgun loadouts

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -725,6 +725,9 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 	),
 	SQUAD_SMARTGUNNER = list(
 		/obj/item/clothing/glasses/night/m56_goggles = 1,
+		/obj/item/storage/holster/belt/pistol/smart_pistol = 1,
+		/obj/item/weapon/gun/pistol/smart_pistol = 1,
+		/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = 2,
 	),
 	SQUAD_LEADER = list(
 		/obj/item/explosive/plastique = 1,


### PR DESCRIPTION

## About The Pull Request
Loadouts will no longer be cursed and not vend a gun/ammo/smart pistol etc.
The smart pistol and related stuff was not correctly added to the vendor.
## Why It's Good For The Game
Cursed loadouts bad.
## Changelog
:cl:
fix: fixed SG loadouts often not spawning everything they should
/:cl:
