### PR TITLE
Fixes near-infinite loop with primordial crusher ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -197,7 +197,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	X.face_atom(A)
 	X.set_canmove(FALSE)
-	if(!do_after(X, 10, NONE, X, BUSY_ICON_DANGER))
+	if(!do_after(X, 10, NONE, X, BUSY_ICON_DANGER) || !((target_turf = get_turf(A))))
 		if(!X.stat)
 			X.set_canmove(TRUE)
 		return fail_activate()
@@ -216,7 +216,12 @@
 		if(i % 2)
 			playsound(X, "alien_charge", 50)
 			new /obj/effect/temp_visual/xenomorph/afterimage(get_turf(X), X)
+
 		X.Move(get_step(X, aimdir), aimdir)
+
+		target_turf = get_turf(A)
+		if(isnull(A) || (A.z != X.z)) //Target's off the map or on another z level
+			break
 		aimdir = get_dir(X,target_turf)
 
 	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -189,6 +189,11 @@
 
 
 /datum/action/ability/activable/xeno/advance/use_ability(atom/A)
+	var/turf/target_turf = get_turf(A)
+	var/turf/starting_turf = get_turf(owner)
+	if(!target_turf || !starting_turf)
+		return
+
 	var/mob/living/carbon/xenomorph/X = owner
 	X.face_atom(A)
 	X.set_canmove(FALSE)
@@ -199,19 +204,21 @@
 	X.set_canmove(TRUE)
 
 	var/datum/action/ability/xeno_action/ready_charge/charge = X.actions_by_path[/datum/action/ability/xeno_action/ready_charge]
-	var/aimdir = get_dir(X,A)
+	var/aimdir = get_dir(X, target_turf)
 	if(charge)
 		charge.charge_on(FALSE)
 		charge.do_stop_momentum(FALSE) //Reset charge so next_move_limit check_momentum() does not cuck us and 0 out steps_taken
 		charge.do_start_crushing()
 		charge.valid_steps_taken = charge.max_steps_buildup - 1
 		charge.charge_dir = aimdir //Set dir so check_momentum() does not cuck us
-	for(var/i=0 to get_dist(X, A))
+
+	for(var/i in 0 to get_dist(starting_turf, target_turf))
 		if(i % 2)
 			playsound(X, "alien_charge", 50)
 			new /obj/effect/temp_visual/xenomorph/afterimage(get_turf(X), X)
 		X.Move(get_step(X, aimdir), aimdir)
-		aimdir = get_dir(X,A)
+		aimdir = get_dir(X,target_turf)
+
 	succeed_activate()
 	add_cooldown()
 


### PR DESCRIPTION

## About The Pull Request
get_dist() will return -1 when Loc1 and Loc2 are the same object. If one or both of them is not on the map, an infinite value is returned.
https://www.byond.com/docs/ref/#/proc/get_dist
## Changelog
:cl:
fix: Primordial crusher doesn't crash the server anymore.
/:cl:
