### PR TITLE
Campaign UI colour tweaks

### DIFF
--- a/tgui/packages/tgui/interfaces/CampaignMenu/CampaignAssets.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/CampaignAssets.tsx
@@ -42,7 +42,7 @@ export const CampaignAssets = (props) => {
                 onClick={() => setSelectedReward(reward)}
                 color={
                   selectedReward.name === reward.name
-                    ? 'orange'
+                    ? 'green'
                     : reward.currently_active
                       ? 'yellow'
                       : reward.is_debuff
@@ -60,9 +60,9 @@ export const CampaignAssets = (props) => {
                     className={classes([
                       'campaign_assets18x18',
                       selectedReward.name === reward.name
-                        ? reward.icon + '_red'
+                        ? reward.icon + '_green'
                         : reward.currently_active
-                          ? reward.icon + '_orange'
+                          ? reward.icon + '_yellow'
                           : reward.is_debuff
                             ? reward.icon + '_red'
                             : reward.uses_remaining > 0

--- a/tgui/packages/tgui/interfaces/CampaignMenu/CampaignMissions.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/CampaignMissions.tsx
@@ -34,7 +34,7 @@ export const CampaignMissions = (props) => {
                 onClick={() => setSelectedMission(mission)}
                 color={
                   selectedMission.name === mission.name
-                    ? 'orange'
+                    ? 'green'
                     : mission.mission_critical
                       ? 'red'
                       : 'blue'
@@ -47,7 +47,7 @@ export const CampaignMissions = (props) => {
                     className={classes([
                       'campaign_missions24x24',
                       selectedMission.name === mission.name
-                        ? mission.mission_icon + '_yellow'
+                        ? mission.mission_icon + '_green'
                         : mission.mission_critical
                           ? mission.mission_icon + '_red'
                           : mission.mission_icon + '_blue',

--- a/tgui/packages/tgui/interfaces/CampaignMenu/CampaignPurchase.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/CampaignPurchase.tsx
@@ -40,7 +40,7 @@ export const CampaignPurchase = (props) => {
                 onClick={() => setSelectedReward(reward)}
                 color={
                   selectedReward.name === reward.name
-                    ? 'orange'
+                    ? 'green'
                     : reward.uses_remaining > 0
                       ? 'blue'
                       : reward.uses_remaining < 0
@@ -54,7 +54,7 @@ export const CampaignPurchase = (props) => {
                     className={classes([
                       'campaign_assets18x18',
                       selectedReward.name === reward.name
-                        ? reward.icon + '_red'
+                        ? reward.icon + '_green'
                         : reward.icon + '_blue',
                     ])}
                   />

--- a/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignMenu/index.tsx
@@ -91,7 +91,7 @@ export const CampaignMenu = (props) => {
     <Window
       theme={data.ui_theme}
       title={data.faction + ' Mission Control'}
-      width={700}
+      width={800}
       height={650}
     >
       <Window.Content>

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualLoadouts.tsx
@@ -83,12 +83,14 @@ export const IndividualLoadouts = (props) => {
                       color={
                         selectedLoadoutItem.item_type.name ===
                         equippeditem.item_type.name
-                          ? 'orange'
+                          ? 'green'
                           : equippeditem.item_type.quantity === 0
                             ? 'grey'
-                            : equippeditem.item_type.valid_choice === 0
+                            : !equippeditem.item_type.valid_choice
                               ? 'red'
-                              : 'blue'
+                              : equippeditem.item_type.purchase_cost > 0
+                                ? 'orange'
+                                : 'blue'
                       }
                     >
                       <Stack align="center">
@@ -100,12 +102,14 @@ export const IndividualLoadouts = (props) => {
                               'campaign_loadout_items32x32',
                               selectedLoadoutItem.item_type.name ===
                               equippeditem.item_type.name
-                                ? equippeditem.item_type.icon + '_orange'
+                                ? equippeditem.item_type.icon + '_green'
                                 : equippeditem.item_type.quantity === 0
                                   ? equippeditem.item_type.icon + '_grey'
-                                  : equippeditem.item_type.valid_choice === 0
+                                  : !equippeditem.item_type.valid_choice
                                     ? equippeditem.item_type.icon + '_red'
-                                    : equippeditem.item_type.icon + '_blue',
+                                    : equippeditem.item_type.purchase_cost > 0
+                                      ? equippeditem.item_type.icon + '_orange'
+                                      : equippeditem.item_type.icon + '_blue',
                             ])}
                           />
                         )}
@@ -155,13 +159,15 @@ export const IndividualLoadouts = (props) => {
                       }}
                       color={
                         selectedPossibleItem.name === potentialitem.name
-                          ? 'orange'
+                          ? 'green'
                           : !potentialitem.unlocked ||
                               potentialitem.quantity === 0
                             ? 'grey'
                             : !potentialitem.valid_choice
                               ? 'red'
-                              : 'blue'
+                              : potentialitem.purchase_cost > 0
+                                ? 'orange'
+                                : 'blue'
                       }
                     >
                       <Stack align="center" direction="column">
@@ -170,13 +176,15 @@ export const IndividualLoadouts = (props) => {
                             className={classes([
                               'campaign_loadout_items64x64',
                               selectedPossibleItem.name === potentialitem.name
-                                ? potentialitem.icon + '_orange' + '_big'
+                                ? potentialitem.icon + '_green' + '_big'
                                 : !potentialitem.unlocked ||
                                     potentialitem.quantity === 0
                                   ? potentialitem.icon + '_grey' + '_big'
                                   : !potentialitem.valid_choice
                                     ? potentialitem.icon + '_red' + '_big'
-                                    : potentialitem.icon + '_blue' + '_big',
+                                    : potentialitem.purchase_cost > 0
+                                      ? potentialitem.icon + '_orange' + '_big'
+                                      : potentialitem.icon + '_blue' + '_big',
                             ])}
                           />
                         )}
@@ -211,7 +219,7 @@ export const IndividualLoadouts = (props) => {
                     mr={1}
                     className={classes([
                       'campaign_loadout_items64x64',
-                      selectedPossibleItem.icon + '_orange' + '_big',
+                      selectedPossibleItem.icon + '_green' + '_big',
                     ])}
                   />
                   <Stack.Item fontSize="150%" grow={1}>

--- a/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/IndividualPerks.tsx
@@ -53,7 +53,7 @@ export const IndividualPerks = (props) => {
                     }}
                     color={
                       selectedPerk.name === perk.name
-                        ? 'orange'
+                        ? 'green'
                         : perk.currently_active > 0
                           ? 'blue'
                           : perk.cost > data.currency
@@ -67,7 +67,7 @@ export const IndividualPerks = (props) => {
                         className={classes([
                           'campaign_perks18x18',
                           selectedPerk.name === perk.name
-                            ? perk.icon + '_orange'
+                            ? perk.icon + '_green'
                             : perk.currently_active > 0
                               ? perk.icon + '_blue'
                               : perk.cost > data.currency
@@ -93,7 +93,7 @@ export const IndividualPerks = (props) => {
                     mr={1.5}
                     className={classes([
                       'campaign_perks36x36',
-                      selectedPerk.icon + '_orange' + '_big',
+                      selectedPerk.icon + '_green' + '_big',
                     ])}
                   />
                   <Flex.Item fontSize="150%" grow={1}>


### PR DESCRIPTION

## About The Pull Request
Colour tweaks for improved visibility maybe.

Selected colour is now green instead of orange.
If a loadout item has an equip cost, its cost is now orange.
## Why It's Good For The Game
Being able to see at a glance what items have a cost is good.
## Changelog
:cl:
qol: Campaign: Loadout options with a cost are now coloured to indicate this
/:cl:
