### PR TITLE
[NO GBP] Observers and AI itself can read VOX announcement too

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -114,7 +114,7 @@
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	minor_announce(capitalize(message), "[name] announces:", should_play_sound = FALSE)
+	minor_announce(capitalize(message), "[name] announces:", receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list), should_play_sound = FALSE)
 
 	for(var/word in words) //play vox sounds to the rest of our zlevel
 		play_vox_word(word, src.z, null)


### PR DESCRIPTION
## About The Pull Request
forgot to include receivers from my previous pull request

## Changelog
:cl:
code: Observers and AI now receive VOX announcement message
/:cl:
