### PR TITLE
Campaign tower fix

### DIFF
--- a/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
+++ b/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
@@ -6491,10 +6491,6 @@
 	},
 /turf/open/floor/mainship/sterile/purple,
 /area/patricks_rest/surface/building/science)
-"Eq" = (
-/obj/effect/landmark/campaign_structure/sensor_tower,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/patricks_rest/ground/colonys)
 "Er" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23730,7 +23726,7 @@ Lr
 VG
 VG
 UR
-Eq
+wz
 tz
 Km
 Km

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -3446,6 +3446,10 @@
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/dorms)
+"rD" = (
+/obj/effect/landmark/campaign_structure/sensor_tower,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outposts)
 "rE" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -4310,6 +4314,7 @@
 /area/orion_outpost/ground/outpostsw)
 "vX" = (
 /obj/effect/landmark/sensor_tower,
+/obj/effect/landmark/campaign_structure/sensor_tower,
 /turf/open/floor/mainship/terragov{
 	dir = 1
 	},
@@ -7396,6 +7401,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"Me" = (
+/obj/effect/landmark/campaign_structure/sensor_tower,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostse)
 "Mf" = (
 /turf/closed/mineral/smooth,
 /area/orion_outpost/ground/outpostw)
@@ -9274,6 +9283,10 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/brig)
+"VD" = (
+/obj/effect/landmark/campaign_structure/sensor_tower,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/cargo)
 "VE" = (
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/nebuilding)
@@ -9865,6 +9878,7 @@
 /area/orion_outpost/surface/building/vehicledepot)
 "YG" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/campaign_structure/sensor_tower,
 /turf/open/floor/mainship/terragov{
 	dir = 1
 	},
@@ -18270,7 +18284,7 @@ Qp
 Qp
 Qp
 DU
-DU
+rD
 Qp
 Du
 Gp
@@ -20982,7 +20996,7 @@ Qw
 pW
 pW
 pW
-Qw
+VD
 Qw
 Qw
 pW
@@ -22517,7 +22531,7 @@ yu
 Nk
 Nk
 cT
-Nk
+Me
 Nk
 hP
 Tm

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		/datum/campaign_mission/destroy_mission/base_rescue = 12,
 	),
 	FACTION_SOM = list(
-		/datum/campaign_mission/tdm/lv624 = 10,
+		/datum/campaign_mission/tdm/orion = 10,
 		/datum/campaign_mission/destroy_mission/fire_support_raid/som = 15,
 		/datum/campaign_mission/tdm/mech_wars/som = 12,
 		/datum/campaign_mission/destroy_mission/supply_raid/som = 15,

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -215,7 +215,7 @@
 	map_text_broadcast(losing_team, "[objective] was activated by the enemy. Get it offline!", "Activation cancelled")
 
 ///test missions
-/datum/campaign_mission/tdm/lv624
+/datum/campaign_mission/tdm/orion
 	name = "Combat patrol 2"
 	map_name = "Orion Outpost"
 	map_file = '_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm'

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -436,7 +436,7 @@
 /obj/effect/landmark/sensor_tower
 	name = "Sensor tower"
 	icon = 'icons/obj/structures/sensor.dmi'
-	icon_state = "sensor_loyalist"
+	icon_state = "sensor"
 
 /obj/effect/landmark/sensor_tower/Initialize(mapload)
 	..()

--- a/code/game/objects/structures/campaign_structures/capture_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/capture_objectives.dm
@@ -139,7 +139,7 @@
 	icon_state = "sensor"
 	mission_types = list(
 		/datum/campaign_mission/tdm,
-		/datum/campaign_mission/tdm/lv624,
+		/datum/campaign_mission/tdm/orion,
 		/datum/campaign_mission/tdm/first_mission,
 		/datum/campaign_mission/tdm/mech_wars,
 		/datum/campaign_mission/tdm/mech_wars/som,


### PR DESCRIPTION

## About The Pull Request
Fixed combat patrol on Orion not having sensor tower landmarks.
Fixed Patrick's Rest having 2 towers on the south side.
## Why It's Good For The Game
Fixes.
## Changelog
:cl:
fix: Campaign: Fixed an issue with towers on Orion Outpost and Patrick's Rest
/:cl:
