### PR TITLE
Activating supply beacons makes the supply console do a noise

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -67,6 +67,9 @@
 #define COMSIG_GLOB_CAS_LASER_CREATED "!cas_laser_sent"
 #define COMSIG_GLOB_RAILGUN_LASER_CREATED "!railgun_laser_sent"
 
+//Signals for fire support
+#define COMSIG_GLOB_SUPPLY_BEACON_CREATED "!supply_beacon_created"
+
 //Signals for shuttle
 #define COMSIG_GLOB_SHUTTLE_TAKEOFF "!shuttle_take_off"
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -67,7 +67,7 @@
 #define COMSIG_GLOB_CAS_LASER_CREATED "!cas_laser_sent"
 #define COMSIG_GLOB_RAILGUN_LASER_CREATED "!railgun_laser_sent"
 
-//Signals for fire support
+//Sent when a supply beacon is activated
 #define COMSIG_GLOB_SUPPLY_BEACON_CREATED "!supply_beacon_created"
 
 //Signals for shuttle

--- a/code/datums/components/beacon.dm
+++ b/code/datums/components/beacon.dm
@@ -128,6 +128,7 @@
 	user.show_message(span_notice("The [source] beeps and states, \"Your current coordinates were registered by the supply console. LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(source)]\""), EMOTE_AUDIBLE, span_notice("The [source] vibrates but you can not hear it!"))
 	beacon_datum = new /datum/supply_beacon("[user.name] + [A]", get_turf(source), user.faction)
 	RegisterSignal(beacon_datum, COMSIG_QDELETING, PROC_REF(clean_beacon_datum))
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SUPPLY_BEACON_CREATED, src)
 	source.update_appearance()
 
 ///Deactivates the beacon

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -35,7 +35,7 @@
 			supply_pad = _supply_pad
 			return
 
-
+/// Used to notify of a new beacon target
 /obj/machinery/computer/supplydrop_console/proc/ping_beacon()
 	SIGNAL_HANDLER
 	playsound(src,'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -25,6 +25,7 @@
 
 /obj/machinery/computer/supplydrop_console/Initialize(mapload)
 	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_SUPPLY_BEACON_CREATED, PROC_REF(ping_beacon))
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/supplydrop_console/LateInitialize()
@@ -34,9 +35,15 @@
 			supply_pad = _supply_pad
 			return
 
+
+/obj/machinery/computer/supplydrop_console/proc/ping_beacon()
+	SIGNAL_HANDLER
+	playsound(src,'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+
 /obj/machinery/computer/supplydrop_console/Destroy()
 	supply_beacon = null
 	supply_pad = null
+	UnregisterSignal(SSdcs, COMSIG_GLOB_SUPPLY_BEACON_CREATED)
 	return ..()
 
 /obj/machinery/computer/supplydrop_console/ui_interact(mob/user, datum/tgui/ui)

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -43,7 +43,6 @@
 /obj/machinery/computer/supplydrop_console/Destroy()
 	supply_beacon = null
 	supply_pad = null
-	UnregisterSignal(SSdcs, COMSIG_GLOB_SUPPLY_BEACON_CREATED)
 	return ..()
 
 /obj/machinery/computer/supplydrop_console/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request
When you activate a beacon, it will do a noise to notify any nearby RO that something changed regarding the beacon list. 
I would have put an inverse noise, but I didn't find any that was good enough
## Why It's Good For The Game
Makes it easier for req workers to know when that dang beacon is down, PFC jim!
## Changelog
:cl:
qol: Activating supply beacons notify the shipside console with a noise
/:cl:
