### PR TITLE
Fixes caste swapping/regressing while zoomed in causing your vision to get stuck forward

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -123,6 +123,9 @@
 	if(HAS_TRAIT(src, TRAIT_CASTE_SWAP))
 		GLOB.key_to_time_of_caste_swap[key] = world.time
 
+	if(xeno_flags & XENO_ZOOMED)
+		zoom_out()
+
 	SStgui.close_user_uis(src) //Force close all UIs upon evolution.
 	finish_evolve(new_mob_type)
 


### PR DESCRIPTION

## About The Pull Request
Fixes #15015

## Why It's Good For The Game

You no longer have to ghost in and out if you commit the sin of caste swapping/ regressing while zoomed in as boiler

## Changelog
:cl:
fix: Fixes view getting bugged if you regress/caste swap while zoomed in
/:cl:
