### PR TITLE
client/New() actually deals with the nulls in the global client list instead of letting them stay

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -188,7 +188,7 @@
 	if(CONFIG_GET(flag/log_access))
 		for(var/I in GLOB.clients)
 			if(!I)
-				stack_trace("null in GLOB.clients during client/New()")
+				listclearnulls(GLOB.clients)
 				continue
 			if(I == src)
 				continue


### PR DESCRIPTION

## About The Pull Request

![Code_zp9mHMkdms](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/a01b2400-7ee9-4d37-9c4e-2224a0733276)

Instead of dealing with the nulls in the list, it'd just tell you... there were some. Very helpful.
## Why It's Good For The Game

Nulls in client list are horribly bad and can brick rounds until the server maint subsys gets to them
## Changelog
:cl:
fix: Nulls in the global client list shouldnt be as common anymore
/:cl:
