### PR TITLE
Acid wells, acid turrets and heal fruit have opaque acid smoke again

### DIFF
--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -51,7 +51,7 @@
 			to_chat(creator, span_xenoannounce("You sense your acid well at [A.name] has been destroyed!") )
 
 	if(damage_amount || damage_flag) //Spawn the gas only if we actually get destroyed by damage
-		var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
+		var/datum/effect_system/smoke_spread/xeno/acid/opaque/A = new(get_turf(src))
 		A.set_up(clamp(CEILING(charges*0.5, 1),0,3),src) //smoke scales with charges
 		A.start()
 	return ..()
@@ -89,7 +89,7 @@
 	charges--
 	update_icon()
 	var/turf/T = get_turf(src)
-	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke = new(T) //spawn acid smoke when charges are actually used
+	var/datum/effect_system/smoke_spread/xeno/acid/opaque/acid_smoke = new(T) //spawn acid smoke when charges are actually used
 	acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
 	acid_smoke.start()
 
@@ -185,7 +185,7 @@
 	if(!charges_used)
 		return
 
-	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
+	var/datum/effect_system/smoke_spread/xeno/acid/opaque/acid_smoke
 	acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
 	acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
 	acid_smoke.start()

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -185,8 +185,7 @@
 	if(!charges_used)
 		return
 
-	var/datum/effect_system/smoke_spread/xeno/acid/opaque/acid_smoke
-	acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
+	var/datum/effect_system/smoke_spread/xeno/acid/opaque/acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
 	acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
 	acid_smoke.start()
 

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -58,7 +58,7 @@
 
 /obj/structure/xeno/xeno_turret/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
 	if(damage_amount) //Spawn the gas only if we actually get destroyed by damage
-		var/datum/effect_system/smoke_spread/xeno/smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
+		var/datum/effect_system/smoke_spread/xeno/acid/opaque/smoke = new(get_turf(src))
 		smoke.set_up(1, get_turf(src))
 		smoke.start()
 	return ..()

--- a/code/modules/xenomorph/xenoplant.dm
+++ b/code/modules/xenomorph/xenoplant.dm
@@ -74,7 +74,7 @@
 	if(!do_after(user, 2 SECONDS, IGNORE_HELD_ITEM, src))
 		return FALSE
 	if(!isxeno(user))
-		var/datum/effect_system/smoke_spread/xeno/acid/plant_explosion = new(get_turf(src))
+		var/datum/effect_system/smoke_spread/xeno/acid/opaque/plant_explosion = new(get_turf(src))
 		plant_explosion.set_up(3,src)
 		plant_explosion.start()
 		visible_message(span_danger("[src] bursts, releasing toxic gas!"))


### PR DESCRIPTION

## About The Pull Request

Acid wells make opaque smoke when someone walks through them, acid turrets make opaque smoke when they get destroyed and heal fruit blows up into opaque smoke when a non xeno tries to eat it.
## Why It's Good For The Game

I'm pretty sure barnet didn't intend to change these in the PR where they made boiler and baneling smoke opaque.

This makes acid wells quite single use, only really useful as a utility to extinguish yourself and knock sticky nades off, which is sad. The main appeal of them WAS the line of sight block, considering it does next to no damage to heavier armors. 

The other two are just for consistency's sake.
## Changelog
:cl:
balance: Acid wells, acid turrets and heal fruit have opaque acid smoke again
/:cl:
