### PR TITLE
Fixes campaign mortar acid smoke

### DIFF
--- a/code/datums/fire_support.dm
+++ b/code/datums/fire_support.dm
@@ -391,7 +391,7 @@
 	icon_state = "acid_smoke_mortar"
 	initiate_chat_message = "COORDINATES CONFIRMED. MORTAR BARRAGE INCOMING."
 	initiate_screen_message = "Coordinates confirmed, acid smoke inbound!"
-	smoketype = /datum/effect_system/smoke_spread/xeno/acid
+	smoketype = /datum/effect_system/smoke_spread/xeno/acid/opaque
 	smokeradius = 5
 
 /datum/fire_support/mortar/smoke/satrapine


### PR DESCRIPTION

## About The Pull Request
Campaign acid smoke was supposed to be opaque like the rest of the HvH smokes (like the acid nade)
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: Campaign mortar acid smoke is opaque
/:cl:
