### PR TITLE
HvX plasma availability tweaks and fix

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -29,6 +29,7 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
+			/obj/item/cell/lasgun/plasma = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -29,7 +29,6 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
-			/obj/item/cell/lasgun/plasma = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3384,12 +3384,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flame_radius(2, T, burn_duration = 9, colour = "blue")
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
-/datum/ammo/energy/plasma/cannon_standard
-	damage = 20
-	penetration = 15
-	sundering = 0.75
-	damage_falloff = 0.75
-
 #define PLASMA_CANNON_INNER_STAGGERSTUN_RANGE 3
 #define PLASMA_CANNON_STAGGERSTUN_RANGE 9
 #define PLASMA_CANNON_STAGGER_DURATION 3 SECONDS

--- a/code/modules/projectiles/guns/plasma.dm
+++ b/code/modules/projectiles/guns/plasma.dm
@@ -135,11 +135,12 @@
 	unload_sound = 'sound/weapons/guns/interact/plasma_unload_2.ogg'
 	reload_sound = 'sound/weapons/guns/interact/plasma_reload_1.ogg'
 	force = 35
-	ammo_datum_type = /datum/ammo/energy/plasma/cannon_standard
+	ammo_datum_type = /datum/ammo/energy/plasma/cannon_heavy
 	gun_firemode = GUN_FIREMODE_AUTOMATIC
-	fire_delay = 2.5 SECONDS
+	fire_delay = 2 SECONDS
 	heat_per_fire = 50
 	rounds_per_shot = 180
+	windup_delay = 0.5 SECONDS
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/plasma_cannon/cannon_standard,
 		"Shatter" = /datum/lasrifle/base/plasma_cannon/shatter_blast,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -360,12 +360,12 @@ WEAPONS
 /datum/supply_packs/weapons/plasma_smg
 	name = "PL-51 Plasma SMG"
 	contains = list(/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/smg)
-	cost = 250
+	cost = 400
 
 /datum/supply_packs/weapons/plasma_rifle
 	name = "PL-38 Plasma Rifle"
 	contains = list(/obj/item/weapon/gun/energy/lasgun/lasrifle/plasma/rifle)
-	cost = 300
+	cost = 350
 
 /datum/supply_packs/weapons/plasma_cannon
 	name = "PL-96 Plasma Cannon"


### PR DESCRIPTION
## About The Pull Request
Edit: Kuro says keep funny free ammo.

Removed the funny free plasma cells from the weapon vendor, I didn't realise req guns already had free ammo for whatever reason?

Made the SMG/rifle a bit more expensive.

Also fixed a bug with the cannon having an incorrect couple of vars set by default
## Why It's Good For The Game
Funny spam bad.
## Changelog
:cl:
balance: Made SMG and rifle more expensive
fix: Fixed plasma cannon starting with an incorrect ammo type set
/:cl:
