### PR TITLE
Revert spit being unstaggerable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -717,7 +717,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
 	)
-	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_BUCKLED|ABILITY_DO_AFTER_ATTACK|ABILITY_USE_STAGGERED
+	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_BUCKLED|ABILITY_DO_AFTER_ATTACK
 	target_flags = ABILITY_MOB_TARGET
 	///Current target that the xeno is targeting. This is for aiming.
 	var/current_target


### PR DESCRIPTION
## About The Pull Request
Xenos can no longer spit while staggered, as in #15124 @Barnet2 @Kuro020 

## Why It's Good For The Game
> Xeno spit is essentially the caste's basic attack, a ranged slash if you will.

For simple fairness' sake, marines lose 50% of their damage dealt while staggered, and doing this makes spit castes ignore a similar penalty.

> There is a good amount of ways to just shut down spit castes at medium range (slug, gl54 namely) and even more at close range.

They're usually far away enough to dodge stagger projectiles anyways, they can just shuffle next to a wall, and throwing a stagger projectile just to get them to fuck off for a bit when it does hit seems fine to me.

Using a stagger weapon is a choice to deal less damage in exchange for the Xeno dealing less damage, whether because it stunlocks you or spams damage abilities.

> It trades perma damage and unlimited use (it has a plasma cost) while also helping prevent fractures for range. 

It really just exchanges no risk for no permanent damage and a soft counter in the form of stagger. Which is unlike a hard counter where you just die.



> If this makes spit slash absurdly strong (queen already has the best of it with more HP and armor, being able to stay in melee for quite a long time) then I can tune down melee damage, however spit castes should be able to use their basic attack at range without being staggered out of it.

By early-day TGMC convention (anecdotal, like 2018-2019), the reason why Xenos have spit-slash in-spite of consideration in its removal is because it can be cancelled with stagger. It was either that or getting no melee damage. 

You would have gotten something like 5-10 melee damage (I don't remember, it was just to equalize DPS to every other caste's melee, *boo-womp*) if stagger didn't affect spit.

But the risk-reward incentive was fun, so it stayed in the game.

## Changelog
:cl:
balance: Xeno spit is staggerable.
/:cl: