### PR TITLE
Xeno plasma code optimisation and bug fix

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -174,7 +174,6 @@
 
 
 /mob/living/carbon/xenomorph/med_hud_set_status()
-	hud_set_plasma()
 	hud_set_pheromone()
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -193,7 +193,7 @@
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	if(target.stat == DEAD)
 		return
-	owner_xeno.plasma_stored = min(owner_xeno.plasma_stored + round(damage / 0.9), owner_xeno.xeno_caste.plasma_max)
+	owner_xeno.gain_plasma(floor(damage * 1.1))
 
 // ***************************************
 // *********** Stitch Puppet

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -193,7 +193,7 @@
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	if(target.stat == DEAD)
 		return
-	owner_xeno.gain_plasma(floor(damage * 1.1))
+	owner_xeno.gain_plasma(floor(damage / 0.9))
 
 // ***************************************
 // *********** Stitch Puppet

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
@@ -23,5 +23,5 @@
 	SIGNAL_HANDLER
 	if(target.stat == DEAD)
 		return
-	gain_plasma(floor(damage * 1.25))
+	gain_plasma(floor(damage / 0.8))
 	SEND_SIGNAL(src, COMSIG_PUPPET_CHANGE_ALL_ORDER, PUPPET_ATTACK, target) //we are on harm intent so it probably means we want to kill the target

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
@@ -23,5 +23,5 @@
 	SIGNAL_HANDLER
 	if(target.stat == DEAD)
 		return
-	plasma_stored = min(plasma_stored + round(damage / 0.8), xeno_caste.plasma_max)
+	gain_plasma(floor(damage * 1.25))
 	SEND_SIGNAL(src, COMSIG_PUPPET_CHANGE_ALL_ORDER, PUPPET_ATTACK, target) //we are on harm intent so it probably means we want to kill the target

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -113,9 +113,10 @@
 
 /mob/living/carbon/xenomorph/proc/handle_living_plasma_updates()
 	var/turf/T = loc
-	if(!T || !istype(T))
+	if(!istype(T)) //This means plasma doesn't update while you're in things like a vent, but since you don't have weeds in a vent or can actually take advantage of pheros, this is fine
 		return
-	if(plasma_stored >= xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)
+
+	if(!current_aura && (plasma_stored >= xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)) //no loss or gain
 		return
 
 	if(current_aura)
@@ -126,12 +127,9 @@
 		else
 			use_plasma(pheromone_cost, FALSE)
 
-	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN))
-		hud_set_plasma()
-		return
-
-	if(!loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
-		hud_set_plasma()
+	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN) || !loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
+		if(current_aura) //we only need to update if we actually used plasma from pheros
+			hud_set_plasma()
 		return
 
 	var/plasma_gain = xeno_caste.plasma_gain
@@ -145,8 +143,7 @@
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod)
 
-	gain_plasma(plasma_mod[1], FALSE)
-	hud_set_plasma()
+	gain_plasma(plasma_mod[1])
 
 /mob/living/carbon/xenomorph/can_receive_aura(aura_type, atom/source, datum/aura_bearer/bearer)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -120,18 +120,18 @@
 
 	if(current_aura)
 		if(plasma_stored < pheromone_cost)
-			use_plasma(plasma_stored)
+			use_plasma(plasma_stored, FALSE)
 			QDEL_NULL(current_aura)
 			src.balloon_alert(src, "Stop emitting, no plasma")
 		else
-			use_plasma(pheromone_cost)
+			use_plasma(pheromone_cost, FALSE)
 
 	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN))
 		hud_set_plasma()
 		return
 
 	if(!loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
-		hud_set_plasma() // since we used some plasma via the aura
+		hud_set_plasma()
 		return
 
 	var/plasma_gain = xeno_caste.plasma_gain
@@ -145,8 +145,8 @@
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod)
 
-	gain_plasma(plasma_mod[1])
-	hud_set_plasma() //update plasma amount on the plasma mob_hud
+	gain_plasma(plasma_mod[1], FALSE)
+	hud_set_plasma()
 
 /mob/living/carbon/xenomorph/can_receive_aura(aura_type, atom/source, datum/aura_bearer/bearer)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -40,7 +40,6 @@
 	update_fire() //the fire overlay depends on the xeno's stance, so we must update it.
 	update_wounds()
 
-	hud_set_plasma()
 	med_hud_set_health()
 	hud_set_sunder()
 	hud_set_firestacks()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -109,7 +109,7 @@
 	maxHealth = xeno_caste.max_health * GLOB.xeno_stat_multiplicator_buff
 	if(restore_health_and_plasma)
 		// xenos that manage plasma through special means shouldn't gain it for free on aging
-		plasma_stored = max(plasma_stored, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)
+		set_plasma(max(plasma_stored, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit))
 		health = maxHealth
 	setXenoCasteSpeed(xeno_caste.speed)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -184,16 +184,25 @@
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/xenomorph/proc/use_plasma(value)
+/mob/living/carbon/xenomorph/proc/set_plasma(value, update_plasma = TRUE)
+	plasma_stored = clamp(value, 0, xeno_caste.plasma_max)
+	if(!update_plasma)
+		return
+	hud_set_plasma()
+
+/mob/living/carbon/xenomorph/proc/use_plasma(value, update_plasma = TRUE)
 	plasma_stored = max(plasma_stored - value, 0)
 	update_action_button_icons()
+	if(!update_plasma)
+		return
+	hud_set_plasma()
 
-/mob/living/carbon/xenomorph/proc/gain_plasma(value)
+/mob/living/carbon/xenomorph/proc/gain_plasma(value, update_plasma = TRUE)
 	plasma_stored = min(plasma_stored + value, xeno_caste.plasma_max)
 	update_action_button_icons()
-
-
-
+	if(!update_plasma)
+		return
+	hud_set_plasma()
 
 //Strip all inherent xeno verbs from your caste. Used in evolution.
 /mob/living/carbon/xenomorph/proc/remove_inherent_verbs()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -374,7 +374,7 @@
 
 
 /mob/living/carbon/xenomorph/revive(admin_revive = FALSE)
-	plasma_stored = xeno_caste.plasma_max
+	set_plasma(xeno_caste.plasma_max)
 	sunder = 0
 	if(stat == DEAD)
 		hive?.on_xeno_revive(src)


### PR DESCRIPTION

## About The Pull Request
Fixes pheros not using any plasma if you're at full plasma... even off weeds.

Optimises the use of hud_set_plasma() so its not getting called multiple times every life tick and other random times. Instead, plasma is now only updated by the setter procs, and plasma hud is only updated when plasma actually changes.
## Why It's Good For The Game
Bug fix good.
Optimisation = better perf
Also the happy upside is that your plasma hud will update instantly when it changes (from using an ability etc) instead of waiting for a life tick.
## Changelog
:cl:
qol: Xeno plasma levels will update on the hud as soon as plasma levels change, instead of waiting for life ticks
fix: fixed pheros not using plasma if you were on full plasma, even off weeds
code: Improved some xeno plasma hud code
/:cl:
