### PR TITLE
buffs to veteran ERT and specops ERT skills

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -71,6 +71,11 @@
 #define SQUAD_VATGROWN "Squad VatGrown"
 #define SILICON_AI "AI"
 
+/// ERT
+#define VETERAN "Veteran"
+#define VETERAN_CAPTAIN "Veteran Captain"
+#define SPECOPS "Special Operations Soldier"
+
 //SOM
 #define SOM_COMMANDER "SOM Commander"
 #define SOM_FIELD_COMMANDER "SOM Field Commander"

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -71,11 +71,6 @@
 #define SQUAD_VATGROWN "Squad VatGrown"
 #define SILICON_AI "AI"
 
-/// ERT
-#define VETERAN "Veteran"
-#define VETERAN_CAPTAIN "Veteran Captain"
-#define SPECOPS "Special Operations Soldier"
-
 //SOM
 #define SOM_COMMANDER "SOM Commander"
 #define SOM_FIELD_COMMANDER "SOM Field Commander"

--- a/code/datums/jobs/job/retired.dm
+++ b/code/datums/jobs/job/retired.dm
@@ -4,7 +4,7 @@
 	paygrade = "MSGT"
 	access = ALL_ANTAGONIST_ACCESS
 	minimal_access = ALL_ANTAGONIST_ACCESS
-	skills_type = /datum/skills/fo //they're old, they know their stuff
+	skills_type = /datum/skills/veteran //they're old, they know their stuff
 	faction = FACTION_TERRAGOV
 	outfit = /datum/outfit/job/retired
 
@@ -49,7 +49,7 @@
 /datum/job/retired/leader
 	title = "TGMC retired veteran expedition leader"
 	paygrade = "LtCol"
-	skills_type = /datum/skills/captain //The leader gets even more skills
+	skills_type = /datum/skills/veteran_captain //The leader gets even more skills
 	outfit = /datum/outfit/job/retired/leader
 
 /datum/outfit/job/retired/leader

--- a/code/datums/jobs/job/special_forces.dm
+++ b/code/datums/jobs/job/special_forces.dm
@@ -183,8 +183,7 @@
 /datum/job/special_forces/medic
 	title = "Special Response Force Medic"
 	outfit = /datum/outfit/job/special_forces/medic
-	skills_type = /datum/skills/combat_medic/crafty
-
+	skills_type = /datum/skills/combat_medic/special_forces
 /datum/outfit/job/special_forces/medic
 	name = "Special Response Force Medic"
 	jobtype = /datum/job/special_forces/medic

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -295,6 +295,12 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
 
+/datum/skills/combat_medic/special_forces
+	name = "Special Operations Medic"
+	construction = SKILL_CONSTRUCTION_METAL
+	engineer = SKILL_ENGINEER_METAL
+	smgs = SKILL_SMGS_TRAINED
+
 /datum/skills/doctor
 	name = "Doctor"
 	cqc = SKILL_CQC_WEAK
@@ -467,7 +473,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	leadership = SKILL_LEAD_TRAINED
 	powerloader = SKILL_POWERLOADER_MASTER
 	police = SKILL_POLICE_MP
-	smgs = SKILL_SMGS_TRAINED
 
 /datum/skills/st
 	name = SHIP_TECH
@@ -495,6 +500,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
 	police = SKILL_POLICE_MP
+	smgs = SKILL_SMGS_TRAINED
 
 /datum/skills/sl
 	name = SQUAD_LEADER
@@ -534,6 +540,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 /datum/skills/sl/pmc/special_forces
 	name = "Special Force Leader"
 	police = SKILL_POLICE_MP
+	smgs = SKILL_SMGS_TRAINED
 
 /datum/skills/sl/icc
 	name = "ICC Leader"

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -386,7 +386,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	cqc = SKILL_CQC_TRAINED
 
 /datum/skills/veteran
-	name = VETERAN
+	name = "TGMC Retired Veteran"
 	engineer = SKILL_ENGINEER_ENGI //to fix CIC apc.
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	leadership = SKILL_LEAD_MASTER
@@ -399,7 +399,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	rifles = SKILL_RIFLES_TRAINED
 
 /datum/skills/veteran_captain
-	name = VETERAN_CAPTAIN
+	name = "TGMC Retired Veteran Expedition Leader"
 	leadership = SKILL_LEAD_MASTER
 	police = SKILL_POLICE_MP
 	medical = SKILL_MEDICAL_COMPETENT
@@ -491,7 +491,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	engineer = SKILL_ENGINEER_ENGI
 
 /datum/skills/special_forces_standard
-	name = "Special Force Standard"
+	name = "Special Response Force Standard"
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
 	police = SKILL_POLICE_MP

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -385,6 +385,32 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	powerloader = SKILL_POWERLOADER_TRAINED
 	cqc = SKILL_CQC_TRAINED
 
+/datum/skills/veteran
+	name = VETERAN
+	engineer = SKILL_ENGINEER_ENGI //to fix CIC apc.
+	construction = SKILL_CONSTRUCTION_PLASTEEL
+	leadership = SKILL_LEAD_MASTER
+	medical = SKILL_MEDICAL_PRACTICED
+	surgery = SKILL_SURGERY_AMATEUR
+	police = SKILL_POLICE_MP
+	powerloader = SKILL_POWERLOADER_TRAINED
+	cqc = SKILL_CQC_TRAINED
+	firearms = SKILL_FIREARMS_TRAINED
+	rifles = SKILL_RIFLES_TRAINED
+
+/datum/skills/veteran_captain
+	name = VETERAN_CAPTAIN
+	leadership = SKILL_LEAD_MASTER
+	police = SKILL_POLICE_MP
+	medical = SKILL_MEDICAL_COMPETENT
+	surgery = SKILL_SURGERY_AMATEUR
+	engineer = SKILL_ENGINEER_ENGI
+	construction = SKILL_CONSTRUCTION_ADVANCED
+	powerloader = SKILL_POWERLOADER_MASTER
+	firearms = SKILL_FIREARMS_TRAINED
+	rifles = SKILL_RIFLES_TRAINED
+	smartgun = SKILL_SMART_TRAINED
+
 /datum/skills/so
 	name = STAFF_OFFICER
 	construction = SKILL_CONSTRUCTION_PLASTEEL
@@ -441,6 +467,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	leadership = SKILL_LEAD_TRAINED
 	powerloader = SKILL_POWERLOADER_MASTER
 	police = SKILL_POLICE_MP
+	smgs = SKILL_SMGS_TRAINED
 
 /datum/skills/st
 	name = SHIP_TECH


### PR DESCRIPTION

## About The Pull Request
Veteran ERT members now all have SKILL_FIREARMS_TRAINED and SKILL_RIFLES_TRAINED (+1 from DEFAULT)
Special ops ERT members now have SKILL_SMG_TRAINED (+1 from DEFAULT)

## Why It's Good For The Game
These 2 are some of the most underpowered ERTs. I also believe its also logical for them to have better skills .
## Changelog
:cl:
balance: Veteran ERT now starts with their firearms and rifles skills at trained instead of the default(+1)
balance: Special Ops ERT now starts with their smg skill set to trained instead of the default(+1)
/:cl:
