### PR TITLE
Synthetic critical condition changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -629,7 +629,7 @@
 
 /datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
-		H.adjustFireLoss(rand(15, 25)) // This may need tweaks
+		H.adjustFireLoss(rand(18, 28)) // This may need tweaks
 		if(prob(8))
 			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -538,8 +538,8 @@
 
 	total_health = 125 //more health than regular humans
 
-	brute_mod = 0.70
-	burn_mod = 0.70 //Synthetics should not be instantly melted by acid compared to humans - This is a test to hopefully fix very glaring issues involving synthetics taking 2.6 trillion damage when so much as touching acid
+	brute_mod = 0.7
+	burn_mod = 0.8 // A slight amount of burn resistance. Changed from 0.7 due to their critical condition phase.
 
 	cold_level_1 = -1
 	cold_level_2 = -1
@@ -566,16 +566,24 @@
 	warcries = list(MALE = "male_warcry", FEMALE = "female_warcry")
 	special_death_message = "You have been shut down.<br><small>But it is not the end of you yet... if you still have your body, wait until somebody can resurrect you...</small>"
 
+/datum/species/synthetic/handle_unique_behavior(mob/living/carbon/human/H)
+	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
+		H.adjustFireLoss(rand(16, 27)) // This may need tweaks. But synth burn is really fucked up.
+		if(prob(8))
+			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
+
 /datum/species/synthetic/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.add_hud_to(H)
+	H.health_threshold_crit = -100 // You overheat below -30 health.
 
 
 /datum/species/synthetic/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.remove_hud_from(H)
+	H.health_threshold_crit = -50
 
 /mob/living/carbon/human/species/synthetic/binarycheck(mob/H)
 	return TRUE
@@ -619,16 +627,24 @@
 	warcries = list(MALE = "male_warcry", FEMALE = "female_warcry")
 	special_death_message = "You have been shut down.<br><small>But it is not the end of you yet... if you still have your body, wait until somebody can resurrect you...</small>"
 
+/datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
+	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
+		H.adjustFireLoss(rand(22, 34)) // This may need tweaks. But synth burn is really fucked up.
+		if(prob(8))
+			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
+
 /datum/species/early_synthetic/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.add_hud_to(H)
+	H.health_threshold_crit = -100 // You overheat below -30 health.
 
 
 /datum/species/early_synthetic/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.remove_hud_from(H)
+	H.health_threshold_crit = -50
 
 /mob/living/carbon/human/species/early_synthetic/binarycheck(mob/H)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -568,7 +568,7 @@
 
 /datum/species/synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
-		H.adjustFireLoss(rand(16, 27)) // This may need tweaks. But synth burn is really fucked up.
+		H.adjustFireLoss(rand(14, 24)) // This may need tweaks
 		if(prob(8))
 			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
 
@@ -629,7 +629,7 @@
 
 /datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
-		H.adjustFireLoss(rand(22, 34)) // This may need tweaks. But synth burn is really fucked up.
+		H.adjustFireLoss(rand(15, 25)) // This may need tweaks
 		if(prob(8))
 			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
 


### PR DESCRIPTION
## About The Pull Request
Synthetics/Early Synthetics will no longer enter critical condition, but instead, at -30 health, you start to overheat rapidly. I've tried to make it so you can still self repair to delay your death or even stop overheating, but not getting repaired can quickly kill you. 
The numbers may need tuning, but my reason is the burn mods for synths are fucked up real good. Or I'm just not mathing right.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/bd2837fb-b7f8-426a-bb72-edd002c09701)
If the balance gods want I could just make it so they still enter crit but take a lot of burn damage so you can't be dragged by xenos or stuck in crit. But I want to try this option first.
## Why It's Good For The Game
Synths slumping over the moment they hit -50 health is pretty boring, along with the situations where your body could be hidden by xenos or you could be stuck in crit for a long time.

Synthetics not falling over in crit, in exchange for both taking a lot of burn and also having to repair all that burn if they ever make it out should be more interesting than immediately falling over at -50 health.
## Changelog
:cl:
balance: late synths have a 20% burn reduction instead of 30%
balance: synths/early synths will no longer be unconscious at -50 health
balance: synths/early synths take rapid burn damage at -30 health
/:cl:
