### PR TITLE
All AMR ammo costs the same.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -588,13 +588,13 @@ WEAPONS
 /datum/supply_packs/weapons/antimaterial_incend_ammo
 	name = "SR-26 AMR incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/sniper/incendiary)
-	cost = 50
+	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial_flak_ammo
 	name = "SR-26 AMR flak magazine"
 	contains = list(/obj/item/ammo_magazine/sniper/flak)
-	cost = 40
+	cost = 30
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specminigun


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
The base mags are probably the best type of ammo for the AMR so it makes little sense for the other ammo types to be more expensive.

(Also this appeases my reqtorio addition many moons ago.)
## Changelog
:cl:
balance: All AMR mags cost the same.
/:cl:
