### PR TITLE
Adds some adjacency sanity to some xeno abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -26,7 +26,7 @@
 	X.create_stomp() //Adds the visual effect. Wom wom wom
 
 	for(var/mob/living/M in range(1, get_turf(X)))
-		if(X.issamexenohive(M) || M.stat == DEAD || isnestedhost(M))
+		if(X.issamexenohive(M) || M.stat == DEAD || isnestedhost(M) || !Adjacent(M))
 			continue
 		var/distance = get_dist(M, X)
 		var/damage = X.xeno_caste.stomp_damage/max(1, distance + 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -37,7 +37,7 @@
 	var/list/L = orange(sweep_range, X)		// Not actually the fruit
 
 	for (var/mob/living/carbon/human/H in L)
-		if(H.stat == DEAD)
+		if(H.stat == DEAD || !Adjacent(H))
 			continue
 		H.add_filter("defender_tail_sweep", 2, gauss_blur_filter(1)) //Add cool SFX; motion blur
 		addtimer(CALLBACK(H, TYPE_PROC_REF(/atom, remove_filter), "defender_tail_sweep"), 0.5 SECONDS) //Remove cool SFX

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -114,7 +114,7 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
-		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE))
+		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !Adjacent(ravaged))
 			continue
 		if(!ishuman(ravaged))
 			ravaged.attack_alien(X, X.xeno_caste.melee_damage)


### PR DESCRIPTION

## About The Pull Request

Fixes tail sweep, crusher stomp and ravager ravage going through walls if the person being affected by them is standing in a missing corner.

Before
https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/0e5d7c4e-b561-48ac-9ca1-0c1b84e4e2eb

After
https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/bb310afb-8f03-4423-bd96-b8904a83f361
## Why It's Good For The Game

Bug bad
## Changelog
:cl:
fix: Xenos abilities shouldn't go through missing corners anymore
/:cl:
