### PR TITLE
Boiler nerfs #2 (hopefully final)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -51,7 +51,7 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 7
 	bomb_strength = 1.3 //Multiplier to the effectiveness of the boiler glob.
-	bomb_delay = 27 SECONDS
+	bomb_delay = 32 SECONDS
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_damage = 16

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -4176,7 +4176,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	///As opposed to normal globs, this will pass by the target tile if they hit nothing.
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_LEAVE_TURF
 	danger_message = span_danger("A pressurized glob of acid lands with a nasty splat and explodes into noxious fumes!")
-	max_range = 40
+	max_range = 25
 	damage = 75
 	penetration = 70
 	reagent_transfer_amount = 55
@@ -4196,7 +4196,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	///As opposed to normal globs, this will pass by the target tile if they hit nothing.
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_LEAVE_TURF
 	danger_message = span_danger("A pressurized glob of acid lands with a concerning hissing sound and explodes into corrosive bile!")
-	max_range = 40
+	max_range = 25
 	damage = 75
 	penetration = 70
 	passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/acid/light
@@ -4205,7 +4205,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hit_drowsyness = 2
 	fixed_spread_range = 2
 	accuracy = 100
-	accurate_range = 30
 	shell_speed = 1.5
 
 /datum/ammo/xeno/hugger


### PR DESCRIPTION
## About The Pull Request
Boiler glob CD increased by 5 seconds (old elder time)
Boiler lance range only extends to their zoom range
## Why It's Good For The Game
These issues still plagued boiler even when it had root, but of course people didn't really play Boiler.
The gas uptime can be quite oppressive hence the CD nerf, should be fine around there given previous Elder boiler
The lance change is a bit more complicated. Lance going offscreen of boiler range seems to hint that it was made to counter snipers, as the snipers cannot see the Boiler. That doesn't exactly make sense since snipers are supposed to at least plink at the boiler. Lance still will remain effective in that it goes past the targeted turf while doing mega, mega damage. Normal glob keeps the 30 range since it cannot shoot offscreen without other xeno aid. The 25 range for lance will be slightly offscreen if they are facing north since north + south are two tiles shorter due to widescreen, but should be alot better than 40 at max.
## Changelog
:cl:
balance: Boiler glob CD increased by 5
balance: Boiler lance has a range of 25, the same distance as it's horizontal zoom range.
/:cl:
