### PR TITLE
Restores original order for defiler chems

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -87,10 +87,10 @@ GLOBAL_LIST_INIT(pheromone_images_list, list(
 
 //List of Defiler toxin types available for selection
 GLOBAL_LIST_INIT(defiler_toxin_type_list, list(
-		/datum/reagent/toxin/xeno_ozelomelyn,
+		/datum/reagent/toxin/xeno_neurotoxin,
 		/datum/reagent/toxin/xeno_hemodile,
 		/datum/reagent/toxin/xeno_transvitox,
-		/datum/reagent/toxin/xeno_neurotoxin,
+		/datum/reagent/toxin/xeno_ozelomelyn,
 		))
 
 //List of toxins improving defile's damage


### PR DESCRIPTION

## About The Pull Request
#10523 changed the order of defiler chems to Ozy-Hemo-Trans-Neuro, this changes it back to the original Neuro-Hemo-Trans-Ozy
## Why It's Good For The Game
The original cycle made the standard combo of neuro smoke into hemo/trans/ozy slashes much easier. Defilers will suffer no more!
## Changelog
:cl:
qol: Defiler chems once again cycle Neuro-Hemo-Trans-Ozy.
/:cl:
