### PR TITLE
rds now gives aim speed mult instead of fire delay

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -565,7 +565,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	slot = ATTACHMENT_SLOT_RAIL
 	accuracy_mod = 0.15
 	accuracy_unwielded_mod = 0.1
-	aim_mode_delay_mod = -0.5
+	aim_mode_movement_mult = -0.35
 	variants_by_parent_type = list(/obj/item/weapon/gun/rifle/som = "", /obj/item/weapon/gun/shotgun/som = "")
 
 /obj/item/attachable/m16sight


### PR DESCRIPTION

## About The Pull Request
-0.35 aim speed mult rather than fire delay.
## Why It's Good For The Game
Aim fire delay was a mistake, though it'll need a new gimmick so this should at least keep it a useable attachie over magnetic harness.
## Changelog
:cl:
balance: rds now gives bonus speed while aiming instead of increased firerate.
/:cl:
