### PR TITLE
AI VOX announcement 

### DIFF
--- a/code/__HELPERS/announce.dm
+++ b/code/__HELPERS/announce.dm
@@ -135,7 +135,7 @@
  * * alert - optional, alert or notice?
  * * receivers - a list of all players to send the message to
  */
-/proc/minor_announce(message, title = "Attention:", alert, list/receivers = GLOB.alive_human_list)
+/proc/minor_announce(message, title = "Attention:", alert, list/receivers = GLOB.alive_human_list, should_play_sound = TRUE)
 	if(!message)
 		return
 
@@ -148,7 +148,8 @@
 				message = message,
 				minor = TRUE
 			))
-			SEND_SOUND(M, S)
+			if(should_play_sound)
+				SEND_SOUND(M, S)
 
 #undef span_alert_header
 #undef span_faction_alert_title

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -114,7 +114,7 @@
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	to_chat(src, span_notice("The following vocal announcement has been made: [message]."))
+	minor_announce(capitalize(message), "[name] announces:", should_play_sound = FALSE)
 
 	for(var/word in words) //play vox sounds to the rest of our zlevel
 		play_vox_word(word, src.z, null)


### PR DESCRIPTION
## About The Pull Request
Implements minor announcement for AI's VOX ability.
This PR also adds `should_play_sound` override to `minor_announce`.

## Why It's Good For The Game
Reading chat is important

## Changelog
:cl:
add: AI VOX announcements are now visible on chat
/:cl:
