### PR TITLE
Minor jump tweaks

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -121,7 +121,8 @@
 #define ABOVE_LYING_MOB_LAYER 3.9 //drone (not the xeno)
 
 //#define MOB_LAYER 4
-#define RIVER_OVERLAY_LAYER 4.01
+
+#define MOB_JUMP_LAYER 4.05
 
 #define ABOVE_MOB_LAYER 4.1
 

--- a/code/game/objects/structures/campaign_props.dm
+++ b/code/game/objects/structures/campaign_props.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/prop/train/update_overlays()
 	. = ..()
-	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_MOB_LAYER, dir)
+	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_ALL_MOB_LAYER, dir)
 	. += new_overlay
 
 /obj/structure/prop/train/carriage

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -73,7 +73,7 @@
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/update_overlays()
 	. = ..()
-	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_MOB_LAYER, dir)
+	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_ALL_MOB_LAYER, dir)
 	. += new_overlay
 
 /obj/structure/campaign_objective/destruction_objective/mlrs/plastique_act(mob/living/plastique_user)
@@ -173,7 +173,7 @@
 
 /obj/structure/campaign_objective/destruction_objective/supply_objective/train/update_overlays()
 	. = ..()
-	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_MOB_LAYER, dir)
+	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_ALL_MOB_LAYER, dir)
 	. += new_overlay
 
 /obj/effect/landmark/campaign_structure/train/carriage
@@ -209,7 +209,7 @@
 
 /obj/structure/campaign_objective/destruction_objective/supply_objective/phoron_stack/update_overlays()
 	. = ..()
-	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_MOB_LAYER, dir)
+	var/image/new_overlay = image(icon, src, "[icon_state]_overlay", ABOVE_ALL_MOB_LAYER, dir)
 	. += new_overlay
 
 //NT base


### PR DESCRIPTION

## About The Pull Request
Proper preservation of jumper layer and passflags, for a for edge cases.

Edited a few layers for a more consistant experience. Namely that jumping now has its own specific layer, and a few prop overlays have a higher layer so a few things don't overlay over them improperly.

Killed an unused define
## Why It's Good For The Game
Visual clean up/fix some edge case issues.
## Changelog
:cl:
fix: fixed a couple of minor edge case bugs with jumping
/:cl:
