### PR TITLE
DNR now simply makes you unable to return to your body.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -263,14 +263,7 @@
 			status_hud.icon_state = "hudsynthdnr"
 			return TRUE
 		else
-			if(!mind)
-				var/mob/dead/observer/G = get_ghost(TRUE)
-				if(!G)
-					status_hud.icon_state = "hudsynthdnr"
-				else
-					status_hud.icon_state = "hudsynthdead"
-			else
-				status_hud.icon_state = "hudsynthdead"
+			status_hud.icon_state = "hudsynthdead"
 			return TRUE
 		infection_hud.icon_state = "hudsynth" //Xenos can feel synths are not human.
 		return TRUE
@@ -308,11 +301,6 @@
 				hud_list[HEART_STATUS_HUD].icon_state = "still_heart"
 				status_hud.icon_state = "huddead"
 				return TRUE
-			if(!mind)
-				var/mob/dead/observer/ghost = get_ghost(TRUE)
-				if(!ghost?.can_reenter_corpse)
-					status_hud.icon_state = "huddead"
-					return TRUE
 			var/stage
 			switch(dead_ticks)
 				if(0 to 0.4 * TIME_BEFORE_DNR)

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -201,17 +201,6 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Paddles registering >100,000 ohms, Possible cause: Suit or Armor interferring."))
 		return
 
-	var/mob/dead/observer/G = H.get_ghost()
-	if(G)
-		G.reenter_corpse()
-	else if(!H.mind && !H.get_ghost(TRUE))
-		//We couldn't find a suitable ghost, this means the person is not returning
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
-		return
-	else if(!H.client) //Currently disconnected.
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's soul has almost departed. Please try again."))
-		return
-
 	user.visible_message(span_notice("[user] starts setting up the paddles on [H]'s chest."),
 	span_notice("You start setting up the paddles on [H]'s chest."))
 	playsound(get_turf(src),'sound/items/defib_charge.ogg', 25, 0) //Do NOT vary this tune, it needs to be precisely 7 seconds
@@ -252,23 +241,6 @@
 		if(braincase.limb_status & LIMB_DESTROYED)
 			user.visible_message("[icon2html(src, viewers(user))] \The [src] buzzes: Positronic brain missing, cannot reboot.")
 			return
-
-	if(!H.client) //Either client disconnected after being dragged in, ghosted, or this mob isn't a player (but that is caught way earlier).
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: No soul detected, Attempting to revive..."))
-
-	if(!H.mind) //Check if their ghost still exists if they aren't in their body.
-		G = H.get_ghost(TRUE)
-		if(istype(G))
-			user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's soul has almost departed, please try again."))
-			return
-		//No mind and no associated ghost exists. This one is DNR.
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
-		return
-
-	if(!H.client) //No client, but has a mind. This means the player was in their body, but potentially disconnected.
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. No soul detected. Please try again."))
-		playsound(get_turf(src), 'sound/items/defib_failed.ogg', 35, 0)
-		return
 
 	//At this point, the defibrillator is ready to work
 	if(HAS_TRAIT(H, TRAIT_IMMEDIATE_DEFIB)) // this trait ignores user skill for the heal amount

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -846,11 +846,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	set name = "Do Not Revive"
 	set desc = "Noone will be able to revive you."
 
-	if(!isnull(can_reenter_corpse) && tgui_alert(usr, "Are you sure? You won't be able to get revived.", "Confirmation", list("Yes", "No")) == "Yes")
-		var/mob/living/carbon/human/human_current = can_reenter_corpse.resolve()
-		if(istype(human_current))
-			human_current.set_undefibbable(TRUE)
-
+	if(!isnull(can_reenter_corpse) && tgui_alert(usr, "Are you sure? You won't be able to return to your body anymore.", "Confirmation", list("Yes", "No")) == "Yes")
 		can_reenter_corpse = null
 		to_chat(usr, span_notice("You can no longer be revived."))
 		return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -33,12 +33,11 @@
 
 		else //Dead
 			dead_ticks ++
-			var/mob/dead/observer/related_ghost = get_ghost(TRUE)
 			var/datum/limb/headcheck = get_limb("head")
-			// boolean, determines if the body's ghost can reenter the body
-			var/ghost_left = !mind && (!(!headcheck || (headcheck.limb_status & LIMB_DESTROYED)) || (!(species.species_flags & DETACHABLE_HEAD))) && !related_ghost?.can_reenter_corpse
-			if(dead_ticks > TIME_BEFORE_DNR || ghost_left)
-				set_undefibbable(ghost_left)
+			// boolean, determines if headless
+			var/headless = !(!headcheck || (headcheck.limb_status & LIMB_DESTROYED)) || (!(species.species_flags & DETACHABLE_HEAD))
+			if(dead_ticks > TIME_BEFORE_DNR)
+				set_undefibbable(headless)
 			else
 				med_hud_set_status()
 


### PR DESCRIPTION
## About The Pull Request
Now you can revive people who DNR so their mob can be taken by a ghost.

May have unintended consequences if there are any checks that utilize !mind to assume someone is DNR without explicitly checking.

## Why It's Good For The Game
So marines can still be revived by medics even if the player previously playing is no longer willing.

## Changelog
:cl:
code: Mindless or ownerless bodies no longer become undefibbable before the revive timer is up.
/:cl:
