### PR TITLE
Storage opening QOL

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -559,7 +559,7 @@
 				return do_refill(I, user)
 
 	if(!can_be_inserted(I))
-		open(usr)
+		open(user)
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)
 

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -559,6 +559,7 @@
 				return do_refill(I, user)
 
 	if(!can_be_inserted(I))
+		open(usr)
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)
 


### PR DESCRIPTION

## About The Pull Request
Clicking on a storage with an item that cannot be inserted in said storage will open it

## Why It's Good For The Game
QOL, reduce jungling a bit when trying to reload.

For example, if you thought about opening your ammunition belt before the fight, you can do a tactical reload.
If you forgot to have the storage screen opened, you need to fumble a bit which is clonky. 

## Changelog
:cl:
qol: Clicking on a storage with an item that cannot be inserted in said storage will open it
/:cl:
