### PR TITLE
Reworks Grenade req pricing and reqtorio pricing and yield. Actually adds cloak nade refill to req.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1146,9 +1146,9 @@
 /obj/item/storage/box/visual/grenade/phosphorus
 	name = "\improper M40 HPDP grenade box"
 	desc = "A secure box holding 15 M40 HPDP white phosphorous grenades. War crimes for the entire platoon!"
-	storage_slots = 15
+	storage_slots = 25
 	max_storage_space = 30
-	spawn_number = 15
+	spawn_number = 25
 	spawn_type = /obj/item/explosive/grenade/phosphorus
 	closed_overlay = "grenade_box_overlay_phosphorus"
 
@@ -1190,9 +1190,9 @@
 /obj/item/storage/box/visual/grenade/razorburn
 	name = "razorburn grenade box"
 	desc = "A secure box holding 15 razor burn grenades. Used for quick flank coverage."
-	storage_slots = 15
+	storage_slots = 25
 	max_storage_space = 30
-	spawn_number = 15
+	spawn_number = 25
 	spawn_type = /obj/item/explosive/grenade/chem_grenade/razorburn_small
 	closed_overlay = "grenade_box_overlay_razorburn"
 

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -110,67 +110,67 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/bignade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/incennade_refill
 	name = "box of incendiary grenade plates"
 	desc = "A box with round metal plates inside that could be used to construct Incendiary genades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/incennade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/stickynade_refill
 	name = "box of adhesive genade plates"
 	desc = "A box with round metal plates inside that could be used to construct Adhesive grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/stickynade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/phosnade_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/phosnade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/cloaknade_refill
 	name = "box of cloaking grenade plates"
 	desc = "A box with round metal plates inside that could be used to construct Cloaking grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/cloaknade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/tfootnade_refill
 	name = "box of tangle grenade plates"
 	desc = "A box with round metal plates inside that could be used to construct Tanglefoot grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/tfootnade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/trailblazer_refill
 	name = "box of trailblazer grenade plates"
 	desc = "A box with round metal plates inside that could be used to construct Trailblazer genades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/trailblazer
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/lasenade_refill
 	name = "box of laser grenade plates and cells."
 	desc = "A box with plates and cells inside that could be used to construct Laser grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/lasenade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/hefanade_refill
 	name = "box of hefa nade plates and shells."
 	desc = "A box with plates and shells inside that could be used to construct HEFA grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/hefanade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/antigas_refill
 	name = "box of Anti-Gas plates."
 	desc = "A box with plates inside that could be used to construct M40-AG grenades. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/antigas
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/razornade_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/razornade
-	refill_amount = 40
+	refill_amount = 50
 
 /obj/item/factory_refill/pizza_refill
 	name = "box of rounded metal plates"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -903,7 +903,7 @@ EXPLOSIVES
 	name = "M40 HSDP white phosphorous grenade box crate"
 	notes = "Contains 15 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/phosphorus)
-	cost = 700
+	cost = 1000
 
 /datum/supply_packs/explosives/explosives_hefa
 	name = "M25 HEFA grenade box crate"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -835,7 +835,7 @@ EXPLOSIVES
 
 /datum/supply_packs/explosives/explosives_razor
 	name = "Razorburn grenade box crate"
-	notes = "Contains 15 razor burns"
+	notes = "Contains 25 razor burns"
 	contains = list(/obj/item/storage/box/visual/grenade/razorburn)
 	cost = 500
 
@@ -843,25 +843,25 @@ EXPLOSIVES
 	name = "M40 adhesive charge grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/sticky)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_smokebomb
 	name = "M40 HSDP smokebomb grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/smokebomb)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_hedp
 	name = "M40 HEDP high explosive grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/frag)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_cloaker
 	name = "M45 Cloaker grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/cloaker)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_antigas
 	name = "M40-AG Anti-Gas grenade box crate"
@@ -873,13 +873,13 @@ EXPLOSIVES
 	name = "M40-2 SCDP grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/cloak)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_lasburster
 	name = "M80 lasburster grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/lasburster)
-	cost = 310
+	cost = 300
 
 /datum/supply_packs/explosives/explosives_hidp
 	name = "M40 HIDP incendiary explosive grenade box crate"
@@ -889,7 +889,7 @@ EXPLOSIVES
 
 /datum/supply_packs/explosives/explosives_m15
 	name = "M15 fragmentation grenade box crate"
-	notes = "Contains 15 grenades"
+	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/M15)
 	cost = 350
 
@@ -897,7 +897,7 @@ EXPLOSIVES
 	name = "M45 Trailblazer grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/trailblazer)
-	cost = 350
+	cost = 500
 
 /datum/supply_packs/explosives/explosives_hsdp
 	name = "M40 HSDP white phosphorous grenade box crate"
@@ -909,7 +909,7 @@ EXPLOSIVES
 	name = "M25 HEFA grenade box crate"
 	notes = "Contains 25 grenades"
 	contains = list(/obj/item/storage/box/visual/grenade/hefa)
-	cost = 550
+	cost = 500
 
 /datum/supply_packs/explosives/plastique
 	name = "C4 plastic explosive"
@@ -2098,12 +2098,12 @@ FACTORY
 /datum/supply_packs/factory/bignaderefill
 	name = "Rounded M15 plates refill"
 	contains = list(/obj/item/factory_refill/bignade_refill)
-	cost = 700
+	cost = 550
 
 /datum/supply_packs/factory/incennaderefill
 	name = "Incendiary grenade refill"
 	contains = list(/obj/item/factory_refill/incennade_refill)
-	cost = 500
+	cost = 550
 
 /datum/supply_packs/factory/stickynaderefill
 	name = "Adhesive grenade refill"
@@ -2113,12 +2113,17 @@ FACTORY
 /datum/supply_packs/factory/phosphosrefill
 	name = "Phosphorus-resistant plates refill"
 	contains = list(/obj/item/factory_refill/phosnade_refill)
-	cost = 1400
+	cost = 1050
+
+/datum/supply_packs/factory/cloaknade_refill
+	name = "Cloak grenade refill"
+	contains = list(/obj/item/factory_refill/cloaknade_refill)
+	cost = 450
 
 /datum/supply_packs/factory/trailblazerrefill
 	name = "Trailblazer grenade refill"
 	contains = list(/obj/item/factory_refill/trailblazer_refill)
-	cost = 500
+	cost = 750
 
 /datum/supply_packs/factory/lasenaderefill
 	name = "Laserburster grenade refill"
@@ -2128,17 +2133,17 @@ FACTORY
 /datum/supply_packs/factory/hefanaderefill
 	name = "HEFA fragmentation grenade refill"
 	contains = list(/obj/item/factory_refill/hefanade_refill)
-	cost = 700
+	cost = 750
 
 /datum/supply_packs/factory/antigasrefill
 	name = "Anti-Gas grenade refill"
 	contains = list(/obj/item/factory_refill/antigas_refill)
-	cost = 800
+	cost = 900
 
 /datum/supply_packs/factory/razornade_refill
 	name = "Razornade assembly refill"
 	contains = list(/obj/item/factory_refill/razornade_refill)
-	cost = 1000
+	cost = 750
 
 /datum/supply_packs/factory/sadar_refill_he
 	name = "SADAR HE missile assembly refill"


### PR DESCRIPTION
## About The Pull Request
This adjusts the several grenade boxes' pricing in req as well as the cost and amount of grenades produced in reqtorio.
All grenade boxes will now contain 25 grenades.
All reqtorio grenade factories will produce 50 grenades.
The reqtorio cost efficiency is 1.5 times cheaper than buying boxes.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/yashm/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/yashm/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{text-align:center;}
.xl66
	{text-align:center;
	border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl67
	{font-weight:700;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
.xl68
	{font-weight:700;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl69
	{border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl70
	{border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl71
	{border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
.xl72
	{text-align:center;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl73
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl74
	{text-align:center;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


Grenade | Cost | Amount | Reqtorio Cost   (40 nades) | Rework Cost | Rework Amount | Reqtorio Cost   (50 nades)
-- | -- | -- | -- | -- | -- | --
HEDP | 310 | 25 | - | 300 | 25 | -
M15 | 350 | 15 | 700 | 350 | 25 | 550
Incen | 350 | 25 | 500 | 350 | 25 | 550
Sticky | 310 | 25 | 450 | 300 | 25 | 450
Phos | 1000 | 15 | 1400 | 700 | 25 | 1500
Tfoot | - | - | - | - | - | -
Cloak | 310 | 25 | 450 | 300 | 25 | 450
Trail | 350 | 25 | 500 | 500 | 25 | 750
Laser | 310 | 25 | 450 | 300 | 25 | 450
HEFA | 550 | 25 | 700 | 500 | 25 | 750
Antigas | 600 | 25 | 800 | 600 | 25 | 900
Razor | 500 | 15 | 1000 | 500 | 25 | 750



</body>

</html>


This also adds cloak nade refills to req as I missed that out earlier.
## Why It's Good For The Game
Grenade pricing was horribly inconsistent. This should help keep them in line with consistency as well as make them more appealing to purchase or produce.
## Changelog
:cl:
add: Actually adds the cloak nade refill to req.
balance: rebalances grenade pricing and reqtorio yield.
/:cl:
