### PR TITLE
Evolution tower nerf

### DIFF
--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -12,7 +12,7 @@
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
 	///maturity boost amt to be added per tower per cycle
-	var/maturty_boost_amount = 0.8
+	var/maturty_boost_amount = 0.4
 
 /obj/structure/xeno/evotower/Initialize(mapload, _hivenumber)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Changes the maturity gain amount from 0.8 to 0.4 per tower
## Why It's Good For The Game
In #14912 I did a massive overbuff which this PR rectifies. If you want to get the same old 4 maturity towers, you will have to spend all of your tower points (600 after silo) on it. Xenos are way stronger than during the maturity era, especially with early primo and I miscalculated.
## Changelog
:cl:
balance: Evolution towers give 0.4 maturity per tick instead of 0.8
/:cl:
