### PR TITLE
Removes traumatic shock from organ damage, health analyzer can see organ damage from above 5 instead of 10.

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -253,11 +253,16 @@ REAGENT SCANNER
 		data["implants"] = unknown_implants
 		var/damaged_organs = list()
 		for(var/datum/internal_organ/organ AS in human_patient.internal_organs)
-			if(organ.organ_status == ORGAN_HEALTHY)
+			if(organ.damage <= 0)
 				continue
+			var/organ_health_status = ""
+			if(organ.organ_status == ORGAN_HEALTHY)
+				organ_health_status = "Scarred"
+			else
+				organ_health_status = organ.organ_status == ORGAN_BRUISED ? "Bruised" : "Broken"
 			var/current_organ = list(
 				"name" = organ.name,
-				"status" = organ.organ_status == ORGAN_BRUISED ? "Bruised" : "Broken",
+				"status" = organ_health_status,
 				"damage" = organ.damage
 			)
 			damaged_organs += list(current_organ)

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -253,7 +253,7 @@ REAGENT SCANNER
 		data["implants"] = unknown_implants
 		var/damaged_organs = list()
 		for(var/datum/internal_organ/organ AS in human_patient.internal_organs)
-			if(organ.damage <= 0)
+			if(organ.damage <= 5)
 				continue
 			var/organ_health_status = ""
 			if(organ.organ_status == ORGAN_HEALTHY)

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -87,10 +87,6 @@
 			if(O.germ_level >= INFECTION_LEVEL_ONE)
 				traumatic_shock += O.germ_level * 0.05
 
-		//Internal organs hurt too
-		for(var/datum/internal_organ/O in M.internal_organs)
-			if(O.damage) 											traumatic_shock += O.damage * 1.5
-
 		if(M.protection_aura)
 			traumatic_shock -= 20 + M.protection_aura * 20 //-40 pain for SLs, -80 for Commanders
 

--- a/tgui/packages/tgui/interfaces/MedScanner.jsx
+++ b/tgui/packages/tgui/interfaces/MedScanner.jsx
@@ -305,7 +305,7 @@ export const MedScanner = (props) => {
                 >
                   <Box
                     inline
-                    color={organ.status === 'Bruised' ? 'orange' : 'red'}
+                    color={organ.status === 'Broken' ? 'red' : 'orange'}
                     bold={1}
                   >
                     {organ.status + ' with ' + organ.damage + ' damage'}


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
For traumatic shock:
After doing a bit of research I found out that the only thing organ damage does below threshold was traumatic shock, which essentially seems to be pain. This led to invisible pain, and then past threshold it just stacked with the extremely debilitating effects of a bruised organ (heart, for example, at bruised gives -20 max hp and reduced stamina.) Below the 10 threshold it was pain you could not really deal with besides also getting pain from cloneloss if you took peri+, alongside the reduced max HP.
For the health analyzer: You should be able to see when a organ is getting close to be bruised. I picked above 5 as the most reasonable number to start seeing organ damage at, as fracture RNG can pick from 3 - 5 damage; since the max is 5, this should give you a pre-warning when the next time you take organ damage you may meet the threshold, and thus doctors can assist with peri+ which is meant for lower amounts of organ damage in the first place.
## Changelog
:cl:
balance: Organ damage no longer does traumatic shock
balance: Health Analyzer can see organ damage above 5 instead of 10 and above
/:cl:
