### PR TITLE
Removes Valhalla Mech Pilot Radio

### DIFF
--- a/code/datums/jobs/job/fallen.dm
+++ b/code/datums/jobs/job/fallen.dm
@@ -71,7 +71,7 @@
 	skills_type = /datum/skills/mech_pilot
 	access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_MECH, ACCESS_CIVILIAN_PUBLIC)
 	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_MECH, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
-	outfit = /datum/outfit/job/command/mech_pilot
+	outfit = /datum/outfit/job/command/mech_pilot/fallen
 
 /datum/job/fallen/marine/fieldcommander
 	title = ROLE_FALLEN(FIELD_COMMANDER)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -513,6 +513,9 @@ You can serve your Division in a variety of roles, so choose carefully."})
 	shoes = /obj/item/clothing/shoes/marine/full
 	gloves = /obj/item/clothing/gloves/marine
 
+/datum/outfit/job/command/mech_pilot/fallen
+	ears = null
+
 #define ASSAULT_CREWMAN_POPLOCK 50
 //tank/arty driver+gunner
 /datum/job/terragov/command/assault_crewman


### PR DESCRIPTION

## About The Pull Request
Removes the radio that the mech pilot in valhalla spawns with
## Why It's Good For The Game
Fixes #15719
## Changelog
:cl:
fix: Removed the Valhalla mech pilot's radio
/:cl:
