### PR TITLE
Increases crusher sunder multiplier

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -36,7 +36,7 @@
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.5
+	sunder_multiplier = 0.7
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"


### PR DESCRIPTION

## About The Pull Request
Increases crusher sunder multiplier from .5 to .7
Barnet gave me his blessing for this one
## Why It's Good For The Game
Crusher can currently outheal most sources of sunder, and doubly so with a hivelord beam. Making them take more sunder should make them leave combat instead of rarely dropping below 75% armor.
## Changelog
:cl:
balance: Increases crusher sunder multiplier
/:cl:
