### PR TITLE
scout droid fix port from rutgmc

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -348,15 +348,16 @@
 			clear_fullscreen("remote_view", 0)
 
 /mob/living/silicon/ai/update_sight()
-	see_in_dark = initial(see_in_dark)
-	lighting_alpha = initial(lighting_alpha)
-	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
-	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	if(HAS_TRAIT(src, TRAIT_SEE_IN_DARK))
 		see_in_dark = max(see_in_dark, 8)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 		eyeobj.see_in_dark = max(eyeobj.see_in_dark, 8)
 		eyeobj.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+		return ..()
+	see_in_dark = initial(see_in_dark)
+	lighting_alpha = initial(lighting_alpha)
+	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
+	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	return ..()
 
 /mob/living/silicon/ai/get_status_tab_items()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -348,18 +348,16 @@
 			clear_fullscreen("remote_view", 0)
 
 /mob/living/silicon/ai/update_sight()
-	. = ..()
+	see_in_dark = initial(see_in_dark)
+	lighting_alpha = initial(lighting_alpha)
+	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
+	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	if(HAS_TRAIT(src, TRAIT_SEE_IN_DARK))
 		see_in_dark = max(see_in_dark, 8)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 		eyeobj.see_in_dark = max(eyeobj.see_in_dark, 8)
 		eyeobj.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-		return
-	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
-	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
-	see_in_dark = initial(see_in_dark)
-	lighting_alpha = initial(lighting_alpha) // yes you really have to change both the eye and the ai vars
-
+	return ..()
 
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

ports https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/pull/186

## Why It's Good For The Game

scout droids are meant to grant nightvision. AI is meant to have restricted vision.
scout droids of current do not have nightvision. AI deploying to one then returning to core gives the AI nightvision.
bugs bad.

## Changelog
:cl:
fix: fix scout droids not having nightvision
fix: fixes AIs getting permanent nightvision after deploying to their scout droid
/:cl: