### PR TITLE
Daedalus Changes (#2)

### DIFF
--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -300,7 +300,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/sportstorage)
 "anl" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -310,7 +310,7 @@
 /turf/open/floor/tile/green/greentaupe,
 /area/daedalusprison/inside/hydroponics)
 "anT" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /turf/open/floor/prison/green{
 	dir = 6
@@ -373,7 +373,7 @@
 	},
 /area/daedalusprison/inside/security/office)
 "aqf" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/firstaid,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
@@ -461,7 +461,7 @@
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/centralhalls)
 "auq" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/bunker)
 "auD" = (
@@ -500,7 +500,7 @@
 	},
 /area/daedalusprison/inside/sportstorage)
 "avR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -566,7 +566,7 @@
 /turf/closed/wall,
 /area/daedalusprison/inside/colonydorms)
 "ays" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle,
 /obj/item/cell/lasgun/lasrifle,
 /obj/effect/landmark/weed_node,
@@ -626,7 +626,7 @@
 	},
 /area/daedalusprison/inside/security/office)
 "aAN" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/beaker/largeweighted,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
@@ -731,7 +731,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/habitationsouth)
 "aFk" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/heal_pack,
 /obj/machinery/light,
 /turf/open/floor/prison/sterilewhite,
@@ -766,6 +766,10 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/pmcdropship)
+"aGY" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/daedalusprison/inside/prisonshower)
 "aHc" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 9
@@ -777,7 +781,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "aHB" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/tool/surgery/suture,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical/treatment)
@@ -937,7 +941,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/centralhalls)
 "aMO" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/door/poddoor/shutters{
 	id = "DPsec"
 	},
@@ -1292,7 +1296,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/colonydorms)
 "bfk" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/lobby)
@@ -1335,7 +1339,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "bkc" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/book/manual/engineering_guide,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/east)
@@ -1500,7 +1504,7 @@
 	},
 /area/daedalusprison/inside/pmcdropship)
 "bqd" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 4
 	},
@@ -1622,7 +1626,7 @@
 	},
 /area/daedalusprison/inside/seccheckpoint)
 "bui" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 5
 	},
@@ -1873,7 +1877,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/south)
 "bDu" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/prison,
@@ -1956,8 +1960,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "bGE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -2141,7 +2143,7 @@
 	},
 /area/daedalusprison/inside/lobby)
 "bQa" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/darkred/full,
 /area/daedalusprison/inside/security/easternbooth)
@@ -2150,7 +2152,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/miner/damaged,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/execution)
 "bRq" = (
@@ -2236,7 +2237,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "bUX" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -2357,7 +2358,7 @@
 	},
 /area/daedalusprison/inside/security/secbreakroom)
 "bZU" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -2365,7 +2366,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westcomputerlab)
 "bZX" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 5;
 	pixel_y = 3
@@ -2582,7 +2583,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
 "cjT" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/box/gloves{
 	pixel_x = 6;
 	pixel_y = 10
@@ -2724,7 +2725,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/office)
 "cmU" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/syringe,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -2885,7 +2886,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "cww" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/security/medsec)
 "cwy" = (
@@ -3094,7 +3095,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/chapel)
 "cEp" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -3441,7 +3442,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "cWx" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/tile/dark2,
@@ -3972,7 +3973,7 @@
 /turf/closed/wall/prison,
 /area/daedalusprison/inside/northclass)
 "dqo" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/operating,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -4055,7 +4056,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/centralhalls)
 "dtu" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/trash/plate,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/bunker/center)
@@ -4092,7 +4093,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/centralhalls)
 "dvf" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
@@ -4243,6 +4244,13 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/security/office)
+"dCb" = (
+/obj/structure/fence/broken,
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/south)
 "dCh" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/light,
@@ -4461,13 +4469,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "dLr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/surgical_tray,
 /turf/open/floor/tile/dark,
 /area/daedalusprison/inside/medical)
@@ -4494,7 +4501,7 @@
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
 "dMn" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/clothing/gloves/insulated,
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
@@ -4628,8 +4635,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/cameras)
+"dQI" = (
+/obj/structure/cable,
+/turf/open/floor/prison/plate,
+/area/daedalusprison/inside/security/warden)
 "dQO" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -4945,7 +4956,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
 "eey" = (
@@ -4973,6 +4984,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/habitationnorth)
+"efq" = (
+/obj/effect/acid_hole,
+/turf/closed/wall/prison,
+/area/daedalusprison/inside/freezer)
 "efF" = (
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/tile/dark/red2{
@@ -5002,7 +5017,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/daedalusprison/inside/centralhalls)
 "egs" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/bloodpack,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
@@ -5125,7 +5140,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westcomputerlab)
 "emm" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/heal_pack,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical/treatment)
@@ -5250,7 +5265,7 @@
 /turf/open/shuttle/dropship/three,
 /area/daedalusprison/inside/pmcdropship)
 "eqA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/red,
 /area/daedalusprison/inside/security/cameras)
@@ -5285,7 +5300,7 @@
 	},
 /area/daedalusprison/inside/mining)
 "eri" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/firstaid,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
@@ -5451,7 +5466,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/bar)
 "eAp" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
@@ -5507,7 +5522,7 @@
 	},
 /area/daedalusprison/caves/research)
 "eCq" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/prison,
@@ -5656,7 +5671,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/prisonshower)
 "eIf" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/engineering/tool,
 /obj/machinery/light,
 /turf/open/floor/tile/dark2,
@@ -5767,7 +5782,7 @@
 	},
 /area/daedalusprison/inside/pmcdropship)
 "eOa" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
@@ -6033,7 +6048,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/colonydorms)
 "eYR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/clothing/sunglasses,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -6488,7 +6503,7 @@
 	},
 /area/daedalusprison/inside/mechanicshop)
 "fqe" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/security{
 	network = list("PRISON")
 	},
@@ -6570,7 +6585,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "ftS" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/center)
 "ftT" = (
@@ -6611,7 +6626,7 @@
 	},
 /area/daedalusprison/inside/centralhalls)
 "fwe" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -6809,7 +6824,7 @@
 /turf/open/floor/tile/green/greentaupecorner,
 /area/daedalusprison/inside/garden)
 "fET" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/ammo_casing,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westernbooth)
@@ -6977,7 +6992,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "fMS" = (
@@ -6999,7 +7013,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/engineering)
 "fNC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/health_analyzer,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -7238,7 +7252,7 @@
 	},
 /area/daedalusprison/inside/security/secbreakroom)
 "fXz" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -7393,7 +7407,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "ghq" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/prison/red,
 /area/daedalusprison/inside/habitationsouth)
@@ -7471,7 +7485,7 @@
 	},
 /area/daedalusprison/inside/pmcdropship)
 "glg" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/medhud,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -7671,7 +7685,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/engineering)
 "gsE" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/pillbottle,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
@@ -8086,7 +8100,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/habitationnorth)
 "gLZ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/donut_box,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/seccheckpoint)
@@ -8365,7 +8379,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/colonydorms)
 "gZR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/paper{
 	pixel_x = 5
 	},
@@ -8527,7 +8541,7 @@
 	},
 /area/daedalusprison/inside/centralhalls)
 "hgT" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -8687,7 +8701,7 @@
 /turf/closed/mineral/smooth/darkfrostwall/cuttable,
 /area/daedalusprison/caves/rock)
 "hoW" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/donut_box,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -8892,7 +8906,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/inside/easternhalls)
 "hzR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/ten,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/center)
@@ -9139,7 +9153,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/inside/substation)
 "hIy" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -9241,7 +9255,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/centralhalls)
 "hOg" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/heal_pack,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -9313,7 +9327,7 @@
 /turf/open/floor/mainship/floor,
 /area/daedalusprison/caves/research)
 "hSN" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/medhud,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -9594,7 +9608,7 @@
 	},
 /area/daedalusprison/inside/centralhalls)
 "ifQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/door_control/old/checkpoint{
 	id = "DPsec"
 	},
@@ -9804,7 +9818,7 @@
 /turf/open/floor/prison/kitchen,
 /area/daedalusprison/inside/prisonshower)
 "inQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/security{
 	network = list("PRISON")
 	},
@@ -10232,7 +10246,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/engineering)
 "iFy" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/heal_pack,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
@@ -10742,7 +10756,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/inside/substation)
 "iYJ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -10809,7 +10823,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/daedalusprison/inside/pmcdropship)
 "jch" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /turf/open/floor/tile/dark,
@@ -10920,7 +10934,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "jgk" = (
@@ -10967,7 +10980,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/janitorial)
 "jiL" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/recharger,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
@@ -11186,7 +11199,7 @@
 	},
 /area/daedalusprison/inside/gym)
 "jrt" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/surgical_tray,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical/treatment)
@@ -11227,7 +11240,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "jtC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -11478,7 +11491,7 @@
 /area/daedalusprison/inside/easternhalls)
 "jCA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/bodybag/cryobag,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
@@ -11593,7 +11606,7 @@
 /area/daedalusprison/inside/hydroponics)
 "jGD" = (
 /obj/effect/landmark/weed_node,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/westernbooth)
 "jGF" = (
@@ -11735,6 +11748,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "jMO" = (
@@ -11772,6 +11786,10 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/barracks)
+"jOU" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/north)
 "jPp" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -11840,7 +11858,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/inside/centralhalls)
 "jRA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/reagent_containers/glass/beaker/cryomix{
 	name = "cryo beaker"
 	},
@@ -11954,7 +11972,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/habitationnorth)
 "jVK" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/defibrillator,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -12430,7 +12448,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
 "kqD" = (
@@ -12505,7 +12523,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "ktc" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/phone,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -12714,7 +12732,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/colonydorms)
 "kCB" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
@@ -12885,7 +12903,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/centralhalls)
 "kKe" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/ashtray/bronze,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/west)
@@ -13076,7 +13094,7 @@
 /turf/open/floor/prison/red,
 /area/daedalusprison/inside/habitationsouth)
 "kRH" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/west)
@@ -13529,6 +13547,10 @@
 	dir = 6
 	},
 /area/daedalusprison/inside/westernbooth)
+"ljp" = (
+/obj/effect/acid_hole,
+/turf/closed/wall/prison,
+/area/daedalusprison/inside/medical)
 "ljq" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -13682,7 +13704,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "lqs" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/ten,
 /turf/open/floor/prison/red{
 	dir = 4
@@ -13698,7 +13720,7 @@
 /turf/open/floor/prison/red/corner,
 /area/daedalusprison/inside/habitationnorth)
 "lrq" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -13956,10 +13978,10 @@
 	},
 /area/daedalusprison/inside/colonydorms)
 "lzM" = (
-/obj/structure/fence,
 /obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 8
+	dir = 10
 	},
+/obj/structure/fence/broken,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
 "lAz" = (
@@ -14089,7 +14111,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "lHv" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/twelve,
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -14313,7 +14335,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "lRF" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
@@ -14410,6 +14432,10 @@
 	dir = 6
 	},
 /area/daedalusprison/inside/mechanicshop)
+"lVv" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/daedalusprison/outside/southwest)
 "lVE" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/landmark/weed_node,
@@ -14465,7 +14491,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/centralhalls)
 "lXY" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/medbelt,
 /obj/machinery/light{
 	dir = 4
@@ -14576,7 +14602,7 @@
 	},
 /area/daedalusprison/inside/medical)
 "mdG" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/prison/whitegreen{
@@ -14663,7 +14689,7 @@
 /turf/open/floor/prison/whitepurple,
 /area/daedalusprison/inside/medical/chemistry)
 "mgR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/tile/dark2,
@@ -14733,7 +14759,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/habitationsouth)
 "mkc" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/prison/whitegreen{
@@ -14840,7 +14866,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "mpC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -14942,7 +14968,7 @@
 /turf/open/floor/plating/ground/concrete,
 /area/daedalusprison/inside/garage)
 "mua" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/prison/whitegreen{
@@ -15050,7 +15076,7 @@
 /turf/open/floor/tile/dark/yellow2,
 /area/daedalusprison/inside/engineering)
 "mxI" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -15207,7 +15233,7 @@
 /turf/open/floor/prison/red,
 /area/daedalusprison/inside/security/office)
 "mDU" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -15320,7 +15346,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/caves/research)
 "mIb" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/healthanalyzer,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -15378,7 +15404,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/prisongarden)
 "mJF" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -15620,7 +15646,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/mechanicshop)
 "mRv" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/bodybag,
 /obj/item/bodybag,
 /turf/open/floor/tile/dark,
@@ -15662,7 +15688,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/northeast)
 "mSE" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westernbooth)
 "mSL" = (
@@ -15959,7 +15985,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "ngx" = (
@@ -16105,7 +16131,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/centralhalls)
 "nmO" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 1
 	},
@@ -16533,7 +16559,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/daedalusprison/outside/east)
 "nDY" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/faxmachine,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
@@ -16733,7 +16759,7 @@
 	},
 /area/daedalusprison/inside/gym)
 "nNj" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 6
 	},
@@ -17158,7 +17184,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
@@ -17178,7 +17204,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/habitationsouth)
 "oiU" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/red{
@@ -17189,7 +17215,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
@@ -17216,7 +17242,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/north)
 "ojY" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
 "okb" = (
@@ -17274,7 +17300,7 @@
 	},
 /area/daedalusprison/inside/corporateoffice)
 "omE" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/bloodpack,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -17391,16 +17417,16 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/barracks)
 "otF" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/tile/dark,
 /area/daedalusprison/inside/medical)
 "otI" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/red/full,
 /area/daedalusprison/inside/bunker/east)
 "otK" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/flashlight/lamp,
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
@@ -17463,7 +17489,7 @@
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
 "ovt" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/southwest)
@@ -17585,7 +17611,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/centralhalls)
 "ozV" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
@@ -17916,7 +17942,7 @@
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/centralhalls)
 "oMz" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/prison/darkred{
 	dir = 1
@@ -17968,7 +17994,7 @@
 	},
 /area/daedalusprison/inside/medical)
 "oOb" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/recharger,
 /obj/structure/sign/safety/autodoc,
 /obj/machinery/light,
@@ -18249,7 +18275,7 @@
 	},
 /area/daedalusprison/inside/easternhalls)
 "oXj" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical)
@@ -18415,7 +18441,7 @@
 /turf/open/floor,
 /area/daedalusprison/inside/hydroponics)
 "pdg" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "pdu" = (
@@ -18543,7 +18569,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
 "piI" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
 "piO" = (
@@ -18731,7 +18757,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "ppC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/bunker/west)
@@ -18920,7 +18946,7 @@
 	},
 /area/daedalusprison/inside/habitationsouth)
 "puZ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/box/gloves,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -19019,7 +19045,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/pill_bottle/tramadol,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -19069,7 +19095,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/janitorial)
 "pBx" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/beaker/regularweighted,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -19219,7 +19245,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/recreation)
 "pID" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/lobby)
 "pIH" = (
@@ -19269,7 +19295,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
@@ -19593,7 +19619,7 @@
 /turf/open/floor/prison/green,
 /area/daedalusprison/inside/northmeetingroom)
 "qcb" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/faxmachine,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
@@ -19618,7 +19644,7 @@
 /turf/open/floor/tile/green/greentaupecorner,
 /area/daedalusprison/inside/garden)
 "qdf" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/faxmachine,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -19698,12 +19724,12 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/caves/nukestorage)
 "qft" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/surgical_tray,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "qfz" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/seccheckpoint)
 "qfK" = (
@@ -20045,12 +20071,12 @@
 /area/daedalusprison/inside/southclass)
 "qsH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/trash/burger,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "qta" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -20118,7 +20144,7 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/daedalusprison/inside/sportstorage)
 "qvj" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/south)
@@ -20257,7 +20283,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/centralhalls)
 "qDm" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/tool/hand_labeler,
 /obj/machinery/door/poddoor/shutters{
 	id = "DPsec"
@@ -20417,7 +20443,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "qLA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/box/gloves,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -20434,7 +20460,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/office)
 "qLN" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/security{
 	network = list("PRISON")
 	},
@@ -20514,7 +20540,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/secbreakroom)
 "qPQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/red{
 	dir = 8
@@ -20589,7 +20615,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/habitationsouth)
 "qUH" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark,
 /area/daedalusprison/inside/medical)
 "qVp" = (
@@ -20623,7 +20649,7 @@
 /turf/open/floor/prison/kitchen,
 /area/daedalusprison/inside/prisonshower)
 "qWH" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/effect/landmark/weed_node,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 9
@@ -21077,7 +21103,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westcomputerlab)
 "roj" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/bloodpack,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical/treatment)
@@ -21215,7 +21241,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical/treatment)
 "rvc" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/detective_scanner,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/seccheckpoint)
@@ -21342,7 +21368,7 @@
 /turf/open/floor/tile/brown/full,
 /area/daedalusprison/inside/engineering)
 "rAg" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/medbottle,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
@@ -21793,7 +21819,7 @@
 	},
 /area/daedalusprison/inside/westernbooth)
 "rQl" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/bunker/east)
@@ -21855,6 +21881,8 @@
 /area/daedalusprison/inside/habitationnorth)
 "rSI" = (
 /obj/machinery/photocopier,
+/obj/machinery/power/apc,
+/obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -22399,7 +22427,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/habitationnorth)
 "srk" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /turf/open/floor/prison/whitegreen,
@@ -22449,7 +22477,7 @@
 	},
 /area/daedalusprison/inside/medical)
 "stv" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
 /turf/open/floor/prison/green,
 /area/daedalusprison/inside/westcomputerlab)
@@ -22976,7 +23004,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/inside/landingzoneone)
 "sJI" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/prison/whitegreen{
@@ -23206,7 +23234,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/basketball)
 "sTb" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/bloodpack,
 /obj/machinery/light{
 	dir = 1
@@ -23475,7 +23503,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
 "tcJ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/security{
 	network = list("PRISON")
 	},
@@ -23789,7 +23817,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/mining)
 "tsG" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/effect/landmark/weed_node,
 /obj/structure/platform/rockcliff/icycliff/nondense,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -23800,7 +23828,7 @@
 /area/daedalusprison/outside/northeast)
 "ttq" = (
 /obj/item/clothing/mask/bandanna/black,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/light,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/execution)
@@ -24479,14 +24507,14 @@
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/colonydorms)
 "tWQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/syringe,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
 /area/daedalusprison/inside/medical)
 "tWS" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
 /area/daedalusprison/inside/substation)
@@ -24532,7 +24560,7 @@
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/daedalusprison/inside/engineering)
 "tZK" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/bunker/west)
@@ -24884,7 +24912,7 @@
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/daedalusprison/inside/engineering)
 "uoi" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/ten,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
@@ -25076,7 +25104,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/secbreakroom)
 "uwC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
@@ -25122,7 +25150,7 @@
 	},
 /area/daedalusprison/inside/engineering)
 "uye" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/surgical_tray,
 /obj/machinery/light,
 /turf/open/floor/prison/whitegreen{
@@ -25148,7 +25176,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
 "uyE" = (
@@ -25167,7 +25195,7 @@
 	},
 /area/daedalusprison/inside/medical)
 "uzt" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/bloodpack,
 /obj/machinery/light{
 	dir = 8
@@ -25277,7 +25305,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "uDP" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/lobby)
@@ -25378,7 +25406,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "uHQ" = (
@@ -25541,7 +25569,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/mining)
 "uOS" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/medhud,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
@@ -25749,7 +25777,7 @@
 /turf/closed/wall/prison,
 /area/daedalusprison/inside/laundromat)
 "uYz" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/security/warden)
 "uYA" = (
@@ -25775,7 +25803,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
 "uZt" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/darkred/full,
 /area/daedalusprison/inside/security/medsec)
@@ -26165,7 +26193,7 @@
 	},
 /area/daedalusprison/inside/laundromat)
 "vpx" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/tool/pen,
 /obj/item/paper{
 	pixel_x = 5
@@ -26409,7 +26437,7 @@
 /turf/open/floor/wood,
 /area/daedalusprison/inside/colonydorms)
 "vDj" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
 	dir = 1
@@ -26599,7 +26627,7 @@
 	},
 /area/daedalusprison/inside/colonydorms)
 "vKM" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
 "vKN" = (
@@ -26677,7 +26705,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/south)
 "vNf" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/effect/landmark/weed_node,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 1
@@ -26685,7 +26713,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
 "vNi" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin,
 /obj/item/tool/pen/blue,
 /turf/open/floor/prison/sterilewhite,
@@ -26769,7 +26797,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/misc/paperbin,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
@@ -26786,7 +26814,7 @@
 /turf/open/floor/tile/dark/green2,
 /area/daedalusprison/inside/colonydorms)
 "vRA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/westernbooth)
@@ -27293,7 +27321,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "wlV" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/paper,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/library)
@@ -27327,7 +27355,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/daedalusprison/inside/pmcdropship)
 "wmz" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/syringes,
 /turf/open/floor/prison/whitegreen,
@@ -27455,7 +27483,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/daedalusprison/inside/secoffices)
 "wqd" = (
@@ -27686,7 +27714,7 @@
 	},
 /area/daedalusprison/inside/engineering)
 "wzL" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/ten,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
@@ -27712,7 +27740,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "wAs" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -27909,7 +27937,7 @@
 	},
 /area/daedalusprison/inside/mechanicshop)
 "wJE" = (
-/obj/structure/fence,
+/obj/structure/fence/broken,
 /obj/structure/platform/rockcliff/icycliff/nondense{
 	dir = 1
 	},
@@ -27988,7 +28016,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/easternhalls)
 "wNT" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/storage/firstaid/rad,
 /obj/item/storage/firstaid/rad,
 /turf/open/floor/prison/whitegreen{
@@ -28126,7 +28154,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/daedalusprison/inside/pmcdropship)
 "wSQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/book/manual/barman_recipes,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
@@ -28197,7 +28225,7 @@
 	},
 /area/daedalusprison/inside/medical)
 "wVL" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/centralbooth)
@@ -28304,7 +28332,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/daedalusprison/inside/cafeteria)
 "wZA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/fourteen,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
@@ -28327,7 +28355,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "xaQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/effect/spawner/random/medical/heal_pack,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical/treatment)
@@ -28406,7 +28434,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
 "xdi" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/revolver/judge,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/centralbooth)
@@ -28735,7 +28763,7 @@
 /turf/open/floor,
 /area/daedalusprison/inside/colonydorms)
 "xqC" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/button,
 /obj/machinery/light,
 /obj/effect/landmark/weed_node,
@@ -28803,7 +28831,7 @@
 /turf/open/floor/prison/darkyellow,
 /area/daedalusprison/inside/sportstorage)
 "xtH" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -28943,7 +28971,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/colonyauxstorage)
 "xzI" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
@@ -29096,7 +29124,7 @@
 /turf/open/floor/tile/dark/red2,
 /area/daedalusprison/inside/seccheckpoint)
 "xGm" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/machinery/button,
 /obj/machinery/light{
 	dir = 1
@@ -29261,7 +29289,7 @@
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/westernbooth)
 "xLX" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/structure/prop/computer/broken/nineteen,
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
@@ -29625,7 +29653,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/lobby)
 "ydR" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced/weak,
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle,
 /obj/item/cell/lasgun/lasrifle,
 /turf/open/floor/prison/red{
@@ -37350,7 +37378,7 @@ rUP
 rUP
 rUP
 rUP
-rUP
+aGY
 rUP
 rUP
 rUP
@@ -38686,7 +38714,7 @@ dLg
 dVz
 dVz
 eZo
-nmY
+dVz
 dVz
 dLg
 liI
@@ -39239,7 +39267,7 @@ eFJ
 eFJ
 eFJ
 eFJ
-eFJ
+rit
 eFJ
 eFJ
 eFJ
@@ -46946,7 +46974,7 @@ aok
 fir
 dmP
 dmP
-dmP
+lVv
 fir
 dmP
 dmP
@@ -51152,9 +51180,9 @@ fir
 dmP
 fir
 piI
-lzM
-lzM
-lzM
+dCb
+dCb
+dCb
 lzM
 prx
 prx
@@ -51937,7 +51965,7 @@ hAM
 kKm
 glb
 xIF
-jXr
+ljp
 dXL
 dXL
 dXL
@@ -55784,7 +55812,7 @@ jbA
 jbA
 uRM
 uRM
-uRM
+efq
 uRM
 uRM
 uRM
@@ -58365,8 +58393,8 @@ prx
 prx
 prx
 qWH
-lzM
-lzM
+dCb
+dCb
 piI
 kaT
 bUI
@@ -61479,7 +61507,7 @@ jXr
 jXr
 dXL
 spn
-dXL
+jOU
 dXL
 spn
 cAe
@@ -67844,7 +67872,7 @@ lMW
 hUa
 rSI
 jMm
-vNs
+dQI
 aHc
 twa
 sUX

--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -339,10 +339,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
-"aoX" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/ice,
-/area/daedalusprison/caves/northeast)
 "apf" = (
 /turf/closed/wall/prison,
 /area/daedalusprison/inside/southclass)
@@ -62515,7 +62511,7 @@ mkY
 mkY
 nMf
 mkY
-aoX
+mkY
 nMf
 mkY
 kOm

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -16,6 +16,8 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_FENCE)
 	canSmoothWith = list(SMOOTH_GROUP_FENCE)
+	///Chance for the fence to break on /init
+	var/chance_to_break = 80 //Defaults to 80%
 
 /obj/structure/fence/ex_act(severity)
 	switch(severity)
@@ -123,7 +125,7 @@
 /obj/structure/fence/Initialize(mapload, start_dir)
 	. = ..()
 
-	if(!obj_integrity || prob(80))
+	if(prob(chance_to_break))
 		obj_integrity = 0
 		deconstruct(FALSE)
 
@@ -141,4 +143,4 @@
 	return ..()
 
 /obj/structure/fence/broken
-	obj_integrity = 0
+	chance_to_break = 100

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -123,7 +123,7 @@
 /obj/structure/fence/Initialize(mapload, start_dir)
 	. = ..()
 
-	if(prob(80))
+	if(!obj_integrity || prob(80))
 		obj_integrity = 0
 		deconstruct(FALSE)
 
@@ -139,3 +139,6 @@
 	if(exposed_temperature > T0C + 800)
 		take_damage(round(exposed_volume / 100), BURN, "fire")
 	return ..()
+
+/obj/structure/fence/broken
+	obj_integrity = 0

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -465,6 +465,10 @@
 	table_status = TABLE_STATUS_FIRM
 	return TRUE
 
+/obj/structure/table/reinforced/weak //used for the icon, functionally similar to a table.
+	name = "rickety reinforced table"
+	desc = "A square metal surface resting on four legs. It has seen better days to whence it was strong."
+	max_integrity = 40
 
 /obj/structure/table/reinforced/prison
 	desc = "A square metal surface resting on four legs. This one has side panels, making it useful as a desk, but impossible to flip."

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -6,7 +6,7 @@
 /turf/open/floor/plating/ground/snow
 	name = "snow layer"
 	icon = 'icons/turf/snow2.dmi'
-	icon_state = "snow_0"
+	icon_state = "snow_0_1"
 	hull_floor = TRUE
 	shoefootstep = FOOTSTEP_SNOW
 	barefootstep = FOOTSTEP_SNOW
@@ -190,20 +190,20 @@
 
 //SNOW LAYERS-----------------------------------//
 /turf/open/floor/plating/ground/snow/layer0
-	icon_state = "snow_0"
+	icon_state = "snow_0_1"
 	slayer = 0
 	minimap_color = MINIMAP_DIRT
 
 /turf/open/floor/plating/ground/snow/layer1
-	icon_state = "snow_1"
+	icon_state = "snow_1_1"
 	slayer = 1
 
 /turf/open/floor/plating/ground/snow/layer2
-	icon_state = "snow_2"
+	icon_state = "snow_2_1"
 	slayer = 2
 
 /turf/open/floor/plating/ground/snow/layer3
-	icon_state = "snow_3"
+	icon_state = "snow_3_1"
 	slayer = 3
 
 


### PR DESCRIPTION
## About The Pull Request
Weaker reinforced tables
Pre-broken fences
A few more melt holes
Some new miners and some moved/removed
Fixed a bug where snow would show up as a missing texture on SDMM
## Why It's Good For The Game
Hopefully makes prep less torture for the normal xeno on Daedalus. Also, bug fix good.
## Changelog
:cl:
balance: Daedalus Prison has weaker tables and pre-broken fences for a better prep experience
fix: Snows shows up as a proper texture in SDMM
/:cl:
