### PR TITLE
Punchstun and shovestun no longer care about armor and always stuns for 4 seconds now. (HVH PR)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -122,7 +122,7 @@
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
-				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				apply_effect((4 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				hit_report += "(KO)"
 
 			damage += attack.damage
@@ -169,7 +169,7 @@
 			var/randn = rand(1, 100) + skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD - human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD
 
 			if (randn <= 25)
-				apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				apply_effect((4 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
 				log_combat(human_user, src, "pushed")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -122,7 +122,7 @@
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
-				apply_effect(4 SECONDS, WEAKEN)
+				apply_effect(3 SECONDS, WEAKEN)
 				hit_report += "(KO)"
 
 			damage += attack.damage
@@ -169,7 +169,7 @@
 			var/randn = rand(1, 100) + skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD - human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD
 
 			if (randn <= 25)
-				apply_effect(4 SECONDS, WEAKEN)
+				apply_effect(3 SECONDS, WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
 				log_combat(human_user, src, "pushed")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -122,7 +122,7 @@
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
-				apply_effect((4 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				apply_effect(4 SECONDS, WEAKEN)
 				hit_report += "(KO)"
 
 			damage += attack.damage
@@ -169,7 +169,7 @@
 			var/randn = rand(1, 100) + skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD - human_user.skills.getRating(SKILL_CQC) * CQC_SKILL_DISARM_MOD
 
 			if (randn <= 25)
-				apply_effect((4 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				apply_effect(4 SECONDS, WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
 				log_combat(human_user, src, "pushed")


### PR DESCRIPTION

## About The Pull Request
Removes the odd piece of coding that made people with more armor stun for shorter times, but people who are bare naked get stunned for a maximum of **6** (holy shit) seconds
## Why It's Good For The Game
If you get hit by a 25% chance stun (punches) or a disarm that can only go up to 35% max if you have max cqc and your target doesn't. 

You'd still more likely either get taken down by: Melee weapons, shotguns, airburst rifles/rifles in general and SMG AP burst auto equivalent weaponry honestly.
## Changelog
:cl:
balance: Punch stun and Shove stun no longer get lowered by more armor, and increased with less armor, and will now always stun for 4 seconds. (Old values: 6 second stun base, lowered by armor rating.)
/:cl:
