### PR TITLE
Campaign timing adjustments

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -130,8 +130,8 @@
 ///sets up the newly selected mission
 /datum/game_mode/hvh/campaign/proc/load_new_mission(datum/campaign_mission/new_mission)
 	current_mission = new_mission
-	current_mission.load_mission()
 	addtimer(CALLBACK(src, PROC_REF(autobalance_cycle)), CAMPAIGN_AUTOBALANCE_DELAY) //we autobalance teams after a short delay to account for slow respawners
+	current_mission.load_mission()
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, bioscan_interval)
 
 ///Checks team balance and tries to correct if possible

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -7,7 +7,8 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
 	mission_flags = MISSION_DISALLOW_TELEPORT
-	max_game_time = 8 MINUTES
+	max_game_time = 8.5 MINUTES
+	game_timer_delay = 90 SECONDS
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 90 SECONDS,
 		MISSION_HOSTILE_FACTION = 0,

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -7,7 +7,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
 	mission_flags = MISSION_DISALLOW_TELEPORT
-	max_game_time = 8.5 MINUTES
+	max_game_time = 9 MINUTES
 	game_timer_delay = 90 SECONDS
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 90 SECONDS,

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -8,6 +8,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
 	max_game_time = 10 MINUTES
+	game_timer_delay = 90 SECONDS
 	objectives_total = 9
 	min_destruction_amount = 7
 	shutter_open_delay = list(

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -229,6 +229,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
 	map_light_levels = list(200, 100, 75, 50)
+	mission_start_delay = 3 MINUTES
 
 /datum/campaign_mission/tdm/first_mission/end_mission()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Adjusted a couple of timings.
First mission initial delay is a little longer again for latejoins.
Autobalance proc is called earlier so it doesn't get delayed by late z-level loading funniness
ASAT and fire support missions get slightly (1 minute and 30 seconds respectively) extra. Mainly this was just to line up the game clock starting with the attacking team deploying.
## Why It's Good For The Game
Fix some wack timing issues
## Changelog
:cl:
qol: Campaign: fixed the timing of the autobalance prompt
balance: Very slight increase in time for ASAT and firesupport missions
/:cl:
