### PR TITLE
Arachne Vehicle Bay Expansion

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -90,6 +90,11 @@
 	},
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
+"ahs" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/firealarm,
+/turf/open/floor/mainship/orange,
+/area/mainship/living/tankerbunks)
 "ahx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -1366,7 +1371,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/tankerbunks)
 "bpK" = (
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -1851,7 +1859,9 @@
 /area/mainship/command/corporateliaison)
 "bKM" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/mainship/orange,
 /area/mainship/living/tankerbunks)
 "bLH" = (
 /obj/structure/window/reinforced{
@@ -2883,14 +2893,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/tankerbunks)
-"cHG" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "cIX" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -3935,7 +3937,10 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/tankerbunks)
 "dxv" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -3963,7 +3968,9 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/tankerbunks)
 "dyr" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -5906,6 +5913,16 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"fej" = (
+/obj/machinery/door/poddoor/mainship/mech{
+	name = "Vehicle Bay Shutters";
+	id = "vehicle_shutters"
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "feu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6213,7 +6230,9 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "ftG" = (
 /obj/machinery/cic_maptable/drawable/big{
@@ -6543,7 +6562,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "fHx" = (
 /obj/structure/cable,
@@ -6853,6 +6874,13 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"fUa" = (
+/obj/machinery/door/poddoor/mainship/mech{
+	name = "Vehicle Bay Shutters";
+	id = "vehicle_shutters"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "fUS" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7423,7 +7451,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange,
 /area/mainship/living/tankerbunks)
 "gvF" = (
 /turf/open/floor/mainship/black{
@@ -8779,11 +8807,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/mech,
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/mainship/mech{
+	name = "Vehicle Bay Shutters";
+	id = "vehicle_shutters"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "hBd" = (
@@ -8837,7 +8868,10 @@
 /obj/machinery/door_control/mainship/mech{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/orange/corner{
+	dir = 2
+	},
 /area/mainship/living/tankerbunks)
 "hDj" = (
 /obj/structure/cable,
@@ -9778,7 +9812,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/orange/corner{
+	dir = 4
+	},
 /area/mainship/living/tankerbunks)
 "irt" = (
 /obj/structure/cable,
@@ -9845,7 +9882,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "iuE" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -10197,7 +10236,9 @@
 	dir = 10
 	},
 /obj/structure/closet/firecloset,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange/corner{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "iIJ" = (
 /turf/open/floor/mainship/orange{
@@ -11504,11 +11545,14 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/machinery/power/apc/mainship{
+/obj/machinery/door_control/mainship/mech{
+	dir = 4;
+	name = "Vehicle Bay Shutter";
+	id = "vehicle_shutters"
+	},
+/turf/open/floor/mainship/orange/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "jKK" = (
 /turf/open/floor/mainship/floor,
@@ -12065,7 +12109,8 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/orange,
 /area/mainship/living/tankerbunks)
 "kmZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -13994,6 +14039,16 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"lGy" = (
+/obj/machinery/door_control/mainship/mech{
+	dir = 8;
+	name = "Vehicle Bay Shutter";
+	id = "vehicle_shutters"
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "lHe" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/corner{
@@ -14904,7 +14959,9 @@
 	dir = 9
 	},
 /obj/structure/closet/toolcloset,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange/corner{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "mvW" = (
 /turf/open/floor/mainship/silver{
@@ -15487,7 +15544,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "mUv" = (
 /obj/structure/closet/emcloset,
@@ -15527,6 +15586,17 @@
 "mXB" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/starboard_atmos)
+"mXC" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/orange,
+/area/mainship/living/tankerbunks)
 "mXH" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/lighter/zippo{
@@ -15686,6 +15756,17 @@
 /obj/machinery/marine_selector/clothes/synth,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engineering_workshop)
+"ndO" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/living/tankerbunks)
 "neB" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18278,7 +18359,9 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange/corner{
+	dir = 2
+	},
 /area/mainship/living/tankerbunks)
 "phY" = (
 /obj/structure/cable,
@@ -18522,7 +18605,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange/corner{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "ptU" = (
 /turf/open/floor/mainship/sterile/side,
@@ -18785,18 +18870,6 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
-"pFg" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door_control/mainship/mech{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "pGa" = (
 /obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /turf/open/floor/mainship/sterile/dark,
@@ -18961,7 +19034,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "pNg" = (
 /obj/machinery/holopad,
@@ -19470,13 +19545,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
-"qjY" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "qkF" = (
 /obj/machinery/chem_master,
 /turf/open/floor/mainship/sterile/side{
@@ -20316,7 +20384,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/tankerbunks)
 "qWn" = (
 /turf/open/floor/grass,
@@ -20342,7 +20412,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "qXD" = (
 /obj/machinery/light/mainship{
@@ -20539,7 +20611,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "rgl" = (
 /obj/structure/cable,
@@ -21745,7 +21819,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "sbO" = (
 /obj/structure/cable,
@@ -22202,6 +22278,20 @@
 /obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"suD" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/orange,
+/area/mainship/living/tankerbunks)
 "suO" = (
 /obj/machinery/door/airlock/mainship/command/CPToffice{
 	dir = 2
@@ -22224,7 +22314,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "svI" = (
 /obj/machinery/loadout_vendor,
@@ -23056,7 +23148,9 @@
 	dir = 1
 	},
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/tankerbunks)
 "ttg" = (
 /obj/machinery/camera/autoname/mainship{
@@ -23886,7 +23980,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange/corner{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "uhS" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -24221,11 +24317,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/firealarm{
+/turf/open/floor/mainship/orange{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "uwN" = (
 /obj/structure/cable,
@@ -25271,9 +25365,12 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "vnZ" = (
-/obj/machinery/door/poddoor/mainship/mech,
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/mainship/mech{
+	name = "Vehicle Bay Shutters";
+	id = "vehicle_shutters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
@@ -26924,7 +27021,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/tankerbunks)
 "wGu" = (
 /obj/machinery/crema_switch{
@@ -27435,7 +27534,7 @@
 "xgg" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange,
 /area/mainship/living/tankerbunks)
 "xgp" = (
 /obj/structure/cable,
@@ -37298,13 +37397,13 @@ kpw
 tys
 sWV
 uGv
-vSg
+tys
 tys
 aGN
 tys
 tys
+lGy
 lWW
-nHc
 eUr
 sdU
 uEz
@@ -37400,11 +37499,11 @@ nLY
 bMa
 eiz
 mrs
-eiz
+fUa
 vnZ
 hAQ
 vnZ
-eiz
+fej
 eiz
 mrs
 nnu
@@ -37499,13 +37598,13 @@ eiz
 hCq
 dxr
 bpv
-cHG
+qVG
 iro
 phV
-pFg
+qVG
 qVG
 dyl
-qjY
+uvX
 uvX
 jKk
 eOG
@@ -37705,7 +37804,7 @@ mmP
 bzN
 mmP
 svj
-kKd
+mXC
 iQF
 iQF
 iQF
@@ -37904,18 +38003,18 @@ oUe
 vtz
 fRR
 eiz
-bKM
+ahs
 kPm
 iQF
 iQF
 fHe
-vvS
+suD
 iQF
 iQF
 iQF
 iQF
 iQF
-sbi
+ndO
 eiz
 wIF
 wNT

--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -1260,7 +1260,7 @@
 "bnf" = (
 /obj/machinery/vending/cargo_supply,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/green{
 	dir = 2
 	},
@@ -1730,7 +1730,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bFc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/holopad,
 /turf/open/floor/plating/plating_catwalk,
@@ -1815,7 +1815,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/numbertwobunks)
 "bIO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/yjunc{
 	dir = 8
@@ -2263,7 +2263,7 @@
 "chN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
@@ -2585,7 +2585,7 @@
 "cuU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -2758,7 +2758,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_ert)
 "cAR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
@@ -4125,6 +4125,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "dDc" = (
@@ -4225,7 +4226,7 @@
 "dHM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
@@ -5407,7 +5408,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/mainship/red{
 	dir = 8
@@ -6050,7 +6051,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -6173,7 +6174,7 @@
 /area/mainship/medical/upper_medical)
 "foM" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
@@ -6506,7 +6507,7 @@
 "fFA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "fFS" = (
@@ -7152,7 +7153,7 @@
 /turf/closed/wall/mainship/research/containment/wall/purple,
 /area/mainship/medical/medical_science)
 "gjQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -8373,7 +8374,7 @@
 "hlj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
@@ -9109,6 +9110,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hNU" = (
@@ -9320,6 +9322,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "hYA" = (
@@ -9612,7 +9615,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -9986,7 +9989,7 @@
 "iyV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -10019,7 +10022,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/cmo_office)
 "izM" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10207,7 +10210,7 @@
 /area/mainship/command/corporateliaison)
 "iGR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -10358,7 +10361,7 @@
 /area/mainship/shipboard/weapon_room)
 "iNv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
@@ -10940,7 +10943,7 @@
 /area/mainship/living/numbertwobunks)
 "jlh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11695,7 +11698,7 @@
 /area/mainship/hull/starboard_hull)
 "jQw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12462,7 +12465,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/corner{
 	dir = 1
@@ -12639,7 +12642,7 @@
 /area/mainship/hallways/hangar)
 "kER" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
@@ -12759,7 +12762,7 @@
 /area/mainship/engineering/engineering_workshop)
 "kIx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -13159,7 +13162,7 @@
 /area/mainship/medical/chemistry)
 "kXK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13914,7 +13917,7 @@
 /obj/item/tool/taperoll/engineering,
 /obj/item/clothing/gloves/insulated,
 /obj/item/lightreplacer,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
@@ -14141,7 +14144,7 @@
 	},
 /area/mainship/hull/starboard_hull)
 "lNB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -14678,7 +14681,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
 "miU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/evacuation)
@@ -15445,7 +15448,7 @@
 /area/mainship/squads/req)
 "mPC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
@@ -15644,7 +15647,6 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -15960,7 +15962,7 @@
 "nmt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
 	},
@@ -16496,7 +16498,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "nJH" = (
@@ -17175,7 +17176,7 @@
 /area/mainship/hull/port_hull)
 "olm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
@@ -17530,17 +17531,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
-"ozH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/engineering/engineering_workshop)
 "ozU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18128,7 +18118,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "oZE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -18261,7 +18251,7 @@
 	},
 /area/mainship/command/airoom)
 "pdI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -18624,7 +18614,7 @@
 "put" = (
 /obj/structure/table/mainship/nometal,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -19704,7 +19694,7 @@
 /area/mainship/living/bridgebunks)
 "qpQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
@@ -21785,7 +21775,7 @@
 /turf/open/floor/wood,
 /area/mainship/hallways/port_ert)
 "sal" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -21817,6 +21807,9 @@
 /area/mainship/hull/starboard_hull)
 "sbi" = (
 /obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /turf/open/floor/mainship/orange{
@@ -23464,7 +23457,7 @@
 "tFh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -23507,7 +23500,7 @@
 /area/mainship/living/grunt_rnr)
 "tIN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -24268,7 +24261,6 @@
 /obj/machinery/door/firedoor{
 	dir = 1
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "uud" = (
@@ -24546,7 +24538,7 @@
 "uEC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
@@ -26812,7 +26804,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/starboard_atmos)
 "wzR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -26900,7 +26892,7 @@
 /area/mainship/shipboard/brig)
 "wCN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -27107,7 +27099,7 @@
 /area/mainship/living/cryo_cells)
 "wJE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/mainship/medical/medical_science)
@@ -27234,7 +27226,7 @@
 /area/mainship/medical/lower_medical)
 "wOQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27384,7 +27376,7 @@
 "wXK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
@@ -27478,7 +27470,7 @@
 "xen" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "xez" = (
@@ -27714,7 +27706,7 @@
 /area/mainship/medical/medical_science)
 "xop" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/side{
@@ -34059,7 +34051,7 @@ goY
 uEC
 kse
 eUB
-ozH
+eRd
 ukp
 owW
 mZd

--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -90,14 +90,6 @@
 	},
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
-"ahj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange/corner{
-	dir = 8
-	},
-/area/mainship/living/pilotbunks)
 "ahx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -288,15 +280,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/upper_engine_monitoring)
-"aoX" = (
-/obj/machinery/vending/nanomed{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "apm" = (
 /obj/structure/prop/mainship/ship_memorial,
 /turf/open/floor/grass,
@@ -330,10 +313,15 @@
 "aqt" = (
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"aro" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
+"arc" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/living/pilotbunks)
 "arw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/firealarm,
@@ -747,11 +735,6 @@
 	dir = 5
 	},
 /area/mainship/hallways/starboard_ert)
-"aKV" = (
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "aLj" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
@@ -1096,7 +1079,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "beT" = (
@@ -1138,12 +1123,14 @@
 	},
 /area/mainship/living/grunt_rnr)
 "bfZ" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/orange/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/area/mainship/hallways/hangar/flight_control)
+/turf/open/floor/mainship/black,
+/area/mainship/living/pilotbunks)
 "bgn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1370,9 +1357,17 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "bpv" = (
-/obj/structure/table/mainship/nometal,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/tankerbunks)
 "bpK" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1726,14 +1721,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
-"bFa" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "bFc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -1769,7 +1756,7 @@
 "bGJ" = (
 /obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/orange{
-	dir = 4
+	dir = 6
 	},
 /area/mainship/hallways/hangar)
 "bHp" = (
@@ -1863,14 +1850,9 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "bKM" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "bLH" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1890,14 +1872,10 @@
 /turf/open/floor/mainship/black,
 /area/mainship/hallways/port_hallway)
 "bMa" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
-	},
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/obj/machinery/door/poddoor/shutters/mainship/open/hangar,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/flight_control)
+/obj/machinery/door/poddoor/mainship/mech,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "bMC" = (
 /obj/machinery/vending/uniform_supply,
 /obj/machinery/camera/autoname/mainship{
@@ -2197,19 +2175,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"cef" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar/flight_control)
 "cek" = (
 /obj/effect/turf_decal/warning_stripes/box/small,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -2350,15 +2315,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/starboard_atmos)
-"ckG" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
-	dir = 1
-	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "ckM" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -2726,14 +2682,18 @@
 	},
 /area/mainship/living/commandbunks)
 "cza" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/ai_node,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/orange{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
 	dir = 8
 	},
 /area/mainship/living/pilotbunks)
@@ -2915,11 +2875,23 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/chief_mp_office)
+"cGW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "cHG" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/security/marinemainship_network,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/tankerbunks)
 "cIX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -2946,16 +2918,6 @@
 "cJw" = (
 /turf/open/floor/mainship/silver,
 /area/mainship/hallways/port_ert)
-"cKm" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "cKw" = (
 /obj/structure/mirror,
 /obj/structure/sink,
@@ -3086,11 +3048,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/upper_medical)
-"cPM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/black,
-/area/mainship/hallways/hangar)
 "cPU" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/structure/cable,
@@ -3339,20 +3296,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
-"cWw" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
-"cWK" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/living/pilotbunks)
 "cWN" = (
 /obj/machinery/door/window/secure/bridge{
 	dir = 8
@@ -3989,25 +3932,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "dxr" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/door_control/old/cic/hangar_shutters{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/machinery/door_control/old{
-	id = "ammo1";
-	name = "Dropship Armament Storage";
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/machinery/door_control/old{
-	id = "ammo2";
-	name = "Dropship Ammo Storage";
-	pixel_x = 8;
-	pixel_y = -4
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/tankerbunks)
 "dxv" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -4024,15 +3953,16 @@
 /turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
 "dyl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "dyr" = (
@@ -4041,6 +3971,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/starboard_atmos)
+"dyw" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "dzr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4179,6 +4123,21 @@
 "dDc" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
+"dDu" = (
+/obj/structure/window/framed/mainship,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "dDO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4199,10 +4158,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
-"dEY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "dGb" = (
 /turf/open/floor/plating,
 /area/mainship/medical/upper_medical)
@@ -5050,14 +5005,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
-"esT" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/living/pilotbunks)
 "esW" = (
 /obj/structure/closet/crate/ammo,
 /turf/open/floor/plating,
@@ -5067,6 +5014,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"etD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "etL" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
@@ -5509,12 +5463,6 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
-"eMA" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "eNb" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/sterile/side,
@@ -5774,10 +5722,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/hallways/port_ert)
 "eVP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
 "eWn" = (
@@ -5856,10 +5806,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/starboard_atmos)
 "eYK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/mainship/orange{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/black{
 	dir = 1
 	},
 /area/mainship/living/pilotbunks)
@@ -6084,6 +6035,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "fjj" = (
@@ -6202,14 +6154,6 @@
 	},
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
-"for" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "foM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
@@ -6268,12 +6212,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "ftG" = (
@@ -6481,14 +6420,20 @@
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
 "fBI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/orange{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/black{
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
@@ -6591,6 +6536,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
+"fHe" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "fHx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -6603,12 +6557,6 @@
 	dir = 6
 	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
-"fHP" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
 /area/mainship/hallways/hangar)
 "fIp" = (
 /obj/structure/table/mainship/nometal,
@@ -6697,10 +6645,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"fKK" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/orange/corner,
-/area/mainship/living/pilotbunks)
 "fLd" = (
 /obj/effect/spawner/random/misc/paperbin{
 	pixel_x = 7;
@@ -6998,12 +6942,10 @@
 	},
 /area/mainship/hallways/hangar)
 "fZg" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/emails{
-	pixel_y = 5
+/turf/open/floor/mainship/black/corner{
+	dir = 8
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/pilotbunks)
 "fZl" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/floor,
@@ -7066,12 +7008,6 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
-"gdx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "gdD" = (
 /obj/machinery/computer/security/marinemainship{
 	dir = 8;
@@ -7082,13 +7018,6 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
-"gdS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction/flipped{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "gdV" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/structure/cable,
@@ -7319,14 +7248,10 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/command/airoom)
 "gpD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/firealarm{
+/obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/orange{
+/turf/open/floor/mainship/black{
 	dir = 8
 	},
 /area/mainship/living/pilotbunks)
@@ -7493,10 +7418,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
 "gvu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/closet/emcloset,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "gvF" = (
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -8149,8 +8077,10 @@
 /area/mainship/shipboard/brig)
 "gXF" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/living/pilotbunks)
 "gYt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8279,14 +8209,6 @@
 	dir = 8
 	},
 /area/mainship/living/grunt_rnr)
-"heV" = (
-/obj/structure/window/framed/mainship,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/pilotbunks)
 "hfg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8339,14 +8261,6 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"hgl" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar/flight_control)
 "hgr" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/squad_changer,
@@ -8515,7 +8429,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "hnH" = (
-/turf/open/floor/mainship/orange/corner{
+/turf/open/floor/mainship/black/corner{
 	dir = 1
 	},
 /area/mainship/living/pilotbunks)
@@ -8869,6 +8783,7 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "hBd" = (
@@ -8916,10 +8831,14 @@
 	},
 /area/mainship/hallways/port_ert)
 "hCq" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/door_control/mainship/mech{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/tankerbunks)
 "hDj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -8989,7 +8908,7 @@
 "hER" = (
 /obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/mainship/orange{
-	dir = 8
+	dir = 10
 	},
 /area/mainship/hallways/hangar)
 "hEZ" = (
@@ -9079,14 +8998,6 @@
 "hIO" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
-"hIQ" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/megaphone,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/orange/corner{
-	dir = 4
-	},
-/area/mainship/hallways/hangar/flight_control)
 "hJf" = (
 /obj/machinery/door/airlock/mainship/generic/glass{
 	dir = 8
@@ -9765,14 +9676,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/upper_engine_monitoring)
-"inL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "inM" = (
 /obj/machinery/door/airlock/multi_tile/mainship/comdoor{
 	dir = 8
@@ -9866,8 +9769,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iro" = (
-/turf/closed/wall/mainship,
-/area/mainship/hallways/hangar/flight_control)
+/obj/structure/rack,
+/obj/item/tool/crowbar,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "irt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9927,17 +9839,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/telecomms)
 "iua" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
 	},
-/obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "iuE" = (
@@ -9953,10 +9860,6 @@
 	dir = 6
 	},
 /area/mainship/shipboard/firing_range)
-"iva" = (
-/obj/machinery/holopad,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "ivy" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
@@ -10133,11 +10036,7 @@
 	},
 /area/mainship/medical/upper_medical)
 "iCP" = (
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
+/turf/open/floor/mainship/black{
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
@@ -10294,8 +10193,12 @@
 	},
 /area/mainship/hallways/port_ert)
 "iHE" = (
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "iIJ" = (
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -10556,12 +10459,6 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
-"iRF" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/cable,
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "iSa" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating/plating_catwalk,
@@ -10932,13 +10829,6 @@
 /obj/structure/morgue,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/morgue)
-"jiF" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
-	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/hangar)
 "jiL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10962,6 +10852,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"jja" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "jjn" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
@@ -11436,12 +11332,20 @@
 "jCa" = (
 /turf/open/floor/mainship/red,
 /area/mainship/command/cic)
-"jCj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction/flipped,
-/turf/open/floor/mainship/orange,
-/area/mainship/living/pilotbunks)
+"jDg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "jDI" = (
 /obj/structure/barricade/metal{
 	dir = 1
@@ -11597,19 +11501,13 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/port_hallway)
 "jKk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/power/apc/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "jKK" = (
@@ -11941,9 +11839,7 @@
 /area/mainship/command/corporateliaison)
 "jZO" = (
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -12165,12 +12061,12 @@
 	},
 /area/mainship/hallways/hangar)
 "kmn" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/phone,
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/orange/corner,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "kmZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating/plating_catwalk,
@@ -12798,16 +12694,6 @@
 /obj/structure/curtain/open/shower,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/medical_science)
-"kHL" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/pilotbunks)
 "kIg" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship/black{
@@ -12850,18 +12736,16 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
-"kJT" = (
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "kKd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/tankerbunks)
 "kKF" = (
 /obj/structure/window/framed/mainship,
@@ -13041,14 +12925,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kPm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/mainship/living/tankerbunks)
 "kPp" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -13571,10 +13450,6 @@
 	},
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
-"lmo" = (
-/obj/effect/soundplayer,
-/turf/closed/wall/mainship,
-/area/mainship/hallways/hangar/flight_control)
 "lmX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13878,10 +13753,6 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"lyb" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "lym" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -13988,6 +13859,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/black/corner{
 	dir = 4
 	},
@@ -14220,13 +14092,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "lNL" = (
-/obj/machinery/door/airlock/mainship/generic/mech_pilot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/door/airlock/mainship/generic/pilot/quarters,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
@@ -14817,18 +14683,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"mkw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/living/pilotbunks)
 "mkO" = (
 /obj/structure/bed/chair/sofa{
 	dir = 1
@@ -15045,6 +14899,13 @@
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"mvD" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "mvW" = (
 /turf/open/floor/mainship/silver{
 	dir = 5
@@ -15484,14 +15345,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
-"mNP" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/mainship/mech,
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/tankerbunks)
 "mOa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15538,7 +15391,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "mPK" = (
@@ -15548,6 +15400,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
+"mPT" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/hangar)
 "mQp" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -15619,6 +15483,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
@@ -15864,6 +15731,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"nfy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "nfH" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/camera/autoname/mainship,
@@ -16013,12 +15890,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hull/port_hull)
-"nmW" = (
-/obj/machinery/vending/marineFood,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "nnc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -16291,18 +16162,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
-"nyG" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
-	dir = 2
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "nyM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16419,16 +16284,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"nDU" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "nEI" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -16637,13 +16492,16 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/morgue)
 "nLY" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/open/hangar,
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
+/obj/machinery/door/poddoor/mainship/mech,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/flight_control)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "nME" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -16812,23 +16670,9 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"nSL" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/power/monitor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "nSM" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engine_core)
-"nSU" = (
-/obj/machinery/door/airlock/mainship/generic/mech_pilot,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "nTa" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/reagentgrinder,
@@ -16873,21 +16717,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"nTZ" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
-	dir = 2
-	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
 "nUb" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
@@ -16928,6 +16757,16 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/upper_medical)
+"nWn" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "nWx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17008,9 +16847,6 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
 	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "nZH" = (
@@ -17031,9 +16867,6 @@
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
-"oaN" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "oaU" = (
 /obj/machinery/marine_selector/clothes/engi,
 /turf/open/floor/mainship/black{
@@ -17422,11 +17255,7 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "osB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange/corner{
+/turf/open/floor/mainship/black/corner{
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
@@ -17739,12 +17568,6 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
-"oCX" = (
-/obj/effect/decal/cleanable/blood/oil/streak{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "oDl" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -17939,6 +17762,17 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
+"oLd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "oLL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18385,13 +18219,6 @@
 	dir = 4
 	},
 /area/mainship/medical/upper_medical)
-"pfr" = (
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
-"pfx" = (
-/obj/effect/decal/cleanable/blood/gibs/robot,
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "pfy" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -18432,14 +18259,24 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "phV" = (
-/obj/structure/cable,
 /obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -5;
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 8
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
@@ -18672,26 +18509,18 @@
 /turf/closed/wall/mainship,
 /area/mainship/hull/starboard_hull)
 "ptK" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/closet/firecloset/full,
-/obj/machinery/light/mainship{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/tankerbunks)
 "ptL" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
@@ -18951,25 +18780,21 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/medical/upper_medical)
-"pEn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/pilotbunks)
 "pES" = (
 /obj/machinery/vending/armor_supply,
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "pFg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
 /obj/machinery/door_control/mainship/mech{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "pGa" = (
@@ -19129,11 +18954,13 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/vending/tool,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "pNg" = (
@@ -19567,13 +19394,13 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
 "qeB" = (
-/obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/shutters/mainship/open/hangar,
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
 	},
+/obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/area/mainship/living/pilotbunks)
 "qfD" = (
 /obj/structure/bed/chair/nometal,
 /obj/machinery/light/mainship{
@@ -19630,6 +19457,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "qjP" = (
@@ -19640,11 +19471,10 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "qjY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "qkF" = (
@@ -19970,12 +19800,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/starboard_atmos)
-"qyy" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "qyM" = (
 /obj/machinery/griddle,
 /obj/structure/disposalpipe/segment{
@@ -20152,25 +19976,14 @@
 /turf/open/floor/wood,
 /area/mainship/hallways/starboard_ert)
 "qIa" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
-	dir = 2
-	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/flight_control)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/mainship,
+/area/mainship/living/tankerbunks)
 "qIr" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/atmos_alert,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
+/turf/open/floor/mainship/black/corner,
+/area/mainship/living/pilotbunks)
 "qIC" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship/floor,
@@ -20380,15 +20193,6 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
-"qRL" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar/flight_control)
 "qRZ" = (
 /obj/machinery/door/airlock/mainship/research/glass/wing{
 	dir = 2
@@ -20415,15 +20219,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"qSV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/orange/corner{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "qTP" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -20515,10 +20310,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "qVG" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "qWn" = (
@@ -20545,8 +20342,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "qXD" = (
@@ -20661,12 +20456,6 @@
 	dir = 6
 	},
 /area/mainship/hallways/hangar/droppod)
-"rcX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
 "rdC" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/crew,
@@ -20737,11 +20526,19 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/effect/ai_node,
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "rgl" = (
@@ -20828,7 +20625,7 @@
 	amount = 25
 	},
 /turf/open/floor/mainship/orange{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/hallways/hangar)
 "rif" = (
@@ -20878,14 +20675,13 @@
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
 "rjM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/ai_node,
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -7
 	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
+/turf/open/floor/plating,
+/area/mainship/living/tankerbunks)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -21241,12 +21037,13 @@
 /area/mainship/engineering/upper_engine_monitoring)
 "rzu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
 "rAj" = (
@@ -21822,8 +21619,9 @@
 	},
 /area/mainship/medical/upper_medical)
 "rXs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
@@ -21944,19 +21742,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "sbi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /turf/open/floor/mainship/floor,
@@ -22040,7 +21826,7 @@
 /turf/open/floor/plating,
 /area/mainship/command/airoom)
 "sfd" = (
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -22265,6 +22051,13 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"smQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "snb" = (
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship/black{
@@ -22424,6 +22217,15 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/commandbunks)
+"svj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "svI" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/sterile/purple,
@@ -22640,13 +22442,14 @@
 	},
 /area/mainship/hallways/hangar)
 "sIO" = (
-/obj/structure/window/framed/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/cable,
+/obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "sIR" = (
@@ -22850,6 +22653,7 @@
 "sUB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -23182,8 +22986,6 @@
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
 "tqd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -23234,13 +23036,6 @@
 	dir = 1
 	},
 /area/mainship/living/evacuation)
-"trQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "tsI" = (
 /obj/machinery/door/poddoor/mainship/ammo{
 	dir = 2;
@@ -23257,18 +23052,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
 "tsS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "ttg" = (
@@ -23811,21 +23598,6 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
-"tRk" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "tRx" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/chem_dispenser/beer{
@@ -23949,6 +23721,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -24099,8 +23874,18 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
 	},
-/obj/machinery/vending/engivend,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "uhS" = (
@@ -24372,25 +24157,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/medical/upper_medical)
-"usx" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -7
-	},
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "usI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
-"utM" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "uub" = (
 /obj/machinery/door/airlock/mainship/research{
 	dir = 2
@@ -24446,14 +24218,13 @@
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
 "uvX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/firealarm{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
 "uwN" = (
@@ -25208,12 +24979,6 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig_cells)
-"vcI" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "vdi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/corner{
@@ -25697,13 +25462,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vvS" = (
-/obj/structure/rack,
-/obj/item/tool/crowbar,
-/obj/effect/spawner/random/engineering/toolbox,
-/obj/item/stack/cable_coil,
 /obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/tankerbunks)
 "vwt" = (
 /obj/structure/rack,
@@ -26089,9 +25859,14 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "vMS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flipped,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
 "vNz" = (
@@ -26961,16 +26736,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/port_ert)
-"wAA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
 "wAE" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -27152,15 +26917,15 @@
 	},
 /area/mainship/command/cic)
 "wGl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/flight_control)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "wGu" = (
 /obj/machinery/crema_switch{
 	id = 2;
@@ -27454,15 +27219,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_ert)
-"wTx" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/flight_control)
 "wTK" = (
 /obj/machinery/bot/roomba,
 /turf/open/floor/mainship/red{
@@ -27613,7 +27369,7 @@
 "xdD" = (
 /obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/orange{
-	dir = 8
+	dir = 9
 	},
 /area/mainship/hallways/hangar)
 "xem" = (
@@ -27677,9 +27433,10 @@
 	},
 /area/mainship/squads/general)
 "xgg" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/orange,
-/area/mainship/hallways/hangar/flight_control)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "xgp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -28003,12 +27760,6 @@
 "xwJ" = (
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"xwR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
 "xwV" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -28118,14 +27869,6 @@
 /obj/machinery/self_destruct/console,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"xCm" = (
-/obj/structure/window/framed/mainship,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
 "xCr" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -28401,12 +28144,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"xOi" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/living/pilotbunks)
 "xOn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -28933,6 +28670,19 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
+"ylE" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/window/framed/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/pilotbunks)
 "ylH" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -34487,7 +34237,7 @@ sMT
 yeb
 kMa
 xop
-nNN
+smQ
 tqM
 nNN
 cSO
@@ -37048,7 +36798,7 @@ cpj
 cpj
 cpj
 cpj
-cpj
+jja
 cpj
 fEb
 xlZ
@@ -37442,14 +37192,14 @@ ixI
 ixI
 ixI
 ixI
-ixI
+aib
 ixI
 ffD
 ixI
 ixI
 ixI
-aib
-ixI
+nfy
+etD
 ixI
 nDC
 oJJ
@@ -37542,17 +37292,17 @@ oUe
 vtz
 qEX
 nHc
-uGv
-tys
-tys
-tys
-sWV
-cWw
 vSg
-fHP
+tys
 kpw
 tys
+sWV
 uGv
+vSg
+tys
+aGN
+tys
+tys
 lWW
 nHc
 eUr
@@ -37642,16 +37392,16 @@ poV
 ssO
 cVV
 xPo
-jiF
-lmo
-nLY
-nLY
+cVV
+mrs
+eiz
+bMa
 nLY
 bMa
-iro
 eiz
 mrs
-mNP
+eiz
+vnZ
 hAQ
 vnZ
 eiz
@@ -37745,7 +37495,7 @@ hIO
 hFf
 vtz
 kEL
-iro
+eiz
 hCq
 dxr
 bpv
@@ -37847,16 +37597,16 @@ orq
 oUe
 vtz
 van
-iro
+eiz
 kmn
-hgl
-hgl
-hIQ
-iro
+iQF
+iQF
+iQF
+nWn
 kKd
 iQF
 iQF
-xwR
+iQF
 iQF
 iQF
 tsS
@@ -37949,16 +37699,16 @@ orq
 oUe
 vtz
 dBe
-iro
+eiz
 bKM
-vcI
-iva
-eMA
-iro
-kJT
-usx
+mmP
+bzN
+mmP
+svj
+kKd
 iQF
-oCX
+iQF
+iQF
 iQF
 iQF
 sbi
@@ -38051,22 +37801,22 @@ orq
 oUe
 vtz
 fRR
-nyG
+eiz
 xgg
-gdx
-oaN
-wTx
-iro
+rOU
+iQF
+rOU
+dyw
 ptK
 iQF
-mmP
 iQF
-mmP
-dEY
+iQF
+iQF
+iQF
 iua
 tqd
-trQ
-wOQ
+nnu
+kDg
 pnh
 eQh
 jLZ
@@ -38151,21 +37901,21 @@ mQp
 mQp
 weJ
 oUe
-xqh
-vjQ
-nTZ
-rcX
+vtz
+fRR
+eiz
+bKM
 kPm
-wAA
-nmW
-iro
+iQF
+iQF
+fHe
 vvS
 iQF
-rOU
 iQF
-rOU
-bzN
-tRk
+iQF
+iQF
+iQF
+sbi
 eiz
 wIF
 wNT
@@ -38254,20 +38004,20 @@ hul
 tsI
 bca
 beP
-cPM
-nyG
+fRR
+eiz
 gvu
-gdS
-inL
+iQF
+iQF
 rjM
-iro
-iRF
+cGW
+vvS
 iQF
-bFa
-pfx
-aro
 iQF
-tRk
+iQF
+iQF
+iQF
+tsS
 eOG
 dNX
 kDg
@@ -38355,14 +38105,14 @@ nPa
 nPa
 igO
 oUe
-wXN
+jDg
 fRR
 qIa
 iHE
-gdx
+qXu
 wGl
-aoX
-iro
+qXu
+mvD
 ugZ
 pNb
 mUj
@@ -38457,21 +38207,21 @@ pef
 sIN
 orq
 oUe
-vtz
-fRR
-nyG
-iHE
-gdx
-wGl
-aKV
-lmo
-pya
-pya
-nSU
+khM
+kEL
 eiz
+pya
 lNL
 pya
-xCm
+lNL
+pya
+pya
+pya
+lNL
+dDu
+lNL
+pya
+pya
 mrs
 nnu
 kDg
@@ -38559,23 +38309,23 @@ geW
 fZU
 orq
 oUe
-vtz
+khM
 fRR
-iro
+cGx
 qIr
-nSL
-wGl
-utM
-cKm
-fKK
 iCP
-cWK
+fhU
+iCP
+iCP
+fhU
+iCP
+iCP
 fBI
-mkw
+iCP
 iCP
 osB
-kHL
-qyy
+cGx
+dNX
 kDg
 pnh
 eQh
@@ -38661,23 +38411,23 @@ sIT
 gis
 orq
 oUe
-vtz
-van
-iro
+oLd
+mPT
+ylE
 bfZ
-qRL
-cef
-qSV
-nDU
-jCj
-pEn
+eVP
+eVP
+eVP
+eVP
+eVP
+eVP
 eVP
 rzu
 vMS
 rXs
 eYK
 sIO
-for
+qSb
 hlj
 pnh
 eQh
@@ -38763,20 +38513,20 @@ mQp
 qUh
 hIO
 hFf
-vtz
-kEL
-iro
+wXN
+fRR
+cGx
 fZg
-lyb
-pfr
+ggB
+ggB
 gXF
-ckG
-ahj
-esT
-xOi
+gpD
+ggB
+ggB
+ggB
 gpD
 cza
-esT
+ggB
 hnH
 cGx
 dNX
@@ -38867,13 +38617,13 @@ ssO
 cVV
 xPo
 cVV
-lmo
+lXb
 qeB
 qeB
 qeB
 qeB
-lmo
-heV
+lXb
+cBC
 cBC
 vXt
 xMD
@@ -38976,7 +38726,7 @@ tEM
 psG
 xMD
 jZO
-fhU
+arc
 sfd
 lCp
 qjy


### PR DESCRIPTION
## About The Pull Request

Expands the Arachne mech bay to allow for the incoming vehicle additions.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66712007/24ba1ae3-f08d-45d2-a1bb-139e53b6ff64)

## Why It's Good For The Game

Update compatibility, good!

## Changelog

:cl:
add: Expanded the Arachne vehicle bay.
del: Removed the Arachne flight control station, to make room for the vehicle bay.
/:cl: