### PR TITLE
Reqtorio expansion V 1.6

### DIFF
--- a/code/modules/factory/howtopaper.dm
+++ b/code/modules/factory/howtopaper.dm
@@ -10,11 +10,8 @@
 	Machines will always output in the direction they are facing and input from the opposite direction.<br>
 	<br>
 	RECIPES:<br>
-	WP GRENADE:<br>
-	UNBOXER -> CUTTER -> HEATER -> FORMER<br>
-	<br>
-	M15 GRENADE:<br>
-	UNBOXER -> CUTTER -> FORMER<br>
+	ALL GRENADES:<br>
+	UNBOXER -> CUTTER -> HEATER -> FORMER -> COMPRESSOR<br>
 	<br>
 	PIZZA:<br>
 	UNBOXER -> CUTTER -> HEATER<br>
@@ -38,17 +35,10 @@
 	UNBOXER -> CUTTER -> FLATTER<br>
 	<br>
 	ALL RAILGUN AMMO:<br>
-	ALL RAILGUN AMMO:<br>
 	UNBOXER -> CUTTER -> FLATTER -> ATOMIC RECONSTRUCTOR<br>
 	<br>
 	MINIGUN POWERPACK:<br>
 	UNBOXER -> CUTTER -> ATMOIC RECONSTRUCTOR -> FORMER<br>
-	<br>
-	RAZORFOAM GRENADES:<br>
-	UNBOXER -> CUTTER -> FORMER -> HEATER<br>
-	<br>
-	SR-127 FLAK AMMO:<br>
-	UNBOXER -> CUTTER -> ATOMIC RECONSTRUCTOR<br>
 	<br>
 	SR-127 FLAK AMMO:<br>
 	UNBOXER -> CUTTER -> ATOMIC RECONSTRUCTOR<br>

--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -39,25 +39,11 @@
 	next_machine = recipe[stage][STEP_NEXT_MACHINE]
 	icon_state = recipe[stage][STEP_ICON_STATE]
 
-GLOBAL_LIST_INIT(phosnade_recipe, list(
+GLOBAL_LIST_INIT(grenade, list(
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "uncutplate"),
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_HEATER, STEP_ICON_STATE = "cutplate"),
-	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_FORMER, STEP_ICON_STATE = "hotplate"),
-	))
-
-/obj/item/factory_part/phosnade
-	name = "phosphorus grenade assembly"
-	desc = "A incomplete phosphorus grenade assembly"
-	result = /obj/item/explosive/grenade/phosphorus
-
-/obj/item/factory_part/phosnade/Initialize(mapload)
-	. = ..()
-	recipe = GLOB.phosnade_recipe
-
-
-GLOBAL_LIST_INIT(bignade_recipe,  list(
-	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "uncutplate"),
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_FORMER, STEP_ICON_STATE = "roundplate"),
+	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_COMPRESSOR, STEP_ICON_STATE = "hotplate"),
 	))
 
 /obj/item/factory_part/bignade
@@ -67,7 +53,97 @@ GLOBAL_LIST_INIT(bignade_recipe,  list(
 
 /obj/item/factory_part/bignade/Initialize(mapload)
 	. = ..()
-	recipe = GLOB.bignade_recipe
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/incennade
+	name = "incendiary grenade assembly"
+	desc = "An incomplete incendiary grenade casing."
+	result = /obj/item/explosive/grenade/incendiary
+
+/obj/item/factory_part/incennade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/stickynade
+	name = "adhesive grenade assembly."
+	desc = "An incomplete adhesive grenade casing."
+	result = /obj/item/explosive/grenade/sticky
+
+/obj/item/factory_part/stickynade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/phosnade
+	name = "phosphorus grenade assembly"
+	desc = "An incomplete phosphorus grenade casing."
+	result = /obj/item/explosive/grenade/phosphorus
+
+/obj/item/factory_part/phosnade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/cloaknade
+	name = "cloaking grenade assembly"
+	desc = "An incomplete cloaking grenade casing."
+	result = /obj/item/explosive/grenade/smokebomb/cloak
+
+/obj/item/factory_part/cloaknade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/tfootnade
+	name = "tanglefoot grenade assembly"
+	desc ="An incomplete tanglefoot grenade casing."
+	result = /obj/item/explosive/grenade/smokebomb/drain
+
+/obj/item/factory_part/tfootnade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/trailblazer
+	name = "trailblazer grenade assembly"
+	desc = "An incomplete trailblazer grenade casing."
+	result = /obj/item/explosive/grenade/sticky/trailblazer
+
+/obj/item/factory_part/trailblazer/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/lasenade
+	name = "laser grenade assembly"
+	desc = "An incomplete laser grenade casing."
+	result = /obj/item/explosive/grenade/bullet/laser
+
+/obj/item/factory_part/lasenade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/hefanade
+	name = "HEFA fragmentation grenade assembly"
+	desc = "An incomplete HEFA fragmentation grenade casing."
+	result = /obj/item/explosive/grenade/bullet/hefa
+
+/obj/item/factory_part/hefanade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/antigas
+	name = "anti-gas smoke grenade assembly"
+	desc = "An incomplete anti-gas smoke grenade casing."
+	result = /obj/item/explosive/grenade/smokebomb/antigas
+
+/obj/item/factory_part/antigas/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
+
+/obj/item/factory_part/razornade
+	name = "razorfoam grenade assembly"
+	desc = "An unfinished Razorfoam grenade casing."
+	result = /obj/item/explosive/grenade/chem_grenade/razorburn_small
+
+/obj/item/factory_part/razornade/Initialize(mapload)
+	. = ..()
+	recipe = GLOB.grenade
 
 GLOBAL_LIST_INIT(pizza_recipe,  list(
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "dough"),
@@ -387,20 +463,6 @@ GLOBAL_LIST_INIT(minigun_powerpack, list(
 /obj/item/factory_part/minigun_powerpack/Initialize(mapload)
 	. = ..()
 	recipe = GLOB.minigun_powerpack
-
-GLOBAL_LIST_INIT(razornade, list(
-	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "uncutplate"),
-	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_FORMER, STEP_ICON_STATE = "roundplate"),
-	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_HEATER, STEP_ICON_STATE = "cutplate"),
-	))
-/obj/item/factory_part/razornade
-	name = "razorfoam grenade"
-	desc = "An unfinished Razorfoam grenade casing."
-	result = /obj/item/explosive/grenade/chem_grenade/razorburn_small
-
-/obj/item/factory_part/razornade/Initialize(mapload)
-	. = ..()
-	recipe = GLOB.razornade
 
 GLOBAL_LIST_INIT(howitzer_shell, list(
 	list(STEP_NEXT_MACHINE = FACTORY_MACHINE_CUTTER, STEP_ICON_STATE = "uncutplate"),

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -106,16 +106,71 @@
 		qdel(refill)
 		new /obj/item/stack/sheet/metal(user.loc)//simulates leftover trash
 
-/obj/item/factory_refill/phosnade_refill
-	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/phosnade
-	refill_amount = 25
-
 /obj/item/factory_refill/bignade_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/bignade
+	refill_amount = 40
+
+/obj/item/factory_refill/incennade_refill
+	name = "box of incendiary grenade plates"
+	desc = "A box with round metal plates inside that could be used to construct Incendiary genades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/incennade
+	refill_amount = 40
+
+/obj/item/factory_refill/stickynade_refill
+	name = "box of adhesive genade plates"
+	desc = "A box with round metal plates inside that could be used to construct Adhesive grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/stickynade
+	refill_amount = 40
+
+/obj/item/factory_refill/phosnade_refill
+	name = "box of rounded metal plates"
+	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/phosnade
+	refill_amount = 40
+
+/obj/item/factory_refill/cloaknade_refill
+	name = "box of cloaking grenade plates"
+	desc = "A box with round metal plates inside that could be used to construct Cloaking grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/cloaknade
+	refill_amount = 40
+
+/obj/item/factory_refill/tfootnade_refill
+	name = "box of tangle grenade plates"
+	desc = "A box with round metal plates inside that could be used to construct Tanglefoot grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/tfootnade
+	refill_amount = 40
+
+/obj/item/factory_refill/trailblazer_refill
+	name = "box of trailblazer grenade plates"
+	desc = "A box with round metal plates inside that could be used to construct Trailblazer genades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/trailblazer
+	refill_amount = 40
+
+/obj/item/factory_refill/lasenade_refill
+	name = "box of laser grenade plates and cells."
+	desc = "A box with plates and cells inside that could be used to construct Laser grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/lasenade
+	refill_amount = 40
+
+/obj/item/factory_refill/hefanade_refill
+	name = "box of hefa nade plates and shells."
+	desc = "A box with plates and shells inside that could be used to construct HEFA grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/hefanade
+	refill_amount = 40
+
+/obj/item/factory_refill/antigas_refill
+	name = "box of Anti-Gas plates."
+	desc = "A box with plates inside that could be used to construct M40-AG grenades. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/antigas
+	refill_amount = 40
+
+/obj/item/factory_refill/razornade_refill
+	name = "box of rounded metal plates"
+	desc = "A box with round metal plates inside. Used to refill Unboxers."
+	refill_type = /obj/item/factory_part/razornade
+	refill_amount = 40
 
 /obj/item/factory_refill/pizza_refill
 	name = "box of rounded metal plates"
@@ -262,12 +317,6 @@
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/minigun_powerpack
 	refill_amount = 10
-
-/obj/item/factory_refill/razornade_refill
-	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/razornade
-	refill_amount = 30
 
 /obj/item/factory_refill/sniper_flak_magazine_refill
 	name = "box of rounded metal plates"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2061,15 +2061,55 @@ FACTORY
 	contains = list(/obj/machinery/unboxer)
 	cost = 50
 
-/datum/supply_packs/factory/phosphosrefill
-	name = "Phosphorus-resistant plates refill"
-	contains = list(/obj/item/factory_refill/phosnade_refill)
-	cost = 900
-
 /datum/supply_packs/factory/bignaderefill
 	name = "Rounded M15 plates refill"
 	contains = list(/obj/item/factory_refill/bignade_refill)
+	cost = 700
+
+/datum/supply_packs/factory/incennaderefill
+	name = "Incendiary grenade refill"
+	contains = list(/obj/item/factory_refill/incennade_refill)
 	cost = 500
+
+/datum/supply_packs/factory/stickynaderefill
+	name = "Adhesive grenade refill"
+	contains = list(/obj/item/factory_refill/stickynade_refill)
+	cost = 450
+
+/datum/supply_packs/factory/phosphosrefill
+	name = "Phosphorus-resistant plates refill"
+	contains = list(/obj/item/factory_refill/phosnade_refill)
+	cost = 1400
+
+/datum/supply_packs/factory/tfootnaderefill
+	name = "Tanglefoot grenade refill"
+	contains = list(/obj/item/factory_refill/tfootnade_refill)
+	cost = 800
+
+/datum/supply_packs/factory/trailblazerrefill
+	name = "Trailblazer grenade refill"
+	contains = list(/obj/item/factory_refill/trailblazer_refill)
+	cost = 500
+
+/datum/supply_packs/factory/lasenaderefill
+	name = "Laserburster grenade refill"
+	contains = list(/obj/item/factory_refill/lasenade_refill)
+	cost = 450
+
+/datum/supply_packs/factory/hefanaderefill
+	name = "HEFA fragmentation grenade refill"
+	contains = list(/obj/item/factory_refill/hefanade_refill)
+	cost = 700
+
+/datum/supply_packs/factory/antigasrefill
+	name = "Anti-Gas grenade refill"
+	contains = list(/obj/item/factory_refill/antigas_refill)
+	cost = 800
+
+/datum/supply_packs/factory/razornade_refill
+	name = "Razornade assembly refill"
+	contains = list(/obj/item/factory_refill/razornade_refill)
+	cost = 1000
 
 /datum/supply_packs/factory/sadar_refill_he
 	name = "SADAR HE missile assembly refill"
@@ -2180,11 +2220,6 @@ FACTORY
 	name = "Minigun powerpack assembly refill"
 	contains = list(/obj/item/factory_refill/minigun_powerpack_refill)
 	cost = 250
-
-/datum/supply_packs/factory/razornade_refill
-	name = "Razornade assembly refill"
-	contains = list(/obj/item/factory_refill/razornade_refill)
-	cost = 500
 
 /datum/supply_packs/factory/flak_sniper_refill
 	name = "SR-127 flak magazine assembly refill"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2081,11 +2081,6 @@ FACTORY
 	contains = list(/obj/item/factory_refill/phosnade_refill)
 	cost = 1400
 
-/datum/supply_packs/factory/tfootnaderefill
-	name = "Tanglefoot grenade refill"
-	contains = list(/obj/item/factory_refill/tfootnade_refill)
-	cost = 800
-
 /datum/supply_packs/factory/trailblazerrefill
 	name = "Trailblazer grenade refill"
 	contains = list(/obj/item/factory_refill/trailblazer_refill)


### PR DESCRIPTION
## About The Pull Request
Adds every grenade to reqtorio and standardizes the grenade recipe.
Reworks the cost and amount of WP, razor and M15 nades in reqtorio.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/73274515/58da2342-f75f-4bb0-8190-ebcb56d88c24)

## Why It's Good For The Game
More recipes, more reqtorio, more fun.
## Changelog
:cl:
add: Adds Incendiary, Sticky, Cloak, Tfoot, Trailblazer, Lasernade, HEFA and Antigas grenades to reqtorio.
balance: Adjusted the price and yield of M15, WP and razor nades in reqtorio.
/:cl:
