### PR TITLE
Campaign mission timer pause

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -107,6 +107,10 @@
 #define COMSIG_GLOB_CAMPAIGN_DROPBLOCKER_DISABLED "!campaign_dropblocker_disabled"
 ///Override code for NT base rescue mission
 #define COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE "!campaign_nt_override_code"
+///Code computer starts running
+#define COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING "!campaign_nt_override_running"
+///Code computer stops running
+#define COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING "!campaign_nt_override_stop_running"
 ///Campaign OB beacon deployed
 #define COMSIG_GLOB_CAMPAIGN_OB_BEACON_ACTIVATION "!campaign_ob_beacon_activation"
 ///Campaign OB beacon going off

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -259,3 +259,6 @@
 //regress and caste swap UI
 #define TRAIT_CASTE_SWAP "caste_swap"
 #define TRAIT_REGRESSING "regressing"
+
+///Pauses campaign mission timer
+#define CAMPAIGN_MISSION_TIMER_PAUSED "campaign_mission_timer_paused"

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -52,7 +52,7 @@
 	. = ..()
 	for(var/obj/effect/landmark/patrol_point/exit_point AS in GLOB.patrol_point_list) //som 'ship' map is now ground, but this ensures we clean up exit points if this changes in the future
 		qdel(exit_point)
-	load_new_mission(new /datum/campaign_mission/raiding_base(factions[1])) //this is the 'roundstart' mission
+	load_new_mission(new /datum/campaign_mission/tdm/first_mission(factions[1])) //this is the 'roundstart' mission
 
 	for(var/i in stat_list)
 		var/datum/faction_stats/selected_faction = stat_list[i]

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -52,7 +52,7 @@
 	. = ..()
 	for(var/obj/effect/landmark/patrol_point/exit_point AS in GLOB.patrol_point_list) //som 'ship' map is now ground, but this ensures we clean up exit points if this changes in the future
 		qdel(exit_point)
-	load_new_mission(new /datum/campaign_mission/tdm/first_mission(factions[1])) //this is the 'roundstart' mission
+	load_new_mission(new /datum/campaign_mission/raiding_base(factions[1])) //this is the 'roundstart' mission
 
 	for(var/i in stat_list)
 		var/datum/faction_stats/selected_faction = stat_list[i]

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -77,7 +77,7 @@
 	/// Timer used to calculate how long till mission ends
 	var/game_timer
 	///The length of time until mission ends, if timed
-	var/max_game_time = null
+	var/max_game_time = 0
 	///Whether the max game time has been reached
 	var/max_time_reached = FALSE
 	///Delay before the mission actually starts
@@ -207,7 +207,7 @@
 	if(max_time_reached)
 		items += "Mission status: Mission complete"
 		items += ""
-	else if(game_timer)
+	else
 		items += "Mission time remaining: [mission_end_countdown()]"
 		items += ""
 
@@ -255,16 +255,35 @@
 
 ///sets up the timer for the mission
 /datum/campaign_mission/proc/set_mission_timer()
-	if(!iscampaigngamemode(SSticker.mode))
+	if(game_timer)
 		return
-
 	game_timer = addtimer(VARSET_CALLBACK(src, max_time_reached, TRUE), max_game_time, TIMER_STOPPABLE)
+
+///Pauses the gametimer, recording the remaining time left in max_game_time
+/datum/campaign_mission/proc/pause_mission_timer(trait_source = TRAIT_GENERIC)
+	if(!trait_source)
+		trait_source = TRAIT_GENERIC
+	ADD_TRAIT(src, CAMPAIGN_MISSION_TIMER_PAUSED, trait_source)
+	if(!game_timer)
+		return
+	max_game_time = timeleft(game_timer)
+	deltimer(game_timer)
+	game_timer = null
+
+///Attempts to resume the gametimer
+/datum/campaign_mission/proc/resume_mission_timer(trait_source = TRAIT_GENERIC, forced = FALSE)
+	REMOVE_TRAIT(src, CAMPAIGN_MISSION_TIMER_PAUSED, trait_source)
+	if(!forced && HAS_TRAIT(src, CAMPAIGN_MISSION_TIMER_PAUSED))
+		return
+	set_mission_timer()
 
 ///accesses the timer for status panel
 /datum/campaign_mission/proc/mission_end_countdown()
-	if(max_time_reached)
-		return "Mission finished"
-	var/eta = timeleft(game_timer) * 0.1
+	//if(max_time_reached)
+	//	return "Mission finished"
+	if(!game_timer && HAS_TRAIT(src, CAMPAIGN_MISSION_TIMER_PAUSED))
+		return "Timer paused"
+	var/eta = game_timer ? (timeleft(game_timer) * 0.1) : (max_game_time * 0.1)
 	if(eta > 0)
 		return "[(eta / 60) % 60]:[add_leading(num2text(eta % 60), 2, "0")]"
 

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -10,7 +10,7 @@
 	map_light_levels = list(225, 150, 100, 75)
 	objectives_total = 1
 	min_destruction_amount = 1
-	max_game_time = 17 MINUTES
+	max_game_time = 15 MINUTES
 	shutter_open_delay = list(
 		MISSION_STARTING_FACTION = 60 SECONDS,
 		MISSION_HOSTILE_FACTION = 0,

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -42,8 +42,8 @@
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission()
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE, PROC_REF(override_code_received))
-	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING, PROC_REF(override_code_received))
-	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING, PROC_REF(override_code_received))
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING, PROC_REF(computer_running))
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING, PROC_REF(computer_stop_running))
 
 /datum/campaign_mission/destroy_mission/base_rescue/set_factions()
 	attacking_faction = hostile_faction

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -42,6 +42,8 @@
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission()
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE, PROC_REF(override_code_received))
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING, PROC_REF(override_code_received))
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING, PROC_REF(override_code_received))
 
 /datum/campaign_mission/destroy_mission/base_rescue/set_factions()
 	attacking_faction = hostile_faction
@@ -49,7 +51,7 @@
 
 /datum/campaign_mission/destroy_mission/base_rescue/unregister_mission_signals()
 	. = ..()
-	UnregisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE)
+	UnregisterSignal(SSdcs, list(COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING, COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING))
 
 /datum/campaign_mission/destroy_mission/base_rescue/play_start_intro()
 	intro_message = list(
@@ -118,6 +120,15 @@
 	map_text_broadcast(attacking_faction, message_to_play, "[color] override broadcast", /atom/movable/screen/text/screen_text/picture/potrait/unknown)
 	map_text_broadcast(defending_faction, message_to_play, "[color] override broadcast", /atom/movable/screen/text/screen_text/picture/potrait/unknown)
 
+///Code computer is actively running a segment
+/datum/campaign_mission/destroy_mission/base_rescue/proc/computer_running(datum/source, obj/machinery/computer/nt_access/code_computer)
+	SIGNAL_HANDLER
+	pause_mission_timer(REF(code_computer))
+
+///Code computer stops running a segment
+/datum/campaign_mission/destroy_mission/base_rescue/proc/computer_stop_running(datum/source, obj/machinery/computer/nt_access/code_computer)
+	SIGNAL_HANDLER
+	resume_mission_timer(REF(code_computer))
 
 /obj/effect/landmark/campaign_structure/weapon_x
 	name = "weapon X spawner"

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -153,6 +153,7 @@
 ///Handles a beacon being destroyed. Separate from normal objective destruction for convenience as we want the specific beacon ref
 /datum/campaign_mission/raiding_base/proc/beacon_destroyed(obj/structure/campaign_objective/destruction_objective/bunker_buster/beacon)
 	SIGNAL_HANDLER
+	UnregisterSignal(beacon, COMSIG_QDELETING)
 	resume_mission_timer(REF(beacon))
 	beacons_remaining --
 	if(outcome)

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -54,7 +54,7 @@
 	///Records whether the OB has been called
 	var/ob_called = FALSE
 	///Count of beacons still in play
-	var/beacons_remaining = 3
+	var/beacons_remaining = 4
 
 /datum/campaign_mission/raiding_base/get_status_tab_items(mob/source, list/items)
 	. = ..()
@@ -67,9 +67,7 @@
 	for(var/i = 1 to beacons_remaining)
 		new /obj/item/explosive/plastique(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
 		new /obj/item/explosive/plastique(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
-
-		var/beacon = new /obj/item/campaign_beacon/bunker_buster(get_turf(pick(GLOB.campaign_reward_spawners[starting_faction])))
-		RegisterSignal(beacon, COMSIG_QDELETING, PROC_REF(beacon_destroyed))
+		new /obj/item/campaign_beacon/bunker_buster(get_turf(pick(GLOB.campaign_reward_spawners[starting_faction])))
 
 /datum/campaign_mission/raiding_base/start_mission()
 	. = ..()
@@ -146,13 +144,16 @@
 ///Reacts to an OB beacon being successfully triggered
 /datum/campaign_mission/raiding_base/proc/beacon_placed(datum/source, obj/structure/campaign_objective/destruction_objective/bunker_buster/beacon)
 	SIGNAL_HANDLER
+	RegisterSignal(beacon, COMSIG_QDELETING, PROC_REF(beacon_destroyed))
+	pause_mission_timer(REF(beacon))
 	var/area/deployed_area = get_area(beacon)
 	map_text_broadcast(starting_faction, "Confirming beacon deployed in [deployed_area]. Defend it until we can secure a target lock marines!", "TGS Horizon", /atom/movable/screen/text/screen_text/picture/potrait/pod_officer, "sound/effects/alert.ogg")
 	map_text_broadcast(hostile_faction, "Orbital beacon detected in [deployed_area]. Destroy that beacon before they can secure a target lock!", "Overwatch", sound_effect = "sound/effects/alert.ogg")
 
-///Handles a beacon being destroyed. Separate from normal objective destruction as the beacon item is not an objective type
-/datum/campaign_mission/raiding_base/proc/beacon_destroyed(obj/item/campaign_beacon/source)
+///Handles a beacon being destroyed. Separate from normal objective destruction for convenience as we want the specific beacon ref
+/datum/campaign_mission/raiding_base/proc/beacon_destroyed(obj/structure/campaign_objective/destruction_objective/bunker_buster/beacon)
 	SIGNAL_HANDLER
+	resume_mission_timer(REF(beacon))
 	beacons_remaining --
 	if(outcome)
 		return
@@ -163,12 +164,13 @@
 ///Reacts to an OB beacon being successfully triggered
 /datum/campaign_mission/raiding_base/proc/beacon_triggered(datum/source, obj/structure/campaign_objective/destruction_objective/bunker_buster/beacon, activation_delay)
 	SIGNAL_HANDLER
-	deltimer(game_timer) //stops the game from ending if it comes down to the wire
+	pause_mission_timer() //stops the game from ending if it comes down to the wire
 	addtimer(CALLBACK(src, PROC_REF(beacon_effect), beacon, beacon.loc), activation_delay)
 
 ///Handles the actual detonation effects
 /datum/campaign_mission/raiding_base/proc/beacon_effect(obj/structure/campaign_objective/destruction_objective/bunker_buster/beacon, turf/location)
 	ob_called = TRUE
+	resume_mission_timer(src, TRUE)
 	//We handle this here instead of the beacon structure because it could be destroyed before this triggers
 	explosion(location, 25, 30)
 	if(QDELETED(beacon))

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -173,7 +173,7 @@
 	ob_called = TRUE
 	resume_mission_timer(src, TRUE)
 	//We handle this here instead of the beacon structure because it could be destroyed before this triggers
-	explosion(location, 25, 30)
+	explosion(location, 45, flame_range = 45)
 	if(QDELETED(beacon))
 		return
 	qdel(beacon)

--- a/code/game/objects/machinery/computer/nt_access.dm
+++ b/code/game/objects/machinery/computer/nt_access.dm
@@ -134,6 +134,7 @@
 				visible_message(span_notice("[src] beeps as it finishes sending the security override command."))
 				SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_CODE, code_color)
 				busy = FALSE
+				set_disabled() //stops spamming the signal
 				return
 
 			busy = TRUE
@@ -144,7 +145,7 @@
 				return
 
 			busy = FALSE
-
+			SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_RUNNING, src)
 			current_timer = addtimer(CALLBACK(src, PROC_REF(complete_segment)), segment_time, TIMER_STOPPABLE)
 			update_minimap_icon()
 			running = TRUE
@@ -154,6 +155,7 @@
 
 ///Completes a stage of program progress
 /obj/machinery/computer/nt_access/proc/complete_segment()
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_NT_OVERRIDE_STOP_RUNNING, src)
 	playsound(src, 'sound/machines/ping.ogg', 25, 1)
 	deltimer(current_timer)
 	current_timer = null


### PR DESCRIPTION
## About The Pull Request
Deploying beacons in Raiding Base now pauses the mission timer. Also increased beacons to 4 instead of 3.
Running disk on NT base rescue also pauses the timer. Slightly decreases mission timer since you can now potentially extend it out quite a bit.

## Why It's Good For The Game
The time pressure on these mission was quite tough , especially considering the beacon has a fairly long timer on raid base.
## Changelog
:cl:
balance: Campaign: Deploying an OB beacon in the Raiding Base mission pauses the game timer
balance: Campaign: Running a code computer on NT Base Rescue pauses the game timer
/:cl:
