### PR TITLE
Artillery pieces (Mortar, Howitzer) are now slashable by xenos

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -12,6 +12,7 @@
 	density = TRUE
 	coverage = 20
 	layer = ABOVE_MOB_LAYER //So you can't hide it under corpses
+	resistance_flags = XENO_DAMAGEABLE
 	/// list of the target x and y, and the dialing we can do to them
 	var/list/coords = list("name"= "", "targ_x" = 0, "targ_y" = 0, "dial_x" = 0, "dial_y" = 0)
 	/// saved last three inputs that were actually used to fire a round
@@ -477,6 +478,7 @@
 	icon = 'icons/Marine/howitzer.dmi'
 	icon_state = "howitzer"
 	max_integrity = 400
+	resistance_flags = XENO_DAMAGEABLE
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE
 	w_class = WEIGHT_CLASS_HUGE
 	deployable_item = /obj/machinery/deployable/mortar/howitzer


### PR DESCRIPTION

## About The Pull Request
Salt pr? Maybe.
## Why It's Good For The Game
Artillery has the advantage of being able to be placed in a faraway location and still shoot at the battlefield. If you don't put it in a safe place, that's your fault, and xenos should be able to take advantage of it and destroy the artillery without needing to drag a spitter or other caste with acid over.
## Changelog
:cl:
balance: Artillery pieces may now be slashed by xenos
/:cl:
