### PR TITLE
Visible antigas

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -297,9 +297,9 @@
 ////////////////////////////////////
 
 /obj/effect/particle_effect/smoke/antigas
-	alpha = 25
+	alpha = 65
 	opacity = FALSE
-	color = "#030101"
+	color = "#1b1b1b"
 	smoke_traits = SMOKE_PURGER
 
 //////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
This shit is impossible to see right now. Between the various light sources and dark areas, would you even know there is anti gas here?
Current:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/f197cbbf-707c-4329-a5dc-586cb91c1dfd)


After:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/764a899b-76da-4a17-8233-a1f3c890f2a1)
## Why It's Good For The Game
Being able to see stuff is good.
## Changelog
:cl:
qol: Antigas smoke is more visible
/:cl:
