### PR TITLE
Examining Stasis Bodybag now show DNR timer and Defib status (DNR or Almost departed)

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -350,16 +350,18 @@
 	if(H.stat != DEAD)
 		return
 	var/timer = 0 // variable for DNR timer check
+	if(H.dead_ticks < TIME_BEFORE_DNR) //Check if DNR timer already passed
+		timer = (TIME_BEFORE_DNR-(H.dead_ticks))*2 //Time to DNR left in seconds
 	if(!H.mind && !H.get_ghost(TRUE)|| H.dead_ticks > TIME_BEFORE_DNR || H.suiciding) //We couldn't find a suitable ghost or patient has passed their DNR timer or suicided, this means the person is not returning
 		. += "<span class = 'deptradio'>Patient is DNR</span>"
 	else if(!H.mind && H.get_ghost(TRUE)) // Ghost is available but outside of the body
 		. += "<span class = 'deptradio'>Defib patient to check departed status</span>"
+		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
 	else if(!H.client) //Mind is in the body but no client, most likely currently disconnected.
 		. += "<span class = 'deptradio'>Patient is almost departed</span>"
-	else if(H.dead_ticks < TIME_BEFORE_DNR) //Check if DNR timer already passed
-		timer = (TIME_BEFORE_DNR-(H.dead_ticks))*2 //Time to DNR left in seconds
 		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
 		return
+
 
 
 /obj/structure/closet/bodybag/cryobag/Topic(href, href_list)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -360,7 +360,9 @@
 	else if(!H.client) //Mind is in the body but no client, most likely currently disconnected.
 		. += "<span class = 'deptradio'>Patient is almost departed</span>"
 		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
-		return
+	else
+		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
+		return	
 
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -334,29 +334,29 @@
 
 /obj/structure/closet/bodybag/cryobag/examine(mob/living/user)
 	. = ..()
-	var/mob/living/carbon/human/Occupant = bodybag_occupant 
-	if(!ishuman(Occupant))
+	var/mob/living/carbon/human/occupant = bodybag_occupant 
+	if(!ishuman(occupant))
 		return
 	if(!hasHUD(user,"medical"))
 		return
 	for(var/datum/data/record/medical_record AS in GLOB.datacore.medical)
-		if(medical_record.fields["name"] != Occupant.real_name)
+		if(medical_record.fields["name"] != occupant.real_name)
 			continue
 		if(!(medical_record.fields["last_scan_time"]))
 			. += "<span class = 'deptradio'>No scan report on record</span>"
 		else
 			. += "<span class = 'deptradio'><a href='?src=[text_ref(src)];scanreport=1'>Scan from [medical_record.fields["last_scan_time"]]</a></span>"
 		break
-	if(Occupant.stat != DEAD)
+	if(occupant.stat != DEAD)
 		return
 	var/timer = 0 // variable for DNR timer check
-	timer = (TIME_BEFORE_DNR-(Occupant.dead_ticks))*2 //Time to DNR left in seconds
-	if(!Occupant.mind && !Occupant.get_ghost(TRUE) || Occupant.dead_ticks > TIME_BEFORE_DNR || Occupant.suiciding) //We couldn't find a suitable ghost or patient has passed their DNR timer or suicided, this means the person is not returning
+	timer = (TIME_BEFORE_DNR-(occupant.dead_ticks))*2 //Time to DNR left in seconds
+	if(!occupant.mind && !occupant.get_ghost(TRUE) || occupant.dead_ticks > TIME_BEFORE_DNR || occupant.suiciding) //We couldn't find a suitable ghost or patient has passed their DNR timer or suicided, this means the person is not returning
 		. += span_scanner("Patient is DNR")
-	else if(!Occupant.mind && Occupant.get_ghost(TRUE)) // Ghost is available but outside of the body
+	else if(!occupant.mind && occupant.get_ghost(TRUE)) // Ghost is available but outside of the body
 		. += span_scanner("Defib patient to check departed status")
 		. += span_scanner("Patient have [timer] seconds left before DNR")
-	else if(!Occupant.client) //Mind is in the body but no client, most likely currently disconnected.
+	else if(!occupant.client) //Mind is in the body but no client, most likely currently disconnected.
 		. += span_scanner("Patient is almost departed")
 		. += span_scanner("Patient have [timer] seconds left before DNR")
 	else

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -334,37 +334,34 @@
 
 /obj/structure/closet/bodybag/cryobag/examine(mob/living/user)
 	. = ..()
-	var/mob/living/carbon/human/H = bodybag_occupant 
-	if(!ishuman(H))
+	var/mob/living/carbon/human/Occupant = bodybag_occupant 
+	if(!ishuman(Occupant))
 		return
 	if(!hasHUD(user,"medical"))
 		return
 	for(var/datum/data/record/medical_record AS in GLOB.datacore.medical)
-		if(medical_record.fields["name"] != H.real_name)
+		if(medical_record.fields["name"] != Occupant.real_name)
 			continue
 		if(!(medical_record.fields["last_scan_time"]))
 			. += "<span class = 'deptradio'>No scan report on record</span>"
 		else
 			. += "<span class = 'deptradio'><a href='?src=[text_ref(src)];scanreport=1'>Scan from [medical_record.fields["last_scan_time"]]</a></span>"
 		break
-	if(H.stat != DEAD)
+	if(Occupant.stat != DEAD)
 		return
 	var/timer = 0 // variable for DNR timer check
-	if(H.dead_ticks < TIME_BEFORE_DNR) //Check if DNR timer already passed
-		timer = (TIME_BEFORE_DNR-(H.dead_ticks))*2 //Time to DNR left in seconds
-	if(!H.mind && !H.get_ghost(TRUE)|| H.dead_ticks > TIME_BEFORE_DNR || H.suiciding) //We couldn't find a suitable ghost or patient has passed their DNR timer or suicided, this means the person is not returning
-		. += "<span class = 'deptradio'>Patient is DNR</span>"
-	else if(!H.mind && H.get_ghost(TRUE)) // Ghost is available but outside of the body
-		. += "<span class = 'deptradio'>Defib patient to check departed status</span>"
-		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
-	else if(!H.client) //Mind is in the body but no client, most likely currently disconnected.
-		. += "<span class = 'deptradio'>Patient is almost departed</span>"
-		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
+	timer = (TIME_BEFORE_DNR-(Occupant.dead_ticks))*2 //Time to DNR left in seconds
+	if(!Occupant.mind && !Occupant.get_ghost(TRUE) || Occupant.dead_ticks > TIME_BEFORE_DNR || Occupant.suiciding) //We couldn't find a suitable ghost or patient has passed their DNR timer or suicided, this means the person is not returning
+		. += span_scanner("Patient is DNR")
+	else if(!Occupant.mind && Occupant.get_ghost(TRUE)) // Ghost is available but outside of the body
+		. += span_scanner("Defib patient to check departed status")
+		. += span_scanner("Patient have [timer] seconds left before DNR")
+	else if(!Occupant.client) //Mind is in the body but no client, most likely currently disconnected.
+		. += span_scanner("Patient is almost departed")
+		. += span_scanner("Patient have [timer] seconds left before DNR")
 	else
-		. += "<span class = 'deptradio'>Patient have [timer] seconds left before DNR</span>"
-		return	
-
-
+		. += span_scanner("Patient have [timer] seconds left before DNR")
+	
 
 /obj/structure/closet/bodybag/cryobag/Topic(href, href_list)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Examining Bodybag now show DNR timer and Defib status (DNR or Almost departed), you still have need to wear a medhud for it to work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm tired of guessing when an almost departed body (disconnected people) get their ghost back (reconnected), even if its rare. Plus a DNR timer to give people time to prep for CPR if needed.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Examining stasis bag while wearing med hud now show defib status (DNR, Almost departed) and DNR timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
