### PR TITLE
Gives APCs Periscopes

### DIFF
--- a/_maps/interiors/apc_medical.dmm
+++ b/_maps/interiors/apc_medical.dmm
@@ -108,6 +108,13 @@
 "Y" = (
 /turf/closed/interior/apc/one,
 /area/interior/apc)
+"Z" = (
+/obj/structure/bed/chair/loader_seat{
+	pixel_y = -5
+	},
+/obj/structure/periscope/apc,
+/turf/open/interior/apc/twentynine,
+/area/interior/apc)
 
 (1,1,1) = {"
 Y
@@ -148,7 +155,7 @@ l
 H
 t
 D
-O
+Z
 l
 "}
 (7,1,1) = {"

--- a/_maps/interiors/apc_transport.dmm
+++ b/_maps/interiors/apc_transport.dmm
@@ -24,6 +24,13 @@
 "l" = (
 /turf/closed/interior/apc/five,
 /area/interior/apc)
+"m" = (
+/obj/structure/periscope/apc,
+/obj/structure/bed/chair/loader_seat{
+	pixel_y = -5
+	},
+/turf/open/interior/apc/nine,
+/area/interior/apc)
 "n" = (
 /obj/structure/bed/chair/dropship/doublewide/left,
 /obj/structure/bed/chair/dropship/doublewide/right,
@@ -39,6 +46,13 @@
 /obj/structure/bed/chair/dropship/doublewide/left,
 /obj/structure/bed/chair/dropship/doublewide/right,
 /turf/open/interior/apc/nine,
+/area/interior/apc)
+"s" = (
+/obj/structure/periscope/apc,
+/obj/structure/bed/chair/loader_seat{
+	pixel_y = -5
+	},
+/turf/open/interior/apc/twentynine,
 /area/interior/apc)
 "u" = (
 /obj/structure/gun_breech/secondary,
@@ -130,9 +144,9 @@ x
 "}
 (6,1,1) = {"
 b
-r
+m
 T
-J
+s
 x
 "}
 (7,1,1) = {"

--- a/code/modules/vehicles/armored/interiors/periscope.dm
+++ b/code/modules/vehicles/armored/interiors/periscope.dm
@@ -32,3 +32,7 @@
 	REMOVE_TRAIT(source, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	source.client.view_size.reset_to_default()
 	source.update_sight()
+
+/obj/structure/periscope/apc
+	name = "apc periscope"
+


### PR DESCRIPTION
## About The Pull Request
Gives the APCs periscopes, specifically 2 for the transport module, and 1 for the medical module.
## Why It's Good For The Game
Currently, being a support passenger for the apc means staring at an unchanging boxed room. This let's passengers such as doctors or synths that are going to be staying in the apc a lot look at something actually interesting.
## Changelog
:cl:
add: Added periscopes to the interior of APCs
/:cl:
