### PR TITLE
Campaign auto respawn window

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -2,7 +2,7 @@
 #define CAMPAIGN_MAX_VICTORY_POINTS 7
 
 ///Respawn time in campaign mode
-#define CAMPAIGN_RESPAWN_TIME 2 MINUTES
+#define CAMPAIGN_RESPAWN_TIME 10 SECONDS
 
 ///stats/points/etc recorded by faction
 #define MISSION_SELECTION_ALLOWED  (1<<0)

--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -2,7 +2,7 @@
 #define CAMPAIGN_MAX_VICTORY_POINTS 7
 
 ///Respawn time in campaign mode
-#define CAMPAIGN_RESPAWN_TIME 10 SECONDS
+#define CAMPAIGN_RESPAWN_TIME 2 MINUTES
 
 ///stats/points/etc recorded by faction
 #define MISSION_SELECTION_ALLOWED  (1<<0)

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -29,6 +29,8 @@
 	var/list/datum/faction_stats/stat_list = list()
 	///List of death times by ckey. Used for respawn time
 	var/list/player_death_times = list()
+	///List of timers to auto open the respawn window
+	var/list/respawn_timers = list()
 
 /datum/game_mode/hvh/campaign/announce()
 	to_chat(world, "<b>The current game mode is - Campaign!</b>")
@@ -196,15 +198,31 @@
 	if(!(player.faction in factions))
 		return
 	player_death_times[player.ckey] = world.time
+	respawn_timers[player.ckey] = addtimer(CALLBACK(src, PROC_REF(auto_attempt_respawn), player.ckey), CAMPAIGN_RESPAWN_TIME + stat_list[player.faction]?.respawn_delay_modifier + 1, TIMER_STOPPABLE)
+
+///Auto pops up the respawn window
+/datum/game_mode/hvh/campaign/proc/auto_attempt_respawn(respawnee_ckey)
+	for(var/mob/player AS in GLOB.player_list)
+		if(player.ckey != respawnee_ckey)
+			continue
+		respawn_timers[respawnee_ckey] = null
+		if(isliving(player) && player.stat != DEAD)
+			return
+		player_respawn(player)
+		return
 
 ///Wrapper for cutting the deathlist via timer due to the players not immediately returning to base
 /datum/game_mode/hvh/campaign/proc/cut_death_list_timer(datum/source)
 	SIGNAL_HANDLER
 	addtimer(CALLBACK(src, PROC_REF(cut_death_list)), AFTER_MISSION_TELEPORT_DELAY + 1)
 
-///cuts the death time list at mission end
+///cuts the death time and respawn_timers list at mission end
 /datum/game_mode/hvh/campaign/proc/cut_death_list(datum/source)
 	player_death_times.Cut()
+	for(var/ckey in respawn_timers)
+		auto_attempt_respawn(ckey) //Faction datum doesn't pop up for ghosts
+		deltimer(respawn_timers[ckey])
+	respawn_timers.Cut()
 
 ///respawns the player if attrition points are available
 /datum/game_mode/hvh/campaign/proc/attempt_attrition_respawn(mob/candidate)

--- a/code/datums/gamemodes/campaign/rewards/reserves.dm
+++ b/code/datums/gamemodes/campaign/rewards/reserves.dm
@@ -52,8 +52,14 @@
 	for(var/mob/candidate AS in GLOB.player_list)
 		if(candidate.faction != faction.faction)
 			continue
+		if(candidate.stat != DEAD)
+			continue
 		mode.player_death_times -= candidate.ckey
 		to_chat(candidate, "<span class='warning'>Tactical reserves mobilised. You can now respawn immediately if possible.<spawn>")
 		candidate.playsound_local(null, 'sound/ambience/votestart.ogg', 50)
+		var/datum/game_mode/hvh/campaign/mode = SSticker.mode
+		deltimer(mode.respawn_timers[candidate.ckey])
+		mode.respawn_timers[candidate.ckey] = null
+		player_respawn(player)
 
 

--- a/code/datums/gamemodes/campaign/rewards/reserves.dm
+++ b/code/datums/gamemodes/campaign/rewards/reserves.dm
@@ -55,11 +55,11 @@
 		if(candidate.stat != DEAD)
 			continue
 		mode.player_death_times -= candidate.ckey
-		to_chat(candidate, "<span class='warning'>Tactical reserves mobilised. You can now respawn immediately if possible.<spawn>")
-		candidate.playsound_local(null, 'sound/ambience/votestart.ogg', 50)
-		var/datum/game_mode/hvh/campaign/mode = SSticker.mode
 		deltimer(mode.respawn_timers[candidate.ckey])
 		mode.respawn_timers[candidate.ckey] = null
-		mode.player_respawn(player)
+		mode.player_respawn(candidate)
+
+		to_chat(candidate, "<span class='warning'>Tactical reserves mobilised. You can now respawn immediately if possible.<spawn>")
+		candidate.playsound_local(null, 'sound/ambience/votestart.ogg', 50)
 
 

--- a/code/datums/gamemodes/campaign/rewards/reserves.dm
+++ b/code/datums/gamemodes/campaign/rewards/reserves.dm
@@ -60,6 +60,6 @@
 		var/datum/game_mode/hvh/campaign/mode = SSticker.mode
 		deltimer(mode.respawn_timers[candidate.ckey])
 		mode.respawn_timers[candidate.ckey] = null
-		player_respawn(player)
+		mode.player_respawn(player)
 
 


### PR DESCRIPTION

## About The Pull Request
When your respawn timer runs out, the respawn window automatically opens for you.

Also made the respawn window open for ghosts on mission end (previous only did so for living mobs)

Finally made the rapid reserver asset also make the window pop up.
## Why It's Good For The Game
QOL, especially you didn't realise the timer was up/didn't hear the sound etc.
## Changelog
:cl:
qol: Campaign: Respawn window automatically opens when your respawn timer is up, or when the rapid reserve asset is used
/:cl:
