### PR TITLE
Facehuggers actually prioritize the nearest marine

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -7,8 +7,8 @@
 
 #define CARDINAL_DIRS list(1,2,4,8)
 #define CARDINAL_ALL_DIRS list(1,2,4,5,6,8,9,10)
-#define get_dist_euclide_square(A, B) (A && B ? A.z == B.z ? (A.x - B.x)**2 + (A.y - B.y)**2 : INFINITY : INFINITY)
-#define get_dist_euclide(A, B) (sqrt(get_dist_euclide_square(A, B)))
+#define get_dist_euclidean_square(A, B) (A && B ? A.z == B.z ? (A.x - B.x)**2 + (A.y - B.y)**2 : INFINITY : INFINITY)
+#define get_dist_euclidean(A, B) (sqrt(get_dist_euclidean_square(A, B)))
 
 #define LEFT 1
 #define RIGHT 2

--- a/code/controllers/subsystem/advanced_pathfinding.dm
+++ b/code/controllers/subsystem/advanced_pathfinding.dm
@@ -82,8 +82,8 @@ GLOBAL_LIST_EMPTY(goal_nodes)
 
 /datum/path_step/New(atom/previous_atom, atom/current_atom, atom/goal_atom, old_distance_walked)
 	..()
-	distance_to_goal = get_dist_euclide_square(current_atom, goal_atom)
-	distance_walked = old_distance_walked + get_dist_euclide_square(current_atom, previous_atom)
+	distance_to_goal = get_dist_euclidean_square(current_atom, goal_atom)
+	distance_walked = old_distance_walked + get_dist_euclidean_square(current_atom, previous_atom)
 	src.current_atom = current_atom
 	src.previous_atom = previous_atom
 

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -69,7 +69,7 @@ SUBSYSTEM_DEF(weeds)
 		return FALSE
 
 	for(var/turf/T AS in node.node_turfs)
-		if(pending[T] && (get_dist_euclide_square(node, T) >= get_dist_euclide_square(get_step(pending[T], 0), T)))
+		if(pending[T] && (get_dist_euclidean_square(node, T) >= get_dist_euclidean_square(get_step(pending[T], 0), T)))
 			continue
 		pending[T] = node
 		spawn_attempts_by_node[T] = 5 //5 attempts maximum
@@ -92,7 +92,7 @@ SUBSYSTEM_DEF(weeds)
 			if(istype(O, /obj/alien/weeds/node))
 				return
 			var/obj/alien/weeds/weed = O
-			if(weed.parent_node && weed.parent_node != node && get_dist_euclide_square(node, weed) >= get_dist_euclide_square(weed.parent_node, weed))
+			if(weed.parent_node && weed.parent_node != node && get_dist_euclidean_square(node, weed) >= get_dist_euclidean_square(weed.parent_node, weed))
 				return
 			if((weed.type == weed_to_spawn) && (weed.color_variant == node.color_variant))
 				weed.set_parent_node(node)

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -565,7 +565,7 @@
 
 	if(dist_x > dist_y)
 		var/error = dist_x/2 - dist_y
-		while(!gc_destroyed && target &&((((x < target.x && dx == EAST) || (x > target.x && dx == WEST)) && get_dist_euclide(origin, src) < range) || isspaceturf(loc)) && throwing && istype(loc, /turf))
+		while(!gc_destroyed && target &&((((x < target.x && dx == EAST) || (x > target.x && dx == WEST)) && get_dist_euclidean(origin, src) < range) || isspaceturf(loc)) && throwing && istype(loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dy)
@@ -591,7 +591,7 @@
 					sleep(0.1 SECONDS)
 	else
 		var/error = dist_y/2 - dist_x
-		while(!gc_destroyed && target &&((((y < target.y && dy == NORTH) || (y > target.y && dy == SOUTH)) && get_dist_euclide(origin, src) < range) || isspaceturf(loc)) && throwing && istype(loc, /turf))
+		while(!gc_destroyed && target &&((((y < target.y && dy == NORTH) || (y > target.y && dy == SOUTH)) && get_dist_euclidean(origin, src) < range) || isspaceturf(loc)) && throwing && istype(loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dx)

--- a/code/game/objects/items/devices/minimap_tablet.dm
+++ b/code/game/objects/items/devices/minimap_tablet.dm
@@ -310,7 +310,7 @@ GLOBAL_PROTECT(roles_allowed_minimap_draw)
 		var/curr_dist
 		var/turf/nearest
 		for(var/turf/label AS in labelled_turfs)
-			var/dist = get_dist_euclide(label, target)
+			var/dist = get_dist_euclidean(label, target)
 			if(dist > LABEL_REMOVE_RANGE)
 				continue
 			if(!curr_dist || curr_dist > dist)

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -273,7 +273,7 @@
 	var/obj/projectile/shell = new /obj/projectile(loc)
 	var/datum/ammo/ammo = GLOB.ammo_list[arty_shell.ammo_type]
 	shell.generate_bullet(ammo)
-	var/shell_range = min(get_dist_euclide(src, target), ammo.max_range)
+	var/shell_range = min(get_dist_euclidean(src, target), ammo.max_range)
 	shell.fire_at(target, null, src, shell_range, ammo.shell_speed)
 
 	perform_firing_visuals()
@@ -375,7 +375,7 @@
 	location.ceiling_debris_check(2)
 	log_game("[key_name(user)] has fired the [src] at [AREACOORD(target)]")
 
-	var/max_offset = round(abs((get_dist_euclide(src,target)))/offset_per_turfs)
+	var/max_offset = round(abs((get_dist_euclidean(src,target)))/offset_per_turfs)
 	var/firing_spread = max_offset + spread
 	if(firing_spread > max_spread)
 		firing_spread = max_spread

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -230,7 +230,7 @@
 		if(!silent)
 			owner.balloon_alert(owner, "Dead")
 		return FALSE
-	if(get_dist_euclide_square(living_target, owner) > WARRIOR_LUNGE_RANGE * 5)
+	if(get_dist_euclidean_square(living_target, owner) > WARRIOR_LUNGE_RANGE * 5)
 		if(!silent)
 			owner.balloon_alert(owner, "Too far")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -258,16 +258,23 @@
 			go_idle()
 		return
 
-	var/i = 10//So if we have a pile of dead bodies around, it doesn't scan everything, just ten iterations.
-	for(var/mob/living/carbon/M in view(4,src))
-		if(!i)
-			break
-		if(M.can_be_facehugged(src))
-			visible_message(span_warning("\The scuttling [src] leaps at [M]!"), null, null, 4)
-			leaping = TRUE
-			throw_at(M, 4, 1)
-			return //We found a target and will jump towards it; cancel out. If we didn't find anything, continue and try again later
-		--i
+	var/mob/living/carbon/chosen_target
+
+	for(var/mob/living/carbon/M in view(4, src))
+		// Using euclidean distance means it will prioritize cardinal directions, which are less likely to miss due to wall jank.
+		if(chosen_target && (get_dist_euclidean(src, M) > get_dist_euclidean(src, chosen_target)))
+			continue
+
+		if(!M.can_be_facehugged(src))
+			continue
+
+		chosen_target = M
+
+	if(chosen_target)
+		visible_message(span_warning("\The scuttling [src] leaps at [M]!"), null, null, 4)
+		leaping = TRUE
+		throw_at(M, 4, 1)
+		return
 
 	remove_danger_overlay() //Remove the danger overlay
 	pre_leap() //Go into the universal leap set up proc

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -271,9 +271,9 @@
 		chosen_target = M
 
 	if(chosen_target)
-		visible_message(span_warning("\The scuttling [src] leaps at [M]!"), null, null, 4)
+		visible_message(span_warning("\The scuttling [src] leaps at [chosen_target]!"), null, null, 4)
 		leaping = TRUE
-		throw_at(M, 4, 1)
+		throw_at(chosen_target, 4, 1)
 		return
 
 	remove_danger_overlay() //Remove the danger overlay

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		CRASH("staggerstun called without a mob target")
 	if(!isliving(victim))
 		return
-	if(get_dist_euclide(proj.starting_turf, victim) > max_range)
+	if(get_dist_euclidean(proj.starting_turf, victim) > max_range)
 		return
 	var/impact_message = ""
 	if(isxeno(victim))


### PR DESCRIPTION

## About The Pull Request
Byond's `view()` proc does not return objects in outwards order. It uses a very weird "snake" like pattern, starting from the top-left turf. This means that `leap_at_nearest_target()` was not infact leaping at the nearest target.

Additionally, I made it use Euclidean distance so that it prefers cardinal movement over diagonal movement, because diagonal `throw_at()` fucks up when theres a wall along the diagonal move.

## Changelog
:cl:
fix: Facehuggers will now prioritize the nearest marine, preferring cardinal directions.
/:cl:
