### PR TITLE
Removes larva penalty

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -28,10 +28,6 @@ SUBSYSTEM_DEF(silo)
 	//We are processing wether we hijacked or not (hijacking gives a bonus)
 	current_larva_spawn_rate *= SSmonitor.gamestate == SHIPSIDE ? 3 : 1
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
-	//We scale the rate based on the current ratio of humans to xenos
-	var/current_human_to_xeno_ratio = active_humans / active_xenos
-	var/optimal_human_to_xeno_ratio = xeno_job.job_points_needed / LARVA_POINTS_REGULAR
-	current_larva_spawn_rate *= clamp(current_human_to_xeno_ratio / optimal_human_to_xeno_ratio , 0.7, 1)
 
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
 


### PR DESCRIPTION
## About The Pull Request
Removes the silo scaling penalty for having too many xenos.

This system currently gives a penalty to xenos larva gen if they exceed the 2:5 ratio. The system only accounts for living marines groundside, which can quickly screw over xenos in a variety of ways.

If 8 xenos are fighting 20 marines and 2 marines go shipside or die or go on the APC, xenos are already penalized with 91% silo efficiency. If xenos manage to get a small wipe of 4 marines, they go down to 81%.
## Why It's Good For The Game
This system screws over xenos too hard for playing well and makes it so more deaths = less larva, getting even fewer people back into the game.
## Changelog
:cl:
balance: Removed the silo scaling system for xenos getting too ahead.
/:cl:
