### PR TITLE
Changes Tadpole's Med Dispenser Layer

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -381,6 +381,7 @@
 /obj/machinery/vending/nanomed/tadpolemed
 	name = "Flight surgeon medical equipment dispenser"
 	desc = "Dedicated for the surgeon with wings, this humble box contains a lot for its size."
+	layer = ABOVE_OBJ_LAYER
 	products = list(
 		"Autoinjectors" = list(
 			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 2,


### PR DESCRIPTION

## About The Pull Request
Changes the layer of the flight surgeon dispenser on the tadpole to be above objects.
## Why It's Good For The Game
Currently, it not only gets lost under the clutter of items that is usually on the tad, but also layers under the tadpole wall itself. This makes using the soporific injectors in them a pain in the ass. This pr helps make it so using the dispenser a lot is a lot easier, especially for researchers/synths/CMOs performing tad surgery. 
## Changelog
:cl:
qol: The tadpole surgery dispenser now layers over objects
/:cl:
