### PR TITLE
Clarify body scans in the medHud + Minor fixes

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 /client/verb/toggle_gas_mask_sound()
 	set category = "Preferences"
-	set name = "Toggle Gas Mask sounds."
+	set name = "Toggle Gas Mask sounds"
 
 	usr.client.prefs.toggles_sound ^= SOUND_GAS_MASK
 	usr.client.prefs.save_preferences()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -494,7 +494,8 @@
 
 	if(hasHUD(user,"medical"))
 		var/cardcolor = holo_card_color
-		if(!cardcolor) cardcolor = "none"
+		if(!cardcolor) 
+			cardcolor = "none"
 		msg += "[span_deptradio("Triage holo card:")] <a href='?src=[text_ref(src)];medholocard=1'>\[[cardcolor]\]</a> - "
 
 		// scan reports

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -496,7 +496,7 @@
 		var/cardcolor = holo_card_color
 		if(!cardcolor) 
 			cardcolor = "none"
-		msg += "[span_deptradio("Triage holo card:")] <a href='?src=[text_ref(src)];medholocard=1'>\[[cardcolor]\]</a> - "
+		msg += "[span_deptradio("Triage holo card:")] <a href='?src=[text_ref(src)];medholocard=1'>\[[cardcolor]\]</a> | "
 
 		// scan reports
 		var/datum/data/record/N = null
@@ -506,9 +506,9 @@
 				break
 		if(!isnull(N))
 			if(!(N.fields["last_scan_time"]))
-				msg += "[span_deptradio("No scan report on record")]\n"
+				msg += "[span_deptradio("No body scan report on record")]\n"
 			else
-				msg += "[span_deptradio("<a href='?src=[text_ref(src)];scanreport=1'>Scan from [N.fields["last_scan_time"]]</a>")]\n"
+				msg += "[span_deptradio("<a href='?src=[text_ref(src)];scanreport=1'>Body scan from [N.fields["last_scan_time"]]</a>")]\n"
 
 	if(hasHUD(user,"squadleader"))
 		var/mob/living/carbon/human/H = user

--- a/strings/tips/xeno.txt
+++ b/strings/tips/xeno.txt
@@ -58,8 +58,8 @@ As a warlock, your offensive abilities can be cast through glass. Give laser-usi
 As a boiler, primordial hivelord, the King or the Queen, you have the most powerful corrosive acid for melting things.
 As the Shrike, take advantage of your psychic abilities. Use Psychic Fling and Unrelenting Force to displace a marine or even push certain and hazardous objects towards your enemies and vice versa.
 As the Queen, your screech does not only affect the mobs on view, but affects through walls or gases. However, the effect of the screech will be reduced.
-As a drone, hivelord, Hivemind, Shrike, and the Queen, a large maze is almost always a good investment.
-As a drone, hivelord, Hivemind, Shrike, and the Queen, be clever with your walling. Try to allow for as much fluid movement as possible.
+As a drone, Hivelord, Hivemind, Shrike, and the Queen, a large maze is almost always a good investment.
+As a drone, Hivelord, Hivemind, Shrike, and the Queen, be clever with your walling. Try to allow for as much fluid movement as possible.
 As a shrike, queen, or king, hijacking the alamo will kill every xeno that you leave groundside, as well as destroying every structure and resetting your psy count. However, dead xenos will be refunded as burrowed larva. Call burrowed after a hijack!
 Sticky resin can act as the path for your maze to be built around.
 The Hivemind is very skilled at flanking marines. Wait for them to push, and wall them off from behind!


### PR DESCRIPTION

## About The Pull Request
Fixes : https://github.com/tgstation/TerraGov-Marine-Corps/issues/15586
Capitalized the spelling of hivelord in 2 round start tips I saw
Removed an extra dot at the end of a sound preference
Made a line of code go back to the line, as it clashes with the way we write our code.

## Why It's Good For The Game
Fixes good, and code improvements good. 
It should also be clearer what the holocards do.  They honestly could use a little icon, though. 


## Changelog
:cl:
qol: Made it clearer that the scans on medHud humans inspections refers to body scans, not handheld scanners.
spellcheck: fixed missing capitalization regarding 2 tips
spellcheck: removed superfluous dot at the end of Gas Mask preference
code: Go back to the line for some code.
/:cl:
