### PR TITLE
Increases AMR flak ammo sunder.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1203,7 +1203,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "sniper_flak"
 	damage = 90
 	penetration = 0
-	sundering = 15
+	sundering = 30
 	airburst_multiplier = 0.5
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
Flak ammo is pretty bad even with its funny AOE gimmick and regular ammo is always the way to go. This should help flak rounds fill a more supportive role without actually being definitively worse than the standard ammo.

It still takes more shots to kill a crusher with this buff than standard ammo but it does hurt tankier castes a bit more now.
## Changelog
:cl:
balance: Increases the sunder of AMR flak rounds.
/:cl:
