### PR TITLE
Runner can once again slash during evasion

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -28,14 +28,6 @@
 	if(. == CONSCIOUS && layer != initial(layer))
 		layer = MOB_LAYER
 
-/mob/living/carbon/xenomorph/runner/UnarmedAttack(atom/A, has_proximity, modifiers)
-	/// Runner should not be able to slash while evading.
-	var/datum/action/ability/xeno_action/evasion/evasion_action = actions_by_path[/datum/action/ability/xeno_action/evasion]
-	if(evasion_action.evade_active)
-		balloon_alert(src, "Cannot slash while evading")
-		return
-	return ..()
-
 /mob/living/carbon/xenomorph/runner/med_hud_set_status()
 	. = ..()
 	hud_set_evasion()


### PR DESCRIPTION
## About The Pull Request
See title. Does not remove the option to cancel evasion early (just in case you need to take a sadar shot for the queen).
## Why It's Good For The Game
Runner used to be a very noob friendly caste because it had a baseline value of damage it could provide even against larger groups of marines. Marines could still deal with an evading runner by using fire, PBing it, claymores, staggering it before evasion, and using explosives. With directional attacks for all guns it is now easier than ever to land a 240 damage shotgun PB to send a runner back to the queue. 

This change will make the caste more forgiving for newer players and hopefully give the caste back some power.
## Changelog
:cl:
balance: Runner can once again slash during evasion.
/:cl:
