### PR TITLE
Fixes the deathtile bug

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -304,7 +304,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 ///bounces the projectile by creating a new projectile and calculating an angle of reflection
 /datum/ammo/proc/reflect(turf/T, obj/projectile/proj, scatter_variance)
 	var/new_range = proj.proj_max_range - proj.distance_travelled
-	if(new_range <= 0)
+	if(new_range <= 4)
 		return
 
 	var/dir_to_proj = get_dir(T, proj)


### PR DESCRIPTION

## About The Pull Request

Someone found out why the bug is happening and as I'm no coder or smart enough to describe it here it is https://github.com/tgstation/TerraGov-Marine-Corps/issues/15535#issuecomment-2033282217
But in the issues section of the bug the guy talked about why it happened and it's because it bounces more than 30 times on the object :sob: so put the range so it bounces less times

## Why It's Good For The Game

I fix the godforsaken bug I unearthed.

## Changelog

Fixes the Deathtile bug for the ricochet
Also nerfs the ricochet by reducing it's range by 4 tiles

:cl:
fix: fixed the deathtile bug
balance: reduces lassniper ricochets firemode reflectable tiles by 4
/:cl:
