### PR TITLE
Mini Bull rework and buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -5,7 +5,7 @@
 /datum/action/ability/activable/xeno/bull_charge
 	name = "Plow Charge"
 	action_icon_state = "bull_charge"
-	desc = "The plow charge is similar to the crusher charge, as it deals damage and throws anyone hit out of your way. Hitting a host does not stop or slow you down."
+	desc = "When you hit a host, knock them out of your way while continuing your charge undeterred. The force of your charge also disarms them."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLCHARGE,
 	)
@@ -19,7 +19,7 @@
 /datum/action/ability/activable/xeno/bull_charge/headbutt
 	name = "Headbutt Charge"
 	action_icon_state = "bull_headbutt"
-	desc = "The headbutt charge, when it hits a host, stops your charge while knocking them down stunned for some time."
+	desc = "When you hit a host, stops your charge while headbutting them, flinging them in the air and stunning them for some time."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLHEADBUTT,
 	)
@@ -28,7 +28,7 @@
 /datum/action/ability/activable/xeno/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
-	desc = "The gore charge, when it hits a host, stops your charge while dealing a large amount of damage where you are targeting dependant on your charge speed."
+	desc = "When you hit a host, stops your charge while piercing them for a large amount of damage where you are targeting, in addition to injecting the Ozelomelyn toxin."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLGORE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -564,7 +564,9 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 2.5 SECONDS)
+			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
+		if(CHARGE_BULL)
+			Paralyze(CHARGE_SPEED(charge_datum) * 0.2 SECONDS)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)
@@ -610,7 +612,7 @@
 
 		if(CHARGE_BULL_HEADBUTT)
 			var/fling_dir = charger.a_intent == INTENT_HARM ? charger.dir : REVERSE_DIR(charger.dir)
-			var/fling_dist = min(round(CHARGE_SPEED(charge_datum)) + 1, 3)
+			var/fling_dist = min(round(CHARGE_SPEED(charge_datum)) + 2, 3)
 			var/turf/destination = loc
 			var/turf/temp
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -567,6 +567,10 @@
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL)
 			Paralyze(CHARGE_SPEED(charge_datum) * 0.2 SECONDS)
+		if(CHARGE_BULL_GORE)
+			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
+			reagents.add_reagent(/datum/reagent/toxin/xeno_ozelomelyn, 10)
+			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
## About The Pull Request

- Gore: The bull now has poison glands in the roots of its horns that produce Ozelymelon, and the horns double as stingers. i.e Gore charge now also injects 10u Oze (same as Shrike sting). And it also deals 1 second of stagger (-50% damage).

- Headbutt: Stun time 2.5 > 2 seconds. Displacement 2 > 3 tiles (at max speed).

- Plow: Deals 0.2 seconds of stun (disarms whoever is hit), and can't multi-ram anymore.

## Why It's Good For The Game

Bull is objectively the weakest T2 in the game right now, worse than even T1s in most situations. I think one of the bigger issues with it is the fact that its abilities are designed for killing, and yet are also terrible at securing kills. Like man, if a marine enters crit (or even just lays down), its abilities are rendered completely useless, and slashing is generally a bad idea due to its slow speed outside of charges. So, instead of just pure damage, I'm tweaking Bulls abilities to be a mix of damage and support.

- Gore: While the damage is good, gore felt just a little weaker than it should be. The Oze forces the hit marine to slow down and eat meds again, pretty self-explanatory. The 1 second of stagger is there just to weaken a PB right after a successful gore, because walking into a charge just so you can PB the Bull is pretty silly (you just got penetrated by at least 10 inches of horn). Should significantly increase Bulls survivability after good hits.

- Headbutt: Less stun is more fun. The increased displacement also makes it easier for other Xenos to follow up and wombo combo.

- Plow: In practice, Plow simply disarms the marine now. This turns Plow into an anti-aimmode charge meant for causing chaos in unga lines. Though, the bigger reason for the micro stun is to circumvent multi-ram (see low quality video). Multi ram happened because a marine could bounce off a nearby wall and end up right back in front of the Bull to get hit again. But the bouncing off walls was entirely dependent on rng, meaning Plow could deal 15, 30, or 45 damage depending on rng. Neither side likes rng, so away it goes.

https://github.com/tgstation/TerraGov-Marine-Corps/assets/128223413/c23eeaf4-28f4-4f3c-86a8-171b919fc016

I'd also like to make a PSA:
Currently, the Bull primo does not work in Valhalla due to wacky code. It only works if it's acquired normally through upgrade progress. The Bull primo is actually good when its working, so I'm not making any changes to it yet.

## Changelog

:cl:
balance: Gore charge injects 10u Ozelymelon and deals 1 second of stagger
balance: Plow charge deals 0.2 seconds of stun
balance: Headbutt charge max stun reduced to 2 seconds, and displacement increased by 1 tile
fix: Bull can no longer multi-ram
spellcheck: Updated Bull ability descriptions.
/:cl: