### PR TITLE
Xeno's health and plasma HUDs will now properly update

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -273,12 +273,13 @@
 
 //related mob procs
 
-///deducts the cost of using an ability
+///deducts the cost of using an ability & updates plasma HUD accordingly
 /mob/living/carbon/proc/deduct_ability_cost(amount)
 	return
 
 /mob/living/carbon/xenomorph/deduct_ability_cost(amount)
 	use_plasma(amount)
+	hud_set_plasma()
 
 ///adds an ability to the mob
 /mob/living/carbon/proc/add_ability(datum/action/ability/new_ability)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -229,6 +229,7 @@
 		return
 	health = maxHealth - getFireLoss() - getBruteLoss() //Xenos can only take brute and fire damage.
 	med_hud_set_health()
+	handle_regular_hud_updates()
 	update_stat()
 	update_wounds()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title; expect xeno HUDs to actually be consistent now, rather than only updating after a delay.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More responsiveness for xenos is very good. Health updates should **not** have a significant performance impact since this already updates for the little green/blue bars next to the xeno, this just updates the HUD on the right of the screen. (the little ovals)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xeno health/plasma HUD now update correctly when the xeno is damaged/used an ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
