### PR TITLE
Campaign loadout UI performance improvement

### DIFF
--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -319,6 +319,9 @@
 			selected_job = new_job
 			user.playsound_local(user, 'sound/effects/menu_click.ogg', 50)
 			return TRUE
+		if("play_ding")
+			user.playsound_local(user, 'sound/effects/menu_click.ogg', 50) //just for the consistant experience
+			return TRUE
 		if("unlock_perk")
 			var/unlocked_perk = text2path(params["selected_perk"])
 			if(!unlocked_perk)

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -20,7 +20,9 @@
 	var/list/datum/outfit_holder/loadouts = list()
 	///The faction associated with these stats
 	var/faction
+	///Currently selected UI category tab
 	var/selected_tab = TAB_LOADOUT
+	///Currently selected UI job tab
 	var/selected_job
 
 /datum/individual_stats/New(mob/living/carbon/new_mob, new_faction, new_currency)
@@ -405,6 +407,7 @@
 	if(!stats)
 		return
 	stats.current_mob = owner //taking over ssd's creates a mismatch
+	//we have to update selected tab/job so we load the correct data for the UI
 	if(!isliving(owner))
 		stats.selected_job = stats.valid_jobs[1]
 	else

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -178,26 +178,24 @@
 	data["current_job"] = istype(living_user) ? living_user.job.title : null
 	data["currency"] = currency
 
-	//if(selected_tab == TAB_PERKS)
-	//perk stuff
-	var/list/perks_data = list()
-	for(var/datum/perk/perk AS in GLOB.campaign_perks_by_role[selected_job])
-		var/list/perk_data = list()
-		perk_data["name"] = perk.name
-		perk_data["job"] = selected_job
-		perk_data["type"] = perk.type
-		perk_data["desc"] = perk.desc
-		perk_data["requirements"] = perk.req_desc
-		perk_data["cost"] = perk.unlock_cost
-		perk_data["icon"] = perk.ui_icon
-		perk_data["currently_active"] = !!(perk in perks_by_job[selected_job])
-		perks_data += list(perk_data)
-	data["perks_data"] = perks_data
-	//return data
+	if(selected_tab == TAB_PERKS)
+		var/list/perks_data = list()
+		for(var/datum/perk/perk AS in GLOB.campaign_perks_by_role[selected_job])
+			var/list/perk_data = list()
+			perk_data["name"] = perk.name
+			perk_data["job"] = selected_job
+			perk_data["type"] = perk.type
+			perk_data["desc"] = perk.desc
+			perk_data["requirements"] = perk.req_desc
+			perk_data["cost"] = perk.unlock_cost
+			perk_data["icon"] = perk.ui_icon
+			perk_data["currently_active"] = !!(perk in perks_by_job[selected_job])
+			perks_data += list(perk_data)
+		data["perks_data"] = perks_data
+		return data
 
 	if(selected_tab != TAB_LOADOUT)
-		return data //something fucked up but ok
-	//loadout stuff
+		return data //How'd you fuck up this badly?
 	var/list/equipped_loadouts_data = list() //items currently equipped to ALL job outfits
 	var/list/available_loadouts_data = list() //all available AND purchasable loadout options
 	var/list/outfit_cost_data = list() //Current cost of all outfits
@@ -412,6 +410,7 @@
 	else
 		var/mob/living/living_owner = owner
 		stats.selected_job = living_owner.job.title
+	stats.selected_tab = TAB_LOADOUT
 	stats.interact(owner)
 
 #undef TAB_LOADOUT

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -180,24 +180,9 @@
 	data["current_job"] = istype(living_user) ? living_user.job.title : null
 	data["currency"] = currency
 
-	if(selected_tab == TAB_PERKS)
-		var/list/perks_data = list()
-		for(var/datum/perk/perk AS in GLOB.campaign_perks_by_role[selected_job])
-			var/list/perk_data = list()
-			perk_data["name"] = perk.name
-			perk_data["job"] = selected_job
-			perk_data["type"] = perk.type
-			perk_data["desc"] = perk.desc
-			perk_data["requirements"] = perk.req_desc
-			perk_data["cost"] = perk.unlock_cost
-			perk_data["icon"] = perk.ui_icon
-			perk_data["currently_active"] = !!(perk in perks_by_job[selected_job])
-			perks_data += list(perk_data)
-		data["perks_data"] = perks_data
-		return data
-
 	if(selected_tab != TAB_LOADOUT)
-		return data //How'd you fuck up this badly?
+		return data
+	//This cannot be static data due to the limitations on how frequently static data can be updated, and clicking on loadout options requires a data update.
 	var/list/equipped_loadouts_data = list() //items currently equipped to ALL job outfits
 	var/list/available_loadouts_data = list() //all available AND purchasable loadout options
 	var/list/outfit_cost_data = list() //Current cost of all outfits
@@ -291,6 +276,21 @@
 	data["faction"] = faction
 	data["jobs"] = valid_jobs
 
+	var/list/perks_data = list()
+	for(var/job in perks_by_job)
+		for(var/datum/perk/perk AS in GLOB.campaign_perks_by_role[job])
+			var/list/perk_data = list()
+			perk_data["name"] = perk.name
+			perk_data["job"] = job
+			perk_data["type"] = perk.type
+			perk_data["desc"] = perk.desc
+			perk_data["requirements"] = perk.req_desc
+			perk_data["cost"] = perk.unlock_cost
+			perk_data["icon"] = perk.ui_icon
+			perk_data["currently_active"] = !!(perk in perks_by_job[job])
+			perks_data += list(perk_data)
+		data["perks_data"] = perks_data
+
 	return data
 
 /datum/individual_stats/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -328,6 +328,7 @@
 			var/datum/perk/perk = GLOB.campaign_perk_list[unlocked_perk]
 			if(!purchase_perk(perk, user))
 				return
+			ui.send_full_update()
 			user.playsound_local(user, 'sound/effects/menu_click.ogg', 50)
 			return TRUE
 		if("equip_item")

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
@@ -83,6 +83,7 @@ export const IndividualLoadouts = (props) => {
                       mr="3px"
                       ml="3px"
                       onClick={() => {
+                        act('play_ding');
                         setselectedLoadoutItem(equippeditem);
                         setselectedPossibleItem(equippeditem.item_type);
                       }}

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
@@ -47,7 +47,10 @@ export const IndividualPerks = (props) => {
                   <Button
                     width={'220px'}
                     height={'22px'}
-                    onClick={() => setSelectedPerk(perk)}
+                    onClick={() => {
+                      act('play_ding');
+                      setSelectedPerk(perk);
+                    }}
                     color={
                       selectedPerk.name === perk.name
                         ? 'orange'

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
@@ -24,9 +24,9 @@ export const IndividualPerks = (props) => {
   );
   const [selectedPerk, setSelectedPerk] = useLocalState(
     'selectedPerk',
-    perks_data ? perks_data[0] : null,
+    perks_data[0],
   );
-  perks_data?.sort((a, b) => {
+  perks_data.sort((a, b) => {
     const used_asset_a = a.currently_active;
     const used_asset_b = b.currently_active;
     if (used_asset_a && used_asset_b) return 0;
@@ -40,45 +40,43 @@ export const IndividualPerks = (props) => {
       <Stack.Item>
         <Section>
           <Stack vertical>
-            {!perks_data
-              ? null
-              : perks_data
-                  .filter((perk) => perk.job === selectedJob)
-                  .map((perk) => (
-                    <Stack.Item key={perk.name}>
-                      <Button
-                        width={'220px'}
-                        height={'22px'}
-                        onClick={() => setSelectedPerk(perk)}
-                        color={
-                          selectedPerk?.name === perk.name
-                            ? 'orange'
+            {perks_data
+              .filter((perk) => perk.job === selectedJob)
+              .map((perk) => (
+                <Stack.Item key={perk.name}>
+                  <Button
+                    width={'220px'}
+                    height={'22px'}
+                    onClick={() => setSelectedPerk(perk)}
+                    color={
+                      selectedPerk.name === perk.name
+                        ? 'orange'
+                        : perk.currently_active > 0
+                          ? 'blue'
+                          : perk.cost > data.currency
+                            ? 'red'
+                            : 'grey'
+                    }
+                  >
+                    <Flex align="center" mt="1px">
+                      <Flex.Item
+                        mr={1.5}
+                        className={classes([
+                          'campaign_perks18x18',
+                          selectedPerk.name === perk.name
+                            ? perk.icon + '_orange'
                             : perk.currently_active > 0
-                              ? 'blue'
+                              ? perk.icon + '_blue'
                               : perk.cost > data.currency
-                                ? 'red'
-                                : 'grey'
-                        }
-                      >
-                        <Flex align="center" mt="1px">
-                          <Flex.Item
-                            mr={1.5}
-                            className={classes([
-                              'campaign_perks18x18',
-                              selectedPerk?.name === perk.name
-                                ? perk.icon + '_orange'
-                                : perk.currently_active > 0
-                                  ? perk.icon + '_blue'
-                                  : perk.cost > data.currency
-                                    ? perk.icon + '_red'
-                                    : perk.icon + '_grey',
-                            ])}
-                          />
-                          {perk.name}
-                        </Flex>
-                      </Button>
-                    </Stack.Item>
-                  ))}
+                                ? perk.icon + '_red'
+                                : perk.icon + '_grey',
+                        ])}
+                      />
+                      {perk.name}
+                    </Flex>
+                  </Button>
+                </Stack.Item>
+              ))}
           </Stack>
         </Section>
       </Stack.Item>
@@ -125,9 +123,9 @@ export const IndividualPerks = (props) => {
             <LabeledList.Item label="Cost">
               {selectedPerk?.cost}
             </LabeledList.Item>
-            {selectedPerk?.requirements && (
+            {selectedPerk.requirements && (
               <LabeledList.Item label="Requirements">
-                {selectedPerk?.requirements}
+                {selectedPerk.requirements}
               </LabeledList.Item>
             )}
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
@@ -24,9 +24,9 @@ export const IndividualPerks = (props) => {
   );
   const [selectedPerk, setSelectedPerk] = useLocalState(
     'selectedPerk',
-    perks_data[0],
+    perks_data ? perks_data[0] : null,
   );
-  perks_data.sort((a, b) => {
+  perks_data?.sort((a, b) => {
     const used_asset_a = a.currently_active;
     const used_asset_b = b.currently_active;
     if (used_asset_a && used_asset_b) return 0;
@@ -40,43 +40,45 @@ export const IndividualPerks = (props) => {
       <Stack.Item>
         <Section>
           <Stack vertical>
-            {perks_data
-              .filter((perk) => perk.job === selectedJob)
-              .map((perk) => (
-                <Stack.Item key={perk.name}>
-                  <Button
-                    width={'220px'}
-                    height={'22px'}
-                    onClick={() => setSelectedPerk(perk)}
-                    color={
-                      selectedPerk.name === perk.name
-                        ? 'orange'
-                        : perk.currently_active > 0
-                          ? 'blue'
-                          : perk.cost > data.currency
-                            ? 'red'
-                            : 'grey'
-                    }
-                  >
-                    <Flex align="center" mt="1px">
-                      <Flex.Item
-                        mr={1.5}
-                        className={classes([
-                          'campaign_perks18x18',
-                          selectedPerk.name === perk.name
-                            ? perk.icon + '_orange'
+            {!perks_data
+              ? null
+              : perks_data
+                  .filter((perk) => perk.job === selectedJob)
+                  .map((perk) => (
+                    <Stack.Item key={perk.name}>
+                      <Button
+                        width={'220px'}
+                        height={'22px'}
+                        onClick={() => setSelectedPerk(perk)}
+                        color={
+                          selectedPerk?.name === perk.name
+                            ? 'orange'
                             : perk.currently_active > 0
-                              ? perk.icon + '_blue'
+                              ? 'blue'
                               : perk.cost > data.currency
-                                ? perk.icon + '_red'
-                                : perk.icon + '_grey',
-                        ])}
-                      />
-                      {perk.name}
-                    </Flex>
-                  </Button>
-                </Stack.Item>
-              ))}
+                                ? 'red'
+                                : 'grey'
+                        }
+                      >
+                        <Flex align="center" mt="1px">
+                          <Flex.Item
+                            mr={1.5}
+                            className={classes([
+                              'campaign_perks18x18',
+                              selectedPerk?.name === perk.name
+                                ? perk.icon + '_orange'
+                                : perk.currently_active > 0
+                                  ? perk.icon + '_blue'
+                                  : perk.cost > data.currency
+                                    ? perk.icon + '_red'
+                                    : perk.icon + '_grey',
+                            ])}
+                          />
+                          {perk.name}
+                        </Flex>
+                      </Button>
+                    </Stack.Item>
+                  ))}
           </Stack>
         </Section>
       </Stack.Item>
@@ -123,9 +125,9 @@ export const IndividualPerks = (props) => {
             <LabeledList.Item label="Cost">
               {selectedPerk?.cost}
             </LabeledList.Item>
-            {selectedPerk.requirements && (
+            {selectedPerk?.requirements && (
               <LabeledList.Item label="Requirements">
-                {selectedPerk.requirements}
+                {selectedPerk?.requirements}
               </LabeledList.Item>
             )}
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
@@ -30,18 +30,15 @@ export type PerkData = {
 
 export type IndividualData = {
   ui_theme: string;
-  perks_data?: PerkData[];
+  perks_data: PerkData[];
   currency: number;
   current_job?: string;
   faction: string;
   jobs: string[];
   perk_icons?: string[];
-  mission_icons?: string[];
-  equipped_loadouts_data?: EquippedItemData[];
-  available_loadouts_data?: LoadoutItemData[];
-  purchasable_loadouts_data?: LoadoutItemData[];
-  outfit_slots?: string[];
-  outfit_cost_data?: OutfitCostData[];
+  equipped_loadouts_data: EquippedItemData[];
+  available_loadouts_data: LoadoutItemData[];
+  outfit_cost_data: OutfitCostData[];
 };
 
 export type OutfitCostData = {

--- a/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
@@ -30,18 +30,18 @@ export type PerkData = {
 
 export type IndividualData = {
   ui_theme: string;
-  perks_data: PerkData[];
+  perks_data?: PerkData[];
   currency: number;
   current_job?: string;
   faction: string;
   jobs: string[];
   perk_icons?: string[];
   mission_icons?: string[];
-  equipped_loadouts_data: EquippedItemData[];
-  available_loadouts_data: LoadoutItemData[];
-  purchasable_loadouts_data: LoadoutItemData[];
-  outfit_slots: string[];
-  outfit_cost_data: OutfitCostData[];
+  equipped_loadouts_data?: EquippedItemData[];
+  available_loadouts_data?: LoadoutItemData[];
+  purchasable_loadouts_data?: LoadoutItemData[];
+  outfit_slots?: string[];
+  outfit_cost_data?: OutfitCostData[];
 };
 
 export type OutfitCostData = {
@@ -217,7 +217,12 @@ export const IndividualStats = (props) => {
                 selected={jobname === selectedJob}
                 fontSize="130%"
                 textAlign="center"
-                onClick={() => setSelectedJob(jobname)}
+                onClick={() => {
+                  act('set_selected_job', {
+                    new_selected_job: jobname,
+                  });
+                  setSelectedJob(jobname);
+                }}
               >
                 {jobname}
               </Tabs.Tab>
@@ -239,7 +244,12 @@ export const IndividualStats = (props) => {
                 selected={tabname === selectedTab}
                 fontSize="130%"
                 textAlign="center"
-                onClick={() => setSelectedTab(tabname)}
+                onClick={() => {
+                  act('set_selected_tab', {
+                    new_selected_tab: tabname,
+                  });
+                  setSelectedTab(tabname);
+                }}
               >
                 {tabname}
               </Tabs.Tab>


### PR DESCRIPTION

## About The Pull Request
Should greatly improve the perf of this UI (usually its fine but some times/for some people it lags horribly).
Now it just loads the perk or loadout data (not both) and only loads it for the currently selected job tab.
## Why It's Good For The Game
Bad perf is bad.
## Changelog
:cl:
code: Some performance improvements to campaign loadout UI
/:cl:
