### PR TITLE
Adds a mortar bag to basic mortar kit

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -786,7 +786,7 @@
 	desc = "A crate containing a basic set of a mortar and some shells, to get an engineer started."
 
 /obj/structure/closet/crate/mortar_ammo/mortar_kit/PopulateContents()
-	new /obj/item/mortar_kit(src)
+	new /obj/item/storage/holster/backholster/mortar/full(src)
 	new /obj/item/mortal_shell/he(src)
 	new /obj/item/mortal_shell/he(src)
 	new /obj/item/mortal_shell/he(src)


### PR DESCRIPTION
## About The Pull Request
Replaces the mortar in the roundstart mortar kit with a full mortar bag
## Why It's Good For The Game

Mortar has poor long range accuracy. Frequently the roundstart mortar kit is operated from the FOB resulting in friendly fire incidents. 

This lets an ordinary marine operate the mortar kit near the frontlines. This how the tool is intended to be used. Encourages more coordinated and strategic mortar usage. Mortar is cool.
## Changelog
:cl:
balance: Mortar kit now includes a bag.
/:cl:
