### PR TITLE
Synthetic overheating damage tweak + cool effects

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -632,7 +632,7 @@
 /datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
 		H.apply_effect(4 SECONDS, STUTTER) // Added flavor
-		H.adjustFireLoss(rand(7, 24)) // Melting even more!!!
+		H.adjustFireLoss(rand(7, 19)) // Melting even more!!!
 		if(prob(12))
 			H.visible_message(span_boldwarning("[H] shudders violently and shoots out sparks!"), span_warning("Critical damage sustained. Internal temperature regulation systems offline. Shutdown imminent. <b>Estimated integrity: [round(H.health)]%.</b>"))
 			do_sparks(4, TRUE, H)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -568,9 +568,11 @@
 
 /datum/species/synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
-		H.adjustFireLoss(rand(14, 24)) // This may need tweaks
-		if(prob(8))
-			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
+		H.apply_effect(4 SECONDS, STUTTER) // Added flavor
+		H.adjustFireLoss(rand(5, 16)) // Melting!!!
+		if(prob(12))
+			H.visible_message(span_boldwarning("[H] shudders violently and shoots out sparks!"), span_warning("Critical damage sustained. Internal temperature regulation systems offline. Shutdown imminent. <b>Estimated integrity: [round(H.health)]%.</b>"))
+			do_sparks(4, TRUE, H)
 
 /datum/species/synthetic/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
@@ -629,9 +631,11 @@
 
 /datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= -30 && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
-		H.adjustFireLoss(rand(18, 28)) // This may need tweaks
-		if(prob(8))
-			to_chat(H, span_alert("<b>Critical damage sustained. Internal temperature regulation systems offline. <u>Immediate repair required.</u></b>"))
+		H.apply_effect(4 SECONDS, STUTTER) // Added flavor
+		H.adjustFireLoss(rand(7, 24)) // Melting even more!!!
+		if(prob(12))
+			H.visible_message(span_boldwarning("[H] shudders violently and shoots out sparks!"), span_warning("Critical damage sustained. Internal temperature regulation systems offline. Shutdown imminent. <b>Estimated integrity: [round(H.health)]%.</b>"))
+			do_sparks(4, TRUE, H)
 
 /datum/species/early_synthetic/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Changes the values for Synthetic burn damage when in critical condition. These should be a little more lenient but still able to add a decent drawback and kill you if you don't repair quickly.
People will get into crazy situations on live and this could end up needing a tweak again, but we should just try this for now.
* Normal Synthetic damage range: 5-16
* Early Synthetic damage range: 7-19
* Both types will stammer when in critical condition.
* 12% chance each tick to spark with a visible message in chat.
## Why It's Good For The Game
I think I messed up the damage range last PR, some people have complained about Early/Normal Synthetics taking too much damage. These should be less intense but able to kill quickly.
Sparking occasionally and stammering are a cool flavor change.
## Changelog
:cl:
balance: The overheating damage for Normal Synthetics is now 5-16
balance: The overheating damage for Early Synthetics is now 7-19
add: Synthetics may spark when overheating from severe damage. They will also stammer when overheating.
/:cl:
