### PR TITLE
All HvH gamemodes now force the IMMEDIATE_DEFIB trait.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -50,6 +50,8 @@
 #define MODE_ALLOW_XENO_QUICKBUILD (1<<14)
 #define MODE_DISALLOW_RAILGUN (1<<15)
 #define MODE_FORCE_CUSTOMSQUAD_UI (1<<16)
+/// Forces all defibs to act like everyone has the IMMEDIATE_DEFIB trait.
+#define MODE_FORCE_IMMEDIATE_DEFIB (1<<17)
 
 #define MODE_INFESTATION_X_MAJOR "Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR "Marine Major Victory"

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/hvh/campaign
 	name = "Campaign"
 	config_tag = "Campaign"
-	round_type_flags = MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY
+	round_type_flags = MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_FORCE_IMMEDIATE_DEFIB
 	whitelist_ship_maps = list(MAP_ITERON)
 	whitelist_ground_maps = list(MAP_FORT_PHOBOS)
 	bioscan_interval = 3 MINUTES

--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/hvh/combat_patrol
 	name = "Combat Patrol"
 	config_tag = "Combat Patrol"
-	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY
+	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_FORCE_IMMEDIATE_DEFIB
 	shutters_drop_time = 3 MINUTES
 	whitelist_ship_maps = list(MAP_COMBAT_PATROL_BASE)
 	blacklist_ship_maps = null

--- a/code/datums/gamemodes/hvh.dm
+++ b/code/datums/gamemodes/hvh.dm
@@ -1,7 +1,7 @@
 //The base setup for HvH gamemodes, not for actual use
 /datum/game_mode/hvh
 	name = "HvH base mode"
-	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_TWO_HUMAN_FACTIONS
+	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_TWO_HUMAN_FACTIONS|MODE_ENFORCE_IMMEDIATE_DEFIB
 	shutters_drop_time = 3 MINUTES
 	xeno_abilities_flags = ABILITY_CRASH
 	factions = list(FACTION_TERRAGOV, FACTION_SOM)

--- a/code/datums/gamemodes/hvh.dm
+++ b/code/datums/gamemodes/hvh.dm
@@ -1,7 +1,7 @@
 //The base setup for HvH gamemodes, not for actual use
 /datum/game_mode/hvh
 	name = "HvH base mode"
-	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_TWO_HUMAN_FACTIONS|MODE_ENFORCE_IMMEDIATE_DEFIB
+	round_type_flags = MODE_LATE_OPENING_SHUTTER_TIMER|MODE_TWO_HUMAN_FACTIONS|MODE_HUMAN_ONLY|MODE_TWO_HUMAN_FACTIONS|MODE_FORCE_IMMEDIATE_DEFIB
 	shutters_drop_time = 3 MINUTES
 	xeno_abilities_flags = ABILITY_CRASH
 	factions = list(FACTION_TERRAGOV, FACTION_SOM)

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -271,7 +271,7 @@
 		return
 
 	//At this point, the defibrillator is ready to work
-	if(HAS_TRAIT(H, TRAIT_IMMEDIATE_DEFIB)) // this trait ignores user skill for the heal amount
+	if(HAS_TRAIT(H, TRAIT_IMMEDIATE_DEFIB) || SSticker.mode.round_type_flags & MODE_FORCE_IMMEDIATE_DEFIB) // this trait ignores user skill for the heal amount
 		H.setOxyLoss(0)
 		H.updatehealth()
 


### PR DESCRIPTION

## About The Pull Request
This PR adds the MODE_FORCE_IMMEDIATE_DEFIB and applies to to all HvH gamemodes ( Combat patrol , campaign and HvH)
This will make it so anyone past the defibrilation threshold will get healed to the minimum health value that won't allow them to die instantly (if they get no extra damage).

## Why It's Good For The Game
HvH gamemods have a habit of no-restriction damage stacking on people , either through dragging dead bodies through fire, stacking grenades , or shooting bodies. This PR serves to make tactics that involve stacking damage on a body to prevent revivals impossible, since i believe that revivals should only be prevented if the medic can't do it without getting shot or the body can't be physically dragged to one.

## Changelog
:cl:
code: Added the MODE_FORCE_IMMEDIATE_DEFIB trait. This will force all defibrilators to act as if all mobs have the IMMEDIATE_DEFIB trait
balance: All HvH gamemods(Campaign ,HvH , Combat Patrol) have received the MODE_FORCE_IMMEDIATE_DEFIB trait. All humans past the revival threshold will be healed to the minimum health before they would die again and then succesfully revived.
/:cl:
