### PR TITLE
Bull buffs

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -110,6 +110,13 @@
 	keybind_signal = COMSIG_XENOABILITY_XENO_SPIT
 	hotkey_keys = list("Q")
 
+/datum/keybinding/xeno/long_range_sight
+	name = "long_range_sight"
+	full_name = "Long Range Sight"
+	description = "Toggles the zoom in."
+	keybind_signal = COMSIG_XENOABILITY_LONG_RANGE_SIGHT
+	hotkey_keys = list("E")
+
 /datum/keybinding/xeno/xenohide
 	name = "xenohide"
 	full_name = "Hide"
@@ -205,13 +212,6 @@
 // Single caste, alphabetical order
 //
 
-/datum/keybinding/xeno/long_range_sight
-	name = "long_range_sight"
-	full_name = "Boiler: Long Range Sight"
-	description = "Toggles the zoom in."
-	keybind_signal = COMSIG_XENOABILITY_LONG_RANGE_SIGHT
-	hotkey_keys = list("E")
-
 /datum/keybinding/xeno/toggle_bomb
 	name = "toggle_bomb"
 	full_name = "Boiler: Toggle Bombard Type"
@@ -251,7 +251,7 @@
 	full_name = "Bull: Headbutt Charge"
 	description = "A charge that tosses the victim forward or backwards, depending on intent."
 	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
-	hotkey_keys = list("E")
+	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/gore_charge
 	name = "gore_charge"

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
@@ -10,6 +10,7 @@
 	plasma_stored = 200
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_NORMAL
+	mob_size = MOB_SIZE_BIG
 
 	pixel_x = -16
 	pixel_y = -3

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -48,6 +48,7 @@
 		/datum/action/ability/activable/xeno/bull_charge,
 		/datum/action/ability/activable/xeno/bull_charge/headbutt,
 		/datum/action/ability/activable/xeno/bull_charge/gore,
+		/datum/action/ability/xeno_action/toggle_long_range,
 	)
 
 /datum/xeno_caste/bull/normal


### PR DESCRIPTION

## About The Pull Request
**For the love of god do a test merge**
Bull has boiler's zoom ability
Bull is now a big mob (same size as crusher for the purpose of abilities)
## Why It's Good For The Game
For the zoom ability:
Crusher and Bull are interesting because they are both very similar and very different. One main difference is the fact that bull is not affected by razor wire, but Crusher is. Giving zoom to either of these xenos to allow them to make a good decision based on information given has been an idea that has floated in the air for awhile; though I feel like it is better for bull to have and crusher to not. Crusher has the ability to shrug off alot more than Bull, as well as the counter of razor as a surprise. Giving it zoom would sort of ruin the purpose. Bull has many more ways to die instantly when charging, thus I believe the zoom is a good addition.
For mob size:
This was requested by Kuro as a buff, and honestly it might be too big of one but it'll have to be seen with a TM. You can still get staggered but like with most T3's you won't get knocked over and back by slugs. One slugger would make Bull completely useless because they could either deny your charge or just knock you back into the marines repeatedly. Again, has to be TM'd to see if this is way too strong.
## Changelog
:cl:
balance: Bull now has Boiler's zoom ability
balance: Bull is now has a mob size of big
/:cl:
