### PR TITLE
Gives ice colony 2100 QB from 1600

### DIFF
--- a/_maps/ice_colony_v2.json
+++ b/_maps/ice_colony_v2.json
@@ -9,7 +9,7 @@
 		"basic": 1
 	},
     "armor": "ice",
-	"quickbuilds": 1600,
+	"quickbuilds": 2100,
 	"announce_text": "A garbled, unintelligible communications message was broadcasted over a general frequency, and picked up by our comms relay. The message appears to have come from a second generation settlement, located on an ice cold planet. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",
 	"traits":[{
 		"weather_snowstorm": true


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
Even Big Red had more QB than this map, and this map is likely the most open in the game next to my notoriously open maps, which have way more QB. It's funny when you maze one of the big three open fields and run out of QB, hopefully this helps alleviate this.
## Changelog
:cl:
balance: Ice colony now has 2100 quickbuild points instead of 1600.
/:cl:
