### PR TITLE
Fix some toggle visuals

### DIFF
--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -25,9 +25,10 @@
 	return ..()
 
 /datum/action/item_action/action_activate()
-	if(target)
-		var/obj/item/I = target
-		I.ui_action_click(owner, src, holder_item)
+	if(!target)
+		return FALSE
+	var/obj/item/I = target
+	return I.ui_action_click(owner, src, holder_item)
 
 /datum/action/item_action/can_use_action()
 	if(QDELETED(owner) || owner.incapacitated() || owner.lying_angle)
@@ -57,6 +58,8 @@
 
 /datum/action/item_action/toggle/action_activate()
 	. = ..()
+	if(!.)
+		return
 	set_toggle(!toggled)
 
 /datum/action/item_action/toggle/suit_toggle
@@ -75,6 +78,12 @@
 /datum/action/item_action/firemode/New()
 	. = ..()
 	holder_gun = holder_item
+	update_button_icon()
+
+/datum/action/item_action/firemode/action_activate()
+	. = ..()
+	if(!.)
+		return
 	update_button_icon()
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -824,7 +824,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 //The default action is attack_self().
 //Checks before we get to here are: mob is alive, mob is not restrained, paralyzed, asleep, resting, laying, item is on the mob.
 /obj/item/proc/ui_action_click(mob/user, datum/action/item_action/action)
-	attack_self(user)
+	return attack_self(user)
 
 /obj/item/proc/toggle_item_state(mob/user)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/objects/items/blink_drive.dm
+++ b/code/game/objects/items/blink_drive.dm
@@ -70,7 +70,7 @@
 	standing.overlays.Add(emissive_overlay)
 
 /obj/item/blink_drive/ui_action_click(mob/user, datum/action/item_action/action, target)
-	teleport(target, user)
+	return teleport(target, user)
 
 ///Handles the actual teleportation
 /obj/item/blink_drive/proc/teleport(atom/A, mob/user)
@@ -129,6 +129,7 @@
 	deltimer(charge_timer)
 	charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME * 2, TIMER_STOPPABLE)
 	update_icon()
+	return TRUE
 
 ///Recharges the drive, and sets another timer if not maxed out
 /obj/item/blink_drive/proc/recharge()

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -43,7 +43,7 @@
 	return ..()
 
 /obj/item/implant/ui_action_click(mob/user, datum/action/item_action/action)
-	activate()
+	return activate()
 
 ///Handles the actual activation of the implant/it's effects. Returns TRUE on succesful activation and FALSE on failure for parentcalls
 /obj/item/implant/proc/activate()

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -53,7 +53,7 @@
 	toggle_action.remove_action(user)
 
 /obj/item/jetpack_marine/ui_action_click(mob/user, datum/action/item_action/action, target)
-	use_jetpack(target, user)
+	return use_jetpack(target, user)
 
 ///remove the flame overlay
 /obj/item/jetpack_marine/proc/reset_flame(mob/living/carbon/human/human_user)

--- a/code/game/objects/items/motion_detector.dm
+++ b/code/game/objects/items/motion_detector.dm
@@ -72,13 +72,14 @@
 /obj/item/attachable/motiondetector/activate(mob/user, turn_off)
 	if(operator)
 		clean_operator(forced = TRUE)
-		return
+		return TRUE
 	operator = user
 	RegisterSignals(operator, list(COMSIG_QDELETING, COMSIG_GUN_USER_UNSET), PROC_REF(clean_operator))
 	RegisterSignals(src, list(COMSIG_ITEM_EQUIPPED_TO_SLOT, COMSIG_ITEM_REMOVED_INVENTORY), PROC_REF(clean_operator))
 	UnregisterSignal(operator, COMSIG_GUN_USER_SET)
 	START_PROCESSING(SSobj, src)
 	update_icon()
+	return TRUE
 
 ///Activate the attachement when your are putting the gun out of your suit slot
 /obj/item/attachable/motiondetector/proc/start_processing_again(datum/source, obj/item/weapon/gun/equipping)
@@ -93,11 +94,6 @@
 
 /obj/item/attachable/motiondetector/attack_self(mob/user)
 	activate(user)
-
-/obj/item/attachable/motiondetector/update_icon()
-	. = ..()
-	for(var/datum/action/action AS in master_gun?.actions)
-		action.update_button_icon()
 
 /obj/item/attachable/motiondetector/update_icon_state()
 	. = ..()

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -157,8 +157,8 @@
 	var/mob/living/carbon/human/H = user
 	if(H.wear_suit != src)
 		return
-	turn_light(user, !light_on)
-	return TRUE
+	if(turn_light(user, !light_on) == CHECKS_PASSED)
+		return TRUE
 
 /obj/item/clothing/suit/modular/item_action_slot_check(mob/user, slot)
 	if(!light_range) // No light no ability

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -83,8 +83,8 @@
 	var/mob/living/carbon/human/H = user
 	if(H.wear_suit != src)
 		return
-	turn_light(user, !light_on)
-	return TRUE
+	if(turn_light(user, !light_on) == CHECKS_PASSED)
+		return TRUE
 
 /obj/item/clothing/suit/storage/marine/item_action_slot_check(mob/user, slot)
 	if(!ishuman(user))
@@ -396,8 +396,8 @@
 	var/mob/living/carbon/human/H = user
 	if(H.wear_suit != src) return
 
-	turn_light(user, !light_on)
-	return 1
+	if(turn_light(user, !light_on) == CHECKS_PASSED)
+		return TRUE
 
 /obj/item/clothing/suit/storage/faction/item_action_slot_check(mob/user, slot)
 	if(!ishuman(user)) return FALSE

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -310,8 +310,9 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 /obj/item/attachable/ui_action_click(mob/living/user, datum/action/item_action/action, obj/item/weapon/gun/G)
 	if(G == user.get_active_held_item() || G == user.get_inactive_held_item() || CHECK_BITFIELD(G.flags_item, IS_DEPLOYED))
-		if(activate(user)) //success
+		if(activate(user))
 			playsound(user, activation_sound, 15, 1)
+			return TRUE
 	else
 		to_chat(user, span_warning("[G] must be in our hands to do this."))
 
@@ -1533,7 +1534,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 /obj/item/attachable/shoulder_mount/ui_action_click(mob/living/user, datum/action/item_action/action, obj/item/weapon/gun/G)
 	if(!istype(master_gun.loc, /obj/item/clothing/suit/modular) || master_gun.loc.loc != user)
 		return
-	activate(user)
+	return activate(user)
 
 /obj/item/attachable/shoulder_mount/activate(mob/user, turn_off)
 	. = ..()

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -220,12 +220,9 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	var/datum/action/item_action/firemode/firemode_action = action
 	if(!istype(firemode_action))
 		if(master_gun)
-			activate(user)
-			return
+			return activate(user)
 		return ..()
-	do_toggle_firemode()
-	user.update_action_buttons()
-
+	return do_toggle_firemode()
 
 /mob/living/carbon/human/verb/toggle_autofire()
 	set category = "Weapons"
@@ -334,11 +331,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	if(ishuman(source))
 		to_chat(source, span_notice("[icon2html(src, source)] You switch to <b>[gun_firemode]</b>."))
-		if(source == gun_user)
-			gun_user.update_action_buttons()
 	playsound(src, 'sound/weapons/guns/interact/selector.ogg', 15, 1)
 	SEND_SIGNAL(src, COMSIG_GUN_FIRE_MODE_TOGGLE, gun_firemode)
 	setup_bullet_accuracy()
+	return TRUE
 
 
 /obj/item/weapon/gun/proc/add_firemode(added_firemode, mob/user)


### PR DESCRIPTION

## About The Pull Request
Fix/improve a variety of action toggles.

- Suit lights can no longer have the button toggled when the light is on cooldown.
- Improved some code to reduce excessive/unneeded updates

:cl:
qol: Suit lights no longer mismatch their actual state and action state if spammed
/:cl:
