### PR TITLE
Increase the AI cargo droid movespeed

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -131,7 +131,7 @@
 	desc = "A cargo droid, rigged with experimental technology to allow AI control. The claw is not standard and cannot grasp warheads."
 	icon = 'icons/obj/powerloader.dmi'
 	icon_state = "ai_powerloader"
-	move_delay = 7
+	move_delay = 5
 	max_integrity = 550
 	spawn_equipped_type = null
 	unmanned_flags = GIVE_NIGHT_VISION


### PR DESCRIPTION

## About The Pull Request
Reduces the AI cargo droid movespeed delay. 
## Why It's Good For The Game
The AI drone is actually painfully slow to use. This thing moves as slow as a ripley with a PVT using it, without as much functionnality. It just makes sense that something with less capacity moves faster. 
## Changelog
:cl:
qol: Reduced the AI droid movespeed delay
/:cl:
