### PR TITLE
Perk item upgrade fix

### DIFF
--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -4,7 +4,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 300
+	var/currency = 30000
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference
@@ -126,7 +126,7 @@
 	return TRUE
 
 ///Adds and equips a loadout item, replacing another
-/datum/individual_stats/proc/replace_loadout_option(new_item, removed_item, job_type_or_types, job_req_override = TRUE)
+/datum/individual_stats/proc/replace_loadout_option(new_item, removed_item, job_type_or_types, job_req_override = FALSE)
 	if(!islist(job_type_or_types))
 		job_type_or_types = list(job_type_or_types)
 	var/datum/loadout_item/item = GLOB.campaign_loadout_item_type_list[new_item]

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -4,7 +4,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 30000
+	var/currency = 300
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference

--- a/code/datums/gamemodes/campaign/outfit_holder.dm
+++ b/code/datums/gamemodes/campaign/outfit_holder.dm
@@ -52,7 +52,7 @@
 
 ///Adds a new loadout_item to the available list
 /datum/outfit_holder/proc/unlock_new_option(datum/loadout_item/new_item)
-	available_list["[new_item.item_slot]"] += new_item
+	available_list["[new_item.item_slot]"] |= new_item
 	purchasable_list["[new_item.item_slot]"] -= new_item
 
 ///Adds a new loadout_item to the purchasable list


### PR DESCRIPTION

## About The Pull Request
Fixed a bug causing some classes to get items they're not supposed to/duplicated. I set a default arg to the wrong thing.
Also made the unlock perk itself a bit safer just in case.
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: Campaign: Fixed an issue with some perks unlocking items incorrectly
/:cl:
