### PR TITLE
Fixes posters

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -36,6 +36,7 @@
 
 /obj/structure/sign/poster/Initialize(mapload)
 	. = ..()
+	icon = 'icons/obj/contraband.dmi'
 	switch(dir)
 		if(NORTH)
 			pixel_y = 30


### PR DESCRIPTION

## About The Pull Request

So, apparently posters are all broken. They've been broken for some time, but since I made the invalid icon_state icon an error sign now you can actually tell.
This PR should fix them.

## Why It's Good For The Game

People don't like looking at error signs all over the maps. 

## Changelog
:cl:
fix: Fixed posters displaying error signs instead of their valid icon.
/:cl:
