### PR TITLE
Lowers warlock HP

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -12,7 +12,7 @@
 	speed = -0.5
 	plasma_max = 1700
 	plasma_gain = 60
-	max_health = 375
+	max_health = 325
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	spit_types = list(/datum/ammo/energy/xeno/psy_blast)
 


### PR DESCRIPTION

## About The Pull Request
Nerfs warlock HP from 375 to 325.
## Why It's Good For The Game
This caste has very high stats despite also being extremely safe. Hopefully this should make a warlock think twice before taking an AP rocket to the face which they would previously not even drop into crit from.
## Changelog
:cl:
balance: Lowers warlock HP from 375 to 325.
/:cl:
