### PR TITLE
Changes Fire-safety Locker Layer, Changes It's Position On Standard Tad

### DIFF
--- a/_maps/shuttles/minidropship_standard.dmm
+++ b/_maps/shuttles/minidropship_standard.dmm
@@ -52,6 +52,9 @@
 	name = "inner door-control"
 	},
 /obj/item/stack/barbed_wire/half_stack,
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	pixel_x = -25
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "n" = (
@@ -77,9 +80,6 @@
 "q" = (
 /obj/machinery/vending/nanomed/tadpolemed{
 	pixel_x = 5
-	},
-/obj/structure/closet/walllocker/hydrant/extinguisher{
-	pixel_x = -25
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -50,6 +50,7 @@
 	icon_closed = "hydrant"
 	icon_opened = "hydrantopen"
 	overlay_welded = "hydrant-medical_welded"
+	layer = ABOVE_OBJ_LAYER
 
 /obj/structure/closet/walllocker/hydrant/extinguisher
 


### PR DESCRIPTION

## About The Pull Request
Changes the layer of the fire-safety lockers to layer above objects, changes it's position on the standard tad
## Why It's Good For The Game
Similar reason to #15174, moved it over so if #15174 goes through, the spot won't be covered completely by the 2 items.
## Changelog
:cl:
qol: Fire-safety cabinets now layer above objects
qol: Moved the fire cabinet on the standard tad model to the other side of the pilot computer.
/:cl:
