### PR TITLE
gives SOs powerloader and engineer skills (so, buff)

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -387,12 +387,12 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 /datum/skills/so
 	name = STAFF_OFFICER
-	engineer = SKILL_ENGINEER_PLASTEEL
+	engineer = SKILL_ENGINEER_ENGI
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	leadership = SKILL_LEAD_EXPERT
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_AMATEUR
-	powerloader = SKILL_POWERLOADER_PRO
+	powerloader = SKILL_POWERLOADER_TRAINED
 	police = SKILL_POLICE_MP
 
 /datum/skills/pilot

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -387,10 +387,12 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 /datum/skills/so
 	name = STAFF_OFFICER
+	engineer = SKILL_ENGINEER_PLASTEEL
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	leadership = SKILL_LEAD_EXPERT
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_AMATEUR
+	powerloader = SKILL_POWERLOADER_PRO
 	police = SKILL_POLICE_MP
 
 /datum/skills/pilot


### PR DESCRIPTION
## About The Pull Request

gives Staff Officers POWERLOADER_TRAINED and ENGINEER_ENGI where they previously inherited the values for engineering and powerloader skills from the base skill datum, aka, what squad marines have.

## Why It's Good For The Game
Engineering skill affects whether you fumble with loading the OB or not, and whether you fumble changing out generators, which is a significant part of the SO's job. I'd like it to be one level lower but OB fumble procs on anything lower than ENGI; which changing would implicate other balance adjustments regarding SL or combat engi skillsets. 

Powerloader is helpful for req and OB, and Captain, for example, has max powerloader skill, FC has trained skill; I thought trained skill was appropriate for an SO where they'd be helping out with req or loading OB, especially as FC has it at trained probably for similar reasons where they'd be doing req or loading up the TAD/Alamo, despite FC being distinctively less about that kind of thing.

I don't think it makes much sense to have a CIC role, totally capable of firing the OB and accessing the OB room, to struggle in loading the OB. They still wouldn't be AS fast as the CSE or Captain, but shouldn't have a 12-15 second fumble on every step.

## Changelog
:cl:
balance: SOs have higher engineering and powerloader skill now (shouldn't fumble with OB)
/:cl: