### PR TITLE
Autocannon wall true damage buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1490,7 +1490,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 1
 	max_range = 35
 	///Bonus flat damage to walls, balanced around resin walls.
-	var/autocannon_wall_bonus = 20
+	var/autocannon_wall_bonus = 50
 
 /datum/ammo/bullet/auto_cannon/on_hit_turf(turf/T, obj/projectile/P)
 	P.proj_max_range -= 20
@@ -1515,7 +1515,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 5
 	max_range = 30
 	airburst_multiplier = 1
-	autocannon_wall_bonus = 5
+	autocannon_wall_bonus = 25
 
 /datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)


### PR DESCRIPTION

## About The Pull Request
20->50 wall damage bonus for HV, flak gets 5->25
## Why It's Good For The Game
Walls got some pretty big buffs to their resistances, and ACs entire gimmick is shooting down walls. So it has to be buffed to be up to par.
## Changelog
:cl:
balance: AC has significantly more wall damage to keep up with wall resistance buffs.
/:cl:
