### PR TITLE
Fixes caste passive plasma regen limits not applying under certain circumstances

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -140,6 +140,8 @@
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod)
 
+	plasma_mod[1] = clamp(plasma_mod[1], 0, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit - plasma_stored)
+
 	gain_plasma(plasma_mod[1])
 
 /mob/living/carbon/xenomorph/can_receive_aura(aura_type, atom/source, datum/aura_bearer/bearer)


### PR DESCRIPTION

## About The Pull Request
Title.
#15167 broke a certain case where some xenomorphs that have a set plasma regen limit can regenerate past said limit if they do a specific thing.
This fixes that by clamping the actual plasma regeneration before applying it.
(Alternatively could be done by having another arg in the add_plasma proc that tells whether to respect the cap, but since the proc I'm adjusting is the only one that is for natural plasma regeneration this should be fine)
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: Certain xenomorphs can no longer regenerate past their plasma cap under specific circumstances.
/:cl:
