### PR TITLE
buffs autoinjector storage mod by adding 2 more slots

### DIFF
--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -340,8 +340,8 @@
 	))
 
 /datum/storage/internal/injector
-	max_storage_space = 10
-	storage_slots = 10
+	max_storage_space = 12
+	storage_slots = 12
 	max_w_class = WEIGHT_CLASS_TINY
 
 /datum/storage/internal/injector/New(atom/parent)


### PR DESCRIPTION
## About The Pull Request
title.
currently holds 10 slots; this makes it 12.
autoinjector storage mod is also kind of backwards compared to med storage mod where the medkit pouch holds more and the medical storage holds less.
an injector storage module holds 10, up to 12 autoinjectors; an injector storage pouch holds 7 autoinjectors.

## Why It's Good For The Game

autoinjector storage is woefully inferior to medical storage, and probably always will be because of reagent amounts per item stored. so this doesnt fix that and doesnt really claim to.
mostly it's a very difficult module to work around, though, which i think for the drawbacks of less reagents per stored item, it should be minimally more flexible for playstyles.
10 slots = 2 sets of BTTK + 2 injectors of your choice (think dylo and hypervene)
12 slots = 3 sets of BTTK, or 2 sets of BTTK + 4 injectors of your choice (dylo, hypervene, inap, combat)
basically, playing with this a bit, i think allowing people to take their two doses of BTTK plus four extras (dylo, hyper, inap, combat injector) is like, useful, man. allows a little more variance for someone and coexistence between "i have all the meds *I* need for myself" and "I have the key meds needed for *others*".

this module is still bad compared to med storage, but if you're the kind of person who carries two inap injectors or combat injectors for other people when they're downed, this maybe affords a couple extra slots for that. or two extra slots for your tricordrazine addiction, that's fine too.

## Changelog
:cl:
balance: autoinjector suit storage mod has 12 slots now, up from 10
/:cl: