### PR TITLE
Campaign loadout popup

### DIFF
--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -144,6 +144,9 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		get_player_stats(new_member)
 	var/datum/action/campaign_loadout/loadouts = new
 	loadouts.give_action(new_member)
+	if(!(new_member.job.job_cost))
+		return
+	loadouts.action_activate()
 
 ///Returns a users individual stat datum, generating a new one if required
 /datum/faction_stats/proc/get_player_stats(mob/user)


### PR DESCRIPTION

## About The Pull Request
When you spawn in during campaign, it will not auto open the loadout screen (but not for the reinforcement roles as they don't need it).
## Why It's Good For The Game
QOL, faster for this mandatory screen and helps new players.
## Changelog
:cl:
qol: Campaign: Loadout screen automatically opens on spawn where required
/:cl:
