### PR TITLE
Increases warrior slash damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -9,7 +9,7 @@
 	wound_type = "warrior" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 22
 
 	// *** Speed *** //
 	speed = -0.5


### PR DESCRIPTION

## About The Pull Request
Increased from 20 to 22, still below pre-rework Warrior
## Why It's Good For The Game
Warriors damage output was made extremely gimmicky with wall throws, and even then is mediocre damage. Stunning into marines means you are throwing them back into the marine horde, and stunning on a wall is the only useful application of the new warrior besides throwing behind you. Hopefully allows warrior to still have less damage (especially since jab was killed and replaced with something worse) but not the same damage as spitter slashing. Small numbers matter, alot.
## Changelog
:cl:
balance: Warrior slash increase from 20 to 22
/:cl:
