### PR TITLE
ASAT desc fix

### DIFF
--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -53,7 +53,7 @@
 
 /datum/campaign_mission/capture_mission/asat/load_objective_description()
 	starting_faction_objective_description = "Major Victory:Capture all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Capture at least [min_capture_amount] ASAT systems." : ""]"
-	hostile_faction_objective_description = "Major Victory:Prevent the capture of all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Prevent the capture of atleast [min_capture_amount] ASAT systems." : ""]"
+	hostile_faction_objective_description = "Major Victory:Prevent the capture of all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Prevent the capture of atleast [objectives_total - min_capture_amount + 1] ASAT systems." : ""]"
 
 /datum/campaign_mission/capture_mission/asat/check_mission_progress()
 	if(outcome)


### PR DESCRIPTION

## About The Pull Request
Fixed the objective desc for TGMC to actually state the correct number of objectives you need to protect (2) instead of the amount SOM need to cap (5)
## Why It's Good For The Game
Misleading objective bad.
## Changelog
:cl:
fix: Campaign: Fixed an incorrect objective desc for ASAT Capture
/:cl:
