### PR TITLE
Changes gargoyle's alert sound

### DIFF
--- a/code/modules/xenomorph/resin_gargoyle.dm
+++ b/code/modules/xenomorph/resin_gargoyle.dm
@@ -39,7 +39,7 @@
 			return
 
 	is_alerting = TRUE
-	GLOB.hive_datums[hivenumber].xeno_message("Our [name] has detected a hostile [hostile] at [get_area(hostile)].", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien_help2.ogg', FALSE, null, /atom/movable/screen/arrow/leader_tracker_arrow)
+	GLOB.hive_datums[hivenumber].xeno_message("Our [name] has detected a hostile [hostile] at [get_area(hostile)].", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien_talk2.ogg', FALSE, null, /atom/movable/screen/arrow/leader_tracker_arrow)
 	COOLDOWN_START(src, proxy_alert_cooldown, XENO_GARGOYLE_DETECTION_COOLDOWN)
 	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_GARGOYLE_DETECTION_COOLDOWN, TIMER_STOPPABLE)
 	update_minimap_icon()


### PR DESCRIPTION

## About The Pull Request
Changes the resin gargoyles' alert sound to be growl alert, rather than the screech one.
## Why It's Good For The Game
The sound it currently uses is bad due to causing ear pain, especially if there are many of em and/or a lot of marines in an area.
## Changelog
:cl:
qol: The alert for resin gargoyles have been changed to use the growl sound effect instead of the screech.
/:cl:
