### PR TITLE
Fixes kotahi shuffling

### DIFF
--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -139,14 +139,9 @@
 		user.visible_message("\The [user] deals a card to \the [target].")
 	H.throw_at(get_step(target,target.dir),10,1,H)
 
-/obj/item/toy/deck/attack_self(mob/user as mob)
-
-	var/list/newcards = list()
-	while(length(cards))
-		var/datum/playingcard/P = pick(cards)
-		newcards += P
-		cards -= P
-	cards = newcards
+/obj/item/toy/deck/attack_self(mob/user)
+	. = ..()
+	shuffle_inplace(cards)
 	user.visible_message("\The [user] shuffles [src].")
 
 /obj/item/toy/deck/MouseDrop(atom/over)
@@ -369,6 +364,7 @@
 		P.card_icon = "Wildcard"
 		cards += P
 	for(var/k in 0 to 3)
+		P = new()
 		P.name= "Draw 4"
 		P.card_icon = "Draw 4"
 		cards += P


### PR DESCRIPTION

## About The Pull Request

d

## Changelog
:cl:
code: kotahi uses proper shuffling in backend
fix: Fix kotahi always spitting out 4 +4s in a row
/:cl:
