### PR TITLE
Water is now recognizable by medical scanners

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -30,6 +30,7 @@
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable)
 	purge_rate = 1
 	taste_description = "water"
+	scannable = TRUE
 
 /datum/reagent/water/reaction_turf(turf/T, volume)
 	if(volume >= 3)


### PR DESCRIPTION
## About The Pull Request
When you scan someone with water, it should now not say it is an unknown reagent.

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14537

## Why It's Good For The Game
Water shouldn't be a mystery reagent.

## Changelog
:cl:
fix: water is now scannable by medical scanners
/:cl:
