### PR TITLE
Gun codex shows relevant weapon skill

### DIFF
--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -14,6 +14,24 @@
 	. = ..()
 	var/list/traits = list()
 
+	var/skill_name
+	switch(gun_skill_category)
+		if(SKILL_RIFLES)
+			skill_name = "rifle skill"
+		if(SKILL_SMGS)
+			skill_name = "SMG skill"
+		if(SKILL_HEAVY_WEAPONS)
+			skill_name = "heavy weapon skill"
+		if(SKILL_SMARTGUN)
+			skill_name = "smartgun skill"
+		if(SKILL_SHOTGUNS)
+			skill_name = "shotgun skill"
+		if(SKILL_PISTOLS)
+			skill_name = "pistol skill"
+
+	if(skill_name)
+		traits += "This weapons is effected by the user's <U>[skill_name]</U> rating. <br>"
+
 	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY)
 		traits += "This can only be fired with a two-handed grip."
 	else


### PR DESCRIPTION

## About The Pull Request
You can now check what weapon skill applies to a given weapon by checking its codex entry.
## Why It's Good For The Game
Choosing gun perks in campaign is kinda funny when its not clear which guns it will apply to in some cases.
## Changelog
:cl:
qol: Gun codex entries now state what weapon skill applies to them
/:cl:
