### PR TITLE
Focus aura no longer gives you firerate bonuses in aim mode.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1842,9 +1842,6 @@
 			gun_accuracy_mod -= round(min(20, (shooter_human.shock_stage * 0.2))) //Accuracy declines with pain, being reduced by 0.2% per point of pain.
 			if(shooter_human.marksman_aura)
 				gun_accuracy_mod += 10 + max(5, shooter_human.marksman_aura * 5) //Accuracy bonus from active focus order
-				add_aim_mode_fire_delay(AURA_HUMAN_FOCUS, initial(aim_fire_delay) * -0.5)
-			else
-				remove_aim_mode_fire_delay(AURA_HUMAN_FOCUS)
 
 /obj/item/weapon/gun/proc/simulate_recoil(recoil_bonus = 0, firing_angle)
 	if(CHECK_BITFIELD(flags_item, IS_DEPLOYED) || !gun_user)


### PR DESCRIPTION

## About The Pull Request
Title. Basically a revert of Lumis PR way back.
## Why It's Good For The Game
Aim mode fire delay order is kinda insane, let's you hit basically IFF speeds of fire downrange, which is kinda absurd. It being instant aim mode again should be enough.
## Changelog
:cl:
balance: Focus order no longer gives a firerate increase while aiming.
/:cl:
