### PR TITLE
Changes Server Poll Management to use new rank, R_POLLS

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -43,8 +43,9 @@
 #define R_DBRANKS (1<<13)
 #define R_RUNTIME (1<<14)
 #define R_LOG (1<<15)
+#define R_POLLS (1<<16)
 
-#define R_EVERYTHING (1<<16)-1 //the sum of all other rank permissions, used for +EVERYTHING
+#define R_EVERYTHING (ALL) //the sum of all other rank permissions, used for +EVERYTHING
 
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];moreinfo=[REF(user)]'>?</a>)"
 #define ADMIN_FLW(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];observefollow=[REF(user)]'>FLW</a>)"

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -173,6 +173,8 @@
 		. += "[seperator]+RUNTIME"
 	if(rights & R_LOG)
 		. += "[seperator]+LOG"
+	if(rights & R_POLLS)
+		. += "[seperator]+POLLS"
 
 
 /proc/ui_style2icon(ui_style)

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -15,7 +15,8 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"SPAWN" = R_SPAWN,
 		"DBRANKS" = R_DBRANKS,
 		"RUNTIME" = R_RUNTIME,
-		"LOG" = R_LOG
+		"LOG" = R_LOG,
+		"POLLS" = R_POLLS
 	),
 	"machine_stat" = list(
 		"BROKEN" = BROKEN,

--- a/code/_onclick/hud/screen_objects/menu_text_objects.dm
+++ b/code/_onclick/hud/screen_objects/menu_text_objects.dm
@@ -159,6 +159,6 @@
 /atom/movable/screen/text/lobby/clickable/polls/Click()
 	. = ..()
 	var/mob/new_player/player = hud.mymob
-	player.handle_playeR_DBRANKSing()
+	player.handle_playeR_POLLSing()
 	fetch_polls()
 

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -82,6 +82,8 @@
 				flag = R_DBRANKS
 			if("LOG")
 				flag = R_LOG
+			if("POLLS")
+				flag = R_POLLS
 			if("EVERYTHING")
 				flag = R_EVERYTHING
 			if("@")

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -464,7 +464,6 @@ GLOBAL_PROTECT(admin_verbs_server)
 /world/proc/AVpermissions()
 	return list(
 	/client/proc/edit_admin_permissions,
-	/client/proc/poll_panel,
 	)
 GLOBAL_LIST_INIT(admin_verbs_permissions, world.AVpermissions())
 GLOBAL_PROTECT(admin_verbs_permissions)
@@ -507,6 +506,13 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 GLOBAL_LIST_INIT(admin_verbs_log, world.AVlog())
 GLOBAL_PROTECT(admin_verbs_log)
 
+/world/proc/AVpolls()
+	return list(
+	/client/proc/poll_panel,
+	)
+GLOBAL_LIST_INIT(admin_verbs_polls, world.AVpolls())
+GLOBAL_PROTECT(admin_verbs_polls)
+
 /client/proc/add_admin_verbs()
 	if(holder)
 		var/rights = holder.rank.rights
@@ -541,6 +547,8 @@ GLOBAL_PROTECT(admin_verbs_log)
 			add_verb(src, GLOB.admin_verbs_spawn)
 		if(rights & R_LOG)
 			add_verb(src, GLOB.admin_verbs_log)
+		if(rights & R_POLLS)
+			add_verb(src, GLOB.admin_verbs_polls)
 
 
 /client/proc/remove_admin_verbs()

--- a/code/modules/admin/panels/poll_panel.dm
+++ b/code/modules/admin/panels/poll_panel.dm
@@ -1,7 +1,7 @@
 /client/proc/poll_panel()
 	set name = "Server Poll Management"
 	set category = "Admin"
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	holder.poll_list_panel()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Server Poll Management") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2117,7 +2117,7 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 
 	else if(href_list["clearpollvotes"])
 		var/datum/poll_question/poll = locate(href_list["clearpollvotes"]) in GLOB.polls
-		poll.cleaR_DBRANKS_votes()
+		poll.cleaR_POLLS_votes()
 		poll_management_panel(poll)
 
 	else if(href_list["addpolloption"])

--- a/code/modules/admin/verbs/poll_managment.dm
+++ b/code/modules/admin/verbs/poll_managment.dm
@@ -242,7 +242,7 @@
  *
  */
 /datum/admins/proc/poll_parse_href(list/href_list, datum/poll_question/poll)
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -351,7 +351,7 @@
  *
  */
 /datum/poll_question/proc/delete_poll()
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -376,11 +376,11 @@
  * Uses INSERT ON DUPLICATE KEY UPDATE to handle both inserting and updating at once.
  * The start and end datetimes and poll id for new polls is then retrieved for the poll datum.
  * Arguments:
- * * clear_votes - When true will call cleaR_DBRANKS_votes() to delete all votes matching this poll id.
+ * * clear_votes - When true will call cleaR_POLLS_votes() to delete all votes matching this poll id.
  *
  */
 /datum/poll_question/proc/save_poll_data(clear_votes)
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -427,7 +427,7 @@
 		future_poll = text2num(query_get_poll_id_start_endtime.item[3])
 	qdel(query_get_poll_id_start_endtime)
 	if(clear_votes)
-		cleaR_DBRANKS_votes()
+		cleaR_POLLS_votes()
 	edit_ready = TRUE
 	var/msg = "has [new_poll ? "created a new" : "edited a"][admin_only ? " admin only" : ""] server poll. Question: [question]"
 	if(admin_only)
@@ -456,8 +456,8 @@
  * Deletes all votes or text replies for this poll, depending on its type.
  *
  */
-/datum/poll_question/proc/cleaR_DBRANKS_votes()
-	if(!check_rights(R_DBRANKS))
+/datum/poll_question/proc/cleaR_POLLS_votes()
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -465,14 +465,14 @@
 	var/table = "poll_vote"
 	if(poll_type == POLLTYPE_TEXT)
 		table = "poll_textreply"
-	var/datum/db_query/query_cleaR_DBRANKS_votes = SSdbcore.NewQuery(
+	var/datum/db_query/query_cleaR_POLLS_votes = SSdbcore.NewQuery(
 		"UPDATE [format_table_name(table)] SET deleted = 1 WHERE pollid = :poll_id",
 		list("poll_id" = poll_id)
 	)
-	if(!query_cleaR_DBRANKS_votes.warn_execute())
-		qdel(query_cleaR_DBRANKS_votes)
+	if(!query_cleaR_POLLS_votes.warn_execute())
+		qdel(query_cleaR_POLLS_votes)
 		return
-	qdel(query_cleaR_DBRANKS_votes)
+	qdel(query_cleaR_POLLS_votes)
 	poll_votes = 0
 	to_chat(usr, span_danger("Poll [poll_type == POLLTYPE_TEXT ? "responses" : "votes"] cleared."))
 
@@ -540,7 +540,7 @@
  *
  */
 /datum/admins/proc/poll_option_parse_href(list/href_list, datum/poll_question/poll, datum/poll_option/option)
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -638,7 +638,7 @@
  *
  */
 /datum/poll_option/proc/save_option()
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	if(!SSdbcore.Connect())
 		to_chat(usr, span_danger("Failed to establish database connection."))
@@ -672,7 +672,7 @@
  *
  */
 /datum/poll_option/proc/delete_option()
-	if(!check_rights(R_DBRANKS))
+	if(!check_rights(R_POLLS))
 		return
 	. = parent_poll
 	if(option_id)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -167,7 +167,7 @@
 			DIRECT_OUTPUT(usr, browse(null, "window=xenosunbalanced"))
 
 	if(href_list["showpoll"])
-		handle_playeR_DBRANKSing()
+		handle_playeR_POLLSing()
 		return
 
 	if(href_list["viewpoll"])

--- a/code/modules/mob/new_player/poll.dm
+++ b/code/modules/mob/new_player/poll.dm
@@ -2,7 +2,7 @@
  * Shows a list of currently running polls a player can vote/has voted on
  *
  */
-/mob/new_player/proc/handle_playeR_DBRANKSing()
+/mob/new_player/proc/handle_playeR_POLLSing()
 	var/list/output = list("<div align='center'><B>Player polls</B><hr><table>")
 	var/rs = REF(src)
 	for(var/p in GLOB.polls)


### PR DESCRIPTION
## About The Pull Request
New permission, R_POLLS. Used for the Server Poll Management verb. Would be given to those with DBRANKS and maintainers to collect data. Needs lead permission to be merged.

**ACTIONS REQUIRED FOR THIS TO WORK**
Someone with +DBRANKS is required to add +POLLS to the followings ranks:
- Host
- Headcoder
- Headmin
- Seniormin
These ranks already have +DBRANKS. The following ranks need +POLLS but do not have +DBRANKS.
- Maintainer
- Art Maintainer
## Changelog
:cl:
admin: R_POLLS rank used for Server Poll Management
/:cl:
