### PR TITLE
Gives airbursting effects to praetorian spits

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -35,7 +35,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy/praetorian)
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_range = 5

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3701,7 +3701,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 100
 	damage = 40
 	smoke_strength = 0.4
-	reagent_transfer_amount = 8
+	reagent_transfer_amount = 5
 	bonus_projectiles_type = /datum/ammo/xeno/toxin/smoke_spread
 	bonus_projectiles_scatter = 25
 	var/bonus_projectile_quantity = 2
@@ -3751,12 +3751,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_XENO|AMMO_PASS_THROUGH_MOVABLE
 	icon_state = null
 	max_range = 2
-	damage = 1
+	damage = 0
 	stagger_stacks = 0 SECONDS
 	slowdown_stacks = 0
 	smoke_range = 0
 	smoke_strength = 0.4
-	reagent_transfer_amount = 1
+	reagent_transfer_amount = 0
 
 /datum/ammo/xeno/toxin/smoke_spread/on_hit_mob()
 	return

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3614,6 +3614,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/datum/effect_system/smoke_spread/xeno/smoke_system
 	var/smoke_strength
 	var/smoke_range
+	var/smoke_lifetime
 	///The hivenumber of this ammo
 	var/hivenumber = XENO_HIVE_NORMAL
 
@@ -3632,6 +3633,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
+	smoke_lifetime = 4
 	reagent_transfer_amount = 4
 
 ///Set up the list of reagents the spit transfers upon impact
@@ -3677,7 +3679,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 	set_smoke()
 	smoke_system.strength = smoke_strength
-	smoke_system.lifetime = 4
+	smoke_system.lifetime = smoke_lifetime
 	smoke_system.set_up(smoke_range, T)
 	smoke_system.start()
 	smoke_system = null

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3703,6 +3703,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 100
 	damage = 40
 	smoke_strength = 0.4
+	smoke_lifetime = 2
 	reagent_transfer_amount = 5
 	bonus_projectiles_type = /datum/ammo/xeno/toxin/smoke_spread
 	bonus_projectiles_scatter = 25
@@ -3758,6 +3759,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	slowdown_stacks = 0
 	smoke_range = 0
 	smoke_strength = 0.4
+	smoke_lifetime = 3
 	reagent_transfer_amount = 0
 
 /datum/ammo/xeno/toxin/smoke_spread/on_hit_mob()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3941,6 +3941,45 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 8
 	puddle_duration = 1 SECONDS //Lasts 2-4 seconds
 
+///For the Praetorian's Acid Splash ability
+/datum/ammo/xeno/acid/heavy/praetorian
+	puddle_duration = 3 SECONDS
+	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/praetorian_splash
+	bonus_projectiles_scatter = 10
+	var/bonus_projectile_quantity = 3
+	var/bonus_projectile_range = 1.5
+	var/bonus_projectile_speed = 1.5
+
+/datum/ammo/xeno/acid/heavy/praetorian/on_hit_mob(mob/M, obj/projectile/P)
+	var/turf/initial_turf = get_turf(M)
+	drop_nade(initial_turf)
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+
+/datum/ammo/xeno/acid/heavy/praetorian/on_hit_obj(obj/O, obj/projectile/P)
+	var/turf/initial_turf = O.density ? P.loc : get_turf(O)
+	drop_nade(initial_turf)
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+
+/datum/ammo/xeno/acid/heavy/praetorian/on_hit_turf(turf/T, obj/projectile/P)
+	var/turf/initial_turf = T.density ? P.loc : T
+	drop_nade(initial_turf)
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+
+/datum/ammo/xeno/acid/heavy/praetorian/do_at_max_range(turf/T, obj/projectile/P)
+	var/turf/initial_turf = T.density ? P.loc : T
+	drop_nade(T.density ? P.loc : T)
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+
+/datum/ammo/xeno/acid/heavy/praetorian_splash
+	icon_state = null
+	puddle_duration = 2 SECONDS
+	flags_ammo_behavior = AMMO_XENO|AMMO_PASS_THROUGH_MOVABLE
+	icon_state = null
+	damage = 0
+
+/datum/ammo/xeno/acid/heavy/praetorian_splash/on_hit_mob()
+	return
+
 /datum/ammo/xeno/boiler_gas
 	name = "glob of gas"
 	icon_state = "boiler_gas2"


### PR DESCRIPTION
## About The Pull Request

- Praetorian's acid splash will now splash onto nearby tiles
- Adds two secondary gas projectiles to praetorian's neurotoxin spit
- Reduces the strength of praetorian's neurotoxin gas by 60%
- Significantly reduces the duration of this neurotoxin gas


https://github.com/tgstation/TerraGov-Marine-Corps/assets/49888953/685ed823-6f23-4718-9ce6-b0e3349378d1


## Why It's Good For The Game
Our walance maints have suggested that the acid spit is underpowered and that xenos need more AOE damage.

Currently, the gas component of praetorian's neuro splash is only useful for punishing static marines and stacking up more single-target neurotoxin. This makes it look cooler, while giving it some additional functionality for area saturation

## Changelog
:cl:
balance: Praetorian's acid splash now scatters onto nearby tiles
balance: Praetorian's neurotoxin splash now releases an airburst of weakened neurotoxic gas

/:cl:
