### PR TITLE
Campaign: Improved constitution perk unlocks Tyr/Lorica for all jobs

### DIFF
--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -7,7 +7,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 45000
+	var/currency = 450
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference

--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -7,7 +7,7 @@
 	///currently occupied mob - if any
 	var/mob/living/carbon/current_mob
 	///Credits. You buy stuff with it
-	var/currency = 450
+	var/currency = 45000
 	///List of job types based on faction
 	var/list/valid_jobs = list()
 	///Single list of unlocked perks for easy reference

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
@@ -50,6 +50,9 @@
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/clothing/suit/modular/som/heavy/lorica = ITEM_SLOT_OCLOTHING)
 
+/datum/loadout_item/helmet/som_tyr/universal
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	loadout_item_flags = NONE
 /datum/loadout_item/helmet/som_mimir
 	name = "Biohazard helmet"
 	desc = "A standard combat helmet with a Mithridatius 'Mith' environmental protection module."

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -125,6 +125,11 @@
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/charger/somvet = ITEM_SLOT_SUITSTORE)
 
+/datum/loadout_item/suit_slot/som_heavy_tyr/universal
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	loadout_item_flags = null
+	item_whitelist = null
+
 /datum/loadout_item/suit_slot/gorgon
 	name = "Gorgon armor"
 	desc = "M-35 'Gorgon' armor with integrated Apollo automedical module. Provides outstanding protection without severely limiting mobility. \

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/head.dm
@@ -62,10 +62,13 @@
 	jobs_supported = list(SQUAD_MARINE)
 	item_whitelist = list(/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two = ITEM_SLOT_OCLOTHING)
 
-
 /datum/loadout_item/helmet/tyr/smartgunner
 	jobs_supported = list(SQUAD_SMARTGUNNER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
+
+/datum/loadout_item/helmet/tyr/universal
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	loadout_item_flags = NONE
 
 /datum/loadout_item/helmet/white_dress
 	name = "Dress Cap"

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -137,6 +137,11 @@
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 	item_whitelist = null
 
+/datum/loadout_item/suit_slot/heavy_tyr/universal
+	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	loadout_item_flags = NONE
+	item_whitelist = null
+
 /datum/loadout_item/suit_slot/medium_valk
 	name = "M Valkyrie armor"
 	desc = "Medium armor with a Valkyrie automedical module. Provides respectable protection, powerful automatic medical assistance, but modest mobility."

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -100,7 +100,8 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 
 /datum/perk/trait/hp_boost
 	name = "Improved constitution"
-	desc = "Through disciplined training and hypno indoctrination, your body is able to tolerate higher levels of trauma. +25 max health, +25 pain resistance."
+	desc = "Through disciplined training and hypno indoctrination, your body is able to tolerate higher levels of trauma. +25 max health, +25 pain resistance. \
+	Also unlocks heavier armor for most roles."
 	ui_icon = "health_1"
 	all_jobs = TRUE
 	unlock_cost = 800
@@ -116,6 +117,18 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	. = ..()
 	owner.maxHealth -= health_mod
 
+/datum/perk/trait/hp_boost/unlock_bonus(mob/living/carbon/owner, datum/individual_stats/owner_stats)
+	if(owner_stats.faction == FACTION_TERRAGOV)
+		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/heavy_tyr/universal, /datum/loadout_item/suit_slot/heavy_tyr, SQUAD_MARINE)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/heavy_tyr/universal, list(SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_LEADER, FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/tyr/universal, list(SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_LEADER, FIELD_COMMANDER), owner)
+
+	else if(owner_stats.faction == FACTION_SOM)
+		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, /datum/loadout_item/suit_slot/som_heavy_tyr, SOM_SQUAD_MARINE)
+		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, /datum/loadout_item/suit_slot/som_heavy_tyr/veteran, SOM_SQUAD_VETERAN)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, list(SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/som_tyr/universal, list(SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
+
 /datum/perk/trait/hp_boost/two
 	name = "Extreme constitution"
 	desc = "Military grade biological augmentations are used to harden your body against grievous bodily harm. Provides an addition +25 max health and +10 pain resistance."
@@ -124,6 +137,9 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	prereq_perks = list(/datum/perk/trait/hp_boost)
 	traits = list(TRAIT_MEDIUM_PAIN_RESIST)
 	unlock_cost = 1000
+
+/datum/perk/trait/hp_boost/two/unlock_bonus(mob/living/carbon/owner, datum/individual_stats/owner_stats)
+	return
 
 /datum/perk/trait/quiet
 	name = "Light footed"


### PR DESCRIPTION

## About The Pull Request
Wht it says on the tin. the first health perk unlocks heavy tyr/lorica for all jobs.
May be very strong, but overclocked shields are also rather good without slowdown, and there's more AP ammo available now so should be fine.
## Why It's Good For The Game
More perk bonuses/variety
## Changelog
:cl:
balance: Campaign: Improved constitution perk unlocks Tyr/Lorica for all jobs
/:cl:
