### PR TITLE
Triples CAS fuel capacity

### DIFF
--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -29,7 +29,7 @@
 	///Number for how much fuel we have left, this x5 seconds is how much time we have while flying
 	var/fuel_left = 120
 	///How much fuel we can hold maximum
-	var/fuel_max = 40
+	var/fuel_max = 120
 	///Our currently selected weapon we will fire
 	var/obj/structure/dropship_equipment/cas/weapon/active_weapon
 	///Minimap for the pilot to know where the marines have ran off to

--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -26,8 +26,8 @@
 	var/mob/camera/aiEye/remote/hud/eyeobj
 	///Action to stop the eye
 	var/datum/action/innate/camera_off/cas/off_action
-	///Number for how much fuel we have left, this x15 seconds is how much time we have while flying
-	var/fuel_left = 40
+	///Number for how much fuel we have left, this x5 seconds is how much time we have while flying
+	var/fuel_left = 120
 	///How much fuel we can hold maximum
 	var/fuel_max = 40
 	///Our currently selected weapon we will fire


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases CAS fuel and max_fuel from 40 (200s flytime) to 120 (600s) flytime
Fixed code comment being wrong , slowprocess fires every 5 seconds not 15 seconds.
Put as balance change because a comment from 3 years ago might not be reflective to the current balance.

## Why It's Good For The Game
Reduces CAS tedium , its kind of QOL. Might make it more effective since it can fly for more time and be able to oversee for longer, but CAS has already a lot of telegraphing in place.
(Also cause comment said its meant to fly for 600 seconds ? not 200s)
## Changelog
:cl:
balance: Increase the CAS fuel capacity from 40 to 120. leading to a Flight time increasing from 200 seconds to 600 seconds.
code: Fixed a misleading comment in CAS code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
