### PR TITLE
Allow ghosts to examine miners

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -249,7 +249,7 @@
 
 /obj/machinery/miner/examine(mob/user)
 	. = ..()
-	if(!ishuman(user))
+	if(!ishuman(user) && !isobserver(user))
 		return
 	if(!miner_upgrade_type)
 		. += span_info("[src]'s module sockets seem empty, an upgrade could be installed.")


### PR DESCRIPTION

## About The Pull Request
Ghosts can now see if there's minerals to sell, or what upgrades are on the drills. 
## Why It's Good For The Game
No reason why they can't see that.
## Changelog
:cl:
add: Add ghosts can now examine miners 
/:cl:
