### PR TITLE
Storage closing fix

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -319,7 +319,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 				INVOKE_ASYNC(src, PROC_REF(do_refill), attacking_item, user)
 				return
 	if(!can_be_inserted(attacking_item, user))
-		open(user)
+		if(!opened) //this would close the open storage otherwise
+			open(user)
 		return FALSE
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), attacking_item, FALSE, user)
 	return COMPONENT_NO_AFTERATTACK


### PR DESCRIPTION

## About The Pull Request
Trying to store something (either directly or via quick equip) into an open storage that it can't fit in will no longer close said storage.
## Why It's Good For The Game
This was extremely annoying, where you'd quick equip store something, but because it always tries your open storage first, it would close it. So basically any time you stored your gun, your storage would close.
## Changelog
:cl:
fix: quick equip storing will no longer close your active storage
/:cl:
