### PR TITLE
Minor lava refactor

### DIFF
--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -422,6 +422,9 @@ directive is properly returned.
 /atom/proc/fire_act()
 	return
 
+///Effects of lava. Return true where we want the lava to keep processing
+/atom/proc/lava_act()
+	fire_act()
 
 /atom/proc/hitby(atom/movable/AM, speed = 5)
 	if(density)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -65,6 +65,11 @@
 		if(EXPLODE_WEAK)
 			take_damage(rand(5, 45), BRUTE, BOMB, 0)
 
+/obj/lava_act()
+	take_damage(25, BURN, FIRE)
+	if(QDELETED(src))
+		return
+	fire_act()
 
 /obj/hitby(atom/movable/AM, speed = 5)
 	. = ..()

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -193,9 +193,6 @@
 	icon_state = "shallow_water_cave_waterway_edge"
 
 // LAVA
-
-#define LAVA_TILE_BURN_DAMAGE 20
-
 /turf/open/liquid/lava
 	name = "lava"
 	icon = 'icons/turf/lava.dmi'
@@ -232,35 +229,12 @@
 	if(!burn_stuff())
 		STOP_PROCESSING(SSobj, src)
 
+///Handles burning turf contents or an entering AM. Returns true to keep processing
 /turf/open/liquid/lava/proc/burn_stuff(AM)
-	. = FALSE
-
-	var/thing_to_check = src
-	if (AM)
-		thing_to_check = list(AM)
-	for(var/thing in thing_to_check)
-		if(ismecha(thing))
-			var/obj/vehicle/sealed/mecha/burned_mech = thing
-			burned_mech.take_damage(rand(40, 120), BURN, FIRE)
+	var/thing_to_check = AM ? list(AM) : src
+	for(var/atom/thing AS in thing_to_check)
+		if(!thing.lava_act())
 			. = TRUE
-
-		else if(isobj(thing))
-			var/obj/O = thing
-			O.fire_act(10000, 1000)
-
-		else if (isliving(thing))
-			var/mob/living/L = thing
-
-			if(L.stat == DEAD)
-				continue
-
-			if(!L.on_fire || L.getFireLoss() <= 200)
-				var/damage_amount = max(L.modify_by_armor(LAVA_TILE_BURN_DAMAGE, FIRE), LAVA_TILE_BURN_DAMAGE * 0.3) //snowflakey interaction to stop complete lava immunity
-				L.take_overall_damage(damage_amount, BURN, updating_health = TRUE, max_limbs = 3)
-				if(!CHECK_BITFIELD(L.pass_flags, PASS_FIRE))//Pass fire allow to cross lava without igniting
-					L.adjust_fire_stacks(20)
-					L.IgniteMob()
-				. = TRUE
 
 /turf/open/liquid/lava/attackby(obj/item/C, mob/user, params)
 	. = ..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -185,6 +185,17 @@
 	adjust_fire_stacks(rand(1,2))
 	IgniteMob()
 
+mob/living/lava_act()
+	if(stat == DEAD)
+		return TRUE
+
+	var/lava_damage = 20
+	take_overall_damage(max(modify_by_armor(lava_damage, FIRE), lava_damage * 0.3), BURN, updating_health = TRUE, max_limbs = 3) //snowflakey interaction to stop complete lava immunity
+	if(!CHECK_BITFIELD(pass_flags, PASS_FIRE))//Pass fire allow to cross lava without igniting
+		adjust_fire_stacks(20)
+		IgniteMob()
+	return
+
 /mob/living/flamer_fire_act(burnlevel)
 	if(!burnlevel)
 		return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -185,7 +185,7 @@
 	adjust_fire_stacks(rand(1,2))
 	IgniteMob()
 
-mob/living/lava_act()
+/mob/living/lava_act()
 	if(stat == DEAD)
 		return TRUE
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -157,6 +157,9 @@
 			cookedalive.adjust_fire_stacks(1)
 			cookedalive.IgniteMob()
 
+/obj/vehicle/sealed/mecha/lava_act()
+	take_damage(80, BURN, FIRE, armour_penetration = 30)
+
 /obj/vehicle/sealed/mecha/attackby_alternate(obj/item/weapon, mob/user, params)
 	if(istype(weapon, /obj/item/mecha_parts))
 		var/obj/item/mecha_parts/parts = weapon


### PR DESCRIPTION

## About The Pull Request
Lava now has a lava_act proc at the atom level, instead of handling everything snowflakely in the laval proc itself.

Fixed lava not properly hurting mechs.
Lava will now actually damage/destroy objects.

Cleaned up some code a little.
## Why It's Good For The Game
Less snowflakey, lava actually destroys items insted of just floating around chilling.
## Changelog
:cl:
balance: Lava will actually melt objects now
/:cl:
