### PR TITLE
Xeno spit is unstaggerable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -717,7 +717,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
 	)
-	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_BUCKLED|ABILITY_DO_AFTER_ATTACK
+	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_BUCKLED|ABILITY_DO_AFTER_ATTACK|ABILITY_USE_STAGGERED
 	target_flags = ABILITY_MOB_TARGET
 	///Current target that the xeno is targeting. This is for aiming.
 	var/current_target


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
Castes affected:
Sentinel
Hivelord
Spitter
Praetorian
## Why It's Good For The Game
Xeno spit is essentially the caste's basic attack, a ranged slash if you will. It trades perma damage and unlimited use (it has a plasma cost) while also helping prevent fractures for range. There is a good amount of ways to just shut down spit castes at medium range (slug, gl54 namely) and even more at close range. If this makes spit slash absurdly strong (queen already has the best of it with more HP and armor, being able to stay in melee for quite a long time) then I can tune down melee damage, however spit castes should be able to use their basic attack at range without being staggered out of it.
## Changelog
:cl:
balance: Xeno spit is unstaggerable
/:cl:
