### PR TITLE
style hats now mask hair

### DIFF
--- a/code/modules/clothing/modular_armor/style_line.dm
+++ b/code/modules/clothing/modular_armor/style_line.dm
@@ -116,6 +116,7 @@
 	icon_state = "beret_inhand"
 	item_state = "beret"
 	starting_attachments = list(/obj/item/armor_module/storage/helmet, /obj/item/armor_module/armor/stylehat_badge)
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 
 /obj/item/clothing/head/modular/style/classic_beret
@@ -124,18 +125,21 @@
 	icon_state = "classic_beret_inhand"
 	item_state = "classic_beret"
 	starting_attachments = list(/obj/item/armor_module/storage/helmet, /obj/item/armor_module/armor/stylehat_badge/classic)
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 /obj/item/clothing/head/modular/style/boonie
 	name = "TGMC boonie"
 	desc = "A boonie hat used by the TGMC, purpose made for operations in enviroments with a lot of sun, or dense vegetation."
 	icon_state = "boonie_inhand"
 	item_state = "boonie"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 /obj/item/clothing/head/modular/style/cap
 	name = "TGMC cap"
 	desc = "A common patrol cap used by the TGMC, stylish and comes in many colors. Mostly useful to keep the sun and officers away."
 	icon_state = "cap_inhand"
 	item_state = "cap"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 
 /obj/item/clothing/head/modular/style/slouchhat
@@ -143,6 +147,7 @@
 	desc = "A slouch hat, makes you feel down under, doesn't it? Has 'PROPERTY OF THE TGMC' markings under the hat."
 	icon_state = "slouch_inhand"
 	item_state = "slouch"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 /obj/item/clothing/head/modular/style/ushanka
 	name = "TGMC ushanka"
@@ -150,6 +155,7 @@
 	icon_state = "ushanka_inhand"
 	item_state = "ushanka"
 	starting_attachments = list(/obj/item/armor_module/storage/helmet, /obj/item/armor_module/armor/stylehat_badge/ushanka)
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 
 /obj/item/clothing/head/modular/style/campaignhat
@@ -157,6 +163,7 @@
 	desc = "A campaign hat, you can feel the menacing aura that this hat erodes just by looking at it."
 	icon_state = "campaign_inhand"
 	item_state = "campaign"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 
 /obj/item/clothing/head/modular/style/beanie
@@ -164,6 +171,7 @@
 	desc = "A beanie, just looking at it makes you feel like an 'Oussama', or in better terms- A modern phenomenon of people suddenly needing to bench once they put on a beanie."
 	icon_state = "beanie_inhand"
 	item_state = "beanie"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 /obj/item/clothing/head/modular/style/headband
 	name = "TGMC headband"
@@ -177,6 +185,7 @@
 	desc = "A bandana that goes on your head. Has TGMC markings on the back tie, and it seems that the knot will never come undone somehow."
 	icon_state = "headbandana_inhand"
 	item_state = "headbandana"
+	flags_inv_hide = HIDE_EXCESS_HAIR
 
 // style masks
 /obj/item/clothing/mask/gas/modular/skimask


### PR DESCRIPTION
## About The Pull Request

is it a fix? is it qol? we don't know
hairs now mask on style line hats where appropriate

everything but the headband has the flag `HIDE_EXCESS_HAIR` added, which is just a fancy way of saying that if you wear any of these hats, your hair won't clip to the sides or above around the hat. 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/c538710c-62e4-4257-92c1-1ea01ad04db3)


## Why It's Good For The Game
i think it looks really nice and makes the hats stand out more
here's how it is now
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/73fc68b8-3547-45c6-8bd9-69ac2bf85a85)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/29965103/e0388773-a5a8-452e-b813-5d01c318fdb0)

## Changelog
:cl:
qol: style hats now mask hairs behind them so they look like they're layered on your head properly
/:cl:
