### PR TITLE
Glasses and goggles can be activated properly again

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -59,10 +59,13 @@
 
 ///Toggle the functions of the glasses
 /obj/item/clothing/glasses/proc/activate(mob/user)
-	if(activation_sound && deactivation_sound)
-		playsound(get_turf(src), active ? deactivation_sound : activation_sound, 15)
-
 	active = !active
+
+	if(active && activation_sound)
+		playsound(get_turf(src), activation_sound, 15)
+	else if(deactivation_sound)
+		playsound(get_turf(src), deactivation_sound, 15)
+
 	update_icon()	//Found out the hard way this has to be before update_inv_glasses()
 	user?.update_inv_glasses()
 	user?.update_sight()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -51,10 +51,9 @@
 /obj/item/clothing/glasses/ui_action_click(mob/user, datum/action/item_action/action)
 	//In case someone in the future adds a non-toggle action to a child type
 	if(istype(action, /datum/action/item_action/toggle))
-		var/datum/action/item_action/toggle/toggle = action
-		//Toggling item actions are dumb; it has to be done this way for the icon to properly update
-		toggle.set_toggle(activate(user))
-		return
+		activate(user)
+		//Always return TRUE for toggles so that the UI button icon updates
+		return TRUE
 
 	return activate(user)
 
@@ -64,7 +63,7 @@
 		playsound(get_turf(src), active ? deactivation_sound : activation_sound, 15)
 
 	active = !active
-	update_icon_state()	//Found out the hard way this has to be before update_inv_glasses()
+	update_icon()	//Found out the hard way this has to be before update_inv_glasses()
 	user?.update_inv_glasses()
 	user?.update_sight()
 
@@ -249,14 +248,9 @@
 		activate(usr)
 
 /obj/item/clothing/glasses/welding/activate(mob/user)
-	if(active)
-		DISABLE_BITFIELD(flags_inventory, COVEREYES)
-		DISABLE_BITFIELD(flags_inv_hide, HIDEEYES)
-		DISABLE_BITFIELD(flags_armor_protection, EYES)
-	else
-		ENABLE_BITFIELD(flags_inventory, COVEREYES)
-		ENABLE_BITFIELD(flags_inv_hide, HIDEEYES)
-		ENABLE_BITFIELD(flags_armor_protection, EYES)
+	TOGGLE_BITFIELD(flags_inventory, COVEREYES)
+	TOGGLE_BITFIELD(flags_inv_hide, HIDEEYES)
+	TOGGLE_BITFIELD(flags_armor_protection, EYES)
 
 	eye_protection = active ? 0 : initial(eye_protection)
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -63,7 +63,7 @@
 
 	if(active && activation_sound)
 		playsound(get_turf(src), activation_sound, 15)
-	else if(deactivation_sound)
+	else if(!active && deactivation_sound)
 		playsound(get_turf(src), deactivation_sound, 15)
 
 	update_icon()	//Found out the hard way this has to be before update_inv_glasses()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -248,19 +248,32 @@
 		activate(usr)
 
 /obj/item/clothing/glasses/welding/activate(mob/user)
-	TOGGLE_BITFIELD(flags_inventory, COVEREYES)
-	TOGGLE_BITFIELD(flags_inv_hide, HIDEEYES)
-	TOGGLE_BITFIELD(flags_armor_protection, EYES)
-
-	eye_protection = active ? 0 : initial(eye_protection)
-
-	if(user)
-		to_chat(usr, "You [active ? "push [src] up out of your face" : "flip [src] down to protect your eyes"].")
+	. = ..()
+	if(active)
+		flip_up()
+	else
+		flip_down()
 
 	//I imagine some signals use it so letting it still call it
 	toggle_item_state(user)
 
-	return ..()
+///Toggle the welding goggles on
+/obj/item/clothing/glasses/welding/proc/flip_up()
+	DISABLE_BITFIELD(flags_inventory, COVEREYES)
+	DISABLE_BITFIELD(flags_inv_hide, HIDEEYES)
+	DISABLE_BITFIELD(flags_armor_protection, EYES)
+	eye_protection = 0
+	update_icon()
+	to_chat(usr, "You push [src] up out of your face.")
+
+///Toggle the welding goggles off
+/obj/item/clothing/glasses/welding/proc/flip_down()
+	ENABLE_BITFIELD(flags_inventory, COVEREYES)
+	ENABLE_BITFIELD(flags_inv_hide, HIDEEYES)
+	ENABLE_BITFIELD(flags_armor_protection, EYES)
+	eye_protection = initial(eye_protection)
+	update_icon()
+	to_chat(usr, "You flip [src] down to protect your eyes.")
 
 /obj/item/clothing/glasses/welding/update_icon_state()
 	icon_state = "[initial(icon_state)][!active ? "up" : ""]"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -31,9 +31,7 @@
 	return ..()
 
 
-/obj/item/clothing/glasses/hud/activate(mob/user, silent = FALSE)
-	if(QDELETED(affected_user))
-		return
+/obj/item/clothing/glasses/hud/activate(mob/user)
 	if(!ishuman(user))
 		return
 

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -32,6 +32,9 @@
 
 
 /obj/item/clothing/glasses/hud/activate(mob/user)
+	//Run the activation stuff BEFORE getting to the HUD de/activations
+	. = ..()
+
 	if(!ishuman(user))
 		return
 
@@ -40,11 +43,9 @@
 		return
 
 	if(active)
-		deactivate_hud(hud_user)
-	else
 		activate_hud(hud_user)
-
-	return ..()
+	else
+		deactivate_hud(hud_user)
 
 ///Activates the hud(s) these glasses have
 /obj/item/clothing/glasses/hud/proc/activate_hud(mob/living/carbon/human/user)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -235,6 +235,8 @@
 	hud_type = list(DATA_HUD_MEDICAL_OBSERVER, DATA_HUD_XENO_STATUS, DATA_HUD_SECURITY_ADVANCED, DATA_HUD_SQUAD_TERRAGOV, DATA_HUD_SQUAD_SOM, DATA_HUD_ORDER)
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	activation_sound = null
+	deactivation_sound = null
 
 /obj/item/clothing/glasses/hud/sa/Initialize(mapload)
 	. = ..()

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1188,7 +1188,7 @@ CLOTHING
 
 /datum/supply_packs/clothing/night_vision_mounted
 	name = "BE-35 Night Vision Module"
-	contains = list(/obj/item/clothing/glasses/night_vision/mounted)
+	contains = list(/obj/item/armor_module/module/night_vision)
 	cost = 300
 
 /datum/supply_packs/clothing/night_vision_batteries


### PR DESCRIPTION
## About The Pull Request

Welding goggles use `activate()` like every other eye wear. Medhuds should also work again, apparently the `if(QDELETED)` was not needed (yet it worked before I made any changes to it somehow?). A lot of the code is mostly so the action icons properly changed to reflect the state they were in.

## Why It's Good For The Game

Oopsy poopsy broke the glassies.

## Changelog
:cl:
fix: Welding goggles and HUD glasses work again. Night vision module req order spawns the actual module.
/:cl:
