### PR TITLE
Make all reagents scannable by default

### DIFF
--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	/// increases as addiction gets worse
 	var/addiction_stage = 0
 	/// does this show up on health analyzers
-	var/scannable = FALSE
+	var/scannable = TRUE
 	/// if false stops metab in liverless mobs
 	var/self_consuming = FALSE
 	/// List of reagents removed by this chemical

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -13,7 +13,6 @@
 	color = COLOR_REAGENT_INAPROVALINE
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2
-	scannable = TRUE
 	trait_flags = TACHYCARDIC
 
 /datum/reagent/medicine/inaprovaline/on_mob_add(mob/living/L, metabolism)
@@ -54,7 +53,6 @@
 	description = "Ryetalyn is a long-duration shield against toxic chemicals."
 	reagent_state = SOLID
 	color = COLOR_REAGENT_RYETALYN
-	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.125
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/zombium)
 	purge_rate = 5
@@ -87,7 +85,6 @@
 	name = "Paracetamol"
 	description = "Most probably know this as Tylenol, but this chemical is a mild, simple painkiller, good for enduring heavy labor."
 	color = COLOR_REAGENT_PARACETAMOL
-	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.125
 	purge_list = list(/datum/reagent/medicine/kelotane, /datum/reagent/medicine/bicaridine)
 	purge_rate = 1
@@ -113,7 +110,6 @@
 	name = "Tramadol"
 	description = "A simple, yet effective painkiller."
 	color = COLOR_REAGENT_TRAMADOL
-	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
@@ -139,7 +135,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 1.25
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
-	scannable = TRUE
 
 /datum/reagent/medicine/oxycodone/on_mob_add(mob/living/L, metabolism)
 	if(TIMER_COOLDOWN_CHECK(L, name))
@@ -181,7 +176,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = REAGENTS_OVERDOSE*0.6 //You aren't using this out of combat. And only the B18 makes it.
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
-	scannable = TRUE
 
 /datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
@@ -200,7 +194,6 @@
 	name = "Leporazine"
 	description = "Leporazine can be use to stabilize an individuals body temperature."
 	color = COLOR_REAGENT_LEPORAZINE
-	scannable = TRUE
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 
@@ -223,7 +216,6 @@
 	name = "Kelotane"
 	description = "Kelotane is a drug used to treat burns."
 	color = COLOR_REAGENT_KELOTANE
-	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/ryetalyn)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
@@ -253,7 +245,6 @@
 	color = COLOR_REAGENT_DERMALINE
 	overdose_threshold = REAGENTS_OVERDOSE*0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
-	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
 
@@ -283,7 +274,6 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "salty water"
-	scannable = TRUE
 
 /datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
 	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
@@ -302,7 +292,6 @@
 	color = COLOR_REAGENT_DEXALIN
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/dexalin/on_mob_life(mob/living/L,metabolism)
 	L.adjustOxyLoss(-3*effect_str)
@@ -321,7 +310,6 @@
 	color = COLOR_REAGENT_DEXALINPLUS
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
-	scannable = TRUE
 
 /datum/reagent/medicine/dexalinplus/on_mob_life(mob/living/L,metabolism)
 	L.adjustOxyLoss(-L.getOxyLoss())
@@ -338,7 +326,6 @@
 	name = "Tricordrazine"
 	description = "Tricordrazine is a highly potent stimulant, originally derived from cordrazine. Can be used to treat a wide range of injuries."
 	color = COLOR_REAGENT_TRICORDRAZINE
-	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/ryetalyn)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
@@ -367,7 +354,6 @@
 	name = "Dylovene"
 	description = "Dylovene is a broad-spectrum antitoxin."
 	color = COLOR_REAGENT_DYLOVENE
-	scannable = TRUE
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/research/stimulon, /datum/reagent/consumable/drink/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
@@ -442,7 +428,6 @@
 	color = COLOR_REAGENT_SYNAPTIZINE
 	overdose_threshold = REAGENTS_OVERDOSE/5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5
-	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	purge_list = list(/datum/reagent/toxin/mindbreaker)
 	purge_rate = 5
@@ -535,7 +520,6 @@
 	custom_metabolism = REAGENTS_METABOLISM
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/hyronalin/on_mob_life(mob/living/L)
 	L.adjustToxLoss(-effect_str)
@@ -554,7 +538,6 @@
 	custom_metabolism = REAGENTS_METABOLISM
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
-	scannable = TRUE
 
 /datum/reagent/medicine/arithrazine/on_mob_life(mob/living/L)
 	L.adjustToxLoss(-0.5*effect_str)
@@ -575,7 +558,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	overdose_threshold = REAGENTS_OVERDOSE/2   //so it makes the OD threshold effectively 15 so two pills is too much but one is fine
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2.5 //and this makes the Critical OD 20
-	scannable = TRUE
 
 /datum/reagent/medicine/russian_red/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
@@ -611,7 +593,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/alkysine/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_LIGHT
@@ -631,7 +612,6 @@
 	color = COLOR_REAGENT_IMIDAZOLINE
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 	taste_description = "dull toxin"
 
 /datum/reagent/medicine/imidazoline/on_mob_life(mob/living/L, metabolism)
@@ -657,7 +637,6 @@
 	overdose_threshold = REAGENTS_OVERDOSE/30
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/25
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
-	scannable = TRUE
 
 /datum/reagent/medicine/peridaxon_plus/on_mob_life(mob/living/L, metabolism)
 	L.reagents.add_reagent(/datum/reagent/toxin/scannable,5)
@@ -686,7 +665,6 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
 	L.heal_overall_damage(effect_str, 0)
@@ -710,7 +688,6 @@
 	color = COLOR_REAGENT_MERALYNE
 	overdose_threshold = REAGENTS_OVERDOSE*0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
-	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
 
@@ -736,7 +713,6 @@
 	color = COLOR_REAGENT_QUICKCLOT
 	overdose_threshold = REAGENTS_OVERDOSE/2 //Was 4, now 6 //Now 15
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
-	scannable = TRUE //scannable now.  HUZZAH.
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 
 /datum/reagent/medicine/quickclot/on_mob_life(mob/living/L, metabolism)
@@ -763,7 +739,6 @@
 	color = COLOR_REAGENT_QUICKCLOTPLUS
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //12u
-	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 2.5
 	///The IB wound this dose of QCP will cure, if it lasts long enough
 	var/datum/wound/internal_bleeding/target_IB
@@ -837,7 +812,6 @@
 	color = COLOR_REAGENT_NANOBLOOD
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //10u
-	scannable = TRUE
 
 /datum/reagent/medicine/nanoblood/on_mob_life(mob/living/L, metabolism)
 	L.adjust_blood_volume(2.4)
@@ -961,7 +935,6 @@
 	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the targets body temperature must be under 170K for it to metabolise correctly."
 	reagent_state = LIQUID
 	color = COLOR_REAGENT_CRYOXADONE
-	scannable = TRUE
 	taste_description = "sludge"
 	trait_flags = BRADYCARDICS
 
@@ -977,7 +950,6 @@
 	name = "Clonexadone"
 	description = "A liquid compound similar to that used in the cloning process. Can be used to 'finish' the cloning process when used in conjunction with a cryo tube."
 	color = COLOR_REAGENT_CLONEXADONE
-	scannable = TRUE
 	taste_description = "muscle"
 	trait_flags = BRADYCARDICS
 
@@ -997,7 +969,6 @@
 	color = COLOR_REAGENT_REZADONE
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 	taste_description = "fish"
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/L, metabolism)
@@ -1032,7 +1003,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.05
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/spaceacillin/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, TOX)
@@ -1046,7 +1016,6 @@
 	color = COLOR_REAGENT_POLYHEXANIDE
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 
 /datum/reagent/medicine/polyhexanide/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1070,7 +1039,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
-	scannable = TRUE
 
 /datum/reagent/medicine/larvaway/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1126,7 +1094,6 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	purge_list = list(/datum/reagent/medicine, /datum/reagent/toxin, /datum/reagent/zombium)
 	purge_rate = 5
-	scannable = TRUE
 	taste_description = "punishment"
 	taste_multi = 8
 
@@ -1177,7 +1144,6 @@
 	description = "Accelerates natural bone repair in a low temperature environment. Causes severe pain."
 	color = COLOR_REAGENT_BIHEXAJULINE
 	taste_description = "skim milk"
-	scannable = TRUE
 	overdose_threshold = REAGENTS_OVERDOSE
 
 /datum/reagent/medicine/bihexajuline/on_mob_life(mob/living/L, metabolism)
@@ -1218,7 +1184,6 @@
 	description = "This is a latent poison, designed to quickly and painlessly kill you in the event that you become unable to fight. Never washes out on it's own, must be purged."
 	color = COLOR_REAGENT_QUIETUS
 	custom_metabolism = 0
-	scannable = TRUE
 	taste_description = "Victory"
 
 /datum/reagent/medicine/research/quietus/on_mob_add(mob/living/L, metabolism)
@@ -1250,7 +1215,6 @@
 	name = "Somolent"
 	description = "This is a highly potent regenerative drug, designed to heal critically injured personnel. Only functions on unconscious or sleeping people."
 	color = COLOR_REAGENT_SOMOLENT
-	scannable = TRUE
 	overdose_threshold = REAGENTS_OVERDOSE
 	taste_description = "naptime"
 
@@ -1280,7 +1244,6 @@
 	description = "These are a batch of construction nanites altered for in-vivo replication. They can heal wounds using the iron present in the bloodstream. Medical care is recommended during injection."
 	color = COLOR_REAGENT_MEDICALNANITES
 	custom_metabolism = 0
-	scannable = TRUE
 	taste_description = "metal, followed by mild burning"
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
 	purge_list = list(
@@ -1348,7 +1311,6 @@
 	description = "A chemical designed to boost running by driving your body beyond it's normal limits. Can have unpredictable side effects, caution recommended."
 	color = COLOR_REAGENT_STIMULON
 	custom_metabolism = 0
-	scannable = TRUE
 
 /datum/reagent/medicine/research/stimulon/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("You feel jittery and fast! Time to MOVE!"))

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -30,7 +30,6 @@
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable)
 	purge_rate = 1
 	taste_description = "water"
-	scannable = TRUE
 
 /datum/reagent/water/reaction_turf(turf/T, volume)
 	if(volume >= 3)
@@ -346,7 +345,6 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "iron"
-	scannable = TRUE
 
 /datum/reagent/iron/overdose_process(mob/living/L, metabolism)
 	L.apply_damages(1, 0, 1)
@@ -655,4 +653,3 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -19,7 +19,6 @@
 
 ///For medicines that generate toxin reagent when metabolized
 /datum/reagent/toxin/scannable
-	scannable = TRUE
 
 /datum/reagent/toxin/hptoxin
 	name = "Toxin"
@@ -218,7 +217,6 @@
 	toxpwr = 0
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	scannable = TRUE
 	taste_description = "cough syrup"
 	trait_flags = BRADYCARDICS
 
@@ -449,7 +447,6 @@
 	color = COLOR_TOXIN_XENO_NEUROTOXIN
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = 10000 //Overdosing for neuro is what happens when you run out of stamina to avoid its oxy and toxin damage
-	scannable = TRUE
 	toxpwr = 0
 
 /datum/reagent/toxin/xeno_neurotoxin/on_mob_life(mob/living/L, metabolism)
@@ -496,7 +493,6 @@
 	color = COLOR_TOXIN_XENO_HEMODILE
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
-	scannable = TRUE
 	toxpwr = 0
 
 /datum/reagent/toxin/xeno_hemodile/on_mob_life(mob/living/L, metabolism)
@@ -533,7 +529,6 @@
 	color = COLOR_TOXIN_XENO_TRANSVITOX
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
-	scannable = TRUE
 	toxpwr = 0
 
 /datum/reagent/toxin/xeno_transvitox/on_mob_add(mob/living/L, metabolism, affecting)
@@ -589,7 +584,6 @@
 	color = COLOR_TOXIN_XENO_SANGUINAL
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
-	scannable = TRUE
 	toxpwr = 0
 
 /datum/reagent/toxin/xeno_sanguinal/on_mob_life(mob/living/L, metabolism)
@@ -623,7 +617,6 @@
 	color = COLOR_TOXIN_XENO_OZELOMELYN
 	custom_metabolism = 1.5 // metabolizes decently quickly. A sting does 15 at the same rate as neurotoxin.
 	overdose_threshold = 10000
-	scannable = TRUE
 	toxpwr = 0 // This is going to do slightly snowflake tox damage.
 	purge_list = list(/datum/reagent/medicine)
 	purge_rate = 5
@@ -644,7 +637,6 @@
 	reagent_state = LIQUID
 	color = COLOR_TOXIN_ZOMBIUM
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
-	scannable = TRUE
 	overdose_threshold = 20
 	overdose_crit_threshold = 50
 
@@ -684,7 +676,6 @@
 	color = COLOR_TOXIN_SATRAPINE
 	overdose_threshold = 10000
 	custom_metabolism = REAGENTS_METABOLISM
-	scannable = TRUE
 	toxpwr = 0
 	purge_list = list(
 		/datum/reagent/medicine/tramadol,


### PR DESCRIPTION

## About The Pull Request
Makes all chems scannable by a health scanner by default
## Why It's Good For The Game
As we've seen in:
https://github.com/tgstation/TerraGov-Marine-Corps/pull/15326
https://github.com/tgstation/TerraGov-Marine-Corps/pull/15465
People want to be able to see what chems are circulating through their system.
I don't see any reason why we would want to have invisible chems, so imo they should all be made scannable in a single PR, rather than slowly make every single chem scannable individually.
## Changelog
:cl:
qol: All chems (except neuraline) are scannable by a health scanner
/:cl:
