### PR TITLE
Fixes unlimited Igunana ammo reloads

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -186,7 +186,6 @@
 		qdel(reload_ammo)
 	user.visible_message(span_notice("[user] reloads [src] with [reload_ammo]."), span_notice("You reload [src] with [reload_ammo]. It now has [current_rounds] shots left out of a maximum of [max_rounds]."))
 	playsound(loc, 'sound/weapons/guns/interact/smartgun_unload.ogg', 25, 1)
-
 	update_icon()
 	hud_set_uav_ammo()
 

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -182,10 +182,11 @@
 		var/extra_rounds = current_rounds - max_rounds
 		reload_ammo.current_rounds = extra_rounds
 		current_rounds = max_rounds
+	else
+		qdel(reload_ammo)
 	user.visible_message(span_notice("[user] reloads [src] with [reload_ammo]."), span_notice("You reload [src] with [reload_ammo]. It now has [current_rounds] shots left out of a maximum of [max_rounds]."))
 	playsound(loc, 'sound/weapons/guns/interact/smartgun_unload.ogg', 25, 1)
-	if(reload_ammo.current_rounds < 1)
-		qdel(reload_ammo)
+
 	update_icon()
 	hud_set_uav_ammo()
 


### PR DESCRIPTION
## About The Pull Request
Fixes #15360

## Why It's Good For The Game
No more unlimited ammo for the Igunananana

## Changelog
:cl:
fix: Iguana ammo boxes now properly delete themselves when they perform a reload that uses up all their ammo
/:cl:
