### PR TITLE
Refactors a number of connected xeno handling using mobs instead of xeno_caste

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -585,13 +585,6 @@
 						L[T] = TRUE
 		return L
 
-///takes a path and only returns direct children
-/proc/directsubtypesof(path)
-	. = list()
-	for(var/datum/typepath AS in subtypesof(path))
-		if(initial(typepath.parent_type) == path)
-			. += typepath
-
 //Copies a list, and all lists inside it recusively
 //Does not copy any other reference type
 /proc/deepCopyList(list/L)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -585,6 +585,12 @@
 						L[T] = TRUE
 		return L
 
+///takes a path and only returns direct children
+/proc/directsubtypesof(path)
+	. = list()
+	for(var/datum/typepath AS in subtypesof(path))
+		if(initial(typepath.parent_type) == path)
+			. += typepath
 
 //Copies a list, and all lists inside it recusively
 //Does not copy any other reference type

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -49,11 +49,16 @@ GLOBAL_LIST_INIT_TYPED(xeno_caste_datums, /list/datum/xeno_caste, init_xeno_cast
 
 /proc/init_xeno_caste_list()
 	. = list()
-	for(var/X in subtypesof(/datum/xeno_caste))
-		var/datum/xeno_caste/C = new X
-		if(!(C.caste_type_path in .))
-			.[C.caste_type_path] = list()
-		.[C.caste_type_path][C.upgrade] = C
+	var/list/typelist = subtypesof(/datum/xeno_caste)
+	for(var/datum/xeno_caste/typepath AS in typelist)
+		if(initial(typepath.upgrade) == XENO_UPGRADE_BASETYPE)
+			.[typepath] = list()
+			.[typepath][XENO_UPGRADE_BASETYPE] = new typepath // TODO unit test this?
+			typelist -= typepath
+
+	for(var/typepath in typelist)
+		var/datum/xeno_caste/caste = new typepath
+		.[caste.get_base_caste_type()][caste.upgrade] = caste
 
 GLOBAL_LIST_INIT(all_xeno_types, list(
 	/mob/living/carbon/xenomorph/runner,
@@ -110,10 +115,10 @@ GLOBAL_LIST_INIT(all_xeno_types, list(
 	/mob/living/carbon/xenomorph/spiderling,
 	/mob/living/carbon/xenomorph/baneling,
 	))
-GLOBAL_LIST_INIT(xeno_types_tier_one, list(/mob/living/carbon/xenomorph/runner, /mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/sentinel, /mob/living/carbon/xenomorph/defender))
-GLOBAL_LIST_INIT(xeno_types_tier_two, list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/spitter, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/bull, /mob/living/carbon/xenomorph/wraith, /mob/living/carbon/xenomorph/puppeteer))
-GLOBAL_LIST_INIT(xeno_types_tier_three, list(/mob/living/carbon/xenomorph/gorger, /mob/living/carbon/xenomorph/widow, /mob/living/carbon/xenomorph/ravager, /mob/living/carbon/xenomorph/praetorian, /mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/defiler, /mob/living/carbon/xenomorph/crusher, /mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/behemoth, /mob/living/carbon/xenomorph/warlock))
-GLOBAL_LIST_INIT(xeno_types_tier_four, list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king))
+GLOBAL_LIST_INIT(xeno_types_tier_one, list(/datum/xeno_caste/runner, /datum/xeno_caste/drone, /datum/xeno_caste/sentinel, /datum/xeno_caste/defender))
+GLOBAL_LIST_INIT(xeno_types_tier_two, list(/datum/xeno_caste/hunter, /datum/xeno_caste/warrior, /datum/xeno_caste/spitter, /datum/xeno_caste/hivelord, /datum/xeno_caste/carrier, /datum/xeno_caste/bull, /datum/xeno_caste/wraith, /datum/xeno_caste/puppeteer))
+GLOBAL_LIST_INIT(xeno_types_tier_three, list(/datum/xeno_caste/gorger, /datum/xeno_caste/widow, /datum/xeno_caste/ravager, /datum/xeno_caste/praetorian, /datum/xeno_caste/boiler, /datum/xeno_caste/defiler, /datum/xeno_caste/crusher, /datum/xeno_caste/shrike, /datum/xeno_caste/behemoth, /datum/xeno_caste/warlock))
+GLOBAL_LIST_INIT(xeno_types_tier_four, list(/datum/xeno_caste/shrike, /datum/xeno_caste/queen, /datum/xeno_caste/king))
 
 GLOBAL_LIST_INIT_TYPED(hive_datums, /datum/hive_status, init_hive_datum_list()) // init by make_datum_references_lists()
 

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT_TYPED(xeno_caste_datums, /list/datum/xeno_caste, init_xeno_cast
 	for(var/datum/xeno_caste/typepath AS in typelist)
 		if(initial(typepath.upgrade) == XENO_UPGRADE_BASETYPE)
 			.[typepath] = list()
-			.[typepath][XENO_UPGRADE_BASETYPE] = new typepath // TODO unit test this?
+			.[typepath][XENO_UPGRADE_BASETYPE] = new typepath
 			typelist -= typepath
 
 	for(var/typepath in typelist)

--- a/code/datums/jobs/job/job_exp.dm
+++ b/code/datums/jobs/job/job_exp.dm
@@ -103,8 +103,8 @@ GLOBAL_PROTECT(exp_to_update)
 		else
 			return_text += "<LI>[dep] [get_exp_format(exp_data[dep])] </LI>"
 
-	for(var/mob_type AS in GLOB.xeno_caste_datums)
-		var/datum/xeno_caste/caste_type = GLOB.xeno_caste_datums[mob_type][XENO_UPGRADE_BASETYPE]
+	for(var/caste_typepath AS in GLOB.xeno_caste_datums)
+		var/datum/xeno_caste/caste_type = GLOB.xeno_caste_datums[caste_typepath][XENO_UPGRADE_BASETYPE]
 		return_text += "<LI>[caste_type.caste_name] [get_exp_format(play_records[caste_type.caste_name])] while alive.</LI>"
 
 	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_other_rights(src, R_ADMIN, FALSE))

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/baneling.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/baneling
-	caste_base_type = /mob/living/carbon/xenomorph/baneling
+	caste_base_type = /datum/xeno_caste/baneling
 	name = "Baneling"
 	desc = "An oozy, squishy alien that can roll in agile speeds, storing various dangerous chemicals in its sac..."
 	icon = 'icons/Xeno/castes/baneling.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/beetle/beetle.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/beetle
-	caste_base_type = /mob/living/carbon/xenomorph/beetle
+	caste_base_type = /datum/xeno_caste/beetle
 	name = "Beetle"
 	desc = "A bulky, six-legged alien with a horn. Its carapace seems quite durable."
 	icon = 'icons/Xeno/castes/beetle.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/behemoth
-	caste_base_type = /mob/living/carbon/xenomorph/behemoth
+	caste_base_type = /datum/xeno_caste/behemoth
 	name = "Behemoth"
 	desc = "A resilient and equally ferocious monster that commands the earth itself."
 	icon = 'icons/Xeno/castes/behemoth.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -25,7 +25,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/bull
+	deevolves_to = /datum/xeno_caste/bull
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_IS_STRONG|CASTE_STAGGER_RESISTANT

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/boiler
-	caste_base_type = /mob/living/carbon/xenomorph/boiler
+	caste_base_type = /datum/xeno_caste/boiler
 	name = "Boiler"
 	desc = "A huge, grotesque xenomorph covered in glowing, oozing acid slime."
 	icon = 'icons/Xeno/castes/boiler.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -28,7 +28,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/spitter
+	deevolves_to = /datum/xeno_caste/spitter
 
 	// *** Darksight *** ///
 	conscious_see_in_dark = 20

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/bull
-	caste_base_type = /mob/living/carbon/xenomorph/bull
+	caste_base_type = /datum/xeno_caste/bull
 	name = "Bull"
 	desc = "A bright red alien with a matching temper."
 	icon = 'icons/Xeno/castes/bull.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -25,9 +25,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = list(
-		/mob/living/carbon/xenomorph/runner,
-	)
+	deevolves_to = /datum/xeno_caste/runner
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/carrier
-	caste_base_type = /mob/living/carbon/xenomorph/carrier
+	caste_base_type = /datum/xeno_caste/carrier
 	name = "Carrier"
 	desc = "A strange-looking alien creature. It carries a number of scuttling jointed crablike creatures."
 	icon = 'icons/Xeno/castes/carrier.dmi' //They are now like, 2x2

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -27,7 +27,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/drone
+	deevolves_to = /datum/xeno_caste/drone
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -26,7 +26,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/bull
+	deevolves_to = /datum/xeno_caste/bull
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/crusher
-	caste_base_type = /mob/living/carbon/xenomorph/crusher
+	caste_base_type = /datum/xeno_caste/crusher
 	name = "Crusher"
 	desc = "A huge alien with an enormous armored head crest."
 	icon = 'icons/Xeno/castes/crusher.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/defender
-	caste_base_type = /mob/living/carbon/xenomorph/defender
+	caste_base_type = /datum/xeno_caste/defender
 	name = "Defender"
 	desc = "An alien with an armored head crest."
 	icon = 'icons/Xeno/castes/defender.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -26,7 +26,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/carrier
+	deevolves_to = /datum/xeno_caste/carrier
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/defiler
-	caste_base_type = /mob/living/carbon/xenomorph/defiler
+	caste_base_type = /datum/xeno_caste/defiler
 	name = "Defiler"
 	desc = "A large, powerfully muscled xeno replete with dripping spines and gas leaking dorsal vents."
 	icon = 'icons/Xeno/castes/defiler.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/drone
-	caste_base_type = /mob/living/carbon/xenomorph/drone
+	caste_base_type = /datum/xeno_caste/drone
 	name = "Drone"
 	desc = "An Alien Drone"
 	icon = 'icons/Xeno/castes/drone.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -29,7 +29,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = list(/mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/hivelord)
+	deevolves_to = /datum/xeno_caste/warrior
 
 	// *** Flags *** //
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/gorger.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/gorger
-	caste_base_type = /mob/living/carbon/xenomorph/gorger
+	caste_base_type = /datum/xeno_caste/gorger
 	name = "Gorger"
 	desc = "A large, powerfully muscled xeno with seemingly more vitality than others."
 	icon = 'icons/Xeno/castes/gorger.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -28,7 +28,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/drone
+	deevolves_to = /datum/xeno_caste/drone
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_IS_BUILDER

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/hivelord.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/hivelord
-	caste_base_type = /mob/living/carbon/xenomorph/hivelord
+	caste_base_type = /datum/xeno_caste/hivelord
 	name = "Hivelord"
 	desc = "A huge ass xeno covered in weeds! Oh shit!"
 	icon = 'icons/Xeno/castes/hivelord.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -1,7 +1,7 @@
 #define TIME_TO_TRANSFORM 1 SECONDS
 
 /mob/living/carbon/xenomorph/hivemind
-	caste_base_type = /mob/living/carbon/xenomorph/hivemind
+	caste_base_type =/datum/xeno_caste/hivemind
 	name = "Hivemind"
 	real_name = "Hivemind"
 	desc = "A glorious singular entity."

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -32,7 +32,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/runner
+	deevolves_to = /datum/xeno_caste/runner
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED
@@ -96,6 +96,7 @@
 	upgrade_name = ""
 	caste_desc = "A fast, powerful creature. It has some kind of machinery attached to its head."
 	caste_type_path = /mob/living/carbon/xenomorph/hunter/weapon_x
+	upgrade = XENO_UPGRADE_BASETYPE
 
 	// *** Melee Attacks *** //
 	melee_damage = 26

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/hunter
-	caste_base_type = /mob/living/carbon/xenomorph/hunter
+	caste_base_type = /datum/xeno_caste/hunter
 	name = "Hunter"
 	desc = "A beefy, fast alien with sharp claws."
 	icon = 'icons/Xeno/castes/hunter.dmi'
@@ -19,7 +19,7 @@
 	ADD_TRAIT(src, TRAIT_SILENT_FOOTSTEPS, XENO_TRAIT)
 
 /mob/living/carbon/xenomorph/hunter/weapon_x
-	caste_base_type = /mob/living/carbon/xenomorph/hunter/weapon_x
+	caste_base_type = /datum/xeno_caste/hunter/weapon_x
 
 /mob/living/carbon/xenomorph/hunter/weapon_x/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/king
-	caste_base_type = /mob/living/carbon/xenomorph/king
+	caste_base_type = /datum/xeno_caste/king
 	name = "King"
 	desc = "A primordial creature, evolved to smash the hardiest of defences and hunt the hardiest of prey."
 	icon = 'icons/Xeno/castes/king.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/larva
-	caste_base_type = /mob/living/carbon/xenomorph/larva
+	caste_base_type = /datum/xeno_caste/larva
 	speak_emote = list("hisses")
 	icon_state = "Bloody Larva"
 	bubble_icon = "alien"

--- a/code/modules/mob/living/carbon/xenomorph/castes/mantis/mantis.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/mantis/mantis.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/mantis
-	caste_base_type = /mob/living/carbon/xenomorph/mantis
+	caste_base_type = /datum/xeno_caste/mantis
 	name = "Mantis"
 	desc = "A red, violent alien with four legs and two deadly scythes. Its eyes hone sharply onto its prey..."
 	icon = 'icons/Xeno/castes/mantis.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/nymph/nymph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/nymph/nymph.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/nymph
-	caste_base_type = /mob/living/carbon/xenomorph/nymph
+	caste_base_type = /datum/xeno_caste/nymph
 	name = "Nymph"
 	desc = "An ant-looking creature."
 	icon = 'icons/Xeno/castes/nymph.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -24,7 +24,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/spitter
+	deevolves_to = /datum/xeno_caste/spitter
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/praetorian.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/praetorian
-	caste_base_type = /mob/living/carbon/xenomorph/praetorian
+	caste_base_type = /datum/xeno_caste/praetorian
 	name = "Praetorian"
 	desc = "A huge, looming beast of an alien."
 	icon = 'icons/Xeno/castes/praetorian.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/puppet
-	caste_base_type = /mob/living/carbon/xenomorph/puppet
+	caste_base_type = /datum/xeno_caste/puppet
 	name = "Puppet"
 	desc = "A reanimated body, crudely pieced together and held in place by an ominous energy tethered to some unknown force."
 	icon = 'icons/Xeno/castes/puppet.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -19,7 +19,7 @@
 	upgrade_threshold = TIER_TWO_THRESHOLD
 	evolution_threshold = 225
 
-	deevolves_to = list(/mob/living/carbon/xenomorph/defender)
+	deevolves_to = /datum/xeno_caste/defender
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_LEADER
 	caste_traits = null

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/puppeteer.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/puppeteer
-	caste_base_type = /mob/living/carbon/xenomorph/puppeteer
+	caste_base_type = /datum/xeno_caste/puppeteer
 	name = "Puppeteer"
 	desc = "A xenomorph of terrifying display, it has a tail adorned with needles that drips a strange chemical and elongated claws."
 	icon = 'icons/Xeno/castes/puppeteer.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -45,10 +45,10 @@
 			message = input,
 			color_override = "purple"
 		))
-		switch(Q.caste_base_type)
-			if(/mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/shrike)
+		switch(Q.caste_base_type) // TODO MAKE DYING SOUND A CASTE VAR????
+			if(/datum/xeno_caste/queen, /datum/xeno_caste/shrike)
 				SEND_SOUND(X, queen_sound)
-			if(/mob/living/carbon/xenomorph/king)
+			if(/datum/xeno_caste/king)
 				SEND_SOUND(X, king_sound)
 		//Display the ruler's hive message at the top of the game screen.
 		X.play_screen_text(queens_word, /atom/movable/screen/text/screen_text/queen_order)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/queen
-	caste_base_type = /mob/living/carbon/xenomorph/queen
+	caste_base_type = /datum/xeno_caste/queen
 	name = "Queen"
 	desc = "A huge, looming alien creature. The biggest and the baddest."
 	icon = 'icons/Xeno/castes/queen.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -28,7 +28,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/hunter
+	deevolves_to = /datum/xeno_caste/hunter
 
 	// *** Flags *** //
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/ravager
-	caste_base_type = /mob/living/carbon/xenomorph/ravager
+	caste_base_type = /datum/xeno_caste/ravager
 	name = "Ravager"
 	desc = "A huge, nasty red alien with enormous scythed claws."
 	icon = 'icons/Xeno/castes/ravager.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/runner
-	caste_base_type = /mob/living/carbon/xenomorph/runner
+	caste_base_type = /datum/xeno_caste/runner
 	name = "Runner"
 	desc = "A small red alien that looks like it could run fairly quickly..."
 	icon = 'icons/Xeno/castes/runner.dmi' //They are now like, 2x1 or something

--- a/code/modules/mob/living/carbon/xenomorph/castes/scorpion/scorpion.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/scorpion/scorpion.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/scorpion
-	caste_base_type = /mob/living/carbon/xenomorph/scorpion
+	caste_base_type = /datum/xeno_caste/scorpion
 	name = "Scorpion"
 	desc = "An eerie, four-legged alien with a hollow tail. A green, jelly-like texture characterizes its eyes and underbelly."
 	icon = 'icons/Xeno/castes/scorpion.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/sentinel.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/sentinel
-	caste_base_type = /mob/living/carbon/xenomorph/sentinel
+	caste_base_type = /datum/xeno_caste/sentinel
 	name = "Sentinel"
 	desc = "A slithery, spitting kind of alien."
 	icon = 'icons/Xeno/castes/sentinel.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -29,7 +29,7 @@
 	maximum_active_caste = 1
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/drone
+	deevolves_to = /datum/xeno_caste/drone
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_IS_STRONG|CASTE_IS_BUILDER|CASTE_INSTANT_EVOLUTION|CASTE_EVOLUTION_ALLOWED|CASTE_LEADER_TYPE

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/shrike
-	caste_base_type = /mob/living/carbon/xenomorph/shrike
+	caste_base_type = /datum/xeno_caste/shrike
 	name = "Shrike"
 	desc = "A large, lanky alien creature. It seems psychically unstable."
 	icon = 'icons/Xeno/castes/shrike.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -5,7 +5,7 @@
 #define SPIDERLING_NORMAL "spiderling_normal"
 
 /mob/living/carbon/xenomorph/spiderling
-	caste_base_type = /mob/living/carbon/xenomorph/spiderling
+	caste_base_type = /datum/xeno_caste/spiderling
 	name = "Spiderling"
 	desc = "A widow spawn, it chitters angrily without any sense of self-preservation, only to obey the widow's will."
 	icon = 'icons/Xeno/Effects.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -25,9 +25,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = list(
-		/mob/living/carbon/xenomorph/sentinel,
-	)
+	deevolves_to = /datum/xeno_caste/sentinel
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/spitter.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/spitter
-	caste_base_type = /mob/living/carbon/xenomorph/spitter
+	caste_base_type = /datum/xeno_caste/spitter
 	name = "Spitter"
 	desc = "A gross, oozing alien of some kind."
 	icon = 'icons/Xeno/castes/spitter.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -16,7 +16,7 @@
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	spit_types = list(/datum/ammo/energy/xeno/psy_blast)
 
-	deevolves_to = list(/mob/living/carbon/xenomorph/wraith, /mob/living/carbon/xenomorph/puppeteer)
+	deevolves_to = /datum/xeno_caste/wraith
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
 	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 10, BIO = 35, FIRE = 35, ACID = 35)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/warlock
-	caste_base_type = /mob/living/carbon/xenomorph/warlock
+	caste_base_type = /datum/xeno_caste/warlock
 	name = "Warlock"
 	desc = "A large, physically frail creature. It hovers in the air and seems to buzz with psychic power."
 	icon = 'icons/Xeno/castes/warlock.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -25,7 +25,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/defender
+	deevolves_to = /datum/xeno_caste/defender
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_IS_STRONG

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/warrior
-	caste_base_type = /mob/living/carbon/xenomorph/warrior
+	caste_base_type = /datum/xeno_caste/warrior
 	name = "Warrior"
 	desc = "A beefy, alien with an armored carapace."
 	icon = 'icons/Xeno/castes/warrior.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -25,7 +25,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 
