### PR TITLE
Tad can't land indoors

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -295,7 +295,7 @@
 	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
 		return SHUTTLE_DOCKER_BLOCKED
 	var/area/turf_area = get_area(T)
-	if(turf_area.ceiling >= CEILING_OBSTRUCTED)
+	if(turf_area.ceiling >= CEILING_METAL)
 		return SHUTTLE_DOCKER_BLOCKED
 	// If it's one of our shuttle areas assume it's ok to be there
 	if(shuttle_port.shuttle_areas[T.loc])


### PR DESCRIPTION

## About The Pull Request
Tad can no longer land in areas with metal roofs. (It can smash through glass roofs just fine though).
## Why It's Good For The Game
The tad is strangely inconsistant with drop pods, and being able to land inside funny buildings just makes tad turtling easier and is generally worse for gameplay.
## Changelog
:cl:
balance: Tadpole can no longer land in metal roofed areas
/:cl:
