### PR TITLE
Xeno charge fixes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -680,6 +680,8 @@
 
 #define COMSIG_XENO_PSYCHIC_LINK_REMOVED "xeno_psychic_link_removed"
 
+#define COMSIG_XENOMORPH_LEAP_BUMP "xenomorph_leap_bump" //from /mob/living/carbon/xenomorph/bump
+
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -717,6 +717,9 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define TIME_TO_DISSOLVE 5 SECONDS
 #define SPIDERLING_RAGE_RANGE 10 // how close a nearby human has to be in order to be targeted
 
+//Praetorian defines
+#define PRAE_CHARGEDISTANCE 5
+
 //misc
 
 #define STANDARD_SLOWDOWN_REGEN 0.3

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -444,6 +444,10 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 
 //Xeno Defines
+//Xeno flags
+///Xeno is currently performing a leap/dash attack
+#define XENO_LEAPING (1<<0)
+
 
 #define XENO_DEFAULT_VENT_ENTER_TIME 4.5 SECONDS //Standard time for a xeno to enter a vent.
 #define XENO_DEFAULT_VENT_EXIT_TIME 2 SECONDS //Standard time for a xeno to exit a vent.

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/abilities_beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/abilities_beetle.dm
@@ -1,5 +1,5 @@
-/datum/action/ability/activable/xeno/forward_charge/unprecise
+/datum/action/ability/activable/xeno/charge/forward_charge/unprecise
 	cooldown_duration = 30 SECONDS
 
-/datum/action/ability/activable/xeno/forward_charge/unprecise/use_ability(atom/A)
+/datum/action/ability/activable/xeno/charge/forward_charge/unprecise/use_ability(atom/A)
 	return ..(get_turf(A))

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
@@ -12,17 +12,3 @@
 	tier = XENO_TIER_MINION
 	upgrade = XENO_UPGRADE_BASETYPE
 	pull_speed = -2
-
-/mob/living/carbon/xenomorph/beetle/Bump(atom/A)
-	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
-		return ..()
-	if(!ishuman(A))
-		return ..()
-	var/mob/living/carbon/human/H = A
-	var/extra_dmg = xeno_caste.melee_damage * xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
-	H.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
-	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
-	target_turf = get_step_rand(target_turf) //Scatter
-	H.throw_at(get_turf(target_turf), 4, 5, H)
-	H.Paralyze(2 SECONDS)
-	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
@@ -14,7 +14,7 @@
 	pull_speed = -2
 
 /mob/living/carbon/xenomorph/beetle/Bump(atom/A)
-	if(!throwing || !throw_source || !thrower)
+	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
 		return ..()
 	if(!ishuman(A))
 		return ..()
@@ -25,3 +25,4 @@
 	target_turf = get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), 4, 5, H)
 	H.Paralyze(2 SECONDS)
+	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/castedatum_beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/castedatum_beetle.dm
@@ -35,5 +35,5 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
-		/datum/action/ability/activable/xeno/forward_charge/unprecise,
+		/datum/action/ability/activable/xeno/charge/forward_charge/unprecise,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -137,7 +137,7 @@
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	var/mob/living/carbon/carbon_victim = living_target
 	var/extra_dmg = xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
-	carbon_victim.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
+	carbon_victim.attack_alien_harm(xeno_owner, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
 	var/target_turf = get_ranged_target_turf(carbon_victim, get_dir(src, carbon_victim), rand(1, 2)) //we blast our victim behind us
 	target_turf = get_step_rand(target_turf) //Scatter
 	carbon_victim.throw_at(get_turf(target_turf), charge_range, 5, src)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -99,20 +99,6 @@
 	///How long is the windup before charging
 	var/windup_time = 0.5 SECONDS
 
-/datum/action/ability/activable/xeno/charge/forward_charge/mob_hit(datum/source, mob/living/living_target)
-	. = TRUE
-	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) //we leap past xenos
-		return
-
-	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	var/mob/living/carbon/carbon_victim = living_target
-	var/extra_dmg = xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
-	carbon_victim.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
-	var/target_turf = get_ranged_target_turf(carbon_victim, get_dir(src, carbon_victim), rand(1, 2)) //we blast our victim behind us
-	target_turf = get_step_rand(target_turf) //Scatter
-	carbon_victim.throw_at(get_turf(target_turf), charge_range, 5, src)
-	carbon_victim.Paralyze(4 SECONDS)
-
 /datum/action/ability/activable/xeno/charge/forward_charge/use_ability(atom/A)
 	if(!A)
 		return
@@ -142,6 +128,20 @@
 	xeno_owner.throw_at(A, charge_range, 5, xeno_owner)
 
 	add_cooldown()
+
+/datum/action/ability/activable/xeno/charge/forward_charge/mob_hit(datum/source, mob/living/living_target)
+	. = TRUE
+	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) //we leap past xenos
+		return
+
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	var/mob/living/carbon/carbon_victim = living_target
+	var/extra_dmg = xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
+	carbon_victim.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
+	var/target_turf = get_ranged_target_turf(carbon_victim, get_dir(src, carbon_victim), rand(1, 2)) //we blast our victim behind us
+	target_turf = get_step_rand(target_turf) //Scatter
+	carbon_victim.throw_at(get_turf(target_turf), charge_range, 5, src)
+	carbon_victim.Paralyze(4 SECONDS)
 
 /datum/action/ability/activable/xeno/charge/forward_charge/ai_should_use(atom/target)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -120,19 +120,14 @@
 	target.hitby(owner, speed) //This resets throwing.
 	charge_complete()
 
-/datum/action/ability/activable/xeno/forward_charge/can_use_ability(atom/A, silent = FALSE, override_flags)
-	. = ..()
-	if(!.)
-		return FALSE
-	if(!A)
-		return FALSE
-
 /datum/action/ability/activable/xeno/forward_charge/on_cooldown_finish()
 	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use Forward Charge again."))
 	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
 	return ..()
 
 /datum/action/ability/activable/xeno/forward_charge/use_ability(atom/A)
+	if(!A)
+		return
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 
 	if(!do_after(xeno_owner, windup_time, IGNORE_HELD_ITEM, xeno_owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, PROC_REF(can_use_ability), A, FALSE, ABILITY_USE_BUSY)))
@@ -146,17 +141,17 @@
 		fortify_action.add_cooldown()
 		to_chat(xeno_owner, span_xenowarning("We rapidly untuck ourselves, preparing to surge forward."))
 
-	xeno_owner.visible_message(span_danger("[X] charges towards \the [A]!"), \
+	xeno_owner.visible_message(span_danger("[xeno_owner] charges towards \the [A]!"), \
 	span_danger("We charge towards \the [A]!") )
 	xeno_owner.emote("roar")
 	succeed_activate()
 
-	RegisterSignal(X, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
-	RegisterSignal(X, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
-	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
+	RegisterSignal(xeno_owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
+	RegisterSignal(xeno_owner, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
+	RegisterSignal(xeno_owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
 	xeno_owner.xeno_flags |= XENO_LEAPING
 
-	xeno_owner.throw_at(A, DEFENDER_CHARGE_RANGE, 5, X)
+	xeno_owner.throw_at(A, DEFENDER_CHARGE_RANGE, 5, xeno_owner)
 
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -98,12 +98,14 @@
 	///How long is the windup before charging
 	var/windup_time = 0.5 SECONDS
 
+///Deals with hitting objects
 /datum/action/ability/activable/xeno/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_XENOMORPH_LEAP_BUMP, COMSIG_MOVABLE_POST_THROW))
 	var/mob/living/carbon/xenomorph/ravager/xeno_owner = owner
 	xeno_owner.xeno_flags &= ~XENO_LEAPING
 
+///Deals with hitting mobs. Triggered by bump instead of throw impact as we want to plow past mobs
 /datum/action/ability/activable/xeno/forward_charge/proc/mob_hit(datum/source, mob/living/living_target)
 	SIGNAL_HANDLER
 	. = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -49,7 +49,7 @@
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/toggle_crest_defense,
 		/datum/action/ability/xeno_action/fortify,
-		/datum/action/ability/activable/xeno/forward_charge,
+		/datum/action/ability/activable/xeno/charge/forward_charge,
 		/datum/action/ability/xeno_action/tail_sweep,
 		/datum/action/ability/xeno_action/regenerate_skin,
 	)
@@ -69,7 +69,7 @@
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/toggle_crest_defense,
 		/datum/action/ability/xeno_action/fortify,
-		/datum/action/ability/activable/xeno/forward_charge,
+		/datum/action/ability/activable/xeno/charge/forward_charge,
 		/datum/action/ability/xeno_action/tail_sweep,
 		/datum/action/ability/xeno_action/regenerate_skin,
 		/datum/action/ability/xeno_action/centrifugal_force,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -48,19 +48,6 @@
 // ***************************************
 // *********** Mob overrides
 // ***************************************
-/mob/living/carbon/xenomorph/defender/Bump(atom/A)
-	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
-		return ..()
-	if(!ishuman(A))
-		return ..()
-	var/mob/living/carbon/human/human_victim = A
-	var/extra_dmg = xeno_caste.melee_damage * xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
-	human_victim.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
-	var/target_turf = get_ranged_target_turf(human_victim, get_dir(src, human_victim), rand(1, 2)) //we blast our victim behind us
-	target_turf = get_step_rand(target_turf) //Scatter
-	human_victim.throw_at(get_turf(target_turf), DEFENDER_CHARGE_RANGE, 5, src)
-	human_victim.Paralyze(4 SECONDS)
-	return TRUE
 
 /mob/living/carbon/xenomorph/defender/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -49,7 +49,7 @@
 // *********** Mob overrides
 // ***************************************
 /mob/living/carbon/xenomorph/defender/Bump(atom/A)
-	if(!throwing || !throw_source || !thrower)
+	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
 		return ..()
 	if(!ishuman(A))
 		return ..()
@@ -60,6 +60,7 @@
 	target_turf = get_step_rand(target_turf) //Scatter
 	human_victim.throw_at(get_turf(target_turf), DEFENDER_CHARGE_RANGE, 5, src)
 	human_victim.Paralyze(4 SECONDS)
+	return TRUE
 
 /mob/living/carbon/xenomorph/defender/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -300,7 +300,7 @@
 		owner.buckled.unbuckle_mob(owner)
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(movement_fx))
 	RegisterSignal(owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(object_hit))
-	RegisterSignal(owner, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
+	RegisterSignal(owner, COMSIG_XENOMORPH_LEAP_BUMP, PROC_REF(mob_hit))
 	RegisterSignal(owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(pounce_complete))
 	SEND_SIGNAL(owner, COMSIG_XENOMORPH_POUNCE)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
@@ -322,15 +322,17 @@
 
 /datum/action/ability/activable/xeno/pounce/proc/mob_hit(datum/source, mob/living/living_target)
 	SIGNAL_HANDLER
-	if(living_target.stat)
+	. = TRUE
+	if(living_target.stat || isxeno(living_target)) //we leap past xenos
 		return
+
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	if(ishuman(living_target) && (angle_to_dir(Get_Angle(xeno_owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
 		var/mob/living/carbon/human/human_target = living_target
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
 			xeno_owner.Paralyze(XENO_POUNCE_SHIELD_STUN_DURATION)
 			xeno_owner.set_throwing(FALSE)
-			return COMPONENT_KEEP_THROWING
+			return
 	trigger_pounce_effect(living_target)
 	pounce_complete()
 
@@ -344,7 +346,7 @@
 
 /datum/action/ability/activable/xeno/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER
-	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_XENO_OBJ_THROW_HIT, COMSIG_XENO_LIVING_THROW_HIT, COMSIG_MOVABLE_POST_THROW))
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_XENO_OBJ_THROW_HIT, COMSIG_XENOMORPH_LEAP_BUMP, COMSIG_MOVABLE_POST_THROW))
 	SEND_SIGNAL(owner, COMSIG_XENOMORPH_POUNCE_END)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.xeno_flags &= ~XENO_LEAPING

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -282,8 +282,6 @@
 /datum/action/ability/activable/xeno/pounce/on_cooldown_finish()
 	owner.balloon_alert(owner, "Pounce ready")
 	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
-	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	xeno_owner.usedPounce = FALSE
 	return ..()
 
 /datum/action/ability/activable/xeno/pounce/can_use_ability(atom/A, silent = FALSE, override_flags)
@@ -306,7 +304,7 @@
 	RegisterSignal(owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(pounce_complete))
 	SEND_SIGNAL(owner, COMSIG_XENOMORPH_POUNCE)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	xeno_owner.usedPounce = TRUE
+	xeno_owner.xeno_flags |= XENO_LEAPING
 	xeno_owner.pass_flags |= PASS_LOW_STRUCTURE|PASS_FIRE|PASS_XENO
 	xeno_owner.throw_at(A, pounce_range, XENO_POUNCE_SPEED, xeno_owner)
 	addtimer(CALLBACK(src, PROC_REF(reset_pass_flags)), 0.6 SECONDS)
@@ -348,6 +346,8 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_XENO_OBJ_THROW_HIT, COMSIG_XENO_LIVING_THROW_HIT, COMSIG_MOVABLE_POST_THROW))
 	SEND_SIGNAL(owner, COMSIG_XENOMORPH_POUNCE_END)
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	xeno_owner.xeno_flags &= ~XENO_LEAPING
 
 /datum/action/ability/activable/xeno/pounce/proc/reset_pass_flags()
 	var/mob/living/carbon/xenomorph/xeno_owner = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -136,6 +136,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ACID_DASH,
 	)
+	charge_range = PRAE_CHARGEDISTANCE
 	///Can we use the ability again
 	var/recast_available = FALSE
 	///Is this the recast
@@ -161,7 +162,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 
 	last_turf = get_turf(owner)
 	owner.pass_flags = PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE
-	owner.throw_at(A, 5, 2, owner)
+	owner.throw_at(A, charge_range, 2, owner)
 
 /datum/action/ability/activable/xeno/charge/acid_dash/mob_hit(datum/source, mob/living/living_target)
 	. = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 
 	RegisterSignal(xeno_owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
 	RegisterSignal(xeno_owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
-	RegisterSignal(xeno_owner, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
+	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_LEAP_BUMP, PROC_REF(mob_hit))
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(acid_steps)) //We drop acid on every tile we pass through
 
 	xeno_owner.visible_message(span_danger("[xeno_owner] slides towards \the [A]!"), \
@@ -163,10 +163,16 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	owner.pass_flags = PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE
 	owner.throw_at(A, 5, 2, owner)
 
-/datum/action/ability/activable/xeno/charge/acid_dash/mob_hit(datum/source, mob/M)
-	. = ..()
-	if(. == COMPONENT_KEEP_THROWING && !recast)
-		recast_available = TRUE
+/datum/action/ability/activable/xeno/charge/acid_dash/mob_hit(datum/source, mob/living/living_target)
+	. = TRUE
+	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) //we leap past xenos
+		return
+	var/mob/living/carbon/carbon_victim = living_target
+	carbon_victim.ParalyzeNoChain(0.5 SECONDS)
+
+	to_chat(carbon_victim, span_highdanger("The [src] tackles us, sending us behind them!"))
+	owner.visible_message(span_xenodanger("\The [src] tackles [carbon_victim], swapping location with them!"), \
+		span_xenodanger("We push [carbon_victim] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
 
 /datum/action/ability/activable/xeno/charge/acid_dash/charge_complete()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -123,10 +123,11 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, spray)
 		do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, (distance_left < 5) ? CONE_PART_MIDDLE : CONE_PART_MIDDLE_DIAG, spray)
 
+
 // ***************************************
 // *********** Acid dash
 // ***************************************
-/datum/action/ability/activable/xeno/acid_dash
+/datum/action/ability/activable/xeno/charge/acid_dash
 	name = "Acid Dash"
 	action_icon_state = "pounce"
 	desc = "Instantly dash, tackling the first marine in your path. If you manage to tackle someone, gain another weaker cast of the ability."
@@ -135,8 +136,6 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ACID_DASH,
 	)
-	///How far can we dash
-	var/range = 5
 	///Can we use the ability again
 	var/recast_available = FALSE
 	///Is this the recast
@@ -144,84 +143,49 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	///The last tile we dashed through, used when swapping with a human
 	var/turf/last_turf
 
-/datum/action/ability/activable/xeno/acid_dash/on_cooldown_finish()
-	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use Acid Dash again."))
-	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
-	return ..()
-
-///Called when the dash is finished, handles cooldowns and recast. Clears signals too
-/datum/action/ability/activable/xeno/acid_dash/proc/dash_complete()
-	var/mob/living/carbon/xenomorph/X = owner
-	SIGNAL_HANDLER
-	if(recast_available)
-		addtimer(CALLBACK(src, PROC_REF(dash_complete)), 2 SECONDS) //Delayed recursive call, this time you won't gain a recast so it will go on cooldown in 2 SECONDS.
-		recast = TRUE
-	else
-		recast = FALSE
-		add_cooldown()
-	X.pass_flags = initial(X.pass_flags)
-	recast_available = FALSE
-	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_MOVABLE_POST_THROW, COMSIG_XENO_LIVING_THROW_HIT, COMSIG_MOVABLE_MOVED))
-
-///Called whenever the owner hits a mob during the dash
-/datum/action/ability/activable/xeno/acid_dash/proc/mob_hit(datum/source, mob/M)
-	SIGNAL_HANDLER
-	if(recast || !ishuman(M)) //That's the recast, we don't stop for mobs
-		return COMPONENT_KEEP_THROWING
-
-	//Swapping part
-	var/mob/living/carbon/human/target = M
-	var/owner_passmob = (owner.pass_flags & PASS_MOB)
-	var/target_passmob = (target.pass_flags & PASS_MOB)
-	owner.pass_flags |= PASS_MOB
-	target.pass_flags |= PASS_MOB
-	target.forceMove(last_turf)
-	if(!owner_passmob)
-		owner.pass_flags &= ~PASS_MOB
-	if(!target_passmob)
-		target.pass_flags &= ~PASS_MOB
-
-	target.ParalyzeNoChain(0.5 SECONDS) //Extremely brief, we don't want them to take 289732 ticks of acid
-
-	to_chat(target, span_highdanger("The [owner] tackles us, sending us behind them!"))
-	owner.visible_message(span_xenodanger("\The [owner] tackles [target], swapping location with them!"), \
-		span_xenodanger("We push [target] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
-
-	recast_available = TRUE
-
-///Called whenever the owner hits an object during the dash
-/datum/action/ability/activable/xeno/acid_dash/proc/obj_hit(datum/source, obj/target, speed)
-	SIGNAL_HANDLER
-	if(istype(target, /obj/structure/table))
-		var/obj/structure/S = target
-		owner.visible_message(span_danger("[owner] plows straight through [S]!"), null, null, 5)
-		S.deconstruct(FALSE)
+/datum/action/ability/activable/xeno/charge/acid_dash/use_ability(atom/A)
+	if(!A)
 		return
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
 
-	target.hitby(owner, speed)
-	dash_complete()
-
-///Drops an acid puddle on the current owner's tile, will do 0 damage if the owner has no acid_spray_damage
-/datum/action/ability/activable/xeno/acid_dash/proc/acid_steps(atom/A, atom/OldLoc, Dir, Forced)
-	SIGNAL_HANDLER
-	last_turf = OldLoc
-	var/mob/living/carbon/xenomorph/X = owner
-	new /obj/effect/xenomorph/spray(get_turf(X), 5 SECONDS, X.xeno_caste.acid_spray_damage) //Add a modifier here to buff the damage if needed
-	for(var/obj/O in get_turf(X))
-		O.acid_spray_act(X)
-
-/datum/action/ability/activable/xeno/acid_dash/use_ability(atom/A)
-	RegisterSignal(owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
-	RegisterSignal(owner, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
+	RegisterSignal(xeno_owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
+	RegisterSignal(xeno_owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
+	RegisterSignal(xeno_owner, COMSIG_XENO_LIVING_THROW_HIT, PROC_REF(mob_hit))
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(acid_steps)) //We drop acid on every tile we pass through
-	RegisterSignal(owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(dash_complete))
 
-	owner.visible_message(span_danger("[owner] slides towards \the [A]!"), \
+	xeno_owner.visible_message(span_danger("[xeno_owner] slides towards \the [A]!"), \
 	span_danger("We dash towards \the [A], spraying acid down our path!") )
+	xeno_owner.emote("roar")
+	xeno_owner.xeno_flags |= XENO_LEAPING //This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown
 	succeed_activate()
 
 	last_turf = get_turf(owner)
 	owner.pass_flags = PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE
-	owner.throw_at(A, range, 2, owner)
+	owner.throw_at(A, 5, 2, owner)
 
-	return TRUE
+/datum/action/ability/activable/xeno/charge/acid_dash/mob_hit(datum/source, mob/M)
+	. = ..()
+	if(. == COMPONENT_KEEP_THROWING && !recast)
+		recast_available = TRUE
+
+/datum/action/ability/activable/xeno/charge/acid_dash/charge_complete()
+	. = ..()
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	if(recast_available)
+		addtimer(CALLBACK(src, PROC_REF(charge_complete)), 2 SECONDS) //Delayed recursive call, this time you won't gain a recast so it will go on cooldown in 2 SECONDS.
+		recast = TRUE
+	else
+		recast = FALSE
+		add_cooldown()
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+	xeno_owner.pass_flags = initial(xeno_owner.pass_flags)
+	recast_available = FALSE
+
+///Drops an acid puddle on the current owner's tile, will do 0 damage if the owner has no acid_spray_damage
+/datum/action/ability/activable/xeno/charge/acid_dash/proc/acid_steps(atom/A, atom/OldLoc, Dir, Forced)
+	SIGNAL_HANDLER
+	last_turf = OldLoc
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	new /obj/effect/xenomorph/spray(get_turf(xeno_owner), 5 SECONDS, xeno_owner.xeno_caste.acid_spray_damage) //Add a modifier here to buff the damage if needed
+	for(var/obj/O in get_turf(xeno_owner))
+		O.acid_spray_act(xeno_owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -172,8 +172,8 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/mob/living/carbon/carbon_victim = living_target
 	carbon_victim.ParalyzeNoChain(0.5 SECONDS)
 
-	to_chat(carbon_victim, span_highdanger("The [src] tackles us, sending us behind them!"))
-	owner.visible_message(span_xenodanger("\The [src] tackles [carbon_victim], swapping location with them!"), \
+	to_chat(carbon_victim, span_highdanger("The [owner] tackles us, sending us behind them!"))
+	owner.visible_message(span_xenodanger("\The [owner] tackles [carbon_victim], swapping location with them!"), \
 		span_xenodanger("We push [carbon_victim] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
 
 /datum/action/ability/activable/xeno/charge/acid_dash/charge_complete()

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	. = TRUE
 	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) //we leap past xenos
 		return
+	recast_available = TRUE
 	var/mob/living/carbon/carbon_victim = living_target
 	carbon_victim.ParalyzeNoChain(0.5 SECONDS)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -81,7 +81,7 @@
 		/datum/action/ability/activable/xeno/corrosive_acid,
 		/datum/action/ability/activable/xeno/xeno_spit,
 		/datum/action/ability/activable/xeno/spray_acid/cone,
-		/datum/action/ability/activable/xeno/acid_dash,
+		/datum/action/ability/activable/xeno/charge/acid_dash,
 		/datum/action/ability/xeno_action/pheromones,
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
@@ -14,16 +14,3 @@
 	tier = XENO_TIER_THREE
 	upgrade = XENO_UPGRADE_NORMAL
 	bubble_icon = "alienroyal"
-
-/mob/living/carbon/xenomorph/praetorian/Bump(atom/A)
-	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
-		return ..()
-	if(!ishuman(A))
-		return ..()
-	var/mob/living/carbon/human/human_victim = A
-	human_victim.ParalyzeNoChain(0.5 SECONDS)
-
-	to_chat(human_victim, span_highdanger("The [src] tackles us, sending us behind them!"))
-	visible_message(span_xenodanger("\The [src] tackles [human_victim], swapping location with them!"), \
-		span_xenodanger("We push [human_victim] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
-	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
@@ -15,3 +15,15 @@
 	upgrade = XENO_UPGRADE_NORMAL
 	bubble_icon = "alienroyal"
 
+/mob/living/carbon/xenomorph/praetorian/Bump(atom/A)
+	if(!(xeno_flags & XENO_LEAPING) || !throwing || !throw_source || !thrower)
+		return ..()
+	if(!ishuman(A))
+		return ..()
+	var/mob/living/carbon/human/human_victim = A
+	human_victim.ParalyzeNoChain(0.5 SECONDS)
+
+	to_chat(human_victim, span_highdanger("The [src] tackles us, sending us behind them!"))
+	visible_message(span_xenodanger("\The [src] tackles [human_victim], swapping location with them!"), \
+		span_xenodanger("We push [human_victim] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
+	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -71,7 +71,7 @@
 		return
 
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
-	living_target.attack_alien_harm(src, xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * 0.25, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
+	living_target.attack_alien_harm(xeno_owner, xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * 0.25, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
 	var/target_turf = get_ranged_target_turf(living_target, get_dir(src, living_target), rand(1, 3)) //we blast our victim behind us
 	target_turf = get_step_rand(target_turf) //Scatter
 	if(iscarbon(living_target))

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -14,6 +14,8 @@
 /datum/action/ability/activable/xeno/charge/proc/charge_complete()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_MOVABLE_POST_THROW, COMSIG_XENO_LIVING_THROW_HIT))
+	var/mob/living/carbon/xenomorph/ravager/xeno_owner = owner
+	xeno_owner.xeno_flags &= ~XENO_LEAPING
 
 /datum/action/ability/activable/xeno/charge/proc/obj_hit(datum/source, obj/target, speed)
 	SIGNAL_HANDLER
@@ -42,8 +44,6 @@
 /datum/action/ability/activable/xeno/charge/on_cooldown_finish()
 	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use Eviscerating Charge again."))
 	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
-	var/mob/living/carbon/xenomorph/ravager/X = owner
-	X.usedPounce = FALSE
 	return ..()
 
 /datum/action/ability/activable/xeno/charge/use_ability(atom/A)
@@ -55,8 +55,8 @@
 
 	X.visible_message(span_danger("[X] charges towards \the [A]!"), \
 	span_danger("We charge towards \the [A]!") )
-	X.emote("roar") //heheh
-	X.usedPounce = TRUE //This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown
+	X.emote("roar")
+	X.xeno_flags |= XENO_LEAPING //This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown
 	succeed_activate()
 
 	X.throw_at(A, RAV_CHARGEDISTANCE, RAV_CHARGESPEED, X)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -17,6 +17,7 @@
 	var/mob/living/carbon/xenomorph/ravager/xeno_owner = owner
 	xeno_owner.xeno_flags &= ~XENO_LEAPING
 
+///Deals with hitting objects
 /datum/action/ability/activable/xeno/charge/proc/obj_hit(datum/source, obj/target, speed)
 	SIGNAL_HANDLER
 	if(istype(target, /obj/structure/table))
@@ -28,6 +29,7 @@
 	target.hitby(owner, speed) //This resets throwing.
 	charge_complete()
 
+///Deals with hitting mobs. Triggered by bump instead of throw impact as we want to plow past mobs
 /datum/action/ability/activable/xeno/charge/proc/mob_hit(datum/source, mob/living/living_target)
 	SIGNAL_HANDLER
 	. = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -34,19 +34,14 @@
 		return
 	return COMPONENT_KEEP_THROWING //Ravagers plow straight through humans; we only stop on hitting a dense turf
 
-/datum/action/ability/activable/xeno/charge/can_use_ability(atom/A, silent = FALSE, override_flags)
-	. = ..()
-	if(!.)
-		return FALSE
-	if(!A)
-		return FALSE
-
 /datum/action/ability/activable/xeno/charge/on_cooldown_finish()
-	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use Eviscerating Charge again."))
+	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use [name] again."))
 	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
 	return ..()
 
 /datum/action/ability/activable/xeno/charge/use_ability(atom/A)
+	if(!A)
+		return
 	var/mob/living/carbon/xenomorph/ravager/X = owner
 
 	RegisterSignal(X, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -10,6 +10,8 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RAVAGER_CHARGE,
 	)
+	///charge distance
+	var/charge_range = RAV_CHARGEDISTANCE
 
 /datum/action/ability/activable/xeno/charge/proc/charge_complete()
 	SIGNAL_HANDLER
@@ -43,7 +45,7 @@
 	if(iscarbon(living_target))
 		var/mob/living/carbon/carbon_victim = living_target
 		carbon_victim.Paralyze(2 SECONDS)
-	living_target.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, src)
+	living_target.throw_at(get_turf(target_turf), charge_range, RAV_CHARGESPEED, src)
 
 /datum/action/ability/activable/xeno/charge/on_cooldown_finish()
 	to_chat(owner, span_xenodanger("Our exoskeleton quivers as we get ready to use [name] again."))
@@ -65,7 +67,7 @@
 	X.xeno_flags |= XENO_LEAPING //This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown
 	succeed_activate()
 
-	X.throw_at(A, RAV_CHARGEDISTANCE, RAV_CHARGESPEED, X)
+	X.throw_at(A, charge_range, RAV_CHARGESPEED, X)
 
 	add_cooldown()
 
@@ -75,14 +77,13 @@
 /datum/action/ability/activable/xeno/charge/ai_should_use(atom/target)
 	if(!iscarbon(target))
 		return FALSE
-	if(!line_of_sight(owner, target, 4))
+	if(!line_of_sight(owner, target, charge_range))
 		return FALSE
 	if(!can_use_ability(target, override_flags = ABILITY_IGNORE_SELECTED_ABILITY))
 		return FALSE
 	if(target.get_xeno_hivenumber() == owner.get_xeno_hivenumber())
 		return FALSE
 	return TRUE
-
 
 // ***************************************
 // *********** Ravage

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -23,7 +23,7 @@
 // *********** Mob overrides
 // ***************************************
 /mob/living/carbon/xenomorph/ravager/Bump(atom/A)
-	if(!throwing || !usedPounce || !throw_source || !thrower) //Must currently be charging to knock aside and slice marines in it's path
+	if(!throwing || !(xeno_flags & XENO_LEAPING) || !throw_source || !thrower) //Must currently be charging to knock aside and slice marines in it's path
 		return ..() //It's not pouncing; do regular Bump() IE body block but not throw_impact() because ravager isn't being thrown
 	if(!ishuman(A)) //Must also be a human; regular Bump() will default to throw_impact() which means ravager will plow through tables but get stopped by cades and walls
 		return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -22,19 +22,6 @@
 // ***************************************
 // *********** Mob overrides
 // ***************************************
-/mob/living/carbon/xenomorph/ravager/Bump(atom/A)
-	if(!throwing || !(xeno_flags & XENO_LEAPING) || !throw_source || !thrower) //Must currently be charging to knock aside and slice marines in it's path
-		return ..() //It's not pouncing; do regular Bump() IE body block but not throw_impact() because ravager isn't being thrown
-	if(!ishuman(A)) //Must also be a human; regular Bump() will default to throw_impact() which means ravager will plow through tables but get stopped by cades and walls
-		return ..()
-	var/mob/living/carbon/human/human_victim = A
-	human_victim.attack_alien_harm(src, xeno_caste.melee_damage * xeno_melee_damage_modifier * 0.25, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
-	var/target_turf = get_ranged_target_turf(human_victim, get_dir(src, human_victim), rand(1, 3)) //we blast our victim behind us
-	target_turf = get_step_rand(target_turf) //Scatter
-	human_victim.Paralyze(2 SECONDS)
-	human_victim.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, src)
-	return TRUE
-
 /mob/living/carbon/xenomorph/ravager/flamer_fire_act(burnlevel)
 	. = ..()
 	if(stat)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -31,8 +31,9 @@
 	human_victim.attack_alien_harm(src, xeno_caste.melee_damage * xeno_melee_damage_modifier * 0.25, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
 	var/target_turf = get_ranged_target_turf(human_victim, get_dir(src, human_victim), rand(1, 3)) //we blast our victim behind us
 	target_turf = get_step_rand(target_turf) //Scatter
-	human_victim.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, src)
 	human_victim.Paralyze(2 SECONDS)
+	human_victim.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, src)
+	return TRUE
 
 /mob/living/carbon/xenomorph/ravager/flamer_fire_act(burnlevel)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -51,17 +51,6 @@
 	update_inv_l_hand()
 	update_icons()
 
-
-/mob/living/carbon/xenomorph/update_inv_pockets()
-	if(l_store)
-		if(client && hud_used && hud_used.hud_shown)
-			l_store.screen_loc = ui_storage1
-			client.screen += l_store
-	if(r_store)
-		if(client && hud_used && hud_used.hud_shown)
-			r_store.screen_loc = ui_storage2
-			client.screen += r_store
-
 /mob/living/carbon/xenomorph/update_inv_r_hand()
 	remove_overlay(R_HAND_LAYER)
 	if(r_hand)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -278,11 +278,12 @@
 	gib_chance = 5
 	light_system = MOVABLE_LIGHT
 
+	///Hive name define
 	var/hivenumber = XENO_HIVE_NORMAL
-
+	///Hive datum we belong to
 	var/datum/hive_status/hive
 	///Xeno mob specific flags
-	var/xeno_flags = NONE
+	var/xeno_flags = NONE //TODO: There are loads of vars below that should be flags
 
 	///State tracking of hive status toggles
 	var/status_toggle_flags = HIVE_STATUS_DEFAULTS
@@ -292,8 +293,7 @@
 	var/datum/xeno_caste/xeno_caste
 	var/caste_base_type
 	var/language = "Xenomorph"
-	var/obj/item/r_store = null
-	var/obj/item/l_store = null
+	///Plasma currently stored
 	var/plasma_stored = 0
 
 	///A mob the xeno ate

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -281,6 +281,8 @@
 	var/hivenumber = XENO_HIVE_NORMAL
 
 	var/datum/hive_status/hive
+	///Xeno mob specific flags
+	var/xeno_flags = NONE
 
 	///State tracking of hive status toggles
 	var/status_toggle_flags = HIVE_STATUS_DEFAULTS
@@ -290,12 +292,9 @@
 	var/datum/xeno_caste/xeno_caste
 	var/caste_base_type
 	var/language = "Xenomorph"
-	var/obj/item/clothing/suit/wear_suit = null
-	var/obj/item/clothing/head/head = null
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/plasma_stored = 0
-	var/time_of_birth
 
 	///A mob the xeno ate
 	var/mob/living/carbon/eaten_mob
@@ -309,9 +308,6 @@
 	var/sunder = 0
 	///The ammo datum for our spit projectiles. We're born with this, it changes sometimes.
 	var/datum/ammo/xeno/ammo = null
-
-	var/list/upgrades_bought = list()
-
 	///The aura we're currently emitted. Destroyed whenever we change or stop pheromones.
 	var/datum/aura_bearer/current_aura
 	/// If we're chosen as leader, this is the leader aura we emit.
@@ -339,8 +335,6 @@
 	var/attack_delay = 0
 	///This will track their "tier" to restrict/limit evolutions
 	var/tier = XENO_TIER_ONE
-
-	var/emotedown = 0
 	///which resin structure to build when we secrete resin
 	var/selected_resin = /turf/closed/wall/resin/regenerating
 	///which reagent to slash with using reagent slash
@@ -368,9 +362,6 @@
 	//Charge vars
 	///Will the mob charge when moving ? You need the charge verb to change this
 	var/is_charging = CHARGE_OFF
-
-	//Pounce vars
-	var/usedPounce = 0
 
 	// Gorger vars
 	var/overheal = 0

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -13,7 +13,6 @@
 	light_pixel_y -= pixel_y
 	. = ..()
 	set_datum()
-	time_of_birth = world.time
 	add_inherent_verbs()
 	var/datum/action/minimap/xeno/mini = new
 	mini.give_action(src)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -1,3 +1,10 @@
+/mob/living/carbon/xenomorph/Bump(atom/A)
+	if(!(xeno_flags & XENO_LEAPING))
+		return ..()
+	if(!isliving(A))
+		return ..()
+	return SEND_SIGNAL(src, COMSIG_XENOMORPH_LEAP_BUMP, A)
+
 /mob/living/carbon/xenomorph/verb/hive_status()
 	set name = "Hive Status"
 	set desc = "Check the status of your current hive."

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -267,7 +267,7 @@
 /mob/living/carbon/xenomorph/throw_impact(atom/hit_atom, speed)
 	set waitfor = FALSE
 
-	if(stat || !usedPounce)
+	if(stat || !(xeno_flags & XENO_LEAPING))
 		return ..()
 
 	if(isobj(hit_atom)) //Deal with smacking into dense objects. This overwrites normal throw code.


### PR DESCRIPTION
## About The Pull Request
Fixes #14883
Fixes all xeno charge abilities (rav/defender/beetle/prae) that had various issues that prevented them from working partially or entirely.
Refactored all these abilities to a single charge type since they're all fundamentally the same. Desnowflaked a lot of code, although it can probably be improved further.
Removed some old unused xeno vars.
Added a new xeno_flag var for xeno mobs (someone thats not me please move the gorillion vars that should be vars to actual flags)
## Changelog
:cl:
fix: fixed various bugs with xeno charge abilities
refactor: Refactored xeno charge abilities
/:cl:
