### PR TITLE
Removes larva generation from psychic drain and cocoon opening

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -444,12 +444,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.ravager_rages] number of times Ravagers raged."
 	if(GLOB.round_statistics.hunter_silence_targets)
 		parts += "[GLOB.round_statistics.hunter_silence_targets] number of targets silenced by Hunters."
-	if(GLOB.round_statistics.larva_from_psydrain)
-		parts += "[GLOB.round_statistics.larva_from_psydrain] larvas came from psydrain."
 	if(GLOB.round_statistics.larva_from_silo)
 		parts += "[GLOB.round_statistics.larva_from_silo] larvas came from silos."
-	if(GLOB.round_statistics.larva_from_cocoon)
-		parts += "[GLOB.round_statistics.larva_from_cocoon] larvas came from cocoons."
 	if(GLOB.round_statistics.larva_from_marine_spawning)
 		parts += "[GLOB.round_statistics.larva_from_marine_spawning] larvas came from marine spawning."
 	if(GLOB.round_statistics.larva_from_siloing_body)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -89,8 +89,6 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/ravager_rages = 0
 	var/larva_from_marine_spawning = 0
 	var/larva_from_silo = 0
-	var/larva_from_cocoon = 0
-	var/larva_from_psydrain = 0
 	var/larva_from_siloing_body = 0
 	var/req_items_produced = list()
 	var/psy_crushes = 0

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -18,8 +18,6 @@
 	var/cocoon_life_time = 5 MINUTES
 	///Standard busy check
 	var/busy = FALSE
-	///How much larva points it gives at the end of its life time (8 points for one larva in distress)
-	var/larva_point_reward = 1.5
 
 
 /obj/structure/cocoon/Initialize(mapload, _hivenumber, mob/living/_victim)
@@ -66,11 +64,6 @@
 	if(anchored)
 		unanchor_from_nest()
 	if(must_release_victim)
-		var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-		xeno_job.add_job_points(larva_point_reward)
-		var/datum/hive_status/hive_status = GLOB.hive_datums[hivenumber]
-		hive_status.update_tier_limits()
-		GLOB.round_statistics.larva_from_cocoon += larva_point_reward / xeno_job.job_points_needed
 		release_victim()
 	update_icon()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1133,8 +1133,6 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HEADBITE,
 	)
 	gamemode_flags = ABILITY_NUCLEARWAR
-	///How much larva points it gives (8 points for one larva in distress)
-	var/larva_point_reward = 1
 
 /datum/action/ability/activable/xeno/psydrain/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..() //do after checking the below stuff
@@ -1207,10 +1205,6 @@
 		psy_points_reward = psy_points_reward * 3
 	SSpoints.add_strategic_psy_points(X.hivenumber, psy_points_reward)
 	SSpoints.add_tactical_psy_points(X.hivenumber, psy_points_reward*0.25)
-	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	xeno_job.add_job_points(larva_point_reward)
-	X.hive.update_tier_limits()
-	GLOB.round_statistics.larva_from_psydrain +=larva_point_reward / xeno_job.job_points_needed
 
 	if(owner.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
_Preface_
Let's get started with what happens when a member on either side of the team dies and has their body secured.
Marine: Drained / Cocoon
- 20 cloneloss (pretty moot)
- If perma or DNR, -1 marine
- Psy points scaling on population, which can be used to purchase a plethora of things
- Larva points (the issue I will speak about)

Xeno: Sold
- Minus 1 xeno
- Req points

With the merge of #14927, I believe now is an appropriate time to look at snowballing on both sides. Though marine requisitions will remain superior to the Blessing tab as of now, psy draining is usually more accessible and has the benefit of **population snowballing,** which I believe is the most powerful snowballing you can get; thus the PR. This is also compounded by the fact xenos have a rather high regeneration rate with silo, alongside being able to spend psy points on getting more xenos (more silos). Primos are also very strong, too. My argument comes down to "there is too much in the basket of drain/cocoon" given the other things it gives. I would enjoy any critiques in the comment as I might just be schizo here.
## Changelog
:cl:
balance: Removed larva generation on psy drain and cocoon
/:cl:
