### PR TITLE
Increases BR QB to 2300 from 1800

### DIFF
--- a/_maps/bigred_v2.json
+++ b/_maps/bigred_v2.json
@@ -5,7 +5,7 @@
 	"disk_sets": {
 		"basic": 1
 	},
-	"quickbuilds": 1800,
+	"quickbuilds": 2300,
 	"announce_text": "A second generation colony has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!",
 	"traits":[{
 		"weather_sandstorm": true


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
BR is a deceptively big map and often basically all of the caves besides silo goes unmazed if colony is mazed, allowing people to just run through it.
## Changelog
:cl:
balance: Big Red now has 2300 quickbuild points instead of 1800
/:cl:
