### PR TITLE
Interactive emotes converted to using a keybinding

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -742,6 +742,7 @@
 #define COMSIG_KB_TOGGLE_MINIMAP "toggle_minimap"
 #define COMSIG_KB_TOGGLE_EXTERNAL_MINIMAP "toggle_external_minimap"
 #define COMSIG_KB_SELFHARM "keybind_selfharm"
+#define COMSIG_KB_INTERACTIVE_EMOTE "keybinding_interactive_emote"
 
 // mecha keybinds
 #define COMSIG_MECHABILITY_TOGGLE_INTERNALS "mechability_toggle_internals"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -358,12 +358,6 @@ if(selected_ability.target_flags & flagname && !istype(A, typepath)){\
 
 	return A.RightClick(src)
 
-/mob/living/carbon/RightClickOn(atom/A)
-	. = ..()
-	//Any carbon type mob can begin an interaction when right clicking another mob on help intent
-	if(ismob(A) && a_intent == INTENT_HELP && Adjacent(A) && interaction_emote(A))
-		return TRUE
-
 /mob/living/carbon/human/RightClickOn(atom/A)
 	var/obj/item/held_thing = get_active_held_item()
 

--- a/code/_onclick/hud/interactive_emotes.dm
+++ b/code/_onclick/hud/interactive_emotes.dm
@@ -1,7 +1,7 @@
 ///All in one function to begin interactions
 /mob/proc/interaction_emote(mob/target)
 	if(!target || target == src)
-		return FALSE
+		return
 
 	var/list/interactions_list = list("Headbutt" = /atom/movable/screen/interaction/headbutt)	//Universal interactions
 	if(isxeno(src))	//Benos don't high five each other, they slap tails! A beno cannot initiate a high five, but can recieve one if prompted by a human
@@ -13,13 +13,13 @@
 	var/atom/movable/screen/interaction/interaction = interactions_list[tgui_input_list(src, "Select an interaction type", "Interactive Emotes", interactions_list)]
 
 	if(!interaction)
-		return FALSE
+		return
 
 	if(LAZYLEN(target.queued_interactions))
 		for(var/atom/movable/screen/interaction/element AS in target.queued_interactions)
 			if(element.initiator == src)
 				balloon_alert(src, "Slow your roll!")
-				return FALSE
+				return
 
 	interaction = new interaction()
 	interaction.owner = target
@@ -34,8 +34,6 @@
 	animate(interaction, transform = matrix(), time = 2.5, easing = CUBIC_EASING)
 
 	interaction.timer_id = addtimer(CALLBACK(interaction, TYPE_PROC_REF(/atom/movable/screen/interaction, end_interaction), FALSE), interaction.timeout, TIMER_STOPPABLE|TIMER_UNIQUE)
-
-	return TRUE
 
 //Mob interactions
 /atom/movable/screen/interaction
@@ -273,4 +271,4 @@
 	var/mob/target = tgui_input_list(user, "Select a target", "Select a target", GLOB.alive_living_list)
 	if(!target)
 		return
-	target.interaction_emote(user, TRUE)
+	target.interaction_emote(user)

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -312,3 +312,32 @@
 		return
 	user.mob.do_self_harm = !user.mob.do_self_harm
 	user.mob.balloon_alert(user.mob, "You can [user.mob.do_self_harm ? "now" : "no longer"] hit yourself")
+
+/datum/keybinding/mob/interactive_emote
+	name = "interactive_emote"
+	full_name = "Do interactive emote"
+	description = "Perform an interactive emote with another player."
+	keybind_signal = COMSIG_KB_INTERACTIVE_EMOTE
+
+/datum/keybinding/mob/interactive_emote/down(client/user)
+	. = ..()
+	if(. || !isliving(user.mob) || CHECK_BITFIELD(user.mob.status_flags, INCORPOREAL) || !user.mob.can_interact(user.mob))
+		return
+
+	var/list/adjacent_mobs = cheap_get_living_near(user.mob, 1)
+	adjacent_mobs.Remove(user.mob)	//Get rid of self
+	for(var/mob/M AS in adjacent_mobs)
+		if(!M.client)
+			adjacent_mobs.Remove(M)	//Get rid of non-players
+
+	if(!length(adjacent_mobs))
+		return
+
+	if(length(adjacent_mobs) == 1)
+		user.mob.interaction_emote(adjacent_mobs[1])
+		return
+
+	var/mob/target = tgui_input_list(user, "Who do you want to interact with?", "Select a target", adjacent_mobs)
+	if(!target || !user.mob.Adjacent(target))	//In case the target moved away while selecting them
+		return
+	user.mob.interaction_emote(target)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -31,10 +31,6 @@
 				return TRUE
 
 			if(health >= get_crit_threshold())
-
-				if(interaction_emote(src))
-					return TRUE
-
 				help_shake_act(human_user)
 				return TRUE
 


### PR DESCRIPTION

## About The Pull Request

No one told me not to use right clicks, so making it set via a keybind as someone suggested so it does not interfere with abilities and underbarrel guns. It is unbound by default. When the associated key is pressed, a list of nearby players is given for the user to pick who to interact with. Or auto-pick for the user if there is only one nearby candidate.

## Why It's Good For The Game

Players can use right click again.

## Changelog
:cl:
code: Interactive emotes can be bound to a key instead of using right clicking.
/:cl:
