### PR TITLE
Less RNG in flame_radius, incen OB buff

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -218,18 +218,19 @@
 	qdel(src)
 
 
-/proc/flame_radius(radius = 1, turf/epicenter, burn_intensity = 25, burn_duration = 25, burn_damage = 25, fire_stacks = 15, int_var = 0.5, dur_var = 0.5, colour = "red") //~Art updated fire.
+/proc/flame_radius(radius = 1, turf/epicenter, burn_intensity = 25, burn_duration = 25, burn_damage = 25, fire_stacks = 15, colour = "red") //~Art updated fire.
 	if(!isturf(epicenter))
 		CRASH("flame_radius used without a valid turf parameter")
 	radius = clamp(radius, 1, 50) //Sanitize inputs
-	int_var = clamp(int_var, 0.1,0.5)
-	dur_var = clamp(int_var, 0.1,0.5)
-	fire_stacks = randfloat(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + randfloat(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
-	burn_damage = randfloat(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + randfloat(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 
 	for(var/t in filled_turfs(epicenter, radius, "circle", air_pass = TRUE))
 		var/turf/turf_to_flame = t
-		turf_to_flame.ignite(randfloat(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + randfloat(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), randfloat(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + randfloat(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, burn_damage, fire_stacks)
+		// Slight randomization on how long a fire last so that a sea of fire does not delete instantly at the same time. Flat for high durations, % for low.
+		if(burn_duration >= 10)
+			burn_duration = burn_duration - randfloat(0, 2)
+		else
+			burn_duration = randfloat(burn_duration, burn_duration*0.95)
+		turf_to_flame.ignite(burn_duration, burn_intensity, colour, burn_damage, fire_stacks)
 
 /obj/item/explosive/grenade/incendiary/som
 	name = "\improper S30-I incendiary grenade"
@@ -411,7 +412,7 @@
 	smoke.set_up(6, loc, 7)
 	smoke.start()
 	flame_radius(4, get_turf(src))
-	flame_radius(1, get_turf(src), burn_intensity = 45, burn_duration = 75, burn_damage = 15, fire_stacks = 75)	//The closer to the middle you are the more it hurts
+	flame_radius(1, get_turf(src), burn_intensity = 75, burn_duration = 45, burn_damage = 15, fire_stacks = 75)	//The closer to the middle you are the more it hurts
 	qdel(src)
 
 /obj/item/explosive/grenade/phosphorus/activate(mob/user)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -225,9 +225,9 @@
 
 	for(var/t in filled_turfs(epicenter, radius, "circle", air_pass = TRUE))
 		var/turf/turf_to_flame = t
-		// Slight randomization on how long a fire last so that a sea of fire does not delete instantly at the same time. Flat for high durations, % for low.
+		// Slight randomization on how long a fire last so that a sea of fire does not delete instantly at the same time. High % for long durations, low % for short.
 		if(burn_duration >= 10)
-			burn_duration = burn_duration - randfloat(0, 2)
+			burn_duration = randfloat(burn_duration, burn_duration*0.5)
 		else
 			burn_duration = randfloat(burn_duration, burn_duration*0.95)
 		turf_to_flame.ignite(burn_duration, burn_intensity, colour, burn_damage, fire_stacks)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -225,12 +225,7 @@
 
 	for(var/t in filled_turfs(epicenter, radius, "circle", air_pass = TRUE))
 		var/turf/turf_to_flame = t
-		// Slight randomization on how long a fire last so that a sea of fire does not delete instantly at the same time. High % for long durations, low % for short.
-		if(burn_duration >= 10)
-			burn_duration = randfloat(burn_duration, burn_duration*0.5)
-		else
-			burn_duration = randfloat(burn_duration, burn_duration*0.95)
-		turf_to_flame.ignite(burn_duration, burn_intensity, colour, burn_damage, fire_stacks)
+		turf_to_flame.ignite(randfloat(burn_duration*0.75, burn_duration), burn_intensity, colour, burn_damage, fire_stacks)
 
 /obj/item/explosive/grenade/incendiary/som
 	name = "\improper S30-I incendiary grenade"

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -441,7 +441,7 @@
 /obj/structure/ship_ammo/cas/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
 	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range)
-	flame_radius(fire_range, impact, 60, 30) //cooking for a long time
+	flame_radius(fire_range, impact, 30, 60) //cooking for a long time
 	var/datum/effect_system/smoke_spread/phosphorus/warcrime = new
 	warcrime.set_up(fire_range + 1, impact, 7)
 	warcrime.start()

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -378,7 +378,7 @@
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
 	. = ..()
 	var/range_num = max(15 - inaccuracy_amt, 12)
-	flame_radius(range_num, target,	burn_intensity = 36, burn_duration = 40, colour = "blue")
+	flame_radius(range_num, target,	burn_intensity = 46, burn_duration = 40, colour = "blue")
 	var/datum/effect_system/smoke_spread/phosphorus/warcrime = new
 	warcrime.set_up(17, target, 20)
 	warcrime.start()

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -240,13 +240,13 @@
 	exploding = TRUE
 
 	if(reagents.total_volume > 500)
-		flame_radius(5, loc, 46, 40, 31, 30, colour = "blue")
+		flame_radius(5, loc, 40, 46, 31, 30, colour = "blue")
 		explosion(loc, light_impact_range = 5)
 	else if(reagents.total_volume > 100)
-		flame_radius(4, loc, 46, 40, 31, 30, colour = "blue")
+		flame_radius(4, loc, 40, 46, 31, 30, colour = "blue")
 		explosion(loc, light_impact_range = 4)
 	else
-		flame_radius(3, loc, 46, 40, 31, 30, colour = "blue")
+		flame_radius(3, loc, 40, 46, 31, 30, colour = "blue")
 		explosion(loc, light_impact_range = 3)
 
 	qdel(src)

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -665,7 +665,7 @@
 /proc/delayed_detonate_bomb_napalm(turf/impact)
 	impact.ceiling_debris_check(3)
 	explosion(impact, 2, 3, 4, 0, 6)
-	flame_radius(5, impact, 60, 30)
+	flame_radius(5, impact, 30, 60)
 
 
 /datum/admins/proc/drop_dynex_bomb()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2692,7 +2692,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke.set_up(6, T, 7)
 	smoke.start()
 	flame_radius(4, T)
-	flame_radius(1, T, burn_intensity = 45, burn_duration = 75, burn_damage = 15, fire_stacks = 75)
+	flame_radius(1, T, burn_intensity = 75, burn_duration = 45, burn_damage = 15, fire_stacks = 75)
 
 /datum/ammo/mortar/smoke/howi/plasmaloss
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**PLEASE TM, THERE COULD BE VERY FUCKED THINGS HAPPENING**
Completely changes around flame_radius to eliminate damage RNG and make duration RNG more sane. Incen OB now has the same burn_intensity as xfuel.
Swapped around burn_intensity and burn_duration values on everything I could fine, because previously duration was being used for burnlevel (the damage) and intensity for firelevel (the duration), which was extremely fucked.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less RNG is usually better, plus incen was laughably bad at clearing resin walls, where you could have tangle OB do the same area denial but marines could move in and clear the walls themselves way more reliably.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Explosives using flame_radius (phos nades, incen nades) no longer have damage RNG, and less duration RNG
balance: Incendiary OB now has the same burn level as xfuel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
