### PR TITLE
Increases expert timelock to 25 hours

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(jobs_fallen_marine, typecacheof(list(/datum/job/fallen/marine),
 #define XP_REQ_UNSEASONED 60
 #define XP_REQ_INTERMEDIATE 180
 #define XP_REQ_EXPERIENCED 600
-#define XP_REQ_EXPERT 900
+#define XP_REQ_EXPERT 1500
 
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 1


### PR DESCRIPTION

## About The Pull Request
What it says on the tin
## Why It's Good For The Game
Maintainer request on transport officer PR 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/0204c6e1-463a-47b6-9ed9-af9f3fb80095)
## Changelog
:cl:
admin: Expert timelock increased to 25 hours
/:cl:
