### PR TITLE
rust-g with the pathfinder compiled

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -185,7 +185,7 @@
 /**²
  * Remove every link to the node with unique_id. Replace that node by null
  */
-#define rustg_remove_node_astart(unique_id) RUSTG_CALL(RUST_G, "remove_node_astar")(unique_id)
+#define rustg_remove_node_astar(unique_id) RUSTG_CALL(RUST_G, "remove_node_astar")(unique_id)
 
 /**
  * Compute the shortest path between start_node and goal_node using A*. Heuristic used is simple geometric distance

--- a/code/modules/ai/ai_node.dm
+++ b/code/modules/ai/ai_node.dm
@@ -58,7 +58,7 @@
 
 /obj/effect/ai_node/Destroy()
 	GLOB.all_nodes[unique_id + 1] = null
-	rustg_remove_node_astart("[unique_id]")
+	rustg_remove_node_astar("[unique_id]")
 	//Remove our reference to self from nearby adjacent node's adjacent nodes
 	for(var/direction AS in adjacent_nodes)
 		var/obj/effect/ai_node/node = adjacent_nodes[direction]


### PR DESCRIPTION

## About The Pull Request
rustg but with the pathfinder actually compiled also fixes a type with rustg_remove_node_astart to rustg_remove_node_astar
## Why It's Good For The Game
fixes advanced pathfinding procs being undefined
## Changelog
:cl:
fix: rust-g not compiled with pathfinder feature
/:cl:
