### PR TITLE
Loadout changes

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -89,6 +89,7 @@
 		MISSION_STARTING_FACTION = "starting faction intro text here",
 		MISSION_HOSTILE_FACTION = "hostile faction intro text here",
 	)
+	///Message to players when a mission ends
 	var/list/outro_message = list(
 		MISSION_OUTCOME_MAJOR_VICTORY = list(
 			MISSION_STARTING_FACTION = "<u>Major victory</u><br> All mission objectives achieved, outstanding work!",

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
@@ -29,7 +29,7 @@
 	name = "X-fuel tank"
 	desc = "A specialized fuel tank of ultra thick napthal type X, known for its extreme heat and slow burn rate, as well as it's distinct blue flames. For use with the V-62 incinerator."
 	item_typepath = /obj/item/ammo_magazine/flamer_tank/backtank/X
-	purchase_cost = 25
+	purchase_cost = 40
 	unlock_cost = 200
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_UNLOCKABLE
 

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
@@ -67,7 +67,7 @@
 	desc = "This backpack holds 4 RPGs, in addition to a V-71 RPG launcher. Equipped with radioactive and incendiary warheads, \
 	the V-71 is incredibly effective at softening up or flushing out organic targets, making them easy prey to finish off. Has a draw delay."
 	req_desc = "Requires a suit with a Mithridatius environmental protection module."
-	purchase_cost = 100
+	purchase_cost = 50
 	quantity = 2
 	item_typepath = /obj/item/storage/holster/backholster/rpg/som/war_crimes
 	jobs_supported = list(SOM_SQUAD_VETERAN)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
@@ -15,13 +15,20 @@
 	item_typepath = /obj/item/storage/pouch/firstaid/som/combat_patrol_leader
 	jobs_supported = list(SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 
-/datum/loadout_item/r_pocket/som_standard_grenades
-	name = "Grenade pouch"
-	desc = "A pouch carrying a set of six standard support grenades."
+/datum/loadout_item/r_pocket/som_support_grenades
+	name = "Support grenades"
+	desc = "A pouch carrying a set of six standard support grenades. Includes smoke grenades of both lethal and nonlethal varieties, as well as stun grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/som/combat_patrol
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
+
+/datum/loadout_item/r_pocket/som_standard_grenades
+	name = "Standard grenades"
+	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE and incendiary grenades."
+	ui_icon = "grenade"
+	item_typepath = /obj/item/storage/pouch/grenade/som/standard
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 
 /datum/loadout_item/r_pocket/war_crime_grenades
 	name = "Warcrime grenades"
@@ -115,11 +122,18 @@
 	jobs_supported = list(SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
-/datum/loadout_item/l_pocket/som_standard_grenades
-	name = "Grenade pouch"
-	desc = "A pouch carrying a set of six standard support grenades."
+/datum/loadout_item/l_pocket/som_support_grenades
+	name = "Support grenades"
+	desc = "A pouch carrying a set of six standard support grenades. Includes smoke grenades of both lethal and nonlethal varieties, as well as stun grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/som/combat_patrol
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+
+/datum/loadout_item/l_pocket/som_standard_grenades
+	name = "Standard grenades"
+	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE and incendiary grenades."
+	ui_icon = "grenade"
+	item_typepath = /obj/item/storage/pouch/grenade/som/standard
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 
 /datum/loadout_item/l_pocket/war_crime_grenades

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
@@ -3,7 +3,7 @@
 	desc = "Standard SOM first-aid pouch. Contains a basic set of medical supplies."
 	ui_icon = "medkit"
 	item_typepath = /obj/item/storage/pouch/firstaid/som/combat_patrol
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN)
 
 /datum/loadout_item/r_pocket/som_standard_first_aid/standard_improved
 	desc = "Standard SOM first-aid pouch. Contains a improved set of medical supplies."
@@ -20,7 +20,7 @@
 	desc = "A pouch carrying a set of six standard support grenades. Includes smoke grenades of both lethal and nonlethal varieties, as well as stun grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/som/combat_patrol
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
 /datum/loadout_item/r_pocket/som_standard_grenades
@@ -28,7 +28,7 @@
 	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE and incendiary grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/som/standard
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 
 /datum/loadout_item/r_pocket/war_crime_grenades
 	name = "Warcrime grenades"
@@ -78,7 +78,7 @@
 	desc = "A pouch containing three ammo magazines."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/magazine/large/som
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	item_blacklist = list(
 		/obj/item/weapon/gun/rifle/som_mg/standard = ITEM_SLOT_SUITSTORE,
 		/obj/item/weapon/twohanded/fireaxe/som = ITEM_SLOT_SUITSTORE,

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -144,7 +144,7 @@
 	item_typepath = /obj/item/clothing/suit/modular/som/heavy/mithridatius
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/head/modular/som/bio = ITEM_SLOT_HEAD)
-	purchase_cost = 50
+	purchase_cost = 75
 	quantity = 4
 
 //engineer

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -144,7 +144,8 @@
 	item_typepath = /obj/item/clothing/suit/modular/som/heavy/mithridatius
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/head/modular/som/bio = ITEM_SLOT_HEAD)
-	quantity = 2
+	purchase_cost = 50
+	quantity = 4
 
 //engineer
 /datum/loadout_item/suit_slot/som_engineer

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/uniform.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/uniform.dm
@@ -43,9 +43,6 @@
 	item_typepath = /obj/item/clothing/under/som/webbing
 	jobs_supported = list(SOM_SQUAD_ENGINEER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
-	item_whitelist = list(
-		/obj/item/storage/pouch/tools/som/full = ITEM_SLOT_R_POCKET,
-	)
 
 /datum/loadout_item/uniform/som_field_commander
 	name = "Officer uniform"

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
@@ -61,7 +61,7 @@
 	name = "X-fuel tank"
 	desc = "A specialized fuel tank of ultra thick napthal type X, known for its extreme heat and slow burn rate, as well as it's distinct blue flames. For use with the FL-84 flamethrower and FL-240 incinerator unit."
 	item_typepath = /obj/item/ammo_magazine/flamer_tank/backtank/X
-	purchase_cost = 25
+	purchase_cost = 40
 	unlock_cost = 200
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_UNLOCKABLE
 

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
@@ -153,7 +153,7 @@
 	. = ..()
 	wearer.equip_to_slot_or_del(new /obj/item/minelayer, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/storage/box/explosive_mines/large, SLOT_IN_BACKPACK)
-	wearer.equip_to_slot_or_del(new /obj/item/storage/box/explosive_mines, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/storage/box/explosive_mines/large, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
@@ -55,7 +55,7 @@
 	name = "Standard grenades"
 	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE, lasburster and incendiary grenades."
 	ui_icon = "grenade"
-	item_typepath = /obj/item/storage/pouch/grenade/standard/standard
+	item_typepath = /obj/item/storage/pouch/grenade/standard
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
 /datum/loadout_item/r_pocket/shotgun
@@ -168,7 +168,7 @@
 	name = "Standard grenades"
 	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE, lasburster and incendiary grenades."
 	ui_icon = "grenade"
-	item_typepath = /obj/item/storage/pouch/grenade/standard/standard
+	item_typepath = /obj/item/storage/pouch/grenade/standard
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
 /datum/loadout_item/l_pocket/shotgun

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
@@ -31,7 +31,7 @@
 	desc = "Standard marine first-aid pouch. Contains a basic set of medical supplies."
 	ui_icon = "medkit"
 	item_typepath = /obj/item/storage/pouch/firstaid/combat_patrol
-	jobs_supported = list(SQUAD_MARINE, SQUAD_ENGINEER, SQUAD_SMARTGUNNER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_SMARTGUNNER)
 
 /datum/loadout_item/r_pocket/standard_first_aid/standard_improved
 	desc = "Standard marine first-aid pouch. Contains a improved set of medical supplies."
@@ -48,7 +48,7 @@
 	desc = "A pouch carrying a set of six standard support grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/combat_patrol
-	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
 /datum/loadout_item/r_pocket/marine_standard_grenades
@@ -56,7 +56,7 @@
 	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE, lasburster and incendiary grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/standard
-	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
 /datum/loadout_item/r_pocket/shotgun
 	name = "Buckshot shells"
@@ -89,7 +89,7 @@
 	desc = "A pouch containing three ammo magazines."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/magazine/large
-	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 	item_blacklist = list(
 		/obj/item/weapon/gun/rifle/standard_smartmachinegun/patrol = ITEM_SLOT_SUITSTORE,
 		/obj/item/weapon/gun/minigun/smart_minigun/motion_detector = ITEM_SLOT_SUITSTORE,

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
@@ -43,13 +43,20 @@
 	item_typepath = /obj/item/storage/pouch/firstaid/combat_patrol_leader
 	jobs_supported = list(SQUAD_LEADER, FIELD_COMMANDER)
 
-/datum/loadout_item/r_pocket/marine_standard_grenades
-	name = "Grenade pouch"
+/datum/loadout_item/r_pocket/marine_support_grenades
+	name = "Support grenades"
 	desc = "A pouch carrying a set of six standard support grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/combat_patrol
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
+
+/datum/loadout_item/r_pocket/marine_standard_grenades
+	name = "Standard grenades"
+	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE, lasburster and incendiary grenades."
+	ui_icon = "grenade"
+	item_typepath = /obj/item/storage/pouch/grenade/standard/standard
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
 /datum/loadout_item/r_pocket/shotgun
 	name = "Buckshot shells"
@@ -150,11 +157,18 @@
 	jobs_supported = list(SQUAD_LEADER, FIELD_COMMANDER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
-/datum/loadout_item/l_pocket/marine_standard_grenades
-	name = "Grenade pouch"
+/datum/loadout_item/l_pocket/marine_support_grenades
+	name = "Support grenades"
 	desc = "A pouch carrying a set of six standard support grenades. Includes smoke grenades of both lethal and nonlethal varieties, as well as stun grenades."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/grenade/combat_patrol
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+
+/datum/loadout_item/l_pocket/marine_standard_grenades
+	name = "Standard grenades"
+	desc = "A pouch carrying a set of six standard offensive grenades. Contains HE, lasburster and incendiary grenades."
+	ui_icon = "grenade"
+	item_typepath = /obj/item/storage/pouch/grenade/standard/standard
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
 /datum/loadout_item/l_pocket/shotgun

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
@@ -1323,7 +1323,7 @@
 		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/packet/p10x20mm, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
 	if(loadout.l_store == /obj/item/storage/pouch/magazine/large)

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
@@ -764,14 +764,14 @@
 		wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/sticky, SLOT_IN_BACKPACK)
 		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/packet/p10x25mm, SLOT_IN_BACKPACK)
 
-/datum/loadout_item/suit_store/main_gun/corpsman/pdw
-	name = "SMG-90"
-	desc = "Equipped with a red dot sight, recoil compensator and laser sight. The SMG-90 is a PDW that offers outstanding mobility and handling, and respectable damage output and magazine capacity. \
-	Its lower damage output compared to rifles, and significantly worse performance at range means it is usually seen on second line units or in the hands of supporting roles. It uses 10x20mm caseless rounds."
+/datum/loadout_item/suit_store/main_gun/corpsman/standard_smg
+	name = "SMG-25"
+	desc = "Equipped with a mag harness, recoil compensator and gyroscopic stabilizer. SMG-25 submachinegun, is a large capacity smg, able to be be used effectively one or two handed. \
+	Like all smgs, it has excellent mobility and handling, but has poor damage application at longer ranges. Uses 10x20mm caseless ammunition."
 	ui_icon = "smg"
-	item_typepath = /obj/item/weapon/gun/smg/standard_smg/tactical
+	item_typepath = /obj/item/weapon/gun/smg/m25/magharness
 
-/datum/loadout_item/suit_store/main_gun/corpsman/pdw/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+/datum/loadout_item/suit_store/main_gun/corpsman/standard_smg/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()
 	if(!istype(wearer.back, /obj/item/storage))
 		return ..()
@@ -923,6 +923,13 @@
 	Variable firemodes gives it additional flexibility over its ballistic counterpart. Uses TE power cells that are shared across all TGMC laser weaponry."
 	ui_icon = "lasergun"
 	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine/gyro
+
+/datum/loadout_item/suit_store/main_gun/engineer/standard_smg
+	name = "SMG-25"
+	desc = "Equipped with a mag harness, recoil compensator and vertical grip. SMG-25 submachinegun, is a large capacity smg, able to be be used effectively one or two handed. \
+	Like all smgs, it has excellent mobility and handling, but has poor damage application at longer ranges. Uses 10x20mm caseless ammunition."
+	ui_icon = "smg"
+	item_typepath = /obj/item/weapon/gun/smg/m25/vgrip
 
 //Smartgunner
 

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit_storage.dm
@@ -1281,6 +1281,60 @@
 		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_R_POUCH)
 		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/tx54, SLOT_IN_R_POUCH)
 
+/datum/loadout_item/suit_store/main_gun/squad_leader/standard_smg
+	name = "SMG-25"
+	desc = "Equipped with a mag harness, recoil compensator and plasma pistol. SMG-25 submachinegun, is a large capacity smg, intended to be used two handed to take advantage of the attached plasma pistol. \
+	Like all smgs, it has excellent mobility and handling, but has poor damage application at longer ranges. Uses 10x20mm caseless ammunition, and comes with multiple ammo types."
+	ui_icon = "smg"
+	item_typepath = /obj/item/weapon/gun/smg/m25/plasma
+
+/datum/loadout_item/suit_store/main_gun/squad_leader/standard_smg/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	. = ..()
+	if(!istype(wearer.back, /obj/item/storage)) //bruh
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_ACCESSORY)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_ACCESSORY)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25, SLOT_IN_ACCESSORY)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/plasma_pistol, SLOT_IN_ACCESSORY)
+		wearer.equip_to_slot_or_del(new /obj/item/binoculars/fire_support/campaign, SLOT_IN_ACCESSORY)
+		return
+
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/m15, SLOT_IN_ACCESSORY)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/m15, SLOT_IN_ACCESSORY)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary, SLOT_IN_ACCESSORY)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/smokebomb/cloak, SLOT_IN_ACCESSORY)
+	wearer.equip_to_slot_or_del(new /obj/item/binoculars/fire_support/campaign, SLOT_IN_ACCESSORY)
+
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/storage/box/MRE, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/plasma_pistol, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/plasma_pistol, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/plasma_pistol, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
+
+/datum/loadout_item/suit_store/main_gun/squad_leader/standard_smg/role_post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	if(istype(wearer.belt, /obj/item/storage/belt))
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_BELT)
+	if(loadout.l_store == /obj/item/storage/pouch/magazine/large)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_L_POUCH)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_L_POUCH)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/extended, SLOT_IN_L_POUCH)
+	if(loadout.r_store == /obj/item/storage/pouch/magazine/large)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_R_POUCH)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/ap, SLOT_IN_R_POUCH)
+		wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m25/extended, SLOT_IN_R_POUCH)
+
 //FC
 /datum/loadout_item/suit_store/officer_sword
 	name = "Officers sword"

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/uniform.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/uniform.dm
@@ -93,9 +93,6 @@
 	item_typepath = /obj/item/clothing/under/marine/engineer/black_vest
 	jobs_supported = list(SQUAD_ENGINEER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
-	item_whitelist = list(
-		/obj/item/storage/pouch/tools/full = ITEM_SLOT_R_POCKET,
-	)
 
 //FC
 /datum/loadout_item/uniform/field_commander

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -438,6 +438,15 @@
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 
+/obj/item/storage/pouch/grenade/standard/standard/Initialize(mapload)
+	. = ..()
+	new /obj/item/explosive/grenade(src)
+	new /obj/item/explosive/grenade(src)
+	new /obj/item/explosive/grenade(src)
+	new /obj/item/explosive/grenade/bullet/laser(src)
+	new /obj/item/explosive/grenade/bullet/laser(src)
+	new /obj/item/explosive/grenade/incendiary(src)
+
 /obj/item/storage/pouch/grenade/som
 	desc = "It can contain grenades. This one looks to be made out of traditional SOM leather."
 	icon_state = "grenade_som"
@@ -460,6 +469,15 @@
 	new /obj/item/explosive/grenade/smokebomb/satrapine(src)
 	new /obj/item/explosive/grenade/som(src)
 	new /obj/item/explosive/grenade/som(src)
+
+/obj/item/storage/pouch/grenade/som/standard/Initialize(mapload)
+	. = ..()
+	new /obj/item/explosive/grenade/som(src)
+	new /obj/item/explosive/grenade/som(src)
+	new /obj/item/explosive/grenade/som(src)
+	new /obj/item/explosive/grenade/som(src)
+	new /obj/item/explosive/grenade/incendiary/som(src)
+	new /obj/item/explosive/grenade/incendiary/som(src)
 
 /obj/item/storage/pouch/medkit
 	name = "medkit pouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -438,7 +438,7 @@
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 
-/obj/item/storage/pouch/grenade/standard/standard/Initialize(mapload)
+/obj/item/storage/pouch/grenade/standard/Initialize(mapload)
 	. = ..()
 	new /obj/item/explosive/grenade(src)
 	new /obj/item/explosive/grenade(src)

--- a/code/modules/clothing/modular_armor/som.dm
+++ b/code/modules/clothing/modular_armor/som.dm
@@ -179,6 +179,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/som,
 		/obj/item/armor_module/module/hlin_explosive_armor,
 		/obj/item/armor_module/module/eshield/som,
+		/obj/item/armor_module/module/eshield/som/overclocked,
 		/obj/item/armor_module/storage/general,
 		/obj/item/armor_module/storage/ammo_mag,
 		/obj/item/armor_module/storage/engineering,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -275,6 +275,9 @@
 /obj/item/weapon/gun/smg/m25/magharness
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/attachable/gyro)
 
+/obj/item/weapon/gun/smg/m25/plasma
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/weapon/gun/pistol/plasma_pistol)
+
 /obj/item/weapon/gun/smg/m25/elite
 	name = "\improper SMG-25B2 submachinegun"
 	desc = "The RivArms SMG-25 submachinegun, B2 variant. Has an integrated barrel charger. This reliable weapon fires armor piercing 10x20mm rounds and is used by elite troops."

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -275,6 +275,9 @@
 /obj/item/weapon/gun/smg/m25/magharness
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/attachable/gyro)
 
+/obj/item/weapon/gun/smg/m25/vgrip
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/attachable/verticalgrip)
+
 /obj/item/weapon/gun/smg/m25/plasma
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/compensator, /obj/item/weapon/gun/pistol/plasma_pistol)
 


### PR DESCRIPTION
## About The Pull Request
More tweaks.

- SOM bio trooper equip cost is now split across the armour (75) and the rockets (50). This is because the armour itself unlocks the free rad smg and rad nades via pouches or backpack.
- Bio armour now has a limit of 4 instead of 2 (rockets still have a limit of 2)
- Xfuel is slightly more expensive at 40 instead of 25.
- Added 'standard' nade pouches, with HE, incendiary and for TGMC, laser hefa nades. No extra cost currently.
- Added an SMG-25 loadout for TGMC SL's. Has a plasma pistol attachment, and a mix of normal and AP ammo (extendo mags if you take mag pouches).
- Added SMG-25 loadouts for medic and engie also, with standard ammo. (replaced smg90 for medic as its kinda just worse)
- Fixes gorgon armour not being able to take overclocked shield mods.
- Engies no longer have invalid pocket options (instead of making tool pouch mandatory, I just removed the other options from right pouch so its less confusing).
- Demo engie gets a few more claymores.

## Why It's Good For The Game
## Changelog
:cl:
balance: Campaign: Some loadout additions and tweaks
fix: fixed gorgon armour being unable to equip overclocked shield modules
/:cl:
