### PR TITLE
Job point fix

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -17,7 +17,7 @@
 		/datum/job/som/squad/standard = -1,
 		/datum/job/som/squad/medic = 8,
 		/datum/job/som/squad/engineer = 4,
-		/datum/job/som/squad/veteran = 2,
+		/datum/job/som/squad/veteran = 4,
 		/datum/job/som/squad/leader = 4,
 		/datum/job/som/command/fieldcommander = 1,
 		/datum/job/som/command/staffofficer = 2,

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -292,7 +292,8 @@
 		if(corpse.z != mission_z_level.z_value)
 			continue
 		if(!HAS_TRAIT(corpse, TRAIT_UNDEFIBBABLE) && corpse.job.job_cost)
-			corpse.job.add_job_positions(1)
+			corpse.job.free_job_positions(1)
+
 		qdel(corpse)
 
 ///Unregisters all signals when the mission finishes

--- a/code/datums/gamemodes/hvh.dm
+++ b/code/datums/gamemodes/hvh.dm
@@ -6,19 +6,20 @@
 	flags_xeno_abilities = ABILITY_CRASH
 	factions = list(FACTION_TERRAGOV, FACTION_SOM)
 	valid_job_types = list(
-		/datum/job/terragov/squad/engineer = 4,
+		/datum/job/terragov/squad/engineer = 8,
 		/datum/job/terragov/squad/corpsman = 8,
 		/datum/job/terragov/squad/smartgunner = 4,
 		/datum/job/terragov/squad/leader = 4,
 		/datum/job/terragov/squad/standard = -1,
 		/datum/job/som/squad/leader = 4,
-		/datum/job/som/squad/veteran = 2,
-		/datum/job/som/squad/engineer = 4,
+		/datum/job/som/squad/veteran = 4,
+		/datum/job/som/squad/engineer = 8,
 		/datum/job/som/squad/medic = 8,
 		/datum/job/som/squad/standard = -1,
 	)
 	job_points_needed_by_job_type = list(
-		/datum/job/som/squad/veteran = 5, //Every 5 non vets join, a new vet slot opens
+		/datum/job/terragov/squad/smartgunner = 5,
+		/datum/job/som/squad/veteran = 5,
 	)
 	/// Time between two bioscan
 	var/bioscan_interval = 3 MINUTES
@@ -27,13 +28,6 @@
 	. = ..()
 	for(var/z_num in SSmapping.areas_in_z)
 		set_z_lighting(z_num)
-
-/datum/game_mode/hvh/scale_roles()
-	. = ..()
-	if(!.)
-		return
-	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/som/squad/veteran)
-	scaled_job.job_points_needed = 5 //Every 5 non vets join, a new vet slot opens
 
 //sets TGMC and SOM squads
 /datum/game_mode/hvh/set_valid_squads()

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -227,8 +227,9 @@ GLOBAL_PROTECT(exp_specialmap)
 		var/datum/job/scaled_job = SSjob.GetJobType(index)
 		if(!(scaled_job in SSjob.active_joinable_occupations))
 			continue
-		scaled_job.add_job_points(-jobworth[index])
+		scaled_job.remove_job_points(jobworth[index])
 
+///Adds to job points, adding a new slot if threshold reached
 /datum/job/proc/add_job_points(amount)
 	job_points += amount
 	if(total_positions >= max_positions)
@@ -236,6 +237,17 @@ GLOBAL_PROTECT(exp_specialmap)
 	if(job_points >= job_points_needed )
 		job_points -= job_points_needed
 		add_job_positions(1)
+
+///Removes job points, and if needed, job positions
+/datum/job/proc/remove_job_points(amount)
+	if(job_points_needed == INFINITY || total_positions == -1)
+		return
+	if(job_points >= amount)
+		job_points -= amount
+		return
+	var/job_slots_removed = ROUND_UP((amount - job_points) / job_points_needed)
+	remove_job_positions(job_slots_removed)
+	job_points += (job_slots_removed * job_points_needed) - amount
 
 /datum/job/proc/add_job_positions(amount)
 	if(!(job_flags & (JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE)))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -67,7 +67,7 @@
 		DISABLE_BITFIELD(status_flags, XENO_HOST)
 
 	if((SSticker.mode?.flags_round_type & MODE_TWO_HUMAN_FACTIONS) && job?.job_cost)
-		job.add_job_positions(1)
+		job.free_job_positions(1)
 	if(hud_list)
 		med_hud_set_status()
 


### PR DESCRIPTION

## About The Pull Request
Removing job points now correctly removes job points, and removes job slots as required.
Made a couple of HvH things call this correctly. This means scaling roles (specifically SOM veterans) now actually dynamically scale, instead of just getting more and more slots as the  game progresses.

Additionally, some minor related HvH balance changes. SG scales in HvH like it does in HvX.
Vet base slots increased to 4 now that they will actually update correctly.
Corrected engie slots to 8, in line with medics.
## Why It's Good For The Game
Working code good. Previously it just deducted job points even if it went into the negative. While overall that meant you wouldn't get more slots than intended, it means you could stretch past what it should be at a given time.

In HvH, it simply wasn't calling the right proc to begin with, so it WOULD get more slots than intended.
## Changelog
:cl:
balance: Campaign: Updated a few job slot limits for consistancy
fix: fixed job slots not being closed correctly in some cases
/:cl:
