### PR TITLE
Fixes APC having insane ram damage

### DIFF
--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -16,6 +16,7 @@
 	obj_integrity = 2000
 	max_integrity = 2000
 	max_occupants = 20 //Clown car? Clown car.
+	ram_damage = 25
 	move_delay = 0.5 SECONDS
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,


### PR DESCRIPTION

## About The Pull Request

Forgot to set the ram damage so it was inheriting from the way slower tank

## Changelog
:cl:
balance: Fixes APC having insane ram damage (it now has 25% of previous value)
/:cl:
