### PR TITLE
Squad management fix

### DIFF
--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -370,7 +370,8 @@ You are also in charge of communicating with command and letting them know about
 			new_human.wear_id.paygrade = "E9"
 		if(60001 to INFINITY) // 1000 hrs
 			new_human.wear_id.paygrade = "E9E" //If you play way too much TGMC. 1000 hours.
-	addtimer(CALLBACK(GLOB.squad_manager, TYPE_PROC_REF(/datum, interact), new_human), 2 SECONDS)
+	if(SSticker.mode.flags_round_type & MODE_FORCE_CUSTOMSQUAD_UI)
+		addtimer(CALLBACK(GLOB.squad_manager, TYPE_PROC_REF(/datum, interact), new_human), 2 SECONDS)
 	if(!latejoin)
 		return
 	if(!new_human.assigned_squad)


### PR DESCRIPTION

## About The Pull Request
Squad management autopop up now only opens on the relevant gamemode
## Why It's Good For The Game
Annoying pop up go home.
## Changelog
:cl:
fix: fixed the squad management pop up opening for SL's on non nukewar modes
/:cl:
