### PR TITLE
Vehicle entry QOL

### DIFF
--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -99,6 +99,16 @@
 	. = ..()
 	owner.interior.mob_leave(user)
 
+/turf/closed/interior/tank/door/MouseDrop_T(atom/movable/dropping, mob/M)
+	if(!ismob(dropping))
+		return ..()
+	owner.interior.mob_leave(dropping)
+
+/turf/closed/interior/tank/door/grab_interact(obj/item/grab/grab, mob/user, base_damage, is_sharp)
+	if(!ismob(grab.grabbed_thing))
+		return ..()
+	owner.interior.mob_leave(grab.grabbed_thing)
+
 ///returns where we want to spit out new enterers
 /turf/closed/interior/tank/door/proc/get_enter_location()
 	return get_step(src, EAST)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -269,7 +269,7 @@
 	if(isgrabitem(thing_to_load))
 		var/obj/item/grab/grab_item = thing_to_load
 		thing_to_load = grab_item.grabbed_thing
-	if(!is_type_in_typecache(thing_to_load.type, easy_load_list))
+	if(!isliving(thing_to_load) && !is_type_in_typecache(thing_to_load.type, easy_load_list))
 		return
 	if(!interior)
 		user.balloon_alert(user, "no interior")
@@ -281,8 +281,7 @@
 	if(!((user.loc in enter_locs) || (thing_to_load.loc in enter_locs)))
 		user.balloon_alert(user, "not at entrance")
 		return
-	if(iscarbon(thing_to_load))
-		//thing_to_load.Move(user.loc)
+	if(isliving(thing_to_load))
 		user.visible_message(span_notice("[user] starts to stuff [thing_to_load] into \the [src]!"))
 		mob_try_enter(thing_to_load, TRUE)
 		return

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -145,10 +145,10 @@
 		initialize_passenger_action_type(/datum/action/vehicle/sealed/armored/swap_seat)
 
 ///returns a list of possible locations that this vehicle may be entered from
-/obj/vehicle/sealed/armored/proc/enter_locations(mob/M)
+/obj/vehicle/sealed/armored/proc/enter_locations(atom/movable/entering_thing)
 	// from any adjacent position
-	if(Adjacent(M, src))
-		return list(get_turf(M))
+	if(Adjacent(entering_thing, src))
+		return list(get_turf(entering_thing))
 
 /obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag)
 	. = ..()
@@ -265,8 +265,11 @@
 	mob_exit(leaver, TRUE)
 
 /// call to try easy_loading an item into the tank. Checks for all being in the list , interior existing and the user bieng at the enter loc
-/obj/vehicle/sealed/armored/proc/try_easy_load(atom/movable/item, mob/living/user)
-	if(!is_type_in_typecache(item.type, easy_load_list))
+/obj/vehicle/sealed/armored/proc/try_easy_load(atom/movable/thing_to_load, mob/living/user)
+	if(isgrabitem(thing_to_load))
+		var/obj/item/grab/grab_item = thing_to_load
+		thing_to_load = grab_item.grabbed_thing
+	if(!is_type_in_typecache(thing_to_load.type, easy_load_list))
 		return
 	if(!interior)
 		user.balloon_alert(user, "no interior")
@@ -274,32 +277,38 @@
 	if(!interior.door)
 		user.balloon_alert(user, "no door")
 		return
-	if(!(user.loc in enter_locations(user)))
+	var/list/enter_locs = enter_locations(user)
+	if(!((user.loc in enter_locs) || (thing_to_load.loc in enter_locs)))
 		user.balloon_alert(user, "not at entrance")
 		return
-	user.temporarilyRemoveItemFromInventory(item)
-	item.forceMove(interior.door.get_enter_location())
+	if(iscarbon(thing_to_load))
+		//thing_to_load.Move(user.loc)
+		user.visible_message(span_notice("[user] starts to stuff [thing_to_load] into \the [src]!"))
+		mob_try_enter(thing_to_load, TRUE)
+		return
+	user.temporarilyRemoveItemFromInventory(thing_to_load)
+	thing_to_load.forceMove(interior.door.get_enter_location())
 	user.balloon_alert(user, "item thrown inside")
 
-/obj/vehicle/sealed/armored/mob_try_enter(mob/M)
-	if(isobserver(M))
-		interior?.mob_enter(M)
+/obj/vehicle/sealed/armored/mob_try_enter(mob/entering_mob, loc_override = FALSE)
+	if(isobserver(entering_mob))
+		interior?.mob_enter(entering_mob)
 		return FALSE
-	if(!ishuman(M))
+	if(!ishuman(entering_mob))
 		return FALSE
-	if(M.skills.getRating(SKILL_LARGE_VEHICLE) < required_entry_skill)
+	if(entering_mob.skills.getRating(SKILL_LARGE_VEHICLE) < required_entry_skill)
 		return FALSE
-	if(!(M.loc in enter_locations(M)))
-		balloon_alert(M, "not at entrance")
+	if(!loc_override && !(entering_mob.loc in enter_locations(entering_mob)))
+		balloon_alert(entering_mob, "not at entrance")
 		return FALSE
 	return ..()
 
-/obj/vehicle/sealed/armored/enter_checks(mob/M)
+/obj/vehicle/sealed/armored/enter_checks(mob/entering_mob, loc_override = FALSE)
 	. = ..()
 	if(!.)
 		return
-	if(LAZYLEN(M.buckled_mobs))
-		balloon_alert(M, "remove riders first")
+	if(LAZYLEN(entering_mob.buckled_mobs))
+		balloon_alert(entering_mob, "remove riders first")
 		return FALSE
 
 /obj/vehicle/sealed/armored/add_occupant(mob/M, control_flags)
@@ -338,8 +347,8 @@
 		UnregisterSignal(M, COMSIG_MOB_MOUSEDOWN)
 
 /obj/vehicle/sealed/armored/remove_occupant(mob/M)
-	M.hud_used.remove_ammo_hud(primary_weapon)
-	M.hud_used.remove_ammo_hud(secondary_weapon)
+	M?.hud_used?.remove_ammo_hud(primary_weapon)
+	M?.hud_used?.remove_ammo_hud(secondary_weapon)
 	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	UnregisterSignal(M, COMSIG_LIVING_DO_RESIST)
 	return ..()

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -24,14 +24,14 @@
 		/obj/item/ammo_magazine/tank,
 	)
 
-/obj/vehicle/sealed/armored/multitile/enter_locations(mob/M)
+/obj/vehicle/sealed/armored/multitile/enter_locations(atom/movable/entering_thing)
 	return list(get_step_away(get_step(src, REVERSE_DIR(dir)), src, 2))
 
 /obj/vehicle/sealed/armored/multitile/exit_location(mob/M)
 	return pick(enter_locations(M))
 
-/obj/vehicle/sealed/armored/multitile/enter_checks(mob/M)
+/obj/vehicle/sealed/armored/multitile/enter_checks(mob/entering_mob, loc_override = FALSE)
 	. = ..()
 	if(!.)
 		return
-	return (M.loc in enter_locations(M))
+	return (loc_override || (entering_mob.loc in enter_locations(entering_mob)))

--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -20,4 +20,5 @@
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,
 		/obj/structure/largecrate,
+		/mob/living/carbon,
 	)

--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -20,5 +20,4 @@
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,
 		/obj/structure/largecrate,
-		/mob/living/carbon,
 	)

--- a/code/modules/vehicles/armored/medium_tank.dm
+++ b/code/modules/vehicles/armored/medium_tank.dm
@@ -15,5 +15,5 @@
 	max_integrity = 1300
 	max_occupants = 3
 
-/obj/vehicle/sealed/armored/multitile/medium/enter_locations(mob/M)
+/obj/vehicle/sealed/armored/multitile/medium/enter_locations(atom/movable/entering_thing)
 	return list(get_step(src, REVERSE_DIR(dir)))

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
@@ -65,9 +65,9 @@
 	return ..()
 
 
-/obj/vehicle/sealed/mecha/combat/greyscale/mob_try_enter(mob/M)
-	if((mecha_flags & MECHA_SKILL_LOCKED) && M.skills.getRating(SKILL_LARGE_VEHICLE) < SKILL_LARGE_VEHICLE_VETERAN)
-		balloon_alert(M, "You don't know how to pilot this")
+/obj/vehicle/sealed/mecha/combat/greyscale/mob_try_enter(mob/entering_mob, loc_override = FALSE)
+	if((mecha_flags & MECHA_SKILL_LOCKED) && entering_mob.skills.getRating(SKILL_LARGE_VEHICLE) < SKILL_LARGE_VEHICLE_VETERAN)
+		balloon_alert(entering_mob, "You don't know how to pilot this")
 		return FALSE
 	return ..()
 

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -1,36 +1,36 @@
-/obj/vehicle/sealed/mecha/mob_try_enter(mob/M)
-	if(!ishuman(M)) // no silicons or drones in mechas.
+/obj/vehicle/sealed/mecha/mob_try_enter(mob/entering_mob, loc_override = FALSE)
+	if(!ishuman(entering_mob)) // no silicons or drones in mechas.
 		return
-	log_message("[M] tried to move into [src].", LOG_MECHA)
+	log_message("[entering_mob] tried to move into [src].", LOG_MECHA)
 	if(dna_lock)
-		var/mob/living/carbon/entering_carbon = M
+		var/mob/living/carbon/entering_carbon = entering_mob
 		if(md5(REF(entering_carbon)) != dna_lock)
-			to_chat(M, span_warning("Access denied. [name] is secured with a DNA lock."))
+			to_chat(entering_mob, span_warning("Access denied. [name] is secured with a DNA lock."))
 			log_message("Permission denied (DNA LOCK).", LOG_MECHA)
 			return
-	if(!operation_allowed(M))
-		to_chat(M, span_warning("Access denied. Insufficient operation keycodes."))
+	if(!operation_allowed(entering_mob))
+		to_chat(entering_mob, span_warning("Access denied. Insufficient operation keycodes."))
 		log_message("Permission denied (No keycode).", LOG_MECHA)
 		return
 	. = ..()
 	if(.)
-		moved_inside(M)
+		moved_inside(entering_mob)
 
-/obj/vehicle/sealed/mecha/enter_checks(mob/M)
+/obj/vehicle/sealed/mecha/enter_checks(mob/entering_mob, loc_override = FALSE)
 	if(obj_integrity <= 0)
-		to_chat(M, span_warning("You cannot get in the [src], it has been destroyed!"))
+		to_chat(entering_mob, span_warning("You cannot get in the [src], it has been destroyed!"))
 		return FALSE
-	if(M.buckled)
-		to_chat(M, span_warning("You can't enter the exosuit while buckled."))
+	if(entering_mob.buckled)
+		to_chat(entering_mob, span_warning("You can't enter the exosuit while buckled."))
 		log_message("Permission denied (Buckled).", LOG_MECHA)
 		return FALSE
-	if(LAZYLEN(M.buckled_mobs))
-		to_chat(M, span_warning("You can't enter the exosuit with other creatures attached to you!"))
+	if(LAZYLEN(entering_mob.buckled_mobs))
+		to_chat(entering_mob, span_warning("You can't enter the exosuit with other creatures attached to you!"))
 		log_message("Permission denied (Attached mobs).", LOG_MECHA)
 		return FALSE
-	var/obj/item/I = M.get_item_by_slot(SLOT_BACK)
+	var/obj/item/I = entering_mob.get_item_by_slot(SLOT_BACK)
 	if(I && istype(I, /obj/item/jetpack_marine))
-		to_chat(M, span_warning("Something on your back prevents you from entering the mech!"))
+		to_chat(entering_mob, span_warning("Something on your back prevents you from entering the mech!"))
 		return FALSE
 	return ..()
 

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -61,6 +61,7 @@
 /obj/vehicle/sealed/proc/enter_checks(mob/entering_mob, loc_override = FALSE)
 	return occupant_amount() < max_occupants
 
+///Enters the vehicle
 /obj/vehicle/sealed/proc/mob_enter(mob/M, silent = FALSE)
 	if(!istype(M))
 		return FALSE
@@ -70,9 +71,11 @@
 	add_occupant(M)
 	return TRUE
 
+///Exit checks for the mob before exiting the vehicle
 /obj/vehicle/sealed/proc/mob_try_exit(mob/M, mob/user, silent = FALSE, randomstep = FALSE)
 	mob_exit(M, silent, randomstep)
 
+///Exits the vehicle
 /obj/vehicle/sealed/proc/mob_exit(mob/M, silent = FALSE, randomstep = FALSE)
 	SIGNAL_HANDLER
 	if(!istype(M))

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -43,12 +43,12 @@
 	. = ..()
 	REMOVE_TRAIT(M, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
 
-
-/obj/vehicle/sealed/proc/mob_try_enter(mob/M)
-	if(!istype(M))
+///Entry checks for the mob before entering the vehicle
+/obj/vehicle/sealed/proc/mob_try_enter(mob/entering_mob, loc_override = FALSE)
+	if(!istype(entering_mob))
 		return FALSE
-	if(do_after(M, get_enter_delay(M), NONE, extra_checks = CALLBACK(src, PROC_REF(enter_checks), M)))
-		mob_enter(M)
+	if(do_after(entering_mob, get_enter_delay(entering_mob), user_display = BUSY_ICON_FRIENDLY, extra_checks = CALLBACK(src, PROC_REF(enter_checks), entering_mob, loc_override)))
+		mob_enter(entering_mob)
 		return TRUE
 	return FALSE
 
@@ -58,7 +58,7 @@
 	return enter_delay
 
 ///Extra checks to perform during the do_after to enter the vehicle
-/obj/vehicle/sealed/proc/enter_checks(mob/M)
+/obj/vehicle/sealed/proc/enter_checks(mob/entering_mob, loc_override = FALSE)
 	return occupant_amount() < max_occupants
 
 /obj/vehicle/sealed/proc/mob_enter(mob/M, silent = FALSE)


### PR DESCRIPTION

## About The Pull Request
You can now exit or enter OTHER mobs into multitile vehicles.
Drag a mob (or click while grabbed) to shove a mob in or out of a tank/apc.

It still does the normal checks so you can't exploit it to shove xenos in or something (however it will work if EITHER you or the entering mob are at the door). Mainly useful for moving bodies in and out, or managing ungabrains I guess.

This doesn't address body/cryobags, but that can be another pr.
## Why It's Good For The Game
QOL.
## Changelog
:cl:
qol: You can click drag or grab click mobs into, or out of multitile vehicles
/:cl:
