### PR TITLE
FK-88 buff, and some housecleaning

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2144,16 +2144,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	explosion(T, 0, 0, 5, 0, 5)
 
 /datum/ammo/rocket/heavy_isg
-	name = "15cm round"
+	name = "8.8cm round"
 	icon_state = "heavyrr"
 	hud_state = "bigshell_he"
 	hud_state_empty = "shell_empty"
 	flags_ammo_behavior = AMMO_ROCKET|AMMO_EXPLOSIVE
-	damage = 50
+	damage = 100
 	penetration = 200
 	max_range = 30
 	shell_speed = 0.75
-	accuracy = 30
 	accurate_range = 21
 	handful_amount = 1
 
@@ -2165,15 +2164,14 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_ROCKET
 
 /datum/ammo/bullet/heavy_isg_apfds
-	name = "15cm APFDS round"
+	name = "8.8cm APFDS round"
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 200
+	damage = 275
 	penetration = 75
 	shell_speed = 7
 	accurate_range = 24
-	accurate_range_min = 6
 	max_range = 35
 
 /datum/ammo/bullet/isg_apfds/on_hit_turf(turf/T, obj/projectile/P)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -315,17 +315,17 @@ WEAPONS
 /datum/supply_packs/weapons/flak_gun
 	name = "FK-88 Flak Gun"
 	contains = list(/obj/item/weapon/gun/heavy_isg)
-	cost = 1200
+	cost = 1000
 
 /datum/supply_packs/weapons/flak_he
 	name = "FK-88 HE Shell"
 	contains = list(/obj/item/ammo_magazine/heavy_isg/he)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/weapons/flak_sabot
 	name = "FK-88 APFDS Shell"
 	contains = list(/obj/item/ammo_magazine/heavy_isg/sabot)
-	cost = 120
+	cost = 50
 
 /datum/supply_packs/weapons/heayvlaser_emplacement
 	name = "Mounted Heavy Laser"


### PR DESCRIPTION

## About The Pull Request
Does some ammo datum name housecleaning on the side so people stop bothering about the 8.8cm gun firing a 15cm shell.
Either way.

- APFDS
- damage 200->275
- penetration 70->50
- slowdown stays 0.5
- No longer has a minimum range.

- HE
- damage 50->100 (matches HE sadar)
## Why It's Good For The Game
FK-88 is insanely cost inefficent, I was too cautious cost wise so making it old sadar cost was a fools errand, 1000 points is a much fairer milestone to aim for, the ammo is also 50 points overall.
The ammo buffs are to make the ammo feel more high impact, you already have a high cost to entry, and the minimum range on AFPDS just makes it play silly as there's no real way for the player to tell that their shot missed due to the shell moving so quickly.
## Changelog
:cl:
balance: FK-88 Ammo changes. APFDS no longer has a minimum range, does 275 damage, has 20 less pen. HE does 100 damage, matching SADAR.
/:cl:
