### PR TITLE
Removes the ability to vote for the current map during groundmap vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -273,10 +273,12 @@ SUBSYSTEM_DEF(vote)
 					var/datum/map_config/VM = config.maplist[GROUND_MAP][map]
 					if(!VM.voteweight)
 						continue
+					if(VM.map_name == SSmapping.configs[GROUND_MAP].map_name) //Current map is not votable
+						continue
 					if(next_gamemode.whitelist_ground_maps)
 						if(!(VM.map_name in next_gamemode.whitelist_ground_maps))
 							continue
-					else if(next_gamemode.blacklist_ground_maps) //can't blacklist and whitelist for the same map
+					else if(next_gamemode.blacklist_ground_maps) //Can't blacklist and whitelist for the same map
 						if(VM.map_name in next_gamemode.blacklist_ground_maps)
 							continue
 					if(VM.config_max_users || VM.config_min_users)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
A common complaint was the same map 3-4 times in a row. This eliminates that.
## Changelog
:cl:
del: Removes the ability to vote for the current map during groundmap vote
/:cl:
