### PR TITLE
Removes and moves Ice Colony phoron miners

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -21354,10 +21354,6 @@
 	dir = 8
 	},
 /area/ice_colony/surface/storage_unit/power)
-"hqp" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/ice_colony/exterior/surface/valley/southeast)
 "hqr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23397,10 +23393,6 @@
 	dir = 8
 	},
 /area/ice_colony/underground/requesition)
-"kqC" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/ice_colony/exterior/surface/valley/south)
 "kqN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -24972,10 +24964,6 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/landing_pad2)
-"mxl" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/ice_colony/exterior/surface/clearing/south)
 "mxE" = (
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/surface/landing_pad_external)
@@ -31794,10 +31782,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/ice_colony/underground/westroadtunnel)
-"vGy" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/ice_colony/exterior/surface/valley/north)
 "vGO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -49100,7 +49084,7 @@ xJX
 hKV
 vCr
 eAl
-kqC
+eAl
 bVW
 eAl
 eAl
@@ -54808,7 +54792,7 @@ aKC
 aKC
 vPZ
 aXE
-mxl
+aKC
 aKC
 aKC
 exj
@@ -59626,7 +59610,7 @@ nsF
 nsF
 nsF
 wkf
-mTO
+wkf
 wkf
 wkf
 hlm
@@ -60427,7 +60411,7 @@ uSg
 uSg
 hKV
 fIm
-vGy
+fIm
 fIm
 fIm
 fIm
@@ -67441,7 +67425,7 @@ wkf
 xCs
 wkf
 mqj
-jPw
+mqj
 wkf
 wkf
 xCs
@@ -70255,7 +70239,7 @@ fIR
 uXx
 xnK
 uUO
-hqp
+xnK
 xnK
 sZv
 sZv
@@ -70653,7 +70637,7 @@ xnK
 xnK
 pdQ
 sZv
-hqp
+xnK
 oYT
 bqg
 xnK
@@ -71899,7 +71883,7 @@ aiX
 aiX
 wkf
 wkf
-wkf
+mTO
 cZy
 nsF
 wkf


### PR DESCRIPTION

## About The Pull Request
This removes 7 of Ice Colony's 16 phoron miners and places 1 new one.
<img width="533" alt="Ice Colony Miners" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/c9c25420-9f05-4988-89f2-26d020394546">
## Why It's Good For The Game
Ice Colony has the highest number of phoron miners out of all of our maps, beating even Big Red's 13 miners. This map is already marine sided with its numerous open fields and choke points, but it gives marines an extreme snowball advantage just for taking the areas they would be taking to regardless of miners. Unlike Big Red, many of Ice Colony's miners are much harder to siege and many of them also help defend other miners, which creates a compounding problem where marines will have their full force at the southern disks which threatens a silo rush, while 6 phoron miners are ticking away and covering each others flanks up at the open fields near engi. 

My decisions on which miners to specifically remove are mostly opinion based, but I tried to take out the miners that I thought had the least interesting fights over them.
## Changelog
:cl:
balance:  Removed 7 phoron miners from Ice Colony, Added 1.
/:cl:
