### PR TITLE
Supply raid objective tweak

### DIFF
--- a/code/datums/gamemodes/campaign/missions/supply_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/supply_raid.dm
@@ -87,5 +87,5 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_levels = list(225, 150, 100, 75)
 	objectives_total = 8
-	min_destruction_amount = 5
+	min_destruction_amount = 6
 	hostile_faction_additional_rewards = "Prevent the degradation of our attrition generation. B18 power armour available if you successfully protect this depot."


### PR DESCRIPTION

## About The Pull Request
Adjusted the SOM supply raid mission so SOM have to destroy 6 objectives instead of 5 for a minor victory.
## Why It's Good For The Game
More in line with the Marine mission, where you have to destroy 4/6 objectives to win
## Changelog
:cl:
balance: Campaign: SOM have to destroy 6 objectives to win on Supply Raid
/:cl:
