### PR TITLE
Warding nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -161,10 +161,10 @@
 
 	if(warding_aura != (received_auras[AURA_XENO_WARDING] || 0))
 		if(warding_aura) //If either the new or old warding is 0, we can skip adjusting armor for it.
-			soft_armor = soft_armor.modifyAllRatings(-warding_aura * 2.5)
+			soft_armor = soft_armor.modifyAllRatings(-warding_aura * 1.25)
 		warding_aura = received_auras[AURA_XENO_WARDING] || 0
 		if(warding_aura)
-			soft_armor = soft_armor.modifyAllRatings(warding_aura * 2.5)
+			soft_armor = soft_armor.modifyAllRatings(warding_aura * 1.25)
 
 	recovery_aura = received_auras[AURA_XENO_RECOVERY] || 0
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -161,10 +161,10 @@
 
 	if(warding_aura != (received_auras[AURA_XENO_WARDING] || 0))
 		if(warding_aura) //If either the new or old warding is 0, we can skip adjusting armor for it.
-			soft_armor = soft_armor.modifyAllRatings(-warding_aura * 1.25)
+			soft_armor = soft_armor.modifyAllRatings(-warding_aura * 1.5)
 		warding_aura = received_auras[AURA_XENO_WARDING] || 0
 		if(warding_aura)
-			soft_armor = soft_armor.modifyAllRatings(warding_aura * 1.25)
+			soft_armor = soft_armor.modifyAllRatings(warding_aura * 1.5)
 
 	recovery_aura = received_auras[AURA_XENO_RECOVERY] || 0
 


### PR DESCRIPTION
## About The Pull Request
Near halves the armor warding gives, essentially what I did in #14030.
## Why It's Good For The Game
As we learned with hold order, stacking armor values at the higher end can lead to some really wacky damage. For example, with king warding on crusher you could be receiving 3.75dmg from a T12 bullet, which not accounting for sunder (you can heal the in-combat sunder with hivelord beam or just existing, meaning getting shot by the small arms will only increase sunder very slowly) would take over 100 bullets to kill, realistically 70+ with sunder accounted for.
## Changelog
:cl:
balance: Warding pheros have near half effectiveness, from 2.5 armor per aura level to 1.5
/:cl:
