### PR TITLE
cleans up synth vendor tgui

### DIFF
--- a/tgui/packages/tgui/interfaces/MarineSelector.jsx
+++ b/tgui/packages/tgui/interfaces/MarineSelector.jsx
@@ -166,27 +166,27 @@ const ItemLine = (props) => {
           )}
           {prod_color === 'synth-storage' && (
             <Box inline mr="6px" ml="6px" color="magenta">
-              Provides Storage
+              Storage
             </Box>
           )}
           {prod_color === 'synth-armor' && (
             <Box inline mr="6px" ml="6px" color="red">
-              Provides Armor
+              Armor
             </Box>
           )}
           {prod_color === 'synth-rcmarmor' && (
             <Box inline mr="6px" ml="6px" color="orange">
-              Recommended - Provides Armor
+              Recommended - Armor
             </Box>
           )}
           {prod_color === 'synth-rcmarmstorage' && (
             <Box inline mr="6px" ml="6px" color="green">
-              Recommended - Provides Armor and Suit Storage
+              Recommended - Armor and Suit Storage
             </Box>
           )}
           {prod_color === 'synth-attachable' && (
             <Box inline mr="6px" ml="6px" color="green">
-              Recommended - Can be attached to flak jacket
+              Recommended - Attachable to Flak Jacket
             </Box>
           )}
           {prod_cost > 0 && (


### PR DESCRIPTION
## About The Pull Request
in the synth vendor, there was a really long tag on a singular armor (flak jacket)
this pushed the "vend" button for all options outside the area of the default window
i've gone ahead and cleaned up the language for this, not only because the buttons didn't fit, but because I think the verbiage was too wordy and would rather not have it so close to the object name itself.

## Why It's Good For The Game

better looking ui

## Changelog
not super needed? it's 7px of difference