### PR TITLE
Sword lunge fix

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -71,7 +71,7 @@
 	var/mob/living/carbon/carbon_owner = owner
 
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_MOVED, PROC_REF(movement_fx))
-	RegisterSignal(carbon_owner, COMSIG_MOVABLE_IMPACT, PROC_REF(lunge_impact))
+	RegisterSignal(carbon_owner, COMSIG_MOVABLE_BUMP, PROC_REF(lunge_impact))
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
 
 	carbon_owner.visible_message(span_danger("[carbon_owner] charges towards \the [A]!"))
@@ -88,7 +88,7 @@
 ///Unregisters signals after lunge complete
 /datum/action/ability/activable/weapon_skill/sword_lunge/proc/charge_complete()
 	SIGNAL_HANDLER
-	UnregisterSignal(owner, list(COMSIG_MOVABLE_IMPACT, COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_MOVED))
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_MOVED))
 
 ///Sig handler for atom impacts during lunge
 /datum/action/ability/activable/weapon_skill/sword_lunge/proc/lunge_impact(datum/source, obj/target, speed)


### PR DESCRIPTION

## About The Pull Request
This ability broke in the same way as xeno lunges, but I forgot to update this to a bump signal instant.
## Why It's Good For The Game
Working ability is gud.
## Changelog
:cl:
fix: Campaign: Fixed the sword lunge ability not properly doing damage
/:cl:
