### PR TITLE
fixes a missing category in gear preferences

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -359,7 +359,6 @@
 	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	see_in_dark = initial(see_in_dark)
 	lighting_alpha = initial(lighting_alpha) // yes you really have to change both the eye and the ai vars
-
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -359,6 +359,8 @@
 	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	see_in_dark = initial(see_in_dark)
 	lighting_alpha = initial(lighting_alpha) // yes you really have to change both the eye and the ai vars
+
+
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -348,18 +348,16 @@
 			clear_fullscreen("remote_view", 0)
 
 /mob/living/silicon/ai/update_sight()
-	. = ..()
+	see_in_dark = initial(see_in_dark)
+	lighting_alpha = initial(lighting_alpha)
+	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
+	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
 	if(HAS_TRAIT(src, TRAIT_SEE_IN_DARK))
 		see_in_dark = max(see_in_dark, 8)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 		eyeobj.see_in_dark = max(eyeobj.see_in_dark, 8)
 		eyeobj.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-		return
-	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
-	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
-	see_in_dark = initial(see_in_dark)
-	lighting_alpha = initial(lighting_alpha) // yes you really have to change both the eye and the ai vars
-
+	return ..()
 
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -348,16 +348,17 @@
 			clear_fullscreen("remote_view", 0)
 
 /mob/living/silicon/ai/update_sight()
-	see_in_dark = initial(see_in_dark)
-	lighting_alpha = initial(lighting_alpha)
-	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
-	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
+	. = ..()
 	if(HAS_TRAIT(src, TRAIT_SEE_IN_DARK))
 		see_in_dark = max(see_in_dark, 8)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 		eyeobj.see_in_dark = max(eyeobj.see_in_dark, 8)
 		eyeobj.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	return ..()
+		return
+	eyeobj.see_in_dark = initial(eyeobj.see_in_dark)
+	eyeobj.lighting_alpha = initial(eyeobj.lighting_alpha)
+	see_in_dark = initial(see_in_dark)
+	lighting_alpha = initial(lighting_alpha) // yes you really have to change both the eye and the ai vars
 
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
@@ -12,6 +12,7 @@ export const GearCustomization = (props) => {
     10: 'Head',
     8: 'Eyewear',
     9: 'Mouth',
+    17: 'Other',
   };
 
   const bySlot = {};
@@ -92,6 +93,30 @@ export const GearCustomization = (props) => {
               ))}
             </LabeledList>
           </Section>
+          <Stack.Item grow>
+            <Section title={'Other'}>
+              <LabeledList>
+                {bySlot['Other']?.map((item) => (
+                  <LabeledList.Item
+                    key={item.name}
+                    label={`${item.name}
+                  (${item.cost})`}
+                  >
+                    <Button.Checkbox
+                      inline
+                      content={'Equipped'}
+                      checked={gear.includes(item.name)}
+                      onClick={() =>
+                        gear.includes(item.name)
+                          ? act('loadoutremove', { gear: item.name })
+                          : act('loadoutadd', { gear: item.name })
+                      }
+                    />
+                  </LabeledList.Item>
+                ))}
+              </LabeledList>
+            </Section>
+          </Stack.Item>
         </Stack.Item>
       </Stack>
       <Stack>


### PR DESCRIPTION
## About The Pull Request

category for misc. things that equipped to right-hand slot was tagged but unused in actual UI preferences.
sets up a new category for "Other" gear trinkets and enables them. choosing multiple trinkets from this category properly puts the extra trinkets into your backpack (if you have one)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/5a188537-1f0e-4d98-97ed-2791e92f6194)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/f9ab6316-58fe-4c37-b954-e6fbad6128ba)

## Why It's Good For The Game
fixes #15262

## Changelog

:cl:
fix: new category for other trinkets available in "gear preferences" under the "preferences" window
/:cl: