### PR TITLE
Fixes Nade box storage.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1147,7 +1147,7 @@
 	name = "\improper M40 HPDP grenade box"
 	desc = "A secure box holding 15 M40 HPDP white phosphorous grenades. War crimes for the entire platoon!"
 	storage_slots = 25
-	max_storage_space = 30
+	max_storage_space = 50
 	spawn_number = 25
 	spawn_type = /obj/item/explosive/grenade/phosphorus
 	closed_overlay = "grenade_box_overlay_phosphorus"
@@ -1191,7 +1191,7 @@
 	name = "razorburn grenade box"
 	desc = "A secure box holding 15 razor burn grenades. Used for quick flank coverage."
 	storage_slots = 25
-	max_storage_space = 30
+	max_storage_space = 50
 	spawn_number = 25
 	spawn_type = /obj/item/explosive/grenade/chem_grenade/razorburn_small
 	closed_overlay = "grenade_box_overlay_razorburn"


### PR DESCRIPTION

## About The Pull Request
In #15488 I increased the nades but not the storage space so while boxes spawn with 25 nades, they can't actually hold them, i.e you can remove them but you can't put them back.
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: fixes grenade box storage amount for some of the boxes.
/:cl:
