### PR TITLE
Reduces crash xeno starting pop by 1

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -12,7 +12,7 @@
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/fieldcommander = 1,
-		/datum/job/xenomorph = FREE_XENO_AT_START
+		/datum/job/xenomorph = 1
 	)
 	job_points_needed_by_job_type = list(
 		/datum/job/terragov/squad/smartgunner = 20,


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
3 xenos for 4 marines is uh, a bit too funny. Part of the reason over the months Crash winrates are so skewed.
## Changelog
:cl:
balance: Crash xeno starting pop is 1 instead of 2
/:cl:
