### PR TITLE
adjusted values of larmor and vlarmor

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -123,8 +123,8 @@
 //Slowdown from various armors.
 #define SHOES_SLOWDOWN -1.0			// How much shoes slow you down by default. Negative values speed you up
 
-#define SLOWDOWN_ARMOR_VERY_LIGHT 0.20
-#define SLOWDOWN_ARMOR_LIGHT 0.3
+#define SLOWDOWN_ARMOR_VERY_LIGHT 0.15
+#define SLOWDOWN_ARMOR_LIGHT 0.2
 #define SLOWDOWN_ARMOR_MEDIUM 0.5
 #define SLOWDOWN_ARMOR_HEAVY 0.7
 #define SLOWDOWN_ARMOR_VERY_HEAVY 1


### PR DESCRIPTION
## About The Pull Request
Changes light armor slowdown from .3 to .2 and vlarmor from .2 to .15
## Why It's Good For The Game
Light armor while it should remain fragile, feels way too slow for what its purpose is supposed to fulfill.
 With the slowdown being almost negligible when compared to medium armor the cons seem to outweigh any of the pros it should have.
Adjusting the slowdown should allow light armor to feel well "light."
## Changelog
:cl:
balance: Changes light armor slowdown from .3 to .2 and vlarmor from .2 to .15
/:cl:
