### PR TITLE
Fixes some factory oopsies nobody has bothered to fix

### DIFF
--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -303,13 +303,13 @@
 /obj/item/factory_refill/railgun_hvap_magazine_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/railgun_magazine
+	refill_type = /obj/item/factory_part/railgun_hvap_magazine
 	refill_amount = 20
 
 /obj/item/factory_refill/railgun_smart_magazine_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/railgun_magazine
+	refill_type = /obj/item/factory_part/railgun_smart_magazine
 	refill_amount = 20
 
 /obj/item/factory_refill/minigun_powerpack_refill
@@ -317,12 +317,6 @@
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/minigun_powerpack
 	refill_amount = 10
-
-/obj/item/factory_refill/sniper_flak_magazine_refill
-	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Unboxers."
-	refill_type = /obj/item/factory_part/sniper_flak_magazine
-	refill_amount = 20
 
 /obj/item/factory_refill/sniper_flak_magazine_refill
 	name = "box of rounded metal plates"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2218,12 +2218,12 @@ FACTORY
 
 /datum/supply_packs/factory/railgun_hvap_magazine_refill
 	name = "Railgun HVAP magazine assembly refill"
-	contains = list(/obj/item/factory_refill/railgun_magazine_refill)
+	contains = list(/obj/item/factory_refill/railgun_hvap_magazine_refill)
 	cost = 200
 
 /datum/supply_packs/factory/railgun_smart_magazine_refill
 	name = "Railgun magazine assembly refill"
-	contains = list(/obj/item/factory_refill/railgun_magazine_refill)
+	contains = list(/obj/item/factory_refill/railgun_smart_magazine_refill)
 	cost = 200
 
 /datum/supply_packs/factory/minigun_powerpack_refill
@@ -2237,17 +2237,17 @@ FACTORY
 	cost = 600
 
 /datum/supply_packs/factory/amr_magazine_refill
-	name = "T-26 AMR magazine assembly refill"
+	name = "T-26 AMR standard magazine assembly refill"
 	contains = list(/obj/item/factory_refill/amr_magazine_refill)
 	cost = 400
 
 /datum/supply_packs/factory/amr_magazine_incend_refill
-	name = "T-26 AMR magazine assembly refill"
+	name = "T-26 AMR incendiary magazine assembly refill"
 	contains = list(/obj/item/factory_refill/amr_magazine_incend_refill)
 	cost = 400
 
 /datum/supply_packs/factory/amr_magazine_flak_refill
-	name = "T-26 AMR magazine assembly refill"
+	name = "T-26 AMR flak magazine assembly refill"
 	contains = list(/obj/item/factory_refill/amr_magazine_flak_refill)
 	cost = 400
 


### PR DESCRIPTION

## About The Pull Request
All AMR magazine refills were called the same in req, despite giving you one of three seperate mags. This corrects the supply pack names.
Additionally, railgun factory parts said they gave you different ammo types, but all three of them just gave you standard refills. They now actually give you the correct ammo types.
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: Railgun factory parts now give you their respective ammunition types instead of only standard canisters.
spellcheck: AMR factory parts now can be differentiated by name as opposed to by feeling.
/:cl:
