### PR TITLE
Campaign mech colours

### DIFF
--- a/code/datums/gamemodes/campaign/missions/mech_wars.dm
+++ b/code/datums/gamemodes/campaign/missions/mech_wars.dm
@@ -86,55 +86,6 @@
 	else if(dead_mech.faction == starting_faction)
 		hostile_team_cap_points += 10
 
-//mech spawn points
-/obj/effect/landmark/campaign/mech_spawner
-	name = "tgmc med mech spawner"
-	icon_state = "mech"
-	var/faction = FACTION_TERRAGOV
-	var/list/colors = list(ARMOR_PALETTE_SPACE_CADET, ARMOR_PALETTE_GREYISH_TURQUOISE, VISOR_PALETTE_MAGENTA)
-	var/obj/vehicle/sealed/mecha/combat/greyscale/mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/assault/noskill
-
-/obj/effect/landmark/campaign/mech_spawner/Initialize(mapload)
-	. = ..()
-	GLOB.campaign_mech_spawners[faction] += list(src)
-
-/obj/effect/landmark/campaign/mech_spawner/Destroy()
-	GLOB.campaign_mech_spawners[faction] -= src
-	return ..()
-
-/obj/effect/landmark/campaign/mech_spawner/proc/spawn_mech()
-	var/obj/vehicle/sealed/mecha/combat/greyscale/new_mech = new mech_type(loc)
-	for(var/i in new_mech.limbs)
-		var/datum/mech_limb/limb = new_mech.limbs[i]
-		limb.update_colors(arglist(colors))
-	new_mech.update_icon()
-	return new_mech
-
-/obj/effect/landmark/campaign/mech_spawner/heavy
-	name = "tgmc heavy mech spawner"
-	icon_state = "mech_heavy"
-	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/vanguard/noskill
-
-/obj/effect/landmark/campaign/mech_spawner/light
-	name = "tgmc light mech spawner"
-	icon_state = "mech_light"
-	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/recon/noskill
-
-/obj/effect/landmark/campaign/mech_spawner/som
-	name = "som med mech spawner"
-	faction = FACTION_SOM
-	colors = list(ARMOR_PALETTE_GINGER, ARMOR_PALETTE_BLACK, VISOR_PALETTE_SYNDIE_GREEN)
-
-/obj/effect/landmark/campaign/mech_spawner/som/heavy
-	name = "som heavy mech spawner"
-	icon_state = "mech_heavy"
-	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/vanguard/noskill
-
-/obj/effect/landmark/campaign/mech_spawner/som/light
-	name = "som light mech spawner"
-	icon_state = "mech_light"
-	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/recon/noskill
-
 /datum/campaign_mission/tdm/mech_wars/som
 	name = "Mech war"
 	mission_icon = "mech_war"

--- a/code/datums/gamemodes/campaign/rewards/mechs.dm
+++ b/code/datums/gamemodes/campaign/rewards/mechs.dm
@@ -35,3 +35,65 @@
 
 /datum/campaign_asset/mech/heavy/som
 	spawner_type = /obj/effect/landmark/campaign/mech_spawner/som/heavy
+
+//mech spawn points
+/obj/effect/landmark/campaign/mech_spawner
+	name = "tgmc med mech spawner"
+	icon_state = "mech"
+	///Faction associated with this spawner
+	var/faction = FACTION_TERRAGOV
+	///Colours to paint mechs from this spawner
+	var/list/colors = list(ARMOR_PALETTE_SPACE_CADET, ARMOR_PALETTE_GREYISH_TURQUOISE)
+	///Colours to paint mech heads from this spawner for better visual clarity
+	var/list/head_colors = list(ARMOR_PALETTE_STORM, ARMOR_PALETTE_GREYISH_TURQUOISE, VISOR_PALETTE_SYNDIE_GREEN)
+	///Mech type for this spawner
+	var/obj/vehicle/sealed/mecha/combat/greyscale/mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/assault/noskill
+
+/obj/effect/landmark/campaign/mech_spawner/Initialize(mapload)
+	. = ..()
+	GLOB.campaign_mech_spawners[faction] += list(src)
+
+/obj/effect/landmark/campaign/mech_spawner/Destroy()
+	GLOB.campaign_mech_spawners[faction] -= src
+	return ..()
+
+///Creates and sets up the mech
+/obj/effect/landmark/campaign/mech_spawner/proc/spawn_mech()
+	var/obj/vehicle/sealed/mecha/combat/greyscale/new_mech = new mech_type(loc)
+	for(var/i in new_mech.limbs)
+		var/datum/mech_limb/limb = new_mech.limbs[i]
+		limb.update_colors(arglist(istype(limb, /datum/mech_limb/head) ? head_colors : colors))
+	new_mech.update_icon()
+	return new_mech
+
+/obj/effect/landmark/campaign/mech_spawner/heavy
+	name = "tgmc heavy mech spawner"
+	icon_state = "mech_heavy"
+	head_colors = list(ARMOR_PALETTE_RED, ARMOR_PALETTE_GREYISH_TURQUOISE, VISOR_PALETTE_SYNDIE_GREEN)
+	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/vanguard/noskill
+
+/obj/effect/landmark/campaign/mech_spawner/light
+	name = "tgmc light mech spawner"
+	icon_state = "mech_light"
+	head_colors = list(ARMOR_PALETTE_SPACE_CADET, ARMOR_PALETTE_GREYISH_TURQUOISE, VISOR_PALETTE_SYNDIE_GREEN)
+	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/recon/noskill
+
+/obj/effect/landmark/campaign/mech_spawner/som
+	name = "som med mech spawner"
+	faction = FACTION_SOM
+	colors = list(ARMOR_PALETTE_GINGER, ARMOR_PALETTE_ANGELIC)
+	head_colors = list(ARMOR_PALETTE_ANGELIC, ARMOR_PALETTE_GREY, VISOR_PALETTE_SYNDIE_GREEN)
+
+/obj/effect/landmark/campaign/mech_spawner/som/heavy
+	name = "som heavy mech spawner"
+	icon_state = "mech_heavy"
+	colors = list(ARMOR_PALETTE_GINGER, ARMOR_PALETTE_MAGENTA)
+	head_colors = list(ARMOR_PALETTE_MAGENTA, ARMOR_PALETTE_GRAPE, VISOR_PALETTE_ELITE_ORANGE)
+	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/vanguard/noskill
+
+/obj/effect/landmark/campaign/mech_spawner/som/light
+	name = "som light mech spawner"
+	icon_state = "mech_light"
+	colors = list(ARMOR_PALETTE_GINGER, ARMOR_PALETTE_BLACK)
+	head_colors = list(ARMOR_PALETTE_GINGER, ARMOR_PALETTE_BLACK, VISOR_PALETTE_SYNDIE_GREEN)
+	mech_type = /obj/vehicle/sealed/mecha/combat/greyscale/recon/noskill


### PR DESCRIPTION

## About The Pull Request
Some tweaks to mech colours in campaign so the different mech types are more distinguishable.
TGMC
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/eeb42624-1a7a-485e-ba1b-48ac39a9f78f)

SOM
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/7869430/2ebe2eec-9235-4a5a-ab11-52bf0855f6cd)

Also moved around a bit of code/added some missing autodoc
## Why It's Good For The Game
Mech parts have no rhyme or reason to their design, nothing about them is particularly clear about being light, medium or heavy in class. Adds more visual clarity so you know if a mech is going to die to 2 rockets or 6.
## Changelog
:cl:
qol: Campaign: Updated mech colours to distinguish the different weight classes better
/:cl:
