### PR TITLE
Sound tank fixes

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -71,7 +71,7 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 		M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, S, sound_reciever = M)
 
 	for(var/obj/vehicle/sealed/armored/armor AS in GLOB.tank_list)
-		if(!armor.interior || armor.z != turf_source.z || get_dist(armor, turf_source) > sound_range)
+		if(!armor.interior || armor.z != turf_source.z || get_dist(armor.loc, turf_source) > sound_range)
 			continue
 		for(var/mob/living/crew AS in armor.occupants)
 			//turf source is null on purpose because it will not work properly since crew is on a different z

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -73,7 +73,7 @@ A good representation is: 'byond applies a volume reduction to the sound every X
 	for(var/obj/vehicle/sealed/armored/armor AS in GLOB.tank_list)
 		if(!armor.interior || armor.z != turf_source.z || get_dist(armor.loc, turf_source) > sound_range)
 			continue
-		for(var/mob/living/crew AS in armor.occupants)
+		for(var/mob/crew AS in armor.interior.occupants)
 			//turf source is null on purpose because it will not work properly since crew is on a different z
 			crew.playsound_local(null, soundin, vol*0.5, vary, frequency, falloff, is_global, channel, S, sound_reciever = crew)
 


### PR DESCRIPTION

## About The Pull Request
ghosts now hear soudns in tank properly
crew sound may have been offset? this fixes that
Falloff doesnt work but playsound is hardcoded to take a turf so it needs a more in depth fix

## Changelog
:cl:
fix: fixed tank sound for ghosts, and may have fixed it being offset
/:cl:
