### PR TITLE
Base rescue tweaks

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_assets.dm
+++ b/code/datums/gamemodes/campaign/campaign_assets.dm
@@ -70,8 +70,8 @@
 		immediate_effect()
 
 ///Handles the activated asset process
-/datum/campaign_asset/proc/attempt_activatation(mob/user)
-	if(activation_checks(user))
+/datum/campaign_asset/proc/attempt_activatation(mob/user, check_override = FALSE)
+	if(!check_override && activation_checks(user))
 		return FALSE
 
 	activated_effect()

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -60,8 +60,12 @@
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_pre_mission_bonuses()
 	. = ..()
-	spawn_mech(attacking_faction, 0, 0, 5)
+	spawn_mech(attacking_faction, 0, 0, 4)
 	spawn_mech(defending_faction, 0, 0, 2)
+
+	var/datum/faction_stats/defending_team = mode.stat_list[starting_faction]
+	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
+	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_mortar)
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission_brief()
 	starting_faction_mission_brief = "NanoTrasen has issues an emergency request for assistance at an isolated medical facility located in the Western Ayolan Ranges. \
@@ -70,11 +74,19 @@
 	hostile_faction_mission_brief = "Recon forces have led us to this secure Nanotrasen facility in the Western Ayolan Ranges. Sympathetic native elements suggest NT have been conducting secret research here to the detriment of the local ecosystem and human settlements. \
 		Find the security override terminals to override the facility's emergency lockdown. \
 		Once the lockdown is lifted, destroy what they're working on inside."
+	starting_faction_mission_parameters = "Fire support is unavailable due to the sensitive and costly nature of this NT installation."
 	hostile_faction_mission_parameters = "Teleportation is unavailable in this area due to unknown interference from beneath the NT compound."
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_objective_description()
 	starting_faction_objective_description = "Major Victory:Protect the NT base from SOM attack. Do not allow them to override the security lockdown and destroy NT's sensitive equipment"
 	hostile_faction_objective_description = "Major Victory: Override the security lockdown on the NT facility and destroy whatever secrets they are working on"
+
+/datum/campaign_mission/destroy_mission/base_rescue/start_mission()
+	. = ..()
+	var/datum/faction_stats/attacking_team = mode.stat_list[hostile_faction]
+	attacking_team.add_asset(/datum/campaign_asset/bonus_job/colonial_militia)
+	attacking_team.faction_assets[/datum/campaign_asset/bonus_job/colonial_militia].attempt_activatation(attacking_team.faction_leader, TRUE)
+
 
 /datum/campaign_mission/destroy_mission/base_rescue/apply_major_victory()
 	. = ..()

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -63,7 +63,7 @@
 	spawn_mech(attacking_faction, 0, 0, 4)
 	spawn_mech(defending_faction, 0, 0, 2)
 
-	var/datum/faction_stats/defending_team = mode.stat_list[starting_faction]
+	var/datum/faction_stats/defending_team = mode.stat_list[defending_faction]
 	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
 	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_mortar)
 
@@ -84,30 +84,30 @@
 /datum/campaign_mission/destroy_mission/base_rescue/start_mission()
 	. = ..()
 	//We do this when the mission starts to stop nerds from wasting the militia roles pregame
-	var/datum/faction_stats/attacking_team = mode.stat_list[hostile_faction]
+	var/datum/faction_stats/attacking_team = mode.stat_list[attacking_faction]
 	attacking_team.add_asset(/datum/campaign_asset/bonus_job/colonial_militia)
 	attacking_team.faction_assets[/datum/campaign_asset/bonus_job/colonial_militia].attempt_activatation(attacking_team.faction_leader, TRUE)
 
 
 /datum/campaign_mission/destroy_mission/base_rescue/apply_major_victory()
 	. = ..()
-	var/datum/faction_stats/winning_team = mode.stat_list[starting_faction]
+	var/datum/faction_stats/winning_team = mode.stat_list[defending_faction]
 	winning_team.add_asset(/datum/campaign_asset/bonus_job/pmc)
 	winning_team.add_asset(/datum/campaign_asset/attrition_modifier/corporate_approval)
 
 /datum/campaign_mission/destroy_mission/base_rescue/apply_minor_victory()
 	. = ..()
-	var/datum/faction_stats/winning_team = mode.stat_list[starting_faction]
+	var/datum/faction_stats/winning_team = mode.stat_list[defending_faction]
 	winning_team.add_asset(/datum/campaign_asset/bonus_job/pmc)
 
 /datum/campaign_mission/destroy_mission/base_rescue/apply_minor_loss()
 	. = ..()
-	var/datum/faction_stats/winning_team = mode.stat_list[hostile_faction]
+	var/datum/faction_stats/winning_team = mode.stat_list[attacking_faction]
 	winning_team.add_asset(/datum/campaign_asset/bonus_job/colonial_militia)
 
 /datum/campaign_mission/destroy_mission/base_rescue/apply_major_loss()
 	. = ..()
-	var/datum/faction_stats/winning_team = mode.stat_list[hostile_faction]
+	var/datum/faction_stats/winning_team = mode.stat_list[attacking_faction]
 	winning_team.add_asset(/datum/campaign_asset/bonus_job/colonial_militia)
 	winning_team.add_asset(/datum/campaign_asset/attrition_modifier/local_approval)
 

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -64,8 +64,8 @@
 	spawn_mech(defending_faction, 0, 0, 2)
 
 	var/datum/faction_stats/defending_team = mode.stat_list[starting_faction]
-	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
-	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_mortar)
+	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
+	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_mortar)
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission_brief()
 	starting_faction_mission_brief = "NanoTrasen has issues an emergency request for assistance at an isolated medical facility located in the Western Ayolan Ranges. \
@@ -83,6 +83,7 @@
 
 /datum/campaign_mission/destroy_mission/base_rescue/start_mission()
 	. = ..()
+	//We do this when the mission starts to stop nerds from wasting the militia roles pregame
 	var/datum/faction_stats/attacking_team = mode.stat_list[hostile_faction]
 	attacking_team.add_asset(/datum/campaign_asset/bonus_job/colonial_militia)
 	attacking_team.faction_assets[/datum/campaign_asset/bonus_job/colonial_militia].attempt_activatation(attacking_team.faction_leader, TRUE)


### PR DESCRIPTION

## About The Pull Request
Makes this mission better for SOM.

Marines can no longer use ANY firesupport assets (NT doesn't want you dropping bombs on their expensive outpost).
SOM automatically get some colonial militia support (fluffwise they're the ones that alerted/called in the SOM about this base).

Reduced SOM mech count to 4.
## Why It's Good For The Game
Significantly easier for SOM when they don't have to worry about CAS and mortar dropping on their head.
## Changelog
:cl:
balance: Campaign: NT Base Rescue no longer allows firesupport for TGMC
balance: Campaign: NT Base Rescue provides SOM with automatic militia support
balance: Campaign: NT Base Rescue reduced SOM mech count to 4
/:cl:
