### PR TITLE
Fix blessing menu typo

### DIFF
--- a/tgui/packages/tgui/interfaces/BlessingMenu.tsx
+++ b/tgui/packages/tgui/interfaces/BlessingMenu.tsx
@@ -59,7 +59,7 @@ export const BlessingMenu = (props) => {
           title={
             'Strategic Psychic points: ' +
             (strategicpoints ? strategicpoints : 0) +
-            ' | Strategic Psychic points: ' +
+            ' | Tactical Psychic points: ' +
             (tacticalpoints ? tacticalpoints : 0)
           }
         >


### PR DESCRIPTION

## About The Pull Request

fixs a typo in the blessing menu where both points were called strategic
## Why It's Good For The Game

typo bad
![LiteralyUnplayable](https://github.com/tgstation/TerraGov-Marine-Corps/assets/12964904/9fa2d7c8-e2e1-45dd-a50a-fba911137614)
## Changelog
:cl:
spellcheck: Blessing menu no long has two strategic point values
/:cl:
