### PR TITLE
Mecha keybinds

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPreferences/KeybindSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/KeybindSettings.tsx
@@ -147,6 +147,12 @@ export const KeybindSettings = (props) => {
             {all_keybindings['ITEM']
               ?.filter(filterSearch)
               .map((kb) => <KeybindingPreference key={kb.name} keybind={kb} />)}
+            <LabeledList.Item>
+              <h3>Mecha</h3>
+            </LabeledList.Item>
+            {all_keybindings['MECHA']
+              ?.filter(filterSearch)
+              .map((kb) => <KeybindingPreference key={kb.name} keybind={kb} />)}
           </Section>
         </Stack.Item>
       </Stack>


### PR DESCRIPTION

## About The Pull Request
Mecha keybinds can now actually be set.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/aff4a33b-21a2-4c20-9f62-b54bfe4f1d0b)

Seems they weren't added to the pref menu when ported, so you only got keybinds if you had a new/wiped account, and couldn't change them. Honk.
## Why It's Good For The Game
Being able to use hotkeys is quite useful.
## Changelog
:cl:
qol: Mecha controls can now be correctly hotkeyed
/:cl:
