### PR TITLE
Fixes the missing icon for the generic rocket launcher rocket and M30 box magazine

### DIFF
--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -2,7 +2,7 @@
 	name = "\improper M30 box magazine (10x28mm Caseless)"
 	desc = "A drum of 50 10x28mm caseless rounds for the ST-571 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_NORMAL
-	icon_state = "ua580"
+	icon_state = "sentry"
 	magazine_flags = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500
@@ -22,7 +22,7 @@
 	name = "M30 box magazine (10x28mm Caseless)"
 	desc = "A box of 50 10x28mm caseless rounds for the ST-571 Sentry Gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_NORMAL
-	icon_state = "ua580"
+	icon_state = "sentry"
 	magazine_flags = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -2,7 +2,7 @@
 	name = "\improper M30 box magazine (10x28mm Caseless)"
 	desc = "A drum of 50 10x28mm caseless rounds for the ST-571 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_NORMAL
-	icon_state = "ua571c"
+	icon_state = "ua580"
 	magazine_flags = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500
@@ -22,6 +22,7 @@
 	name = "M30 box magazine (10x28mm Caseless)"
 	desc = "A box of 50 10x28mm caseless rounds for the ST-571 Sentry Gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_NORMAL
+	icon_state = "ua580"
 	magazine_flags = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -238,7 +238,7 @@
 	reload_delay = 30
 
 /obj/item/ammo_magazine/internal/launcher/rocket/oneuse
-	name = "\improper 67mm internal tube"
+	name = "\improper 68mm internal tube"
 	desc = "The internal tube of a one use rpg."
 	caliber = CALIBER_68MM
 	default_ammo = /datum/ammo/rocket/recoilless

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -88,7 +88,7 @@
 	name = "\improper generic high-explosive rocket"
 	desc = "A precursor to all kinds of rocket ammo unfit for normal use. How did you get this anyway?"
 	caliber = CALIBER_84MM
-	icon_state = "rocket"
+	icon_state = "rocket_he"
 	w_class = WEIGHT_CLASS_NORMAL
 	magazine_flags = MAGAZINE_REFUND_IN_CHAMBER
 	max_rounds = 1


### PR DESCRIPTION
## About The Pull Request

As the title says, this PR fixes the missing icons for the generic rocket launcher rocket and the M30 box magazine.

## Why It's Good For The Game

(just pretend those are the good ol normal sentry icons)

![immagine](https://github.com/tgstation/TerraGov-Marine-Corps/assets/75247747/75372ae9-f8f1-43b4-816b-c29bcd8fb021)

![immagine](https://github.com/tgstation/TerraGov-Marine-Corps/assets/75247747/7c14ebd4-fe65-4df7-9563-7e3920882cd4)

## Changelog

:cl:
fix: The M30 box magazine and the generic rocket launcher rocket have now a proper path
fix: Altought impossible to spot in normal game conditions, the 67mm internal tube rocket is now rightfully 68mm
/:cl:
