### PR TITLE
select_reagent() loads new reagent

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -297,8 +297,11 @@
 	var/obj/item/item_parent = parent
 	item_parent.update_icon()
 	loaded_reagent = null
-	reagent_select_action.owner.update_inv_r_hand()
-	reagent_select_action.owner.update_inv_l_hand()
+	var/parent_slot = reagent_select_action.owner.get_equipped_slot(parent)
+	if(parent_slot == SLOT_L_HAND)
+		reagent_select_action.owner.update_inv_l_hand()
+	else
+		reagent_select_action.owner.update_inv_r_hand()
 
 	update_selected_reagent(selected_reagent)
 

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -295,7 +295,7 @@
 			selected_reagent = reagent_entry
 
 	var/obj/item/item_parent = parent
-	item_parent.update_icon()
+	item_parent.update_appearance()
 	loaded_reagent = null
 	var/parent_slot = reagent_select_action.owner.get_equipped_slot(parent)
 	if(parent_slot == SLOT_L_HAND)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -294,8 +294,15 @@
 		if(initial(reagent_entry.name) == selected_option)
 			selected_reagent = reagent_entry
 
+	var/obj/item/item_parent = parent
+	item_parent.update_icon()
+	loaded_reagent = null
+	reagent_select_action.owner.update_inv_r_hand()
+	reagent_select_action.owner.update_inv_l_hand()
+
 	update_selected_reagent(selected_reagent)
 
+	INVOKE_ASYNC(src, PROC_REF(activate_blade_async), item_parent, reagent_select_action.owner) //Load up on the chem we just picked
 
 /datum/component/harvester/proc/update_selected_reagent(datum/reagent/new_reagent)
 	selected_reagent = new_reagent

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -295,7 +295,7 @@
 			selected_reagent = reagent_entry
 
 	var/obj/item/item_parent = parent
-	item_parent.update_appearance()
+	item_parent.update_appearance(UPDATE_ICON)
 	loaded_reagent = null
 	var/parent_slot = reagent_select_action.owner.get_equipped_slot(parent)
 	if(parent_slot == SLOT_L_HAND)


### PR DESCRIPTION

## About The Pull Request
Selecting a new reagent in your harvester weapon will switch your old chem with the new chem.
## Why It's Good For The Game
Some QOL, allows you to be more adaptable with your chems, since you no longer need to smack a corpse in order to purge the old reagent.
## Changelog
:cl:
qol: Selecting a new vali chem will purge the old loaded reagent and load up the new chem
/:cl:
