### PR TITLE
Adds a accuracy malus to Puppeteer and Widow minions

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -71,3 +71,6 @@
 #define EXPLODE_HEAVY 2
 #define EXPLODE_LIGHT 3
 #define EXPLODE_WEAK 4
+
+///Xenomorph accuracy
+#define XENO_DEFAULT_ACCURACY 70

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -47,7 +47,7 @@
 	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
 		affecting = get_limb(X.zone_selected)
 	else
-		affecting = get_limb(ran_zone(X.zone_selected, 70 - X.xeno_caste.accuracy_malus))
+		affecting = get_limb(ran_zone(X.zone_selected, XENO_DEFAULT_ACCURACY - X.xeno_caste.accuracy_malus))
 	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
 		affecting = get_limb(ran_zone(null, 0))
 	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -47,7 +47,7 @@
 	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
 		affecting = get_limb(X.zone_selected)
 	else
-		affecting = get_limb(ran_zone(X.zone_selected, 70))
+		affecting = get_limb(ran_zone(X.zone_selected, 70 - X.xeno_caste.accuracy_malus))
 	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
 		affecting = get_limb(ran_zone(null, 0))
 	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
@@ -10,6 +10,7 @@
 	tier = XENO_TIER_MINION
 	upgrade = XENO_UPGRADE_BASETYPE
 	melee_damage = 15
+	accuracy_malus = 65
 	speed = -0.8
 	plasma_max = 2
 	plasma_gain = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
@@ -12,6 +12,7 @@
 
 	// *** Melee Attacks *** //
 	melee_damage = 8
+	accuracy_malus = 65
 
 	// *** Speed *** //
 	speed = -0.6

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -225,6 +225,8 @@
 	var/evolve_min_xenos = 0
 	// How many of this caste may be alive at once
 	var/maximum_active_caste = INFINITY
+	// Accuracy malus, 0 by default. Should NOT go over 70.
+	var/accuracy_malus = 0
 
 ///Add needed component to the xeno
 /datum/xeno_caste/proc/on_caste_applied(mob/xenomorph)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -68,6 +68,7 @@
 #include "weed_spread.dm"
 #include "xeno_logical_scaling.dm"
 #include "item_variant_test.dm"
+#include "xenoaccuracy.dm"
 
 #ifdef REFERENCE_TRACKING //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter
 #include "find_reference_sanity.dm"

--- a/code/modules/unit_tests/xenoaccuracy.dm
+++ b/code/modules/unit_tests/xenoaccuracy.dm
@@ -1,0 +1,4 @@
+/datum/unit_test/xenoaccuracy/Run()
+	for(var/accuracy_malus in subtypesof(/datum/xeno_caste))
+		if(accuracy_malus >= XENO_DEFAULT_ACCURACY)
+			Fail("A xeno accuracy malus of 70 or over was detected, negatives cannot be used in accuracy calculations.")

--- a/code/modules/unit_tests/xenoaccuracy.dm
+++ b/code/modules/unit_tests/xenoaccuracy.dm
@@ -1,4 +1,6 @@
+/datum/unit_test/xenoaccuracy
+
 /datum/unit_test/xenoaccuracy/Run()
-	for(var/accuracy_malus in subtypesof(/datum/xeno_caste))
-		if(accuracy_malus >= XENO_DEFAULT_ACCURACY)
+	for(var/datum/xeno_caste/caste AS in subtypesof(/datum/xeno_caste))
+		if(initial(caste.accuracy_malus) >= XENO_DEFAULT_ACCURACY)
 			Fail("A xeno accuracy malus of 70 or over was detected, negatives cannot be used in accuracy calculations.")


### PR DESCRIPTION
## About The Pull Request
Instead of a 70% chance to hit a selected limb, widow and puppet minions now have a 5% to hit. Accuracy for Widow, Puppeter and all other castes have not been changed.
## Why It's Good For The Game
Widow and Puppeteer can use their minions as disposables to get free chest fracs. With this change they have to actually get into the fray, and even with that the free fractures won't be so free anymore. Their extremely low TTK has not changed, just less chance for more permanent forms of damage in exchange.
## Changelog
:cl:
balance: Widow and Puppeteer minions have a 5% chance to hit their selected limb (chest) instead of a 70% chance.
/:cl:
