### PR TITLE
Gives cluster OB 1 more tile of devastation

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -398,7 +398,7 @@
 	var/total_amt = max(25 - inaccuracy_amt, 20)
 	for(var/i = 1 to total_amt)
 		var/turf/U = pick_n_take(turf_list)
-		explosion(U, 1, 4, 6, 0, 6, throw_range = 0, adminlog = FALSE) //rocket barrage
+		explosion(U, 2, 4, 6, 0, 6, throw_range = 0, adminlog = FALSE) //rocket barrage
 		sleep(0.1 SECONDS)
 
 /obj/structure/ob_ammo/warhead/plasmaloss


### PR DESCRIPTION

## About The Pull Request
Instead of devastation being on only the tile an explosion hit with a cluster OB, it will extend outwards in a cross section in all 4 cardinal directions 1 tile.
## Why It's Good For The Game
Helps make cluster OB more comparable to the other OBs like HE and Tangle (perhaps incen pending buff). This also means more gibs for more FUN.
## Changelog
:cl:
balance: Cluster OB now has 1 more tile of devastation per hit
/:cl:
