### PR TITLE
end of mission tele fix

### DIFF
--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 ///Returns all faction members back to base after the mission is completed
 /datum/faction_stats/proc/return_to_base(datum/campaign_mission/completed_mission)
 	for(var/mob/living/carbon/human/human_mob AS in GLOB.alive_human_list_faction[faction])
-		if((human_mob.z != completed_mission.mission_z_level.z_value) && human_mob.job.job_cost && human_mob.client)
+		if((human_mob.z && human_mob.z != completed_mission.mission_z_level.z_value) && human_mob.job.job_cost && human_mob.client) //why is byond so cursed that being inside something makes you z = 0
 			human_mob.revive(TRUE)
 			human_mob.overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 			human_mob.overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)


### PR DESCRIPTION

## About The Pull Request
Fixed being inside something (like a mech) causing you to teleport to base instead of despawning
## Why It's Good For The Game
Being sent back to base with depleted gear unintentionally is not ideal.
## Changelog
:cl:
fix: Campaign: Fixed not being properly despawned at the end of a mission in some cases
/:cl:
