### PR TITLE
Larva queue fixes 3 : Off by one mystery

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -991,7 +991,7 @@ to_chat will check for valid clients itself already so no need to double check f
 		return FALSE
 
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	if((xeno_job.total_positions - xeno_job.current_positions) <= 0)
+	if((xeno_job.total_positions - xeno_job.current_positions) < 0)
 		to_chat(xeno_candidate.mob, span_warning("There are no longer burrowed larvas available."))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request
Soo after being done with highly important things (monster hunter) & taking a closer look at the entire proc chain around larva spawns, it turns out the larva slot already gets occupied before the larva spawn stuff is reached, which means a 0 in currently available slots is actually fine (only a value below 0 meaning no slots having been available).
That also opens up the question if the initial PR was needed at all given the slot should already be accounted for when it starts to ask, but oh well may aswell just fix this proc at this point.
## Why It's Good For The Game
:)
## Changelog
:cl:
fix: You no longer need two or more stored larvae to spawn (yippie)
/:cl:
