### PR TITLE
Makes psychic relays, evotowers and pherotowers ignore weed removal.

### DIFF
--- a/code/modules/xenomorph/pherotower.dm
+++ b/code/modules/xenomorph/pherotower.dm
@@ -8,7 +8,7 @@
 	bound_height = 32
 	obj_integrity = 400
 	max_integrity = 400
-	xeno_structure_flags = CRITICAL_STRUCTURE
+	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
 	///The type of pheromone currently being emitted.
 	var/datum/aura_bearer/current_aura
 	///Strength of pheromones given by this tower.

--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -8,7 +8,7 @@
 	bound_height = 64
 	obj_integrity = 600
 	max_integrity = 600
-	xeno_structure_flags = CRITICAL_STRUCTURE
+	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
 	///maturity boost amt to be added per tower per cycle
@@ -43,7 +43,7 @@
 	bound_height = 64
 	obj_integrity = 400
 	max_integrity = 400
-	xeno_structure_flags = CRITICAL_STRUCTURE
+	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
 
 /obj/structure/xeno/psychictower/Initialize(mapload, _hivenumber)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `IGNORE_WEED_REMOVAL` flag to psychic relay, evolution tower and pheromone tower.
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/15073.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You won't delete it on accidents as a xeno, after destroying a wall it was hidden behind.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Psychic Relays, Evolution Towers and Pheromonone Towers now ignore weed removal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
