### PR TITLE
Changes Door Control Button's Layer

### DIFF
--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -19,6 +19,8 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	layer = ABOVE_OBJ_LAYER
+
 
 /obj/machinery/door_control/unmeltable
 	resistance_flags = RESIST_ALL

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -21,7 +21,6 @@
 	active_power_usage = 4
 	layer = ABOVE_OBJ_LAYER
 
-
 /obj/machinery/door_control/unmeltable
 	resistance_flags = RESIST_ALL
 


### PR DESCRIPTION

## About The Pull Request
Changes the door control button to layer above objects
## Why It's Good For The Game
Currently, the buttons are hidden on things like the tad due to layering under the walls and objects on them. This let's them actually see and use the buttons more easily.
## Changelog
:cl:
qol: Door control buttons now layer over objects and the tad's walls.
/:cl:
