### PR TITLE
Beginner loadout vendor in valhalla works.

### DIFF
--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -213,7 +213,9 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 				to_chat(usr, span_warning("This loadout has been depleted, you'll need to pick another."))
 				return
 			var/obj/item/card/id/user_id = usr.get_idcard() //ui.user better?
-			if(selected_loadout.jobtype != user_id.rank)
+			var/user_job = user_id.rank
+			user_job = replacetext(user_job, "Fallen ", "") //So that jobs in valhalla can vend a loadout too
+			if(selected_loadout.jobtype != user_job)
 				to_chat(usr, span_warning("You are not in the right job for this loadout!"))
 				return
 			if(user_id.flags_id & USED_GHMME) //Same check here, in case they opened the UI before vending a loadout somehow


### PR DESCRIPTION
## About The Pull Request
Fixes not being able to vend a beginner loadout in valhalla
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14451
## Why It's Good For The Game
Bugfix
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14451
## Changelog
:cl:
fix: Fix not being able to use the beginner loadout in valhalla
/:cl:
