### PR TITLE
swaps research rig belt dexalin for isotonic

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -342,9 +342,10 @@
 	new /obj/item/storage/pill_bottle/imidazoline(src)
 	new /obj/item/storage/pill_bottle/quickclot(src)
 	new /obj/item/storage/pill_bottle/hypervene(src)
+	new /obj/item/bodybag/cryobag(src)
 	new /obj/item/defibrillator(src)
 	new /obj/item/tool/research/excavation_tool(src)
-	new /obj/item/tool/research/xeno_analyzer(src)
+
 	new /obj/item/healthanalyzer(src)
 
 /obj/item/storage/belt/hypospraybelt

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -345,7 +345,6 @@
 	new /obj/item/bodybag/cryobag(src)
 	new /obj/item/defibrillator(src)
 	new /obj/item/tool/research/excavation_tool(src)
-
 	new /obj/item/healthanalyzer(src)
 
 /obj/item/storage/belt/hypospraybelt

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -336,7 +336,7 @@
 	new /obj/item/storage/pill_bottle/tricordrazine(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/storage/pill_bottle/inaprovaline(src)
-	new /obj/item/storage/pill_bottle/dexalin(src)
+	new /obj/item/storage/pill_bottle/isotonic(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
 	new /obj/item/storage/pill_bottle/alkysine(src)
 	new /obj/item/storage/pill_bottle/imidazoline(src)


### PR DESCRIPTION
## About The Pull Request
swaps researcher med rig dexalin bottle for isotonic

## Why It's Good For The Game

other medrigs have iso so this is part consistency; iso is probably more useful since rig belt comes with tricord anyways for oxy damage; and i dont see much sense to this since researchers can just grab dex+ injectors for free from the medvend and use the superior version of the chem for no cost

probably a greater indicator that dex/dex+ need to be consolidated or differentiated more but i didn't have any big ideas on what to do there

## Changelog
:cl:
balance: researchers spawn with isotonic pill bottles instead of dexalin bottles in their belts
/:cl: