### PR TITLE
Melee special attack adjustments

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -999,7 +999,6 @@
 
 //Weapon related ability keybinds
 #define COMSIG_WEAPONABILITY_AXESWEEP "weaponability_axesweep"
-#define COMSIG_WEAPONABILITY_AXESWEEP_SELECT "weaponability_axesweep_select"
 #define COMSIG_WEAPONABILITY_SWORDLUNGE "weaponability_swordlunge"
 
 // human modules signals for keybindings

--- a/code/datums/actions/weapon_actions.dm
+++ b/code/datums/actions/weapon_actions.dm
@@ -16,7 +16,7 @@
 	if(!.)
 		return
 	var/mob/living/carbon/carbon_owner = owner
-	if(carbon_owner.getStaminaLoss() > -ability_cost)
+	if(carbon_owner.getStaminaLoss() > 0) //this specifically lets you use these abilities with no stamina, but not if you have actual stamina loss
 		if(!silent)
 			A.balloon_alert(owner, "Catch your breath!")
 		return FALSE

--- a/code/datums/actions/weapon_actions.dm
+++ b/code/datums/actions/weapon_actions.dm
@@ -18,7 +18,7 @@
 	var/mob/living/carbon/carbon_owner = owner
 	if(carbon_owner.getStaminaLoss() > 0) //this specifically lets you use these abilities with no stamina, but not if you have actual stamina loss
 		if(!silent)
-			A.balloon_alert(owner, "Catch your breath!")
+			carbon_owner.balloon_alert(owner, "Catch your breath!")
 		return FALSE
 
 /datum/action/ability/activable/weapon_skill/succeed_activate(ability_cost_override)

--- a/code/datums/keybinding/weapons.dm
+++ b/code/datums/keybinding/weapons.dm
@@ -9,12 +9,6 @@
 	keybind_signal = COMSIG_WEAPONABILITY_AXESWEEP
 	hotkey_keys = list("G")
 
-/datum/keybinding/weapon/axe_sweep_select
-	name = "Axe sweep select"
-	full_name = "Breaching axe: Select axe sweep"
-	description = "Selected axe sweep, a powerful sweeping blow that hits foes in the direction you are facing. Cannot stun."
-	keybind_signal = COMSIG_WEAPONABILITY_AXESWEEP_SELECT
-
 /datum/keybinding/weapon/sword_lunge
 	name = "Lunging strike"
 	full_name = "Sword: Lunging strike"

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -101,8 +101,8 @@
 	var/mob/living/carbon/carbon_owner = source
 	if(!ishuman(target))
 		var/obj/obj_victim = target
-		obj_victim.take_damage(damage, BRUTE, MELEE, TRUE, armour_penetration = penetration)
-		if(!obj_victim.anchored)
+		obj_victim.take_damage(damage, BRUTE, MELEE, TRUE, TRUE, get_dir(obj_victim, carbon_owner), penetration, carbon_owner)
+		if(!obj_victim.anchored && obj_victim.move_resist < MOVE_FORCE_VERY_STRONG)
 			obj_victim.knockback(carbon_owner, 1, 2)
 	else
 		var/mob/living/carbon/human/human_victim = target

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -61,7 +61,7 @@
 	name = "Lunging strike"
 	action_icon_state = "sword_lunge"
 	desc = "A powerful leaping strike. Cannot stun."
-	ability_cost = 12
+	ability_cost = 8
 	cooldown_duration = 6 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_WEAPONABILITY_SWORDLUNGE,

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -233,8 +233,8 @@
 	if(!.)
 		return
 	toggle_item_bump_attack(user, TRUE)
-	if(HAS_TRAIT(user, TRAIT_AXE_EXPERT))
-		special_attack.give_action(user)
+	//if(HAS_TRAIT(user, TRAIT_AXE_EXPERT))
+	special_attack.give_action(user)
 
 /obj/item/weapon/twohanded/fireaxe/som/unwield(mob/user)
 	. = ..()
@@ -250,23 +250,21 @@
 	desc = "A powerful sweeping blow that hits foes in the direction you are facing. Cannot stun."
 	ability_cost = 12
 	cooldown_duration = 6 SECONDS
-	keybind_flags = ABILITY_KEYBIND_USE_ABILITY | ABILITY_IGNORE_SELECTED_ABILITY
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_WEAPONABILITY_AXESWEEP,
-		KEYBINDING_ALTERNATE = COMSIG_WEAPONABILITY_AXESWEEP_SELECT,
 	)
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
 
 /datum/action/ability/activable/weapon_skill/axe_sweep/use_ability(atom/A)
+	succeed_activate()
+	add_cooldown()
 	var/mob/living/carbon/carbon_owner = owner
-
-	carbon_owner.emote("roar")
-	carbon_owner.visible_message(span_danger("[carbon_owner] Swing their weapon in a deadly arc!"))
-
+	carbon_owner.Move(get_step_towards(carbon_owner, A), get_dir(src, A))
 	carbon_owner.face_atom(A)
-	activate_particles(carbon_owner.dir)
+	activate_particles(owner.dir)
 	playsound(owner, "sound/effects/alien_tail_swipe3.ogg", 50, 0, 5)
+	owner.visible_message(span_danger("[owner] Swing their weapon in a deadly arc!"))
 
 	var/list/atom/movable/atoms_to_ravage = get_step(owner, owner.dir).contents.Copy()
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
@@ -278,19 +276,16 @@
 			var/obj/obj_victim = victim
 			obj_victim.take_damage(damage, BRUTE, MELEE, TRUE, armour_penetration = penetration)
 			if(!obj_victim.anchored)
-				obj_victim.knockback(carbon_owner, 1, 2)
+				obj_victim.knockback(owner, 1, 2)
 			continue
 		var/mob/living/carbon/human/human_victim = victim
 		if(human_victim.lying_angle)
 			continue
 		human_victim.apply_damage(damage, BRUTE, BODY_ZONE_CHEST, MELEE, TRUE, TRUE, TRUE, penetration)
-		human_victim.knockback(carbon_owner, 1, 2)
+		human_victim.knockback(owner, 1, 2)
 		human_victim.adjust_stagger(1 SECONDS)
 		playsound(human_victim, "sound/weapons/wristblades_hit.ogg", 25, 0, 5)
 		shake_camera(human_victim, 2, 1)
-
-	succeed_activate()
-	add_cooldown()
 
 /// Handles the activation and deactivation of particles, as well as their appearance.
 /datum/action/ability/activable/weapon_skill/axe_sweep/proc/activate_particles(direction)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -274,8 +274,8 @@
 			continue
 		if(!ishuman(victim))
 			var/obj/obj_victim = victim
-			obj_victim.take_damage(damage, BRUTE, MELEE, TRUE, armour_penetration = penetration)
-			if(!obj_victim.anchored)
+			obj_victim.take_damage(damage, BRUTE, MELEE, TRUE, TRUE, get_dir(obj_victim, carbon_owner), penetration, carbon_owner)
+			if(!obj_victim.anchored && obj_victim.move_resist < MOVE_FORCE_VERY_STRONG)
 				obj_victim.knockback(owner, 1, 2)
 			continue
 		var/mob/living/carbon/human/human_victim = victim

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -233,8 +233,8 @@
 	if(!.)
 		return
 	toggle_item_bump_attack(user, TRUE)
-	//if(HAS_TRAIT(user, TRAIT_AXE_EXPERT))
-	special_attack.give_action(user)
+	if(HAS_TRAIT(user, TRAIT_AXE_EXPERT))
+		special_attack.give_action(user)
 
 /obj/item/weapon/twohanded/fireaxe/som/unwield(mob/user)
 	. = ..()
@@ -248,7 +248,7 @@
 	name = "Sweeping blow"
 	action_icon_state = "axe_sweep"
 	desc = "A powerful sweeping blow that hits foes in the direction you are facing. Cannot stun."
-	ability_cost = 12
+	ability_cost = 10
 	cooldown_duration = 6 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_WEAPONABILITY_AXESWEEP,


### PR DESCRIPTION
## About The Pull Request
Both melee specials (sword lunge and axe sweep) can now be used at 0 stamina. This means if you use up all your stamina running, you can still use your special (you can't use it if you have actual stamina damage however, so wouldn't be able to do this repeatedly, or if you were suffering from neuro etc.

Sword lunge uses 8 stam instead of 12.
Axe sweep uses 10 instead of 12.

Axe sweep now takes you one step towards your target before attacking. Unlike  sword lunge, this is a Move, not a throw so you can't bypass cades and the like with it, but it does give you that tiny bit of extra mobility to give you an advantage (and can be used for pretty dirty combos in certain situations).

Both attacks properly use an attack dir (relevant for mech facings), and will no longer knockback mechs or other high throw resist AMs.
## Why It's Good For The Game
More usable melee special attacks.
## Changelog
:cl:
balance: Campaign: Melee special attacks use less stamina, and can be used at 0 stamina loss
balance: Campaign: Axe sweep steps towards you target before sweeping
fix: Fixed a few minor bugs with melee special attacks
/:cl:
