### PR TITLE
Make plasma cutter balloon alerts readable + is_helper

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -225,6 +225,8 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 
 #define iscrowbar(I) (istype(I, /obj/item/tool/crowbar))
 
+#define isplasmacutter(I) istype(I, /obj/item/tool/pickaxe/plasmacutter)
+
 #define iscell(I) (istype(I, /obj/item/cell))
 
 #define isfactorypart(I) (istype(I, /obj/item/factory_part))

--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -166,7 +166,6 @@
 		spark_system.attach(source)
 		spark_system.start(source)
 	if(!no_string)
-		balloon_alert(user, "Cutting...")
 		if(custom_string)
 			to_chat(user, span_notice(custom_string))
 		else
@@ -185,8 +184,6 @@
 	balloon_alert(user, "Charge Remaining: [cell.charge]/[cell.maxcharge]")
 	if(custom_string)
 		to_chat(user, span_notice(custom_string))
-	else
-		balloon_alert(user, "Cuts apart")
 
 /obj/item/tool/pickaxe/plasmacutter/proc/debris(location, metal = 0, rods = 0, wood = 0, wires = 0, shards = 0, plasteel = 0)
 	if(metal)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -91,9 +91,9 @@
 		return
 
 	var/multiplier = 1
-	if(istype(W, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+	if(isplasmacutter(W) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
-		if(P.start_cut(user, src.name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD))
+		if(P.start_cut(user, src.name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD, no_string = TRUE))
 			if(istype(src, /obj/structure/mineral_door/resin))
 				multiplier += PLASMACUTTER_RESIN_MULTIPLIER //Plasma cutters are particularly good at destroying resin structures.
 			else

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -297,7 +297,7 @@
 	icon_state = "Intersection"
 
 /turf/closed/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+	if(isplasmacutter(I) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		if(CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -130,7 +130,7 @@
 	else if(I.damtype == BRUTE)
 		multiplier += 0.75
 
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+	if(isplasmacutter(I) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD))
 			multiplier += PLASMACUTTER_RESIN_MULTIPLIER

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -242,7 +242,7 @@
 	return
 
 /turf/closed/wall/indestructible/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter)) //needed for user feedback, if not included the user will not receive a message when trying plasma cutter wall/indestructible turfs
+	if(isplasmacutter(I)) //needed for user feedback, if not included the user will not receive a message when trying plasma cutter wall/indestructible turfs
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		to_chat(user, span_warning("[P] can't cut through this!"))
 	return

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -324,7 +324,7 @@
 	else if(resistance_flags & INDESTRUCTIBLE)
 		to_chat(user, "[span_warning("[src] is much too tough for you to do anything to it with [I]")].")
 
-	else if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+	else if(isplasmacutter(I) && !user.do_actions)
 		return
 
 	else if(wall_integrity < max_integrity && iswelder(I))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -69,7 +69,7 @@
 
 
 /obj/machinery/atmospherics/components/unary/vent_pump/weld_cut_act(mob/living/user, obj/item/W)
-	if(istype(W, /obj/item/tool/pickaxe/plasmacutter))
+	if(isplasmacutter(W))
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
 		if(!welded)
 			to_chat(user, span_warning("\The [P] can only cut open welds!"))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -66,7 +66,7 @@
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/weld_cut_act(mob/living/user, obj/item/W)
-	if(istype(W, /obj/item/tool/pickaxe/plasmacutter))
+	if(isplasmacutter(W))
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
 
 		if(!welded)

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -132,7 +132,7 @@
 	if(I.damtype == BURN) //Burn damage deals extra vs resin structures (mostly welders).
 		multiplier += 1
 
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+	if(isplasmacutter(I) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD))
 			multiplier += PLASMACUTTER_RESIN_MULTIPLIER


### PR DESCRIPTION

## About The Pull Request
A lot of things were doing istype(I, plasmcutter), So I added an istype helper isplasmacutter(I)
Also I've removed a bunch of balloon alerts, since getting 4 balloon alerts at the same time is completely useless.
## Why It's Good For The Game
Readable balloons good
## Changelog
:cl:
fix: Plasma cutter is no longer spammed by unreadable balloon alerts
code: adds isplasmacutter(I)
/:cl:
