### PR TITLE
Makes sandevistans a round statistic to show at round end

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -479,6 +479,15 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.points_from_mining] requisitions points gained from mining."
 	if(GLOB.round_statistics.points_from_research)
 		parts += "[GLOB.round_statistics.points_from_research] requisitions points gained from research."
+
+	if(GLOB.round_statistics.sandevistan_uses)
+		var/sandevistan_text = "[GLOB.round_statistics.sandevistan_uses] number of times someone was boosted by a sandevistan"
+		if(GLOB.round_statistics.sandevistan_gibs)
+			sandevistan_text += ", of which [GLOB.round_statistics.sandevistan_gibs] resulted in a gib!"
+		else
+			sandevistan_text += ", and nobody was gibbed by it!"
+		parts += sandevistan_text
+
 	if(length(GLOB.round_statistics.req_items_produced))
 		parts += ""  // make it special from other stats above
 		parts += "Requisitions produced: "

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -99,3 +99,5 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/psy_lances = 0
 	var/psy_shields = 0
 	var/psy_shield_blasts = 0
+	var/sandevistan_uses = 0
+	var/sandevistan_gibs = 0

--- a/code/game/objects/items/implants/sandevistan.dm
+++ b/code/game/objects/items/implants/sandevistan.dm
@@ -84,6 +84,7 @@
 				implant_owner.adjustFireLoss(2)
 		if(5.1 SECONDS to INFINITY)//no infinite abuse
 			to_chat(implant_owner, span_userdanger("You feel a slight sense of shame as your brain and spine rip themselves apart from overexertion."))
+			GLOB.round_statistics.sandevistan_gibs++
 			implant_owner.gib()
 			return
 
@@ -111,6 +112,7 @@
 		implant_owner.adjust_mob_scatter(scatter_mod)
 		implant_owner.adjust_mob_accuracy(accuracy_mod)
 		START_PROCESSING(SSfastprocess, src)
+		GLOB.round_statistics.sandevistan_uses++
 	else
 		playsound(implant_owner, 'sound/effects/spinal_implant_off.ogg', 70)
 		implant_owner.next_move_modifier += action_modifier


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
Players would be glad to know how many times someone was gibbed by it.
## Changelog
:cl:
qol: Game will now tally up how many times people used Sandevistans (as well as how many died to it).
/:cl:
