### PR TITLE
Medkit now fits in corpsman backpack/satchel

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -283,6 +283,8 @@
 	item_state = "marinepackm"
 	var/obj/item/cell/high/cell //Starts with a high capacity energy cell.
 	var/icon_skin
+	bypass_w_limit = list(/obj/item/storage/firstaid)
+	storage_type_limits = list(/obj/item/storage/firstaid = 1) //You can only hold 1 medkit
 
 /obj/item/storage/backpack/marine/corpsman/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Corpsman backpack/satchel can hold 1 medkit
## Why It's Good For The Game
Medics spawn with a useless medkit
I think it should be possible to bring it with you.
This might require some balance since it's giga slot efficient, but I think it should either be balanced+allowed in, or removed from their essentials kit.
## Changelog
:cl:
balance: Corpsman backpack/satchel can hold 1 medkit
/:cl:
