### PR TITLE
Adds antigas nades to crash vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -332,6 +332,7 @@
 			/obj/item/explosive/grenade/sticky = 125,
 			/obj/item/explosive/grenade/incendiary = 50,
 			/obj/item/explosive/grenade/smokebomb/cloak = 25,
+			/obj/item/explosive/grenade/smokebomb/antigas = 20,
 			/obj/item/explosive/grenade/mirage = 100,
 			/obj/item/explosive/grenade/bullet/laser = 30,
 			/obj/item/storage/box/m94 = 200,


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
I completely forgot about the crash vendor (said 100 times).
## Changelog
:cl:
balance: Antigas nades are now in the crash weapons vendor
/:cl:
