### PR TITLE
Bull (and Crusher) no longer gets stunned by projectiles/rocket sledge while charging

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -92,6 +92,7 @@
 #define TRAIT_STASIS "stasis"//Subject to the stasis effect
 #define ENDURE_TRAIT "endure" //Ravager Endure ability.
 #define RAGE_TRAIT "rage" //Ravager Rage ability.
+#define CHARGE_TRAIT "charge_stun_immunity" //Charge Stun Immunity
 #define UNMANNED_VEHICLE "unmanned"
 #define STEALTH_TRAIT "stealth" //From hunter stealth
 #define REVIVE_TO_CRIT_TRAIT "revive_to_crit"

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
@@ -10,6 +10,7 @@
 	plasma_stored = 200
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_NORMAL
+	mob_size = MOB_SIZE_BIG
 
 	pixel_x = -16
 	pixel_y = -3

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
@@ -10,7 +10,6 @@
 	plasma_stored = 200
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_NORMAL
-	mob_size = MOB_SIZE_BIG
 
 	pixel_x = -16
 	pixel_y = -3

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -72,6 +72,7 @@
 	RegisterSignal(charger, COMSIG_MOVABLE_MOVED, PROC_REF(update_charging))
 	RegisterSignal(charger, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_change))
 	set_toggle(TRUE)
+	ADD_TRAIT(charger, TRAIT_STUNIMMUNE, BULL_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will charge when moving, now."))
 
@@ -81,6 +82,7 @@
 	if(charger.is_charging != CHARGE_OFF)
 		do_stop_momentum()
 	UnregisterSignal(charger, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_DIR_CHANGE))
+	REMOVE_TRAIT(charger, TRAIT_STUNIMMUNE, BULL_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will no longer charge when moving."))
 	set_toggle(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -72,7 +72,7 @@
 	RegisterSignal(charger, COMSIG_MOVABLE_MOVED, PROC_REF(update_charging))
 	RegisterSignal(charger, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_change))
 	set_toggle(TRUE)
-	ADD_TRAIT(charger, TRAIT_STUNIMMUNE, BULL_TRAIT)
+	ADD_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will charge when moving, now."))
 
@@ -82,7 +82,7 @@
 	if(charger.is_charging != CHARGE_OFF)
 		do_stop_momentum()
 	UnregisterSignal(charger, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_DIR_CHANGE))
-	REMOVE_TRAIT(charger, TRAIT_STUNIMMUNE, BULL_TRAIT)
+	REMOVE_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will no longer charge when moving."))
 	set_toggle(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -72,7 +72,6 @@
 	RegisterSignal(charger, COMSIG_MOVABLE_MOVED, PROC_REF(update_charging))
 	RegisterSignal(charger, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_change))
 	set_toggle(TRUE)
-	ADD_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will charge when moving, now."))
 
@@ -82,7 +81,6 @@
 	if(charger.is_charging != CHARGE_OFF)
 		do_stop_momentum()
 	UnregisterSignal(charger, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_DIR_CHANGE))
-	REMOVE_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will no longer charge when moving."))
 	set_toggle(FALSE)
@@ -134,12 +132,14 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	RegisterSignals(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE), PROC_REF(do_crush))
 	charger.is_charging = CHARGE_ON
+	ADD_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	charger.update_icons()
 
 
 /datum/action/ability/xeno_action/ready_charge/proc/do_stop_crushing()
 	var/mob/living/carbon/xenomorph/charger = owner
 	UnregisterSignal(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE))
+	REMOVE_TRAIT(charger, TRAIT_STUNIMMUNE, CHARGE_TRAIT)
 	if(valid_steps_taken > 0) //If this is false, then do_stop_momentum() should have it handled already.
 		charger.is_charging = CHARGE_BUILDINGUP
 		charger.update_icons()


### PR DESCRIPTION
## About The Pull Request

bull no longer gets stunned by projectiles such as buckshot/slugs while charging. This also affects crushers charge but only in the case of being stunned during charges (only thing I can think of is a mid charge rocket sledge hit)

## Why It's Good For The Game

caste is absolute shit because it just dies on the charge back if it overextends even slightly, immensely inferior to crusher and you're better off playing a different caste now that forced evo paths are gone before playing the better xeno (crusher).
Admittedly this is a band aid fix, there's a lot more problems with the caste that would entail a rework of its abilities/where bull can stand as a t2 however this pr should alleviate a piece of bull being terrible and a throw t2 to evolve to

## Changelog

:cl:
balance: Bull (and Crusher) no longer gets stunned by projectiles/rocket sledge while charging
/:cl:

