### PR TITLE
Long and spread nozzle are gone from acquisition.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -370,7 +370,6 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
-			/obj/item/attachable/flamer_nozzle/wide = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -172,8 +172,6 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
-			/obj/item/attachable/flamer_nozzle/wide = -1,
-			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,
@@ -373,7 +371,6 @@
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
 			/obj/item/attachable/flamer_nozzle/wide = -1,
-			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -727,6 +727,12 @@ WEAPONS
 	cost = 600
 	containertype = null
 
+/datum/supply_packs/weapons/spreadnozzle
+	name = "Flamethrower Spread Nozzle"
+	contains = list(/obj/item/attachable/flamer_nozzle/wide)
+	cost = 500
+	containertype = null
+
 /datum/supply_packs/weapons/rpgoneuse
 	name = "RL-72 Disposable RPG"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/oneuse)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -727,12 +727,6 @@ WEAPONS
 	cost = 600
 	containertype = null
 
-/datum/supply_packs/weapons/spreadnozzle
-	name = "Flamethrower Spread Nozzle"
-	contains = list(/obj/item/attachable/flamer_nozzle/wide)
-	cost = 500
-	containertype = null
-
 /datum/supply_packs/weapons/rpgoneuse
 	name = "RL-72 Disposable RPG"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/oneuse)


### PR DESCRIPTION
## About The Pull Request
See title. They're still in valhalla/hvh
## Why It's Good For The Game
This was literally pure flamer powercreep the day it was introduced, I have no idea why it took so long for anyone including me to decide to nuke this from orbit.
## Changelog
:cl:
del: You can no loner acquire long or wide nozzle in HvX.
/:cl:
