### PR TITLE
Fix some oversights from #15714

### DIFF
--- a/code/__HELPERS/announce.dm
+++ b/code/__HELPERS/announce.dm
@@ -66,8 +66,9 @@
  * * channel_override - optional, what channel is this sound going to be played on?
  * * color_override - **recommended,** string, use the passed color instead of the default blue (see defines in `__HELPERS/announce.dm`)
  * * receivers - a list of all players to send the message to. defaults to all players, not including those in lobby
+ * * playing_sound - optional, is this playing sound?
  */
-/proc/priority_announce(message, title = "Announcement", subtitle = "", type = ANNOUNCEMENT_REGULAR, sound = 'sound/misc/notice2.ogg', channel_override = CHANNEL_ANNOUNCEMENTS, color_override, list/receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list))
+/proc/priority_announce(message, title = "Announcement", subtitle = "", type = ANNOUNCEMENT_REGULAR, sound = 'sound/misc/notice2.ogg', channel_override = CHANNEL_ANNOUNCEMENTS, color_override, list/receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list), playing_sound = TRUE)
 	if(!message)
 		return
 
@@ -110,7 +111,8 @@
 		var/mob/M = i
 		if(!isnewplayer(M))
 			to_chat(M, finalized_announcement)
-			SEND_SOUND(M, s)
+			if(playing_sound)
+				SEND_SOUND(M, s)
 
 
 /proc/print_command_report(papermessage, papertitle = "paper", announcemessage = "A report has been downloaded and printed out at all communications consoles.", announcetitle = "Incoming Classified Message", announce = TRUE)

--- a/code/__HELPERS/announce.dm
+++ b/code/__HELPERS/announce.dm
@@ -65,7 +65,7 @@
  * * sound - optional, the sound played accompanying the announcement
  * * channel_override - optional, what channel is this sound going to be played on?
  * * color_override - **recommended,** string, use the passed color instead of the default blue (see defines in `__HELPERS/announce.dm`)
- * * receivers - a list of all players to send the message to. defaults to all players, not including those in lobby
+ * * receivers - a list of all players to send the message to. defaults to all humans, AIs and ghosts
  * * playing_sound - optional, is this playing sound?
  */
 /proc/priority_announce(message, title = "Announcement", subtitle = "", type = ANNOUNCEMENT_REGULAR, sound = 'sound/misc/notice2.ogg', channel_override = CHANNEL_ANNOUNCEMENTS, color_override, list/receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list), playing_sound = TRUE)

--- a/code/datums/marine_main_ship.dm
+++ b/code/datums/marine_main_ship.dm
@@ -113,7 +113,14 @@ GLOBAL_DATUM_INIT(marine_main_ship, /datum/marine_main_ship, new)
 						SD.set_picture("redalert")
 			if(SEC_LEVEL_DELTA)
 				if(announce)
-					priority_announce("Attention! Delta security level reached! " + CONFIG_GET(string/alert_delta), title = "Ship Destruction Imminent", type = ANNOUNCEMENT_PRIORITY, color_override = "purple")
+					priority_announce(
+						type = ANNOUNCEMENT_PRIORITY,
+						title = "Ship Destruction Imminent",
+						message = "Attention! Delta security level reached! " + CONFIG_GET(string/alert_delta),
+						sound = 'sound/misc/airraid.ogg',
+						channel_override = SSsounds.random_available_channel(),
+						color_override = "purple"
+					)
 				security_level = SEC_LEVEL_DELTA
 				for(var/obj/machinery/door/poddoor/shutters/mainship/D in GLOB.machines)
 					if(D.id == "sd_lockdown")

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -626,7 +626,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/shotgunbox/blank
 	name = "blank ammo box"
 	icon_state = "ammoboxblank"
-	worn_icon_state = "ammoboxblank"
+	item_state = "ammoboxblank"
 	base_icon_state = "ammoboxblank"
 	ammo_type = /datum/ammo/bullet/shotgun/blank
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -626,7 +626,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/shotgunbox/blank
 	name = "blank ammo box"
 	icon_state = "ammoboxblank"
-	item_state = "ammoboxblank"
+	worn_icon_state =  = "ammoboxblank"
 	base_icon_state = "ammoboxblank"
 	ammo_type = /datum/ammo/bullet/shotgun/blank
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -626,7 +626,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/shotgunbox/blank
 	name = "blank ammo box"
 	icon_state = "ammoboxblank"
-	item_state = "ammoboxblank"
+	worn_icon_state = "ammoboxblank"
 	base_icon_state = "ammoboxblank"
 	ammo_type = /datum/ammo/bullet/shotgun/blank
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -626,7 +626,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/shotgunbox/blank
 	name = "blank ammo box"
 	icon_state = "ammoboxblank"
-	worn_icon_state =  = "ammoboxblank"
+	worn_icon_state = "ammoboxblank"
 	base_icon_state = "ammoboxblank"
 	ammo_type = /datum/ammo/bullet/shotgun/blank
 

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -62,7 +62,6 @@
 	log_game("[key_name(human_owner)] has broadcasted the hud message [text] at [AREACOORD(human_owner)]")
 	var/override_color // for squad colors
 	var/list/alert_receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list) // for full faction alerts, do this so that faction's AI and ghosts can hear aswell
-	var/faction_string = "Command" // In case it's not a TGMC announcement, rename this with the faction name
 	if(human_owner.assigned_squad)
 		switch(human_owner.assigned_squad.id)
 			if(ALPHA_SQUAD)
@@ -74,6 +73,8 @@
 			if(DELTA_SQUAD)
 				override_color = "blue"
 		for(var/mob/living/carbon/human/marine AS in human_owner.assigned_squad.marines_list | GLOB.observer_list)
+			S = sound('sound/effects/sos-morse-code.ogg')
+			S.channel = CHANNEL_ANNOUNCEMENTS
 			marine.playsound_local(marine, 'sound/effects/sos-morse-code.ogg', 35)
 			marine.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>Squad [human_owner.assigned_squad.name] Announcement:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, "[human_owner.assigned_squad.color]")
 			to_chat(marine, assemble_alert(
@@ -88,14 +89,9 @@
 		S = sound('sound/misc/notice2.ogg')
 		S.channel = CHANNEL_ANNOUNCEMENTS
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
-			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>COMMAND ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
-			if(human_owner.faction != FACTION_TERRAGOV)
-				faction_string = "[human_owner.faction] Command"
-			to_chat(faction_receiver, assemble_alert(
-				title = "[faction_string] Announcement",
-				subtitle = "Sent by [human_owner.real_name]",
-			))
 			var/faction_title = GLOB.faction_to_acronym[human_owner.faction] ? GLOB.faction_to_acronym[human_owner.faction] + " Command" : "Unknown Faction" + " Command"
+			if(human_owner.faction == FACTION_TERRAGOV)
+				faction_title = "Command"
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
 				title = "[faction_title] Announcement",

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -90,8 +90,6 @@
 		S.channel = CHANNEL_ANNOUNCEMENTS
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
 			var/faction_title = GLOB.faction_to_acronym[human_owner.faction] ? GLOB.faction_to_acronym[human_owner.faction] + " Command" : "Unknown Faction" + " Command"
-			if(human_owner.faction == FACTION_TERRAGOV)
-				faction_title = "Command"
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(faction_title)] ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(
 				title = "[faction_title] Announcement",

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -73,8 +73,6 @@
 			if(DELTA_SQUAD)
 				override_color = "blue"
 		for(var/mob/living/carbon/human/marine AS in human_owner.assigned_squad.marines_list | GLOB.observer_list)
-			S = sound('sound/effects/sos-morse-code.ogg')
-			S.channel = CHANNEL_ANNOUNCEMENTS
 			marine.playsound_local(marine, 'sound/effects/sos-morse-code.ogg', 35)
 			marine.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>Squad [human_owner.assigned_squad.name] Announcement:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, "[human_owner.assigned_squad.color]")
 			to_chat(marine, assemble_alert(

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -162,6 +162,8 @@
 	var/cycle_timer
 	///If first landing is false intro sequence wont play
 	var/static/first_landing = TRUE
+	///If this dropship can play the takeoff announcement
+	var/takeoff_alarm_locked = FALSE
 
 /obj/docking_port/mobile/marine_dropship/register()
 	. = ..()
@@ -173,6 +175,7 @@
 		return
 	// pull the shuttle from datum/source, and state info from the shuttle itself
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_DROPSHIP_TRANSIT)
+	takeoff_alarm_locked = FALSE // Allow the alarm to be used again
 	if(first_landing)
 		first_landing = FALSE
 		var/op_name = GLOB.operation_namepool[/datum/operation_namepool].get_random_name()
@@ -255,7 +258,7 @@
 	if(hijack_state != HIJACK_STATE_NORMAL)
 		return
 	cycle_timer = addtimer(CALLBACK(src, PROC_REF(go_to_previous_destination)), 20 SECONDS, TIMER_STOPPABLE)
-	priority_announce("The Alamo will depart towards [previous.name] in 20 seconds.", "Dropship Automatic Departure", color_override = "grey")
+	priority_announce("The Alamo will depart towards [previous.name] in 20 seconds.", "Dropship Automatic Departure", color_override = "grey", playing_sound = FALSE)
 
 ///Send the dropship to its previous dock
 /obj/docking_port/mobile/marine_dropship/proc/go_to_previous_destination()
@@ -642,6 +645,44 @@
 				deltimer(shuttle.cycle_timer)
 		if("cycle_time_change")
 			shuttle.time_between_cycle = params["cycle_time_change"]
+		if("signal_departure")
+			// Weird cases where the alarm shouldn't be used.
+			switch(shuttle.mode)
+				if(SHUTTLE_RECHARGING)
+					to_chat(usr, span_warning("The dropship is recharging."))
+					return
+				if(SHUTTLE_CALL)
+					to_chat(usr, span_warning("The dropship is in flight."))
+					return
+				if(SHUTTLE_IGNITING)
+					to_chat(usr, span_warning("The dropship is about to take off."))
+					return
+				if(SHUTTLE_PREARRIVAL)
+					to_chat(usr, span_warning("The dropship is about to land."))
+					return
+
+			// It's too early to launch it.
+			#ifndef TESTING
+			if(!(shuttle.shuttle_flags & GAMEMODE_IMMUNE) && world.time < SSticker.round_start_time + SSticker.mode.deploy_time_lock)
+				to_chat(usr, span_warning("It's too early to use the alarm right now."))
+				return TRUE
+			#endif
+
+			// Prevent spamming the alarm.
+			if(shuttle.takeoff_alarm_locked)
+				to_chat(usr, span_boldwarning("The dropship takeoff alarm is locked. To unlock it, the dropship must be cycled."))
+				return
+
+			priority_announce(
+				type = ANNOUNCEMENT_PRIORITY,
+				title = "Dropship Takeoff Imminent",
+				message = "[usr.real_name] has signalled that the Alamo will take off soon.",
+				sound = 'sound/misc/ds_signalled_alarm.ogg',
+				channel_override = SSsounds.random_available_channel(), // Probably important enough to avoid interruption?
+				color_override = "yellow"
+			)
+			to_chat(usr, span_warning("You slam your palm on the alarm button, locking it until the dropship lands again."))
+			shuttle.takeoff_alarm_locked = TRUE
 		//These are actions for the Xeno dropship UI
 		if("hijack")
 			var/mob/living/carbon/xenomorph/xeno = usr


### PR DESCRIPTION
## About The Pull Request
#15714 has quite a few missed features that its changelog says were added or whatever. Hopefully all this is working, but I was in a rush coding this
- Send Orders full faction alerts behave as intended, not sending screentext twice or an empty `assemble_alert`, and faction title works normally
- Delta alert now plays the air raid siren
- *Manual* dropship takeoff alarm is fully implemented now
- *Automatic* dropship takeoff alarm won't play sound as said in 15714's description(?)
## Why It's Good For The Game
Adding stuff that seems to have been left out accidentally is good. Also, same reason for the sounds as in #15714 and #15064: these are dramatic and attention-getting.
## Changelog
:cl:
fix: Dropship Takeoff Alarm is fully implemented
fix: Automatic dropship departure announcement no longer has sound
fix: Delta alert plays the air raid siren
fix: Send Orders behaves normally now
/:cl:
