### PR TITLE
Revert "Interactive emote fixes (#15042)"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -355,14 +355,7 @@ if(selected_ability.target_flags & flagname && !istype(A, typepath)){\
 			return FALSE
 		if(COMSIG_MOB_CLICK_HANDLED)
 			return TRUE
-
 	return A.RightClick(src)
-
-/mob/living/carbon/RightClickOn(atom/A)
-	. = ..()
-	//Any carbon type mob can begin an interaction when right clicking another mob on help intent
-	if(ismob(A) && a_intent == INTENT_HELP && Adjacent(A) && interaction_emote(A))
-		return TRUE
 
 /mob/living/carbon/human/RightClickOn(atom/A)
 	var/obj/item/held_thing = get_active_held_item()

--- a/code/_onclick/hud/interactive_emotes.dm
+++ b/code/_onclick/hud/interactive_emotes.dm
@@ -1,16 +1,17 @@
 ///All in one function to begin interactions
 /mob/proc/interaction_emote(mob/target)
-	if(!target || target == src)
-		return FALSE
-
-	var/list/interactions_list = list("Headbutt" = /atom/movable/screen/interaction/headbutt)	//Universal interactions
-	if(isxeno(src))	//Benos don't high five each other, they slap tails! A beno cannot initiate a high five, but can recieve one if prompted by a human
-		interactions_list["Tail Slap"] = /atom/movable/screen/interaction/fist_bump
-	else
-		interactions_list["High Five"] = /atom/movable/screen/interaction
-		interactions_list["Fist Bump"] = /atom/movable/screen/interaction/fist_bump
-
-	var/atom/movable/screen/interaction/interaction = interactions_list[tgui_input_list(src, "Select an interaction type", "Interactive Emotes", interactions_list)]
+	var/atom/movable/screen/interaction/interaction
+	if(can_interact(target))
+		switch(zone_selected)
+			if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
+				if(isxeno(target) && isxeno(src))	//Benos don't high five each other, they slap tails!
+					interaction = /atom/movable/screen/interaction/fist_bump
+				else
+					interaction = /atom/movable/screen/interaction
+			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
+				interaction = /atom/movable/screen/interaction/fist_bump
+			if(BODY_ZONE_HEAD)
+				interaction = /atom/movable/screen/interaction/headbutt
 
 	if(!interaction)
 		return FALSE
@@ -25,7 +26,7 @@
 	interaction.owner = target
 	interaction.initiator = src
 	interaction.register_movement_signals()
-	LAZYADD(target.queued_interactions, interaction)
+	LAZYADD(queued_interactions, interaction)
 
 	if(target.client && target.hud_used)
 		target.hud_used.update_interactive_emotes()
@@ -264,7 +265,7 @@
 	viewer.client.screen |= interaction
 	return TRUE
 
-//If anyone wants to add more interactions, here is an easy test item to use, just be sure to comment out any can_interact checks and to use the target tgui input list
+//If anyone wants to add more interactions, here is an easy test item to use, just be sure to comment out any can_interact checks and to use the target mob's zone_selected
 /obj/item/interaction_tester
 	name = "interaction tester"
 	icon_state = "coin"

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -204,6 +204,9 @@
 				X.visible_message(span_danger("[X] stares at [src]."), span_notice("We stare at the roasting [src], toasty."), null, 5)
 				return FALSE
 
+			if(interaction_emote(src))
+				return TRUE
+
 			X.visible_message(span_notice("\The [X] caresses [src] with its scythe-like arm."), \
 			span_notice("We caress [src] with our scythe-like arm."), null, 5)
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -94,6 +94,9 @@
 					ExtinguishMob()
 				return TRUE
 
+			if(interaction_emote(src))
+				return TRUE
+
 			X.visible_message(span_notice("\The [X] caresses \the [src] with its scythe-like arm."), \
 			span_notice("We caress \the [src] with our scythe-like arm."), null, 5)
 


### PR DESCRIPTION
This reverts commit #15042
With out the option to toggle this on and off, or even bind it outside of right click makes its uncomfy to use right click abilities on help intent with the pop up.