### PR TITLE
Restores pre-root boiler dig mechanic

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -61,6 +61,7 @@ KEYBINDINGS
 	target = null
 	return ..()
 
+/// Cleans up the action if the owner is deleted
 /datum/action/proc/clean_action()
 	SIGNAL_HANDLER
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -221,36 +221,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		to_chat(firer, span_notice("We relax our stance."))
 	UnregisterSignal(owner, COMSIG_MOB_ATTACK_RANGED)
 
-/datum/action/ability/activable/xeno/bombard/clean_action()
-	var/mob/living/carbon/xenomorph/boiler/firer = owner
-	firer.reset_bombard_pointer()
-	return ..()
-
-/mob/living/carbon/xenomorph/boiler/Moved(atom/OldLoc,Dir)
-	. = ..()
-	if(selected_ability?.type == /datum/action/ability/activable/xeno/bombard)
-		var/datum/action/ability/activable/bomb = actions_by_path[/datum/action/ability/activable/xeno/bombard]
-		bomb.on_deselection()
-		selected_ability.button.icon_state = "template"
-		selected_ability = null
-		update_action_button_icons()
-
-/// Set the boiler's mouse cursor to the green firing cursor.
-/mob/living/carbon/xenomorph/boiler/proc/set_bombard_pointer()
-	if(client)
-		client.mouse_pointer_icon = 'icons/mecha/mecha_mouse.dmi'
-
-/// Resets the boiler's mouse cursor to the default cursor.
-/mob/living/carbon/xenomorph/boiler/proc/reset_bombard_pointer()
-	if(client)
-		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
-
-/// Signal proc for clicking at a distance
-/datum/action/ability/activable/xeno/bombard/proc/on_ranged_attack(mob/living/carbon/xenomorph/X, atom/A, params)
-	SIGNAL_HANDLER
-	if(can_use_ability(A, TRUE))
-		INVOKE_ASYNC(src, PROC_REF(use_ability), A)
-
 /datum/action/ability/activable/xeno/bombard/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
 	if(!.)
@@ -314,6 +284,36 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	boiler_owner.update_boiler_glow()
 	update_button_icon()
 	add_cooldown()
+
+/datum/action/ability/activable/xeno/bombard/clean_action()
+	var/mob/living/carbon/xenomorph/boiler/firer = owner
+	firer.reset_bombard_pointer()
+	return ..()
+
+/// Signal proc for clicking at a distance
+/datum/action/ability/activable/xeno/bombard/proc/on_ranged_attack(mob/living/carbon/xenomorph/X, atom/A, params)
+	SIGNAL_HANDLER
+	if(can_use_ability(A, TRUE))
+		INVOKE_ASYNC(src, PROC_REF(use_ability), A)
+
+/mob/living/carbon/xenomorph/boiler/Moved(atom/OldLoc,Dir)
+	. = ..()
+	if(selected_ability?.type == /datum/action/ability/activable/xeno/bombard)
+		var/datum/action/ability/activable/bomb = actions_by_path[/datum/action/ability/activable/xeno/bombard]
+		bomb.on_deselection()
+		selected_ability.button.icon_state = "template"
+		selected_ability = null
+		update_action_button_icons()
+
+/// Set the boiler's mouse cursor to the green firing cursor.
+/mob/living/carbon/xenomorph/boiler/proc/set_bombard_pointer()
+	if(client)
+		client.mouse_pointer_icon = 'icons/mecha/mecha_mouse.dmi'
+
+/// Resets the boiler's mouse cursor to the default cursor.
+/mob/living/carbon/xenomorph/boiler/proc/reset_bombard_pointer()
+	if(client)
+		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
 
 // ***************************************
 // *********** Acid spray

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -221,6 +221,12 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		to_chat(firer, span_notice("We relax our stance."))
 	UnregisterSignal(owner, COMSIG_MOB_ATTACK_RANGED)
 
+/// If boiler gets out of dig in a way other than their own action (i.e they die), reset the cursor to the original.
+/datum/action/ability/activable/xeno/bombard/clean_action()
+	var/mob/living/carbon/xenomorph/boiler/firer = owner
+	firer.reset_bombard_pointer()
+	return ..()
+
 /// Signal proc for clicking at a distance
 /datum/action/ability/activable/xeno/bombard/proc/on_ranged_attack(mob/living/carbon/xenomorph/X, atom/A, params)
 	SIGNAL_HANDLER
@@ -246,6 +252,8 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 /mob/living/carbon/xenomorph/boiler/proc/reset_bombard_pointer()
 	if(client)
 		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
+
+
 
 /datum/action/ability/activable/xeno/bombard/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -188,37 +188,37 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 
 /datum/action/ability/activable/xeno/bombard/on_cooldown_finish()
 	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))
-	var/mob/living/carbon/xenomorph/boiler/X = owner
-	if(X.selected_ability == src)
-		X.set_bombard_pointer()
+	var/mob/living/carbon/xenomorph/boiler/firer = owner
+	if(firer.selected_ability == src)
+		firer.set_bombard_pointer()
 	return ..()
 
 /datum/action/ability/activable/xeno/bombard/on_selection()
-	var/mob/living/carbon/xenomorph/boiler/X = owner
-	var/current_ammo = X.corrosive_ammo + X.neuro_ammo
+	var/mob/living/carbon/xenomorph/boiler/firer = owner
+	var/current_ammo = firer.corrosive_ammo + firer.neuro_ammo
 	if(current_ammo <= 0)
-		to_chat(X, span_notice("We have nothing prepared to fire."))
+		to_chat(firer, span_notice("We have nothing prepared to fire."))
 		return FALSE
 
-	X.visible_message(span_notice("\The [X] begins digging their claws into the ground."), \
+	firer.visible_message(span_notice("\The [firer] begins digging their claws into the ground."), \
 	span_notice("We begin digging ourselves into place."), null, 5)
-	if(!do_after(X, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
+	if(!do_after(firer, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 		on_deselection()
-		X.selected_ability = null
-		X.update_action_button_icons()
-		X.reset_bombard_pointer()
+		firer.selected_ability = null
+		firer.update_action_button_icons()
+		firer.reset_bombard_pointer()
 		return FALSE
 
-	X.visible_message(span_notice("\The [X] digs itself into the ground!"), \
+	firer.visible_message(span_notice("\The [firer] digs itself into the ground!"), \
 		span_notice("We dig ourselves into place! If we move, we must wait again to fire."), null, 5)
-	X.set_bombard_pointer()
+	firer.set_bombard_pointer()
 	RegisterSignal(owner, COMSIG_MOB_ATTACK_RANGED, TYPE_PROC_REF(/datum/action/ability/activable/xeno/bombard, on_ranged_attack))
 
 /datum/action/ability/activable/xeno/bombard/on_deselection()
-	var/mob/living/carbon/xenomorph/boiler/X = owner
-	if(X.selected_ability == src)
-		X.reset_bombard_pointer()
-		to_chat(X, span_notice("We relax our stance."))
+	var/mob/living/carbon/xenomorph/boiler/firer = owner
+	if(firer.selected_ability == src)
+		firer.reset_bombard_pointer()
+		to_chat(firer, span_notice("We relax our stance."))
 	UnregisterSignal(owner, COMSIG_MOB_ATTACK_RANGED)
 
 /// Signal proc for clicking at a distance
@@ -237,10 +237,12 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		selected_ability = null
 		update_action_button_icons()
 
+/// Set the boiler's mouse cursor to the green firing cursor.
 /mob/living/carbon/xenomorph/boiler/proc/set_bombard_pointer()
 	if(client)
 		client.mouse_pointer_icon = 'icons/mecha/mecha_mouse.dmi'
 
+/// Resets the boiler's mouse cursor to the default cursor.
 /mob/living/carbon/xenomorph/boiler/proc/reset_bombard_pointer()
 	if(client)
 		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -221,18 +221,10 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		to_chat(firer, span_notice("We relax our stance."))
 	UnregisterSignal(owner, COMSIG_MOB_ATTACK_RANGED)
 
-/// If boiler gets out of dig in a way other than their own action (i.e they die), reset the cursor to the original.
 /datum/action/ability/activable/xeno/bombard/clean_action()
 	var/mob/living/carbon/xenomorph/boiler/firer = owner
 	firer.reset_bombard_pointer()
 	return ..()
-
-/// Signal proc for clicking at a distance
-/datum/action/ability/activable/xeno/bombard/proc/on_ranged_attack(mob/living/carbon/xenomorph/X, atom/A, params)
-	SIGNAL_HANDLER
-	if(can_use_ability(A, TRUE))
-		INVOKE_ASYNC(src, PROC_REF(use_ability), A)
-
 
 /mob/living/carbon/xenomorph/boiler/Moved(atom/OldLoc,Dir)
 	. = ..()
@@ -253,7 +245,11 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	if(client)
 		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
 
-
+/// Signal proc for clicking at a distance
+/datum/action/ability/activable/xeno/bombard/proc/on_ranged_attack(mob/living/carbon/xenomorph/X, atom/A, params)
+	SIGNAL_HANDLER
+	if(can_use_ability(A, TRUE))
+		INVOKE_ASYNC(src, PROC_REF(use_ability), A)
 
 /datum/action/ability/activable/xeno/bombard/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -188,6 +188,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 
 /datum/action/ability/activable/xeno/bombard/on_cooldown_finish()
 	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))
+	var/mob/living/carbon/xenomorph/boiler/X = owner
+	if(X.selected_ability == src)
+		X.set_bombard_pointer()
 	return ..()
 
 /datum/action/ability/activable/xeno/bombard/on_selection()


### PR DESCRIPTION

## About The Pull Request
Basically when you select bombard you take 3 seconds to dig in, but can move freely at any time during this. This was behavior removed with root that I forgot to bring back.
## Why It's Good For The Game
Should have been brought back with root removal to restore pre-root behavior.
## Changelog
:cl:
balance: Restores pre-root boiler dig mechanic, have to sit still and wait 3 seconds before firing a glob (you can still move, but cancels the channel)
/:cl:
