### PR TITLE
Reduces AMR slowdown

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -151,7 +151,7 @@
 //Define sniper laser multipliers
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
-#define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
+#define SNIPER_LASER_SLOWDOWN_STACKS 1.5 // Slowdown applied on hit vs the aimed target.
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20


### PR DESCRIPTION

## About The Pull Request
Reduces AMR slowdown on laze from 3 to 1.5.
## Why It's Good For The Game
Slowdown is one of the most oppressive debuffs a weapon can deal and the AMR is tied with the iff railgun for highest slowdown available. Dealing this consistently from offscreen is incredibly oppressive and most t1 and t2 xenos are doomed the instant the first AMR shot hits.

Reducing this to 1.5 still places AMR as the best sniper for dealing slowdown while still being outclassed by close range guns such as the sh15 and repeater for best source of slowdown available.

Will this kill AMR? Definitely not as no other gun can shoot through a wall of xenos to hit the crit one being pulled to safety.
## Changelog
:cl:
balance: Reduced AMR slowdown on laze from 3 to 1.5.
/:cl:
