### PR TITLE
Makes the radial menu for all medicine fit all limbs.

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -292,7 +292,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, angle_override)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
@@ -302,6 +302,8 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		return
 
 	var/datum/radial_menu/menu = new
+	if(angle_override)
+		menu.min_angle = angle_override
 	GLOB.radial_menus[uniqueid] = menu
 	if(radius)
 		menu.radius = radius

--- a/code/modules/radial/radial_body_select.dm
+++ b/code/modules/radial/radial_body_select.dm
@@ -36,7 +36,7 @@
 									"Rfoot" = radial_options[BODY_ZONE_PRECISE_R_FOOT])
 
 	var/datum/limb/affecting = null
-	var/choice = show_radial_menu(doctor, H, radial_options_show, null, 48, null, TRUE)
+	var/choice = show_radial_menu(doctor, H, radial_options_show, null, 48, null, TRUE, null, 30)
 	switch(choice)
 		if("head")
 			affecting = H.get_limb(BODY_ZONE_HEAD)

--- a/code/modules/radial/radial_body_select.dm
+++ b/code/modules/radial/radial_body_select.dm
@@ -25,15 +25,15 @@
 	//the list of the above
 	var/list/radial_options_show = list("head" = radial_options[BODY_ZONE_HEAD],
 									"chest" = radial_options[BODY_ZONE_CHEST],
-									"groin" = radial_options[BODY_ZONE_PRECISE_GROIN],
-									"Larm" = radial_options[BODY_ZONE_L_ARM],
-									"Lhand" = radial_options[BODY_ZONE_PRECISE_L_HAND],
 									"Rarm" = radial_options[BODY_ZONE_R_ARM],
 									"Rhand" = radial_options[BODY_ZONE_PRECISE_R_HAND],
-									"Lleg" = radial_options[BODY_ZONE_L_LEG],
-									"Lfoot" = radial_options[BODY_ZONE_PRECISE_L_FOOT],
 									"Rleg" = radial_options[BODY_ZONE_R_LEG],
-									"Rfoot" = radial_options[BODY_ZONE_PRECISE_R_FOOT])
+									"Rfoot" = radial_options[BODY_ZONE_PRECISE_R_FOOT],
+									"Lfoot" = radial_options[BODY_ZONE_PRECISE_L_FOOT],
+									"Lleg" = radial_options[BODY_ZONE_L_LEG],
+									"Lhand" = radial_options[BODY_ZONE_PRECISE_L_HAND],
+									"Larm" = radial_options[BODY_ZONE_L_ARM],
+									"groin" = radial_options[BODY_ZONE_PRECISE_GROIN])
 
 	var/datum/limb/affecting = null
 	var/choice = show_radial_menu(doctor, H, radial_options_show, null, 48, null, TRUE, null, 30)


### PR DESCRIPTION

## About The Pull Request
Makes the radial menu for applying ointment/medical packs fit all limbs.
Added a override to show_radial_menu for setting the min_angle to a lower value.

## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61350382/ec285c3b-4465-4ab1-b650-ccf493a1e57b)
Massive QoL for medics.


## Changelog
:cl:
qol: Radial menus for applying medicine will now fit all LIMBS on a ring instead of having 2 pages.
/:cl:
