### PR TITLE
AT-36 ammo price increase and amount decrease

### DIFF
--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -484,31 +484,31 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_aphe
-	refill_amount = 15
+	refill_amount = 30
 
 /obj/item/factory_refill/atgun_apcr_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_apcr
-	refill_amount = 15
+	refill_amount = 30
 
 /obj/item/factory_refill/atgun_he_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_he
-	refill_amount = 15
+	refill_amount = 30
 
 /obj/item/factory_refill/atgun_beehive_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_beehive
-	refill_amount = 15
+	refill_amount = 30
 
 /obj/item/factory_refill/atgun_incend_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_incend
-	refill_amount = 15
+	refill_amount = 30
 
 /obj/item/factory_refill/heavy_isg_he_refill
 	name = "box of rounded metal plates"

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -484,31 +484,31 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_aphe
-	refill_amount = 30
+	refill_amount = 15
 
 /obj/item/factory_refill/atgun_apcr_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_apcr
-	refill_amount = 30
+	refill_amount = 15
 
 /obj/item/factory_refill/atgun_he_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_he
-	refill_amount = 30
+	refill_amount = 15
 
 /obj/item/factory_refill/atgun_beehive_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_beehive
-	refill_amount = 30
+	refill_amount = 15
 
 /obj/item/factory_refill/atgun_incend_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Unboxers."
 	refill_type = /obj/item/factory_part/atgun_incend
-	refill_amount = 30
+	refill_amount = 15
 
 /obj/item/factory_refill/heavy_isg_he_refill
 	name = "box of rounded metal plates"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -299,7 +299,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun,
 		/obj/item/ammo_magazine/standard_atgun,
 	)
-	cost = 180
+	cost = 40
 
 /datum/supply_packs/weapons/antitankgunammo/apcr
 	name = "AT-36 APCR Shell (x3)"
@@ -308,7 +308,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/apcr,
 		/obj/item/ammo_magazine/standard_atgun/apcr,
 	)
-	cost = 180
+	cost = 40
 
 /datum/supply_packs/weapons/antitankgunammo/he
 	name = "AT-36 HE Shell (x3)"
@@ -317,7 +317,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/he,
 		/obj/item/ammo_magazine/standard_atgun/he,
 	)
-	cost = 180
+	cost = 40
 
 /datum/supply_packs/weapons/antitankgunammo/beehive
 	name = "AT-36 Beehive Shell (x3)"
@@ -326,7 +326,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/beehive,
 		/obj/item/ammo_magazine/standard_atgun/beehive,
 	)
-	cost = 150
+	cost = 40
 
 /datum/supply_packs/weapons/antitankgunammo/incendiary
 	name = "AT-36 Napalm Shell (x3)"
@@ -335,7 +335,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/incend,
 		/obj/item/ammo_magazine/standard_atgun/incend,
 	)
-	cost = 150
+	cost = 40
 
 /datum/supply_packs/weapons/flak_gun
 	name = "FK-88 Flak Gun"
@@ -2423,27 +2423,27 @@ FACTORY
 /datum/supply_packs/factory/atgun_aphe_refill
 	name = "AT-36 AP-HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_aphe_refill)
-	cost = 600
+	cost = 200
 
 /datum/supply_packs/factory/atgun_apcr_refill
 	name = "AT-36 APCR shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_apcr_refill)
-	cost = 600
+	cost = 200
 
 /datum/supply_packs/factory/atgun_he_refill
 	name = "AT-36 HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_he_refill)
-	cost = 600
+	cost = 200
 
 /datum/supply_packs/factory/atgun_beehive_refill
 	name = "AT-36 Beehive shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_beehive_refill)
-	cost = 500
+	cost = 200
 
 /datum/supply_packs/factory/atgun_incend_refill
 	name = "AT-36 Napalm shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_incend_refill)
-	cost = 500
+	cost = 200
 
 /datum/supply_packs/factory/heavy_isg_he_refill
 	name = "FK-88 Flak HE shell assembly refill"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -299,7 +299,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun,
 		/obj/item/ammo_magazine/standard_atgun,
 	)
-	cost = 20
+	cost = 180
 
 /datum/supply_packs/weapons/antitankgunammo/apcr
 	name = "AT-36 APCR Shell (x3)"
@@ -308,16 +308,16 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/apcr,
 		/obj/item/ammo_magazine/standard_atgun/apcr,
 	)
-	cost = 20
+	cost = 180
 
 /datum/supply_packs/weapons/antitankgunammo/he
 	name = "AT-36 HE Shell (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/standard_atgun/he,
 		/obj/item/ammo_magazine/standard_atgun/he,
-		/obj/item/ammo_magazine/standard_atgun,
+		/obj/item/ammo_magazine/standard_atgun/he,
 	)
-	cost = 20
+	cost = 180
 
 /datum/supply_packs/weapons/antitankgunammo/beehive
 	name = "AT-36 Beehive Shell (x3)"
@@ -326,7 +326,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/beehive,
 		/obj/item/ammo_magazine/standard_atgun/beehive,
 	)
-	cost = 20
+	cost = 150
 
 /datum/supply_packs/weapons/antitankgunammo/incendiary
 	name = "AT-36 Napalm Shell (x3)"
@@ -335,7 +335,7 @@ WEAPONS
 		/obj/item/ammo_magazine/standard_atgun/incend,
 		/obj/item/ammo_magazine/standard_atgun/incend,
 	)
-	cost = 20
+	cost = 150
 
 /datum/supply_packs/weapons/flak_gun
 	name = "FK-88 Flak Gun"
@@ -2423,27 +2423,27 @@ FACTORY
 /datum/supply_packs/factory/atgun_aphe_refill
 	name = "AT-36 AP-HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_aphe_refill)
-	cost = 100
+	cost = 600
 
 /datum/supply_packs/factory/atgun_apcr_refill
 	name = "AT-36 APCR shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_apcr_refill)
-	cost = 100
+	cost = 600
 
 /datum/supply_packs/factory/atgun_he_refill
 	name = "AT-36 HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_he_refill)
-	cost = 100
+	cost = 600
 
 /datum/supply_packs/factory/atgun_beehive_refill
 	name = "AT-36 Beehive shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_beehive_refill)
-	cost = 100
+	cost = 500
 
 /datum/supply_packs/factory/atgun_incend_refill
 	name = "AT-36 Napalm shell assembly refill"
 	contains = list(/obj/item/factory_refill/atgun_incend_refill)
-	cost = 100
+	cost = 500
 
 /datum/supply_packs/factory/heavy_isg_he_refill
 	name = "FK-88 Flak HE shell assembly refill"


### PR DESCRIPTION
## About The Pull Request

- AT ammo price for the 3-shell kits moves from 20 points to 40 points; or 13.3 points per shells
- AT ammo reqtorio kits moves from 100 points to 200 points; or 7 points per shell
- AT HE shell pack (x3) included 2 HE shells and 1 standard shell; this fixes that and makes them all HE

## Why It's Good For The Game

AT is devastatingly good but refills for it are pretty trivial right now. the work of a single well-placed AT shell is definitely worth way more than 3.3 req points. this keeps the supply pipeline for AT a little more in-parallel to the game impact the weapon has, while still providing decent room for one to do TATconomics and turn a profit off of kills to fund more shells to get more kills, etc.

## Changelog
:cl:
balance: AT-36 reqtorio supply packs now have 200 points 
fix: fixed the AT HE shell pack in req including 2 HE and 1 standard shell instead of 3 HE
/:cl: