### PR TITLE
fix + patch: re-balances flanks on icy caves LZ2

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -83,9 +83,6 @@
 /turf/open/floor/cult,
 /area/icy_caves/caves/south)
 "at" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
@@ -279,9 +276,8 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "bm" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/icy_caves/outpost/LZ2)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -554,9 +550,6 @@
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northwestmonorail)
 "cG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2{
 	dir = 5
@@ -811,8 +804,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "ep" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/rock)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/icy_caves/outpost/outside)
 "eq" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/power/apc/drained,
@@ -1236,9 +1230,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"hi" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves/rock)
 "hk" = (
 /obj/machinery/light{
 	dir = 8
@@ -1310,9 +1301,6 @@
 /area/icy_caves/caves/east)
 "hP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
 /turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
@@ -2025,32 +2013,21 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/bright_clean/two,
 /area/icy_caves/caves/northwestmonorail)
-"lP" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "lQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/icy_caves/outpost/outside)
 "lS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	welded = 1
-	},
+/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "lV" = (
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northwestmonorail)
 "lZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
 /turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
@@ -2644,9 +2621,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "po" = (
@@ -3986,13 +3960,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
-"vi" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "vj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Colony Dormitories Canteen"
@@ -4032,12 +3999,6 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
-"vs" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "vt" = (
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
@@ -4788,14 +4749,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
-"zq" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5534,12 +5487,6 @@
 	},
 /turf/open/floor/prison/red/full,
 /area/icy_caves/caves/cavesbrig)
-"CZ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
 "Da" = (
 /turf/open/floor/tile/dark/green2{
 	dir = 1
@@ -5784,12 +5731,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
-"En" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
 "Eo" = (
 /turf/open/floor/tile/dark/green2{
 	dir = 9
@@ -6454,13 +6395,6 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
-"HE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	welded = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "HG" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2
@@ -6473,9 +6407,6 @@
 /turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
 "HI" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
@@ -6816,7 +6747,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/caves/rock)
+/area/icy_caves/outpost/outside)
 "Jn" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
@@ -7388,9 +7319,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"LY" = (
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/outpost/outside)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7630,10 +7558,10 @@
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
 "Nn" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "No" = (
@@ -7985,9 +7913,6 @@
 	},
 /area/icy_caves/caves/cavesbrig)
 "Pc" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8928,15 +8853,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
-"Uo" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/rock)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -9259,13 +9181,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northwestmonorail/hallway)
-"VX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "VY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9335,9 +9250,6 @@
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Wp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
 /obj/machinery/power/apc/lowcharge,
 /obj/machinery/light{
 	dir = 1
@@ -9485,9 +9397,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Xc" = (
@@ -9795,9 +9704,7 @@
 /area/icy_caves/caves/weapon_vault)
 "Yv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "Yx" = (
@@ -9928,14 +9835,6 @@
 /obj/item/clothing/shoes/galoshes,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Zf" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Zg" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -13206,7 +13105,7 @@ dW
 uw
 uw
 dW
-HE
+uw
 uw
 uw
 uw
@@ -13353,16 +13252,16 @@ XW
 bU
 bU
 bU
-VX
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-vs
+bU
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 pp
 uw
 uw
@@ -13509,7 +13408,7 @@ ZI
 ZI
 WD
 uw
-vi
+bU
 WD
 WD
 ZI
@@ -13665,7 +13564,7 @@ ZI
 ZI
 Zm
 uw
-vi
+bU
 Zm
 Zm
 ZP
@@ -13977,7 +13876,7 @@ XO
 XO
 XO
 SI
-Dn
+pc
 Za
 Za
 Nu
@@ -14133,7 +14032,7 @@ XO
 Za
 Za
 SI
-Dn
+pc
 Za
 Za
 Za
@@ -14286,10 +14185,10 @@ vy
 vy
 vy
 Nn
-vy
-vy
-Al
-Qe
+pc
+pc
+lS
+pc
 SI
 SI
 SI
@@ -25346,8 +25245,8 @@ Za
 Za
 oO
 XO
-hi
-hi
+Za
+Za
 RU
 ZI
 ZI
@@ -25489,7 +25388,7 @@ pR
 pR
 pR
 pR
-Uo
+pR
 XO
 XO
 Za
@@ -25499,8 +25398,8 @@ XO
 XO
 XO
 XO
-Uo
-Uo
+pR
+pR
 oO
 Za
 oO
@@ -25642,23 +25541,23 @@ Za
 pR
 pR
 pR
-Uo
 pR
-Uo
-Uo
-Za
-XO
-Uo
+pR
+pR
 pR
 Za
 XO
+pR
+pR
+Za
 XO
-Uo
-Uo
-Uo
-Uo
-Uo
-Uo
+XO
+pR
+pR
+pR
+pR
+pR
+pR
 XO
 oO
 xh
@@ -25796,26 +25695,26 @@ XO
 XO
 Za
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
 pR
 Za
 XO
-Uo
+pR
 pR
 Za
 Za
 XO
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
+pR
 XO
 Za
 Za
@@ -25952,23 +25851,23 @@ Za
 Za
 XO
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
 pR
 Za
 XO
-Uo
-Uo
+pR
+pR
 XO
 Za
 Za
 XO
-Uo
-Uo
-Uo
+pR
+pR
+pR
 XO
 XO
 XO
@@ -26112,11 +26011,11 @@ pR
 pR
 pR
 pR
-Uo
+pR
 pR
 Za
 XO
-Uo
+pR
 pR
 Za
 Za
@@ -26131,7 +26030,7 @@ Za
 XO
 XO
 pR
-ZI
+Lv
 tH
 Hu
 qm
@@ -26272,7 +26171,7 @@ XO
 Za
 Za
 XO
-Uo
+pR
 XO
 XO
 XO
@@ -26286,9 +26185,9 @@ XO
 XO
 XO
 pR
-Uo
-ZI
-ZI
+pR
+Lv
+Lv
 Fr
 yn
 nH
@@ -26441,10 +26340,10 @@ Za
 Za
 Za
 Za
-Uo
-Uo
-Uo
-ZI
+pR
+pR
+pR
+Lv
 tH
 hr
 nH
@@ -26597,7 +26496,7 @@ pR
 pR
 Za
 Za
-Uo
+pR
 pR
 pR
 XO
@@ -27354,14 +27253,14 @@ oO
 Za
 Za
 lA
-lA
-wN
-wN
-wN
-wN
-lA
-lA
-wN
+ep
+ep
+ep
+ep
+ep
+ep
+ep
+ep
 wN
 nz
 wN
@@ -27382,9 +27281,9 @@ wN
 wN
 wN
 wN
-wN
-lA
-XO
+ep
+ep
+ZI
 XO
 XO
 Za
@@ -27512,38 +27411,38 @@ ZI
 Jm
 ZI
 ZI
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 ZI
-ZI
-ZI
-mH
-mH
-oP
-oP
-oP
-oP
-oP
 oP
 at
 IT
 oP
 oP
 oP
-oP
-oP
-nI
+ZI
+ZI
+ZI
 nI
 nI
 ZI
 ZI
-Uo
-Uo
-Uo
-oP
-iK
+ZI
+ZI
+ZI
+ZP
+lQ
+ZI
 XO
-XO
 ZI
-ep
+XO
 Za
 XO
 pR
@@ -27667,12 +27566,12 @@ Za
 pR
 Jm
 ZI
+ZP
+ZP
+ZP
+ZP
 ZI
 ZI
-ZI
-ZI
-mH
-mH
 on
 on
 on
@@ -27686,19 +27585,19 @@ on
 on
 on
 on
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 ZI
-ZI
-ZI
-ZI
-ZI
-ZI
-ZI
-Uo
-oP
-iK
+lQ
 XO
 pR
-Lv
+ZI
 XO
 Za
 XO
@@ -27817,17 +27716,17 @@ ZI
 XO
 pR
 XO
-hi
+Za
 Za
 Za
 pR
 Wu
-oP
+ZI
+ZP
+ZP
+ZP
 ZI
 ZI
-ZI
-ZI
-oP
 RA
 Sc
 WA
@@ -27845,16 +27744,16 @@ mP
 on
 fC
 jW
+ZP
+ZP
+ZP
+ZP
 ZI
 ZI
-ZI
-Uo
-Uo
-oP
 iK
 XO
 XO
-Lv
+ZI
 XO
 XO
 XO
@@ -27978,11 +27877,11 @@ XO
 Za
 XO
 Wu
-hi
+ZI
 on
-wa
-wa
-wa
+ZI
+ZI
+ZI
 sT
 wa
 ka
@@ -28001,11 +27900,11 @@ IT
 HG
 fC
 tL
+ZP
+ZP
 ZI
 ZI
 ZI
-ZI
-Uo
 nI
 Tl
 Za
@@ -28128,7 +28027,7 @@ ZP
 ZP
 pR
 pR
-LY
+ZP
 XO
 XO
 Za
@@ -28155,10 +28054,10 @@ IT
 IT
 IT
 on
-EB
-Qt
-ZI
-ZI
+fC
+tL
+ZP
+ZP
 ZI
 cy
 nI
@@ -28284,7 +28183,7 @@ ZP
 ZP
 pR
 pR
-Lv
+ZI
 ZI
 XO
 XO
@@ -28311,15 +28210,15 @@ IT
 IT
 IT
 on
-on
-on
-mH
-mH
+EB
+Qt
+ZP
+ZI
 ZI
 nI
 nI
 oP
-Tl
+lQ
 Za
 Za
 XO
@@ -28439,9 +28338,9 @@ ZP
 ZP
 ZP
 pR
-Lv
-Lv
-Lv
+ZI
+ZI
+ZI
 np
 XO
 Za
@@ -28466,16 +28365,16 @@ IT
 IT
 IT
 IT
-Wm
-oP
-wa
-wa
-wa
-wa
+on
+on
+on
+ZP
+ZI
+ZI
 nI
 oP
 oP
-iK
+lQ
 XO
 XO
 XO
@@ -28595,8 +28494,8 @@ ZP
 ZP
 ZP
 pR
-LY
-Lv
+ZP
+ZI
 XO
 XO
 XO
@@ -28627,13 +28526,13 @@ wa
 oP
 nI
 nI
-wa
+ZI
 oP
 nI
 oP
-iK
-XO
-XO
+lQ
+ZI
+ZI
 pR
 ZP
 ZP
@@ -28757,8 +28656,8 @@ ZP
 ZP
 ZP
 ZP
-CZ
-oP
+Up
+ZI
 on
 OL
 oP
@@ -28787,8 +28686,8 @@ oP
 oP
 nI
 nI
-Tl
-XO
+lQ
+ZI
 ZP
 ZP
 ZP
@@ -28909,12 +28808,12 @@ ZP
 ZP
 ZP
 ZP
-ZI
-ZI
+ZP
+ZP
 ZI
 ZI
 Up
-oP
+ZI
 on
 oP
 wa
@@ -28943,7 +28842,7 @@ oP
 wa
 nI
 nI
-En
+Uj
 ZI
 ZP
 ZP
@@ -29067,13 +28966,13 @@ ZP
 ZP
 ZP
 ZP
-ZI
+ZP
 ZI
 Up
 ZI
 on
-oP
-oP
+on
+on
 wa
 IT
 IT
@@ -29083,7 +28982,7 @@ IT
 IT
 IT
 ka
-Zf
+lZ
 QW
 ZN
 IT
@@ -29224,12 +29123,12 @@ ZP
 ZP
 ZP
 ZP
-ZI
+ZP
 Up
 ZI
 ZI
+ZI
 on
-oP
 oP
 IT
 RQ
@@ -29239,7 +29138,7 @@ IT
 iV
 IT
 IT
-Zf
+lZ
 QW
 nc
 nc
@@ -29381,7 +29280,7 @@ ZP
 ZP
 ZP
 ZP
-Up
+Xo
 ZI
 ZI
 ZI
@@ -29395,7 +29294,7 @@ lo
 lo
 IT
 on
-Zf
+lZ
 Kt
 nf
 nf
@@ -29407,7 +29306,7 @@ wa
 wa
 oP
 oP
-oP
+ZI
 uq
 oP
 ZI
@@ -29538,10 +29437,10 @@ ZP
 ZP
 ZP
 Xo
+ZP
 ZI
 ZI
-ZI
-ZI
+on
 on
 IT
 IT
@@ -29551,7 +29450,7 @@ lo
 lo
 IT
 on
-Zf
+lZ
 QW
 IT
 IT
@@ -29562,8 +29461,8 @@ Wm
 wa
 oP
 oP
-nI
-oP
+ZI
+ZI
 wa
 oP
 nI
@@ -29695,10 +29594,10 @@ ZP
 ZP
 Xo
 ZP
+ZP
 ZI
 ZI
-ZI
-ZI
+on
 IT
 IT
 on
@@ -29717,9 +29616,9 @@ IT
 ka
 oP
 oP
-nI
-nI
-nI
+ZI
+ZI
+ZI
 wa
 oP
 ZI
@@ -29851,10 +29750,10 @@ ZP
 ZP
 Xo
 ZP
+ZP
 ZI
 ZI
-ZI
-ZI
+on
 td
 IT
 ka
@@ -29863,7 +29762,7 @@ IT
 iV
 IT
 on
-Zf
+lZ
 QW
 yk
 qL
@@ -29873,8 +29772,8 @@ zF
 IT
 oP
 nI
-Uo
-Uo
+ZI
+ZI
 oP
 wa
 oP
@@ -30019,7 +29918,7 @@ lo
 lo
 IT
 ka
-Zf
+lZ
 Kt
 yk
 IT
@@ -30029,9 +29928,9 @@ nl
 Wm
 oP
 wa
-Uo
-Uo
-Uo
+ZI
+ZI
+ZI
 wa
 oP
 ZI
@@ -30162,7 +30061,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 nI
 nI
 nI
@@ -30175,7 +30074,7 @@ lo
 lo
 IT
 IT
-Zf
+lZ
 QW
 yk
 IT
@@ -30183,8 +30082,8 @@ IT
 IT
 yk
 on
-mH
-mH
+ZI
+ZI
 ZI
 ZI
 nI
@@ -30318,7 +30217,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 nI
 nI
 oP
@@ -30331,7 +30230,7 @@ ZD
 lp
 IT
 on
-Zf
+lZ
 QW
 yk
 ZM
@@ -30343,7 +30242,7 @@ on
 on
 ZI
 ZI
-mH
+ZI
 on
 ZI
 ZI
@@ -30474,7 +30373,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 nI
 oP
 oP
@@ -30487,7 +30386,7 @@ on
 on
 on
 on
-Zf
+lZ
 QW
 IT
 on
@@ -30630,7 +30529,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 nI
 oP
 wa
@@ -30643,7 +30542,7 @@ Qp
 oP
 oP
 wa
-zq
+lZ
 QW
 wa
 oP
@@ -30786,7 +30685,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 oP
 wa
@@ -30798,7 +30697,7 @@ oP
 oP
 oP
 wa
-lP
+IT
 lZ
 Kt
 IT
@@ -30942,7 +30841,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 oP
 wa
@@ -30954,7 +30853,7 @@ IT
 IT
 IT
 IT
-lQ
+IT
 IT
 IT
 IT
@@ -31098,7 +30997,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 wa
@@ -31110,7 +31009,7 @@ IT
 IT
 IT
 oP
-lS
+IT
 IT
 IT
 IT
@@ -31254,7 +31153,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 wa
@@ -31410,7 +31309,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 jt
@@ -31566,7 +31465,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -31722,7 +31621,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -31878,7 +31777,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32034,7 +31933,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32190,7 +32089,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32346,7 +32245,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32502,7 +32401,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32658,7 +32557,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32814,7 +32713,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -32970,7 +32869,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -33126,7 +33025,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 ih
@@ -33282,7 +33181,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 oP
 wa
 jt
@@ -33438,7 +33337,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 nI
 oP
 wa
@@ -33594,7 +33493,7 @@ ZP
 ZP
 ZP
 Xo
-ZP
+bm
 on
 nI
 oP
@@ -33750,8 +33649,8 @@ ZP
 ZP
 ZP
 Xo
-ZP
-ZP
+bm
+bm
 mH
 mH
 mH
@@ -33906,9 +33805,9 @@ ZP
 ZP
 ZP
 Xo
-ZP
-ZP
-ZP
+bm
+bm
+bm
 mH
 mH
 mH


### PR DESCRIPTION
## About The Pull Request
title.

1. rebalances flanks based on standardizing the use of mats from the fob builder compared between LZ1 and LZ2 (see "Why" for more)
2. fixes some really weird zoning in LZ2
3. did you know the vent pipe into LZ2 can spawn broken and let xenos into the LZ before first drop? fixed via vent + pipe removal.

new lz2 below 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/c4915f63-62f0-41e7-9efa-8f5f1ce53488)

## Why It's Good For The Game

makes this lz something you can actually pick without throwing
1. LZ1 requires 40 plasteel and 154 metal to build. LZ2 required 50 plasteel and 245 metal to build. the fob builder, by default, has 100 plasteel and 200 metal. why was a lowpop map requiring more metal to secure the FOB than some highpop maps?
2. the open turf inside the shutters is not, in fact, an enclosed area
3. invalidates the point of having this LZ as a choice.

## Changelog
:cl:
balance: rebalanced flanks and exits on Icy Caves LZ2
fix: fixed zoning on Icy Caves LZ2 and vent + broken piping bugs
/:cl: