### PR TITLE
Increases warrior wall hit damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -103,7 +103,7 @@
 // ***************************************
 // *********** Parent Ability
 // ***************************************
-#define WARRIOR_IMPACT_DAMAGE_MULTIPLIER 0.5
+#define WARRIOR_IMPACT_DAMAGE_MULTIPLIER 2
 #define WARRIOR_DISPLACE_KNOCKDOWN 0.4 SECONDS
 
 /datum/action/ability/activable/xeno/warrior/use_ability(atom/A)


### PR DESCRIPTION

## About The Pull Request
Increases the bonus damage on wall hits from 0.5x slash damage to 2x slash damage.
The warrior rework added bonus damage to warrior throwing people against walls. Currently, throwing someone against a wall deals 13.5 damage (before armor) instead of the usual 5. A full combo from a warrior including a wall hit and a grab punch currently deals 25 damage to a medium armor marine. This changes the full combo to 40 damage on a medium armor marine, and 56 for primo. 

For anyone fearing the return of the instafrac, fear not. The damage from the wall hits is already applied randomly so this wont result in anyone instantly getting their limbs torn off.
## Why It's Good For The Game
Warrior used to be a staple burst damage caste that could always provide value to the team even if marines arent blindly rushing into maze waiting to be flung. Right now the caste has very high risks for very little gain. This hopefully increases the baseline value of a warrior allowing it to do things other than just throw people at puppeteers.
## Changelog
:cl:
balance: Warriors now deal 2x slash damage on a wall hit instead of 0.5x.
/:cl:
