### PR TITLE
Add new lemonine duplication using virilyth (the chem vali weapons collect).

### DIFF
--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -177,6 +177,11 @@
 	required_reagents = list(/datum/reagent/medicine/lemoline = 1, /datum/reagent/consumable/larvajelly = 1)
 
 // Cloning chemicals
+/datum/chemical_reaction/dupl_Lemonine
+	name = "Duplicate Lemonine"
+	results = list(/datum/reagent/medicine/lemoline = 2)
+	required_reagents = list(/datum/reagent/virilyth = 5, /datum/reagent/medicine/lemoline = 1) //5 to one Virilyth to Lemonine ratio
+
 /datum/chemical_reaction/dupl_bicaridine
 	name = "Duplicate Bicaridine"
 	results = list(/datum/reagent/medicine/bicaridine = 2)


### PR DESCRIPTION

## About The Pull Request

adds a chemical reaction to virilyth that allows it to duplicate lemonine with a ratio of 5 virilyth to one lemonine.
## Why It's Good For The Game

Gives vali users something to do with their currently useless virilyth and (hopefully) creates a requisition loop between shipside medical making advanced healing chems for vali users who then collect virilyth for more advanced healing chems. Currently the only use for virilyth is duplicateing BKTT witch is irelevant due to the abundance of BKTT.

Why it might not be good for the game
the ratio may be too generous and give vali users enough lemonine to sustainably use a nuraline god-blend. if this is a concern we should nerf the ratio to something like 8:1 or even 10:1.
## Changelog
:cl: UzedPickle
add: Virilyth (the chem vali weapons collect) can now be used for lemonine dupication at a 5:1 ratio
/:cl:
