### PR TITLE
removes "intentional" var from emotes, so involuntary emotes have a cooldown applied

### DIFF
--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -15,4 +15,4 @@
 
 /datum/keybinding/emote/down(client/user)
 	. = ..()
-	user.mob.emote(emote_key, intentional = TRUE)
+	user.mob.emote(emote_key)

--- a/code/game/objects/items/whistle.dm
+++ b/code/game/objects/items/whistle.dm
@@ -46,7 +46,7 @@
 	else
 		TIMER_COOLDOWN_START(user, COOLDOWN_WHISTLE_WARCRY, 1 MINUTES)
 		for(var/mob/living/carbon/human/human in get_hearers_in_view(warcryrange, user.loc))
-			human.emote("warcry", intentional = TRUE)
+			human.emote("warcry")
 			CHECK_TICK
 
 	TIMER_COOLDOWN_START(user, COOLDOWN_WHISTLE_BLOW, 3 SECONDS)

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -42,5 +42,5 @@
 	return
 
 
-/mob/camera/emote(act, m_type, message, intentional = FALSE)
+/mob/camera/emote(act, m_type, message)
 	return

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,5 +1,5 @@
-//The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type, message, intentional = FALSE)
+///The code execution of the emote datum is located at code/datums/emotes.dm
+/mob/proc/emote(act, m_type, message)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findtext(act, " ")
@@ -12,10 +12,10 @@
 	if(!E)
 		to_chat(src, span_notice("Unusable emote '[act]'. Say *help for a list."))
 		return
-	if(!E.check_cooldown(src, intentional))
+	if(!E.check_cooldown(src))
 		to_chat(src, span_notice("You used that emote too recently."))
 		return
-	E.run_emote(src, param, m_type, intentional)
+	E.run_emote(src, param, m_type)
 
 
 /datum/emote/help
@@ -32,7 +32,7 @@
 		if(e in keys)
 			continue
 		E = emote_list[e]
-		if(E.can_run_emote(user, status_check = FALSE, intentional = FALSE))
+		if(E.can_run_emote(user, status_check = FALSE))
 			keys += E.key
 
 	keys = sortList(keys)
@@ -57,7 +57,7 @@
 	emote_flags = NO_KEYBIND //This shouldn't have a keybind
 
 
-/datum/emote/custom/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/custom/run_emote(mob/user, params, type_override, prefix)
 	message = params
 	return ..()
 

--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -3,7 +3,7 @@
 	mob_type_blacklist_typecache = list()
 
 
-/datum/emote/brain/can_run_emote(mob/user, status_check = TRUE, intentional = FALSE)
+/datum/emote/brain/can_run_emote(mob/user, status_check = TRUE)
 	. = ..()
 	var/mob/living/brain/B = user
 	if(!istype(B) || (!(B.container && istype(B.container, /obj/item/mmi))))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -2,7 +2,7 @@
 	mob_type_allowed_typecache = /mob/living/carbon/human
 
 
-/datum/emote/living/carbon/human/run_emote(mob/living/carbon/human/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/run_emote(mob/living/carbon/human/user, params, type_override, prefix)
 	var/paygrade = user.get_paygrade()
 	if(paygrade)
 		prefix = "<b>[paygrade]</b> "
@@ -64,7 +64,7 @@
 	emote_type = EMOTE_AUDIBLE
 
 
-/datum/emote/living/carbon/human/collapse/run_emote(mob/living/carbon/human/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/collapse/run_emote(mob/living/carbon/human/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -111,7 +111,7 @@
 	message = "faints."
 
 
-/datum/emote/living/carbon/human/faint/run_emote(mob/living/carbon/human/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/faint/run_emote(mob/living/carbon/human/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -219,7 +219,7 @@
 	message = "puts their hands on their head and falls to the ground, they surrender!"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/human/surrender/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/human/surrender/run_emote(mob/user, params, type_overrideintentional)
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
@@ -383,7 +383,7 @@
 		return user.species.warcries[NEUTER]
 
 
-/datum/emote/living/carbon/human/warcry/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/warcry/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -462,7 +462,7 @@
 		return user.species.screams[NEUTER]
 
 
-/datum/emote/living/carbon/human/scream/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/scream/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -486,7 +486,7 @@
 		return 'sound/voice/human_female_medic.ogg'
 
 
-/datum/emote/living/carbon/human/medic/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/medic/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -509,7 +509,7 @@
 		return user.species.paincries[NEUTER]
 
 
-/datum/emote/living/carbon/human/pain/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/pain/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -533,7 +533,7 @@
 		return user.species.goredcries[NEUTER]
 
 
-/datum/emote/living/carbon/human/gored/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/gored/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return
@@ -558,7 +558,7 @@
 		return user.species.burstscreams[NEUTER]
 
 
-/datum/emote/living/carbon/human/burstscream/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/human/burstscream/run_emote(mob/user, params, type_override, prefix)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/emote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/emote.dm
@@ -127,7 +127,7 @@
 	sound = 'sound/effects/alien_tail_swipe3.ogg'
 
 
-/datum/emote/living/carbon/xenomorph/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/living/carbon/xenomorph/run_emote(mob/user, params, type_override, prefix)
 	if(istype(user, /mob/living/carbon/xenomorph/larva))
 		playsound(user.loc, "alien_roar_larva", 15)
 	else

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -116,5 +116,5 @@
 ///Check if this message is an emote
 /mob/proc/check_emote(message)
 	if(message[1] == "*")
-		emote(copytext(message, length(message[1]) + 1), intentional = TRUE)
+		emote(copytext(message, length(message[1]) + 1))
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
kills Intentional var on emotes, so now involuntary emotes have a cooldown and involuntarily emotes can't be run a gorillion times in a second. might have to adjust cooldowns for audible emotes for this to work better?
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/88008002/cc5d1be0-50ae-4bd2-b5a2-b57263d23a72)
## Why It's Good For The Game
Emote spam (from involuntary sources) can be funny/dramatic, but it is very loud or annoying in certain situations, like if you're being gibbed, running through fire or hit by a lot of projectiles, such as buckshot from a hefa grenade or shotgun. Not overloading a player's ears as they scream a fucktillion times seems reasonable.
## Changelog
:cl:
del: removed `intentional` on emotes, making involuntary emotes (such as those from combat) affected by the cooldown, as if they were used intentionally
/:cl:
