### PR TITLE
Proper updating for xeno health/plasma side buttons

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -203,3 +203,6 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 #define ERROR_CONSTRUCT 8
 
 #define PUPPET_WITHER_RANGE 15
+
+///Number of icon states to show health and plasma on the side UI buttons
+#define XENO_HUD_ICON_BUCKETS 16

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -149,6 +149,12 @@
 	update_sight()
 	SEND_SIGNAL(src, COMSIG_MOB_HUD_CREATED)
 
+/mob/living/carbon/xenomorph/create_mob_hud()
+	. = ..()
+	//Some parts require hud_used to already be set
+	med_hud_set_health()
+	hud_set_plasma()
+
 //Version denotes which style should be displayed. blank or 0 means "next version"
 /datum/hud/proc/show_hud(version = 0, mob/viewmob)
 	if(!ismob(mymob))

--- a/code/_onclick/hud/xeno/xeno.dm
+++ b/code/_onclick/hud/xeno/xeno.dm
@@ -108,7 +108,6 @@
 	healths = new /atom/movable/screen/healths/alien(null, src)
 	healths.alpha = ui_alpha
 	infodisplay += healths
-	owner.med_hud_set_health()
 
 	using = new /atom/movable/screen/alien/nightvision(null, src)
 	using.alpha = ui_alpha
@@ -117,7 +116,6 @@
 	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay(null, src)
 	alien_plasma_display.alpha = ui_alpha
 	infodisplay += alien_plasma_display
-	owner.hud_set_plasma()
 
 	locate_leader = new /atom/movable/screen/alien/queen_locator(null, src)
 	locate_leader.alpha = ui_alpha

--- a/code/_onclick/hud/xeno/xeno.dm
+++ b/code/_onclick/hud/xeno/xeno.dm
@@ -108,6 +108,7 @@
 	healths = new /atom/movable/screen/healths/alien(null, src)
 	healths.alpha = ui_alpha
 	infodisplay += healths
+	owner.med_hud_set_health()
 
 	using = new /atom/movable/screen/alien/nightvision(null, src)
 	using.alpha = ui_alpha
@@ -116,6 +117,7 @@
 	alien_plasma_display = new /atom/movable/screen/alien/plasmadisplay(null, src)
 	alien_plasma_display.alpha = ui_alpha
 	infodisplay += alien_plasma_display
+	owner.hud_set_plasma()
 
 	locate_leader = new /atom/movable/screen/alien/queen_locator(null, src)
 	locate_leader.alpha = ui_alpha

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -108,6 +108,14 @@
 
 
 /mob/living/carbon/xenomorph/med_hud_set_health()
+	if(hud_used?.healths)
+		var/bucket
+		if(stat == DEAD)
+			bucket = "critical"
+		else
+			bucket = get_bucket(XENO_HUD_ICON_BUCKETS, maxHealth, health, get_crit_threshold(), list("full", "critical"))
+		hud_used.healths.icon_state = "health[bucket]"
+
 	var/image/holder = hud_list[HEALTH_HUD_XENO]
 	if(!holder)
 		return
@@ -464,8 +472,14 @@
 
 
 /mob/living/carbon/xenomorph/proc/hud_set_plasma()
-	if(!xeno_caste) // usually happens because hud ticks before New() finishes.
-		return
+	if(hud_used?.alien_plasma_display)
+		var/bucket
+		if(stat == DEAD)
+			bucket = "empty"
+		else
+			bucket = get_bucket(XENO_HUD_ICON_BUCKETS, xeno_caste.plasma_max, plasma_stored, 0, list("full", "empty"))
+		hud_used.alien_plasma_display.icon_state = "power_display_[bucket]"
+
 	var/image/holder = hud_list[PLASMA_HUD]
 	if(!holder)
 		return

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -472,6 +472,8 @@
 
 
 /mob/living/carbon/xenomorph/proc/hud_set_plasma()
+	if(!xeno_caste) //this is cringe that we need this but currently its called before caste is set on init
+		return
 	if(hud_used?.alien_plasma_display)
 		var/bucket
 		if(stat == DEAD)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -141,8 +141,6 @@
 
 			human_user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 
-			var/target_zone = ran_zone(human_user.zone_selected)
-
 			//Accidental gun discharge
 			if(human_user.skills.getRating(SKILL_CQC) < SKILL_CQC_MP)
 				if (istype(r_hand,/obj/item/weapon/gun) || istype(l_hand,/obj/item/weapon/gun))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -3,8 +3,6 @@
 #define XENO_STANDING_HEAL 0.2
 #define XENO_CRIT_DAMAGE 5
 
-#define XENO_HUD_ICON_BUCKETS 16  // should equal the number of icons you use to represent health / plasma (from 0 -> X)
-
 /mob/living/carbon/xenomorph/Life()
 
 	if(!loc)
@@ -48,7 +46,6 @@
 		handle_critical_health_updates()
 		return
 	if((health >= maxHealth) || on_fire) //can't regenerate.
-		updatehealth() //Update health-related stats, like health itself (using brute and fireloss), health HUD and status.
 		return
 	var/turf/T = loc
 	if(!istype(T))
@@ -173,37 +170,7 @@
 	..()
 
 /mob/living/carbon/xenomorph/handle_regular_hud_updates()
-	if(!client)
-		return FALSE
-
-	// Sanity checks
-	if(!maxHealth)
-		stack_trace("[src] called handle_regular_hud_updates() while having [maxHealth] maxHealth.")
-		return
-	if(!xeno_caste.plasma_max)
-		stack_trace("[src] called handle_regular_hud_updates() while having [xeno_caste.plasma_max] xeno_caste.plasma_max.")
-		return
-
-	// Health Hud
-	if(hud_used?.healths)
-		if(stat != DEAD)
-			var/bucket = get_bucket(XENO_HUD_ICON_BUCKETS, maxHealth, health, get_crit_threshold(), list("full", "critical"))
-			hud_used.healths.icon_state = "health[bucket]"
-		else
-			hud_used.healths.icon_state = "health_dead"
-
-	// Plasma Hud
-	if(hud_used?.alien_plasma_display)
-		if(stat != DEAD)
-			var/bucket = get_bucket(XENO_HUD_ICON_BUCKETS, xeno_caste.plasma_max, plasma_stored, 0, list("full", "empty"))
-			hud_used.alien_plasma_display.icon_state = "power_display_[bucket]"
-		else
-			hud_used.alien_plasma_display.icon_state = "power_display_empty"
-
-
-	interactee?.check_eye(src)
-
-	return TRUE
+	return
 
 /mob/living/carbon/xenomorph/proc/handle_environment() //unused while atmos is not on
 	var/env_temperature = loc.return_temperature()
@@ -225,7 +192,7 @@
 		stat = CONSCIOUS
 		return
 	health = maxHealth - getFireLoss() - getBruteLoss() //Xenos can only take brute and fire damage.
-	med_hud_set_health()
+	med_hud_set_health() //todo: Make all damage update health so we can just kill pointless life updates entirely
 	update_stat()
 	update_wounds()
 

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -40,7 +40,6 @@
 	update_fire() //the fire overlay depends on the xeno's stance, so we must update it.
 	update_wounds()
 
-	med_hud_set_health()
 	hud_set_sunder()
 	hud_set_firestacks()
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -55,9 +55,6 @@
 
 	regenerate_icons()
 
-	hud_set_plasma()
-	med_hud_set_health()
-
 	toggle_xeno_mobhud() //This is a verb, but fuck it, it just werks
 
 	update_spits()


### PR DESCRIPTION

## About The Pull Request
Did what I did for huds, but now for the UI button thingos, making them update whenever plasma and health are updated.

Also removed a bunch of extra calls on these procs on live and init. There's still redundant health calls, but that requires a different refactor to ensure all damage is actually updating health to begin with.
## Why It's Good For The Game
Accurate UI elements is good.
## Changelog
:cl:
qol: Xeno side UI plasma/health icons now also update instantly on change
/:cl:
