### PR TITLE
Mech actuator overload hotkey

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -756,6 +756,7 @@
 #define COMSIG_MECHABILITY_TOGGLE_ZOOM "mechability_toggle_zoom"
 #define COMSIG_MECHABILITY_SKYFALL "mechability_skyfall"
 #define COMSIG_MECHABILITY_STRIKE "mechability_strike"
+#define COMSIG_MECHABILITY_TOGGLE_ACTUATORS "mechability_toggle_actuators"
 
 #define COMSIG_ACTION_EXCLUSIVE_TOGGLE "action_exclusive_toggle"
 // xeno abilities for keybindings

--- a/code/datums/keybinding/mecha.dm
+++ b/code/datums/keybinding/mecha.dm
@@ -50,3 +50,10 @@
 	description = "Bombard an area with rockets"
 	keybind_signal = COMSIG_MECHABILITY_STRIKE
 	hotkey_keys = list("F")
+
+/datum/keybinding/mecha/mech_toggle_actuators
+	name = "mech_toggle_actuators"
+	full_name = "Mecha Toggle Actuators"
+	description = "Toggle leg actuator overload for your mecha"
+	keybind_signal = COMSIG_MECHABILITY_TOGGLE_ACTUATORS
+	hotkey_keys = list("X")

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -27,6 +27,9 @@
 /datum/action/vehicle/sealed/mecha/mech_overload_mode
 	name = "Toggle leg actuators overload"
 	action_icon_state = "mech_overload_off"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_MECHABILITY_TOGGLE_ACTUATORS,
+	)
 
 /datum/action/vehicle/sealed/mecha/mech_overload_mode/action_activate(trigger_flags, forced_state = null)
 	if(!owner || !chassis || !(owner in chassis.occupants))


### PR DESCRIPTION

## About The Pull Request
Adds a hotkey to mech actuator overload.
## Why It's Good For The Game
Its really annoying not having a hotkey.
## Changelog
:cl:
qol: Mech actuator overload has a hotkey
/:cl:
