### PR TITLE
edits beginner loadout tutorials + updates some of the loadouts

### DIFF
--- a/code/datums/quick_load_beginners.dm
+++ b/code/datums/quick_load_beginners.dm
@@ -322,7 +322,7 @@
 	belt = /obj/item/storage/belt/grenade
 	mask = /obj/item/clothing/mask/gas
 	w_uniform = /obj/item/clothing/under/marine/corpman_vest
-	head = /obj/item/clothing/head/modular/m10x/antenna
+	head = /obj/item/clothing/head/modular/m10x/hod
 	shoes = /obj/item/clothing/shoes/marine
 	l_hand = /obj/item/paper/tutorial/beginner_chad
 
@@ -435,7 +435,7 @@
 
 /datum/outfit/quick/beginner/engineer/burnitall
 	name = "Flamethrower"
-	desc = "For those who truly love to watch the world burn. Equipped with a laser and a flamethrower, you can be certain that none of your enemies will be left un-burnt."
+	desc = "For those who truly love to watch the world burn. Equipped with a laser carbine and a flamethrower, you can be certain that none of your enemies will be left un-burnt."
 
 	suit_store = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine/beginner
 	wear_suit = /obj/item/clothing/suit/modular/xenonauten/engineer
@@ -645,7 +645,8 @@
 	human.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/ointment, SLOT_IN_ACCESSORY)
 
 	human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/plasma_pistol, SLOT_IN_BACKPACK)
-	human.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
+	human.equip_to_slot_or_del(new /obj/item/explosive/grenade/smokebomb/cloak, SLOT_IN_BACKPACK)
+	human.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BACKPACK)
 	human.equip_to_slot_or_del(new /obj/item/ammo_magazine/standard_smartmachinegun, SLOT_IN_BACKPACK)
 	human.equip_to_slot_or_del(new /obj/item/ammo_magazine/standard_smartmachinegun, SLOT_IN_BACKPACK)
 	human.equip_to_slot_or_del(new /obj/item/ammo_magazine/standard_smartmachinegun, SLOT_IN_BACKPACK)

--- a/code/modules/paperwork/beginner_tutorials.dm
+++ b/code/modules/paperwork/beginner_tutorials.dm
@@ -2,327 +2,746 @@
 
 /obj/item/paper/tutorial/beginner_rifleman
 	name = "Rifleman Tutorial"
-	info = {"As a rifleman, you are suited for virtually all theatres of combat. Your AR-12 assault rifle is accurate and effective at all ranges, and its powerful underbarrel grenade launcher poses even further danger to mid-range threats. Inside your backpack is a box of flares to refill your flare pouch, gauze and ointment for brute (slashes) and burn (acid) wounds respectively, and backup magazines for your AR 12. Your belt contains backup magazines for your AR-12, while your body armor contains additional grenades to reload your underbarrel grenade launcher with. Your left pocket contains a flare gun holster and several flares. Your right pocket contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your helmet contains two protein bars, in case you get hungry, and your boots contain a standard issue combat knife for clearing weeds or breaking things.<BR>
+	info = {"As a rifleman, you are suited for virtually all theatres of combat.\
+	Your AR-12 assault rifle is accurate and effective at all ranges, and its powerful underbarrel grenade launcher poses even further danger to mid-range threats.\
+	Inside your backpack is a box of flares to refill your flare pouch, gauze and ointment for brute (slashes) and burn (acid) wounds respectively,\
+	and backup magazines for your AR 12.\
+	Your belt contains backup magazines for your AR-12, while your body armor contains additional grenades to reload your underbarrel grenade launcher.\
+	Your left pocket contains a flare gun holster and several flares.\
+	Your right pocket contains a first aid kit, with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your helmet contains two protein bars, in case you get hungry, and your boots contain a standard-issue combat knife for clearing weeds or breaking things.<BR>
 	<BR>
-	Try to spend as much time as possible near other marines - being alone is very dangerous. Your versatility is an immense strength and makes you the ideal battle buddy for virtually any other marine. You can easily work with a shotgunner to clear close quarters areas, or perhaps with a machine gunner to hold a fortified position, or even take point in front of a marksman. When not in immediate danger, use your flare gun to keep your surroundings lit, as your and your fellow marines' lives may very well depend on it.<BR>
+	Try to spend as much time as possible near other marines - being alone is very dangerous.\
+	Your versatility is an immense strength and makes you the ideal battle buddy for virtually any other marine.\
+	You can easily work with a shotgunner to clear close quarters areas, or perhaps with a machine gunner to hold a fortified position, or even take point in front of a marksman.\
+	When not in immediate danger, use your flare gun to keep your surroundings lit, as your and your fellow marines' lives may very well depend on it.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation\
+	that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system,\
+	and too many at once risks a dangerous overdose.\
+	Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment\
+	as long as you hold still. You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	While holding your AR-12, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines. (Note that your grenades will NOT go through marines!) The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic. Automatic modes will keep firing as long as you hold down the mouse button. The third option enables your underbarrel grenade launcher. Once enabled, you can use right click to launch a grenade out!<BR>
+	While holding your AR-12, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire\
+	in exchange for allowing you to shoot through allied marines. (Note that your grenades will NOT go through marines!)\
+	The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic.\
+	Automatic modes will keep firing as long as you hold down the mouse button.\
+	The third option enables your underbarrel grenade launcher. Once enabled, you can use right-click to launch a grenade out!<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the rifle. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without an empty hand and with a different magazine still in the gun. You can reload the underbarrel launcher by right clicking on the gun while holding a valid grenade (like the HEDP grenades in your webbing.)<BR>
+	On running out of ammo, the empty magazine will automatically eject from the rifle.\
+	To reload, simply grab a new magazine with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle,\
+	which can be done without an empty hand and with a different magazine still in the gun.\
+	You can reload the underbarrel launcher by right-clicking on the gun while holding a valid grenade (like the HEDP grenades in your webbing).<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right-clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left-clicking on it while holding a flare box.
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	Your P23 has a pistol lace attached. By toggling it in the top left while wielding it, it becomes impossible for you to drop - or for it to be knocked out of your hand by a xenomorph. Similarly, your AR-12 has a magnetic harness, which means if you drop it or otherwise lose it, it'll automatically snap back to your armor.<BR>
+	Your P23 has a pistol lace attached.\
+	By toggling it in the top left while wielding it, it becomes impossible for you to drop - or for it to be knocked out of your hand by a xenomorph.\
+	Similarly, your AR-12 has a magnetic harness, which means if you drop it or otherwise lose it, it'll automatically snap back to your armor.<BR>
 	<BR>
-	Because your AR-12 can effectively engage at all ranges, your optimal range is whatever your opponent's optimal range isn't. Try keeping the distance from ferocious melee enemies, while getting too close for comfort with squishier ranged ones."}
+	Because your AR-12 can effectively engage at all ranges, your optimal range is whatever your opponent's optimal range isn't.\
+	Try keeping the distance from ferocious melee enemies, while getting too close for comfort with squishier ranged ones."}
 
 /obj/item/paper/tutorial/beginner_machinegunner
 	name = "Machinergunner Tutorial"
-	info = {"As a machinegunner, you are the backbone of a marine force. While you possess heavy armor reinforced with Tyr-pattern plating (strengthening its defense even further against melee attacks), your slow move speed and the unwieldy nature of your MG-60 machine gun means you should not be spearheading any pushes. Aim mode is your best friend - combined with your red dot sight and bipod, you are very apt at sitting just behind the front line, eliminating threats and keeping the marines in front of you safe. Your backpack contains several additional box magazines, allowing you to carry almost two THOUSAND rounds on your person at any time. Your left pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your right pocket contains a flare gun holster and several flares. Your suit storage contains two plasma pistols, which are low in damage but can start fires. Your webbing contains an MRE to eat and both gauze and ointment, your helmet contains two protein bars for further eating, and your boots contain a standard issue combat knife for clearing weeds or breaking things.<BR>
+	info = {"As a machinegunner, you are the backbone of a marine force. While you possess heavy armor reinforced with\
+	Tyr-pattern plating (strengthening its defense even further against melee attacks), your slow move speed and the unwieldy nature of your MG-60 machinegun\
+	means you should not be spearheading any pushes. Aim mode is your best friend - combined with your bipod, you are very apt at sitting just behind the front line,\
+	eliminating threats and keeping the marines in front of you safe.\
+	Your backpack contains several additional box magazines, allowing you to carry almost two THOUSAND rounds on your person at any time.\
+	Your left pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your right pocket contains a flare gun holster and several flares. Your suit storage contains two plasma pistols, which are low in damage but can start fires.\
+	Your webbing contains an MRE to eat and both gauze and ointment, your helmet contains two protein bars for further eating,\
+	and your boots contain a standard-issue combat knife for clearing weeds or breaking things.<BR>
 	<BR>
-	Your full strength is hard to utilize on your own or in the very front of battle. Your ideal positions are either safely behind a barricade guarding a front or flank from assault, or behind your fellow marines, shooting over them with aim mode to protect them from enemies. Keep in mind that your heavy armor and weapon means you move rather slowly - so if you get the order to leave a position, get moving early to avoid being left behind.<BR>
+	Your full strength is hard to utilize on your own or in the very front of battle.\
+	Your ideal positions are either safely behind a barricade guarding a front or flank from assault,\
+	or behind your fellow marines, shooting over them with aim mode to protect them from enemies.\
+	Keep in mind that your heavy armor and weapon means you move rather slowly - so if you get the order to leave a position, get moving early to avoid being left behind.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system,\
+	and too many at once risks a dangerous overdose.\
+	Your gauze and ointment are body-part specific, unlike medication, but once you start applying one,\
+	you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine\
+	that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	While holding your MG-60, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines. The bipod button will deploy your bipod, increasing fire rate and accuracy significantly for as long as you remain stationary.<BR>
+	While holding your MG-60, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire\
+	in exchange for allowing you to shoot through allied marines. The bipod button will deploy your bipod, increasing fire rate and accuracy significantly\
+	for as long as you remain stationary.<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the machine gun. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the machine gun, which can be done without an empty hand and with a different magazine still in the gun.<BR>
+	On running out of ammo, the empty magazine will automatically eject from the machine gun.\
+	To reload, simply grab a new magazine with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the machine gun, which can be done without an empty hand\
+	and with a different magazine still in the gun.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right-clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	On your belt is a belt harness. By left clicking on your belt harness with your machine gun, you can attach them. If you drop your machine gun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached.<BR>
+	On your belt is a belt harness. By left clicking on your belt harness with your machine gun, you can attach them.\
+	If you drop your machine gun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached.<BR>
 	<BR>
-	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire. While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected. You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
+	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire.\
+	While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected.\
+	You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
 	<BR>
-	Your impressive magazine size means you don't need to reload often. You can suppress one spot for an impressive amount of time, and you have the ammo and damage to clear out resin walls.<BR>
+	Your impressive magazine size means you don't need to reload often.\
+	You can suppress one spot for an impressive amount of time, and you have the ammo and damage to clear out resin walls.<BR>
 	<BR>
 	The more bullets you shoot, the better a marine you are. It's actually that simple."}
 
 /obj/item/paper/tutorial/beginner_marksman
 	name = "Marksman Tutorial"
-	info = {"As a marksman, you are a master of precision and range, and should utilize both of these advantages as much as possible. Your DMR-37 is incredibly accurate at long ranges and packs a devastating punch. Due to your ability to engage at long range - and conversely, your inability to engage properly at short range - you should be staying as far from conflict as possible while still remaining in your rifle's effective range. Your backpack and both of your pouches contain spare magazines for your DMR. Your backpack also contains an MRE to eat, and both gauze and ointment for treating injuries. Your armor contains Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and an inaprovaline injector for helping other marines in critical condition. Your webbing contains the MK88 Mod 4, a fully automatic handgun for self-defense, as well as spare magazines for it. Your helmet contains protein bars to eat, and your boots contain a survival knife for clearing weeds and breaking things.<BR>
+	info = {"As a marksman, you are a master of precision and range, and should utilize both of these advantages as much as possible.\
+	Your DMR-37 is incredibly accurate at long ranges and packs a devastating punch. Due to your ability to engage at long range - and conversely,\
+	your inability to engage properly at short range - you should be staying as far from conflict as possible while still remaining in your rifle's effective range.\
+	Your backpack and both of your pouches contain spare magazines for your DMR. Your backpack also contains an MRE to eat, and both gauze and ointment for treating injuries.\
+	Your armor contains Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and an inaprovaline injector for helping other marines in critical condition.\
+	Your webbing contains the MK88 Mod 4, a fully automatic handgun for self-defense, as well as spare magazines for it.\
+	Your helmet contains protein bars to eat, and your boots contain a survival knife for clearing weeds and breaking things.<BR>
 	<BR>
-	With your DMR, aim to support other marines from afar using your scope and aim mode. Your range means that many xenomorphs might not realize you're watching over an area until you're already shooting at them - use this to your advantage. Your rate of fire is relatively slow compared to automatic weapons, so make each of your shots count.<BR>
+	With your DMR, aim to support other marines from afar using your scope and aim mode.\
+	Your range means that many xenomorphs might not realize you're watching over an area until you're already shooting at them - use this to your advantage.\
+	Your rate of fire is relatively slow compared to automatic weapons, so make each of your shots count.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the DMR. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the DMR, which can be done without an empty hand and with a different magazine still in the gun.<BR>
+	On running out of ammo, the empty magazine will automatically eject from the DMR.\
+	To reload, simply grab a new magazine with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the DMR,\
+	which can be done without an empty hand and with a different magazine still in the gun.<BR>
 	<BR>
-	While holding your DMR-37, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines. The scope button will zoom your screen out and towards the direction you're currently facing, allowing you to see (and shoot at) targets much farther away.<BR>
+	While holding your DMR-37, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons.\
+	The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.\
+	The scope button will zoom your screen out and towards the direction you're currently facing, allowing you to see (and shoot at) targets much farther away.<BR>
 	<BR>
-	On your belt is a belt harness. By left clicking on your belt harness with your DMR, you can attach them. If you drop your DMR, or have a xenomorph make you drop it, your DMR will automatically return to your armor if it's attached.<BR>
+	On your belt is a belt harness. By left clicking on your belt harness with your DMR, you can attach them. If you drop your DMR,\
+	or have a xenomorph make you drop it, your DMR will automatically return to your armor if it's attached.<BR>
 	<BR>
-	Try holding your fire until your target is already engaging someone else. While this may seem counter-intuitive, it allows you to wait until they've already committed to a fight (that's likely to damage them) and may cause them to not notice your presence until it's too late, increasing the odds of securing a kill.<BR>
+	Try holding your fire until your target is already engaging someone else. While this may seem counter-intuitive,\
+	it allows you to wait until they've already committed to a fight (that's likely to damage them) and may cause them to not notice your presence until it's too late,\
+	increasing the odds of securing a kill.<BR>
 	<BR>
-	Do not attempt to use your DMR at too close of a range, as marksman weapons have a chance to miss against enemies that are near you. Instead, try switching to your 88 Mod 4, your fully automatic handgun that's much more effective at close range."}
+	Do not attempt to use your DMR at too close of a range, as marksman weapons have a chance to miss against enemies that are near you.\
+	Instead, try switching to your MK88 Mod 4, your fully automatic handgun that's much more effective at close range.\
+	Use your strengths in overwatching the battlefield to assist in securing valuable kills. "}
 
 /obj/item/paper/tutorial/beginner_shotgunner
 	name = "Shotgunner Tutorial"
-	info = {"As a shotgunner, you are the spearhead of the marine force. Your semiautomatic SH-39 fires slugs that will devastate any target at short to medium range, dealing heavy damage as well as leaving them stunned and staggered. Your role is to be at the front of any marine push, side by side with your fellow marines as you charge into danger. Your shotgun shell rig on your belt, as well as your backpack, hold many additional slugs to reload your shotgun with. Your backpack also contains an MRE to eat, and both gauze and ointment for treating injuries, as well as inaprovaline. Your left pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your right pocket contains a flare gun holster and several flares. Your webbing contains a plasma pistol, a low damage sidearm that starts fires wherever it hits. Your suit storage contains boxes of additional flares. Your helmet contains protein bars to eat, and your boot contains a combat knife for clearing weeds and breaking things.<BR>
+	info = {"As a shotgunner, you are the spearhead of the marine force.\
+	Your semiautomatic SH-39 fires slugs that will devastate any target at short to medium range, dealing heavy damage as well as leaving them stunned and staggered.\
+	Your role is to be at the front of any marine push, side by side with your fellow marines as you charge into danger. Your shotgun shell rig on your belt,\
+	as well as your backpack, hold many additional slugs to reload your shotgun with.\
+	Your backpack also contains an MRE to eat, and both gauze and ointment for treating injuries, as well as inaprovaline.\
+	Your left pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage),\
+	Tramadol (which is a painkiller), Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage),\
+	as well as splints and inaprovaline. Your right pocket contains a flare gun holster and several flares.\
+	Your webbing contains a plasma pistol, a low damage sidearm that starts fires wherever it hits.\
+	Your suit storage contains boxes of additional flares. Your helmet contains protein bars to eat, and your boot contains a combat knife for clearing weeds and breaking things.<BR>
 	<BR>
-	You should be close to the enemy constantly to take full advantage of your shotgun. This does not mean you should run off alone, as this is a good way to get yourself killed; rather, be in front of other marines, clearing away enemies to allow them to safely advance and cover you.<BR>
+	You should be close to the enemy constantly to take full advantage of your shotgun.\
+	This does not mean you should run off alone, as this is a good way to get yourself killed;\
+	rather, be in front of other marines, clearing away enemies to allow them to safely advance and cover you.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
 	While holding your SH-39, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right-clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire. While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected. You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
+	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire.\
+	While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected.\
+	You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
 	<BR>
 	To reload your shotgun, take out a handful of shells with a free hand and click your gun with them while it's in your other hand.<BR>
 	<BR>
-	Shotguns can take a variety of rounds, in case slugs aren't your style. Buckshot rounds have more stopping power but fall off at mid range, while flechette rounds are less generally effective in exchange for drastically improved performance against heavily armored targets. The requisitions-exclusive incendiary slugs aren't quite as powerful as standard slugs but set anything they hit on fire!<BR>
+	Shotguns can take a variety of rounds, in case slugs aren't your style. Buckshot rounds have more stopping power but fall off at mid range,\
+	while flechette rounds are less generally effective in exchange for drastically improved performance against heavily armored targets.\
+	The requisitions-exclusive incendiary slugs aren't quite as powerful as standard slugs but set anything they hit on fire!<BR>
 	<BR>
-	The green M50 signal flares in your body armor don't last as long as normal flares but deploying them signals to CAS (close air support) that you're requesting an airstrike in the region, also granting them the ability to see and shoot at xenomorphs in the area.<BR>
+	The green M50 signal flares in your body armor don't last as long as normal flares but deploying them signals to CAS (close air support)\
+	that you're requesting an airstrike in the region, also granting them the ability to see and shoot at xenomorphs in the area.<BR>
 	<BR>
-	Using the powerful knockback of your shotgun to knock xenomorphs TOWARDS other marines is a good way to get kills - most xenomorphs can't deal with that many marines at once!<BR>
+	Using the powerful knockback of your shotgun to knock xenomorphs TOWARDS other marines is a good way to get kills\
+	- most xenomorphs can't deal with that many marines at once!<BR>
 	<BR>
 	Shotguns don't have access to aimmode, so be careful near other marines so you don't risk shooting them.<BR>
 	<BR>
-	You have incredibly high per-shot damage. Waiting a little bit to allow a xenomorph to get closer before opening fire can lure it into a false sense of safety, potentially scoring you a kill."}
+	You have incredibly high per-shot damage. Waiting a little bit to allow a xenomorph to get closer before opening fire can lure it\
+	into a false sense of safety, potentially scoring you a kill."}
 
 /obj/item/paper/tutorial/beginner_shocktrooper
 	name = "Shocktrooper Tutorial"
-	info = {"As a shock trooper, you are a versatile yet powerful frontliner, and aim to change up tactics often to gain the advantage. You use the multimodal laser rifle, an experimental battery-powered weapon with an underbarrel flamethrower. Your belt contains spare energy cells for your laser rifle. Your right pocket and body armor contain a powerpack each- effectively bulkier versions of energy cells. Your body armor also contains a box of flares. Your left pocket contains a flare gun holster and several flares. Your backpack contains a large amount of miniature fuel tanks for use with your underbarrel flamethrower, as well as an inaprovaline autoinjector. Your webbing contains Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and gauze and ointment, which also heal brute and burn damage respectively. Your helmet contains protein bars and your boots contain an MRE, in case you get hungry.<BR>
+	info = {"As a shock trooper, you are a versatile yet powerful frontliner, and aim to change up tactics often to gain the advantage.\
+	You use the multimodal laser rifle, an experimental battery-powered weapon with an underbarrel flamethrower.\
+	Your belt contains spare energy cells for your laser rifle. Your right pocket and body armor contain a powerpack to recharge energy cells.\
+	Your body armor also contains a box of flares. Your left pocket contains a flare gun holster and several flares.\
+	Your backpack contains a large amount of miniature fuel tanks for use with your underbarrel flamethrower, as well as an inaprovaline autoinjector.\
+	Your webbing contains Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller), Tricordrazine (heals all damage, but slowly),\
+	and gauze and ointment, which also heal brute and burn damage, respectively. Your helmet contains protein bars and your boots contain an MRE, in case you get hungry.<BR>
 	<BR>
-	Switching between the different modes of your laser rifle is key to mastery on the battlefield. Like other frontliners, you aim to lead the push into enemy territory, clearing the path forward and facing xenomorphs head-on.<BR>
+	Switching between the different modes of your laser rifle is key to mastery on the battlefield.\
+	Like other frontliners, you aim to lead the push into enemy territory, clearing the path forward and facing xenomorphs head-on.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	On running out of ammo, the empty battery will automatically eject from the rifle. To reload, simply grab a new battery with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the battery from its storage directly onto the rifle, which can be done without an empty hand and with a different battery still in the gun. The powerpacks are a bit different - they have to be click-dragged while in one of your pockets to attach to the gun, and once attached remain in your pocket. However, they have four times the energy of a normal magazine. To refuel your underbarrel flamethrower, right click the gun with an empty hand to remove the old tank, then right click the gun again with a fresh tank.<BR>
+	On running out of ammo, the empty battery will automatically eject from the rifle.\
+	To reload, simply grab a new battery with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the battery from its storage directly onto the rifle,\
+	which can be done without an empty hand and with a different battery still in the gun.\
+	You can click a powercell to your powerpacks to recharge them. They have four times the energy of a normal magazine.\
+	To refuel your underbarrel flamethrower, right-click the gun with an empty hand to remove the old tank, then right-click the gun again with a fresh tank.<BR>
 	<BR>
-	While holding your laser rifle, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. By pressing toggle mini flamethrower, you enable your underbarrel flamethrower, which you can now shoot with right click.<BR>
+	While holding your laser rifle, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons.\
+	By pressing toggle mini flamethrower, you enable your underbarrel flamethrower, which you can now shoot with right-click.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	By pressing unique action (default: space bar), you can cycle between the different modes of your laser gun. Standard mode rapidly fires laser beams, Overcharge mode fires more powerful beams at a lower rate of fire, weakening mode slows the target mildly as well as draining their plasma, and microwave applies a stacking debuff (up to five times) that deals armor-piercing damage over time. Note that different modes consume battery charge at different rates.<BR>
+	By pressing unique action (default: space bar), you can cycle between the different modes of your laser gun.\
+	Standard mode rapidly fires laser beams, Overcharge mode fires more powerful beams at a lower rate of fire, weakening mode slows the target mildly\
+	as well as draining their plasma, and microwave applies a stacking debuff (up to five times) that deals armor-piercing damage over time.\
+	Note that different modes consume battery charge at different rates.<BR>
 	<BR>
-	Laser weapons, unlike traditional ballistics, can fire through windows unimpeded. Use this with stronger windows, such as ballistic glass, to attack the enemy without them being able to attack you back."}
+	Laser weapons, unlike traditional ballistics, can fire through windows unimpeded.\
+	Use this with stronger windows, such as ballistic glass, to attack the enemy without them being able to attack you back."}
 
 /obj/item/paper/tutorial/beginner_hazmat
 	name = "Hazmat Tutorial"
-	info = {"As a HAZMAT, you excel in situations too dangerous for other marines. Your Mimir type armor grants you complete immunity to toxic gas, from acid to neurotoxin. It also provides an increased resistance against acid in general, for dealing with ranged xenomorphs. Your AR-11 is somewhat unwieldy and inaccurate, but packs both potent bursts and an impressive 70-round magazine. Your backpack, left pouch, and suit storage are all filled with spare magazines for your AR-11. Your right pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your webbing contains flares for lighting areas, gauze and ointment for treating wounds, and a miniature fire extinguisher. Your helmet contains protein bars and your boots contain an MRE, for if you get hungry.<BR>
+	info = {"As a HAZMAT, you excel in situations too dangerous for other marines. Your Mimir type armor grants you complete immunity to toxic gas,\
+	from acid to neurotoxin. It also provides an increased resistance against acid in general, for dealing with ranged xenomorphs.\
+	Your AR-11 is somewhat unwieldy and inaccurate, but packs both potent bursts and an impressive 70-round magazine.\
+	Your backpack, left pouch, and suit storage are all filled with spare magazines for your AR-11.\
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your webbing contains flares for lighting areas, gauze and ointment for treating wounds, and a miniature fire extinguisher.\
+	Your helmet contains protein bars and your boots contain an MRE, for if you get hungry.<BR>
 	<BR>
-	Unlike other marines, you have no reason to fear toxic gas - and thanks to your tactical sensor, you pose quite a threat to xenomorphs while in it. Hide in smoke and use your sensor to fire at xenomorphs that can't see you back. In the absence of smoke, your AR-11 is still quite powerful, and can be used in many situations, though its inaccuracy makes it somewhat less potent at longer ranges.<BR>
+	Unlike other marines, you have no reason to fear toxic gas - and thanks to your tactical sensor, you pose quite a threat to xenomorphs while in it.\
+	Hide in smoke and use your sensor to fire at xenomorphs that can't see you back.\
+	In the absence of smoke, your AR-11 is still quite powerful, and can be used in many situations, though its inaccuracy makes it somewhat less potent at longer ranges.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	While holding your AR-11, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines. The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic. Automatic modes will keep firing as long as you hold down the mouse button. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
+	While holding your AR-11, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons.\
+	The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.\
+	The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic. Automatic modes will keep firing as long as you hold down the mouse button.\
+	The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
 	<BR>
-	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen. Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets. This sensor works even without vision, such as through any form of smoke and through walls.<BR>
+	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen.\
+	Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets.\
+	This sensor works even without vision, such as through any form of smoke and through walls.<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the rifle. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without an empty hand and with a different magazine still in the gun.<BR>
+	On running out of ammo, the empty magazine will automatically eject from the rifle.\
+	To reload, simply grab a new magazine with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without an empty hand\
+	and with a different magazine still in the gun.<BR>
 	<BR>
-	Your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility. However, note that xenomorphs will often determine a marine's position in a smoke cloud by their light, so you should turn OFF your light if hiding in smoke!<BR>
+	Your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.\
+	However, note that xenomorphs will often determine a marine's position in a smoke cloud by their light, so you should turn OFF your light if hiding in smoke!<BR>
 	<BR>
-	On your belt is a belt harness. By left clicking on your belt harness with your AR-11, you can attach them. If you drop your AR, or have a xenomorph make you drop it, your AR will automatically return to your armor if it's attached.<BR>
+	On your belt is a belt harness. By left-clicking on your belt harness with your AR-11, you can attach them.\
+	If you drop your AR, or have a xenomorph make you drop it, your AR will automatically return to your armor if it's attached.<BR>
 	<BR>
-	While you're no machinegunner, you have over 700 rounds on you. Don't be afraid to shoot at anything that blips on your tactical sensor (as long as there aren't friendlies in the way!)"}
+	While you're no machinegunner, you have over 700 rounds on you. Don't be afraid to shoot at anything that blips on your tactical sensor\
+	(as long as there aren't friendlies in the way!)"}
 
 /obj/item/paper/tutorial/beginner_cqc
 	name = "CQC Tutorial"
-	info = {"As a CQC marine, you are incredibly mobile, and should be using and abusing your speed to dart in and out of danger. You are effective both spearheading the assault and pushing into flanks. Your AR-18 carbine isn't the most dangerous rifle, nor does it have a particularly high magazine size, but it's incredibly lightweight compared to almost any other weapon, and its relative accuracy and stability even while moving and high fire rate allow it to pose a surprise threat to almost any xenomorphs. Your belt, body armor, and backpack all contain spare magazines for your AR-18. Your backpack also contains an MRE (in case you get hungry) as well as gauze and ointment to treat injuries with. Your left pocket contains a flare gun and several flares. Your right pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your webbing contains gauze and ointment for healing, an MRE for eating, and two boxes of flares. Your helmet contains protein bars for eating, and your boots contain a combat knife for clearing weeds and breaking things.<BR>
+	info = {"As a CQC marine, you are incredibly mobile, and should be using and abusing your speed to dart in and out of danger.\
+	You are effective both spearheading the assault and pushing into flanks.\
+	Your AR-18 carbine isn't the most dangerous rifle, nor does it have a particularly high magazine size, but it's incredibly lightweight\
+	compared to almost any other weapon, and its relative accuracy and stability even while moving and high fire rate allow it to pose\
+	a surprise threat to almost any xenomorphs. Your belt, body armor, and backpack all contain spare magazines for your AR-18.\
+	Your backpack also contains an MRE (in case you get hungry) as well as gauze and ointment to treat injuries with.\
+	Your left pocket contains a flare gun and several flares.\
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your webbing contains gauze and ointment for healing, an MRE for eating, and two boxes of flares.\
+	Your helmet contains protein bars for eating, and your boots contain a combat knife for clearing weeds and breaking things.<BR>
 	<BR>
-	Your speed is your greatest strength. You should be using it to rush into combat and chase after already injured enemies, only to rapidly retreat before things turn south. You're ideal at scouting locations, quickly reinforcing threatened positions, and overall being everywhere at once.<BR>
+	Your speed is your greatest strength. You should be using it to rush into combat and chase after already injured enemies,\
+	only to rapidly retreat before things turn south. You're ideal at scouting locations, quickly reinforcing threatened positions, and being everywhere at once.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	While holding your AR-18, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines. The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic. Automatic modes will keep firing as long as you hold down the mouse button. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
+	While holding your AR-18, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons.\
+	The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.\
+	The second option changes the firing mode, between Single Automatic, Burst, and Burst Automatic.\
+	Automatic modes will keep firing as long as you hold down the mouse button. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the rifle. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without an empty hand and with a different magazine still in the gun.<BR>
+	On running out of ammo, the empty magazine will automatically eject from the rifle.\
+	To reload, simply grab a new magazine with an empty hand and click your gun with it.\
+	Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without\
+	an empty hand and with a different magazine still in the gun.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right-clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	Don't be afraid to charge headfirst into danger if you think you can save a teammate or get a kill - you have the speed to get back out, after all. The ALT key by default allows humans or clones to sprint at the cost of stamina, to go even faster!<BR>
+	Don't be afraid to charge headfirst into danger if you think you can save a teammate or get a kill - you have the speed to get back out, after all.\
+	The ALT key by default allows humans or clones to sprint at the cost of stamina, to go even faster!<BR>
 	<BR>
-	While your rifle runs out of ammo quickly, its rapid fire four round bursts deal impressive damage. Combined with your speed, you are the master of ambushing."}
+	While your rifle runs out of ammo quickly, its rapid-fire four-round bursts deal impressive damage. Combined with your speed, you are the master of ambushing."}
 
 /obj/item/paper/tutorial/beginner_chad
 	name = "Grenadier Tutorial"
-	info = {"As a grenadier, you are the master of area denial. Your six-chamber GL-70 grenade launcher boasts unparalleled roomclearing potential, and impressive lethality - just take care to avoid harming your fellow marines. Your belt, backpack, both pockets, and body armor are all filled with HEDP grenades to reload your grenade launcher with. Your webbing contains Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and gauze and ointment, which also heal brute and burn damage respectively. Your backpack also contains an inaprovaline injector, which can be used to help other critically injured marines. Your helmet contains two protein bars, in case you get hungry, and your boots contain a derringer, a two-shot sidearm for when the first six grenades didn't kill the bug.<BR>
+	info = {"As a grenadier, you are the master of area denial. Your six-chamber GL-70 grenade launcher boasts unparalleled room-clearing potential,\
+	and impressive lethality - just take care to avoid harming your fellow marines.\
+	Your belt, backpack, both pockets, and body armor are all filled with HEDP grenades to reload your grenade launcher with.\
+	Your webbing contains Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller), Tricordrazine (heals all damage, but slowly),\
+	and gauze and ointment, which also heal brute and burn damage respectively. Your backpack also contains an inaprovaline injector.\
+	Your helmet contains two protein bars, in case you get hungry, and your boots contain a derringer, a two-shot sidearm for when the first six grenades didn't kill the bug.<BR>
 	<BR>
-	Your power is as much of a liability as it is a utility if you aren't careful. Before you get happy on the trigger, make SURE there aren't going to be marines in the blast radius, unless you want to end up filled with bullet holes (which your Hod accident prevention plating will partially block!) With that warning out of the way, you can kill even the beefiest of xenomorphs with good aim.<BR>
+	Your power is as much of a liability as it is a utility if you aren't careful.\
+	Before you get happy on the trigger, make SURE there aren't going to be marines in the blast radius, unless you want to end up filled with bullet holes\
+	(which your Hod accident prevention plating will partially block!) With that warning out of the way, you can kill even the beefiest of xenomorphs with good aim.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
 	While holding your grenade launcher, press Z to wield it. You MUST wield your grenade launcher to use it!<BR>
 	<BR>
-	To reload your grenade launcher, grab a grenade from one of your storages and left click the grenade launcher with it while it's in your other hand.<BR>
+	To reload your grenade launcher, grab a grenade from one of your storages and left-click the grenade launcher with it while it's in your other hand.<BR>
 	<BR>
-	You possess an antenna module on your helmet, which allows you to recieve shipments from requisitions (on the ship) while in the field. To request something, say :u followed by a clear and polite request as to what you would like to recieve. For example, if you ran out of grenades, you might say ":u RO, requesting HEDP grenades to my antenna." After some amount of time, you will likely get a response in the requisitions channel (pay attention!) along the lines of "Yourname, your order is ready. Raise your antenna." To do this, click the antenna icon in the top left - you should get a notification in the bottom right informing you it's successfully raised. You should then HOLD STILL until you recieve your order. (Once you've raised your antenna, it's polite to inform the RO, or requisitions officer, that it's raised.) After some time, you should hear a WOOSH noise, and a box will teleport to where you're standing with what you requested.<BR>
+	Hlin-pattern armor plating, orderable from requisitions, makes you practically immune to explosives. Get trigger happy!\
+	(Don't get TOO trigger happy, though - your fellow marines are NOT immune.)<BR>
 	<BR>
-	Hlin-pattern armor plating, orderable from requisitions, makes you practically immune to explosives. Get trigger happy! (Don't get TOO trigger happy, though - your fellow marines are NOT immune.)<BR>
+	Your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.
 	<BR>
-	Your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
-	<BR>
-	Explosions knock anything near them back, even over barricades. With careful aim, you can knock xenomorphs towards marines, who can then finish them off with more traditional firearms - and with REALLY careful aim, you can knock a xenomorph into a barricaded position it can't escape from, practically guaranteeing its demise!<BR>"}
+	As a grenadier, you hold the power to clear rooms and control territory like no other. Victory is just a well-placed grenade away."}
 
 /obj/item/paper/tutorial/builder
 	name = "Builder Tutorial"
-	info = {"The builder loadout is designed around you establishing defenses, barricades made from metal, plasteel or sandbags. You are the frontline, without you marines will be exposed to attacks from any and all directions. Use your quicker build speed and tools to aid and repair barricades, and fix APCs for generating the nuclear disks to win the round! Your loadout contains materials, a MG42 Light machine gun for self defense and suppression, and a radiopack for ordering more material to entrench and establish a fortified defensive position.<BR>
+	info = {"The Builder loadout is designed around you establishing defenses, barricades made from metal, plasteel or sandbags.\
+	You are the frontline - without you marines will be exposed to attacks from any and all directions.\
+	Your backpack contains some materials, a box of flares, and extra drums for your gun, as well as gauze and ointment to treat injuries with.
+	Your left pocket contains a tool pouch for all the tools you'll need to perform your engineering duties.\
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your helmet contains protein bars for eating, and your boots contain an MRE for further eating.\
+	The optical mesons on your eyewear slot give you the ability to see the shape of rooms behind solid walls, though you can't see anything (including xenomorphs!)\
+	behind those walls.\
+	Use your quicker build speed and tools to aid and repair barricades, and fix APCs for generating the nuclear disks to win the round!\
+	Your suit storage contains materials, and your loadout also containsa MG42 Light machine gun for self defense and suppression,\
+	and a radiopack for ordering more material to entrench and establish a fortified defensive position.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for your full one and insert the empty one into your crank and charge it for the next disk!<BR>
+	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for\
+	your full one. Insert the empty one into your crank, press Z to start charging, and charge it for the next disk!<BR>
 	<BR>
-	When building defensive barricades it is best to not make them "flush" with nearby doors or walls. Instead pull back 1 tile and build it there, this prevents xenos from hiding around the corner behind the walls and smacking your cades freely without repercussion.<BR>
+	When building defensive barricades it is best to not make them "flush" with nearby doors or walls.\
+	Instead pull back 1 tile and build it there; this prevents xenos from hiding around the corner behind the walls and smacking your cades freely without repercussion.<BR>
 	<BR>
-	All metal barricades can be upgraded, the basic upgrade is of course barbed wire. This damages xenos when they attack the barricade and prevents them (and marines!) from climbing over the barricade.<BR>
+	All metal barricades can be upgraded, the basic upgrade is barbed wire.\
+	This damages xenos when they attack the barricade and prevents them (and marines!) from climbing over the barricade.\
+	Press Z with metal sheets in your hand to open up a radial menu where you can select to build barbed wire.\
+	You can also build razorwire, which you can deploy to the tile in front of you by using it in-hand. Razorwire can trap charging xenomorphs momentarily to\
+	allow marines to shoot them.\
+	You can click a barricade with a piece of metal to open a radial menu to upgrade it. Cades have to be at full health to upgrade, so you might need to click them with
+	a welder first to fix any damages.\
+	Caustic armor increases the cade's resistance to acid spit and prevents it from being melted.\
+	Concussive armor increases the cade's resistance to explosions and Warlock's gravity crush ability.\
+	Ballistic armor increases the cade's resistance to projectile and melee damage and xenomorph charges.\<BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage."}
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol\
+	used as an all-rounder combat medicine mix for any situation that heals all different types of damage.\
+	Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system,
+	and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
+	<BR>
+	Through your building expertise, marines can hold various critical locations, ensuring steady progress towards mission completion."}
 
 /obj/item/paper/tutorial/flamer
 	name = "Flamer Tutorial"
-	info = {"As a flamethrower specialist your job is to burn, burn some more and BURN again. You are equipped with a flamethrower bag that refills your flamethrower everytime you insert it back into the bag, and also have a lascarbine for more practical and pragmatic self defense. Also comes with a large box of claymore anti-personnel mines, and some general materials for helping fortify positions.<BR>
+	info = {"As a Flamethrower specialist, your job is to burn, burn some more and BURN again.\
+	You are equipped with a flamethrower bag that refills your flamethrower every time you insert it back into the bag,\
+	and also have a laser carbine for more practical and pragmatic self-defense. Also comes with a large box of claymore anti-personnel mines,\
+	and some general materials for helping fortify positions in the suit storage.<BR>
+	Your backpack contains some materials, a box of flares, and extra drums for your gun, as well as gauze and ointment to treat injuries with.
+	Your left pocket contains a tool pouch for all the tools you'll need to perform your engineering duties.\
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your helmet contains protein bars for eating, and your boots contain an MRE for further eating.\
+	The optical mesons on your eyewear slot give you the ability to see the shape of rooms behind solid walls, though you can't see anything (including xenomorphs!)\
+	behind those walls.\
+	Removing resin walls will help open up the battlefield for your fellow marines, ensuring greater vision and mobility, and, hopefully, a greater number of successful\
+	fights against xenomorphs.\
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your flamethrower is best used to clear resin walls, it is a poor weapon for self defense and is best used to help carve a path through enemy mazes and to deny areas of movement without punishing xenos for trekking through the flames.<BR>
+	Your flamethrower is best used to clear resin walls, it is a poor weapon for self defense and is best used to help carve a path through\
+	enemy mazes and to deny areas of movement without punishing xenos for trekking through the flames.<BR>
 	<BR>
-	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for your full one and insert the empty one into your crank and charge it for the next disk!<BR>
+	Red resin walls are fire-resistant and require you to engage them in close quarters with a melee weapon to detroy them - the bayonet on your laser carbine is good for this,\
+	just be careful about any xenomorphs lurking in the mazes!<BR>
 	<BR>
-	Your claymore mines are useful for denying an area from being easily flanked and can cause serious disruption (or even kill!) backlining xenomorphs from causing you a bad day.<BR>
+	Requisitions offers many useful upgrades to your kit. You can request a SURT pyrotechnic module for your armor that will make you unable to be set on fire.\
+	You can also request X Fuel, a fuel for flamethrowers that burns hotter for longer and appears blue.\
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage."}
+	Your laser carbine is good for short-range defense. You can toggle the modes of it using unique action (default: space bar).\
+	The spread mode deals greater armor penetration and damage but is slow to fire. Impact mode knocks back targets. Cripple mode will slow enemies down.<BR>
+	<BR>
+	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for\
+	your full one. Insert the empty one into your crank, press Z to start charging, and charge it for the next disk!<BR>
+	<BR>
+	Your claymore mines are useful for denying an area from being easily flanked and can cause serious disruption for (or even kill)\
+	backlining xenomorphs trying to cause you a bad day.<BR>
+	<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose.\
+	Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying\
+	it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
+	<BR>
+	By removing resin structures with your flamethrower, you ensure area denial and dominance, flushing xenomorphs out and providing favorable battle circumstances for your\
+	fellow marines."}
 
 /obj/item/paper/tutorial/plasmacutter
-	name = "PlasmaCutter Tutorial"
-	info = {"Tired of watching marines endlessly pour into a maze or terribly held choke point? This is the class for you then! With your plasma cutter you will be able to easily delete resin walls from existence, and carve through metal, reinforced or even solid rock walls! With this kit you'll be able to widen choke points and eradicate mazes with ease. This loadout also comes with a few materials for defenses and a MP19 SMG for self defense in your welderpack.<BR>
+	name = "Plasma Cutter Tutorial"
+	info = {"Tired of watching marines endlessly pour into a maze or terribly held choke point? This is the class for you then!\
+	With your plasma cutter, you will be able to easily delete resin walls from existence, and carve through metal, reinforced, or even solid rock walls!\
+	With this kit you'll be able to widen choke points and eradicate mazes with ease.\
+	This loadout also comes with a few materials for defenses in your suit storage, and a MP19 SMG for self-defense in your technician welderpack.\
+	Your left pocket contains a tool pouch for all the tools you'll need to perform your engineering duties.\
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your helmet contains protein bars for eating, and your boots contain an MRE for further eating.\
+	The optical mesons on your eyewear slot give you the ability to see the shape of rooms behind solid walls, though you can't see anything (including xenomorphs!)\
+	behind those walls.\
+	Removing chokes and flanks will help your team to take better angles and more successfully push objectives.\<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your Plasma Cutter (often abbreviated to PC) is a very versatile tool but it contains a limited charge of 7500, for resin walls the charge is rather miniscule at 100 Charge but a much heavier or thicker metallic or rock wall will cost you 1000 charge so make sure to keep track of how much charge your battery contains! Do remember to keep your welding module or goggles on when using it however, as the plasma cutter will damage your eyes until they're blind!<BR>
+	Your Plasma Cutter (often abbreviated to PC) is a very versatile tool but it contains a limited charge of 7500;\
+	for resin walls the charge is rather miniscule at 100 Charge but a much heavier or thicker metallic or rock wall will cost you 1000 Charge,\
+	so make sure to keep track of how much charge your battery contains!\
+	Do remember to keep your welding module or goggles on when using it, however, as the Plasma Cutter will damage your eyes!<BR>
 	<BR>
-	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for your full one and insert the empty one into your crank and charge it for the next disk!<BR>
+	In your webbing you will find a spare powercell and a handheld cell crank charger to charge them, when fixing apcs swap the empty battery for\
+	your full one. Insert the empty one into your crank, press Z to start charging, and charge it for the next disk!<BR>
 	<BR>
-	Your plasma cutter can be used as a melee weapon in emergency situations, while not the best by any means it can work in a pinch and if you manage to smack a xeno you'll get rewarded with draining them of a small amount of plasma and a bit of charge for your plasma cutter. Use this to destroy mazes and punish xenos for trying to attack you by refilling your battery. A recommended combo when frontlining us combining it with a defensive shield!<BR>
+	Your Plasma Cutter can be used as a melee weapon in emergency situations, while not the best by any means it can work in a pinch\
+	and if you manage to smack a xenomorph you'll get rewarded with draining them of a small amount of plasma and earning a bit of charge for your Plasma Cutter.\
+	Use this to destroy mazes and punish xenomorphss for trying to attack you by refilling your battery.<BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage."}
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still.\
+	Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
+	<BR>
+	Your ability to treat terrain as a sandbox has infinite potential for assisting your allies."}
 
 /obj/item/paper/tutorial/lifesaver
 	name = "Lifesaver Tutorial"
-	info = {"As the lifesaver, you are a MEDIC first and foremost. You should be prioritizing healing marines over trying to fight xenomorphs yourself. Your belt contains many pill bottles - examine them to find out what they do with shift click, and draw from them with right click. Your belt also contains splints, which are used on fractured bones, and a medical analyzer, which will tell you exactly what's wrong with a person. Avoid giving someone more than one pill of a given medicine at a time; many pills overdose at three, and some at two, and some marines might go and take a pill themselves, so one is safest. In your armor storage are an assortment of autoinjectors. Combat injectors should be used on marines in active danger, quick clot plus helps deal with internal bleeding, peridaxon plus heals organs, and dexalin plus helps with deoxygenation. Your right pouch contains three stacks of trauma and burn kits, which will cause a body part they're applied to to heal brute or burn damage over time respectively. It also contains a hypospray full of meraderm, a medicine mixture that heals both brute and burn damage quickly. Your webbing contains oxycodone, a painkiller, nanoblood, a blood replacement, a stasis bag to hold patients you aren't actively treating in to prevent their condition from worsening, tweezers to remove shrapnel, a roller bed to roll around patients with, and a medivac to evacuate patients. Your boots and helmet contain food.<BR>
+	info = {"As the lifesaver, you are a MEDIC first and foremost. You should be prioritizing healing marines over trying to fight xenomorphs yourself.\
+	Your belt contains many pill bottles - examine them to find out what they do with shift+click, and draw from them with right-click.\
+	Your belt also contains splints, which are used on fractured bones, and a medical analyzer, which will tell you exactly what's wrong with a person.\
+	Avoid giving someone more than one pill of a given medicine at a time; many pills overdose at three, and some at two, and some marines might go and take a pill themselves,\
+	so one is safest. In your armor storage are an assortment of autoinjectors. Combat injectors should be used on marines in active danger, Quick Clot Plus helps deal\
+	with internal bleeding, Peridaxon Plus heals organs, and Dexalin Plus helps with deoxygenation.\
+	Your right pouch contains three stacks of trauma and burn kits, which will cause a body part they're applied to to heal brute or burn damage over time respectively.\
+	It also contains a hypospray full of MeraDerm, a medicine mixture that heals both brute and burn damage quickly.\
+	Your webbing contains Oxycodone, a painkiller; Nanoblood, a blood replacement; a stasis bag to hold patients you aren't actively treating in to prevent their\
+	condition from worsening; tweezers to remove shrapnel; a roller bed to roll around patients with; and a medivac to evacuate patients.\
+	Your boots and helmet contain food.<BR>
 	<BR>
-	Stay away from the frontlines - let patients come to (or be dragged to) you instead of putting yourself in danger. Try to remain in a safe location, as xenomorphs do not obey the Geneva convention and will in fact deliberately target you and your patients as often as possible.<BR>
+	Stay away from the frontlines - let patients come to (or be dragged to) you instead of putting yourself in danger.\
+	Try to remain in a safe location, as xenomorphs do not obey the Geneva Convention and will in fact deliberately target you and your patients as often as possible.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are defibrillators. By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough. Drag your gloves to your backpack to recharge them. This even works on robots! Make sure your intent is help while doing this or you might just punch them right after they revive, taking them out again.<BR>
+	Your gloves are defibrillators. By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it)\
+	you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough.\
+	Drag your gloves to your backpack to recharge them. This even works on robots!\
+	Make sure your intent is help while doing this or you might just punch them right after they revive, taking them out again.<BR>
 	<BR>
-	While holding your repeater, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.<BR>
+	While holding your repeater, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons.\
+	The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.<BR>
 	<BR>
 	As your rifle is bolt-action, it needs to be racked after every shot. Do this by pressing your Unique Action key, which defaults to the spacebar.<BR>
 	<BR>
-	Your backpack contains ammo packets. You can click on your shotgun shell pouch to quickly transfer ammo into the pouch. You can then reload your repeater by clicking it while it's in your hand with the handful of bullets.<BR>
+	Your backpack contains ammo packets. You can click on your shotgun shell pouch to quickly transfer ammo into the pouch.\
+	You can then reload your repeater by clicking it while it's in your hand with the handful of bullets.<BR>
 	<BR>
-	Before you do ANYTHING to a patient, use your medical analyzer on them. Not analyzing is the number one cause of overdoses. Right clicking with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>
+	Before you do ANYTHING to a patient, use your medical analyzer on them. Not analyzing is the number one cause of overdoses.\
+	Right-clicking with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>
 	<BR>
-	When you dispense your equipment, a medivac beacon will appear on the floor. Pick this up, take your medivac and click it on the beacon so it says linked! Once done, you should go to your ship's medical bay and place the beacon by pressing Z with it in hand. Once groundside, you can now medivac people for treatment shipside. Shipside can fix bone fractures, clone damage, facehugging, and anything else you can't. To evac someone, deploy your medivac by pressing Z with it in hand, drag them onto it to buckle them to it, then right click to send them up. Drag the medivac to you to pick it back up once you're done.<BR>
+	When you dispense your equipment, a medivac beacon will appear on the floor.\
+	Pick this up, take your medivac and click it on the beacon so it says linked!\
+	Once done, you should go to your ship's medical bay and place the beacon by pressing Z with it in hand.\
+	Once groundside, you can now medivac people for treatment shipside.\
+	Shipside can fix bone fractures, clone damage, facehugging, and anything else you can't.\
+	To evac someone, deploy your medivac by pressing Z with it in hand, drag them onto it to buckle them to it, then right click to send them up.\
+	Drag the medivac to you to pick it back up once you're done.<BR>
 	<BR>
-	Marines will "go cold" after five minutes of being dead, rendering them permanently unrevivable. This timer can be extended via your stasis bag or with CPR, which other marines can perform while you work by left clicking the corpse on help intent while neither of them are wearing a mask.<BR>
+	Marines will "go cold" after five minutes of being dead, rendering them permanently unrevivable.\
+	This timer can be extended via your stasis bag or with CPR, which other marines can perform while you work by left-clicking the corpse on help intent\
+	while neither of them are wearing a mask.<BR>
 	<BR>
-	Accidentally overdose a marine? They're full of deadly neurotoxin? Don't panic - use hypervene. While uncomfortable for the marine, this medication (located in your medical belt) will rapidly purge their system.<BR>
+	Accidentally overdose a marine? They're full of deadly neurotoxin? Don't panic - use Hypervene.\
+	While uncomfortable for the marine, this medication (located in your medical belt) will rapidly purge their system.<BR>
 	<BR>
-	You can use meralyne and dermaline at the same time as Bicaridine and kelotane, for an accelerated healing rate."}
+	You can use Meralyne and Dermaline at the same time as Bicaridine and kelotane, for an accelerated healing rate. Keep the Corps well and the rest will follow."}
 
 /obj/item/paper/tutorial/hypobelt
 	name = "Hypobelt Tutorial"
-	info = {"As the hypobelt medic, you are the master of rapid healing. Your belt is full of hyposprays which instantly apply a dose of medicine when you click a marine with them. Examine them with shift click to read their labels to find out what they do. Avoid injecting someone more than once or twice with the same medicine to prevent an overdose! Your pouch contains three stacks of trauma and burn kits, which will cause a body part they're applied to to heal brute or burn damage over time respectively. It also contains a hypospray full of meraderm, a medicine mixture that heals both brute and burn damage quickly. These hyposprays can be refilled by the bottles in the syringe cases of your belt. Your webbing is filled with splints for treating fractures. Your body armor contains oxycodone, a painkiller, a stasis bag to hold patients you aren't actively treating in to prevent their condition from worsening, tweezers to remove shrapnel, a roller bed to roll around patients with, and a medivac to evacuate patients. Your boots and helmet contain food.<BR>
+	info = {"As the hypobelt medic, you are the master of rapid healing.\
+	Your belt is full of hyposprays which instantly apply a dose of medicine when you click a marine with them.\
+	Examine them with shift+click to read their labels to find out what they do.\
+	Avoid injecting someone more than once or twice with the same medicine to prevent an overdose!\
+	Your pouch contains three stacks of trauma and burn kits, which will cause a body part they're applied to to heal brute or burn damage over time respectively.\
+	It also contains a hypospray full of MeraDerm, a medicine mixture that heals both brute and burn damage quickly.\
+	These hyposprays can be refilled by the bottles in the syringe cases of your belt.\
+	Your webbing is filled with splints for treating fractures.\
+	Your body armor contains Oxycodone, a painkiller; a stasis bag to hold patients you aren't actively treating in to prevent their condition from worsening;\
+	tweezers to remove shrapnel; a roller bed to roll around patients with; and a medivac to evacuate patients.\
+	Your boots and helmet contain food.<BR>
 	<BR>
-	Your light armor and quick injectors make you adept at rapidly getting marines back into the action. However, take care to avoid danger; xenomorphs WILL target you, and you will go down fast without proper protection.<BR>
+	Your light armor and quick injectors make you adept at rapidly getting marines back into the action.\
+	However, take care to avoid danger; xenomorphs WILL target you, and you will go down fast without proper protection.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are medical analyzers, which you can use on a patient by left clicking them. Before you do ANYTHING to a patient, use your medical analyzer on them. Not analyzing is the number one cause of overdoses. Right click with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>
+	Your gloves are medical analyzers, which you can use on a patient by left clicking them.\
+	Before you do ANYTHING to a patient, use your medical analyzer on them.\
+	Not analyzing is the number one cause of overdoses.\
+	Right-click with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>
 	<BR>
-	In your backpack is a defibrillator. By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough. Drag your defib to your backpack to recharge them. This even works on robots!<BR>
+	In your backpack is a defibrillator. By holding it and clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it)\
+	you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough.\
+	Drag your defib to your backpack to recharge them. This even works on robots!<BR>
 	<BR>
-	When you dispense your equipment, a medivac beacon will appear on the floor. Pick this up, take your medivac and click it on the beacon so it says linked! Once done, you should go to your ship's medical bay and place the beacon by pressing Z with it in hand. Once groundside, you can now medivac people for treatment shipside. Shipside can fix bone fractures, clone damage, facehugging, and anything else you can't. To evac someone, deploy your medivac by pressing Z with it in hand, drag them onto it to buckle them to it, then right click to send them up. Drag the medivac to you to pick it back up once you're done.<BR>
+	When you dispense your equipment, a medivac beacon will appear on the floor.\
+	Pick this up, take your medivac and click it on the beacon so it says linked!\
+	Once done, you should go to your ship's medical bay and place the beacon by pressing Z with it in hand.\
+	Once groundside, you can now medivac people for treatment shipside. Shipside can fix bone fractures, clone damage, facehugging, and anything else you can't.\
+	To evac someone, deploy your medivac by pressing Z with it in hand, drag them onto it to buckle them to it, then right-click to send them up.\
+	Drag the medivac to you to pick it back up once you're done.<BR>
 	<BR>
-	Marines will "go cold" after five minutes of being dead, rendering them permanently unrevivable. This timer can be extended via your stasis bag or with CPR, which other marines can perform while you work by left clicking the corpse on help intent while neither of them are wearing a mask.<BR>
+	Marines will "go cold" after five minutes of being dead, rendering them permanently unrevivable.\
+	This timer can be extended via your stasis bag or with CPR, which other marines can perform while you work by left-clicking the corpse\
+	on help intent while neither of them are wearing a mask.<BR>
 	<BR>
-	Accidentally overdose a marine? They're full of deadly neurotoxin? Don't panic - use hypervene. While uncomfortable for the marine, this medication (located in your medical belt) will rapidly purge their system.<BR>
+	Accidentally overdose a marine? They're full of deadly neurotoxin? Don't panic - use Hypervene.\
+	While uncomfortable for the marine, this medication (located in your medical belt) will rapidly purge their system.<BR>
 	<BR>
-	You can use meralyne and dermaline at the same time as Bicaridine and kelotane, for an accelerated healing rate.<BR>
+	You can use Meralyne and Dermaline at the same time as Bicaridine and kelotane, for an accelerated healing rate.<BR>
 	<BR>
-	As your shotgun is pump-action, you'll need to pump it after every shot by pressing Unique Action (default space.)<BR>
+	As your shotgun is pump-action, you'll need to pump it after every shot by pressing Unique Action (default space bar).<BR>
 	<BR>
-	You can reload your shotgun by grabbing a handful of slugs from your backpack and clicking your shotgun with them."}
+	You can reload your shotgun by grabbing a handful of slugs from your backpack and clicking your shotgun with them.<BR>
+	<BR>
+	Remember your primary goal is to keep the force healthy and allow them to continue with progressing the operation."}
 
 /obj/item/paper/tutorial/smartmachinegunner
 	name = "Smartmachinegunner Tutorial"
-	info = {"As the smartmachinegunner, you are the very backbone of your squad, and should be behind another marine or three at all times. Your SG-29 is capable of firing directly through your teammates without risk of harm, so staying safe and behind your allies is essential to gaining full value out of it. Your backpack and body armor contain both fire extinguishers and spare ammo, with your backpack also containing a plasma pistol to start fires with. Your left pouch contains a flare gun holster and several flares.  Your right pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your webbing contains flares for creating lights and gauze and ointment for treating injuries. Your helmet and boots contain food, in case you get hungry.<BR>
+	info = {"As the smartmachinegunner, you are the very backbone of your squad, and should be behind another marine or three at all times.\
+	Your SG-29 is capable of firing directly through your teammates without risk of harm, so staying safe and behind your allies is essential\
+	to gaining full value out of it. Your backpack and body armor contain both fire extinguisher and spare ammo, with your backpack also containing\
+	a plasma pistol to start fires with, inaprovaline, and a cloak grenade to escape skirmishes. Your left pouch contains a flare gun holster and several flares.\
+	Your right pouch contains a first aid kit complete with Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller),\
+	Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage), as well as splints and inaprovaline.\
+	Your webbing contains flares for creating lights and gauze and ointment for treating injuries.\
+	Your helmet and boots contain food, in case you get hungry.<BR>
 	<BR>
-	You should NEVER be at the front of a group of marines. Aim to provide covering fire for those who are in front, and let them protect you in turn by, well, being in front of you. Remember that your SG-29 fires through marines, so you don't need to worry about friendly fire.<BR>
+	You should NEVER be at the front of a group of marines.\
+	Aim to provide covering fire for those who are in front, and let them protect you in turn by, well, being in front of you.\
+	Remember that your SG-29 fires through marines, so you don't need to worry about friendly fire.<BR>
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose.\
+	Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that\
+	require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb.\
+	Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious\
+	on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right-clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right-clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	On your belt is a belt harness. By left clicking on your belt harness with your machine gun, you can attach them. If you drop your machine gun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached.<BR>
+	On your belt is a belt harness. By left clicking on your belt harness with your machine gun, you can attach them.\
+	If you drop your machine gun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached.<BR>
 	<BR>
-	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire. While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected. You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
+	If you are facehugged, quickly take out your plasma pistol and shoot the ground with it, then walk into the fire.\
+	While this will cause you to be set on fire, facehuggers will detach in the presence of fire, preventing you from becoming infected.\
+	You can press B (or click resist in the bottom right) once the facehugger has detached to stop, drop, and roll, extinguishing the fire.<BR>
 	<BR>
-	Your impressive magazine size means you don't need to reload often. You can suppress one spot for an impressive amount of time, and you have the ammo and damage to clear out resin walls.<BR>
+	Your impressive magazine size means you don't need to reload often. You can suppress one spot for an impressive amount of time,\
+	and you have the ammo and damage to clear out resin walls.<BR>
 	<BR>
-	While holding your SG-29, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. In the top left of your screen are several weapon-specific buttons. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
+	While holding your SG-29, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil.\
+	In the top left of your screen are several weapon-specific buttons. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
 	<BR>
-	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen. Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets. This sensor works even without vision, such as through any form of smoke and through walls.<BR>
+	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen.\
+	Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets.\
+	This sensor works even without vision, such as through any form of smoke and through walls.<BR>
 	<BR>
-	On running out of ammo, the empty magazine will automatically eject from the smartgun. To reload, simply grab a new magazine with an empty hand and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle, which can be done without an empty hand and with a different magazine still in the gun.<BR>
+	On running out of ammo, the empty magazine will automatically eject from the smartgun. To reload, simply grab a new magazine with an empty hand\
+	and click your gun with it. Alternatively, you can perform a tactical reload by click-dragging the magazine from its storage directly onto the rifle,\
+	which can be done without an empty hand and with a different magazine still in the gun.<BR>
 	<BR>
 	STAY BEHIND OTHER MARINES. I cannot stress this enough. You are a priority target for xenomorphs due to your ability to provide covering fire from behind other marines.<BR>
 	<BR>
-	Your massive drum size of 250 rounds means you don't need to reload often. Because of this, you should avoid reloading in dangerous areas if you can help it, instead waiting until you're back behind fortifications or other marines.<BR>
+	Your massive drum size of 250 rounds means you don't need to reload often. Because of this, you should avoid reloading in dangerous areas if you can help it,\
+	instead waiting until you're back behind fortifications or other marines.<BR>
 	<BR>
-	You possess an antenna module on your helmet, which allows you to receive shipments from requisitions (on the ship) while in the field. To request something, say :u followed by a clear and polite request as to what you would like to receive. For example, if you ran out of ammo, you might say ":u RO, requesting SG-29 drums to my antenna." After some amount of time, you will likely get a response in the requisitions channel (pay attention!) along the lines of "Yourname, your order is ready. Raise your antenna." To do this, click the antenna icon in the top left - you should get a notification in the bottom right informing you it's successfully raised. You should then HOLD STILL until you receive your order. (Once you've raised your antenna, it's polite to inform the RO, or requisitions officer, that it's raised.) After some time, you should hear a WOOSH noise, and a box will teleport to where you're standing with what you requested. Note that requisitions is the ONLY place you can get more smartgun ammo!<BR>
+	Your ammunition refills will come from Requisitions. To request something, say :u followed by a clear and polite request as to what you would like to receive.\
+	For example, if you ran out of ammo, you might say ":u RO, requesting SG-85 bins to the FC's beacon."\
+	After some amount of time, you will likely get a response in the requisitions channel (pay attention!) along the lines of "Yourname, your order is ready. Sending."\
+	After some time, you should hear a WOOSH noise, and a box will teleport to the beacon with what you requested.\
+	Note that requisitions is the ONLY place you can get more smartgun ammo!<BR>
 	<BR>
 	You are the most mobile among smartgunners - use this to your advantage. You are the best at providing cover fire for a mobile squad."}
 
 /obj/item/paper/tutorial/smartminigunner
 	name = "Smartminigunner Tutorial"
-	info = {"As the smartminigunner, you are the very embodiment of BRRT. With your huge SG-85 smart minigun, you can fire ten rounds per second for one hundred straight seconds, providing powerful covering fire for other marines. No enemy wants to get stuck in your line of fire. Instead of a backpack you carry a back mounted powerpack that feeds and powers your SG-85. In your body armor are two bins to refill your powerpack with.  Your left pouch contains a flare gun holster and several flares.  Your right pouch contains a first aid kit, complete with Bicaridine (which heals brute damage), Kelotane (which heals burn damage), Tramadol (which is a painkiller), Tricordrazine (which heals all damage, but slowly), and Dylovene (which heals toxin, or poison damage), as well as splints and inaprovaline. Your webbing contains flares for creating lights and gauze and ointment for treating injuries. Your helmet and boots contain food, in case you get hungry.<BR>
+	info = {"As the smartminigunner, you are the very embodiment of BRRT. With your huge SG-85 smart minigun,\
+	you can fire ten rounds per second for one hundred straight seconds, providing powerful covering fire for other marines.\
+	No enemy wants to get stuck in your line of fire. Instead of a backpack you carry a back mounted powerpack that feeds and powers your SG-85.\
+	In your body armor are two bins to refill your powerpack with.  Your left pouch contains a flare gun holster and several flares. \
+	Your right pouch contains a first aid kit, complete with Bicaridine (heals brute damage), Kelotane (heals burn damage),\
+	Tramadol (a painkiller), Tricordrazine (heals all damage, but slowly), and Dylovene (heals toxin damage),\
+	as well as splints and inaprovaline. Your webbing contains flares for creating lights and gauze and ointment for treating injuries.\
+	Your helmet and boots contain food, in case you get hungry.<BR>
 	<BR>
-	Your minigun boasts both high levels of armor piercing and the ability to shoot through allies - use both to your advantage. Note that the heavy nature of your minigun and your brief windup before you can fire means you're best positioned defensively, firing at the toughest targets within range.<BR>
+	Your minigun boasts both high levels of armor piercing and the ability to shoot through allies - use both to your advantage.\
+	Note that the heavy nature of your minigun and your brief windup before you can fire means you're best positioned defensively, firing at the toughest targets within range.<BR>
 	<BR>
 	<b>TIPS</b><BR>
-	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures, by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state. You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
+	BKTT is an acronym that is used to describe the combination of Bicaridine, Kelotane, Tricordizine, and Tramadol used as an all-rounder combat medicine mix\
+	for any situation that heals all different types of damage. Make sure not to take more than two of each pill at a time - medicine takes a while to process\
+	through your system, and too many at once risks a dangerous overdose. Your gauze and ointment are body-part specific, unlike medication, but once you start\
+	applying one, you will keep applying it to all body parts that require treatment as long as you hold still. Your splints are used to alleviate the effects of bone fractures,\
+	by applying them to a fractured limb. Your inaprovaline autoinjector is not to be applied to yourself - rather, it should be applied to an alive marine that is\
+	so heavily injured they are unconscious on the ground (referred to as "critical condition") to rescue them from that state.\
+	You can remove pills from their packets directly by right clicking on the packet, even while it's in storage.<BR>
 	<BR>
-	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand. Your flare pouch can be refilled by left clicking on it while holding a flare box. Flare any dark area you can see to reduce the risk of a xenomorph ambushing you from the dark. On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
+	Your flare gun can be rapidly reloaded by just right clicking the flare pouch with it in hand.\
+	Your flare pouch can be refilled by left clicking on it while holding a flare box.\
+	Flare any dark area you can see to reduce the risk of a xenomorph ambushing you.\
+	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
-	On your belt is a belt harness. By left clicking on your belt harness with your minigun, you can attach them. If you drop your minigun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached. On the same note, by left clicking your powerpack, you hook up your minigun, allowing it to draw from it for ammo. If you drop your minigun, even if it's saved by the belt harness, you will have to re-attach it to the powerpack.<BR>
+	On your belt is a belt harness. By left clicking on your belt harness with your minigun, you can attach them.\
+	If you drop your minigun, or have a xenomorph make you drop it, your machine gun will automatically return to your armor if it's attached.\
+	On the same note, by left clicking your powerpack, you hook up your minigun, allowing it to draw from it for ammo.\
+	If you drop your minigun, even if it's saved by the belt harness, you will have to re-attach it to the powerpack.<BR>
 	<BR>
 	To reload your power back, take it into your hand, then grab an ammo bin with your other hand and click the power pack with it.<BR>
 	<BR>
-	While holding your SG-85, use Z to wield your weapon with both hands, which is required to fire it. In the top left of your screen are several weapon-specific buttons. The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
+	While holding your SG-85, use Z to wield your weapon with both hands, which is required to fire it. In the top left of your screen are several weapon-specific buttons.\
+	The tactical sensor option toggles your tactical sensor - you should keep this on always.<BR>
 	<BR>
-	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen. Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets. This sensor works even without vision, such as through any form of smoke and through walls.<BR>
+	Your tactical sensor will periodically blip, detecting moving targets in an area a little bigger than your screen.\
+	Green circles are friendly targets (or anyone wearing a marine ID), while red circles accompanied with an audible blip are unknown (almost always hostile) targets.\
+	This sensor works even without vision, such as through any form of smoke and through walls.<BR>
 	<BR>
-	You possess an antenna module on your helmet, which allows you to receive shipments from requisitions (on the ship) while in the field. To request something, say :u followed by a clear and polite request as to what you would like to receive. For example, if you ran out of ammo, you might say ":u RO, requesting SG-85 bins to my antenna." After some amount of time, you will likely get a response in the requisitions channel (pay attention!) along the lines of "Yourname, your order is ready. Raise your antenna." To do this, click the antenna icon in the top left - you should get a notification in the bottom right informing you it's successfully raised. You should then HOLD STILL until you receive your order. (Once you've raised your antenna, it's polite to inform the RO, or requisitions officer, that it's raised.) After some time, you should hear a WOOSH noise, and a box will teleport to where you're standing with what you requested. Note that requisitions is the ONLY place you can get more smartgun ammo!<BR>
+	Your ammunition refills will come from Requisitions. To request something, say :u followed by a clear and polite request as to what you would like to receive.\
+	For example, if you ran out of ammo, you might say ":u RO, requesting SG-85 bins to the FC's beacon."\
+	After some amount of time, you will likely get a response in the requisitions channel (pay attention!) along the lines of "Yourname, your order is ready. Sending."\
+	After some time, you should hear a WOOSH noise, and a box will teleport to the beacon with what you requested.\
+	Note that requisitions is the ONLY place you can get more smartgun ammo!<BR>
 	<BR>
 	STAY BEHIND OTHER MARINES. I cannot stress this enough. You are a priority target for xenomorphs due to your ability to provide covering fire from behind other marines.<BR>
 	<BR>
-	You almost never need to reload - you have enough rounds to fire for almost two straight minutes. Because of this, you should exclusively reload when it is completely safe to do so, as other marines are counting on you to protect them.<BR>
+	You almost never need to reload - you have enough rounds to fire for almost two straight minutes.\
+	Because of this, you should exclusively reload when it is completely safe to do so, as other marines are counting on you to protect them.<BR>
 	<BR>
 	Your minigun boasts an incredibly high amount of armor piercing. Aim for particularly durable targets, like Crushers and Kings, as you'll likely do a lot more damage."}

--- a/code/modules/paperwork/beginner_tutorials.dm
+++ b/code/modules/paperwork/beginner_tutorials.dm
@@ -51,7 +51,7 @@
 	Try keeping the distance from ferocious melee enemies, while getting too close for comfort with squishier ranged ones."}
 
 /obj/item/paper/tutorial/beginner_machinegunner
-	name = "Machinergunner Tutorial"
+	name = "Machinegunner Tutorial"
 	info = {"As a machinegunner, you are the backbone of a marine force. While you possess heavy armor reinforced with\
 	Tyr-pattern plating (strengthening its defense even further against melee attacks), your slow move speed and the unwieldy nature of your MG-60 machinegun\
 	means you should not be spearheading any pushes. Aim mode is your best friend - combined with your bipod, you are very apt at sitting just behind the front line,\


### PR DESCRIPTION
## About The Pull Request

edits beginner loadout tutorials. three parts:
1. wraps the text on them so they're manageable to edit in the future
2. updates outdated things (antenna usage for ammo drops, RDS on MG60)
3. adds more complete info on the engineer kits about everything in them including weapon handling

updates two loadouts:
1. grenadier had helmet module switched from antenna to HOD (matches armor on the set now and more useful)
2. smartminigunner had the backpack fire extinguisher replaced with one cloak grenade and an inap injector (there was another full-sized fire extinguisher in suit storage which doesn't feel very useful)

## Why It's Good For The Game
keep the newbie tutorials updated so they dont wonder why their tutorial talks about their MG60 having an RDS, or why the RO wont send ammo to their antenna when it's active.

loadout tweaks to provide maximum utility for the niches they're designed for

wraps text so i can edit in future while staying sane

## Changelog
:cl:
fix: beginner tutorial sheets updated
/:cl: