### PR TITLE
Mech explosion resistance reduction

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
@@ -20,13 +20,13 @@
 
 /obj/item/mecha_parts/mecha_equipment/armor/explosive
 	name = "explosive armor booster"
-	desc = "Increases armor against explosions by 50%."
+	desc = "Increases armor against explosions by 25%."
 	icon_state = "armor_explosive"
 	iconstate_name = "armor_explosive"
 	protect_name = "Explosive Armor"
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	slowdown = 0.3
-	armor_mod = list(BOMB = 50)
+	armor_mod = list(BOMB = 25)
 
 
 /obj/item/mecha_parts/mecha_equipment/generator/greyscale


### PR DESCRIPTION

## About The Pull Request
Mech explosive armour module now increases bomb armour by 25 instead of 50.
## Why It's Good For The Game
It was pretty smelly in HvH to have complete bomb immunity.
## Changelog
:cl:
balance: Mech explosive armour modules increased bomb armour by 25 instead of 50
/:cl:
