### PR TITLE
Campaign loot table fix

### DIFF
--- a/code/_globalvars/lists/game_modes.dm
+++ b/code/_globalvars/lists/game_modes.dm
@@ -26,3 +26,45 @@ GLOBAL_LIST_INIT(campaign_jobs, list(
 	SOM_STAFF_OFFICER,
 	SOM_COMMANDER,
 ))
+
+///Loot table if Marines win a major victory in a campaign mission
+GLOBAL_LIST_INIT(campaign_tgmc_major_loot, list(
+	/obj/effect/supply_drop/medical_basic = 7,
+	/obj/effect/supply_drop/marine_sentry = 5,
+	/obj/effect/supply_drop/recoilless_rifle = 3,
+	/obj/effect/supply_drop/armor_upgrades = 5,
+	/obj/effect/supply_drop/mmg = 4,
+	/obj/effect/supply_drop/zx_shotgun = 3,
+	/obj/effect/supply_drop/minigun = 3,
+	/obj/effect/supply_drop/scout = 3,
+))
+
+///Loot table if Marines win a minor victory in a campaign mission
+GLOBAL_LIST_INIT(campaign_tgmc_minor_loot, list(
+	/obj/effect/supply_drop/medical_basic = 7,
+	/obj/effect/supply_drop/marine_sentry = 5,
+	/obj/effect/supply_drop/recoilless_rifle = 3,
+	/obj/effect/supply_drop/armor_upgrades = 5,
+	/obj/effect/supply_drop/mmg = 4,
+))
+
+///Loot table if SOM win a major victory in a campaign mission
+GLOBAL_LIST_INIT(campaign_som_major_loot, list(
+	/obj/effect/supply_drop/medical_basic = 7,
+	/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope = 5,
+	/obj/effect/supply_drop/som_rpg = 3,
+	/obj/effect/supply_drop/som_armor_upgrades = 5,
+	/obj/effect/supply_drop/charger = 4,
+	/obj/effect/supply_drop/culverin = 3,
+	/obj/effect/supply_drop/blink_kit = 3,
+	/obj/effect/supply_drop/som_shotgun_burst = 3,
+))
+
+///Loot table if SOM win a minor victory in a campaign mission
+GLOBAL_LIST_INIT(campaign_som_minor_loot, list(
+	/obj/effect/supply_drop/medical_basic = 7,
+	/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope = 5,
+	/obj/effect/supply_drop/som_rpg = 3,
+	/obj/effect/supply_drop/som_armor_upgrades = 5,
+	/obj/effect/supply_drop/charger = 4,
+))

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -161,18 +161,18 @@
 ///Sets up the loot tables for this mission, if required
 /datum/campaign_mission/proc/set_loot_tables()
 	if(starting_faction == FACTION_TERRAGOV)
-		major_victory_reward_table = campaign_tgmc_major_loot
-		minor_victory_reward_table = campaign_tgmc_minor_loot
+		major_victory_reward_table = GLOB.campaign_tgmc_major_loot
+		minor_victory_reward_table = GLOB.campaign_tgmc_minor_loot
 	else if(starting_faction == FACTION_SOM)
-		major_victory_reward_table = campaign_som_major_loot
-		minor_victory_reward_table = campaign_som_minor_loot
+		major_victory_reward_table = GLOB.campaign_som_major_loot
+		minor_victory_reward_table = GLOB.campaign_som_minor_loot
 
 	if(hostile_faction == FACTION_TERRAGOV)
-		minor_loss_reward_table = campaign_tgmc_minor_loot
-		major_loss_reward_table = campaign_tgmc_major_loot
+		minor_loss_reward_table = GLOB.campaign_tgmc_minor_loot
+		major_loss_reward_table = GLOB.campaign_tgmc_major_loot
 	else if(hostile_faction == FACTION_SOM)
-		minor_loss_reward_table = campaign_som_minor_loot
-		major_loss_reward_table = campaign_som_major_loot
+		minor_loss_reward_table = GLOB.campaign_som_minor_loot
+		major_loss_reward_table = GLOB.campaign_som_major_loot
 
 ///Sets up the mission once it has been selected
 /datum/campaign_mission/proc/load_mission()

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -144,6 +144,7 @@
 	op_name_hostile = GLOB.operation_namepool[/datum/operation_namepool].get_random_name()
 
 	load_mission_brief() //late loaded so we can ref the specific factions etc
+	set_loot_tables()
 
 /datum/campaign_mission/Destroy(force, ...)
 	STOP_PROCESSING(SSslowprocess, src)
@@ -156,6 +157,22 @@
 		return
 	end_mission()
 	return PROCESS_KILL
+
+///Sets up the loot tables for this mission, if required
+/datum/campaign_mission/proc/set_loot_tables()
+	if(starting_faction == FACTION_TERRAGOV)
+		major_victory_reward_table = campaign_tgmc_major_loot
+		minor_victory_reward_table = campaign_tgmc_minor_loot
+	else if(starting_faction == FACTION_SOM)
+		major_victory_reward_table = campaign_som_major_loot
+		minor_victory_reward_table = campaign_som_minor_loot
+
+	if(hostile_faction == FACTION_TERRAGOV)
+		minor_loss_reward_table = campaign_tgmc_minor_loot
+		major_loss_reward_table = campaign_tgmc_major_loot
+	else if(hostile_faction == FACTION_SOM)
+		minor_loss_reward_table = campaign_som_minor_loot
+		major_loss_reward_table = campaign_som_major_loot
 
 ///Sets up the mission once it has been selected
 /datum/campaign_mission/proc/load_mission()

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -117,15 +117,15 @@
 	///Operation name for hostile faction
 	var/op_name_hostile
 	///Possible rewards for a major victory, used by Generate_rewards()
-	var/list/major_victory_reward_table = list()
+	var/list/major_victory_reward_table
 	///Possible rewards for a minor victory, used by Generate_rewards()
-	var/list/minor_victory_reward_table = list()
+	var/list/minor_victory_reward_table
 	///Possible rewards for a minor loss, used by Generate_rewards()
-	var/list/minor_loss_reward_table = list()
+	var/list/minor_loss_reward_table
 	///Possible rewards for a major loss, used by Generate_rewards()
-	var/list/major_loss_reward_table = list()
+	var/list/major_loss_reward_table
 	///Possible rewards for a draw, used by Generate_rewards()
-	var/list/draw_reward_table = list()
+	var/list/draw_reward_table
 
 /datum/campaign_mission/New(initiating_faction)
 	. = ..()
@@ -241,6 +241,9 @@
 			reward_table = major_loss_reward_table
 		if(MISSION_OUTCOME_DRAW)
 			reward_table = draw_reward_table
+
+	if(!length(reward_table))
+		return
 
 	for(var/i = 1 to reward_amount)
 		var/obj/reward = pickweight(reward_table)

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -35,40 +35,6 @@
 	starting_faction_additional_rewards = "If the enemy force is wiped out entirely, additional supplies can be diverted to your battalion."
 	hostile_faction_additional_rewards = "If the enemy force is wiped out entirely, additional supplies can be diverted to your battalion."
 
-	major_victory_reward_table = list(
-		/obj/effect/supply_drop/medical_basic = 7,
-		/obj/effect/supply_drop/marine_sentry = 5,
-		/obj/effect/supply_drop/recoilless_rifle = 3,
-		/obj/effect/supply_drop/armor_upgrades = 5,
-		/obj/effect/supply_drop/mmg = 4,
-		/obj/effect/supply_drop/zx_shotgun = 3,
-		/obj/effect/supply_drop/minigun = 3,
-		/obj/effect/supply_drop/scout = 3,
-	)
-	minor_victory_reward_table = list(
-		/obj/effect/supply_drop/medical_basic = 7,
-		/obj/effect/supply_drop/marine_sentry = 5,
-		/obj/effect/supply_drop/recoilless_rifle = 3,
-		/obj/effect/supply_drop/armor_upgrades = 5,
-		/obj/effect/supply_drop/mmg = 4,
-	)
-	minor_loss_reward_table = list(
-		/obj/effect/supply_drop/medical_basic = 7,
-		/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope = 5,
-		/obj/effect/supply_drop/som_rpg = 3,
-		/obj/effect/supply_drop/som_armor_upgrades = 5,
-		/obj/effect/supply_drop/charger = 4,
-	)
-	major_loss_reward_table = list(
-		/obj/effect/supply_drop/medical_basic = 7,
-		/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope = 5,
-		/obj/effect/supply_drop/som_rpg = 3,
-		/obj/effect/supply_drop/som_armor_upgrades = 5,
-		/obj/effect/supply_drop/charger = 4,
-		/obj/effect/supply_drop/culverin = 3,
-		/obj/effect/supply_drop/blink_kit = 3,
-		/obj/effect/supply_drop/som_shotgun_burst = 3,
-	)
 	///Point limit to win the game via objectives
 	var/capture_point_target = 400
 	///starting team's point count

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -81,6 +81,7 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAPTURED, PROC_REF(objective_captured))
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAP_STARTED, PROC_REF(objective_cap_started))
 
+
 /datum/campaign_mission/tdm/unregister_mission_signals()
 	. = ..()
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAPTURED, COMSIG_GLOB_CAMPAIGN_CAPTURE_OBJECTIVE_CAP_STARTED))
@@ -90,7 +91,7 @@
 		MISSION_STARTING_FACTION = "[map_name]<br>" + "[GAME_YEAR]-[time2text(world.realtime, "MM-DD")] [stationTimestamp("hh:mm")]<br>" + "Eliminate all [hostile_faction] resistance in the AO. Reinforcements are limited so preserve your forces as best you can. Good hunting!",
 		MISSION_HOSTILE_FACTION = "[map_name]<br>" + "[GAME_YEAR]-[time2text(world.realtime, "MM-DD")] [stationTimestamp("hh:mm")]<br>" + "Eliminate all [starting_faction] resistance in the AO. Reinforcements are limited so preserve your forces as best you can. Good hunting!",
 	)
-	. = ..()
+	return ..()
 
 /datum/campaign_mission/tdm/get_status_tab_items(mob/source, list/items)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes the loot tables being in the wrong order for the SOM initiated combat patrol/mech war missions.

Made it a generic proc so it sets it for all missions/easy to update for other factions if required.
## Why It's Good For The Game
Fix.
## Changelog
:cl:
fix: Campaign: Fixed some loot tables being wrong from SOM initiated combat patrol/mech war missions
/:cl:
