### PR TITLE
Beacon Auto update when changing Z-level instead of turning off

### DIFF
--- a/code/datums/components/beacon.dm
+++ b/code/datums/components/beacon.dm
@@ -83,11 +83,6 @@
 ///Activates the beacon
 /datum/component/beacon/proc/activate(atom/movable/source, mob/user)
 	var/turf/location = get_turf(source)
-	if(!is_ground_level(location.z))
-		to_chat(user, span_warning("You have to be on the planet to use this or it won't transmit."))
-		active = FALSE
-		return FALSE
-
 	var/area/A = get_area(location)
 	if(A && istype(A) && A.ceiling >= CEILING_DEEP_UNDERGROUND)
 		to_chat(user, span_warning("This won't work if you're standing deep underground."))
@@ -194,9 +189,8 @@
 ///What happens when we change Z level
 /datum/component/beacon/proc/on_z_change(atom/source, old_z, new_z)
 	SIGNAL_HANDLER
-	var/turf/source_turf = get_turf(source)
-	if(!is_ground_level(source_turf.z) && active)
-		INVOKE_ASYNC(src, PROC_REF(deactivate), source)
+	if(active)
+		beacon_datum.drop_location = get_turf(source)
 		return
 
 /datum/component/beacon/ai_droid/RegisterWithParent()

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -75,7 +75,7 @@
 					beacon_list -= beacon_name
 					continue
 			var/datum/supply_beacon/supply_beacon_choice = beacon_list[tgui_input_list(ui.user, "Select the beacon to send supplies", "Beacon choice", beacon_list)]
-			if(!istype(supply_beacon_choice))
+			if(!istype(supply_beacon_choice) && is_ground_level(supply_beacon.drop_location.z))
 				return
 			supply_beacon = supply_beacon_choice
 			RegisterSignal(supply_beacon, COMSIG_QDELETING, PROC_REF(clean_supply_beacon), override = TRUE)

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -68,7 +68,13 @@
 
 	switch(action)
 		if("select_beacon")
-			var/datum/supply_beacon/supply_beacon_choice = GLOB.supply_beacon[tgui_input_list(ui.user, "Select the beacon to send supplies", "Beacon choice", GLOB.supply_beacon)]
+			var/list/beacon_list = GLOB.supply_beacon.Copy()
+			for(var/beacon_name in beacon_list)
+				var/datum/supply_beacon/beacon = beacon_list[beacon_name]
+				if(!is_ground_level(beacon.drop_location.z))
+					beacon_list -= beacon_name
+					continue
+			var/datum/supply_beacon/supply_beacon_choice = beacon_list[tgui_input_list(ui.user, "Select the beacon to send supplies", "Beacon choice", beacon_list)]
 			if(!istype(supply_beacon_choice))
 				return
 			supply_beacon = supply_beacon_choice


### PR DESCRIPTION
## About The Pull Request
Change how Deployed Beacon on Tadpole work back to #14421.

Now it Auto update without needing to Redeploy it every time tad move, and can be deployed in Tad on whatever Z-Level tad is (but still can only be used groundside). Code thanks to lumi

It filter out non groundside beacon from the supply console list, so no clutter. Code thanks to ivan and electric.
## Why It's Good For The Game
One less thing to think about for Tadpole Pilot and ROs, while maintaining beacon usage only to groundside use.
## Changelog
:cl:
qol: Supply Beacon now Auto Update if Tad are moving across Z-level.
/:cl:
