### PR TITLE
Even more Behemoth balancing and fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -306,7 +306,7 @@
 	xeno_owner.face_atom(target)
 	xeno_owner.set_canmove(FALSE)
 	xeno_owner.behemoth_charging = TRUE
-	ADD_TRAIT(xeno_owner, TRAIT_SILENT_FOOTSTEPS, JUMP_COMPONENT)
+	ADD_TRAIT(xeno_owner, TRAIT_SILENT_FOOTSTEPS, XENO_TRAIT)
 	playsound(xeno_owner, 'sound/effects/behemoth/landslide_roar.ogg', 40, TRUE)
 	var/which_step = pick(0, 1)
 	new /obj/effect/temp_visual/behemoth/landslide/dust(owner_turf, direction, which_step)
@@ -474,7 +474,7 @@
 */
 /datum/action/ability/activable/xeno/landslide/proc/end_charge(reason)
 	ability_active = FALSE
-	REMOVE_TRAIT(owner, TRAIT_SILENT_FOOTSTEPS, JUMP_COMPONENT)
+	REMOVE_TRAIT(owner, TRAIT_SILENT_FOOTSTEPS, XENO_TRAIT)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.behemoth_charging = FALSE
 	if(!xeno_owner.lying_angle)


### PR DESCRIPTION
## About The Pull Request
The ride truly never ends, does it?
Even more Behemoth changes because I felt motivated. Mostly code improvements, some fixes, and a bit of balancing.

### Balance changes
- Earth Riser now has a maximum of three pillars. Primordial version is uncapped, and is now limited by a 2s. cooldown instead.
- Earth Riser's displacement is now a knockback. This means it throws people, which has some implications on functionality. Mostly beneficial/buffs.

### Any other changes
- Fixed an issue where footstep changes on Landslide were setup incorrectly, which could lead to wacky behavior in certain cases.
- Fixed an unintended result where the primordial version of Earth Riser had a much shorter cooldown than intended, which made it highly spammable and highly deadly.
- Fixed an issue where hitting Earth Pillars with Seismic Fracture wouldn't begin Earth Riser's cooldown.
- Changed Earth Riser code a little to account for the primordial changes.
- If the owner of an Earth Pillar is somehow deleted while it is active, it will now clean away the reference, which is good code practice last time I checked.
- Changed the name of a proc because it confused the shit out of me by sharing the same name as another global proc. 

## Why It's Good For The Game
- Bit of a buff that I forgot to slap in prior PRs, which should give Behemoths more of an edge and better prep game.
- Bug fixes good. Code improvement good.

## Changelog
:cl: Lewdcifer
balance: Earth Riser maximum pillars increased from 1 to 3. Primordial version now uncapped but limited by a 2s. cooldown.
balance: Earth Riser displacement is now a knockback, meaning it throws people.
fix: Fixed an issue where footstep changes on Landslide were setup incorrectly, which could lead to wacky behavior in certain cases.
fix: Fixed an unintended result where the primordial version of Earth Riser would have a much shorter cooldown than intended.
fix: Fixed an issue where hitting Earth Pillars with Seismic Fracture wouldn't begin Earth Riser's cooldown.
code: If the owner of an Earth Pillar is somehow deleted while it is active, it will now clean away the reference.
code: Changed the name of a Behemoth proc.
/:cl: