### PR TITLE
APC defensive fix

### DIFF
--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -14,6 +14,7 @@
 	pixel_x = -48
 	pixel_y = -40
 	max_integrity = 600
+	soft_armor = list(MELEE = 40, BULLET = 100 , LASER = 90, ENERGY = 60, BOMB = 60, BIO = 60, FIRE = 40, ACID = 40)
 	max_occupants = 20 //Clown car? Clown car.
 	move_delay = 0.5 SECONDS
 	easy_load_list = list(

--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -13,8 +13,7 @@
 	turret_icon = null
 	pixel_x = -48
 	pixel_y = -40
-	obj_integrity = 2000
-	max_integrity = 2000
+	max_integrity = 600
 	max_occupants = 20 //Clown car? Clown car.
 	move_delay = 0.5 SECONDS
 	easy_load_list = list(


### PR DESCRIPTION
## About The Pull Request
Set APC to intended integrity of 600.
Set APC soft armour to intended levels (40 for melee, acid and fire instead of 50)
## Why It's Good For The Game
Tank has 900 for reference, APC was set to 2000.
## Changelog
:cl:
balance: Significantly reduced unintented APC defensive stats
/:cl:
