### PR TITLE
Kill some obj vars

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -526,6 +526,18 @@
 	if(!active)
 		turn_on(user)
 
+/obj/item/explosive/grenade/flare/update_icon_state()
+	if(active && fuel > 0)
+		icon_state = "[initial(icon_state)]_active"
+		item_state = "[initial(item_state)]_active"
+	else if(!fuel)
+		icon_state = "[initial(icon_state)]_empty"
+		item_state = "[initial(item_state)]_empty"
+	else
+		icon_state = initial(icon_state)
+		item_state = initial(item_state)
+
+
 ///Shuts the flare off
 /obj/item/explosive/grenade/flare/proc/turn_off()
 	active = FALSE
@@ -533,8 +545,8 @@
 	heat = 0
 	force = initial(force)
 	damtype = initial(damtype)
-	update_brightness()
-	icon_state = "[initial(icon_state)]_empty" // override icon state set by update_brightness
+	update_icon()
+	set_light_on(FALSE)
 	STOP_PROCESSING(SSobj, src)
 
 ///Activates the flare
@@ -545,19 +557,10 @@
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 	heat = 1500
 	damtype = BURN
-	update_brightness()
+	update_icon()
+	set_light_on(TRUE)
 	playsound(src,'sound/items/flare.ogg', 15, 1)
 	START_PROCESSING(SSobj, src)
-
-/obj/item/explosive/grenade/flare/proc/update_brightness()
-	if(active && fuel > 0)
-		icon_state = "[initial(icon_state)]_active"
-		item_state = "[initial(item_state)]_active"
-		set_light_on(TRUE)
-	else
-		icon_state = initial(icon_state)
-		item_state = initial(item_state)
-		set_light_on(FALSE)
 
 //Starts on
 /obj/item/explosive/grenade/flare/on/Initialize(mapload)
@@ -611,8 +614,7 @@
 	upper_fuel_limit = 20
 	light_system = STATIC_LIGHT//movable light has a max range
 	light_color = LIGHT_COLOR_CYAN
-	///The brightness of the flare
-	var/brightness = 12
+	light_range = 12
 
 /obj/item/explosive/grenade/flare/strongerflare/throw_impact(atom/hit_atom, speed)
 	. = ..()
@@ -620,11 +622,6 @@
 		return
 	anchored = TRUE//prevents marines from picking up and running around with a stronger flare
 
-/obj/item/explosive/grenade/flare/strongerflare/update_brightness()
+/obj/item/explosive/grenade/flare/strongerflare/turn_off()
 	. = ..()
-	if(active && fuel > 0)
-		icon_state = "[initial(icon_state)]_active"
-		set_light(brightness)
-	else
-		icon_state = initial(icon_state)
-		set_light(0)
+	set_light(0)

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -403,7 +403,6 @@ REAGENT SCANNER
 	throw_range = 20
 
 	var/details = FALSE
-	var/recent_fail = TRUE
 
 /obj/item/mass_spectrometer/Initialize(mapload)
 	. = ..()
@@ -434,16 +433,7 @@ REAGENT SCANNER
 			break
 	var/dat = "Trace Chemicals Found: "
 	for(var/R in blood_traces)
-		if(prob(reliability))
-			dat += "\n\t[R][details ? " ([blood_traces[R]] units)" : "" ]"
-			recent_fail = FALSE
-		else if(recent_fail)
-			crit_fail = TRUE
-			reagents.clear_reagents()
-			to_chat(user, span_warning("Device malfunction occured. Please consult manual for manufacturer contact and warranty."))
-			return
-		else
-			recent_fail = TRUE
+		dat += "\n\t[R][details ? " ([blood_traces[R]] units)" : "" ]"
 	to_chat(user, "[dat]")
 	reagents.clear_reagents()
 
@@ -467,7 +457,6 @@ REAGENT SCANNER
 	throw_range = 20
 
 	var/details = FALSE
-	var/recent_fail = FALSE
 
 /obj/item/reagent_scanner/afterattack(obj/O, mob/user as mob, proximity)
 	if(!proximity)
@@ -485,15 +474,7 @@ REAGENT SCANNER
 	var/dat = ""
 	var/one_percent = O.reagents.total_volume / 100
 	for (var/datum/reagent/R in O.reagents.reagent_list)
-		if(prob(reliability))
-			dat += "\n \t [span_notice(" [R.name][details ? ": [R.volume / one_percent]%" : ""]")]"
-			recent_fail = FALSE
-		else if(recent_fail)
-			crit_fail = TRUE
-			to_chat(user, span_warning("Device malfunction occured. Please consult manual for manufacturer contact and warranty."))
-			return
-		else
-			recent_fail = TRUE
+		dat += "\n \t [span_notice(" [R.name][details ? ": [R.volume / one_percent]%" : ""]")]"
 	to_chat(user, span_notice("Chemicals found: [dat]"))
 
 /obj/item/reagent_scanner/adv

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -417,9 +417,6 @@ REAGENT SCANNER
 /obj/item/mass_spectrometer/attack_self(mob/user as mob)
 	if (user.stat)
 		return
-	if (crit_fail)
-		to_chat(user, span_warning("This device has critically failed and is no longer functional!"))
-		return
 	if(!reagents.total_volume)
 		return
 	var/list/blood_traces
@@ -464,9 +461,6 @@ REAGENT SCANNER
 	if (user.stat)
 		return
 	if(!istype(O))
-		return
-	if (crit_fail)
-		to_chat(user, span_warning("This device has critically failed and is no longer functional!"))
 		return
 	if(!O.reagents || !length(O.reagents.reagent_list))
 		to_chat(user, span_notice("No chemical agents found in [O]"))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -66,18 +66,6 @@
 	max_w_class = WEIGHT_CLASS_BULKY
 	max_storage_space = 28
 
-/obj/item/storage/backpack/holding/proc/failcheck(mob/user)
-	if (prob(reliability))
-		return TRUE //No failure
-	if (prob(reliability))
-		to_chat(user, span_warning("The Bluespace portal resists your attempt to add another item."))
-	else
-		to_chat(user, span_warning("The Bluespace generator malfunctions!"))
-		for (var/obj/O in src.contents) //it broke, delete what was in it
-			qdel(O)
-		crit_fail = 1
-		icon_state = "brokenpack"
-
 /obj/item/storage/backpack/holding/attackby(obj/item/I, mob/user, params)
 	if(crit_fail)
 		to_chat(user, span_warning("The Bluespace generator isn't working."))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -67,15 +67,10 @@
 	max_storage_space = 28
 
 /obj/item/storage/backpack/holding/attackby(obj/item/I, mob/user, params)
-	if(crit_fail)
-		to_chat(user, span_warning("The Bluespace generator isn't working."))
-
-	else if(istype(I, /obj/item/storage/backpack/holding) && !I.crit_fail)
-		to_chat(user, span_warning("The Bluespace interfaces of the two devices conflict and malfunction."))
-		qdel(I)
-
-	else
+	if(!istype(I, /obj/item/storage/backpack/holding))
 		return ..()
+	to_chat(user, span_warning("The Bluespace interfaces of the two devices conflict and malfunction."))
+	qdel(I)
 
 /obj/item/storage/backpack/santabag
 	name = "Santa's Gift Bag"

--- a/code/game/objects/machinery/constructable_frame.dm
+++ b/code/game/objects/machinery/constructable_frame.dm
@@ -33,10 +33,6 @@
 
 
 /obj/machinery/constructable_frame/machine_frame/attackby(obj/item/I, mob/living/user, params)
-	if(I.crit_fail)
-		to_chat(user, span_warning("This part is faulty, you cannot add this to the machine!"))
-		return
-
 	switch(state)
 		if(1)
 			if(iscablecoil(I))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -19,7 +19,6 @@
 	var/obj_integrity	//defaults to max_integrity
 	var/max_integrity = 500
 	var/integrity_failure = 0 //0 if we have no special broken behavior
-	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
 	var/crit_fail = 0
 
 	///throwforce needs to be at least 1 else it causes runtimes with shields

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,29 +13,30 @@
 
 	/// %-reduction-based armor.
 	var/datum/armor/soft_armor
-	/// Flat-damage-reduction-based armor.
+	///Modifies the AP of incoming attacks
 	var/datum/armor/hard_armor
-
-	var/obj_integrity	//defaults to max_integrity
+	///Object HP
+	var/obj_integrity
+	///Max object HP
 	var/max_integrity = 500
-	var/integrity_failure = 0 //0 if we have no special broken behavior
-	var/crit_fail = 0
-
-	///throwforce needs to be at least 1 else it causes runtimes with shields
+	///Integrety below this number causes special behavior
+	var/integrity_failure = 0
+	///Base throw damage. Throwforce needs to be at least 1 else it causes runtimes with shields
 	var/throwforce = 1
-
+	///Object behavior flags
 	var/obj_flags = NONE
-	var/hit_sound //Sound this object makes when hit, overrides specific item hit sound.
-	var/destroy_sound //Sound this object makes when destroyed.
-
-	var/item_fire_stacks = 0	//How many fire stacks it applies
-
+	///Sound when hit
+	var/hit_sound
+	///Sound this object makes when destroyed
+	var/destroy_sound
+	///How many fire stacks it applies
+	var/item_fire_stacks = 0 //todo: kill this
+	///ID access where all are required to access this object
 	var/list/req_access = null
+	///ID access where any one is required to access this object
 	var/list/req_one_access = null
-
 	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
 	var/real_explosion_block
-
 	///Odds of a projectile hitting the object, if the object is dense
 	var/coverage = 50
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -33,8 +33,6 @@
 	var/list/req_access = null
 	///ID access where any one is required to access this object
 	var/list/req_one_access = null
-	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
-	var/real_explosion_block
 	///Odds of a projectile hitting the object, if the object is dense
 	var/coverage = 50
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -29,8 +29,6 @@
 	var/hit_sound
 	///Sound this object makes when destroyed
 	var/destroy_sound
-	///How many fire stacks it applies
-	var/item_fire_stacks = 0 //todo: kill this
 	///ID access where all are required to access this object
 	var/list/req_access = null
 	///ID access where any one is required to access this object

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -13,6 +13,8 @@
 	coverage = 20
 	var/dismantle = FALSE //If we're dismantling the window properly no smashy smashy
 	max_integrity = 15
+	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
+	var/real_explosion_block = 0
 	var/state = 2
 	var/reinf = FALSE
 	var/basestate = "window"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -238,9 +238,7 @@
 		cell.charge -= 1000 / severity
 		if (cell.charge < 0)
 			cell.charge = 0
-		if(cell.reliability != 100 && prob(50/severity))
-			cell.reliability -= 10 / severity
-	..()
+	return ..()
 
 // Called just before an attack_hand(), in mob/UnarmedAttack()
 /obj/item/clothing/gloves/proc/Touch(atom/A, proximity)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -298,11 +298,6 @@ Contains most of the procs that are called when a mob is attacked by something
 
 		hit_report += "(RAW DMG: [throw_damage])"
 
-		if(thrown_item.item_fire_stacks)
-			fire_stacks += thrown_item.item_fire_stacks
-			IgniteMob()
-			hit_report += "(set ablaze)"
-
 		//thrown weapon embedded object code.
 		if(affecting.limb_status & LIMB_DESTROYED)
 			hit_report += "(delimbed [affecting.display_name])"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -71,9 +71,6 @@
 		var/obj/O = AM
 		O.stop_throw()
 		apply_damage(O.throwforce*(speed * 0.2), O.damtype, BODY_ZONE_CHEST, MELEE, is_sharp(O), has_edge(O), TRUE, O.penetration)
-		if(O.item_fire_stacks)
-			fire_stacks += O.item_fire_stacks
-			IgniteMob()
 
 	visible_message(span_warning(" [src] has been hit by [AM]."), null, null, 5)
 	if(ismob(AM.thrower))

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -110,8 +110,6 @@
 		M.state = 2
 		M.icon_state = "box_1"
 		for(var/obj/O in component_parts)
-			if(O.reliability != 100 && crit_fail)
-				O.crit_fail = TRUE
 			O.forceMove(loc)
 		qdel(src)
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -57,8 +57,6 @@
 	if(maxcharge < amount)
 		return 0
 	var/amount_used = min(maxcharge-charge,amount)
-	if(crit_fail)
-		return 0
 	charge += amount_used
 	return amount_used
 
@@ -69,8 +67,6 @@
 		. += "The manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.\nThe charge meter reads [round(src.percent() )]%."
 	else
 		. += "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]!\nThe charge meter reads [round(src.percent() )]%."
-	if(crit_fail)
-		. += span_warning("This power cell seems to be faulty.")
 	if(rigged)
 		if(get_dist(user,src) < 3) //Have to be close to make out the *DANGEROUS* details
 			. += span_danger("This power cell looks jury rigged to explode!")

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -54,14 +54,11 @@
 		explode()
 		return 0
 
-	if(maxcharge < amount)	return 0
+	if(maxcharge < amount)
+		return 0
 	var/amount_used = min(maxcharge-charge,amount)
-	if(crit_fail)	return 0
-	if(!prob(reliability))
-		minor_fault++
-		if(prob(minor_fault))
-			crit_fail = 1
-			return 0
+	if(crit_fail)
+		return 0
 	charge += amount_used
 	return amount_used
 
@@ -196,9 +193,7 @@
 	charge -= 1000 / severity
 	if (charge < 0)
 		charge = 0
-	if(reliability != 100 && prob(50/severity))
-		reliability -= 10 / severity
-	..()
+	return ..()
 
 /obj/item/cell/ex_act(severity)
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -223,8 +223,6 @@
 		M.state = 2
 		M.icon_state = "box_1"
 		for(var/obj/O in component_parts)
-			if(O.reliability != 100 && crit_fail)
-				O.crit_fail = TRUE
 			O.forceMove(loc)
 		qdel(src)
 


### PR DESCRIPTION

## About The Pull Request
Crit_fail, reliability and item_fire_stacks go into the bin.

real_explosion_block is moved to windows as thats the only place its used. Could be useful for other stuff but someone can move it back if it is needed.

Cleaned up a bit of incidental flare code since I was already touching it.
## Why It's Good For The Game
Unused/stinky vars.
## Changelog
:cl:
code: Cleaned up some object and flare code
/:cl:
