### PR TITLE
Updates Captain loadout. Adds red Captain cloak variant to Captain's locker.

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -82,9 +82,10 @@ Godspeed, captain! And remember, you are not above the law."})
 	w_uniform = /obj/item/clothing/under/marine/officer/command
 	shoes = /obj/item/clothing/shoes/marinechief/captain
 	gloves = /obj/item/clothing/gloves/marine/techofficer/captain
-	head = /obj/item/clothing/head/tgmcberet/tan
+	head = /obj/item/clothing/head/beret/marine/captain
 	r_store = /obj/item/storage/pouch/general/large/command
 	l_store = /obj/item/hud_tablet/leadership
+	back = /obj/item/storage/backpack/marine/satchel/captain_cloak
 
 /datum/outfit/job/command/captain/robot
 	species = SPECIES_COMBAT_ROBOT

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -21,7 +21,7 @@
 	new /obj/item/clothing/gloves/white(src)
 	new /obj/item/clothing/under/marine/whites(src)
 	new /obj/item/clothing/head/white_dress(src)
-	new /obj/item/storage/backpack/marine/satchel/captain_cloak(src)
+	new /obj/item/storage/backpack/marine/satchel/captain_cloak_red(src)
 	new /obj/item/storage/holster/belt/mateba/officer/full(src)
 
 


### PR DESCRIPTION

## About The Pull Request
Captain now spawns with the Captain's Beret and Captain's cloak.
Adds the red Captain's cloak variant to the Captain's locker.
## Why It's Good For The Game
Always felt odd Captain didn't start with these and adds the unused red variant of the cloak to the locker for more flavour.
## Changelog
:cl:
add: Captain now spawns with Captain's cloak and Captain's Beret.
add: Adds Captain's cloak red to Captain's locker.
del: Removes Captain's cloak from locker (Captain spawns with it now).
/:cl:
