### PR TITLE
suturing with above expert med skill gives more healing than 30 brute/burn damage

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -314,7 +314,7 @@
 	user.visible_message(span_notice("[user] sews some of the wounds on [target]'s [affected.display_name] shut.") , \
 	span_notice("You finish suturing some of the wounds on [target]'s [affected.display_name].") )
 	target.balloon_alert_to_viewers("Success")
-	var/skilled_healing = base_healing * max(user.skills.getPercent(SKILL_SURGERY, SKILL_SURGERY_EXPERT), 0.1)
+	var/skilled_healing = base_healing * (user.skills.getPercent(SKILL_SURGERY, SKILL_SURGERY_EXPERT), 0.1)
 	var/burn_heal = min(skilled_healing, affected.burn_dam)
 	var/brute_heal = max(skilled_healing - burn_heal, 0)
 	affected.heal_limb_damage(brute_heal, burn_heal, updating_health = TRUE) //Corpses need their health updated manually since they don't do it themselves

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -293,7 +293,7 @@
 	min_duration = SUTURE_MIN_DURATION
 	max_duration = SUTURE_MAX_DURATION
 	///Healing applied on step success, split between burn and brute
-	var/base_healing = 30
+	var/base_healing = 37.5
 
 /datum/surgery_step/generic/repair/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	if(!..())
@@ -314,7 +314,7 @@
 	user.visible_message(span_notice("[user] sews some of the wounds on [target]'s [affected.display_name] shut.") , \
 	span_notice("You finish suturing some of the wounds on [target]'s [affected.display_name].") )
 	target.balloon_alert_to_viewers("Success")
-	var/skilled_healing = base_healing * (user.skills.getPercent(SKILL_SURGERY, SKILL_SURGERY_EXPERT), 0.1)
+	var/skilled_healing = base_healing * max(user.skills.getPercent(SKILL_SURGERY, SKILL_SURGERY_MASTER), 0.1)
 	var/burn_heal = min(skilled_healing, affected.burn_dam)
 	var/brute_heal = max(skilled_healing - burn_heal, 0)
 	affected.heal_limb_damage(brute_heal, burn_heal, updating_health = TRUE) //Corpses need their health updated manually since they don't do it themselves


### PR DESCRIPTION
## About The Pull Request

edits the healing of sutures to be 37.5 damage max, with the formula for the healing mutliplier using skill_master as the divisor, instead of skill_expert. tldr: buff to damage healed by CMO suturing

## Why It's Good For The Game

#12505 gave CMO level 5 med and surgery skill; the way this is used in code means that all the surgery steps had their time reduced.
there is a separate formula on suturing as a step to calculate how much suturing heals. the base is 30 damage split between brute and burn, but the formula uses SKILL_SURGERY_EXPERT (4) as the divisor and clamps it at that.
what this means is that those with surgery skill level 4 maximize healing from sutures. those (the CMO) with surgery skill level 5 don't get any additional healing from sutures, which seems odd that a doctor would or should be just as good as the CMO.
this allows healing with sutures by CMOs (and spatial agents?) to provide an additional 7.5 damage healed, for 37.5 total; while no other role sees any reduction or increase in the amount healed from suturing

## Changelog
:cl:
balance: CMOs now heal an additional 7.5 damage per use of sutures
/:cl:
