### PR TITLE
Fix infinite reflect

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -303,6 +303,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 ///bounces the projectile by creating a new projectile and calculating an angle of reflection
 /datum/ammo/proc/reflect(turf/T, obj/projectile/proj, scatter_variance)
+	if(!bonus_projectiles_type) //while fire_bonus_projectiles does not require this var, it can cause infinite recursion in some cases, leading to death tiles
+		return
 	var/new_range = proj.proj_max_range - proj.distance_travelled
 	if(new_range <= 0)
 		return


### PR DESCRIPTION

## About The Pull Request
Fixes projectiles reflect more than they should, which notably leads to death tiles in cases where it recursively bounces enough times to trigger recusion checks which stops the projectiles from processing/deleting.
## Why It's Good For The Game
Funny death tile bad.
## Changelog
:cl:
fix: fixed infinite projectile reflection
/:cl:
