### PR TITLE
Psycrush and psyblast multitile walance changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -405,7 +405,10 @@
 				carbon_victim.add_slowdown(6)
 			else if(isvehicle(victim))
 				var/obj/vehicle/veh_victim = victim
-				veh_victim.take_damage(xeno_owner.xeno_caste.crush_strength * 5, BRUTE, BOMB)
+				var/dam_mult = 1.5 //multitile vehicles can be hit multiple times
+				if(ismecha(veh_victim))
+					dam_mult = 5
+				veh_victim.take_damage(xeno_owner.xeno_caste.crush_strength * dam_mult, BRUTE, BOMB)
 	stop_crush()
 
 /// stops channeling and unregisters all listeners, resetting the ability

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -260,6 +260,8 @@
 // ***************************************
 // *********** psychic crush
 // ***************************************
+
+#define PSY_CRUSH_DAMAGE 50
 /datum/action/ability/activable/xeno/psy_crush
 	name = "Psychic Crush"
 	action_icon_state = "psy_crush"
@@ -399,8 +401,8 @@
 				var/mob/living/carbon/carbon_victim = victim
 				if(isxeno(carbon_victim) || carbon_victim.stat == DEAD)
 					continue
-				carbon_victim.apply_damage(xeno_owner.xeno_caste.crush_strength, BRUTE, blocked = BOMB)
-				carbon_victim.apply_damage(xeno_owner.xeno_caste.crush_strength * 1.5, STAMINA, blocked = BOMB)
+				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE, BRUTE, blocked = BOMB)
+				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE * 1.5, STAMINA, blocked = BOMB)
 				carbon_victim.adjust_stagger(5 SECONDS)
 				carbon_victim.add_slowdown(6)
 			else if(isvehicle(victim))
@@ -408,7 +410,7 @@
 				var/dam_mult = 1.5 //multitile vehicles can be hit multiple times
 				if(ismecha(veh_victim))
 					dam_mult = 5
-				veh_victim.take_damage(xeno_owner.xeno_caste.crush_strength * dam_mult, BRUTE, BOMB)
+				veh_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)
 	stop_crush()
 
 /// stops channeling and unregisters all listeners, resetting the ability
@@ -488,6 +490,8 @@
 /obj/effect/xeno/crush_orb/Initialize(mapload)
 	. = ..()
 	flick("orb_charge", src)
+
+#undef PSY_CRUSH_DAMAGE
 
 // ***************************************
 // *********** Psyblast

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -195,7 +195,6 @@
 		return INITIALIZE_HINT_QDEL
 	owner = creator
 	dir = owner.dir
-	obj_integrity = max_integrity
 	if(dir & (EAST|WEST))
 		bound_height = 96
 		bound_y = -32

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -405,7 +405,7 @@
 				carbon_victim.add_slowdown(6)
 			else if(isvehicle(victim))
 				var/obj/vehicle/veh_victim = victim
-				var/dam_mult = 1.5 //multitile vehicles can be hit multiple times
+				var/dam_mult = 1.5
 				if(ismecha(veh_victim))
 					dam_mult = 5
 				veh_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -182,7 +182,7 @@
 	icon = 'icons/Xeno/96x96.dmi'
 	icon_state = "shield"
 	resistance_flags = BANISH_IMMUNE|UNACIDABLE|PLASMACUTTER_IMMUNE
-	max_integrity = 350
+	max_integrity = 650
 	layer = ABOVE_MOB_LAYER
 	///Who created the shield
 	var/mob/living/carbon/xenomorph/owner
@@ -195,7 +195,6 @@
 		return INITIALIZE_HINT_QDEL
 	owner = creator
 	dir = owner.dir
-	max_integrity = owner.xeno_caste.shield_strength
 	obj_integrity = max_integrity
 	if(dir & (EAST|WEST))
 		bound_height = 96

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -20,7 +20,6 @@
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
 	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 10, BIO = 35, FIRE = 35, ACID = 35)
-	shield_strength = 650
 	minimap_icon = "warlock"
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -21,8 +21,6 @@
 	caste_traits = null
 	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 10, BIO = 35, FIRE = 35, ACID = 35)
 	shield_strength = 650
-	crush_strength = 50
-	blast_strength = 45
 	minimap_icon = "warlock"
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -191,10 +191,6 @@
 	///Damage breakpoint to knock out of stealth
 	var/stealth_break_threshold = 0
 
-	// *** Warlock Abilities ***
-	///The integrity of psychic shields made by the xeno
-	var/shield_strength = 350
-
 	// *** Sentinel Abilities ***
 	/// The additional amount of stacks that the Sentinel will apply on eligible abilities.
 	var/additional_stacks = 0

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -194,10 +194,6 @@
 	// *** Warlock Abilities ***
 	///The integrity of psychic shields made by the xeno
 	var/shield_strength = 350
-	///The strength of psychic crush's effects
-	var/crush_strength = 35
-	///The strength of psychic blast's  AOE effects
-	var/blast_strength = 25
 
 	// *** Sentinel Abilities ***
 	/// The additional amount of stacks that the Sentinel will apply on eligible abilities.

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -28,16 +28,13 @@
 	glow_color = "#9e1f1f"
 	///The AOE for drop_nade
 	var/aoe_range = 2
+	///AOE damage amount
+	var/aoe_damage = 45
 
 /datum/ammo/energy/xeno/psy_blast/drop_nade(turf/T, obj/projectile/P)
 	if(!T || !isturf(T))
 		return
 	playsound(T, 'sound/effects/EMPulse.ogg', 50)
-	var/aoe_damage = 25
-	if(isxeno(P.firer))
-		var/mob/living/carbon/xenomorph/xeno_firer = P.firer
-		aoe_damage = xeno_firer.xeno_caste.blast_strength
-
 	var/list/turf/target_turfs = generate_true_cone(T, aoe_range, -1, 359, 0, air_pass = TRUE)
 	for(var/turf/target_turf AS in target_turfs)
 		for(var/atom/movable/target AS in target_turf)
@@ -50,11 +47,14 @@
 					staggerstun(living_victim, P, 10, slowdown = 1)
 			else if(isobj(target))
 				var/obj/obj_victim = target
+				var/dam_mult = 1
 				if(!(obj_victim.resistance_flags & XENO_DAMAGEABLE))
 					continue
 				if(isbarricade(target))
 					continue
-				obj_victim.take_damage(aoe_damage, BURN, ENERGY, TRUE, armour_penetration = penetration)
+				if(isarmoredvehicle(target))
+					dam_mult -= 0.5
+				obj_victim.take_damage(aoe_damage * dam_mult, BURN, ENERGY, TRUE, armour_penetration = penetration)
 			if(target.anchored)
 				continue
 


### PR DESCRIPTION

## About The Pull Request
Reduces the AOE damage of Psyblast/crush against multitile vehicles.

Also removed some caste define stuff for warlock abilities. With the removal of maturity, they serve no purpose. This probably applies to the majority of ability caste vars, but we'll leave that for another pr.
## Why It's Good For The Game
Multitile vehicles are particularly vulnerable to any kind of AOE damage since it can hit up to 9 times. While I like the idea of being able to get better hits in, currently this means warlock in particular can do HUGE damage to vehicles.
## Changelog
:cl:
balance: Reduced AOE damage of psyblast/psycrush against multitile vehicles
/:cl:
