### PR TITLE
Lava fix

### DIFF
--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -424,7 +424,10 @@ directive is properly returned.
 
 ///Effects of lava. Return true where we want the lava to keep processing
 /atom/proc/lava_act()
+	if(resistance_flags & INDESTRUCTIBLE)
+		return FALSE
 	fire_act()
+	return TRUE
 
 /atom/proc/hitby(atom/movable/AM, speed = 5)
 	if(density)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -66,10 +66,14 @@
 			take_damage(rand(5, 45), BRUTE, BOMB, 0)
 
 /obj/lava_act()
-	take_damage(25, BURN, FIRE)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return FALSE
+	if(!take_damage(50, BURN, FIRE))
+		return FALSE
 	if(QDELETED(src))
-		return
+		return FALSE
 	fire_act()
+	return TRUE
 
 /obj/hitby(atom/movable/AM, speed = 5)
 	. = ..()

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -233,7 +233,7 @@
 /turf/open/liquid/lava/proc/burn_stuff(AM)
 	var/thing_to_check = AM ? list(AM) : src
 	for(var/atom/thing AS in thing_to_check)
-		if(!thing.lava_act())
+		if(thing.lava_act())
 			. = TRUE
 
 /turf/open/liquid/lava/attackby(obj/item/C, mob/user, params)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -186,15 +186,19 @@
 	IgniteMob()
 
 /mob/living/lava_act()
+	if(resistance_flags & INDESTRUCTIBLE)
+		return FALSE
 	if(stat == DEAD)
-		return TRUE
+		return FALSE
+	if(status_flags & GODMODE)
+		return TRUE //while godmode will stop the damage, we don't want the process to stop in case godmode is removed
 
 	var/lava_damage = 20
 	take_overall_damage(max(modify_by_armor(lava_damage, FIRE), lava_damage * 0.3), BURN, updating_health = TRUE, max_limbs = 3) //snowflakey interaction to stop complete lava immunity
 	if(!CHECK_BITFIELD(pass_flags, PASS_FIRE))//Pass fire allow to cross lava without igniting
 		adjust_fire_stacks(20)
 		IgniteMob()
-	return
+	return TRUE
 
 /mob/living/flamer_fire_act(burnlevel)
 	if(!burnlevel)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -158,7 +158,10 @@
 			cookedalive.IgniteMob()
 
 /obj/vehicle/sealed/mecha/lava_act()
+	if(resistance_flags & INDESTRUCTIBLE)
+		return FALSE
 	take_damage(80, BURN, FIRE, armour_penetration = 30)
+	return TRUE
 
 /obj/vehicle/sealed/mecha/attackby_alternate(obj/item/weapon, mob/user, params)
 	if(istype(weapon, /obj/item/mecha_parts))


### PR DESCRIPTION

## About The Pull Request
Stops the sizzle.
Lava_act now actually checks if the thing being melted is indestructable or whatever, so it won't keep trying to burn indestructable fences forever.

Also made lava act return true/false the right way around. It was working fine, I'd just updated the comment but then didn't update the return values in the original pr.
## Why It's Good For The Game
Magmoor being sound hell on top of lava hell is bad.
## Changelog
:cl:
fix: fixed lava trying to burn indestructable things forever
/:cl:
