### PR TITLE
Revert "Silo scaling change"

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -27,9 +27,7 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate *= SSmonitor.gamestate == SHIPSIDE ? 3 : 1
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
 	//We scale the rate based on the current ratio of humans to xenos
-	var/current_human_to_xeno_ratio = active_humans / active_xenos
-	var/optimal_human_to_xeno_ratio = xeno_job.job_points_needed / LARVA_POINTS_REGULAR
-	current_larva_spawn_rate *= clamp(current_human_to_xeno_ratio / optimal_human_to_xeno_ratio , 0.7, 1)
+	current_larva_spawn_rate *= clamp(round((active_humans / active_xenos) / (LARVA_POINTS_REGULAR / xeno_job.job_points_needed), 0.01), 0.5, 1)
 
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 


### PR DESCRIPTION
## About
Reverts tgstation/TerraGov-Marine-Corps#15523
## Why It's Good for the Game
larva gen is super low, even with like 2 silos

## Changelog
:cl: balance: Reverts larva gen from silo ratio nerf
/:cl: