### PR TITLE
Increases nuke war silo scaling, higher excess xeno penalty.

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(silo)
 	//We scale the rate based on the current ratio of humans to xenos
 	var/current_human_to_xeno_ratio = active_humans / active_xenos
 	var/optimal_human_to_xeno_ratio = xeno_job.job_points_needed / LARVA_POINTS_REGULAR
-	current_larva_spawn_rate *= clamp(current_human_to_xeno_ratio / optimal_human_to_xeno_ratio , 0.7, 1)
+	current_larva_spawn_rate *= clamp(current_human_to_xeno_ratio / optimal_human_to_xeno_ratio , 0.5, 1)
 
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
 

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/nuclear_war
 	name = "Nuclear War"
 	config_tag = "Nuclear War"
-	silo_scaling = 1.5
+	silo_scaling = 2
 	round_type_flags = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD|MODE_FORCE_CUSTOMSQUAD_UI
 	xeno_abilities_flags = ABILITY_NUCLEARWAR
 	valid_job_types = list(


### PR DESCRIPTION

## About The Pull Request
Restores us to the 2x silo scaling of olde. Increases the maximum penalty xenos can have for outnumbering marines to 0.5 from 0.7.
## Why It's Good For The Game
20 groundside marines currently produces 1.05 larva points per minute, which makes dying as a xeno overly punishing. This would increase that to 1.4 larva points per minute, giving xenos more leeway with how bad they can be.

Marines like to shoot things, and giving them more chances to do so should make rounds smoother instead of 4 xenos dying early and nothing else happening in the round. This also makes dying more forgiving for new players as they'll have many more chances to try xeno without wasting one of the few precious larva slots.

The penalty xenos get from having excess xenos should help smooth this out on rounds where xenos are significantly ahead, making them rely more on drains for larva than the silo. (This 0.5x is only reached at around a 4:5 xeno to marine ratio).
## Changelog
:cl:
balance: Nuclear war silo scaling increased from 1.5x to 2x.
balance: Maximum xeno larva gen ratio penalty increased from 0.7 to 0.5.
/:cl:
