### PR TITLE
backend fix of early synth med skill naming

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -352,7 +352,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	engineer = SKILL_ENGINEER_INHUMAN
 	construction = SKILL_CONSTRUCTION_INHUMAN
 	firearms = SKILL_FIREARMS_UNTRAINED
-	medical = SKILL_SURGERY_PROFESSIONAL
+	medical = SKILL_MEDICAL_COMPETENT
 	cqc = SKILL_CQC_MASTER
 	surgery = SKILL_SURGERY_PROFESSIONAL
 	pilot = SKILL_PILOT_TRAINED


### PR DESCRIPTION
## About The Pull Request

the definition of their med skill was "SURGERY_SKILL_PROFESSIONAL", when it should've been "MEDICAL_SKILL_COMPETENT"; both values are defined as "3", so this won't affect anything in-practice, it just is consistent code-wise

## Why It's Good For The Game
if we define a var to use for med skillsets, we should use that var and not the one we defined for surgery skillsets.

## Changelog
no player-facing changes