-	deevolves_to = list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/puppeteer)
+	deevolves_to = /datum/xeno_caste/puppeteer
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/widow.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/widow
-	caste_base_type = /mob/living/carbon/xenomorph/widow
+	caste_base_type = /datum/xeno_caste/widow
 	name = "Widow"
 	desc = "A large arachnid xenomorph, with fangs ready to bear and crawling with many little spiderlings ready to grow."
 	icon = 'icons/Xeno/castes/widow.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -25,7 +25,7 @@
 	evolution_threshold = 225
 	upgrade_threshold = TIER_TWO_THRESHOLD
 
-	deevolves_to = /mob/living/carbon/xenomorph/runner
+	deevolves_to = /datum/xeno_caste/runner
 
 	// *** Flags *** //
 	caste_flags = CASTE_EVOLUTION_ALLOWED

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/wraith
-	caste_base_type = /mob/living/carbon/xenomorph/wraith
+	caste_base_type = /datum/xeno_caste/wraith
 	name = "Wraith"
 	desc = "A strange tendriled alien. The air around it warps and shimmers like a heat mirage."
 	icon = 'icons/Xeno/castes/wraith.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -36,7 +36,7 @@
 	for(var/evolves_into in xeno.get_evolution_options())
 		var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[evolves_into][XENO_UPGRADE_BASETYPE]
 		var/list/caste_data = list(
-			"type_path" = caste.caste_type_path,
+			"type_path" = caste.type,
 			"name" = caste.display_name,
 			"abilities" = list(),
 			"instant_evolve" = (caste.caste_flags & CASTE_INSTANT_EVOLUTION || (HAS_TRAIT(xeno, TRAIT_CASTE_SWAP) || HAS_TRAIT(xeno, TRAIT_REGRESSING))),
@@ -73,8 +73,13 @@
 	var/mob/living/carbon/xenomorph/xeno = usr
 	switch(action)
 		if("evolve")
-			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[text2path(params["path"])][XENO_UPGRADE_BASETYPE]
-			xeno.do_evolve(caste.caste_type_path, caste.display_name, (HAS_TRAIT(xeno, TRAIT_CASTE_SWAP) || HAS_TRAIT(xeno, TRAIT_REGRESSING))) // All the checks for can or can't are handled inside do_evolve
+			var/newpath = text2path(params["path"])
+			if(!newpath)
+				return
+			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[newpath][XENO_UPGRADE_BASETYPE]
+			if(!caste)
+				return
+			xeno.do_evolve(caste.type, (HAS_TRAIT(xeno, TRAIT_CASTE_SWAP) || HAS_TRAIT(xeno, TRAIT_REGRESSING))) // All the checks for can or can't are handled inside do_evolve
 			return TRUE
 
 /datum/evolution_panel/ui_close(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -33,7 +33,7 @@
 	ADD_TRAIT(src, TRAIT_REGRESSING, TRAIT_REGRESSING)
 	GLOB.evo_panel.ui_interact(src)
 
-///Creates a list of possible evolution options for a caste based on their tier.
+///Creates a list of possible /datum/xeno_caste options for a caste based on their tier.
 /mob/living/carbon/xenomorph/proc/get_evolution_options()
 	. = list()
 	if(HAS_TRAIT(src, TRAIT_CASTE_SWAP))
@@ -54,7 +54,7 @@
 				else
 					return
 			if(XENO_TIER_ONE)
-				return list(/mob/living/carbon/xenomorph/larva)
+				return list(/datum/xeno_caste/larva)
 			if(XENO_TIER_TWO)
 				return GLOB.xeno_types_tier_one
 			if(XENO_TIER_THREE)
@@ -64,51 +64,46 @@
 			if(!istype(xeno_caste, /datum/xeno_caste/hivemind))
 				return GLOB.xeno_types_tier_one
 		if(XENO_TIER_ONE)
-			return GLOB.xeno_types_tier_two + GLOB.xeno_types_tier_four + /mob/living/carbon/xenomorph/hivemind
+			return GLOB.xeno_types_tier_two + GLOB.xeno_types_tier_four + /datum/xeno_caste/hivemind
 		if(XENO_TIER_TWO)
-			return GLOB.xeno_types_tier_three + GLOB.xeno_types_tier_four + /mob/living/carbon/xenomorph/hivemind
+			return GLOB.xeno_types_tier_three + GLOB.xeno_types_tier_four + /datum/xeno_caste/hivemind
 		if(XENO_TIER_THREE)
-			return GLOB.xeno_types_tier_four + /mob/living/carbon/xenomorph/hivemind
+			return GLOB.xeno_types_tier_four + /datum/xeno_caste/hivemind
 		if(XENO_TIER_FOUR)
 			if(istype(xeno_caste, /datum/xeno_caste/shrike))
 				return list(/mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/king)
 
 
 ///Handles the evolution or devolution of the xenomorph
-/mob/living/carbon/xenomorph/proc/do_evolve(caste_type, forced_caste_name, regression = FALSE)
+/mob/living/carbon/xenomorph/proc/do_evolve(datum/xeno_caste/caste_type, regression = FALSE)
 	if(!generic_evolution_checks())
 		return
 
-	if(caste_type == /mob/living/carbon/xenomorph/hivemind && tgui_alert(src, "You are about to evolve into a hivemind, which places its core on the tile you're on when evolving. This core cannot be moved and you cannot regress. Are you sure you would like to place your core here?", "Evolving to hivemind", list("Yes", "No"), FALSE) != "Yes")
+	if(caste_type == /datum/xeno_caste/hivemind && tgui_alert(src, "You are about to evolve into a hivemind, which places its core on the tile you're on when evolving. This core cannot be moved and you cannot regress. Are you sure you would like to place your core here?", "Evolving to hivemind", list("Yes", "No"), FALSE) != "Yes")
 		return
 
-	var/new_mob_type
-	var/castepick
-	if(caste_type)
-		new_mob_type = caste_type
-		castepick = forced_caste_name
-	else
+	var/new_mob_type = initial(caste_type.caste_type_path)
+	if(!new_mob_type)
 		var/list/castes_to_pick = list()
 		for(var/type in get_evolution_options())
-			var/datum/xeno_caste/Z = GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE]
-			castes_to_pick += Z.caste_name
-		castepick = tgui_input_list(src, "We are growing into a beautiful alien! It is time to choose a caste.", null, castes_to_pick)
+			var/datum/xeno_caste/new_caste = GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE]
+			castes_to_pick += new_caste.caste_name
+		var/castepick = tgui_input_list(src, "We are growing into a beautiful alien! It is time to choose a caste.", null, castes_to_pick)
 		if(!castepick) //Changed my mind
 			return
 
 		for(var/type in get_evolution_options())
 			var/datum/xeno_caste/XC = GLOB.xeno_caste_datums[type][XENO_UPGRADE_BASETYPE]
 			if(castepick == XC.caste_name)
-				new_mob_type = type
+				new_mob_type = XC.caste_type_path
 				break
 
 	if(!new_mob_type)
 		CRASH("[src] tried to evolve but failed to find a new_mob_type")
 
-	if(!caste_evolution_checks(new_mob_type, castepick, regression))
+	if(!caste_evolution_checks(caste_type, regression))
 		return
 
-	to_chat(src, span_xenonotice("It looks like the hive can support our evolution to <span style='font-weight: bold'>[castepick]!</span>"))
 	visible_message(span_xenonotice("\The [src] begins to twist and contort."), \
 	span_xenonotice("We begin to twist and contort."))
 	do_jitter_animation(1000)
@@ -117,8 +112,8 @@
 		balloon_alert(src, span_warning("We must hold still while evolving."))
 		return
 
-	if(!generic_evolution_checks() || !caste_evolution_checks(new_mob_type, castepick, regression))
-		return
+	if(!generic_evolution_checks() || !caste_evolution_checks(caste_type, regression))
+		return // TODO these should be on extra_checks in the todo
 
 	if(HAS_TRAIT(src, TRAIT_CASTE_SWAP))
 		GLOB.key_to_time_of_caste_swap[key] = world.time
@@ -267,16 +262,16 @@
 	return TRUE
 
 ///Check if the xeno can currently evolve into a specific caste
-/mob/living/carbon/xenomorph/proc/caste_evolution_checks(new_mob_type, castepick, regression = FALSE)
-	if(!regression && !(new_mob_type in get_evolution_options()))
+/mob/living/carbon/xenomorph/proc/caste_evolution_checks(new_caste_type, regression = FALSE)
+	if(!regression && !(new_caste_type in get_evolution_options()))
 		balloon_alert(src, "We can't evolve to that caste from our current one")
 		return FALSE
 
 	var/no_room_tier_two = length(hive.xenos_by_tier[XENO_TIER_TWO]) >= hive.tier2_xeno_limit
 	var/no_room_tier_three = length(hive.xenos_by_tier[XENO_TIER_THREE]) >= hive.tier3_xeno_limit
-	var/datum/xeno_caste/new_caste_type = GLOB.xeno_caste_datums[new_mob_type][XENO_UPGRADE_BASETYPE]
+	var/datum/xeno_caste/new_caste = GLOB.xeno_caste_datums[new_caste_type][XENO_UPGRADE_BASETYPE] // tivi todo make so evo takes the strict caste datums
 	// Initial can access uninitialized vars, which is why it's used here.
-	var/new_caste_flags = new_caste_type.caste_flags
+	var/new_caste_flags = new_caste.caste_flags
 	if(CHECK_BITFIELD(new_caste_flags, CASTE_LEADER_TYPE))
 		if(is_banned_from(ckey, ROLE_XENO_QUEEN))
 			balloon_alert(src, "You are jobbanned from xenomorph leader roles")
@@ -286,65 +281,46 @@
 			to_chat(src, span_warning("[get_exp_format(xenojob.required_playtime_remaining(client))] as [xenojob.get_exp_req_type()] required to play queen like roles."))
 			return FALSE
 
-	var/min_xenos = new_caste_type.evolve_min_xenos
+	var/min_xenos = new_caste.evolve_min_xenos
 	if(min_xenos && (hive.total_xenos_for_evolving() < min_xenos))
-		balloon_alert(src, "[min_xenos] xenos needed to become a [initial(new_caste_type.display_name)]")
+		balloon_alert(src, "[min_xenos] xenos needed to become a [initial(new_caste.display_name)]")
 		return FALSE
 	if(CHECK_BITFIELD(new_caste_flags, CASTE_CANNOT_EVOLVE_IN_CAPTIVITY) && isxenoresearcharea(get_area(src)))
 		to_chat(src, "Something in this place is isolating us from Queen Mother's psychic presence. We should leave before it's too late!")
 		return FALSE
 	// Check if there is a death timer for this caste
-	if(new_caste_type.death_evolution_delay)
-		var/death_timer = hive.caste_death_timers[new_caste_type.caste_type_path]
+	if(new_caste.death_evolution_delay)
+		var/death_timer = hive.caste_death_timers[new_caste]
 		if(death_timer)
-			to_chat(src, span_warning("The hivemind is still recovering from the last [initial(new_caste_type.display_name)]'s death. We must wait [DisplayTimeText(timeleft(death_timer))] before we can evolve."))
+			to_chat(src, span_warning("The hivemind is still recovering from the last [initial(new_caste.display_name)]'s death. We must wait [DisplayTimeText(timeleft(death_timer))] before we can evolve."))
 			return FALSE
-	var/maximum_active_caste = new_caste_type.maximum_active_caste
-	if(maximum_active_caste != INFINITY && maximum_active_caste <= length(hive.xenos_by_typepath[new_mob_type]))
-		to_chat(src, span_warning("There is already a [initial(new_caste_type.display_name)] in the hive. We must wait for it to die."))
+	var/maximum_active_caste = new_caste.maximum_active_caste
+	if(maximum_active_caste != INFINITY && maximum_active_caste <= length(hive.xenos_by_typepath[new_caste_type]))
+		to_chat(src, span_warning("There is already a [initial(new_caste.display_name)] in the hive. We must wait for it to die."))
 		return FALSE
 	var/turf/T = get_turf(src)
 	if(CHECK_BITFIELD(new_caste_flags, CASTE_REQUIRES_FREE_TILE) && T.check_alien_construction(src))
 		balloon_alert(src, "We need a empty tile to evolve")
 		return FALSE
 
-	if(istype(new_mob_type, /mob/living/carbon/xenomorph/queen))
-		switch(hivenumber) // because it causes issues otherwise
-			if(XENO_HIVE_CORRUPTED)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/Corrupted
-			if(XENO_HIVE_ALPHA)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/Alpha
-			if(XENO_HIVE_BETA)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/Beta
-			if(XENO_HIVE_ZETA)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/Zeta
-			if(XENO_HIVE_ADMEME)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/admeme
-			if(XENO_HIVE_FALLEN)
-				new_mob_type = /mob/living/carbon/xenomorph/queen/Corrupted/fallen
-
 	if(!regression)
-		if(new_caste_type.tier == XENO_TIER_TWO && no_room_tier_two)
+		if(new_caste.tier == XENO_TIER_TWO && no_room_tier_two)
 			balloon_alert(src, "The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die")
 			return FALSE
-		if(new_caste_type.tier == XENO_TIER_THREE && no_room_tier_three)
+		if(new_caste.tier == XENO_TIER_THREE && no_room_tier_three)
 			balloon_alert(src, "The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die")
 			return FALSE
-		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
+		var/potential_queens = length(hive.xenos_by_typepath[/datum/xeno_caste/larva]) + length(hive.xenos_by_typepath[/datum/xeno_caste/drone])
 		if(SSticker.mode?.round_type_flags & MODE_XENO_RULER && !hive.living_xeno_ruler && potential_queens == 1)
-			if(isxenolarva(src) && new_mob_type != /mob/living/carbon/xenomorph/drone)
+			if(isxenolarva(src) && new_caste_type != /datum/xeno_caste/drone)
 				to_chat(src, span_xenonotice("The hive currently has no sister able to become a ruler! The survival of the hive requires from us to be a Drone!"))
 				return FALSE
-			else if(isxenodrone(src) && new_mob_type != /mob/living/carbon/xenomorph/shrike)
+			else if(isxenodrone(src) && new_caste_type != /datum/xeno_caste/shrike)
 				to_chat(src, span_xenonotice("The hive currently has no sister able to become a ruler! The survival of the hive requires from us to be a Shrike!"))
 				return FALSE
 		if(!CHECK_BITFIELD(new_caste_flags, CASTE_INSTANT_EVOLUTION) && xeno_caste.evolution_threshold && evolution_stored < xeno_caste.evolution_threshold)
 			to_chat(src, span_warning("We must wait before evolving. Currently at: [evolution_stored] / [xeno_caste.evolution_threshold]."))
 			return FALSE
-
-	if(isnull(new_mob_type))
-		CRASH("[src] tried to evolve but their castepick was null")
-
 	return TRUE
 
 ///Handles special conditions that influence a caste's evolution point gain, such as larva gaining a bonus if on weed.

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -43,8 +43,9 @@
 	. = ..()
 	LAZYINITLIST(candidates)
 
-	for(var/caste_type in directsubtypesof(/datum/xeno_caste))
-		xenos_by_typepath[caste_type] = list()
+	for(var/datum/xeno_caste/caste_type AS in subtypesof(/datum/xeno_caste))
+		if(caste_type.upgrade == XENO_UPGRADE_BASETYPE)
+			xenos_by_typepath[caste_type] = list()
 
 	for(var/tier in GLOB.xenotiers)
 		xenos_by_tier[tier] = list()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -402,11 +402,11 @@
 		LAZYADD(xenos_by_zlevel["[X.z]"], X)
 	RegisterSignal(X, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(xeno_z_changed))
 
-	if(!xenos_by_typepath[X.caste_base_type])
+	if(!xenos_by_typepath[X.xeno_caste.get_base_caste_type()])
 		stack_trace("trying to add an invalid typepath into hivestatus list [X.caste_base_type]")
 		return FALSE
 
-	xenos_by_typepath[X.caste_base_type] += X
+	xenos_by_typepath[X.xeno_caste.get_base_caste_type()] += X
 	update_tier_limits() //Update our tier limits.
 
 	return TRUE
@@ -511,11 +511,11 @@
 		stack_trace("trying to remove a xeno from hivestatus upgrade list, nothing was removed!?")
 		return FALSE
 
-	if(!xenos_by_typepath[X.caste_base_type])
+	if(!xenos_by_typepath[X.xeno_caste.get_base_caste_type()])
 		stack_trace("trying to remove an invalid typepath from hivestatus list")
 		return FALSE
 
-	if(!xenos_by_typepath[X.caste_base_type].Remove(X))
+	if(!xenos_by_typepath[X.xeno_caste.get_base_caste_type()].Remove(X))
 		stack_trace("failed to remove a xeno from hive status typepath list, nothing was removed!?")
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -246,6 +246,13 @@
 	for(var/trait in caste_traits)
 		REMOVE_TRAIT(xenomorph, trait, XENO_TRAIT)
 
+///returns the type level below /datum/xeno_caste to get what the base caste is (e.g base rav not primo or strain rav)
+/datum/xeno_caste/proc/get_base_caste_type()
+	var/datum/xeno_caste/current_type = type
+	while(initial(current_type.upgrade) != XENO_UPGRADE_BASETYPE)
+		current_type = initial(current_type.parent_type)
+	return current_type
+
 /mob/living/carbon/xenomorph
 	name = "Drone"
 	desc = "What the hell is THAT?"
@@ -291,6 +298,7 @@
 	var/atom/movable/vis_obj/xeno_wounds/wound_overlay
 	var/atom/movable/vis_obj/xeno_wounds/fire_overlay/fire_overlay
 	var/datum/xeno_caste/xeno_caste
+	/// /datum/xeno_caste that we will be on init
 	var/caste_base_type
 	var/language = "Xenomorph"
 	///Plasma currently stored

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -246,7 +246,7 @@
 	for(var/trait in caste_traits)
 		REMOVE_TRAIT(xenomorph, trait, XENO_TRAIT)
 
-///returns the type level below /datum/xeno_caste to get what the base caste is (e.g base rav not primo or strain rav)
+///returns the basetype caste to get what the base caste is (e.g base rav not primo or strain rav)
 /datum/xeno_caste/proc/get_base_caste_type()
 	var/datum/xeno_caste/current_type = type
 	while(initial(current_type.upgrade) != XENO_UPGRADE_BASETYPE)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -252,7 +252,7 @@
 /mob/living/carbon/xenomorph/proc/update_evolving()
 	if(evolution_stored >= xeno_caste.evolution_threshold || !(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		return
-	if(!hive.check_ruler() && caste_base_type != /mob/living/carbon/xenomorph/larva) // Larva can evolve without leaders at round start.
+	if(!hive.check_ruler() && caste_base_type != /datum/xeno_caste/larva) // Larva can evolve without leaders at round start.
 		return
 
 	// Evolution is increased based on marine to xeno population taking stored_larva as a modifier.

--- a/code/modules/unit_tests/spawn_xenos.dm
+++ b/code/modules/unit_tests/spawn_xenos.dm
@@ -1,13 +1,13 @@
 /datum/unit_test/spawn_xenos/Run()
 	var/list/mob/living/carbon/xenomorph/xenos = list()
 	GLOB.xeno_stat_multiplicator_buff = 1
-	for(var/xeno_type in GLOB.xeno_caste_datums)
+	for(var/castetype in GLOB.xeno_caste_datums)
+		var/xeno_type = GLOB.xeno_caste_datums[castetype][XENO_UPGRADE_BASETYPE].caste_type_path
 		xenos += allocate(xeno_type)
 
 	sleep(1 SECONDS)
 
-	for(var/i in xenos)
-		var/mob/living/carbon/xenomorph/X = i
+	for(var/mob/living/carbon/xenomorph/X AS in xenos)
 		X.upgrade_xeno(X.upgrade_next())
 
 	sleep(1 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Refactors things to be using caste more properly instead of needing a bajillion mobs for when strains happen

## Changelog
:cl:
fix: fixed some edge cases where xenos couldn't do certain things when spawned by admins
refactor: rewrote some code pertaining to xenos to be on castes instead of the actual mob
/:cl:
