### PR TITLE
Xeno respawn timer changes 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -23,8 +23,10 @@
 	if(is_zoomed)
 		zoom_out()
 
-	if(tier != XENO_TIER_MINION)
-		GLOB.key_to_time_of_xeno_death[key] = world.time
+	if(GLOB.xeno_stat_multiplicator_buff == 1) //if autobalance is on, it won't equal 1, so xeno respawn timer is not set
+		switch(tier)
+			if(XENO_TIER_ZERO, XENO_TIER_ONE, XENO_TIER_TWO, XENO_TIER_THREE) //minions and tier fours have no respawn timer
+				GLOB.key_to_time_of_xeno_death[key] = world.time
 
 	SSminimaps.remove_marker(src)
 	set_light_on(FALSE)


### PR DESCRIPTION
## About The Pull Request
If autobalance is on and you die, or if you are a tier four and die, your respawn timer is not set (being a minion still doesn't set your respawn timer too, by the way!)
## Why It's Good For The Game
If you die with autobalance on, it is in the best interest of the hive to have you back in the fight ASAP lest they want your silo to be rushed, which is no bueno. On the T4 side, if you are the only leader because no one else wants to, it can kind of suck if you die and people bicker over who has to take the chore of being leader whereas you could just go Shrike. Keep in mind that King and Queen still have the timers to evo to them after death.
## Changelog
:cl:
balance: If autobalance is on or if you are a tier four, the xeno respawn timer is not applied
/:cl:
