### PR TITLE
Puppeter resist,rest and sleep functionality

### DIFF
--- a/code/modules/ai/ai_behaviors/xeno/puppet.dm
+++ b/code/modules/ai/ai_behaviors/xeno/puppet.dm
@@ -24,6 +24,10 @@
 		RegisterSignal(master, COMSIG_PUPPET_CHANGE_ALL_ORDER, PROC_REF(change_order))
 	RegisterSignal(mob_parent, COMSIG_OBSTRUCTED_MOVE, PROC_REF(deal_with_obstacle))
 	RegisterSignal(mob_parent, COMSIG_PUPPET_CHANGE_ORDER, PROC_REF(change_order))
+	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_REST, PROC_REF(start_resting))
+	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_UNREST, PROC_REF(stop_resting))
+	RegisterSignal(escorted_atom, COMSIG_ELEMENT_JUMP_STARTED, PROC_REF(do_jump))
+	RegisterSignal(escorted_atom, COMSIG_LIVING_DO_RESIST, PROC_REF(parent_resist))
 	return ..()
 
 ///cleans up signals and unregisters obstructed move signal
@@ -181,3 +185,28 @@
 		return
 	if(feed.ai_should_use(target))
 		feed.use_ability(target)
+
+/// rest when puppeter does
+/datum/ai_behavior/puppet/proc/start_resting(mob/source)
+	SIGNAL_HANDLER
+	var/mob/living/living = mob_parent
+	living?.set_resting(TRUE)
+
+/// stop resting when puppeter does, plus unbuckle all mobs so the widow won't get stuck
+/datum/ai_behavior/puppet/proc/stop_resting(mob/source)
+	SIGNAL_HANDLER
+	var/mob/living/living = mob_parent
+	living?.set_resting(FALSE)
+	source?.unbuckle_all_mobs()
+
+/// resist when puppeter does
+/datum/ai_behavior/puppet/proc/do_jump()
+	SIGNAL_HANDLER
+	var/datum/component/jump/jumpy_spider = mob_parent.GetComponent(/datum/component/jump)
+	jumpy_spider?.do_jump(mob_parent)
+
+/// resist when puppeter does
+/datum/ai_behavior/puppet/proc/parent_resist()
+	SIGNAL_HANDLER
+	var/mob/living/carbon/xenomorph/spiderling/spiderling_parent = mob_parent
+	spiderling_parent?.do_resist()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For decades the ability for puppets to rest,resist and jump was an unknown concept.Due to extensive puppeter RnD we have developed 3 extra threads that will achieve the following.
RESTING(and unresting as a treat)
RESISTING
JUMPING


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Slow healing due to lack of rest,death sentence due to fire and complete inability to traverse terain due to small ledges bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Puppets have now the ability to rest and unrest when puppeter does
add: puppets have now the ability to sleep and resist when puppeter does
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
