### PR TITLE
Campaign: Missing whitelist for surt

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -118,6 +118,7 @@
 	req_desc = "Requires a FL-84 flamethrower."
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/surt
 	jobs_supported = list(SQUAD_MARINE)
+	item_whitelist = list(/obj/item/weapon/gun/flamer/big_flamer/marinestandard/wide = ITEM_SLOT_SUITSTORE)
 
 /datum/loadout_item/suit_slot/heavy_tyr
 	name = "H Tyr armor"


### PR DESCRIPTION

## About The Pull Request
Added a missing whitelist for surt armour, for marine standards.
## Why It's Good For The Game
Fix.
## Changelog
:cl:
fix: Campaign: Fixed a missing whitelist requirement for Surt
/:cl:
