### PR TITLE
Let's tad land in more areas

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -254,7 +254,7 @@
 		var/area/A = get_area(T)
 		if(!A)
 			return FALSE
-		if(A.ceiling == CEILING_NONE || A.ceiling == CEILING_GLASS || A.ceiling ==CEILING_METAL)
+		if(A.ceiling == CEILING_NONE || A.ceiling == CEILING_GLASS || A.ceiling == CEILING_METAL)
 			continue
 		return FALSE
 	return TRUE
@@ -295,7 +295,7 @@
 	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
 		return SHUTTLE_DOCKER_BLOCKED
 	var/area/turf_area = get_area(T)
-	if(turf_area.ceiling >= CEILING_METAL)
+	if(turf_area.ceiling >= CEILING_OBSTRUCTED)
 		return SHUTTLE_DOCKER_BLOCKED
 	// If it's one of our shuttle areas assume it's ok to be there
 	if(shuttle_port.shuttle_areas[T.loc])


### PR DESCRIPTION

## About The Pull Request
Let's the tad land in areas with metal ceilings. Also adds a space where a define is used.
## Why It's Good For The Game
Meant to be merged with #15693. If the tad loses it's cades, it can at least be better at transporting, especially on maps like Daedalus, where the vast majority of the map is metal ceilings. The space in the code just makes it cleaner.
## Changelog
:cl:
balance: The tadpole can now land in areas with metal ceilings
/:cl:
