### PR TITLE
Wraith portal destruction change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -561,6 +561,11 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	QDEL_NULL(portal_visuals)
 	return ..()
 
+/obj/effect/wraith_portal/ex_act()
+	if(linked_portal)
+		qdel(linked_portal)
+	qdel(src)
+
 /obj/effect/wraith_portal/attack_ghost(mob/dead/observer/user)
 	. = ..()
 	if(!linked_portal)
@@ -646,8 +651,6 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	animate(get_filter("portal_ripple"), time = 1.3 SECONDS, loop = -1, easing = LINEAR_EASING, radius = 32)
 
 	vis_contents += our_destination
-/obj/effect/wraith_portal/ex_act()
-	qdel(src)
 
 /datum/action/ability/activable/xeno/rewind
 	name = "Time Shift"


### PR DESCRIPTION

## About The Pull Request
Blowing up a portal now destroys BOTH portals.
## Why It's Good For The Game
Currently, you throw a nade through a portal, it destroys the other end, which means the wraith can just instantly build a new portal. To actually counter a portal you have to portal your end, which is often unsafe, and its frankly unintuitive that nuking a portal only hurts one end.
## Changelog
:cl:
balance: Blowing up a wraith portal kills both ends of the portal now
/:cl:
