### PR TITLE
Doubles the Damage of Genghis Charge flames but halves it's total burn time. (rounded up)

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -190,7 +190,7 @@
 		flame_target.ignite(10, 5)
 		qdel(src)
 		return
-	new /obj/flamer_fire/autospread(flame_target, 17, 31)
+	new /obj/flamer_fire/autospread(flame_target, 9, 62)
 	playsound(plant_target, sound(get_sfx("explosion_small")), 100, FALSE, 25)
 	qdel(src)
 

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -226,7 +226,7 @@
 		spread_directions |= old_spreader.possible_directions
 	if(old_flame)
 		qdel(old_flame)
-	new /obj/flamer_fire/autospread(turf_to_burn, 17, 31, flame_color, 0, 0, spread_directions)
+	new /obj/flamer_fire/autospread(turf_to_burn, 9, 62, flame_color, 0, 0, spread_directions)
 
 ///Allows the c4 timer to be tweaked on certain atoms as required
 /atom/proc/plastique_time_mod(time)


### PR DESCRIPTION

## About The Pull Request
As the title says, it changes it's 17 (fire_level) and 32 (burn_level) to 9(rounded up), 62
## Why It's Good For The Game
If you ever get a moment to properly use this you better get mileage out of it instead of waiting for it all to melt.
## Changelog
:cl:
balance: 2x damage on Genghis charge flames, 0.5x on it's timer. (17, 31) --> (9, 62) (Time rounded up.)
/:cl:
