### PR TITLE
Add dispenser to Corpseman automated closet

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -421,6 +421,7 @@ GLOBAL_LIST_INIT(medic_clothes_listed_products, list(
 		/obj/effect/vendor_bundle/robot/heavy_armor = list(CAT_AMR, "Combat robot heavy armor kit", 0, "black"),
 		/obj/item/storage/backpack/marine/corpsman/satchel = list(CAT_BAK, "Satchel", 0, "orange"),
 		/obj/item/storage/backpack/marine/corpsman = list(CAT_BAK, "Corspman Backpack", 0, "black"),
+		/obj/item/storage/backpack/dispenser = list(CAT_BAK, "Dispenser", 0, "black"),
 		/obj/item/armor_module/storage/uniform/brown_vest = list(CAT_WEB, "Tactical brown vest", 0, "orange"),
 		/obj/item/armor_module/storage/uniform/white_vest = list(CAT_WEB, "Corpsman white vest", 0, "black"),
 		/obj/item/armor_module/storage/uniform/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),


### PR DESCRIPTION

## About The Pull Request

adds dispenser to medic_clothes_listed_products
## Why It's Good For The Game

Dispenser's 2 functions are extrme storage capacity and healing nearby robots both of which are things relavant to medics who want to either help out robots some or just carry even more pills. 

Why not put it in automated equipment rack for points? 
I think the trade off of not being able to charge defibs with the dispenser compared to both the corpsman backpack and satchel make choseing between the three a more interesting decision then spending 10 or so points on a dispenser, this also will prevent medics from just vending some and throwing it for anyone to take as if they do so they will be unable to recharge their defib. (I might be totaly wrong about this)

What about dispenser stacking?
I think the fragility of dispensers will prevent marines from slaping down 4 of them and making all robots in a radius near unkillable as xenos should be able to destroy the dispensers with a crusher/boiler/ect...
## Changelog
:cl: UzedPickle
add: Dispensers are now avalable from Automated Corpseman Closets.
/:cl:
