### PR TITLE
Airburst IFF fix

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -273,7 +273,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 		if(isgun(source))
 			var/obj/item/weapon/gun/gun = source
-			gun.apply_gun_modifiers(new_proj, target, shooter)
+			gun.apply_gun_modifiers(new_proj, target)
 
 		//Scatter here is how many degrees extra stuff deviate from the main projectile's firing angle. Fully randomised with no 45 degree cap like normal bullets
 		var/f = (i-1)


### PR DESCRIPTION

## About The Pull Request
Airburst shrap no longer incorrectly inherits IFF.
I'm not sure which pr broke it, but where the original projectile has IFF, the shrap after it explodes should not.
## Why It's Good For The Game
Funny IFF shrap bad.
## Changelog
:cl:
fix: fixed IFF shrap on airburst weapons
/:cl:
