### PR TITLE
Sunder multiplier

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -35,6 +35,10 @@
 	// *** Defense *** //
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 
+	// *** Sunder *** //
+	sunder_recover = 1
+	sunder_max = 50
+
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -36,8 +36,7 @@
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 
 	// *** Sunder *** //
-	sunder_recover = 1
-	sunder_max = 50
+	sunder_multiplier = 0.5 //takes half sunder
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -36,7 +36,7 @@
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.5 //takes half sunder
+	sunder_multiplier = 0.5
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -24,7 +24,7 @@
 	max_health = 500
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.8 //takes 80% sunder
+	sunder_multiplier = 0.8
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -23,6 +23,9 @@
 	// *** Health *** //
 	max_health = 500
 
+	// *** Sunder *** //
+	sunder_multiplier = 0.8 //takes 80% sunder
+
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	evolve_min_xenos = 8

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -92,6 +92,8 @@
 	var/sunder_recover = 0.5
 	///What is the max amount of sunder that can be applied to a xeno (100 = 100%)
 	var/sunder_max = 100
+	///Multiplier on the weapons sunder, e.g 10 sunder on a projectile is reduced to 5 with a 0.5 multiplier.
+	var/sunder_multiplier = 1
 
 	// *** Ranged Attack *** //
 	///Delay timer for spitting

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -493,7 +493,8 @@
 	. = ..()
 	if(.)
 		return
-	sunder = clamp(sunder + (adjustment * xeno_caste.sunder_multiplier), 0, xeno_caste.sunder_max)
+	sunder = clamp(sunder + (adjustment > 0 ? adjustment * xeno_caste.sunder_multiplier : adjustment), 0, xeno_caste.sunder_max)
+//Applying sunder is an adjustment value above 0, healing sunder is an adjustment value below 0. Use multiplier when taking sunder, not when healing.
 
 /mob/living/carbon/xenomorph/set_sunder(new_sunder)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -493,7 +493,7 @@
 	. = ..()
 	if(.)
 		return
-	sunder = clamp(sunder + adjustment, 0, xeno_caste.sunder_max)
+	sunder = clamp(sunder + (adjustment * xeno_caste.sunder_multiplier), 0, xeno_caste.sunder_max)
 
 /mob/living/carbon/xenomorph/set_sunder(new_sunder)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Sunder multiplier: multiplies incoming sunder by this amount.
Gives queen a sunder multiplier of 0.8, crusher 0.5.
## Why It's Good For The Game
Of the three armored castes (queen, crusher, king), crusher has the least of being able to fight without sunder. The other two castes have an ability to operate at range even with sunder, but Crusher is always in there. Queen doesn't exactly require it per-say, but since they are still somewhat of a sunder magnet they have it. King literally needs sunder to die, so no multiplier on his end.
## Changelog
:cl:
balance: Queen has a sunder multiplier of 0.8 (takes 80% sunder), Crusher has a sunder multiplier of 0.5 (takes 50% sunder)
/:cl:
