### PR TITLE
Makes R-walls flat out un-damageable from bullets and lasers

### DIFF
--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -11,7 +11,7 @@
 	max_temperature = 6000
 
 	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	walltype = "rwall"
 	explosion_block = 4

--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -10,6 +10,9 @@
 	max_integrity = 3000
 	max_temperature = 6000
 
+	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+
 	walltype = "rwall"
 	explosion_block = 4
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -12,6 +12,7 @@
 	walltype = "metal"
 
 	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	var/wall_integrity
 	var/max_integrity = 1000 //Wall will break down to girders if damage reaches this point

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -12,7 +12,7 @@
 	walltype = "metal"
 
 	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	var/wall_integrity
 	var/max_integrity = 1000 //Wall will break down to girders if damage reaches this point


### PR DESCRIPTION

## About The Pull Request
see title
this might require map changes
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/65325586/121792e5-b095-45cd-9d39-ab9cfa4cb32e)
## Why It's Good For The Game
Marines have a wide variety of tools available to destroy walls already–ones that either cost req points or require actual risk to use.

Marines should not be able to freely open up the map as much as they can by just getting a guy with a t60 to mindlessly hold M1 at a wall for a couple of minutes; it isn't fun for xenos when marines do it en masse, and it probably isn't fun for the marines doing it except for the inherent satisfaction that comes from doing something stupid with a crowd of people.
## Changelog
:cl:
balance: Reinforced walls are now immune to bullets and lasers. Use your specialized tools, kids.
/:cl:
