### PR TITLE
Fixes mag harness for belt guns

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -671,7 +671,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	. = ..()
 	if(!master_gun)
 		return
-	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BACK))
+	reequip_component = master_gun.AddComponent(/datum/component/reequip, list(SLOT_S_STORE, SLOT_BELT, SLOT_BACK))
 
 /obj/item/attachable/magnetic_harness/on_detach(attaching_item, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Guns that fit in belt slot will now properly re-equip when dropped with a mag harness.
## Why It's Good For The Game
Fixes the inconsistency and hopefully makes these weapons less troll
## Changelog
:cl:
fix: Mag harness now functions properly for belt guns.
/:cl:
