### PR TITLE
Fixes non-custom squad members being unable to talk on custom squad comms

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -421,8 +421,8 @@ GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 	var/freq = FREQ_CUSTOM_SQUAD_MIN + 2 * length(GLOB.custom_squad_radio_freqs)
 	if(freq > FREQ_CUSTOM_SQUAD_MAX)
 		return
-
-	var/new_id = lowertext(squad_name) + "_squad"
+	var/lowertext_name = lowertext(squad_name)
+	var/new_id = lowertext_name + "_squad"
 	if(SSjob.squads[new_id])
 		return
 
@@ -436,6 +436,21 @@ GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 	LAZYADDASSOCSIMPLE(GLOB.radiochannels, "[radio_channel_name]", freq)
 	LAZYADDASSOCSIMPLE(GLOB.reverseradiochannels, "[freq]", radio_channel_name)
 	new_squad.faction = squad_faction
+	var/key_prefix = lowertext_name[1]
+	if(GLOB.department_radio_keys[key_prefix])
+		for(var/letter in splittext(lowertext_name, ""))
+			if(!GLOB.department_radio_keys[letter])
+				key_prefix = letter
+				break
+		//okay... mustve been a very short name, randomly pick things from the alphabet now
+		for(var/letter in shuffle(GLOB.alphabet))
+			if(!GLOB.department_radio_keys[letter])
+				key_prefix = letter
+				break
+		key_prefix = "ERROR"
+	GLOB.department_radio_keys[key_prefix] = radio_channel_name
+	GLOB.channel_tokens[radio_channel_name] = ":[key_prefix]"
+
 	if(new_squad.faction == FACTION_TERRAGOV)
 		var/list/terragov_server_freqs = GLOB.telecomms_freq_listening_list[/obj/machinery/telecomms/server/presets/alpha]
 		var/list/terragov_bus_freqs = GLOB.telecomms_freq_listening_list[/obj/machinery/telecomms/bus/preset_three]


### PR DESCRIPTION
## About The Pull Request
Custom squads will now automatically pick the first most unused letter in the name: (e.g cool squad will be .o because .c is taken) the key can be found by examining your headset. people in the squad still have to use ; because im lazy and didnt fix it

## Changelog

:cl:
fix: Custom squads will now automatically pick the first most unused letter in the name: (e.g cool squad will be .o because .c is taken by charlie by default) the key can be found by examining your headset. people in the squad still have to use ; because im lazy and didnt fix it
/:cl:
