### PR TITLE
Tank cannon now gibs non-xeno mobs again

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -81,7 +81,10 @@
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, 0, 2, 5, 0, 3)
 
-
+/datum/ammo/rocket/ltb/on_hit_mob(mob/victim, obj/projectile/proj)
+	drop_nade(get_turf(victim))
+	if(!isxeno(victim))
+		victim.gib()
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/eaebff5f-9bde-4fac-901e-d4cdff95be62
## Why It's Good For The Game
https://github.com/tgstation/TerraGov-Marine-Corps/assets/20828943/d1924b67-ee36-4b70-8937-eea43ffc6d38

(It was very funny and adds a risk for standing directly infront of tank.)

## Changelog
:cl:
balance: Tank cannon now gibs non-xeno mobs again
/:cl:
