### PR TITLE
Code improvement for akimbo scatter

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -232,7 +232,7 @@
 	///Multiplier. Increased and decreased through attachments. Multiplies the accuracy/scatter penalty of the projectile when firing while moving.
 	var/movement_acc_penalty_mult = 5
 	///For regular shots, how long to wait before firing again.
-	var/fire_delay = 6
+	var/fire_delay = 0.6 SECONDS
 	///Modifies the speed of projectiles fired.
 	var/shell_speed_mod = 0
 	///Modifies projectile damage by a % when a marine gets passed, but not hit

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -174,10 +174,8 @@
 	var/shots_fired = 0
 	///If this gun is in inactive hands and shooting in akimbo
 	var/dual_wield = FALSE
-	///determines upper accuracy modifier in akimbo
-	var/upper_akimbo_accuracy = 2
-	///determines lower accuracy modifier in akimbo
-	var/lower_akimbo_accuracy = 1
+	///mult to scatter when firing akimbo
+	var/akimbo_scatter_mod = 3
 	///If fire delay is 1 second, and akimbo_additional_delay is 0.5, then you'll have to wait 1 second * 0.5 to fire the second gun
 	var/akimbo_additional_delay = 0.5
 	///Delay for the gun winding up before firing.
@@ -1824,7 +1822,7 @@
 			gun_scatter += burst_amount * burst_scatter_mult * 2
 
 	if(dual_wield) //akimbo firing gives terrible scatter
-		gun_scatter += 2 * rand(upper_akimbo_accuracy, lower_akimbo_accuracy) //TODO: remove the rng increase
+		gun_scatter += akimbo_scatter_mod
 
 	if(gun_user)
 		//firearm skills modifiers

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -102,8 +102,7 @@
 	accuracy_mult_unwielded = 0.6
 	scatter_unwielded = 80 //Heavy and unwieldy
 	damage_falloff_mult = 0.5
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
+	akimbo_scatter_mod = 8
 
 /obj/item/weapon/gun/energy/lasgun/unique_action(mob/user, dont_operate = FALSE)
 	QDEL_NULL(in_chamber)

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -69,8 +69,7 @@
 	scatter_unwielded = 4
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 4
+	akimbo_scatter_mod = 8
 
 //-------------------------------------------------------
 //PP-7 Plasma Pistol
@@ -210,7 +209,6 @@
 	accuracy_mult_unwielded = 0.95
 	recoil = -2
 	recoil_unwielded = -2
-	lower_akimbo_accuracy = 2
 
 /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
 	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/flashlight) //Tacticool
@@ -247,7 +245,6 @@
 	accuracy_mult_unwielded = 0.85
 	damage_mult = 1.15
 	recoil = -2
-	lower_akimbo_accuracy = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper P-1911A1 custom pistol"
@@ -541,7 +538,6 @@
 	aim_slowdown = 0.2
 	scatter = 0
 	scatter_unwielded = 6
-	lower_akimbo_accuracy = 2
 	akimbo_additional_delay = 2
 
 /obj/item/weapon/gun/pistol/vp70/tactical

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -20,8 +20,7 @@
 	scatter_unwielded = 13
 	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
+	akimbo_scatter_mod = 8
 
 //-------------------------------------------------------
 //AR-18 Carbine

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -32,8 +32,7 @@
 	recoil = 2
 	recoil_unwielded = 4
 	movement_acc_penalty_mult = 2
-	lower_akimbo_accuracy = 3
-	upper_akimbo_accuracy = 5
+	akimbo_scatter_mod = 8
 
 	placed_overlay_iconstate = "shotgun"
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -29,7 +29,7 @@
 	burst_amount = 3
 	recoil_unwielded = 0.5
 	akimbo_additional_delay = 0.2
-	movement_acc_penalty_mult = 3
+	akimbo_scatter_mod = 8
 
 //-------------------------------------------------------
 // MP-19 Machinepistol. It fits here more.
@@ -80,8 +80,7 @@
 	aim_slowdown = 0.15
 	movement_acc_penalty_mult = 2
 
-	upper_akimbo_accuracy = 12
-	lower_akimbo_accuracy = 9
+	akimbo_scatter_mod = 24
 	burst_amount = 5
 	burst_delay = 0.1 SECONDS
 	akimbo_additional_delay = 20 // Literally do not even bother to try
@@ -141,8 +140,6 @@
 	scatter_unwielded = 8
 	aim_slowdown = 0.2
 	burst_amount = 0
-	upper_akimbo_accuracy = 4
-	lower_akimbo_accuracy = 2
 
 	placed_overlay_iconstate = "t90"
 
@@ -210,8 +207,6 @@
 	scatter = 2
 	scatter_unwielded = 11
 	akimbo_additional_delay = 0.4
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
 
 //-------------------------------------------------------
 //M-25 SMG
@@ -265,8 +260,6 @@
 	aim_slowdown = 0.15
 	burst_amount = 3
 	akimbo_additional_delay = 0.4
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
 	damage_falloff_mult = 0.9
 
 /obj/item/weapon/gun/smg/m25/holstered
@@ -542,8 +535,6 @@
 	burst_scatter_mult = 15
 
 	akimbo_additional_delay = 0.7
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
 
 /obj/item/weapon/gun/smg/som/scout
 	starting_attachment_types = list(
@@ -640,9 +631,6 @@
 	scatter_unwielded = 5
 	aim_slowdown = 0.2
 	wield_delay = 0.55 SECONDS
-
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
 
 /obj/item/weapon/gun/smg/icc_machinepistol/medic
 	starting_attachment_types = list(/obj/item/attachable/foldable/icc_machinepistol, /obj/item/attachable/magnetic_harness, /obj/item/attachable/verticalgrip, /obj/item/attachable/extended_barrel)


### PR DESCRIPTION

## About The Pull Request
Akimbo scatter mod is now a much clearer var.

Previously we have an upper and lower scatter modifier (helpfully named as an accuracy mod), and scatter was modified by a rand between these two values, muliplied by 2.

This is a funny leftover from before scatter was reworked, back when scatter doubled as a probability of scattering, so now the random variation is completely pointless and confusing.
## Why It's Good For The Game
Clearer/less shitty code
## Changelog
:cl:
code: Cleaned up akimbo scatter mod code
/:cl:
