### PR TITLE
Human v Human melee tweaks and fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -99,15 +99,19 @@
 			if(!attack.is_usable(human_user))
 				return FALSE
 
-			if(!human_user.melee_damage)
+			var/attack_verb = pick(attack.attack_verb)
+			//if you're lying/buckled, the miss chance is ignored anyway
+			var/target_zone = get_zone_with_miss_chance(human_user.zone_selected, src, 10 - (human_user.skills.getRating(SKILL_CQC) - skills.getRating(SKILL_CQC)) * 5)
+
+			if(!human_user.melee_damage || !target_zone)
 				human_user.do_attack_animation(src)
 				playsound(loc, attack.miss_sound, 25, TRUE)
-				visible_message(span_danger("[human_user] tried to [pick(attack.attack_verb)] [src]!"), null, null, 5)
-				log_combat(human_user, src, "[pick(attack.attack_verb)]ed", "(missed)")
+				visible_message(span_danger("[human_user] tried to [attack_verb] [src]!"), null, null, 5)
+				log_combat(human_user, src, "[attack_verb]ed", "(missed)")
 				if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 					var/turf/T = get_turf(src)
-					log_ffattack("[key_name(human_user)] missed a punch against [key_name(src)] in [AREACOORD(T)].")
-					msg_admin_ff("[ADMIN_TPMONTY(human_user)] missed a punch against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
+					log_ffattack("[key_name(human_user)] missed a [attack_verb] against [key_name(src)] in [AREACOORD(T)].")
+					msg_admin_ff("[ADMIN_TPMONTY(human_user)] missed a [attack_verb] against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
 				return FALSE
 
 			human_user.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
@@ -116,11 +120,9 @@
 			if(!lying_angle)
 				damage = rand(1, max_dmg)
 
-			var/target_zone = ran_zone(human_user.zone_selected)
-
 			playsound(loc, attack.attack_sound, 25, TRUE)
 
-			visible_message(span_danger("[human_user] [pick(attack.attack_verb)]ed [src]!"), null, null, 5)
+			visible_message(span_danger("[human_user] [attack_verb]ed [src]!"), null, null, 5)
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
@@ -132,7 +134,7 @@
 
 			hit_report += "(RAW DMG: [damage])"
 
-			log_combat(human_user, src, "[pick(attack.attack_verb)]ed", "[hit_report.Join(" ")]")
+			log_combat(human_user, src, "[attack_verb]ed", "[hit_report.Join(" ")]")
 			if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 				var/turf/T = get_turf(src)
 				human_user.ff_check(damage, src)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -6,28 +6,28 @@
 	if(!ishuman(user))
 		return
 
-	var/mob/living/carbon/human/H = user
+	var/mob/living/carbon/human/human_user = user
 
-	if(user != src && !check_shields(COMBAT_TOUCH_ATTACK, H.melee_damage, "melee"))
+	if(user != src && !check_shields(COMBAT_TOUCH_ATTACK, human_user.melee_damage, "melee"))
 		visible_message(span_danger("[user] attempted to touch [src]!"), null, null, 5)
 		return FALSE
 
-	H.changeNext_move(7)
-	switch(H.a_intent)
+	human_user.changeNext_move(7)
+	switch(human_user.a_intent)
 		if(INTENT_HELP)
 			if(on_fire && H != src)
 				fire_stacks = max(fire_stacks - 1, 0)
 				playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
-				H.visible_message(span_danger("[H] tries to put out the fire on [src]!"), \
+				human_user.visible_message(span_danger("[human_user] tries to put out the fire on [src]!"), \
 					span_warning("You try to put out the fire on [src]!"), null, 5)
 				if(fire_stacks <= 0)
-					H.visible_message(span_danger("[H] has successfully extinguished the fire on [src]!"), \
+					human_user.visible_message(span_danger("[human_user] has successfully extinguished the fire on [src]!"), \
 						span_notice("You extinguished the fire on [src]."), null, 5)
 					ExtinguishMob()
 				return TRUE
 
 			if(istype(wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
-				H.stripPanelUnequip(wear_mask, src, SLOT_WEAR_MASK)
+				human_user.stripPanelUnequip(wear_mask, src, SLOT_WEAR_MASK)
 				return TRUE
 
 			if(health >= get_crit_threshold())
@@ -35,93 +35,93 @@
 				if(interaction_emote(src))
 					return TRUE
 
-				help_shake_act(H)
+				help_shake_act(human_user)
 				return TRUE
 
 			if(HAS_TRAIT(src, TRAIT_UNDEFIBBABLE))
-				to_chat(H, span_boldnotice("Can't help this one. Body has gone cold."))
+				to_chat(human_user, span_boldnotice("Can't help this one. Body has gone cold."))
 				return FALSE
 
 			if(species?.species_flags & ROBOTIC_LIMBS)
-				to_chat(H, span_boldnotice("You can't help this one, [p_they()] [p_have()] no lungs!"))
+				to_chat(human_user, span_boldnotice("You can't help this one, [p_they()] [p_have()] no lungs!"))
 				return FALSE
 
 			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
-				to_chat(H, span_boldnotice("Remove [p_their()] mask!"))
+				to_chat(human_user, span_boldnotice("Remove [p_their()] mask!"))
 				return FALSE
 
-			if((H.head && (H.head.flags_inventory & COVERMOUTH)) || (H.wear_mask && (H.wear_mask.flags_inventory & COVERMOUTH)))
-				to_chat(H, span_boldnotice("Remove your mask!"))
+			if((human_user.head && (human_user.head.flags_inventory & COVERMOUTH)) || (human_user.wear_mask && (human_user.wear_mask.flags_inventory & COVERMOUTH)))
+				to_chat(human_user, span_boldnotice("Remove your mask!"))
 				return FALSE
 
 			//CPR
-			if(H.do_actions)
+			if(human_user.do_actions)
 				return TRUE
 
-			H.visible_message(span_danger("[H] is trying perform CPR on [src]!"), null, null, 4)
+			human_user.visible_message(span_danger("[human_user] is trying perform CPR on [src]!"), null, null, 4)
 
-			if(!do_after(H, HUMAN_STRIP_DELAY, NONE, src, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+			if(!do_after(human_user, HUMAN_STRIP_DELAY, NONE, src, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 				return TRUE
 
 			if(health > get_death_threshold() && health < get_crit_threshold())
 				var/suff = min(getOxyLoss(), 5) //Pre-merge level, less healing, more prevention of dieing.
 				adjustOxyLoss(-suff)
 				updatehealth()
-				visible_message(span_warning(" [H] performs CPR on [src]!"),
+				visible_message(span_warning(" [human_user] performs CPR on [src]!"),
 					span_boldnotice("You feel a breath of fresh air enter your lungs. It feels good."),
 					vision_distance = 3)
-				to_chat(H, span_warning("Repeat at least every 7 seconds."))
+				to_chat(human_user, span_warning("Repeat at least every 7 seconds."))
 			else if(!HAS_TRAIT(src, TRAIT_UNDEFIBBABLE) && !TIMER_COOLDOWN_CHECK(src, COOLDOWN_CPR))
 				TIMER_COOLDOWN_START(src, COOLDOWN_CPR, 7 SECONDS)
 				dead_ticks -= 5
-				visible_message(span_warning(" [H] performs CPR on [src]!"), vision_distance = 3)
-				to_chat(H, span_warning("The patient gains a little more time. Repeat every 7 seconds."))
+				visible_message(span_warning(" [human_user] performs CPR on [src]!"), vision_distance = 3)
+				to_chat(human_user, span_warning("The patient gains a little more time. Repeat every 7 seconds."))
 			else
-				to_chat(H, span_warning("You fail to aid [src]."))
+				to_chat(human_user, span_warning("You fail to aid [src]."))
 
 			return TRUE
 
 		if(INTENT_GRAB)
-			if(H == src || anchored)
+			if(human_user == src || anchored)
 				return FALSE
 
-			H.start_pulling(src)
+			human_user.start_pulling(src)
 
 			return TRUE
 
 		if(INTENT_HARM)
 			// See if they can attack, and which attacks to use.
-			if(H == src && !H.do_self_harm)
+			if(human_user == src && !human_user.do_self_harm)
 				return FALSE
-			var/datum/unarmed_attack/attack = H.species.unarmed
-			if(!attack.is_usable(H))
-				attack = H.species.secondary_unarmed
-			if(!attack.is_usable(H))
+			var/datum/unarmed_attack/attack = human_user.species.unarmed
+			if(!attack.is_usable(human_user))
+				attack = human_user.species.secondary_unarmed
+			if(!attack.is_usable(human_user))
 				return FALSE
 
-			if(!H.melee_damage)
-				H.do_attack_animation(src)
+			if(!human_user.melee_damage)
+				human_user.do_attack_animation(src)
 				playsound(loc, attack.miss_sound, 25, TRUE)
-				visible_message(span_danger("[H] tried to [pick(attack.attack_verb)] [src]!"), null, null, 5)
-				log_combat(H, src, "[pick(attack.attack_verb)]ed", "(missed)")
-				if(!H.mind?.bypass_ff && !mind?.bypass_ff && H.faction == faction)
+				visible_message(span_danger("[human_user] tried to [pick(attack.attack_verb)] [src]!"), null, null, 5)
+				log_combat(human_user, src, "[pick(attack.attack_verb)]ed", "(missed)")
+				if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 					var/turf/T = get_turf(src)
-					log_ffattack("[key_name(H)] missed a punch against [key_name(src)] in [AREACOORD(T)].")
-					msg_admin_ff("[ADMIN_TPMONTY(H)] missed a punch against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
+					log_ffattack("[key_name(human_user)] missed a punch against [key_name(src)] in [AREACOORD(T)].")
+					msg_admin_ff("[ADMIN_TPMONTY(human_user)] missed a punch against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
 				return FALSE
 
-			H.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
-			var/max_dmg = max(H.melee_damage + (H.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD), 3)
+			human_user.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
+			var/max_dmg = max(human_user.melee_damage + (human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD), 3)
 			var/damage = rand(1, max_dmg)
 
-			var/target_zone = ran_zone(H.zone_selected)
+			var/target_zone = ran_zone(human_user.zone_selected)
 
 			playsound(loc, attack.attack_sound, 25, TRUE)
 
-			visible_message(span_danger("[H] [pick(attack.attack_verb)]ed [src]!"), null, null, 5)
+			visible_message(span_danger("[human_user] [pick(attack.attack_verb)]ed [src]!"), null, null, 5)
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
-				visible_message(span_danger("[H] has weakened [src]!"), null, null, 5)
+				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
 				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				hit_report += "(KO)"
 
@@ -130,18 +130,18 @@
 
 			hit_report += "(RAW DMG: [damage])"
 
-			log_combat(H, src, "[pick(attack.attack_verb)]ed", "[hit_report.Join(" ")]")
-			if(!H.mind?.bypass_ff && !mind?.bypass_ff && H.faction == faction)
+			log_combat(human_user, src, "[pick(attack.attack_verb)]ed", "[hit_report.Join(" ")]")
+			if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 				var/turf/T = get_turf(src)
-				H.ff_check(damage, src)
-				log_ffattack("[key_name(H)] punched [key_name(src)] in [AREACOORD(T)] [hit_report.Join(" ")].")
-				msg_admin_ff("[ADMIN_TPMONTY(H)] punched [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)] [hit_report.Join(" ")].")
+				human_user.ff_check(damage, src)
+				log_ffattack("[key_name(human_user)] punched [key_name(src)] in [AREACOORD(T)] [hit_report.Join(" ")].")
+				msg_admin_ff("[ADMIN_TPMONTY(human_user)] punched [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)] [hit_report.Join(" ")].")
 
 		if(INTENT_DISARM)
 
-			H.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+			human_user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 
-			var/target_zone = ran_zone(H.zone_selected)
+			var/target_zone = ran_zone(human_user.zone_selected)
 
 			//Accidental gun discharge
 			if(user.skills.getRating(SKILL_CQC) < SKILL_CQC_MP)
@@ -159,37 +159,37 @@
 
 					if(prob(chance))
 						visible_message("<span class='danger'>[src]'s [W] goes off during struggle!", null, null, 5)
-						log_combat(H, src, "disarmed", "making their [W] go off")
+						log_combat(human_user, src, "disarmed", "making their [W] go off")
 						var/list/turfs = list()
 						for(var/turf/T in view())
 							turfs += T
 						var/turf/target = pick(turfs)
 						return W.afterattack(target,src)
 
-			var/randn = rand(1, 100) + skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD - H.skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD
+			var/randn = rand(1, 100) + skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD - human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD
 
 			if (randn <= 25)
 				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
-				visible_message(span_danger("[H] has pushed [src]!"), null, null, 5)
+				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
 				log_combat(user, src, "pushed")
 				return
 
 			if(randn <= 60)
 				//BubbleWrap: Disarming breaks a pull
 				if(pulling)
-					visible_message(span_danger("[H] has broken [src]'s grip on [pulling]!"), null, null, 5)
+					visible_message(span_danger("[human_user] has broken [src]'s grip on [pulling]!"), null, null, 5)
 					stop_pulling()
 				else
 					drop_held_item()
-					visible_message(span_danger("[H] has disarmed [src]!"), null, null, 5)
+					visible_message(span_danger("[human_user] has disarmed [src]!"), null, null, 5)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				log_combat(user, src, "disarmed")
 				return
 
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
-			visible_message(span_danger("[H] attempted to disarm [src]!"), null, null, 5)
+			visible_message(span_danger("[human_user] attempted to disarm [src]!"), null, null, 5)
 			log_combat(user, src, "missed a disarm")
 	return
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -112,7 +112,9 @@
 
 			human_user.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 			var/max_dmg = max(human_user.melee_damage + (human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DAMAGE_MOD), 3)
-			var/damage = rand(1, max_dmg)
+			var/damage = max_dmg
+			if(!lying_angle)
+				damage = rand(1, max_dmg)
 
 			var/target_zone = ran_zone(human_user.zone_selected)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -15,7 +15,7 @@
 	human_user.changeNext_move(7)
 	switch(human_user.a_intent)
 		if(INTENT_HELP)
-			if(on_fire && H != src)
+			if(on_fire && human_user != src)
 				fire_stacks = max(fire_stacks - 1, 0)
 				playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				human_user.visible_message(span_danger("[human_user] tries to put out the fire on [src]!"), \
@@ -26,7 +26,7 @@
 					ExtinguishMob()
 				return TRUE
 
-			if(istype(wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
+			if(istype(wear_mask, /obj/item/clothing/mask/facehugger) && human_user != src)
 				human_user.stripPanelUnequip(wear_mask, src, SLOT_WEAR_MASK)
 				return TRUE
 
@@ -146,7 +146,7 @@
 			var/target_zone = ran_zone(human_user.zone_selected)
 
 			//Accidental gun discharge
-			if(user.skills.getRating(SKILL_CQC) < SKILL_CQC_MP)
+			if(human_user.skills.getRating(SKILL_CQC) < SKILL_CQC_MP)
 				if (istype(r_hand,/obj/item/weapon/gun) || istype(l_hand,/obj/item/weapon/gun))
 					var/obj/item/weapon/gun/W = null
 					var/chance = 0
@@ -174,7 +174,7 @@
 				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
-				log_combat(user, src, "pushed")
+				log_combat(human_user, src, "pushed")
 				return
 
 			if(randn <= 60)
@@ -192,8 +192,7 @@
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
 			visible_message(span_danger("[human_user] attempted to disarm [src]!"), null, null, 5)
-			log_combat(user, src, "missed a disarm")
-	return
+			log_combat(human_user, src, "missed a disarm")
 
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -106,6 +106,19 @@ Contains most of the procs that are called when a mob is attacked by something
 	else
 		target_zone = def_zone ? check_zone(def_zone) : get_zone_with_miss_chance(user.zone_selected, src)
 
+	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacked"
+
+	if(!target_zone)
+		user.do_attack_animation(src)
+		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE)
+		visible_message(span_danger("[user] tried to hit [src] with [I]!"), null, null, 5)
+		log_combat(user, src, "[attack_verb]", "(missed)")
+		if(!user.mind?.bypass_ff && !mind?.bypass_ff && user.faction == faction)
+			var/turf/T = get_turf(src)
+			log_ffattack("[key_name(user)] missed a attack against [key_name(src)] with [I] in [AREACOORD(T)].")
+			msg_admin_ff("[ADMIN_TPMONTY(user)] missed an against [ADMIN_TPMONTY(src)] with [I] in [ADMIN_VERBOSEJMP(T)].")
+		return FALSE
+
 	var/datum/limb/affecting = get_limb(target_zone)
 	if(affecting.limb_status & LIMB_DESTROYED)
 		to_chat(user, "What [affecting.display_name]?")
@@ -122,7 +135,6 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	var/applied_damage = modify_by_armor(damage, MELEE, I.penetration, target_zone)
 	var/percentage_penetration = applied_damage / damage * 100
-	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacked"
 	var/armor_verb
 	switch(percentage_penetration)
 		if(-INFINITY to 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -76,8 +76,8 @@
 		return
 
 	if(pulledby?.grab_state >= GRAB_KILL)
-		Losebreath(3)
-		adjustOxyLoss(3)
+		Losebreath(1)
+		adjustOxyLoss(4)
 	else if(losebreath <= 10)
 		adjust_Losebreath(-1) //Since this happens before checking to take/heal oxyloss, a losebreath of 1 or less won't do anything.
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -78,10 +78,10 @@
 	if(pulledby?.grab_state >= GRAB_KILL)
 		Losebreath(1)
 		adjustOxyLoss(4)
-	else if(losebreath <= 10)
-		adjust_Losebreath(-1) //Since this happens before checking to take/heal oxyloss, a losebreath of 1 or less won't do anything.
-	else
+	else if(losebreath > 10)
 		set_Losebreath(10) //Any single hit is functionally capped - to keep someone suffocating, you need continued losebreath applications.
+	else if(losebreath > 0)
+		adjust_Losebreath(-1) //Since this happens before checking to take/heal oxyloss, a losebreath of 1 or less won't do anything.
 
 	if(health < get_crit_threshold() || losebreath)
 		if(HAS_TRAIT(src, TRAIT_IGNORE_SUFFOCATION)) //Prevent losing health from asphyxiation, but natural recovery can still happen.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -77,6 +77,7 @@
 
 	if(pulledby?.grab_state >= GRAB_KILL)
 		Losebreath(3)
+		adjustOxyLoss(3)
 	else if(losebreath <= 10)
 		adjust_Losebreath(-1) //Since this happens before checking to take/heal oxyloss, a losebreath of 1 or less won't do anything.
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -75,7 +75,9 @@
 	if(species.species_flags & NO_BREATHE)
 		return
 
-	if(losebreath <= 10)
+	if(pulledby?.grab_state >= GRAB_KILL)
+		Losebreath(3)
+	else if(losebreath <= 10)
 		adjust_Losebreath(-1) //Since this happens before checking to take/heal oxyloss, a losebreath of 1 or less won't do anything.
 	else
 		set_Losebreath(10) //Any single hit is functionally capped - to keep someone suffocating, you need continued losebreath applications.

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -61,7 +61,7 @@
 	if(user.grab_state > GRAB_KILL)
 		return
 	user.changeNext_move(CLICK_CD_GRABBING)
-	if(!do_after(user, 2 SECONDS, NONE, victim, BUSY_ICON_HOSTILE, extra_checks = CALLBACK(user, TYPE_PROC_REF(/datum, Adjacent), victim)) || !user.pulling)
+	if(!do_after(user, max(2 SECONDS - (user.skills.getRating(SKILL_CQC) * 0.5 SECONDS), 1 SECONDS), NONE, victim, BUSY_ICON_HOSTILE, extra_checks = CALLBACK(user, TYPE_PROC_REF(/datum, Adjacent), victim)) || !user.pulling)
 		return
 	user.advance_grab_state()
 	if(user.grab_state == GRAB_NECK)


### PR DESCRIPTION
## About The Pull Request
Fixes choking someone to death... not causing any damage.
Fixes weapon miss chance never actually missing.
Fix some runtimes if you miss an attack.

Upgrading your grab now is faster with higher CQC skill.
When punching someone who is prone, you now always do max damage instead of the normal rng damage.
Unarmed attacks now uses the same target zone prob stuff as melee weapons, with the minor exception of it comparing cqc skills of the attacker and defender to modify miss chance.
The effect of this means unarmed attack will generally actually hit the target area you aim for instead of a complete rng shitshow, although some times you can now miss entirely.

Also replaced some one letter var shit.
## Why It's Good For The Game
Fixes and minor cqc buffs to make it mildly less useless
## Changelog
:cl:
balance: Unarmed damage against humans is no longer rng if your victim is prone
balance: CQC skill lowers grab upgrade time
balance: Unarmed attacks against humans uses the same zone targeting as melee weapons
fix: Choking someone to death once again actually causes oxyloss
fix: Melee attack can now actually miss some times as intended (only for humans attacking humans)
/:cl:
