### PR TITLE
Increases RG 220 wield delay

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -994,7 +994,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/ammo_magazine/railgun/hvap,
 	)
 	force = 40
-	wield_delay = 2.0 SECONDS
+	wield_delay = 2.4 SECONDS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 31, "rail_y" = 23, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
@@ -1005,7 +1005,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
 	fire_delay = 3 SECONDS
-	windup_delay = 0.3 SECONDS
 	burst_amount = 1
 	accuracy_mult = 2
 	recoil = 3

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -994,7 +994,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/ammo_magazine/railgun/hvap,
 	)
 	force = 40
-	wield_delay = 2.4 SECONDS
+	wield_delay = 2.0 SECONDS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 31, "rail_y" = 23, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -994,7 +994,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/ammo_magazine/railgun/hvap,
 	)
 	force = 40
-	wield_delay = 1.2 SECONDS
+	wield_delay = 2.0 SECONDS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 31, "rail_y" = 23, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
@@ -1005,6 +1005,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
 	fire_delay = 3 SECONDS
+	windup_delay = 0.3 SECONDS
 	burst_amount = 1
 	accuracy_mult = 2
 	recoil = 3


### PR DESCRIPTION
## About The Pull Request
ided pr
Increases RG 220 wield delay from 1.2 to 2.0 seconds.
## Why It's Good For The Game

Currently, RG 220 is a very powerful operational weapon which easily farms kills and snowballs the game for marines. 

Because it's wield time is significantly shorter than other weapons of it's size/strength, it's incredibly safe to run as a primary weapon - you can wield it quickly out of stuns and force xenos off of you with a single shot.

This change forces RG220 users to carry a backup weapon or consider their positioning more carefully, similar to other weapons of it's caliber.
## Changelog
:cl:
balance: Increased RG220 wield delay from 1.2 to 2.0 seconds
/:cl:
