### PR TITLE
Removes an outdoor plat miner from Icy Caves

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -2115,10 +2115,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves/cavesbrig)
-"mo" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
 "mp" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -19867,7 +19863,7 @@ ow
 ow
 nL
 ZI
-mo
+li
 li
 ow
 ZI


### PR DESCRIPTION
## About The Pull Request
Removes the plat miner above medbay from icy caves.
<img width="556" alt="icycaves miner2" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/d66ffbdd-bb0e-4c14-aca6-53366929d886">


## Why It's Good For The Game
This plat miner is very easy to permanently take just by landing tad in the spot that it would already want to be in for pushing last disk. Icy Caves is also a lowpop map so xenos typically wont have many extra resources to devote to sieging an autism tad plat miner fort.
## Changelog
:cl:
balance: Removed outdoor plat miner from Icy Caves
/:cl:
