### PR TITLE
Several small cosmetic changes to debugabus + pos

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -197,6 +197,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aoQ" = (
@@ -469,6 +472,10 @@
 /obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"aGZ" = (
+/obj/structure/sign/pods,
+/turf/closed/wall/mainship,
+/area/crew_quarters/toilet)
 "aHp" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
@@ -524,6 +531,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
@@ -875,7 +885,7 @@
 "bbw" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "bby" = (
 /obj/effect/ai_node,
 /obj/structure/prop/mainship/name_stencil/G,
@@ -885,6 +895,9 @@
 /area/mainship/squads/general)
 "bch" = (
 /obj/structure/bed/chair/comfy/black,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/silver/full,
 /area/mainship/living/briefing)
 "bck" = (
@@ -1403,6 +1416,12 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
+"bLP" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar/droppod)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -1429,6 +1448,9 @@
 "bNe" = (
 /obj/item/coin/iron,
 /obj/machinery/vending/cigarette,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "bNh" = (
@@ -1666,14 +1688,11 @@
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
 "bZE" = (
-/obj/structure/bed/fancy,
-/obj/effect/landmark/start/job/fieldcommander,
-/obj/item/bedsheet/captain,
-/obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
-/turf/open/floor/carpet/side{
+/obj/machinery/light/mainship{
 	dir = 1
 	},
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "caT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -1715,6 +1734,7 @@
 /obj/machinery/air_alarm{
 	dir = 4
 	},
+/obj/structure/largecrate/guns/russian,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cfw" = (
@@ -1749,6 +1769,9 @@
 "chO" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/light/mainship/small,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/shipboard/weapon_room)
 "cim" = (
@@ -1835,9 +1858,6 @@
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
 /obj/machinery/firealarm,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
 /obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/glass/beaker/cryomix{
 	name = "cryo beaker"
@@ -2182,6 +2202,15 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"cRE" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "cRJ" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/squadengineer,
@@ -2191,6 +2220,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"cRX" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "cSg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2753,9 +2792,6 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -3152,7 +3188,7 @@
 /area/crew_quarters/toilet)
 "dYs" = (
 /obj/effect/ai_node,
-/turf/open/floor/carpet/side,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "dYv" = (
 /turf/open/floor/mainship/red{
@@ -3161,6 +3197,9 @@
 /area/mainship/shipboard/firing_range)
 "dZY" = (
 /obj/structure/window/framed/mainship,
+/obj/machinery/door/poddoor/shutters/mainship/fc_office{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/mainship/living/numbertwobunks)
 "eaH" = (
@@ -3425,6 +3464,9 @@
 /area/mainship/living/numbertwobunks)
 "emm" = (
 /obj/effect/spawner/random/misc/plant,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/silver{
 	dir = 8
 	},
@@ -3532,6 +3574,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "eyX" = (
@@ -3602,6 +3647,9 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"eCk" = (
+/turf/open/floor/carpet/side,
+/area/mainship/living/numbertwobunks)
 "eCr" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -3797,6 +3845,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"eQb" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "eQg" = (
 /obj/effect/turf_decal/warning_stripes/medical,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -4277,6 +4331,9 @@
 "ftK" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/smartfridge/chemistry,
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "ftY" = (
@@ -4313,6 +4370,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/warning_stripes/thick/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "fvY" = (
@@ -4537,9 +4595,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "fGV" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4768,13 +4823,13 @@
 	},
 /area/mainship/medical/lower_medical)
 "fYa" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/shiptech,
 /obj/item/lightreplacer,
 /obj/item/lightreplacer,
 /obj/item/lightreplacer,
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "fYk" = (
@@ -5158,6 +5213,12 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"gpx" = (
+/obj/machinery/light/floor{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "gpB" = (
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
@@ -5192,9 +5253,6 @@
 /area/mainship/medical/lower_medical)
 "gqI" = (
 /obj/machinery/vending/uniform_supply,
-/obj/structure/closet/walllocker/hydrant/extinguisher{
-	dir = 8
-	},
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -5253,7 +5311,7 @@
 "gvN" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
-/turf/open/floor/plating/mainship,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/brig)
 "gwK" = (
 /obj/structure/bed/chair/comfy{
@@ -5315,10 +5373,12 @@
 	},
 /area/mainship/squads/general)
 "gES" = (
-/turf/open/floor/carpet/side{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
 	},
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "gFW" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship,
@@ -5679,6 +5739,9 @@
 /area/mainship/hallways/starboard_hallway)
 "heL" = (
 /obj/machinery/vending/MarineMed,
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 8
+	},
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -5858,7 +5921,7 @@
 /area/mainship/medical/lower_medical)
 "hpS" = (
 /turf/open/floor/carpet/side{
-	dir = 9
+	dir = 5
 	},
 /area/mainship/living/numbertwobunks)
 "hpW" = (
@@ -5957,6 +6020,7 @@
 /area/mainship/shipboard/weapon_room)
 "hzc" = (
 /obj/machinery/door/airlock/mainship/command/CPTstudy,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "hzD" = (
@@ -6018,6 +6082,11 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"hGq" = (
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
+/area/mainship/living/numbertwobunks)
 "hGE" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship,
@@ -6035,6 +6104,12 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
+"hHg" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "hId" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/preset,
@@ -6371,6 +6446,10 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
+"iaf" = (
+/obj/machinery/door_control/mainship/fc_shutters,
+/turf/closed/wall/mainship,
+/area/mainship/living/numbertwobunks)
 "iaH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
@@ -6739,6 +6818,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/generic/bathroom,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "iDm" = (
@@ -6859,6 +6939,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"iJy" = (
+/obj/structure/table/fancywoodentable,
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/mainship/living/numbertwobunks)
 "iKm" = (
 /obj/structure/prop/mainship/mapping_computer,
 /turf/open/floor/mainship/red{
@@ -6975,7 +7061,6 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
-/obj/structure/sign/science,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "iSK" = (
@@ -7293,12 +7378,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "joB" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/machinery/light/mainship/small,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "jqy" = (
@@ -7727,9 +7811,6 @@
 	},
 /area/mainship/command/self_destruct)
 "jXN" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
 "jXW" = (
@@ -7925,6 +8006,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
@@ -8300,7 +8384,7 @@
 "kHT" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "kIc" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -8379,7 +8463,8 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/mainship/droppod,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "kML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8551,6 +8636,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
+"kVD" = (
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/aft_hallway)
 "kWc" = (
 /obj/machinery/door/poddoor/railing{
@@ -9086,9 +9174,6 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
@@ -9166,6 +9251,9 @@
 /area/mainship/hallways/port_umbilical)
 "lEd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -9253,7 +9341,7 @@
 /area/mainship/living/commandbunks)
 "lHu" = (
 /turf/open/floor/carpet/side{
-	dir = 10
+	dir = 6
 	},
 /area/mainship/living/numbertwobunks)
 "lHG" = (
@@ -9309,14 +9397,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
 "lJt" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/spawner/random/misc/structure/showcase,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/living/chapel)
 "lJE" = (
@@ -10067,6 +10148,7 @@
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
+/obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "mFy" = (
@@ -10572,6 +10654,9 @@
 /obj/structure/bed/chair/nometal{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/mainship/white{
 	dir = 10
 	},
@@ -10584,6 +10669,9 @@
 	dir = 4
 	},
 /obj/structure/prop/mainship/halfbuilt_mech/legs,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nku" = (
@@ -10775,6 +10863,9 @@
 /area/mainship/squads/general)
 "nwX" = (
 /obj/machinery/computer/sleep_console,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "nxC" = (
@@ -10803,12 +10894,12 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "nyw" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/light/mainship{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/obj/structure/cable,
+/turf/open/floor/mainship/red/full,
+/area/mainship/living/briefing)
 "nyy" = (
 /obj/effect/soundplayer,
 /obj/structure/sign/science,
@@ -10972,7 +11063,7 @@
 "nIG" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "nJd" = (
 /obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /obj/machinery/door/firedoor/mainship,
@@ -11016,6 +11107,9 @@
 "nMG" = (
 /obj/machinery/vending/tool,
 /obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
 /turf/open/floor/mainship/green{
@@ -11149,6 +11243,9 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "nWT" = (
@@ -11234,19 +11331,22 @@
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
 "obQ" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
+/obj/machinery/light/floor{
+	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+/obj/machinery/light/floor{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "oca" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/medical2,
 /obj/structure/sign/nosmoking_2{
 	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
@@ -11623,6 +11723,10 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"oFH" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "oGN" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/landinglight/tadpole{
@@ -12110,17 +12214,7 @@
 	},
 /area/mainship/medical/chemistry)
 "pgp" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/alamo{
-	dir = 8;
-	pixel_x = 4
-	},
-/obj/structure/largecrate/guns,
+/obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pgq" = (
@@ -12175,10 +12269,26 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"pke" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "pko" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/shipboard/firing_range)
+"pks" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/brig)
 "pkN" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small{
@@ -12220,6 +12330,9 @@
 	},
 /obj/structure/sink{
 	dir = 8
+	},
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
 	},
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
@@ -12739,10 +12852,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "pQc" = (
-/turf/open/floor/carpet/side{
-	dir = 6
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
 	},
-/area/mainship/living/numbertwobunks)
+/obj/machinery/landinglight/alamo{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/machinery/light/floor{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pQn" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
@@ -13281,6 +13402,10 @@
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
 	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2;
+	id = "hangar_lockdown"
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "qAE" = (
@@ -13524,16 +13649,11 @@
 /area/mainship/medical/operating_room_one)
 "qMR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/alamo{
-	dir = 8;
-	pixel_x = 4
+/obj/machinery/light/floor{
+	dir = 4
 	},
-/obj/structure/largecrate/guns/russian,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qNE" = (
@@ -13583,8 +13703,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/brig)
 "qOJ" = (
-/obj/machinery/power/apc,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "qPc" = (
@@ -13612,7 +13732,9 @@
 	dir = 8;
 	pixel_x = 4
 	},
-/obj/structure/largecrate/guns/merc,
+/obj/machinery/light/floor{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qQk" = (
@@ -13950,7 +14072,7 @@
 "roN" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "roU" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/microwave{
@@ -14219,6 +14341,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /obj/item/clothing/head/warning_cone,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "rEM" = (
@@ -14450,8 +14575,11 @@
 /area/mainship/living/grunt_rnr)
 "rWD" = (
 /obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "rWK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -14813,14 +14941,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "swO" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "swY" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship/floor,
@@ -15131,6 +15255,9 @@
 /area/mainship/hallways/hangar)
 "sUb" = (
 /obj/vehicle/ridden/powerloader,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "sUR" = (
@@ -15249,15 +15376,12 @@
 "tbT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "tdm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "tdE" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
 /obj/machinery/vending/nanomed,
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -15409,7 +15533,8 @@
 /area/mainship/hallways/hangar)
 "tlT" = (
 /obj/machinery/door/poddoor/mainship/droppod,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "tnR" = (
 /obj/structure/bed/chair/office/dark,
@@ -15423,13 +15548,6 @@
 	dir = 1
 	},
 /area/mainship/engineering/ce_room)
-"ton" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "tpo" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/surgical_tray,
@@ -16031,9 +16149,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tWq" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16548,7 +16663,7 @@
 "uzy" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "uzA" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -16737,9 +16852,6 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "uMf" = (
@@ -16773,11 +16885,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "uNy" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/structure/bed/fancy,
+/obj/effect/landmark/start/job/fieldcommander,
+/obj/item/bedsheet/captain,
+/obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
+/turf/open/floor/carpet/side{
+	dir = 9
 	},
-/obj/structure/flora/pottedplant/twentytwo,
-/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "uOe" = (
 /obj/structure/closet/bodybag,
@@ -16993,6 +17107,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/living/bridgebunks)
 "van" = (
@@ -17332,7 +17447,7 @@
 /obj/machinery/power/apc,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "vyG" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -17657,7 +17772,7 @@
 "vYB" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17723,6 +17838,13 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"wff" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "wfv" = (
 /obj/machinery/power/apc,
 /obj/structure/cable,
@@ -17809,6 +17931,15 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
+"wkt" = (
+/obj/structure/table/woodentable,
+/obj/structure/mirror,
+/obj/item/camera,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "wkJ" = (
 /obj/machinery/iv_drip,
 /obj/machinery/holopad,
@@ -18646,6 +18777,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "xjs" = (
@@ -18676,7 +18808,7 @@
 "xjD" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "xjF" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -18910,6 +19042,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "xyO" = (
@@ -18947,6 +19082,12 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"xAG" = (
+/obj/machinery/light/floor{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "xAX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -19269,14 +19410,14 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "xSi" = (
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
 /obj/structure/toilet,
 /obj/effect/landmark/corpsespawner/marine/burst,
 /obj/effect/decal/cleanable/blood,
 /obj/item/organ/brain,
 /obj/item/weapon/gun/rifle/standard_autoshotgun,
+/obj/machinery/light/mainship/small{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
 "xSn" = (
@@ -19294,6 +19435,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/mainship,
 /area/mainship/living/numbertwobunks)
 "xSN" = (
@@ -19311,6 +19455,7 @@
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
+/obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "xTr" = (
@@ -19339,7 +19484,7 @@
 /area/mainship/living/commandbunks)
 "xUi" = (
 /obj/structure/cable,
-/turf/open/floor/plating/mainship,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/brig)
 "xVg" = (
 /obj/item/clothing/head/warning_cone,
@@ -19652,10 +19797,14 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "yiq" = (
-/obj/structure/cable,
-/obj/structure/sign/pods,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/aft_hallway)
 "yiF" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/mainship/research/containment/floor2{
@@ -19688,6 +19837,9 @@
 /obj/structure/sign/nosmoking_2{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/operating_room_two)
 "ykK" = (
@@ -19704,6 +19856,7 @@
 /obj/machinery/firealarm{
 	dir = 4
 	},
+/obj/structure/largecrate/guns,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "ylp" = (
@@ -46277,7 +46430,7 @@ xCj
 dUf
 yld
 cfp
-dpY
+pgp
 xIb
 eiU
 iyr
@@ -46597,7 +46750,7 @@ bpc
 jjO
 hvL
 whZ
-jcy
+wkt
 lvV
 whZ
 hUf
@@ -49128,7 +49281,7 @@ jUP
 lAT
 jLn
 lAT
-obQ
+eUN
 dLo
 fZP
 uVk
@@ -49595,10 +49748,10 @@ wPV
 tyN
 eTC
 dGR
-gGg
-vvE
-vvE
-vvE
+gES
+nyw
+nyw
+nyw
 lyl
 mVL
 mVL
@@ -49877,12 +50030,12 @@ pZX
 llR
 pnF
 pnF
-pnF
+pQc
 ubn
 pnF
 uQB
-pgp
-qMR
+gWI
+gWI
 qPD
 gWI
 sSN
@@ -50107,7 +50260,7 @@ hRh
 esN
 pkN
 tyN
-gGg
+bZE
 gGg
 gGg
 vvE
@@ -50429,7 +50582,7 @@ gbM
 gbM
 gbM
 gbM
-nyw
+ekk
 eel
 ekk
 ekx
@@ -50880,13 +51033,13 @@ wPV
 tyN
 bch
 esH
+wEI
 gGg
-gGg
-gGg
+obQ
 orm
 thg
 sEl
-gGg
+obQ
 wEI
 dpY
 dpY
@@ -50950,8 +51103,8 @@ sbN
 vMp
 vMp
 eye
-whb
-whb
+vMp
+vMp
 nWM
 fvD
 hWy
@@ -51162,13 +51315,13 @@ rSQ
 duy
 fwq
 fwq
-fwq
+qMR
 gRV
 dpY
 dpY
 dpY
 dpY
-dpY
+gpx
 dpY
 dpY
 dpY
@@ -51193,12 +51346,12 @@ vAn
 vAn
 wII
 vvV
-vAn
 bYG
 vAn
 vAn
-swO
-vmD
+wII
+swv
+jQT
 vmD
 vmD
 upQ
@@ -51211,7 +51364,7 @@ xYJ
 hxz
 fZX
 xYJ
-lcL
+hHg
 xYJ
 lcL
 sSz
@@ -51649,7 +51802,7 @@ hRh
 esN
 pkN
 tyN
-gGg
+bZE
 gGg
 gGg
 ghW
@@ -51720,12 +51873,12 @@ vmD
 ekx
 wOa
 hwp
-wOa
+pks
 wOa
 xUi
 wOa
 wOa
-wOa
+pks
 hwp
 wOa
 ekx
@@ -51970,7 +52123,7 @@ uVa
 iYf
 roD
 mzh
-dLx
+wff
 vmD
 upQ
 vmD
@@ -52227,7 +52380,7 @@ hhf
 svo
 xfu
 xvF
-dLx
+wff
 vmD
 upQ
 vmD
@@ -54252,7 +54405,7 @@ dpY
 dpY
 dpY
 dpY
-dpY
+xAG
 dpY
 dpY
 dpY
@@ -55020,7 +55173,7 @@ fmN
 lHG
 fku
 tyN
-vGQ
+swO
 rXB
 eFo
 eFo
@@ -55031,15 +55184,15 @@ pqQ
 xLu
 fAJ
 fAJ
+aGZ
 fAJ
-fAJ
+hWt
 yiq
-cTx
-xvv
+vAn
 xjD
-xvv
-xvv
-xvv
+vAn
+vAn
+vAn
 xJn
 uyy
 uyy
@@ -55291,12 +55444,12 @@ iku
 plO
 fAJ
 rWD
-cTx
-xvv
-kWM
-kWM
-kWM
-xvv
+yiq
+vAn
+kVD
+kVD
+kVD
+vAn
 uyy
 jaA
 hRK
@@ -55541,15 +55694,15 @@ eFo
 eFo
 eFo
 eFo
-pqQ
+pke
 xLu
 sAI
 sAI
 ebu
 dXO
-ton
-cTx
-xvv
+hWt
+yiq
+vAn
 kHT
 roN
 nIG
@@ -55805,12 +55958,12 @@ fAJ
 wqZ
 fAJ
 vyj
-cTx
-xvv
+yiq
+vAn
 bbw
 uzy
 tbT
-xvv
+vAn
 uyy
 uyy
 wql
@@ -56054,7 +56207,7 @@ eXp
 fsZ
 eXp
 fsZ
-eXp
+cRX
 vGQ
 xLu
 xSi
@@ -56066,11 +56219,11 @@ cTx
 xvv
 eKC
 kWM
-kWM
-xvv
+bLP
+eQb
 uyy
 uNy
-tzF
+hGq
 uyy
 hDg
 kTn
@@ -56326,12 +56479,12 @@ lIW
 pdj
 pdj
 uyy
-tzF
-tzF
+iJy
+eCk
 uyy
 uyy
 uyy
-uyy
+iaf
 xiV
 uyy
 uyy
@@ -56580,7 +56733,7 @@ gSN
 pfU
 bFG
 kpI
-tCO
+cRE
 giN
 uyy
 hpS
@@ -56840,7 +56993,7 @@ xGl
 xGl
 xGl
 uyy
-bZE
+tzF
 dYs
 qKf
 sQz
@@ -57097,12 +57250,12 @@ xGl
 xGl
 xGl
 uyy
-gES
-pQc
+tzF
+tzF
 aPJ
 rtj
 ivw
-tzF
+oFH
 uEU
 qVS
 uyy
@@ -58373,9 +58526,9 @@ rKn
 xGl
 xGl
 xGl
-pgq
+kKd
 oAz
-xGl
+pgq
 mSh
 xGl
 xGl

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -475,7 +475,7 @@
 "aGZ" = (
 /obj/structure/sign/pods,
 /turf/closed/wall/mainship,
-/area/crew_quarters/toilet)
+/area/mainship/hallways/hangar/droppod)
 "aHp" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
@@ -753,7 +753,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/holopad,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -1785,6 +1784,7 @@
 /area/mainship/living/starboard_garden)
 "ciZ" = (
 /obj/structure/prop/mainship/name_stencil,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -4665,7 +4665,6 @@
 	},
 /area/mainship/squads/general)
 "fKh" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/holosign_switch{
 	id = "or1sign";
@@ -4673,15 +4672,10 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
 	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/operating_room_one)
 "fKj" = (
@@ -5366,7 +5360,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "gCy" = (
-/obj/machinery/holopad,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 6
@@ -6830,6 +6823,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"iDz" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/stern_hallway)
 "iDE" = (
 /obj/machinery/cic_maptable/droppod_maptable,
 /turf/open/floor/mainship/mono,
@@ -8160,11 +8157,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/chapel)
 "kxm" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
 	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
@@ -8837,14 +8833,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "lhT" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/holosign_switch{
 	id = "or2sign"
 	},
+/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
 	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
@@ -9393,9 +9388,11 @@
 	},
 /area/mainship/living/numbertwobunks)
 "lIW" = (
-/obj/structure/sign/pods,
-/turf/closed/wall/mainship,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/holopad,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "lJt" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
@@ -12324,15 +12321,14 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "plO" = (
-/obj/structure/sign/restroom,
-/obj/structure/mirror{
-	dir = 8
-	},
 /obj/structure/sink{
 	dir = 8
 	},
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
+	},
+/obj/structure/mirror{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
@@ -13633,18 +13629,12 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/medical_science)
 "qMJ" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
 	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/operating_room_one)
 "qMR" = (
@@ -18048,8 +18038,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "wqZ" = (
-/obj/structure/sign/restroom,
 /obj/structure/cable,
+/obj/structure/sign/restroom,
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
 "wrb" = (
@@ -46756,7 +46746,7 @@ whZ
 hUf
 uBn
 nHq
-cWu
+iDz
 cWu
 cWu
 bMe
@@ -55184,7 +55174,7 @@ pqQ
 xLu
 fAJ
 fAJ
-aGZ
+fAJ
 fAJ
 hWt
 yiq
@@ -56474,8 +56464,8 @@ fAJ
 tlT
 kMo
 tlT
+aGZ
 pdj
-lIW
 pdj
 pdj
 uyy
@@ -56490,9 +56480,9 @@ uyy
 uyy
 htr
 cPg
-voa
+lOp
 eYx
-cPg
+rHh
 cPg
 cMq
 its
@@ -57523,14 +57513,14 @@ mvQ
 ciZ
 lkH
 lkH
-hdY
+ini
 bby
-lkH
+lIW
 fJI
 lkH
 gCy
 rUm
-lkH
+lIW
 lkH
 lkH
 hdY

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -884,7 +884,7 @@
 "bbw" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "bby" = (
 /obj/effect/ai_node,
 /obj/structure/prop/mainship/name_stencil/G,
@@ -8380,7 +8380,7 @@
 "kHT" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "kIc" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -8634,8 +8634,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "kVD" = (
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/aft_hallway)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "kWc" = (
 /obj/machinery/door/poddoor/railing{
 	id = "supply_elevator_railing"
@@ -11060,7 +11061,7 @@
 "nIG" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "nJd" = (
 /obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /obj/machinery/door/firedoor/mainship,
@@ -14062,7 +14063,7 @@
 "roN" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "roU" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/microwave{
@@ -14569,7 +14570,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "rWK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -15366,7 +15367,7 @@
 "tbT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "tdm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -16653,7 +16654,7 @@
 "uzy" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "uzA" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -17437,7 +17438,7 @@
 /obj/machinery/power/apc,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "vyG" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -17762,7 +17763,7 @@
 "vYB" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18798,7 +18799,7 @@
 "xjD" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar/droppod)
 "xjF" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -19786,15 +19787,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"yiq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "yiF" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/mainship/research/containment/floor2{
@@ -55176,13 +55168,13 @@ fAJ
 fAJ
 fAJ
 fAJ
-hWt
-yiq
-vAn
+kVD
+cTx
+xvv
 xjD
-vAn
-vAn
-vAn
+xvv
+xvv
+xvv
 xJn
 uyy
 uyy
@@ -55434,12 +55426,12 @@ iku
 plO
 fAJ
 rWD
-yiq
-vAn
-kVD
-kVD
-kVD
-vAn
+cTx
+xvv
+kWM
+kWM
+kWM
+xvv
 uyy
 jaA
 hRK
@@ -55690,9 +55682,9 @@ sAI
 sAI
 ebu
 dXO
-hWt
-yiq
-vAn
+kVD
+cTx
+xvv
 kHT
 roN
 nIG
@@ -55948,12 +55940,12 @@ fAJ
 wqZ
 fAJ
 vyj
-yiq
-vAn
+cTx
+xvv
 bbw
 uzy
 tbT
-vAn
+xvv
 uyy
 uyy
 wql

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -1770,9 +1770,7 @@
 /turf/open/floor/mainship,
 /area/mainship/medical/lower_medical)
 "aie" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
+/obj/machinery/bodyscanner,
 /turf/open/floor/mainship,
 /area/mainship/medical/lower_medical)
 "aif" = (
@@ -2265,6 +2263,16 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
+"ayb" = (
+/obj/structure/cable,
+/obj/machinery/landinglight/alamo{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/hallways/hangar)
 "azU" = (
 /turf/open/floor/mainship,
 /area/mainship/command/cic)
@@ -2725,6 +2733,14 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
+"oQd" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/hallways/hangar)
 "qko" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
@@ -2876,6 +2892,21 @@
 "sDt" = (
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
+/area/mainship/hallways/hangar)
+"sPD" = (
+/obj/machinery/landinglight/alamo{
+	dir = 8
+	},
+/obj/machinery/landinglight/cas{
+	dir = 4
+	},
+/obj/machinery/light/floor{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	dir = 4
+	},
+/turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "tae" = (
 /obj/machinery/camera/autoname/mainship{
@@ -4365,7 +4396,7 @@ rPl
 rPl
 dwY
 dwY
-acI
+oQd
 syF
 syF
 syF
@@ -4376,7 +4407,7 @@ syF
 syF
 syF
 syF
-syF
+ayb
 adG
 syF
 syF
@@ -5094,7 +5125,7 @@ ecg
 tWe
 ivw
 ivw
-ivw
+sPD
 ivw
 ivw
 adU
@@ -5104,7 +5135,7 @@ ivw
 ivw
 ivw
 ivw
-ivw
+sPD
 ivw
 ivw
 ahh

--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -474,6 +474,7 @@
 /area/shuttle/dropship/alamo)
 "di" = (
 /obj/machinery/telecomms/relay/preset/telecomms/onboard/nondense,
+/obj/machinery/holopad,
 /turf/open/shuttle/dropship/five,
 /area/shuttle/dropship/alamo)
 "dS" = (
@@ -655,6 +656,10 @@
 "VW" = (
 /turf/open/shuttle/dropship/thirtyfive,
 /area/shuttle/dropship/alamo)
+"Wz" = (
+/obj/machinery/holopad,
+/turf/open/shuttle/dropship/five,
+/area/shuttle/dropship/alamo)
 "Yd" = (
 /obj/machinery/vending/cola/alamo,
 /turf/open/shuttle/dropship/thirtynine,
@@ -793,7 +798,7 @@ jS
 li
 bd
 MG
-aK
+Wz
 jI
 aK
 bp

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -260,6 +260,11 @@
 	id = "cl_shutters"
 	req_access = list(ACCESS_NT_CORPORATE)
 
+/obj/machinery/door_control/mainship/fc_shutters
+	name = "Privacy Shutters"
+	id = "fc_shutters"
+	req_access = list(ACCESS_MARINE_BRIDGE)
+
 /obj/machinery/door_control/mainship/req
 	name = "RO Line Shutters"
 	id = "ROlobby"

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -240,9 +240,9 @@
 	name = "\improper Privacy Shutters"
 	id = "cl_shutters"
 
-/obj/machinery/door/poddoor/shutters/mainship/corporate
+/obj/machinery/door/poddoor/shutters/mainship/fc_office
 	name = "\improper Privacy Shutters"
-	id = "cl_shutters"
+	id = "fc_shutters"
 
 /obj/machinery/door/poddoor/shutters/mainship/cell
 	name = "\improper Containment Cell"


### PR DESCRIPTION
## About The Pull Request
I should have made a progressive list, but I really fixed things as I saw them while overflying things, so this is made at commit time. 

- Verified again that every door has their firelocks
- Verified that all light fixtures, cameras, fire alarms and so on aren't on glass
- Verified that wall mounted things aren't stuffed on glass.
- deleted a number of duplicate lights
- Moved things like lights from being placed under firelocks, which makes no sense
- Added FC privacy shutters
- Added floorlights to the debugabus & POS hangar
- Move the button for medical surgery shutters to not be under cameras
- Moved the leader pods not all being in the centerline of the pod bay
- Added lights to the bathroom and all SO rooms.
- Fixed lots of the new POS hangar not having camera cover


I ran out of steam to update this one, just look at the changelog

## Why It's Good For The Game

Fixes are good, and it makes the ship look a little broken.

## Changelog
:cl:
fix: POS - Fixed a number of areas without any lights
fix: POS - Verified again that every door has their firelocks
fix: POS - Verified that all light fixtures, cameras, fire alarms and so on aren't on glass
fix: POS - deleted a number of duplicate lights
fix: POS - Moved things like lights from being placed under firelocks, which makes no sense
fix: POS - Move the button for medical surgery shutters to not be under cameras
fix: POS - Removed duplicate surgery shutters and make them in the right direction
fix: ALAMO - Added more holopads to it
fix: Debugabus - Fixed the bodyscanner being in the wrong direction
qol: POS - Added FC privacy shutters
qol: POS - Moved the FC not to have their bed in the middle of the room
qol: POS - Added cameras coverage and better floor markings in the OB room and brig
qol: POS - Moved the ammo crates out of the path to the west of the hangar. Things like black market weapons or surplus weapons. 
qol: POS & Debugabus - Added floorlights to the hangar alongside extra default tubes
qol: POS - Moved the leader pods not all being in the centerline of the pod bay
/:cl:
