### PR TITLE
Sentinel nade is now transparent

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -355,7 +355,7 @@
 	alpha = 60
 	opacity = FALSE
 	color = "#00B22C"
-	smoke_traits = SMOKE_XENO|SMOKE_XENO_TOXIC|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH|SMOKE_HUGGER_PACIFY
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_TOXIC|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	color = "#0287A1"

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -352,6 +352,8 @@
 
 /obj/effect/particle_effect/smoke/xeno/toxic
 	lifetime = 2
+	alpha = 60
+	opacity = FALSE
 	color = "#00B22C"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TOXIC|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH|SMOKE_HUGGER_PACIFY
 


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/88deaf81-2521-4ce3-bb24-014d4a222790)
You can now see through it woohoo
## Why It's Good For The Game
Sent primo is arguably the best in the game, gives a T1 a spammable, high damage gas that has no risk. The main benefit of gas is as a smoke screen that blocks LoS, given all the other benefits it has it should not block vision.
## Changelog
:cl:
balance: Sentinel gas nade is now transparent (you can see through it)
/:cl:
