### PR TITLE
Multi tile connect loc

### DIFF
--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -19,7 +19,7 @@
 
 /datum/element/connect_loc/Detach(atom/movable/listener)
 	. = ..()
-	unregister_signals(listener, listener.loc)
+	unregister_signals(listener, listener.loc, listener.locs)
 	UnregisterSignal(listener, COMSIG_MOVABLE_MOVED)
 
 /datum/element/connect_loc/proc/update_signals(atom/movable/listener)
@@ -29,16 +29,25 @@
 
 	for (var/signal in connections)
 		//override=TRUE because more than one connect_loc element instance tracked object can be on the same loc
-		listener.RegisterSignal(listener_loc, signal, connections[signal], override=TRUE)
+		if(length(listener.locs) < 2) //this is kinda funny but a multitile object could be inside something
+			listener.RegisterSignal(listener_loc, signal, connections[signal], override=TRUE)
+			continue
+		for(var/turf/turf AS in listener.locs)
+			listener.RegisterSignal(turf, signal, connections[signal], override=TRUE)
 
-/datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/old_loc)
+
+/datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/old_loc, list/turf/old_locs)
 	if(isnull(old_loc))
 		return
 
 	for (var/signal in connections)
-		listener.UnregisterSignal(old_loc, signal)
+		if(length(old_locs) < 2)
+			listener.UnregisterSignal(old_loc, signal)
+			continue
+		for(var/turf/turf AS in old_locs)
+			listener.UnregisterSignal(turf, signal)
 
-/datum/element/connect_loc/proc/on_moved(atom/movable/listener, atom/old_loc)
+/datum/element/connect_loc/proc/on_moved(atom/movable/listener, atom/old_loc, movement_dir, forced, list/turf/old_locs)
 	SIGNAL_HANDLER
-	unregister_signals(listener, old_loc)
+	unregister_signals(listener, old_loc, old_locs)
 	update_signals(listener)

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -367,12 +367,12 @@
 
 
 /atom/movable/proc/Moved(atom/old_loc, movement_dir, forced = FALSE, list/old_locs)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, old_locs)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, locs)
 	if(client_mobs_in_contents)
 		update_parallax_contents()
 
 	if(pulledby)
-		SEND_SIGNAL(src, COMSIG_MOVABLE_PULL_MOVED, old_loc, movement_dir, forced, old_locs)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_PULL_MOVED, old_loc, movement_dir, forced, locs)
 	//Cycle through the light sources on this atom and tell them to update.
 	for(var/datum/dynamic_light_source/light AS in hybrid_light_sources)
 		light.source_atom.update_light()

--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -178,8 +178,15 @@
 	pixel_x = -16
 	pixel_y = -14
 	coverage = 75
-	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE
+	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
 	bound_width = 64
+
+/obj/machinery/cic_maptable/drawable/big/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+	)
+	AddElement(/datum/element/connect_loc, connections)
 
 /obj/machinery/cic_maptable/drawable/big/som
 	minimap_flag = MINIMAP_FLAG_MARINE_SOM


### PR DESCRIPTION

## About The Pull Request
Connect loc now connects to locs, in the case of multi tile atoms.

Also made big map tables crossable like windowframes/tables etc, as a proof of concept.
## Why It's Good For The Game
Connect loc would only connect to your actual LOC, which creates weird behavior for multitiles in some cases.
## Changelog
:cl:
code: connect_loc now works properly for multitile atoms
/:cl:
