### PR TITLE
Nerfs Aimmode Burst

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -616,7 +616,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0)
 	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING))
 		modify_fire_delay(aim_fire_delay - old_delay)
-		modify_auto_burst_delay(burst_amount * aim_fire_delay / 2 - old_delay) //more delay between bursts when using aim mode
+		modify_auto_burst_delay(burst_amount * aim_fire_delay / 2 - burst_amount * old_delay / 2) //more delay between bursts when using aim mode
 
 ///Adds an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/add_aim_mode_fire_delay(source, value)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -616,7 +616,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0)
 	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING))
 		modify_fire_delay(aim_fire_delay - old_delay)
-		modify_auto_burst_delay(aim_fire_delay - old_delay)
+		modify_auto_burst_delay(burst_amount * aim_fire_delay / 2 - old_delay) //more delay between bursts when using aim mode
 
 ///Adds an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/add_aim_mode_fire_delay(source, value)
@@ -651,12 +651,12 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		REMOVE_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 		user.remove_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN)
 		modify_fire_delay(-aim_fire_delay)
-		modify_auto_burst_delay(-aim_fire_delay)
+		modify_auto_burst_delay(-burst_amount * aim_fire_delay / 2)
 		///if your attached weapon has aim mode, stops it from aimming
 		if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 			REMOVE_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 			gunattachment.modify_fire_delay(-aim_fire_delay)
-			gunattachment.modify_auto_burst_delay(-aim_fire_delay)
+			gunattachment.modify_auto_burst_delay(-burst_amount * aim_fire_delay / 2)
 		to_chat(user, span_notice("You cease aiming."))
 		return
 	if(!(flags_item & WIELDED) && !(flags_item & IS_DEPLOYED))
@@ -680,7 +680,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	ADD_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 	user.add_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN, TRUE, 0, NONE, TRUE, aim_speed_modifier)
 	modify_fire_delay(aim_fire_delay)
-	modify_auto_burst_delay(aim_fire_delay)
+	modify_auto_burst_delay(burst_amount * aim_fire_delay / 2)
 	///if your attached weapon has aim mode, makes it aim
 	if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 		ADD_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1748,7 +1748,7 @@
 						added_delay -= 2 * user.skills.getRating(gun_skill_category)
 	var/delay = last_fired + added_delay
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
-		delay += extra_delay
+		delay += extra_delay * burst_amount / 2
 
 	if(world.time >= delay && (!user || SEND_SIGNAL(user, COMSIG_MOB_GUN_COOLDOWN, src)))
 		return FALSE

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1748,7 +1748,7 @@
 						added_delay -= 2 * user.skills.getRating(gun_skill_category)
 	var/delay = last_fired + added_delay
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
-		delay += extra_delay * burst_amount / 2
+		delay += extra_delay
 
 	if(world.time >= delay && (!user || SEND_SIGNAL(user, COMSIG_MOB_GUN_COOLDOWN, src)))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
Increases the delay between bursts by multiplying aim_fire_delay with burst_amount / 2. Any multiplier could be used instead of 1/2, just the first number I thought of. If you have better values, suggest them and explain why they're better.  

No changes to full auto (with or without aim mode) and no changes to unaimed burst/ autoburst. 

## Why It's Good For The Game
Guns with burstmodes being affected less by aim mode ROF penalties is pretty silly. Many people have complained about aim mode ungaball being oppressive, effectively forcing xenos to gas spam. Somehow no one got around to doing this for years, when it seems like there was a want for it. 

## Changelog
:cl:
balance: increases delay between bursts when using aim mode (aim_fire_delay multiplied by burst_amount / 2)
/:cl:
