### PR TITLE
Removes scope from laser MG

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -863,7 +863,6 @@
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/weapon/gun/flamer/mini_flamer,


### PR DESCRIPTION

## About The Pull Request
Removes the standard scope from laser MG, miniscope left untouched.
## Why It's Good For The Game
Same reasoning as #13587. Snipers should be the premier choice for long range suppression and leaving scopes on machineguns makes it very hard for xenos to meaningfully interact with marines when they are two screens away, and compared to snipers machineguns are impacted far less by smoke.
## Changelog
:cl:
balance: Laser Machinegun can no longer use rail scope.
/:cl:
