### PR TITLE
AT mine tweaks

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -47,7 +47,7 @@ Stepping directly on the mine will also blow it up
 	icon_state = "[initial(icon_state)][armed ? "_armed" : ""]"
 
 /// On explosion mines trigger their own explosion, assuming there were not deleted straight away (larger explosions or probability)
-/obj/item/explosive/mine/ex_act()
+/obj/item/explosive/mine/ex_act(severity)
 	. = ..()
 	if(!QDELETED(src))
 		INVOKE_ASYNC(src, PROC_REF(trigger_explosion))
@@ -249,5 +249,27 @@ Stepping directly on the mine will also blow it up
 	QDEL_NULL(tripwire)
 	qdel(src)
 
-/obj/item/explosive/mine/anti_tank/ex_act()
-	qdel(src)
+/obj/item/explosive/mine/anti_tank/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			take_damage(INFINITY, BRUTE, BOMB, 0)
+			return
+		if(EXPLODE_HEAVY)
+			take_damage(rand(100, 250), BRUTE, BOMB, 0)
+			if(prob(25))
+				return
+		if(EXPLODE_LIGHT)
+			take_damage(rand(10, 90), BRUTE, BOMB, 0)
+			if(prob(50))
+				return
+		if(EXPLODE_WEAK)
+			take_damage(rand(5, 45), BRUTE, BOMB, 0)
+			return //not strong enough to detonate
+	if(QDELETED(src))
+		return
+	if(!armed)
+		return
+	INVOKE_ASYNC(src, PROC_REF(trigger_explosion))
+
+/obj/item/explosive/mine/anti_tank/flamer_fire_act(burnlevel)
+	return //its highly exploitable if fire detonates these


### PR DESCRIPTION

## About The Pull Request
Made some changes to accidental detonations.
Fire still cannot detonate AT mines, however light and medium explosions have a chance to do so if its armed (dev explosions will qdel it, and weak explosions are too weak).
## Why It's Good For The Game
A bit more interactivity, while still avoiding funny zack detonation hijinks.
## Changelog
:cl:
balance: Campaign: Light and medium explosions have a chance to detonate armed AT mines
/:cl:
