### PR TITLE
Removes High-Tier Xenomorph Research Samples

### DIFF
--- a/code/game/objects/effects/landmarks/excavation_site_spawner.dm
+++ b/code/game/objects/effects/landmarks/excavation_site_spawner.dm
@@ -52,5 +52,5 @@
 	rewards_max = 4
 	map_icon = "excav_xeno"
 	rewards = list(
-		/obj/item/research_resource/xeno/tier_one,
+		/obj/item/research_resource/xeno,
 	)

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -248,16 +248,10 @@
 	)
 
 /obj/item/research_resource/xeno
+	name = "Xenomorph research material"
 	research_type = RES_XENO
 	icon = 'icons/obj/alien_autopsy.dmi'
 	icon_state = "sample_0"
-
-/obj/item/research_resource/xeno/Initialize(mapload)
-	. = ..()
-	icon_state = "sample_[rand(0, 11)]"
-
-/obj/item/research_resource/xeno/tier_one
-	name = "Xenomorph research material - tier 1"
 	color = "#f0bee3"
 	reward_probs = list(
 		RES_TIER_BASIC = 100,
@@ -266,35 +260,9 @@
 		RES_TIER_RARE = 1,
 	)
 
-/obj/item/research_resource/xeno/tier_two
-	name = "Xenomorph research material - tier 2"
-	color = "#d6e641"
-	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 40,
-		RES_TIER_UNCOMMON = 20,
-		RES_TIER_RARE = 6,
-	)
-
-/obj/item/research_resource/xeno/tier_three
-	name = "Xenomorph research material - tier 3"
-	color = "#e43939"
-	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 50,
-		RES_TIER_UNCOMMON = 40,
-		RES_TIER_RARE = 10,
-	)
-
-/obj/item/research_resource/xeno/tier_four
-	name = "Xenomorph research material - tier 4"
-	color = "#a800ad"
-	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 50,
-		RES_TIER_UNCOMMON = 40,
-		RES_TIER_RARE = 50,
-	)
+/obj/item/research_resource/xeno/Initialize(mapload)
+	. = ..()
+	icon_state = "sample_[rand(0, 11)]"
 
 ///
 ///Items designed to be products of research


### PR DESCRIPTION
## About The Pull Request

Removes tier 2, 3, and 4 xenomorph research samples, and strikes the reference of being tier one from the remaining sample name.

## Why It's Good For The Game

Following the removal of probing, the only xenomorph sample capable of spawning is the tier one variant, through xenomorph excavation landmarks. This still spawns marked as a tier one sample, implying to players that the higher tier variants are still somehow available.
Removing any reference to being a tiered variant resolves this issue ("Xenomorph research sample - Tier one" to simply "Xenomorph research sample").
Additionally, since the higher tier variants are no longer available through gameplay, they have been removed from the research file to reduce clutter.
 
## Changelog

:cl:
del: Removed references to high-tier xenomorph research samples.
fix: Simplified the name of spawnable xenomorph research samples.
/:cl:
