### PR TITLE
External reinforced walls for magmoor lz1 buildings

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -11036,6 +11036,10 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing/two)
+"iba" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/gambling)
 "ibg" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/silver{
@@ -23281,6 +23285,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/research/containment)
+"rax" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/civilian/gambling)
 "raC" = (
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/power/apc/drained,
@@ -44267,7 +44276,7 @@ xRt
 saX
 kfI
 roE
-sZv
+iba
 mQq
 eCB
 rgm
@@ -44500,7 +44509,7 @@ roE
 kfI
 pLX
 jeO
-sZv
+iba
 mQq
 eCB
 rgm
@@ -44733,7 +44742,7 @@ xRt
 kfI
 kfI
 roE
-sZv
+rax
 avf
 eCB
 rgm
@@ -45665,7 +45674,7 @@ kfI
 roE
 ucS
 roE
-sZv
+iba
 mQq
 eCB
 rgm
@@ -45898,7 +45907,7 @@ bGT
 jeO
 ucS
 roE
-sZv
+iba
 mQq
 eCB
 rgm

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -3742,10 +3742,6 @@
 "cFH" = (
 /turf/open/floor/plating,
 /area/magmoor/compound/north)
-"cFQ" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/magmoor/civilian/arrival)
 "cGh" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
@@ -3793,6 +3789,9 @@
 	dir = 4
 	},
 /area/magmoor/compound/south)
+"cIl" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/arrival)
 "cIn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -3972,9 +3971,6 @@
 "cQo" = (
 /turf/open/floor/tile/neutral,
 /area/magmoor/civilian/pool)
-"cQu" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/arrival)
 "cQv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4628,6 +4624,9 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/lobby)
+"doh" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/hydroponics/south)
 "dop" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5385,6 +5384,9 @@
 /obj/structure/rock/basalt/pile/alt,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/north)
+"dMi" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/basket)
 "dMQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8654,6 +8656,9 @@
 	dir = 4
 	},
 /area/magmoor/medical/treatment)
+"gem" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/bar)
 "geH" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
@@ -8830,9 +8835,6 @@
 	dir = 1
 	},
 /area/magmoor/cargo/processing/south)
-"gkW" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/bar)
 "glm" = (
 /obj/structure/curtain/medical,
 /obj/machinery/shower{
@@ -12973,6 +12975,10 @@
 	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/east)
+"jvl" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/bar)
 "jvK" = (
 /obj/machinery/light{
 	dir = 4
@@ -13670,6 +13676,9 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"jTF" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/rnr)
 "jTN" = (
 /turf/open/floor/mainship/blue/corner{
 	dir = 4
@@ -14770,6 +14779,9 @@
 	dir = 4
 	},
 /area/magmoor/landing)
+"kJp" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/hydroponics/north)
 "kJy" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -14854,10 +14866,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/north)
-"kMS" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/magmoor/civilian/bar)
 "kNv" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/prop/mainship/hangar_stencil/two,
@@ -15211,12 +15219,6 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
-"kZf" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/hydroponics/north)
-"kZn" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/basket)
 "kZC" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -15518,10 +15520,6 @@
 	},
 /turf/open/floor/mainship,
 /area/magmoor/landing/two)
-"lkv" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/magmoor/civilian/cryostasis)
 "llf" = (
 /obj/machinery/smartfridge,
 /turf/open/floor/plating,
@@ -18890,6 +18888,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth,
 /area/magmoor/cave/rock)
+"nUm" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/arrival)
 "nUp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19280,9 +19282,6 @@
 "oiI" = (
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/thermal)
-"oiQ" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/rnr)
 "ojh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22770,9 +22769,6 @@
 	dir = 8
 	},
 /area/magmoor/compound/southwest)
-"qBq" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/gambling)
 "qBL" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
@@ -23473,9 +23469,6 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/magmoor/command/office/main)
-"ria" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/cook)
 "riq" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -24239,6 +24232,10 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/compound)
+"rMX" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/rnr)
 "rNx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24706,9 +24703,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/magmoor/engi/thermal)
-"sgr" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/hydroponics/south)
 "sgy" = (
 /obj/item/ammo_casing,
 /turf/open/floor/mainship/mono,
@@ -25891,6 +25885,9 @@
 	dir = 1
 	},
 /area/magmoor/mining)
+"sZv" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/gambling)
 "sZB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -26713,9 +26710,6 @@
 	},
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound/east)
-"tFD" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/civilian/cryostasis)
 "tFK" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/landmark/weed_node,
@@ -27933,10 +27927,6 @@
 	dir = 8
 	},
 /area/magmoor/civilian/dorms)
-"uuw" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/magmoor/civilian/rnr)
 "uuH" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -29090,7 +29080,7 @@
 	},
 /area/magmoor/compound/north)
 "vpI" = (
-/obj/structure/window/framed/colony,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/civilian/cryostasis)
 "vqd" = (
@@ -31001,6 +30991,9 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/south)
+"wJw" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/cook)
 "wJz" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/landmark/weed_node,
@@ -31060,6 +31053,9 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/research)
+"wMk" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/cryostasis)
 "wMW" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	name = "\improper Colony Administration Office"
@@ -39805,11 +39801,11 @@ dze
 dze
 dRz
 vzO
-kZf
+kJp
 auq
 tva
 prG
-kZf
+kJp
 ybU
 ybU
 eau
@@ -40037,13 +40033,13 @@ pDq
 dze
 tky
 vzO
-kZf
-kZf
-kZf
+kJp
+kJp
+kJp
 qVx
-kZf
-kZf
-kZf
+kJp
+kJp
+kJp
 ybU
 vzO
 ybU
@@ -40270,13 +40266,13 @@ ibO
 pDq
 tky
 ybU
-kZf
+kJp
 uVx
 kDI
 uQr
 lOM
 gaP
-kZf
+kJp
 ybU
 ybU
 ybU
@@ -40503,13 +40499,13 @@ dze
 dze
 tky
 ybU
-kZf
+kJp
 fVD
 hoy
 kiC
 iOh
 uvK
-kZf
+kJp
 ybU
 ygU
 ybU
@@ -40736,27 +40732,27 @@ dze
 dze
 caN
 vzO
-kZf
+kJp
 ndK
 hpj
 pCR
 iOh
 lnZ
-kZf
+kJp
 ybU
 ybU
 ybU
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
-sgr
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
 ybU
 fkP
 dRz
@@ -40767,15 +40763,15 @@ ybU
 ybU
 ygU
 ybU
-tFD
-tFD
-lkv
-tFD
-lkv
-tFD
-lkv
-tFD
-tFD
+wMk
+wMk
+vpI
+wMk
+vpI
+wMk
+vpI
+wMk
+wMk
 eCB
 rgm
 rgm
@@ -40969,17 +40965,17 @@ dze
 dze
 tky
 ybU
-kZf
+kJp
 fVD
 iOh
 cpe
 iOh
 quD
-kZf
+kJp
 ybU
 vzO
 ybU
-sgr
+doh
 cTq
 xTu
 xTu
@@ -40989,18 +40985,18 @@ iui
 cZk
 rDU
 fGJ
-oiQ
-oiQ
-uuw
-uuw
-oiQ
+jTF
+jTF
+rMX
+rMX
+jTF
 lCK
 ayv
-oiQ
-uuw
+jTF
+rMX
 piK
-oiQ
-oiQ
+jTF
+jTF
 kTv
 kTv
 kTv
@@ -41008,7 +41004,7 @@ kTv
 kTv
 kTv
 kTv
-tFD
+wMk
 xlX
 rgm
 eak
@@ -41202,13 +41198,13 @@ pDq
 dze
 tky
 ybU
-kZf
+kJp
 tNC
 fZp
 cpe
 enm
 gZR
-kZf
+kJp
 ybU
 ygU
 ybU
@@ -41233,7 +41229,7 @@ lCK
 tPJ
 lCK
 amd
-bVz
+jTF
 vji
 vji
 vji
@@ -41241,7 +41237,7 @@ vji
 vji
 vji
 vji
-tFD
+wMk
 mQq
 eCB
 wSW
@@ -41441,11 +41437,11 @@ qlq
 lRr
 eXn
 kDI
-kZf
+kJp
 ybU
 ybU
 ybU
-sgr
+doh
 cOn
 xTu
 elf
@@ -41466,15 +41462,15 @@ lCK
 ebH
 lCK
 uBC
-bVz
-fBc
+jTF
+wMk
 vpI
-fBc
+wMk
 vpI
-fBc
+wMk
 vpI
-fBc
-tFD
+wMk
+wMk
 mQq
 eCB
 wSW
@@ -41668,17 +41664,17 @@ dze
 dze
 tky
 ybU
-kZf
+kJp
 fVD
 iOh
 pqI
 iOh
 uvK
-kZf
-kZf
+kJp
+kJp
 wwE
-kZf
-sgr
+kJp
+doh
 bfP
 xTu
 xTu
@@ -41707,7 +41703,7 @@ xoI
 uyh
 bbw
 odV
-tFD
+wMk
 mQq
 eCB
 wSW
@@ -41901,7 +41897,7 @@ dze
 pDq
 caN
 ybU
-kZf
+kJp
 fVD
 iOh
 leF
@@ -41940,7 +41936,7 @@ nBm
 nBm
 dep
 tSL
-tFD
+wMk
 mQq
 eCB
 wSW
@@ -42173,7 +42169,7 @@ qrP
 tXy
 ceG
 azw
-lkv
+vpI
 mQq
 eCB
 eak
@@ -42367,7 +42363,7 @@ dze
 dze
 tky
 ybU
-kZf
+kJp
 llg
 cbr
 csb
@@ -42406,7 +42402,7 @@ sWI
 qhp
 vlF
 vlF
-lkv
+vpI
 avf
 eCB
 wSW
@@ -42600,17 +42596,17 @@ dze
 dze
 tky
 ybU
-kZf
-kZf
-kZf
-kZf
-kZf
-kZf
-kZf
-kZf
+kJp
+kJp
+kJp
+kJp
+kJp
+kJp
+kJp
+kJp
 tEv
-kZf
-sgr
+kJp
+doh
 aXZ
 xTu
 aXZ
@@ -42639,7 +42635,7 @@ cul
 srz
 oEb
 ejQ
-tFD
+wMk
 mQq
 eyI
 wSW
@@ -42843,7 +42839,7 @@ ybU
 ybU
 ybU
 ygU
-sgr
+doh
 ioE
 xTu
 ioE
@@ -42872,7 +42868,7 @@ tAW
 tAW
 efo
 sWI
-tFD
+wMk
 mQq
 eCB
 wSW
@@ -43105,7 +43101,7 @@ pwX
 tyH
 pwX
 jdI
-tFD
+wMk
 mQq
 eCB
 wSW
@@ -43309,7 +43305,7 @@ jaT
 ibO
 dRz
 ybU
-sgr
+doh
 wbx
 xTu
 ioE
@@ -43338,7 +43334,7 @@ tyH
 tyH
 tyH
 tyH
-tFD
+wMk
 mQq
 eCB
 eak
@@ -43541,8 +43537,8 @@ tWr
 dze
 tky
 ybU
-kZn
-kZn
+dMi
+dMi
 eXi
 eXi
 eXi
@@ -43571,7 +43567,7 @@ xZj
 pwX
 fjI
 pwX
-tFD
+wMk
 mQq
 eCB
 rgm
@@ -43774,7 +43770,7 @@ ybU
 dze
 tky
 ybU
-kZn
+dMi
 nrb
 cao
 crA
@@ -43804,8 +43800,8 @@ fBc
 fBc
 fBc
 fBc
-tFD
-tFD
+wMk
+wMk
 eCB
 rgm
 rgm
@@ -44038,7 +44034,7 @@ roE
 uXF
 roE
 anq
-qBq
+sZv
 xlX
 rgm
 rgm
@@ -44271,7 +44267,7 @@ xRt
 saX
 kfI
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -44473,7 +44469,7 @@ mhS
 fkP
 dze
 alo
-kZn
+dMi
 euS
 nov
 lin
@@ -44504,7 +44500,7 @@ roE
 kfI
 pLX
 jeO
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -44706,7 +44702,7 @@ tDP
 ybU
 bGe
 caN
-kZn
+dMi
 tXn
 dVo
 dVo
@@ -44737,7 +44733,7 @@ xRt
 kfI
 kfI
 roE
-qBq
+sZv
 avf
 eCB
 rgm
@@ -44939,7 +44935,7 @@ mhS
 ybU
 bGe
 tky
-kZn
+dMi
 cao
 dVo
 dVo
@@ -44970,7 +44966,7 @@ mSO
 agS
 agS
 roE
-qBq
+sZv
 jyA
 rgm
 rgm
@@ -45203,7 +45199,7 @@ tbP
 gGK
 uQH
 roE
-qBq
+sZv
 xlX
 rgm
 rgm
@@ -45436,7 +45432,7 @@ uXF
 roE
 ucS
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -45638,7 +45634,7 @@ tDP
 ybU
 bGe
 tky
-kZn
+dMi
 cao
 vVM
 lBX
@@ -45669,7 +45665,7 @@ kfI
 roE
 ucS
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -45871,7 +45867,7 @@ qNj
 ybU
 fkP
 dRz
-kZn
+dMi
 tXn
 dVo
 dVo
@@ -45902,7 +45898,7 @@ bGT
 jeO
 ucS
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -46104,7 +46100,7 @@ tDP
 ybU
 ybU
 ybU
-kZn
+dMi
 lsp
 tvO
 ovw
@@ -46135,7 +46131,7 @@ roE
 roE
 ucS
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -46368,7 +46364,7 @@ qxc
 roE
 csn
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -46601,7 +46597,7 @@ tWO
 mSO
 gGn
 roE
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -46803,7 +46799,7 @@ kkl
 vto
 cJW
 hIT
-kZn
+dMi
 nrb
 cao
 crA
@@ -46834,7 +46830,7 @@ qxc
 roE
 jrE
 euH
-qBq
+sZv
 mQq
 eCB
 rgm
@@ -47036,18 +47032,18 @@ cJW
 aje
 hIT
 hIT
-kZn
-kZn
+dMi
+dMi
 wAw
-kZn
-kZn
-kZn
+dMi
+dMi
+dMi
 wAw
-kZn
-kZn
+dMi
+dMi
 pbS
-kZn
-oiQ
+dMi
+jTF
 liW
 lCK
 hCY
@@ -47063,11 +47059,11 @@ wkW
 uhj
 rew
 jNn
-ria
-qBq
-qBq
-qBq
-qBq
+wJw
+sZv
+sZv
+sZv
+sZv
 jyA
 rgm
 rgm
@@ -47280,7 +47276,7 @@ aje
 fIr
 wph
 xmr
-oiQ
+jTF
 lCK
 lCK
 ebH
@@ -47296,7 +47292,7 @@ qxc
 gio
 kpz
 pRU
-ria
+wJw
 rgm
 lWM
 rgm
@@ -47513,7 +47509,7 @@ cax
 tmQ
 wph
 xmr
-oiQ
+jTF
 kyy
 dJw
 bpb
@@ -47529,7 +47525,7 @@ gio
 gio
 tYY
 gio
-ria
+wJw
 kVV
 pLo
 eCB
@@ -47746,7 +47742,7 @@ hzB
 yhx
 kyT
 nuY
-oiQ
+jTF
 aRq
 dJw
 dJw
@@ -47762,7 +47758,7 @@ sci
 jIy
 gio
 ujS
-ria
+wJw
 rgm
 rMC
 rgm
@@ -47979,7 +47975,7 @@ wyb
 wyb
 wyb
 kIw
-gkW
+gem
 ohT
 woH
 ohT
@@ -47995,8 +47991,8 @@ qxc
 qxc
 qxc
 oJD
-ria
-ria
+wJw
+wJw
 rgm
 rgm
 rgm
@@ -48212,7 +48208,7 @@ rKd
 rKd
 ghU
 hIT
-gkW
+gem
 mOs
 ehQ
 vuR
@@ -48229,7 +48225,7 @@ rMh
 eVt
 leY
 slj
-ria
+wJw
 wXM
 wXM
 wXM
@@ -48445,7 +48441,7 @@ hiG
 hiG
 bgh
 ghU
-kMS
+jvl
 oAR
 ehQ
 mlP
@@ -48462,7 +48458,7 @@ bzq
 cJq
 bTc
 ckk
-ria
+wJw
 xMO
 xMO
 xMO
@@ -48678,7 +48674,7 @@ vFy
 vFy
 vFy
 vFy
-kMS
+jvl
 cAw
 ehQ
 fLe
@@ -48911,7 +48907,7 @@ syD
 syD
 syD
 syD
-kMS
+jvl
 vSf
 ehQ
 ehQ
@@ -49144,7 +49140,7 @@ dSO
 mnY
 mnY
 mnY
-kMS
+jvl
 aGz
 ehQ
 ehQ
@@ -49161,7 +49157,7 @@ dJd
 xjx
 abL
 sNp
-ria
+wJw
 rgm
 rgm
 rgm
@@ -49377,7 +49373,7 @@ hiG
 hiG
 hiG
 hiG
-gkW
+gem
 tjh
 mlP
 tct
@@ -49394,7 +49390,7 @@ bXb
 umc
 oLQ
 mbs
-ria
+wJw
 rgm
 rgm
 rgm
@@ -49610,7 +49606,7 @@ hiG
 noo
 bgh
 hiG
-gkW
+gem
 lpK
 ehQ
 wEz
@@ -49627,7 +49623,7 @@ bXb
 umc
 sSX
 eyU
-ria
+wJw
 rgm
 rgm
 rgm
@@ -49843,7 +49839,7 @@ cJW
 hIT
 pKb
 hiG
-gkW
+gem
 ehQ
 ehQ
 dIR
@@ -49860,7 +49856,7 @@ ayS
 tHq
 umc
 oAE
-ria
+wJw
 rgm
 rgm
 rgm
@@ -49875,17 +49871,17 @@ bOC
 pLo
 ugT
 aQh
-cQu
-cQu
-cFQ
-cFQ
-cQu
-cFQ
-cFQ
-cQu
-cQu
-cQu
-cQu
+cIl
+cIl
+nUm
+nUm
+cIl
+nUm
+nUm
+cIl
+cIl
+cIl
+cIl
 wXM
 xMO
 xMO
@@ -50076,7 +50072,7 @@ hIT
 hIT
 hIT
 sgB
-gkW
+gem
 dRZ
 ujc
 ujc
@@ -50093,7 +50089,7 @@ qxc
 qxc
 mpr
 qxc
-ria
+wJw
 ngM
 eTo
 eTo
@@ -50108,7 +50104,7 @@ nHH
 nHH
 kJy
 qne
-cQu
+cIl
 tdT
 qrQ
 qrQ
@@ -50118,7 +50114,7 @@ aKM
 qrQ
 qrQ
 ylX
-cQu
+cIl
 wXM
 wXM
 wXM
@@ -50309,7 +50305,7 @@ hIT
 aje
 hIT
 bou
-kMS
+jvl
 lXE
 ehQ
 mlP
@@ -50326,7 +50322,7 @@ vsV
 pOW
 gYJ
 vsV
-gkW
+gem
 eTo
 eTo
 eTo
@@ -50341,7 +50337,7 @@ rJI
 fhx
 ugT
 qne
-cFQ
+nUm
 fcG
 pzo
 pzo
@@ -50351,7 +50347,7 @@ pzo
 pzo
 pzo
 dhf
-cQu
+cIl
 rgm
 rgm
 rgm
@@ -50559,7 +50555,7 @@ gYJ
 hkb
 gYJ
 vsV
-gkW
+gem
 eTo
 eTo
 eTo
@@ -50574,7 +50570,7 @@ gHV
 pbC
 ugT
 qne
-cFQ
+nUm
 fcG
 pzo
 pzo
@@ -50584,11 +50580,11 @@ bnK
 pzo
 pzo
 lrw
-cQu
-cQu
-cFQ
-cQu
-cQu
+cIl
+cIl
+nUm
+cIl
+cIl
 eTo
 pUx
 ylo
@@ -50792,7 +50788,7 @@ nng
 cOh
 imi
 xLQ
-gkW
+gem
 eTo
 eTo
 eTo
@@ -50807,7 +50803,7 @@ gHV
 pbC
 ugT
 qne
-cFQ
+nUm
 fcG
 rHt
 pzo
@@ -50821,7 +50817,7 @@ pSu
 pSu
 cvs
 pSu
-cQu
+cIl
 eTo
 pUx
 pUx
@@ -51040,7 +51036,7 @@ num
 fhx
 ugT
 qne
-cQu
+cIl
 rSQ
 pzo
 pzo
@@ -51054,7 +51050,7 @@ pzo
 jVi
 rHt
 kyH
-cQu
+cIl
 eTo
 eTo
 pUx
@@ -51241,7 +51237,7 @@ hIT
 hIT
 uRB
 pNC
-gkW
+gem
 lxq
 prR
 dIR
@@ -51273,7 +51269,7 @@ num
 nHH
 ugT
 qne
-cFQ
+nUm
 tsj
 ciw
 gER
@@ -51287,7 +51283,7 @@ pzo
 pzo
 pzo
 ajC
-cQu
+cIl
 eTo
 eTo
 eTo
@@ -51474,7 +51470,7 @@ hIT
 hIT
 hIT
 sgB
-gkW
+gem
 jdR
 mlP
 ehQ
@@ -51487,11 +51483,11 @@ thf
 quC
 xng
 ohT
-gkW
-gkW
-gkW
-gkW
-gkW
+gem
+gem
+gem
+gem
+gem
 eTo
 eTo
 pUx
@@ -51520,7 +51516,7 @@ jpC
 nrk
 jpC
 eAh
-cQu
+cIl
 eTo
 ngM
 eTo
@@ -51707,7 +51703,7 @@ hIT
 rQD
 hIT
 sgB
-gkW
+gem
 inQ
 rVY
 ehQ
@@ -51720,7 +51716,7 @@ hfz
 hfz
 cBO
 wQy
-gkW
+gem
 dum
 dum
 dum
@@ -51753,7 +51749,7 @@ eAh
 xCd
 xYg
 xFo
-cQu
+cIl
 eTo
 eTo
 eTo
@@ -51940,7 +51936,7 @@ ghU
 aje
 hIT
 sgB
-kMS
+jvl
 lBH
 ctN
 dNv
@@ -51972,7 +51968,7 @@ hBq
 nHH
 sEo
 qne
-cFQ
+nUm
 tsj
 pzo
 eAh
@@ -51986,7 +51982,7 @@ djh
 jlJ
 cfL
 cXM
-cQu
+cIl
 eTo
 eTo
 rxl
@@ -52173,7 +52169,7 @@ cJW
 hIT
 hIT
 sgB
-kMS
+jvl
 cFG
 gMI
 dIR
@@ -52205,7 +52201,7 @@ nHH
 nHH
 sEo
 qne
-cQu
+cIl
 ibg
 pzo
 eAh
@@ -52219,7 +52215,7 @@ eAh
 kyc
 lSA
 qnv
-cQu
+cIl
 ngM
 eTo
 rxl
@@ -52406,7 +52402,7 @@ hIT
 hIT
 hIT
 lEa
-kMS
+jvl
 inQ
 rVY
 ehQ
@@ -52438,7 +52434,7 @@ eTo
 ngM
 sEo
 qne
-cFQ
+nUm
 gbc
 pzo
 eAh
@@ -52448,11 +52444,11 @@ dCD
 eAh
 pzo
 vgc
-cQu
-cQu
-cQu
-cQu
-cQu
+cIl
+cIl
+cIl
+cIl
+cIl
 eTo
 rxl
 rxl
@@ -52639,7 +52635,7 @@ hIT
 hIT
 hIT
 sgB
-kMS
+jvl
 mLY
 xng
 mlZ
@@ -52671,7 +52667,7 @@ jCz
 eTo
 sEo
 qne
-cFQ
+nUm
 gbc
 pzo
 jpC
@@ -52681,7 +52677,7 @@ jpj
 jpC
 jVi
 bcN
-cQu
+cIl
 asm
 eTo
 eTo
@@ -52872,7 +52868,7 @@ hIT
 hIT
 hIT
 tcA
-gkW
+gem
 nDT
 gMI
 tFK
@@ -52885,7 +52881,7 @@ mlP
 nUH
 uhg
 jtd
-gkW
+gem
 wXy
 qne
 aXw
@@ -52904,7 +52900,7 @@ eTo
 tvj
 sEo
 fok
-cFQ
+nUm
 wVe
 rHt
 itn
@@ -52914,7 +52910,7 @@ pzo
 itn
 pzo
 bDh
-cFQ
+nUm
 pJc
 eTo
 eTo
@@ -53105,20 +53101,20 @@ hIT
 aje
 hIT
 wzH
-gkW
-gkW
-gkW
+gem
+gem
+gem
 oNd
-kMS
-kMS
+jvl
+jvl
 oNd
 oNd
 sod
 khT
-kMS
-kMS
-gkW
-gkW
+jvl
+jvl
+gem
+gem
 baO
 qne
 pJc
@@ -53137,7 +53133,7 @@ tvj
 dum
 sEo
 qne
-cQu
+cIl
 mxa
 dbe
 pjL
@@ -53147,7 +53143,7 @@ dbe
 dbe
 mCB
 lUg
-cQu
+cIl
 pJc
 eTo
 eTo
@@ -53370,17 +53366,17 @@ dum
 dum
 sEo
 qne
-cQu
-cQu
+cIl
+cIl
 pzo
 jXW
-cFQ
-cFQ
-cFQ
+nUm
+nUm
+nUm
 pzo
 jXW
-cQu
-cQu
+cIl
+cIl
 pJc
 eTo
 eTo

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -3742,6 +3742,10 @@
 "cFH" = (
 /turf/open/floor/plating,
 /area/magmoor/compound/north)
+"cFQ" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/arrival)
 "cGh" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
@@ -3968,6 +3972,9 @@
 "cQo" = (
 /turf/open/floor/tile/neutral,
 /area/magmoor/civilian/pool)
+"cQu" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/arrival)
 "cQv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5204,7 +5211,7 @@
 	},
 /area/magmoor/civilian/arrival/east)
 "dGw" = (
-/obj/structure/window/framed/colony,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark2,
 /area/magmoor/hydroponics/north)
 "dGx" = (
@@ -8823,6 +8830,9 @@
 	dir = 1
 	},
 /area/magmoor/cargo/processing/south)
+"gkW" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/bar)
 "glm" = (
 /obj/structure/curtain/medical,
 /obj/machinery/shower{
@@ -14844,6 +14854,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/north)
+"kMS" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/bar)
 "kNv" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/prop/mainship/hangar_stencil/two,
@@ -15197,6 +15211,12 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
+"kZf" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/hydroponics/north)
+"kZn" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/basket)
 "kZC" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -15498,6 +15518,10 @@
 	},
 /turf/open/floor/mainship,
 /area/magmoor/landing/two)
+"lkv" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/cryostasis)
 "llf" = (
 /obj/machinery/smartfridge,
 /turf/open/floor/plating,
@@ -18611,7 +18635,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/volcano)
 "nHf" = (
-/obj/structure/window_frame/colony,
+/obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/magmoor/civilian/basket)
@@ -19219,7 +19243,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi)
 "oin" = (
-/obj/structure/window/framed/colony,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/hydroponics/south)
 "oiq" = (
@@ -19256,6 +19280,9 @@
 "oiI" = (
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/thermal)
+"oiQ" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/rnr)
 "ojh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20132,7 +20159,7 @@
 /turf/open/floor/tile/dark2,
 /area/magmoor/civilian/mosque)
 "oNd" = (
-/obj/structure/window_frame/colony,
+/obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/magmoor/civilian/bar)
@@ -20730,7 +20757,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/magmoor/engi/power)
 "piK" = (
-/obj/structure/window_frame/colony,
+/obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/magmoor/civilian/rnr)
@@ -22743,6 +22770,9 @@
 	dir = 8
 	},
 /area/magmoor/compound/southwest)
+"qBq" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/gambling)
 "qBL" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
@@ -23443,6 +23473,9 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/magmoor/command/office/main)
+"ria" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/cook)
 "riq" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -24673,6 +24706,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/magmoor/engi/thermal)
+"sgr" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/hydroponics/south)
 "sgy" = (
 /obj/item/ammo_casing,
 /turf/open/floor/mainship/mono,
@@ -26677,6 +26713,9 @@
 	},
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound/east)
+"tFD" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/civilian/cryostasis)
 "tFK" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/landmark/weed_node,
@@ -27894,6 +27933,10 @@
 	dir = 8
 	},
 /area/magmoor/civilian/dorms)
+"uuw" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/civilian/rnr)
 "uuH" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -30209,7 +30252,7 @@
 /turf/open/floor/wood,
 /area/magmoor/medical/lobby)
 "wgR" = (
-/obj/structure/window_frame/colony,
+/obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/magmoor/hydroponics/south)
@@ -30663,7 +30706,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
 "wAw" = (
-/obj/structure/window/framed/colony,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/civilian/basket)
 "wAA" = (
@@ -39762,11 +39805,11 @@ dze
 dze
 dRz
 vzO
-dff
+kZf
 auq
 tva
 prG
-dff
+kZf
 ybU
 ybU
 eau
@@ -39994,13 +40037,13 @@ pDq
 dze
 tky
 vzO
-dff
-dff
-dff
+kZf
+kZf
+kZf
 qVx
-dff
-dff
-dff
+kZf
+kZf
+kZf
 ybU
 vzO
 ybU
@@ -40227,13 +40270,13 @@ ibO
 pDq
 tky
 ybU
-dff
+kZf
 uVx
 kDI
 uQr
 lOM
 gaP
-dff
+kZf
 ybU
 ybU
 ybU
@@ -40460,13 +40503,13 @@ dze
 dze
 tky
 ybU
-dff
+kZf
 fVD
 hoy
 kiC
 iOh
 uvK
-dff
+kZf
 ybU
 ygU
 ybU
@@ -40693,27 +40736,27 @@ dze
 dze
 caN
 vzO
-dff
+kZf
 ndK
 hpj
 pCR
 iOh
 lnZ
-dff
+kZf
 ybU
 ybU
 ybU
-fme
-fme
-fme
-fme
-fme
-fme
-fme
-fme
-fme
-fme
-fme
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
+sgr
 ybU
 fkP
 dRz
@@ -40724,15 +40767,15 @@ ybU
 ybU
 ygU
 ybU
-fBc
-fBc
-vpI
-fBc
-vpI
-fBc
-vpI
-fBc
-fBc
+tFD
+tFD
+lkv
+tFD
+lkv
+tFD
+lkv
+tFD
+tFD
 eCB
 rgm
 rgm
@@ -40926,17 +40969,17 @@ dze
 dze
 tky
 ybU
-dff
+kZf
 fVD
 iOh
 cpe
 iOh
 quD
-dff
+kZf
 ybU
 vzO
 ybU
-fme
+sgr
 cTq
 xTu
 xTu
@@ -40946,18 +40989,18 @@ iui
 cZk
 rDU
 fGJ
-bVz
-bVz
-aWz
-aWz
-bVz
+oiQ
+oiQ
+uuw
+uuw
+oiQ
 lCK
 ayv
-bVz
-aWz
+oiQ
+uuw
 piK
-bVz
-bVz
+oiQ
+oiQ
 kTv
 kTv
 kTv
@@ -40965,7 +41008,7 @@ kTv
 kTv
 kTv
 kTv
-fBc
+tFD
 xlX
 rgm
 eak
@@ -41159,13 +41202,13 @@ pDq
 dze
 tky
 ybU
-dff
+kZf
 tNC
 fZp
 cpe
 enm
 gZR
-dff
+kZf
 ybU
 ygU
 ybU
@@ -41198,7 +41241,7 @@ vji
 vji
 vji
 vji
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -41398,11 +41441,11 @@ qlq
 lRr
 eXn
 kDI
-dff
+kZf
 ybU
 ybU
 ybU
-fme
+sgr
 cOn
 xTu
 elf
@@ -41431,7 +41474,7 @@ vpI
 fBc
 vpI
 fBc
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -41625,17 +41668,17 @@ dze
 dze
 tky
 ybU
-dff
+kZf
 fVD
 iOh
 pqI
 iOh
 uvK
-dff
-dff
+kZf
+kZf
 wwE
-dff
-fme
+kZf
+sgr
 bfP
 xTu
 xTu
@@ -41664,7 +41707,7 @@ xoI
 uyh
 bbw
 odV
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -41858,7 +41901,7 @@ dze
 pDq
 caN
 ybU
-dff
+kZf
 fVD
 iOh
 leF
@@ -41897,7 +41940,7 @@ nBm
 nBm
 dep
 tSL
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -42130,7 +42173,7 @@ qrP
 tXy
 ceG
 azw
-vpI
+lkv
 mQq
 eCB
 eak
@@ -42324,7 +42367,7 @@ dze
 dze
 tky
 ybU
-dff
+kZf
 llg
 cbr
 csb
@@ -42363,7 +42406,7 @@ sWI
 qhp
 vlF
 vlF
-vpI
+lkv
 avf
 eCB
 wSW
@@ -42557,17 +42600,17 @@ dze
 dze
 tky
 ybU
-dff
-dff
-dff
-dff
-dff
-dff
-dff
-dff
+kZf
+kZf
+kZf
+kZf
+kZf
+kZf
+kZf
+kZf
 tEv
-dff
-fme
+kZf
+sgr
 aXZ
 xTu
 aXZ
@@ -42596,7 +42639,7 @@ cul
 srz
 oEb
 ejQ
-fBc
+tFD
 mQq
 eyI
 wSW
@@ -42800,7 +42843,7 @@ ybU
 ybU
 ybU
 ygU
-fme
+sgr
 ioE
 xTu
 ioE
@@ -42829,7 +42872,7 @@ tAW
 tAW
 efo
 sWI
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -43062,7 +43105,7 @@ pwX
 tyH
 pwX
 jdI
-fBc
+tFD
 mQq
 eCB
 wSW
@@ -43266,7 +43309,7 @@ jaT
 ibO
 dRz
 ybU
-fme
+sgr
 wbx
 xTu
 ioE
@@ -43295,7 +43338,7 @@ tyH
 tyH
 tyH
 tyH
-fBc
+tFD
 mQq
 eCB
 eak
@@ -43498,8 +43541,8 @@ tWr
 dze
 tky
 ybU
-eXi
-eXi
+kZn
+kZn
 eXi
 eXi
 eXi
@@ -43528,7 +43571,7 @@ xZj
 pwX
 fjI
 pwX
-fBc
+tFD
 mQq
 eCB
 rgm
@@ -43731,7 +43774,7 @@ ybU
 dze
 tky
 ybU
-eXi
+kZn
 nrb
 cao
 crA
@@ -43761,8 +43804,8 @@ fBc
 fBc
 fBc
 fBc
-fBc
-fBc
+tFD
+tFD
 eCB
 rgm
 rgm
@@ -43995,7 +44038,7 @@ roE
 uXF
 roE
 anq
-eNf
+qBq
 xlX
 rgm
 rgm
@@ -44228,7 +44271,7 @@ xRt
 saX
 kfI
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -44430,7 +44473,7 @@ mhS
 fkP
 dze
 alo
-eXi
+kZn
 euS
 nov
 lin
@@ -44461,7 +44504,7 @@ roE
 kfI
 pLX
 jeO
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -44663,7 +44706,7 @@ tDP
 ybU
 bGe
 caN
-eXi
+kZn
 tXn
 dVo
 dVo
@@ -44694,7 +44737,7 @@ xRt
 kfI
 kfI
 roE
-eNf
+qBq
 avf
 eCB
 rgm
@@ -44896,7 +44939,7 @@ mhS
 ybU
 bGe
 tky
-eXi
+kZn
 cao
 dVo
 dVo
@@ -44927,7 +44970,7 @@ mSO
 agS
 agS
 roE
-eNf
+qBq
 jyA
 rgm
 rgm
@@ -45160,7 +45203,7 @@ tbP
 gGK
 uQH
 roE
-eNf
+qBq
 xlX
 rgm
 rgm
@@ -45393,7 +45436,7 @@ uXF
 roE
 ucS
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -45595,7 +45638,7 @@ tDP
 ybU
 bGe
 tky
-eXi
+kZn
 cao
 vVM
 lBX
@@ -45626,7 +45669,7 @@ kfI
 roE
 ucS
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -45828,7 +45871,7 @@ qNj
 ybU
 fkP
 dRz
-eXi
+kZn
 tXn
 dVo
 dVo
@@ -45859,7 +45902,7 @@ bGT
 jeO
 ucS
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -46061,7 +46104,7 @@ tDP
 ybU
 ybU
 ybU
-eXi
+kZn
 lsp
 tvO
 ovw
@@ -46092,7 +46135,7 @@ roE
 roE
 ucS
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -46325,7 +46368,7 @@ qxc
 roE
 csn
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -46558,7 +46601,7 @@ tWO
 mSO
 gGn
 roE
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -46760,7 +46803,7 @@ kkl
 vto
 cJW
 hIT
-eXi
+kZn
 nrb
 cao
 crA
@@ -46791,7 +46834,7 @@ qxc
 roE
 jrE
 euH
-eNf
+qBq
 mQq
 eCB
 rgm
@@ -46993,18 +47036,18 @@ cJW
 aje
 hIT
 hIT
-eXi
-eXi
+kZn
+kZn
 wAw
-eXi
-eXi
-eXi
+kZn
+kZn
+kZn
 wAw
-eXi
-eXi
+kZn
+kZn
 pbS
-eXi
-bVz
+kZn
+oiQ
 liW
 lCK
 hCY
@@ -47020,11 +47063,11 @@ wkW
 uhj
 rew
 jNn
-qxc
-eNf
-eNf
-eNf
-eNf
+ria
+qBq
+qBq
+qBq
+qBq
 jyA
 rgm
 rgm
@@ -47237,7 +47280,7 @@ aje
 fIr
 wph
 xmr
-bVz
+oiQ
 lCK
 lCK
 ebH
@@ -47253,7 +47296,7 @@ qxc
 gio
 kpz
 pRU
-qxc
+ria
 rgm
 lWM
 rgm
@@ -47470,7 +47513,7 @@ cax
 tmQ
 wph
 xmr
-bVz
+oiQ
 kyy
 dJw
 bpb
@@ -47486,7 +47529,7 @@ gio
 gio
 tYY
 gio
-qxc
+ria
 kVV
 pLo
 eCB
@@ -47703,7 +47746,7 @@ hzB
 yhx
 kyT
 nuY
-bVz
+oiQ
 aRq
 dJw
 dJw
@@ -47719,7 +47762,7 @@ sci
 jIy
 gio
 ujS
-qxc
+ria
 rgm
 rMC
 rgm
@@ -47936,7 +47979,7 @@ wyb
 wyb
 wyb
 kIw
-ohT
+gkW
 ohT
 woH
 ohT
@@ -47952,8 +47995,8 @@ qxc
 qxc
 qxc
 oJD
-qxc
-qxc
+ria
+ria
 rgm
 rgm
 rgm
@@ -48169,7 +48212,7 @@ rKd
 rKd
 ghU
 hIT
-ohT
+gkW
 mOs
 ehQ
 vuR
@@ -48186,7 +48229,7 @@ rMh
 eVt
 leY
 slj
-qxc
+ria
 wXM
 wXM
 wXM
@@ -48402,7 +48445,7 @@ hiG
 hiG
 bgh
 ghU
-woH
+kMS
 oAR
 ehQ
 mlP
@@ -48419,7 +48462,7 @@ bzq
 cJq
 bTc
 ckk
-qxc
+ria
 xMO
 xMO
 xMO
@@ -48635,7 +48678,7 @@ vFy
 vFy
 vFy
 vFy
-woH
+kMS
 cAw
 ehQ
 fLe
@@ -48868,7 +48911,7 @@ syD
 syD
 syD
 syD
-woH
+kMS
 vSf
 ehQ
 ehQ
@@ -49101,7 +49144,7 @@ dSO
 mnY
 mnY
 mnY
-woH
+kMS
 aGz
 ehQ
 ehQ
@@ -49118,7 +49161,7 @@ dJd
 xjx
 abL
 sNp
-qxc
+ria
 rgm
 rgm
 rgm
@@ -49334,7 +49377,7 @@ hiG
 hiG
 hiG
 hiG
-ohT
+gkW
 tjh
 mlP
 tct
@@ -49351,7 +49394,7 @@ bXb
 umc
 oLQ
 mbs
-qxc
+ria
 rgm
 rgm
 rgm
@@ -49567,7 +49610,7 @@ hiG
 noo
 bgh
 hiG
-ohT
+gkW
 lpK
 ehQ
 wEz
@@ -49584,7 +49627,7 @@ bXb
 umc
 sSX
 eyU
-qxc
+ria
 rgm
 rgm
 rgm
@@ -49800,7 +49843,7 @@ cJW
 hIT
 pKb
 hiG
-ohT
+gkW
 ehQ
 ehQ
 dIR
@@ -49817,7 +49860,7 @@ ayS
 tHq
 umc
 oAE
-qxc
+ria
 rgm
 rgm
 rgm
@@ -49832,17 +49875,17 @@ bOC
 pLo
 ugT
 aQh
-jpC
-jpC
-eAh
-eAh
-jpC
-eAh
-eAh
-jpC
-jpC
-jpC
-jpC
+cQu
+cQu
+cFQ
+cFQ
+cQu
+cFQ
+cFQ
+cQu
+cQu
+cQu
+cQu
 wXM
 xMO
 xMO
@@ -50033,7 +50076,7 @@ hIT
 hIT
 hIT
 sgB
-ohT
+gkW
 dRZ
 ujc
 ujc
@@ -50050,7 +50093,7 @@ qxc
 qxc
 mpr
 qxc
-qxc
+ria
 ngM
 eTo
 eTo
@@ -50065,7 +50108,7 @@ nHH
 nHH
 kJy
 qne
-jpC
+cQu
 tdT
 qrQ
 qrQ
@@ -50075,7 +50118,7 @@ aKM
 qrQ
 qrQ
 ylX
-jpC
+cQu
 wXM
 wXM
 wXM
@@ -50266,7 +50309,7 @@ hIT
 aje
 hIT
 bou
-woH
+kMS
 lXE
 ehQ
 mlP
@@ -50283,7 +50326,7 @@ vsV
 pOW
 gYJ
 vsV
-ohT
+gkW
 eTo
 eTo
 eTo
@@ -50298,7 +50341,7 @@ rJI
 fhx
 ugT
 qne
-eAh
+cFQ
 fcG
 pzo
 pzo
@@ -50308,7 +50351,7 @@ pzo
 pzo
 pzo
 dhf
-jpC
+cQu
 rgm
 rgm
 rgm
@@ -50516,7 +50559,7 @@ gYJ
 hkb
 gYJ
 vsV
-ohT
+gkW
 eTo
 eTo
 eTo
@@ -50531,7 +50574,7 @@ gHV
 pbC
 ugT
 qne
-eAh
+cFQ
 fcG
 pzo
 pzo
@@ -50541,11 +50584,11 @@ bnK
 pzo
 pzo
 lrw
-jpC
-jpC
-eAh
-jpC
-jpC
+cQu
+cQu
+cFQ
+cQu
+cQu
 eTo
 pUx
 ylo
@@ -50749,7 +50792,7 @@ nng
 cOh
 imi
 xLQ
-ohT
+gkW
 eTo
 eTo
 eTo
@@ -50764,7 +50807,7 @@ gHV
 pbC
 ugT
 qne
-eAh
+cFQ
 fcG
 rHt
 pzo
@@ -50778,7 +50821,7 @@ pSu
 pSu
 cvs
 pSu
-jpC
+cQu
 eTo
 pUx
 pUx
@@ -50997,7 +51040,7 @@ num
 fhx
 ugT
 qne
-jpC
+cQu
 rSQ
 pzo
 pzo
@@ -51011,7 +51054,7 @@ pzo
 jVi
 rHt
 kyH
-jpC
+cQu
 eTo
 eTo
 pUx
@@ -51198,7 +51241,7 @@ hIT
 hIT
 uRB
 pNC
-ohT
+gkW
 lxq
 prR
 dIR
@@ -51230,7 +51273,7 @@ num
 nHH
 ugT
 qne
-eAh
+cFQ
 tsj
 ciw
 gER
@@ -51244,7 +51287,7 @@ pzo
 pzo
 pzo
 ajC
-jpC
+cQu
 eTo
 eTo
 eTo
@@ -51431,7 +51474,7 @@ hIT
 hIT
 hIT
 sgB
-ohT
+gkW
 jdR
 mlP
 ehQ
@@ -51444,11 +51487,11 @@ thf
 quC
 xng
 ohT
-ohT
-ohT
-ohT
-ohT
-ohT
+gkW
+gkW
+gkW
+gkW
+gkW
 eTo
 eTo
 pUx
@@ -51477,7 +51520,7 @@ jpC
 nrk
 jpC
 eAh
-jpC
+cQu
 eTo
 ngM
 eTo
@@ -51664,7 +51707,7 @@ hIT
 rQD
 hIT
 sgB
-ohT
+gkW
 inQ
 rVY
 ehQ
@@ -51677,7 +51720,7 @@ hfz
 hfz
 cBO
 wQy
-ohT
+gkW
 dum
 dum
 dum
@@ -51710,7 +51753,7 @@ eAh
 xCd
 xYg
 xFo
-jpC
+cQu
 eTo
 eTo
 eTo
@@ -51897,7 +51940,7 @@ ghU
 aje
 hIT
 sgB
-woH
+kMS
 lBH
 ctN
 dNv
@@ -51929,7 +51972,7 @@ hBq
 nHH
 sEo
 qne
-eAh
+cFQ
 tsj
 pzo
 eAh
@@ -51943,7 +51986,7 @@ djh
 jlJ
 cfL
 cXM
-jpC
+cQu
 eTo
 eTo
 rxl
@@ -52130,7 +52173,7 @@ cJW
 hIT
 hIT
 sgB
-woH
+kMS
 cFG
 gMI
 dIR
@@ -52162,7 +52205,7 @@ nHH
 nHH
 sEo
 qne
-jpC
+cQu
 ibg
 pzo
 eAh
@@ -52176,7 +52219,7 @@ eAh
 kyc
 lSA
 qnv
-jpC
+cQu
 ngM
 eTo
 rxl
@@ -52363,7 +52406,7 @@ hIT
 hIT
 hIT
 lEa
-woH
+kMS
 inQ
 rVY
 ehQ
@@ -52395,7 +52438,7 @@ eTo
 ngM
 sEo
 qne
-eAh
+cFQ
 gbc
 pzo
 eAh
@@ -52405,11 +52448,11 @@ dCD
 eAh
 pzo
 vgc
-jpC
-jpC
-jpC
-jpC
-jpC
+cQu
+cQu
+cQu
+cQu
+cQu
 eTo
 rxl
 rxl
@@ -52596,7 +52639,7 @@ hIT
 hIT
 hIT
 sgB
-woH
+kMS
 mLY
 xng
 mlZ
@@ -52628,7 +52671,7 @@ jCz
 eTo
 sEo
 qne
-eAh
+cFQ
 gbc
 pzo
 jpC
@@ -52638,7 +52681,7 @@ jpj
 jpC
 jVi
 bcN
-jpC
+cQu
 asm
 eTo
 eTo
@@ -52829,7 +52872,7 @@ hIT
 hIT
 hIT
 tcA
-ohT
+gkW
 nDT
 gMI
 tFK
@@ -52842,7 +52885,7 @@ mlP
 nUH
 uhg
 jtd
-ohT
+gkW
 wXy
 qne
 aXw
@@ -52861,7 +52904,7 @@ eTo
 tvj
 sEo
 fok
-eAh
+cFQ
 wVe
 rHt
 itn
@@ -52871,7 +52914,7 @@ pzo
 itn
 pzo
 bDh
-eAh
+cFQ
 pJc
 eTo
 eTo
@@ -53062,20 +53105,20 @@ hIT
 aje
 hIT
 wzH
-ohT
-ohT
-ohT
+gkW
+gkW
+gkW
 oNd
-woH
-woH
+kMS
+kMS
 oNd
 oNd
 sod
 khT
-woH
-woH
-ohT
-ohT
+kMS
+kMS
+gkW
+gkW
 baO
 qne
 pJc
@@ -53094,7 +53137,7 @@ tvj
 dum
 sEo
 qne
-jpC
+cQu
 mxa
 dbe
 pjL
@@ -53104,7 +53147,7 @@ dbe
 dbe
 mCB
 lUg
-jpC
+cQu
 pJc
 eTo
 eTo
@@ -53327,17 +53370,17 @@ dum
 dum
 sEo
 qne
-jpC
-jpC
+cQu
+cQu
 pzo
 jXW
-eAh
-eAh
-eAh
+cFQ
+cFQ
+cFQ
 pzo
 jXW
-jpC
-jpC
+cQu
+cQu
 pJc
 eTo
 eTo


### PR DESCRIPTION
## About The Pull Request
Changes the externals of the two buildings outside the left LZ to reinforced walls.

<details>
<summary> Images </summary>

<img width="282" alt="magmoor" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/bdb58024-bec9-4f0c-8dd1-b96af11dc4d3">
<img width="527" alt="magmoor5" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/e242b23a-a71d-43d8-8825-87fc08506751">
<img width="391" alt="magmoor3" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/3cb25de0-5ecc-4099-a852-78209e642680">
<img width="287" alt="magmoor4" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/06359c36-b6ed-42af-a124-f4ee3d681e61">
</details>

## Why It's Good For The Game
This LZ can become a nightmare to assault for xenos if marines flatten these two buildings, which is extremely easy considering they are both entirely regular walls. Making the externals of these two buildings reinforced should hopefully reduce the instances of flattened battlefields while still allowing marines to OB and gut these buildings if they need to hold inside them for whatever reason.
## Changelog
:cl:
balance: Reinforced the external walls of two buildings on Magmoor.
/:cl:
