### PR TITLE
Adds a delay when loading magazines from ammo packets

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -140,14 +140,10 @@
 		to_chat(user, span_warning("\The [source] is empty."))
 		return
 
-	if(istype(source, /obj/item/ammo_magazine/packet) && fill_delay < 1.5 SECONDS)
-		fill_delay = 1.5 SECONDS
-		return
-
-	//using handfuls; and filling internal mags has no delay.
-	if(fill_delay)
+	//if the source has a fill_delay, delay the reload by this amount
+	if(source.fill_delay)
 		to_chat(user, span_notice("You start refilling [src] with [source]."))
-		if(!do_after(user, fill_delay, NONE, src, BUSY_ICON_GENERIC))
+		if(!do_after(user, source.fill_delay, NONE, src, BUSY_ICON_GENERIC))
 			return
 
 	to_chat(user, span_notice("You refill [src] with [source]."))

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -140,6 +140,10 @@
 		to_chat(user, span_warning("\The [source] is empty."))
 		return
 
+	if(istype(source, /obj/item/ammo_magazine/packet) && fill_delay < 1.5 SECONDS)
+		fill_delay = 1.5 SECONDS
+		return
+
 	//using handfuls; and filling internal mags has no delay.
 	if(fill_delay)
 		to_chat(user, span_notice("You start refilling [src] with [source]."))

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -5,6 +5,7 @@
 	desc = "A packet containing some kind of ammo."
 	icon_state_mini = "ammo_packet"
 	w_class = WEIGHT_CLASS_NORMAL
+	fill_delay = 1.5 SECONDS
 
 /obj/item/ammo_magazine/packet/attack_hand_alternate(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds a 1.5 second delay when loading a magazine from an ammo packet

Reworks transfer_ammo to use the fill delay of the source magazine rather than the target (this is currently unused)

## Why It's Good For The Game

Ammo packets generally offer 2-4x space efficiency over magazines when stored in general pouches, armor storage or satchels. Once you have the muscle memory for reloading a primary magazine from ammo packets, there's very little downside to running them - even in the heat of battle. 

This change balances ammo packets by slowing down their reloads and enforcing a bit of realism (loading magazines takes time in the real world). Should encourage healthier and more realistic usage.
## Changelog
:cl:
balance: loading magazines from ammo packets now has a 1.5 second delay
/:cl:
