### PR TITLE
Jungle walls spawn weedable grass when hit with a devastating explosion

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -191,7 +191,7 @@
 /turf/closed/gm/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			ChangeTurf(/turf/open/ground/grass)
+			ChangeTurf(/turf/open/ground/grass/weedable)
 
 /turf/closed/gm/dense
 	name = "dense jungle wall"


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. (Wish I could just add a map edit tag manually.)
## Why It's Good For The Game
The maps left with jungle walls (jungle outpost, slumbridge and lawanka) all use weedable grass. It is weird that these do not either given they are used on all those maps as well.
## Changelog
:cl:
code: Jungle walls spawn weedable grass when hit with a devastating explosion
/:cl:
