### PR TITLE
changes synth vendor insuls for combat insuls

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -641,7 +641,7 @@ GLOBAL_LIST_INIT(synthetic_clothes_listed_products, list(
 		/obj/item/clothing/tie/red = list(CAT_WEB, "Red Tie", 0, "black"),
 		/obj/item/clothing/tie/blue = list(CAT_WEB, "Blue Tie", 0, "black"),
 		/obj/item/clothing/tie/horrible = list(CAT_WEB, "Horrible Tie", 0, "black"),
-		/obj/item/clothing/gloves/insulated = list(CAT_GLO, "Insulated gloves", 0, "black"),
+		/obj/item/clothing/gloves/marine/insulated = list(CAT_GLO, "Insulated combat gloves", 0, "black"),
 		/obj/item/clothing/gloves/latex = list(CAT_GLO, "Latex gloves", 0, "black"),
 		/obj/item/clothing/gloves/marine/officer = list(CAT_GLO, "Officer gloves", 0, "black"),
 		/obj/item/clothing/gloves/white = list(CAT_GLO, "White gloves", 0, "black"),


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

synths spawn with insuls. their vendor also has an option for a second pair of insuls. synths don't have native electrocution resistance despite working with electronics often. 
the primary specialist job performing the same duties in the same environments, engineer, gets insulated combat gloves as a part of their standard kit for no points, and are not left to choose between electrocution resistance or hand armor.

## Changelog
:cl:
balance: made the insuls option in the synthetic vendor combat insuls
/:cl:
