### PR TITLE
Each time you upgrade a grab, you have to resist one more time to escape. (HVH PR)

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -74,6 +74,7 @@
 	var/mob/living/victim = pulling
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, TRUE, 7)
 	setGrabState(grab_state + 1)
+	victim.grab_resist_level -= 1
 	switch(grab_state)
 		if(GRAB_AGGRESSIVE)
 			log_combat(src, victim, "aggressive grabbed")


### PR DESCRIPTION

## About The Pull Request
Old values are: agressive grabs need 1 resist to escape, neckgrabs need 2, strangles need 3.
New values: Agressive grabs are now 2, neckgrabs are 4, strangle is now 6.

For those not nuanced, breaking the resist immediately pulls you out of the hold, so you only really to spend 1 second grabbed by a warrior before being able to resist out and pull out a gun in the same second.
Xenos are not affected by this PR as xenos cannot upgrade their grab state, and warrior doesn't upgrade, they just immediately have you by the neck.
## Why It's Good For The Game
CQC buffs also. For comparison, melee can hit you over and over for a stunlock, most people can shoot you dead before you reach them, and passive grabs do not have a delay for breaking out of them, simply queueing up a movement, even if you're unable to move, breaks the passive grab.
## Changelog
:cl:
balance: You now have to resist 1 more time for each time grabs are upgraded on you. (Old values: Agrab 1, neckgrab 2, strangle 3.) (New: Agrab 2, neckgrab 4(WARRIOR GRAB UNAFFECTED.) strangle 6.
/:cl:
