### PR TITLE
Buffs ozymelyn purge rate from 5u to 10u

### DIFF
--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -622,7 +622,7 @@
 	scannable = TRUE
 	toxpwr = 0 // This is going to do slightly snowflake tox damage.
 	purge_list = list(/datum/reagent/medicine)
-	purge_rate = 5
+	purge_rate = 8
 
 /datum/reagent/toxin/xeno_ozelomelyn/on_mob_life(mob/living/L, metabolism)
 	if(L.getToxLoss() < 40) // if our toxloss is below 40, do 0.75 tox damage.

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -622,7 +622,7 @@
 	scannable = TRUE
 	toxpwr = 0 // This is going to do slightly snowflake tox damage.
 	purge_list = list(/datum/reagent/medicine)
-	purge_rate = 8
+	purge_rate = 10
 
 /datum/reagent/toxin/xeno_ozelomelyn/on_mob_life(mob/living/L, metabolism)
 	if(L.getToxLoss() < 40) // if our toxloss is below 40, do 0.75 tox damage.


### PR DESCRIPTION
## About The Pull Request
Recently tried the defiler caste. The ozymelyn smoke was kind of useless since it was never adjusted for the new reagent BKKT pouches.

## Why It's Good For The Game
A marine standing in a smoke of ozemelyn will usually take a 2-3u dose. Ozymelon has a metab rate of 1.5 units , so it would only purge 10 units. Most marines using BKKT will have 40-50 units inside of them , making the effect kind of underwhelming. With these changes it will purge 20 units, putting a decent dent in a marine's bloodstream meds. (but still not enough to really purge their entire bloodstream, that requires reagent slashing) 
This is without taking into consideration wheter or not they have dylovene . If the marines are also using dylovene the effects are preety much halved (since dylo purges ozymelyn at 1u per tick)

## Changelog
:cl:
balance: Ozymelyn purge rate buffed from 5u to 10u
/:cl:
