### PR TITLE
fix: sulaco cas bay parity

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -13071,6 +13071,10 @@
 	},
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
+"gcZ" = (
+/obj/structure/ship_ammo/cas/heavygun,
+/turf/open/floor/plating,
+/area/sulaco/hangar/cas)
 "gdq" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -59182,7 +59186,7 @@ kwh
 bhA
 ddK
 pwv
-pwv
+gcZ
 pwv
 qct
 pwv
@@ -59439,7 +59443,7 @@ kwh
 bhA
 ddK
 pwv
-pwv
+gcZ
 pwv
 qct
 pwv


### PR DESCRIPTION
~~another parity PR, wowza!~~
## About The Pull Request

probably could've rolled this into the earlier parity PR, tbh; sulaco was two 30mm ammo crates short of every other map for CAS, so i added the two extras

## Why It's Good For The Game

parity good for shipmaps; weird to have access to supplies vary by shipmap, especially if those supplies aren't relevant to shipside use at all

## Changelog

:cl:
fix: adds two more 30mm GAU ammo crates to Sulaco CAS bay to keep it in parity with other ships' CAS bays
/:cl: