### PR TITLE
adds soap to allowed items in medical rig belt

### DIFF
--- a/code/datums/storage/subtypes/belt.dm
+++ b/code/datums/storage/subtypes/belt.dm
@@ -89,6 +89,7 @@
 		/obj/item/defibrillator,
 		/obj/item/roller,
 		/obj/item/tool/research,
+		/obj/item/tool/soap,
 	))
 
 /datum/storage/belt/hypospraybelt


### PR DESCRIPTION
## About The Pull Request
title.

## Why It's Good For The Game
nice to have med stuff in one spot when doing groundside surgegryegreyryg; soap is also kind of mandatory, spaceacilin no longer cuts it.

## Changelog
:cl:
balance: medical rig belts now can hold soap
/:cl: