### PR TITLE
Fix martini belt sprite typo

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -898,7 +898,7 @@
 /obj/item/storage/belt/shotgun/martini
 	name = "martini henry ammo belt"
 	desc = "A belt good enough for holding all your .577/400 ball rounds."
-	icon_state = "marini_belt"
+	icon_state = "martini_belt"
 	storage_slots = 12
 	max_storage_space = 24
 	sprite_slots = 6


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/15013
## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/15013
Bugfix
## Changelog
:cl:
fix: fix typo in martini belt causing broken sprite
/:cl:
