### PR TITLE
Campaign game timer tweaks

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -81,9 +81,9 @@
 	///Whether the max game time has been reached
 	var/max_time_reached = FALSE
 	///Delay before the mission actually starts
-	var/mission_start_delay = 3 MINUTES
+	var/mission_start_delay = 1.5 MINUTES
 	///Delay from shutter drop until game TIMER starts
-	var/game_timer_delay = 3 MINUTES
+	var/game_timer_delay = 1 MINUTES
 	///Map text intro message for the start of the mission
 	var/list/intro_message = list(
 		MISSION_STARTING_FACTION = "starting faction intro text here",

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -10,7 +10,7 @@
 	map_light_levels = list(225, 150, 100, 75)
 	objectives_total = 1
 	min_destruction_amount = 1
-	max_game_time = 15 MINUTES
+	max_game_time = 17 MINUTES
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 60 SECONDS,
 		MISSION_HOSTILE_FACTION = 0,

--- a/code/datums/gamemodes/campaign/missions/mech_wars.dm
+++ b/code/datums/gamemodes/campaign/missions/mech_wars.dm
@@ -9,7 +9,7 @@
 	map_light_levels = list(225, 150, 100, 75)
 	starting_faction_objective_description = "Major Victory: Wipe out all hostiles in the area of operation. Minor Victory: Eliminate more hostiles than you lose."
 	hostile_faction_objective_description = "Major Victory: Wipe out all hostiles in the area of operation. Minor Victory: Eliminate more hostiles than you lose."
-	mission_start_delay = 5 MINUTES //since there is actual mech prep time required
+	mission_start_delay = 3 MINUTES //since there is actual mech prep time required
 	starting_faction_additional_rewards = "Mechanised units will be allocated to your battalion for use in future missions."
 	hostile_faction_additional_rewards = "Mechanised units will be allocated to your battalion for use in future missions."
 

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -8,7 +8,7 @@
 	mission_icon = "combat_patrol"
 	starting_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
 	hostile_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
-	max_game_time = 15 MINUTES
+	max_game_time = 12 MINUTES
 	game_timer_delay = 5 MINUTES
 	victory_point_rewards = list(
 		MISSION_OUTCOME_MAJOR_VICTORY = list(2, 0),

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -8,8 +8,8 @@
 	mission_icon = "combat_patrol"
 	starting_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
 	hostile_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
-	max_game_time = 12 MINUTES
-	game_timer_delay = 5 MINUTES
+	max_game_time = 15 MINUTES
+	game_timer_delay = 3 MINUTES
 	victory_point_rewards = list(
 		MISSION_OUTCOME_MAJOR_VICTORY = list(2, 0),
 		MISSION_OUTCOME_MINOR_VICTORY = list(1, 0),


### PR DESCRIPTION

## About The Pull Request
Reducedthe pregame wait to 90 seconds from 3 minutes.
Reduced it to 3 minutes from 5 for Mech War.

Reduced the delay before game timer starts from 3 minutes to 1.
Reduced it for Combat Patrol (and mech war by extension) to 3 minutes from 5 (it still needs time as a team will instantly lose if no one has deployed when that time has run out... as has happened at least once).

Extended NT Base Rescue game time by 2 minutes. As SOM are the hostile team I don't want to penalise them, however the reduction of game timer delay effectively makes it harder for the attacker on all other missions.
## Why It's Good For The Game
Less waiting around.
More pressure on the attacking team.
## Changelog
:cl:
balance: Campaign: Reduced game and pregame delays on most missions
/:cl:
