### PR TITLE
Fixes landmark resin walls

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -23,7 +23,7 @@
 		weed_type = pickweight(GLOB.weed_prob_list)
 		new weed_type(T)
 	for(var/turf/T AS in GLOB.xeno_resin_wall_turfs)
-		T.ChangeTurf(/turf/closed/wall/resin, T.type)
+		T.ChangeTurf(/turf/closed/wall/resin/regenerating, T.type)
 	for(var/i in GLOB.xeno_resin_door_turfs)
 		new /obj/structure/mineral_door/resin(i)
 	for(var/i in GLOB.xeno_tunnel_spawn_turfs)


### PR DESCRIPTION

## About The Pull Request
Landmark resins walls did not regen and had 200 hp because they didn't use the regenerating subtype, which literally every xeno builds
## Why It's Good For The Game
Fix good
## Changelog
:cl:
fix: Landmark resin walls now properly function
/:cl:
