### PR TITLE
Hopefully fixes Transport Officer icon not showing in orbit menu

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(playable_icons, list(
 	"mech_pilot",
 	"medical",
 	"pilot",
+	"transportofficer",
 	"praetorian",
 	"private",
 	"puppeteer",


### PR DESCRIPTION

## About The Pull Request
What it says on the tin
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: Transport Officer icon should show in orbit menu
/:cl:
