### PR TITLE
Remove old type from map

### DIFF
--- a/_maps/map_files/Campaign maps/som_base/sombase.dmm
+++ b/_maps/map_files/Campaign maps/som_base/sombase.dmm
@@ -15720,11 +15720,6 @@
 /obj/machinery/power/apc,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/living/janitor)
-"vOw" = (
-/obj/structure/table/black,
-/obj/item/hardpoint/treads,
-/turf/open/floor/mainship/mono,
-/area/rocinante_base/surface/building/cargo/southern_aux)
 "vPC" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#5b7857";
@@ -34481,7 +34476,7 @@ gnj
 jaw
 jaw
 jaw
-vOw
+lJq
 tao
 oVs
 pEm
@@ -34633,7 +34628,7 @@ gnj
 aSY
 gOG
 cQP
-vOw
+lJq
 oVs
 oVs
 pEm


### PR DESCRIPTION

## About The Pull Request
One of the campaign maps had some object that was removed in the multitile rework, but it wasn't removed for whatever reason.
## Why It's Good For The Game
cleanup
## Changelog
:cl:
del: Removed a nonexistant item
/:cl:
