### PR TITLE
Xeno spit toxin transfer amount reduced by half when staggered

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -58,6 +58,11 @@
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/carbon_victim, obj/projectile/proj)
 	drop_neuro_smoke(get_turf(carbon_victim))
 
+	if(isxeno(proj.firer))
+		var/mob/living/carbon/xenomorph/xeno = proj.firer
+		if(xeno.IsStaggered())
+			reagent_transfer_amount *= STAGGER_DAMAGE_MULTIPLIER
+
 	if(!istype(carbon_victim) || carbon_victim.stat == DEAD || carbon_victim.issamexenohive(proj.firer) )
 		return
 


### PR DESCRIPTION

## About The Pull Request
Only applies to praetorian since they are the only one with neuro spit
When a praetorian spits neuro at you while staggered, it will reduce the amount transferred by the stagger damage multiplier (50%)
## Why It's Good For The Game
I learned after I made xenos able to spit when staggered that their damage would be reduced by 50%, which honestly seems fine to me. Replicating the behavior to Praetorian spit which does stamina damage AND transfers toxins; this does not touch the gas cloud however, just the on-hit effect
## Changelog
:cl:
balance: Xeno spit toxin transfer amount reduced by half when staggered
/:cl:
