### PR TITLE
Buffs wraith's melee damage, from 20 to 23

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -9,7 +9,7 @@
 	wound_type = "wraith" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 24
+	melee_damage = 23
 
 	// *** Speed *** //
 	speed = -1.25

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -9,7 +9,7 @@
 	wound_type = "wraith" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 24
 
 	// *** Speed *** //
 	speed = -1.25


### PR DESCRIPTION
## About The Pull Request
Wraith currently flops as it's support abilities are super niche even compared to other castes.
This pr is Kuro approved
## Why It's Good For The Game
Wraith's pretty much unused by xeno players after those two nerfs, sadly
## Changelog
:cl:
balance: Ups wraith damage from 20 to 24
/:cl:
