### PR TITLE
Mech stagger

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -85,15 +85,24 @@
 		contents_explosion(severity)
 	if(QDELETED(src))
 		return
+	var/stagger_duration
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(rand(1200, 1800), BRUTE, BOMB, 0)
+			stagger_duration = 7 SECONDS
 		if(EXPLODE_HEAVY)
 			take_damage(rand(400, 600), BRUTE, BOMB, 0)
+			stagger_duration = 5 SECONDS
 		if(EXPLODE_LIGHT)
 			take_damage(rand(150, 300), BRUTE, BOMB, 0)
+			stagger_duration = 2 SECONDS
 		if(EXPLODE_WEAK)
 			take_damage(rand(50, 100), BRUTE, BOMB, 0)
+
+	if(!stagger_duration)
+		return
+	for(var/mob/living/living_occupant AS in occupants)
+		living_occupant.Stagger(stagger_duration)
 
 /obj/vehicle/sealed/mecha/contents_explosion(severity)
 	severity--


### PR DESCRIPTION
## About The Pull Request
Explosions now stagger the occupant of a mech.
On its own this pr will do nothing, but when my projectile code pr's are merged, that means the mech will suffer from the stagger damage penalty of the occupant. i.e. you can stagger mech to reduce damage by 50%.

This is intended to be paired with #15307 so explosions dont throw mechs AND stagger.

I'll probs roll this out to some xeno abilities later, but this is mainly done with HvH in mind.
## Why It's Good For The Game
More mech interactivity.
## Changelog
:cl:
balance: Explosions stagger the occupants of mechs, applying stagger damage penalties to their weapons
/:cl:
