### PR TITLE
some announcement qol

### DIFF
--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(faction_to_iff, list(
 	FACTION_PIRATE = PIRATE_IFF,
 ))
 
-///List of factions by acronym, or the shortest name possible
+///Acronyms for each faction, or the shortest name possible
 GLOBAL_LIST_INIT(faction_to_acronym, list(
 	FACTION_NEUTRAL = "Neutral",
 	FACTION_TERRAGOV = "TGMC",

--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -82,6 +82,24 @@ GLOBAL_LIST_INIT(faction_to_iff, list(
 	FACTION_PIRATE = PIRATE_IFF,
 ))
 
+///List of factions by acronym, or the shortest name possible
+GLOBAL_LIST_INIT(faction_to_acronym, list(
+	FACTION_NEUTRAL = "Neutral",
+	FACTION_TERRAGOV = "TGMC",
+	FACTION_SPECFORCE = "SRF",
+	FACTION_NANOTRASEN = "PMC",
+	FACTION_FREELANCERS = "FRE",
+	FACTION_CLF = "CLF",
+	FACTION_DEATHSQUAD = "Deathsquad",
+	FACTION_IMP = "IMP",
+	FACTION_UNKN_MERCS = "Unknown",
+	FACTION_SECTOIDS = "Sectoids",
+	FACTION_SOM = "SOM",
+	FACTION_ICC = "ICC",
+	FACTION_USL = "USL",
+	FACTION_PIRATE = "Pirates",
+))
+
 ///List of correspond factions to data hud
 GLOBAL_LIST_INIT(faction_to_data_hud, list(
 	FACTION_TERRAGOV = DATA_HUD_SQUAD_TERRAGOV,

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -220,13 +220,16 @@
 	GLOB.round_statistics.obs_fired++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "obs_fired")
 	priority_announce(
-		message = "Get out of danger close!<br><br>Warhead type: [tray.warhead.warhead_kind].<br>[fuel_warning]<br>Estimated location of impact: [get_area(T)].",
+		message = "Evacuate the impact zone immediately!<br><br>Warhead type: [tray.warhead.warhead_kind].<br>[fuel_warning]<br>Estimated location of impact: [get_area(T)].",
 		title = "Orbital bombardment launch command detected!",
 		type = ANNOUNCEMENT_PRIORITY,
 		sound = 'sound/effects/OB_warning_announce.ogg',
 		channel_override = SSsounds.random_available_channel(), // This way, we can't have it be cut off by other sounds.
 		color_override = "red"
 	)
+	var/list/receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list)
+	for(var/mob/living/screentext_receiver AS in receivers)
+		screentext_receiver.play_screen_text("<span class='maptext' style=font-size:36pt;text-align:center valign='top'><u><b>ORBITAL STRIKE IMMINENT</b></u></span><br>TYPE: [uppertext(tray.warhead.warhead_kind)]", /atom/movable/screen/text/screen_text/command_order)
 	playsound(target, 'sound/effects/OB_warning_announce_novoiceover.ogg', 125, FALSE, 30, 10) //VOX-less version for xenomorphs
 
 	var/impact_time = 10 SECONDS + (WARHEAD_FLY_TIME * (GLOB.current_orbit/3))

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -78,8 +78,8 @@
 	for(var/mob/faction_receiver in alert_receivers)
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
 			var/faction_title = "Command" // the default title, for tgmc announcements
-			if(human_owner.faction != FACTION_TERRAGOV)
-				faction_title = "[GLOB.faction_to_acronym[human_owner.faction]] Command" // if the sender doesn't belong to the TGMC, clarify the faction in the title
+			if(human_owner.faction != FACTION_TERRAGOV) // if the sender doesn't belong to the TGMC, clarify the faction in the title
+				faction_title = GLOB.faction_to_acronym[human_owner.faction] ? GLOB.faction_to_acronym[human_owner.faction] + " Command" : "Unknown Faction" + " Command"
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
 				title = "[faction_title] Announcement",

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -77,13 +77,11 @@
 		return
 	for(var/mob/faction_receiver in alert_receivers)
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
-			var/faction_title = "Command" // the default title, for tgmc announcements
-			if(human_owner.faction != FACTION_TERRAGOV) // if the sender doesn't belong to the TGMC, clarify the faction in the title
-				faction_title = GLOB.faction_to_acronym[human_owner.faction] ? GLOB.faction_to_acronym[human_owner.faction] + " Command" : "Unknown Faction" + " Command"
+			var/faction_title = GLOB.faction_to_acronym[human_owner.faction] ? GLOB.faction_to_acronym[human_owner.faction] + " Command" : "Unknown Faction" + " Command"
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
 				title = "[faction_title] Announcement",
-				subtitle = "Sent by [human_owner.real_name]",
+				subtitle = "Sent by [human_owner.job.title] [human_owner.real_name]",
 				message = text
 			))
 			SEND_SOUND(faction_receiver, S)

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -77,9 +77,12 @@
 		return
 	for(var/mob/faction_receiver in alert_receivers)
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
-			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>COMMAND ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
+			var/faction_title = "Command" // the default title, for tgmc announcements
+			if(human_owner.faction != FACTION_TERRAGOV)
+				faction_title = "[human_owner.faction] Command" // in case of hvh or an ert or something, clarify the faction if it isn't tgmc
+			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
-				title = "Command Announcement",
+				title = "[faction_title] Announcement",
 				subtitle = "Sent by [human_owner.real_name]",
 				message = text
 			))

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -79,7 +79,7 @@
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
 			var/faction_title = "Command" // the default title, for tgmc announcements
 			if(human_owner.faction != FACTION_TERRAGOV)
-				faction_title = "[human_owner.faction] Command" // in case of hvh or an ert or something, clarify the faction if it isn't tgmc
+				faction_title = "[GLOB.faction_to_acronym[human_owner.faction]] Command" // if the sender doesn't belong to the TGMC, clarify the faction in the title
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
 				title = "[faction_title] Announcement",


### PR DESCRIPTION
## About The Pull Request
- Orbital bombardment now plays screentext for every human, and changed the content of the message because "get out of danger close" is dumb
  - If possible, I want to make this play over other sources of screentext (Send Orders especially, as it is used almost always before or during an OB) at some point, as a simple narration for the type of an incoming OB is *definitely* more important than whatever the PVT who just unlocked FC has to say. Maybe for a future PR.
- "Send Orders" will now clarify the faction of the sender (EDIT: regardless of TGMC affiliation)
  - `faction_to_acronym` global list for getting faction acronyms to make this possible.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/1473f747-fc4b-4e71-bb93-6061f0eecd7c)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/67217b7b-a9f4-49d1-89b9-395ebc99796d)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/1b6d1054-2979-43a1-8c12-709521a6a25b)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/08401ede-8bbc-42f6-87ca-e6d9fd4758a5)
## Why It's Good For The Game
- Orbital bombardment playing screentext is a good idea to try and get attention of marines who can't afford to look in chat in the middle of combat
- Being able to tell what faction an announcement is from is good. Also, future coders can use the `faction_to_acronym` global list for something interesting
## Changelog
:cl:
qol: Orbital bombardments now play screentext to humans that includes the type of the OB
qol: Send Orders will now include the sender's faction acronym and job
spellcheck: The content of the orbital bombardment announcement is now "Evacuate the impact zone immediately!" instead of "Get out of danger close!"
code: "faction_to_acronym" global list for getting faction acronyms
/:cl:
