### PR TITLE
Add extra clone bays to Theseus medical

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -52923,7 +52923,7 @@ pES
 hjE
 bjV
 biu
-wyX
+nSl
 wyX
 nBH
 uEK

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -15275,10 +15275,6 @@
 "oXT" = (
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
-"oYw" = (
-/obj/structure/closet/secure_closet/guncabinet/emergency_combat_gear,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "oYB" = (
 /obj/machinery/marine_selector/clothes/smartgun,
 /obj/structure/sign/poster,
@@ -17042,6 +17038,10 @@
 	dir = 1
 	},
 /area/mainship/hallways/bow_hallway)
+"rRE" = (
+/obj/structure/closet/secure_closet/guncabinet/emergency_combat_gear,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "rRW" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/binoculars,
@@ -17543,15 +17543,15 @@
 /area/mainship/hallways/bow_hallway)
 "sBz" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/glass/beaker/biomass{
-	pixel_x = 9;
-	pixel_y = 7
-	},
+/obj/item/healthanalyzer,
 /obj/item/storage/box/ids/dogtag{
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/obj/item/healthanalyzer,
+/obj/item/reagent_containers/glass/beaker/biomass{
+	pixel_x = 9;
+	pixel_y = 7
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "sEZ" = (
@@ -54725,7 +54725,7 @@ biu
 nSl
 kFq
 aJS
-oYw
+rRE
 nSl
 uYN
 vmj

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1665,6 +1665,19 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"axx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "axU" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -1990,6 +2003,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -3851,12 +3865,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "boX" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/healthanalyzer,
-/obj/item/reagent_containers/glass/beaker/biomass,
-/obj/item/storage/box/ids/dogtag,
 /obj/machinery/camera/autoname/mainship,
-/obj/item/reagent_containers/glass/beaker/biomass,
+/obj/machinery/computer/cloning_console/vats,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -4003,16 +4014,16 @@
 	},
 /area/mainship/shipboard/firing_range)
 "bqR" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "bqW" = (
@@ -7240,8 +7251,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
 "cjV" = (
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/corner{
+/obj/machinery/computer/cloning_console/vats,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
@@ -7952,11 +7966,17 @@
 	},
 /area/mainship/living/officer_rnr)
 "dus" = (
-/obj/machinery/computer/cloning_console/vats,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/secure_closet/guncabinet/mp_armory,
+/obj/item/weapon/gun/rifle/standard_lmg,
+/obj/item/ammo_magazine/standard_lmg,
+/obj/item/ammo_magazine/standard_lmg,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/space/basic,
+/area/space)
 "dvk" = (
 /obj/structure/closet,
 /obj/item/toy/plush/slime,
@@ -8199,13 +8219,15 @@
 	},
 /area/mainship/medical/cmo_office)
 "dKa" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "dKG" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -8263,8 +8285,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
@@ -9156,10 +9178,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/bow_hallway)
 "fpV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
+/obj/machinery/cloning/vats,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "fqH" = (
@@ -14142,8 +14161,10 @@
 	},
 /area/mainship/hull/port_hull)
 "ndj" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/sterile/side,
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
 /area/mainship/medical/lower_medical)
 "ndz" = (
 /obj/structure/bed,
@@ -14386,6 +14407,23 @@
 /obj/structure/prop/mainship/sensor_computer2/sd,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"nBH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/medical/free_access,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "nCj" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/mainship/sterile/dark,
@@ -15237,6 +15275,10 @@
 "oXT" = (
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
+"oYw" = (
+/obj/structure/closet/secure_closet/guncabinet/emergency_combat_gear,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "oYB" = (
 /obj/machinery/marine_selector/clothes/smartgun,
 /obj/structure/sign/poster,
@@ -15297,6 +15339,10 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"pdH" = (
+/obj/machinery/computer/cloning_console/vats,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "peh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -16025,11 +16071,8 @@
 	},
 /area/mainship/living/commandbunks)
 "qmn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/ai_node,
 /obj/machinery/light/mainship,
+/obj/machinery/cloning/vats,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "qmA" = (
@@ -17499,13 +17542,16 @@
 	},
 /area/mainship/hallways/bow_hallway)
 "sBz" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	dir = 2;
-	name = "\improper Medical Bay"
+/obj/structure/table/mainship/nometal,
+/obj/item/reagent_containers/glass/beaker/biomass{
+	pixel_x = 9;
+	pixel_y = 7
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+/obj/item/storage/box/ids/dogtag{
+	pixel_x = -5;
+	pixel_y = 4
 	},
+/obj/item/healthanalyzer,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "sEZ" = (
@@ -18464,6 +18510,22 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"ufX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/medical/lower_medical)
 "ugh" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -18721,6 +18783,10 @@
 /turf/open/floor/mainship/sterile/side{
 	dir = 5
 	},
+/area/mainship/medical/lower_medical)
+"uEK" = (
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "uEX" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -19280,8 +19346,8 @@
 /area/mainship/hull/starboard_hull)
 "vyn" = (
 /obj/item/toy/plush/rouny{
-	pixel_y = 9;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 9
 	},
 /obj/item/bedsheet/blue,
 /obj/structure/bed/chair/comfy/teal,
@@ -51292,7 +51358,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+dus
 aaa
 aaa
 aaa
@@ -52858,9 +52924,9 @@ hjE
 bjV
 biu
 wyX
-bJG
-yea
-ost
+wyX
+nBH
+uEK
 nSl
 bxw
 iZI
@@ -53115,8 +53181,8 @@ bQZ
 bjV
 blj
 nSl
-wyX
-aJS
+ndj
+ufX
 sBz
 nSl
 fly
@@ -53629,7 +53695,7 @@ aLX
 bjV
 biu
 nSl
-dus
+oxk
 bqR
 qmn
 nSl
@@ -53887,8 +53953,8 @@ bjV
 biu
 nSl
 boX
-aJS
-ost
+axx
+pdH
 nga
 aRw
 jgp
@@ -54402,7 +54468,7 @@ blj
 nSl
 xCj
 yea
-ost
+pdH
 nga
 hQt
 qgb
@@ -54659,7 +54725,7 @@ biu
 nSl
 kFq
 aJS
-ndj
+oYw
 nSl
 uYN
 vmj
@@ -54915,8 +54981,8 @@ bjV
 biu
 nSl
 nSl
-aJS
-sBz
+nBH
+nSl
 nSl
 gCW
 vmj

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -148,3 +148,27 @@
 	new /obj/item/clothing/suit/armor/riot(src)
 	new /obj/item/clothing/suit/armor/riot(src)
 	new /obj/item/storage/box/flashbangs(src)
+
+/obj/structure/closet/secure_closet/guncabinet/emergency_combat_gear
+	name = "\improper emergency combat gear"
+	desc = "Kept in cases of extreme emergency. Tends to feature surplus, second rate gear. Not for regular TGMC squad marines."
+	req_access = null
+
+/obj/structure/closet/secure_closet/guncabinet/emergency_combat_gear/PopulateContents()
+	new /obj/item/clothing/head/helmet/marine
+	new /obj/item/clothing/head/helmet/marine
+	new /obj/item/clothing/shoes/marine/brown
+	new /obj/item/clothing/shoes/marine/brown
+	new /obj/item/clothing/under/marine/camo
+	new /obj/item/clothing/under/marine/camo
+	new /obj/item/storage/backpack/marine/satchel/green
+	new /obj/item/storage/backpack/marine/satchel/green
+	new /obj/item/storage/belt/marine/standard_skirmishrifle
+	new /obj/item/storage/belt/marine/standard_skirmishrifle
+	new /obj/item/weapon/gun/rifle/standard_skirmishrifle/standard
+	new /obj/item/weapon/gun/rifle/standard_skirmishrifle/standard
+	new /obj/item/storage/box/visual/magazine/compact/standard_skirmishrifle
+	new /obj/item/clothing/suit/modular/xenonauten
+	new /obj/item/clothing/suit/modular/xenonauten
+
+


### PR DESCRIPTION

## About The Pull Request
This PR adds extra clone bays to TGS Theseus. It also shuffles the position of some gear and extends the room a little to make space. It also adds an emergency gun cabinet in the corner.

## Why It's Good For The Game
I always liked the fact our ships had unique traits, be it from pods capacity, layout making holding, or deploying easier. However, I figure we can go further in the variations, like having some ships support certain styles of play better. A bit like our seasonals in the weapons vendors. 

That's where this PR comes in. Basically, we get some of those weakass early vatborns for people to play around with, at the cost of having to spend some dosh on biomass to run them all. I do not forsee it being a substantial meta change, but I think it would be noticeable fluff, which changes from the repetition. 

## Changelog
:cl:
add: Added extra clone bays to TGS Theseus 
/:cl:
