### PR TITLE
Campaign light armor prereq fixes

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage.dm
@@ -101,7 +101,10 @@
 	req_desc = "Requires M-11 scout armor."
 	ui_icon = "smg"
 	item_typepath = /obj/item/weapon/gun/smg/som/scout
-	item_whitelist = list(/obj/item/clothing/suit/modular/som/light/shield = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/som/light/shield = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/som/light/shield_overclocked = ITEM_SLOT_OCLOTHING,
+	)
 
 /datum/loadout_item/suit_store/main_gun/som_marine/smg/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()
@@ -131,7 +134,10 @@
 	req_desc = "Requires M-11 scout armor."
 	ui_icon = "shotgun"
 	item_typepath = /obj/item/weapon/gun/shotgun/som/standard
-	item_whitelist = list(/obj/item/clothing/suit/modular/som/light/shield = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/som/light/shield = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/som/light/shield_overclocked = ITEM_SLOT_OCLOTHING,
+	)
 
 /datum/loadout_item/suit_store/main_gun/som_marine/standard_shotgun/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
@@ -402,7 +402,10 @@
 	req_desc = "Requires a light armour suit."
 	ui_icon = "lasergun"
 	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine/scout
-	item_whitelist = list(/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/xenonauten/light/shield_overclocked = ITEM_SLOT_OCLOTHING,
+	)
 
 /datum/loadout_item/suit_store/main_gun/marine/laser_carbine_scout/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()
@@ -436,7 +439,10 @@
 	req_desc = "Requires a light armour suit."
 	ui_icon = "ballistic"
 	item_typepath = /obj/item/weapon/gun/rifle/standard_carbine/scout
-	item_whitelist = list(/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/xenonauten/light/shield_overclocked = ITEM_SLOT_OCLOTHING,
+	)
 
 /datum/loadout_item/suit_store/main_gun/marine/scout_carbine/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()
@@ -526,7 +532,10 @@
 	req_desc = "Requires a light armour suit."
 	ui_icon = "scout"
 	item_typepath = /obj/item/weapon/gun/rifle/tx8/scout
-	item_whitelist = list(/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/xenonauten/light/shield = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/xenonauten/light/shield_overclocked = ITEM_SLOT_OCLOTHING,
+	)
 	purchase_cost = 100
 	quantity = 2
 


### PR DESCRIPTION

## About The Pull Request
Weapons that require light armour also work with upgraded light armour (with the better shields).
:cl:
fix: Campaign: Fixed some guns not working with upgraded shield light armour as expected
/:cl:
