### PR TITLE
Lowers king's phero power from 6 to 4.5

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -37,7 +37,7 @@
 	soft_armor = list(MELEE = 65, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 60, FIRE = 100, ACID = 60)
 
 	// *** Pheromones *** //
-	aura_strength = 6
+	aura_strength = 4.5
 
 	minimap_icon = "xenoking"
 


### PR DESCRIPTION
## About The Pull Request
Brings king's pheros to the same level as prae pheros, because 6 phero strength is actually insane, and MAYBE xenos dont dying might be a bad thing but idk.
THIS SHOULD ONLY BE MERGED IF THE REVERT FOR https://github.com/tgstation/TerraGov-Marine-Corps/pull/15463 GOES IN

## Why It's Good For The Game
Alternative to making all warding pheros useless.

## Changelog
:cl:
balance: Lowers king pheros strength to 4.5
:cl: