### PR TITLE
Adds the Critical sructure and ignore weed removal tag on Gargoyle.

### DIFF
--- a/code/modules/xenomorph/resin_gargoyle.dm
+++ b/code/modules/xenomorph/resin_gargoyle.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/Xeno/2x2building.dmi'
 	icon_state = "gargoyle"
 	max_integrity = 100
+	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
 	///Bool if we're currently alerting
 	var/is_alerting = FALSE
 	//cd tracking for the alert


### PR DESCRIPTION

## About The Pull Request
Adds in the flag that makes it a critical structure, making it visible in pinpointer and able to be tracked on xeno structures list.

The ignore weed removal flag was advised by Xander, saying that other structures had it added due to buggy nature of weeds. with structures(?)
## Why It's Good For The Game
Xenos can track them now, Marines can track them now.
## Changelog
:cl:
add: Gargoyles are now act the same as other structures, and can be tracked with Structure pinpointers and hive tracker.
/:cl:
