### PR TITLE
Silo calc fix

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -16,7 +16,11 @@ SUBSYSTEM_DEF(silo)
 /datum/controller/subsystem/silo/fire(resumed = 0)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/active_humans = length(GLOB.humans_by_zlevel[SSmonitor.gamestate == SHIPSIDE ? "3" : "2"])
-	var/active_xenos = length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) + (xeno_job.total_positions - xeno_job.current_positions)
+	var/active_xenos = xeno_job.total_positions - xeno_job.current_positions //burrowed
+	for(var/mob/living/carbon/xenomorph/xeno AS in GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL])
+		if(xeno.xeno_caste.caste_flags & CASTE_IS_A_MINION)
+			continue
+		active_xenos ++
 	//The larval spawn is based on the amount of silo, ponderated with a define. Larval follow a f(x) = (x + a)/(1 + a) * something law, which is smoother that f(x) = x * something
 	current_larva_spawn_rate = length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]) ? SILO_OUTPUT_PONDERATION + length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]) : 0
 	//We then are normalising with the number of alive marines, so the balance is roughly the same whether or not we are in high pop


### PR DESCRIPTION

## About The Pull Request
Hotfix: Stops the larva gen calc including minions.

So minions are counted as xenos for the glob list purposes. This issue actually effects other stuff (like autobalance) not just larva gen, so a proper fix is needed, but pr'ing this now so benos don't get owned by having loads of minions.
## Why It's Good For The Game
Minion spam nerfing the hive is funny but notgud
## Changelog
:cl:
fix: Larva gen no longer counts minions when calculating xeno pop
/:cl:
