### PR TITLE
Add Toggle Fullscreen client verb

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -460,6 +460,15 @@
 	tgui_panel?.stop_music()
 
 
+/client/verb/toggle_fullscreen()
+	set name = "Toggle Fullscreen"
+	set category = "OOC"
+
+	var/datum/preferences/prefs = src.prefs
+	prefs.fullscreen_mode = !prefs.fullscreen_mode
+	set_fullscreen(prefs.fullscreen_mode)
+
+
 /client/verb/tracked_playtime()
 	set category = "OOC"
 	set name = "View Tracked Playtime"


### PR DESCRIPTION

## About The Pull Request

Adds client verb OOC->Toggle Fullscreen.
## Why It's Good For The Game

I find myself switching between fullscreen and windowed mode a lot, mostly for reconnecting to a game from menu. I find it frustrating to go to prefs every time to change window modes, so I decided to make a verb for it. I placed it in OOC tab to mirror tgstation's UI.
## Changelog
:cl:
add: Add Toggle Fullscreen client verb
/:cl:
