### PR TITLE
Light fix

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -83,8 +83,6 @@
 	switch(status)
 		if(LIGHT_OK)
 			. += "[base_icon_state]_[light_on]"
-		if(LIGHT_EMPTY)
-			. += "[base_icon_state]_empty"
 		if(LIGHT_BURNED)
 			. += "[base_icon_state]_burned"
 		if(LIGHT_BROKEN)


### PR DESCRIPTION

## About The Pull Request
Forgot to remove a line.
## Why It's Good For The Game
Red lights had an error overlay when empty.
## Changelog
:cl:
fix: fixed red lights showing as error when empty
/:cl:
