### PR TITLE
Makes lascarbine spread stats more in line with combat shotgun buckshot's

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3096,12 +3096,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "laser_spread"
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/blast/spread
 	bonus_projectiles_amount = 2
-	bonus_projectiles_scatter = 5
+	bonus_projectiles_scatter = 10
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 5
+	accurate_range = 3
 	max_range = 8
 	damage = 35
+	damage_falloff = 8
 	penetration = 20
 	sundering = 1
 	hitscan_effect_icon = "pu_laser"


### PR DESCRIPTION

## About The Pull Request
Increases the projectile scatter, lowers accurate range, adds damage falloff.
## Why It's Good For The Game
Lascarbine spread generally has very few of the drawbacks that typically come with shotguns, most notably being just as effective at range. With this change, spread will no longer be able to hit all three projectiles outside of a ~3 tile range and will have very weak damage at max range, killing a runner at range at about the same speed as the combat shotgun would with buckshot. For people who want to full sprint and rush at xenos this change will not affect them much, but people who want to sit back and snipe with a shotgun should switch to a different firemode.
## Changelog
:cl:
balance: Reduced lascarbine spread mode's effectiveness at range.
/:cl:
