### PR TITLE
Makes Bull good again (buffs)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -564,7 +564,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 2.5 SECONDS)
+			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)
@@ -610,7 +610,7 @@
 
 		if(CHARGE_BULL_HEADBUTT)
 			var/fling_dir = charger.a_intent == INTENT_HARM ? charger.dir : REVERSE_DIR(charger.dir)
-			var/fling_dist = min(round(CHARGE_SPEED(charge_datum)) + 1, 3)
+			var/fling_dist = min(round(CHARGE_SPEED(charge_datum)) + 2, 3)
 			var/turf/destination = loc
 			var/turf/temp
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -565,6 +565,10 @@
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL_HEADBUTT)
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
+		if(CHARGE_BULL_GORE)
+			target.apply_status_effect(/datum/status_effect/shatter, CHARGE_SPEED(charge_datum) * 5 SECONDS)
+			M.adjust_stagger(CHARGE_SPEED(charge_datum) * 3 SECONDS)
+			M.adjust_slowdown(CHARGE_SPEED(charge_datum) * 3)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -96,7 +96,7 @@
 	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
 	if(agile_charge)
-		speed_down(8)
+		speed_down(6)
 		return
 	do_stop_momentum()
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -566,9 +566,9 @@
 		if(CHARGE_BULL_HEADBUTT)
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL_GORE)
-			target.apply_status_effect(/datum/status_effect/shatter, CHARGE_SPEED(charge_datum) * 5 SECONDS)
-			M.adjust_stagger(CHARGE_SPEED(charge_datum) * 3 SECONDS)
-			M.adjust_slowdown(CHARGE_SPEED(charge_datum) * 3)
+			apply_status_effect(/datum/status_effect/shatter, CHARGE_SPEED(charge_datum) * 5 SECONDS)
+			adjust_stagger(CHARGE_SPEED(charge_datum) * 3 SECONDS)
+			adjust_slowdown(CHARGE_SPEED(charge_datum) * 3)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
## About The Pull Request
Baby's first PR. Buffs Bull across the board. Kuro managed to approve the buff in between his Blackstone gooning sessions.

- Gore charge: Now inflicts 3 seconds of Staggerslow (50% less damage and reduced move speed) and 5 seconds of Shatter (armor decreased by a flat 20). Additional PSA: Gore charge does not inflict guaranteed organ damage and never did, its a myth. It only does 2 instant (normal) slashes.

- Headbutt charge: Stun reduced to 2 seconds from 2.5 seconds, and the target is now displaced 1 tile further.

- Plow charge: (Unchanged) Deals 15 damage and displaces the target in a random direction that isn't forward or backwards.

- Primo: Reduced the amount of speed lost from turning to 6, it was previously 8.

## Why It's Good For The Game
Current Bull is complete doodoo water, I don't think anyone will argue with that. It was so bad that the entire tgmc player base somehow Mandela effected themselves into believing that Gore charge does organ damage.

- Gore charge: Only doing 2 slashes of damage and nothing else felt too weak. The shatter allows gore charge to serve as an opener for other Xenos to deal increased damage. The Stagger is there because being able to PB for full damage right after a bull gores your groin off makes no sense, and should increase the survivability of the Bull on successful charges.

- Headbutt charge: Slightly less CBT stun and more braziling potential instead. More fun for both sides.

- Plow charge: Dealing 15 damage is too weak. However, there is currently a bug/feature that lets the bull multi-ram the same person up to three times due to the way mobs bounce off walls, and it's entirely dependent on rng. So technically good but not really because rng, will make a separate PR to address this.

- Primo: Reducing speed by 8 was far too much and rendered the primo as almost completely worthless. For reference, bull starts charging at 5 speed (5 tiles) and reaches max speed at 10. This meant that you'd have to be at max speed when turning to retain a grand total of 2 speed, and the primo does nothing otherwise. Reducing the speed loss to 6 makes the primo actually do something, without enabling the brainrotting back and forth charge spam of the olden days.

## Changelog
:cl:
balance: Gore charge now inflicts stagger and stun
balance: Headbutt charge stun reduced to 2 seconds, and displacement increased by 1 tile
balance: Primordial turning reduces speed by 6 instead of 8
/:cl:
