### PR TITLE
Campaign credit tweaks

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -68,11 +68,11 @@
 	)
 	///cash rewards for the mission type
 	var/list/cash_rewards = list(
-		MISSION_OUTCOME_MAJOR_VICTORY = list(650, 450),
-		MISSION_OUTCOME_MINOR_VICTORY = list(550, 450),
-		MISSION_OUTCOME_DRAW = list(450, 450),
-		MISSION_OUTCOME_MINOR_LOSS = list(450, 550),
-		MISSION_OUTCOME_MAJOR_LOSS = list(450, 650),
+		MISSION_OUTCOME_MAJOR_VICTORY = list(700, 500),
+		MISSION_OUTCOME_MINOR_VICTORY = list(600, 500),
+		MISSION_OUTCOME_DRAW = list(500, 500),
+		MISSION_OUTCOME_MINOR_LOSS = list(500, 600),
+		MISSION_OUTCOME_MAJOR_LOSS = list(500, 700),
 	)
 	/// Timer used to calculate how long till mission ends
 	var/game_timer
@@ -273,6 +273,7 @@
 /datum/campaign_mission/proc/end_mission()
 	SHOULD_CALL_PARENT(TRUE)
 	unregister_mission_signals()
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
 	QDEL_LIST(GLOB.campaign_objectives)
 	QDEL_LIST(GLOB.campaign_structures)
 	QDEL_LIST(GLOB.patrol_point_list) //purge all existing links, cutting off the current ground map. Start point links are auto severed, and will reconnect to new points when a new map is loaded and upon use.
@@ -280,7 +281,6 @@
 	mission_state = MISSION_STATE_FINISHED
 	apply_outcome()
 	play_outro()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
 	for(var/i in GLOB.quick_loadouts)
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
 		outfit.quantity = initial(outfit.quantity)

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -273,7 +273,6 @@
 /datum/campaign_mission/proc/end_mission()
 	SHOULD_CALL_PARENT(TRUE)
 	unregister_mission_signals()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
 	QDEL_LIST(GLOB.campaign_objectives)
 	QDEL_LIST(GLOB.campaign_structures)
 	QDEL_LIST(GLOB.patrol_point_list) //purge all existing links, cutting off the current ground map. Start point links are auto severed, and will reconnect to new points when a new map is loaded and upon use.
@@ -281,6 +280,7 @@
 	mission_state = MISSION_STATE_FINISHED
 	apply_outcome()
 	play_outro()
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
 	for(var/i in GLOB.quick_loadouts)
 		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
 		outfit.quantity = initial(outfit.quantity)

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	var/active_attrition_points = 0
 	///Multiplier on the passive attrition point gain for this faction
 	var/attrition_gain_multiplier = 1
-	///cumulative loss bonus which is applied to attrition gain mult
+	///cumulative loss bonus which is applied to attrition gain mult and player credit mission reward
 	var/loss_bonus = 0
 	///Future missions this faction can currently choose from
 	var/list/datum/campaign_mission/available_missions = list()
@@ -234,6 +234,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 /datum/faction_stats/proc/apply_cash(amount)
 	if(!amount)
 		return
+	amount *= 1 + loss_bonus
 	accumulated_mission_reward += amount
 	for(var/i in individual_stat_list)
 		var/datum/individual_stats/player_stats = individual_stat_list[i]

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -4,7 +4,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 300
+	var/currency = 450
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference


### PR DESCRIPTION

## About The Pull Request
Some minor credit tweaks.

A little more initial credits and mission end credits.
Loss bonus now also applies to mission credit reward (i.e. the fixed amount, not the individual performance credits)
## Why It's Good For The Game
Very modest increase in credit availability, and loss bonus is good to be less punishing to the losing team.
## Changelog
:cl:
balance: Campaign: Slightly increased some credit reward values, and loss bonus now applies to mission credit rewards
/:cl:
