### PR TITLE
lowers CSE leadership by 1 level

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -431,7 +431,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = CHIEF_SHIP_ENGINEER
 	engineer = SKILL_ENGINEER_MASTER
 	construction = SKILL_CONSTRUCTION_MASTER
-	leadership = SKILL_LEAD_EXPERT
+	leadership = SKILL_LEAD_TRAINED
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_MASTER
 


### PR DESCRIPTION
## About The Pull Request

title
apparently this was also done previously but moved them from MASTER to EXPERT
CSE currently has the same leadership skill as SLs and SOs,
All other department heads (CMO, TO, PO, RO) have leadership at the "TRAINED" level
This makes CSE have leadership at the "TRAINED" level.

## Why It's Good For The Game

consistency. i don't know why a CSE would need higher skills really than like a CMO; even if they're the ones piloting TAD or whatever, I'm not sure why they were better at leadership things than a TO

## Changelog
:cl:
balance:  CSEs now have leadership level 2, down from leadership 3
/:cl:
