### PR TITLE
Simplifies MT - Ares (Multitank tile) reloading. Refactors some tank code.

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -455,7 +455,7 @@
 		return ..()
 	if(!isliving(M))
 		return
-	try_easy_load(droppin, M)
+	try_easy_load(dropping, M)
 
 /obj/vehicle/sealed/armored/grab_interact(obj/item/grab/grab, mob/user, base_damage, is_sharp)
 	if(!is_type_in_typecache(grab.grabbed_thing.type, easy_load_list))

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -69,8 +69,10 @@
 	var/zoom_mode = FALSE
 	/// damage done by rams
 	var/ram_damage = 20
-	/**  List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
-	 This will be turned into a typeCache on  initialize */
+	/***
+	 List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
+	 This will be turned into a typeCache on  initialize
+	 */
 	var/list/easy_load_list
 
 /obj/vehicle/sealed/armored/Initialize(mapload)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -265,6 +265,23 @@
 		return
 	mob_exit(leaver, TRUE)
 
+/// call to try easy_loading an item into the tank. Checks for all being in the list , interior existing and the user bieng at the enter loc
+/obj/vehicle/sealed/armored/proc/try_easy_load(atom/movable/item, mob/living/user)
+	if(!is_type_in_typecache(item.type, easy_load_list))
+		return
+	if(!interior)
+		user.balloon_alert(user, "no interior")
+		return
+	if(!interior.door)
+		user.balloon_alert(user, "no door")
+		return
+	if(!(user.loc in enter_locations(user)))
+		user.balloon_alert(user, "not at entrance")
+		return
+	user.temporarilyRemoveItemFromInventory(item)
+	item.forceMove(interior.door.get_enter_location())
+	user.balloon_alert(user, "item thrown inside")
+
 /obj/vehicle/sealed/armored/mob_try_enter(mob/M)
 	if(isobserver(M))
 		interior?.mob_enter(M)
@@ -409,20 +426,7 @@
 		return
 	if(interior) // if interior handle by gun breech
 		// check for easy loading instead
-		if(!is_type_in_typecache(I.type, easy_load_list))
-			return
-		if(!interior)
-			user.balloon_alert(user, "no interior")
-			return
-		if(!interior.door)
-			user.balloon_alert(user, "no door")
-			return
-		if(!(user.loc in enter_locations(user)))
-			user.balloon_alert(user, "not at entrance")
-			return
-		user.temporarilyRemoveItemFromInventory(I)
-		I.forceMove(interior.door.get_enter_location())
-		user.balloon_alert(user, "item thrown inside")
+		try_easy_load(I, user)
 		return
 	if(istype(I, /obj/item/ammo_magazine))
 		if(!primary_weapon)
@@ -449,36 +453,14 @@
 	// Bypass to parent to handle mobs entering the vehicle.
 	if(dropping == M)
 		return ..()
-	if(!M)
-		return ..()
-	if(!interior)
-		return ..()
-	if(!interior.door)
-		return ..()
-	if(!(ismovable(dropping) && is_type_in_typecache(dropping.type, easy_load_list)))
-		return ..()
-	if(!(M.loc in enter_locations(M)))
-		M.balloon_alert(M, "not at entrance")
+	if(!isliving(M))
 		return
-	M.temporarilyRemoveItemFromInventory(dropping)
-	dropping.forceMove(interior.door.get_enter_location())
-	M.balloon_alert(M, "item thrown inside")
+	try_easy_load(droppin, M)
 
 /obj/vehicle/sealed/armored/grab_interact(obj/item/grab/grab, mob/user, base_damage, is_sharp)
 	if(!is_type_in_typecache(grab.grabbed_thing.type, easy_load_list))
 		return ..()
-	var/atom/movable/grabbed_thing = grab.grabbed_thing
-	if(!interior)
-		user.balloon_alert(user, "no interior")
-		return
-	if(!interior.door)
-		user.balloon_alert(user, "no door")
-		return
-	if(!(user.loc in enter_locations(user)))
-		user.balloon_alert(user, "not at entrance")
-		return
-	grabbed_thing.forceMove(interior.door.get_enter_location())
-	user.balloon_alert(user, "item thrown inside")
+	try_easy_load(grab.grabbed_thing, user)
 
 /obj/vehicle/sealed/armored/attackby_alternate(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -70,9 +70,9 @@
 	/// damage done by rams
 	var/ram_damage = 20
 	/***
-	 List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
-	 This will be turned into a typeCache on  initialize
-	 */
+		List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
+		This will be turned into a typeCache on  initialize
+	*/
 	var/list/easy_load_list
 
 /obj/vehicle/sealed/armored/Initialize(mapload)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -408,19 +408,20 @@
 		return
 	if(interior) // if interior handle by gun breech
 		// check for easy loading instead
-		if(I.type in easy_load_list)
-			if(!interior)
-				user.balloon_alert(user, "no interior")
-				return
-			if(!interior.door)
-				user.balloon_alert(user, "no door")
-				return
-			if(!(user.loc in enter_locations(user)))
-				user.balloon_alert(user, "not at entrance")
-				return
-			user.temporarilyRemoveItemFromInventory(I)
-			I.forceMove(interior.door.get_enter_location())
-			user.balloon_alert(user, "item thrown inside")
+		if(!(I.type in easy_load_list))
+			return
+		if(!interior)
+			user.balloon_alert(user, "no interior")
+			return
+		if(!interior.door)
+			user.balloon_alert(user, "no door")
+			return
+		if(!(user.loc in enter_locations(user)))
+			user.balloon_alert(user, "not at entrance")
+			return
+		user.temporarilyRemoveItemFromInventory(I)
+		I.forceMove(interior.door.get_enter_location())
+		user.balloon_alert(user, "item thrown inside")
 		return
 	if(istype(I, /obj/item/ammo_magazine))
 		if(!primary_weapon)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -69,9 +69,9 @@
 	var/zoom_mode = FALSE
 	/// damage done by rams
 	var/ram_damage = 20
-	/***
-		List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
-		This will be turned into a typeCache on  initialize
+	/**
+	 * List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
+	 * This will be turned into a typeCache on  initialize
 	*/
 	var/list/easy_load_list
 

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -69,8 +69,8 @@
 	var/zoom_mode = FALSE
 	/// damage done by rams
 	var/ram_damage = 20
-	/// List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
-	/// This will be turned into a typeCache on  initialize
+	/**  List for storing all item typepaths that we may "easy load" into the tank by attacking its entrance
+	 This will be turned into a typeCache on  initialize */
 	var/list/easy_load_list
 
 /obj/vehicle/sealed/armored/Initialize(mapload)
@@ -145,11 +145,11 @@
 	if(max_occupants > 1)
 		initialize_passenger_action_type(/datum/action/vehicle/sealed/armored/swap_seat)
 
+///returns a list of possible locations that this vehicle may be entered from
 /obj/vehicle/sealed/armored/proc/enter_locations(mob/M)
 	// from any adjacent position
 	if(Adjacent(M, src))
 		return list(get_turf(M))
-
 
 /obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag)
 	. = ..()
@@ -449,17 +449,20 @@
 	// Bypass to parent to handle mobs entering the vehicle.
 	if(dropping == M)
 		return ..()
-	if(ismovable(dropping) && is_type_in_typecache(dropping.type, easy_load_list) && M)
-		if(!interior)
-			return ..()
-		if(!interior.door)
-			return ..()
-		if(!(M.loc in enter_locations(M)))
-			M.balloon_alert(M, "not at entrance")
-			return
-		M.temporarilyRemoveItemFromInventory(dropping)
-		dropping.forceMove(interior.door.get_enter_location())
-		M.balloon_alert(M, "item thrown inside")
+	if(!M)
+		return ..()
+	if(!interior)
+		return ..()
+	if(!interior.door)
+		return ..()
+	if(!(ismovable(dropping) && is_type_in_typecache(dropping.type, easy_load_list)))
+		return ..()
+	if(!(M.loc in enter_locations(M)))
+		M.balloon_alert(M, "not at entrance")
+		return
+	M.temporarilyRemoveItemFromInventory(dropping)
+	dropping.forceMove(interior.door.get_enter_location())
+	M.balloon_alert(M, "item thrown inside")
 
 /obj/vehicle/sealed/armored/grab_interact(obj/item/grab/grab, mob/user, base_damage, is_sharp)
 	if(!is_type_in_typecache(grab.grabbed_thing.type, easy_load_list))

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -27,7 +27,7 @@
 		/obj/item/ammo_magazine/tank/towlauncher,
 		/obj/item/ammo_magazine/tank/secondary_cupola,
 		/obj/item/ammo_magazine/tank/tank_glauncher,
-		/obj/item/ammo_magazine/tank/tank_slauncher
+		/obj/item/ammo_magazine/tank/tank_slauncher,
 		)
 
 ///returns a list of possible locations that this vehicle may be entered from

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -21,13 +21,7 @@
 	move_delay = 0.9 SECONDS
 	ram_damage = 100
 	easy_load_list = list(
-		/obj/item/ammo_magazine/tank/ltb_cannon,
-		/obj/item/ammo_magazine/tank/ltaap_chaingun,
-		/obj/item/ammo_magazine/tank/flamer,
-		/obj/item/ammo_magazine/tank/towlauncher,
-		/obj/item/ammo_magazine/tank/secondary_cupola,
-		/obj/item/ammo_magazine/tank/tank_glauncher,
-		/obj/item/ammo_magazine/tank/tank_slauncher,
+		/obj/item/ammo_magazine/tank
 	)
 
 ///returns a list of possible locations that this vehicle may be entered from

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -21,7 +21,7 @@
 	move_delay = 0.9 SECONDS
 	ram_damage = 100
 	easy_load_list = list(
-		/obj/item/ammo_magazine/tank
+		/obj/item/ammo_magazine/tank,
 	)
 
 /obj/vehicle/sealed/armored/multitile/enter_locations(mob/M)

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -20,19 +20,22 @@
 	max_occupants = 4
 	move_delay = 0.9 SECONDS
 	ram_damage = 100
+	easy_load_list = list(
+		/obj/item/ammo_magazine/tank/ltb_cannon,
+		/obj/item/ammo_magazine/tank/ltaap_chaingun,
+		/obj/item/ammo_magazine/tank/flamer,
+		/obj/item/ammo_magazine/tank/towlauncher,
+		/obj/item/ammo_magazine/tank/secondary_cupola,
+		/obj/item/ammo_magazine/tank/tank_glauncher,
+		/obj/item/ammo_magazine/tank/tank_slauncher
+		)
 
 ///returns a list of possible locations that this vehicle may be entered from
-/obj/vehicle/sealed/armored/multitile/proc/enter_locations(mob/M)
+/obj/vehicle/sealed/armored/multitile/enter_locations(mob/M)
 	return list(get_step_away(get_step(src, REVERSE_DIR(dir)), src, 2))
 
 /obj/vehicle/sealed/armored/multitile/exit_location(mob/M)
 	return pick(enter_locations(M))
-
-/obj/vehicle/sealed/armored/multitile/mob_try_enter(mob/M)
-	if(!isobserver(M) && !(M.loc in enter_locations(M)))
-		balloon_alert(M, "Not at entrance")
-		return FALSE
-	return ..()
 
 /obj/vehicle/sealed/armored/multitile/enter_checks(mob/M)
 	. = ..()

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -24,7 +24,6 @@
 		/obj/item/ammo_magazine/tank
 	)
 
-///returns a list of possible locations that this vehicle may be entered from
 /obj/vehicle/sealed/armored/multitile/enter_locations(mob/M)
 	return list(get_step_away(get_step(src, REVERSE_DIR(dir)), src, 2))
 

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -28,7 +28,7 @@
 		/obj/item/ammo_magazine/tank/secondary_cupola,
 		/obj/item/ammo_magazine/tank/tank_glauncher,
 		/obj/item/ammo_magazine/tank/tank_slauncher,
-		)
+	)
 
 ///returns a list of possible locations that this vehicle may be entered from
 /obj/vehicle/sealed/armored/multitile/enter_locations(mob/M)


### PR DESCRIPTION
## About The Pull Request
Lets you throw shells inside of the tank by attacking it whilst at its entrance.
Moves  entrance code to the armored/sealed subtype , from armored/sealed/multitile , since it could be applied to 1 tile vehicles too . and so that if they get a interior , they can also be easy shell loaded.
Also adds a codex entry for anything that the tank can easily load:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/61350382/7e17e3eb-b1c2-4891-8b13-f5c4bc5953d4)


## Why It's Good For The Game
No longer 10 minutes of spam clicking and leaving a tank to load in shells
## Changelog
:cl:
code: Moved entrance code from the armored/sealed/multitile type to armored/sealed. Refactors the NT mini tank code to work with this.
balance: You can now throw shells to the interior of the MT Ares by attacking the tank with them at an entrance.
/:cl:
