### PR TITLE
Restores the illusion of choice regarding special resin walls(Fixes not being able to select any other type)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -489,7 +489,7 @@
 	var/resin_choice = show_radial_menu(owner, owner, GLOB.resin_special_images_list, radius = 35)
 	if(!resin_choice)
 		return
-	var/i = GLOB.resin_images_list.Find(resin_choice)
+	var/i = GLOB.resin_special_images_list.Find(resin_choice)
 	X.selected_special_resin = buildable_special_structures[i]
 	var/atom/A = X.selected_special_resin
 	X.balloon_alert(X, initial(A.name))


### PR DESCRIPTION

## About The Pull Request
Fixes not being able to select special resin walls
## Why It's Good For The Game
Its a fix! It also nerfs xenomorphs by letting them choose the worse wall types /s

## Changelog
:cl:
fix: Fixed xenormophs being unable to choose any other special resin wall other than the bulletproof one.
/:cl:
