### PR TITLE
GL-81 now fits attachments

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -669,7 +669,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	. = ..()
 	if(!master_gun)
 		return
-	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BACK))
+	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BELT, SLOT_BACK))
 
 /obj/item/attachable/magnetic_harness/on_detach(attaching_item, mob/user)
 	. = ..()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -669,7 +669,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	. = ..()
 	if(!master_gun)
 		return
-	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BELT, SLOT_BACK))
+	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BACK))
 
 /obj/item/attachable/magnetic_harness/on_detach(attaching_item, mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -221,7 +221,11 @@ The Grenade Launchers
 	wield_delay = 0.2 SECONDS
 	aim_slowdown = 1
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
-	attachable_allowed = list()
+	attachable_allowed = list(
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/scope/mini,
+		)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	fire_delay = 1.05 SECONDS
 	max_chamber_items = 0

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -225,7 +225,7 @@ The Grenade Launchers
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/scope/mini,
-		)
+	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	fire_delay = 1.05 SECONDS
 	max_chamber_items = 0

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -224,7 +224,6 @@ The Grenade Launchers
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/flashlight,
-		/obj/item/attachable/scope/mini,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	fire_delay = 1.05 SECONDS


### PR DESCRIPTION
## About The Pull Request
The single shot grenade launcher now fits magharn and rail flashlight

## Why It's Good For The Game
Consistency with the other GL, hopefully enabling loadouts to use this now that it has mag harness. Its a good side option for rushers to use and has a slightly slower fire rate of 1.25 seconds between grenades vs 1.2 on the GL70, so adding magharness should make it worth placing into loadouts.

## Changelog
:cl:
balance: GL-81 can now fit magnetic harness and rail flashlight.
/:cl:
