### PR TITLE
Shifts tank/apc damage sprite thresholds

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -159,11 +159,11 @@
 	if(!damage_overlay)
 		return
 	switch(PERCENT(obj_integrity / max_integrity))
-		if(0 to 29)
+		if(0 to 20)
 			damage_overlay.icon_state = "damage_veryhigh"
-		if(29 to 59)
+		if(20 to 40)
 			damage_overlay.icon_state = "damage_high"
-		if(59 to 70)
+		if(40 to 70)
 			damage_overlay.icon_state = "damage_medium"
 		if(70 to 90)
 			damage_overlay.icon_state = "damage_small"


### PR DESCRIPTION

## About The Pull Request
Can you guess how much damage this APC has?
<img width="248" alt="58 1%" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/ae26a4e7-1188-48cb-8e48-57a5011c2f70">

If you guessed 58.1%, you'd be right! Thats a whopping 1,162 health left until this baby is destroyed!

The current thresholds are at 90%, 70%, 59%, and 29%. This means the high damage sprite above appears before the APC is even below half health. This PR changes these numbers to 90%, 70%, 40%, and 20%. This most notably extends the medium damage sprite to cover 30% of the durability instead of 11%. 
## Why It's Good For The Game
Both teams should be able to know how damaged the vehicles are instead of having to guess whether the high damage sprite means the vehicle is fucked and needs to leave asap or if it still has more than half durability.
## Changelog
:cl:
qol: Tank and APC sprites will now more accurately reflect their current integrity values.
/:cl:
