### PR TITLE
Campaign map colours

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -202,9 +202,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 //Item sprite variants
 #define ITEM_JUNGLE_VARIANT (1<<0)
 #define ITEM_ICE_VARIANT (1<<1)
-#define ITEM_ICE_PROTECTION (1<<2)
-#define ITEM_PRISON_VARIANT (1<<3)
-#define ITEM_DESERT_VARIANT (1<<4)
+#define ITEM_PRISON_VARIANT (1<<2)
+#define ITEM_DESERT_VARIANT (1<<3)
 
 #define ITEM_UNEQUIP_FAIL 0
 #define ITEM_UNEQUIP_DROPPED 1

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -998,5 +998,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 /datum/game_mode/proc/ghost_verbs(mob/dead/observer/observer)
 	return
 
+///Returns the armor color variant applicable for this mode
 /datum/game_mode/proc/get_map_color_variant()
 	return SSmapping.configs[GROUND_MAP].armor_style

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -997,3 +997,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 ///Returns a list of verbs to give ghosts in this gamemode
 /datum/game_mode/proc/ghost_verbs(mob/dead/observer/observer)
 	return
+
+/datum/game_mode/proc/get_map_color_variant()
+	return SSmapping.configs[GROUND_MAP].armor_style

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -58,6 +58,9 @@
 		var/datum/faction_stats/selected_faction = stat_list[i]
 		addtimer(CALLBACK(selected_faction, TYPE_PROC_REF(/datum/faction_stats, choose_faction_leader)), 90 SECONDS)
 
+/datum/game_mode/hvh/campaign/get_map_color_variant()
+	return current_mission?.map_armor_color
+
 /datum/game_mode/hvh/campaign/player_respawn(mob/respawnee)
 	if(!respawnee?.client)
 		return

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -13,6 +13,8 @@
 	var/list/map_light_colours = list(COLOR_WHITE, COLOR_WHITE, COLOR_WHITE, COLOR_WHITE)
 	///Light levels for the map
 	var/list/map_light_levels = list(200, 100, 75, 50)
+	///Camo color associated with this map
+	var/map_armor_color = MAP_ARMOR_STYLE_DEFAULT
 	///The actual z-level the mission is played on
 	var/datum/space_level/mission_z_level
 	///Optional delay for each faction to be able to deploy, typically used in attacker/defender missions

--- a/code/datums/gamemodes/campaign/missions/airbase_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/airbase_raid.dm
@@ -8,6 +8,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SNOWSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	objectives_total = 6
 	min_destruction_amount = 4
 	victory_point_rewards = list(
@@ -76,6 +77,7 @@
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	objectives_total = 8
 	min_destruction_amount = 5
 	hostile_faction_additional_rewards = "Ensure continued access to close air support. B18 power armour available if you successfully protect this depot."

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -8,6 +8,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SNOWSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_ICE
 	objectives_total = 1
 	min_destruction_amount = 1
 	max_game_time = 15 MINUTES

--- a/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/fire_support_raid.dm
@@ -131,6 +131,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	objectives_total = 5
 	min_destruction_amount = 4
 	hostile_faction_additional_rewards = "Protect our fire support options to ensure continued access to mortar support. Combat robots and fire support is available if you successfully defend this outpost."

--- a/code/datums/gamemodes/campaign/missions/mech_wars.dm
+++ b/code/datums/gamemodes/campaign/missions/mech_wars.dm
@@ -7,6 +7,7 @@
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	starting_faction_objective_description = "Major Victory: Wipe out all hostiles in the area of operation. Minor Victory: Eliminate more hostiles than you lose."
 	hostile_faction_objective_description = "Major Victory: Wipe out all hostiles in the area of operation. Minor Victory: Eliminate more hostiles than you lose."
 	mission_start_delay = 3 MINUTES //since there is actual mech prep time required
@@ -126,6 +127,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SANDSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_DESERT
 
 /datum/campaign_mission/tdm/mech_wars/som/apply_major_victory()
 	winning_faction = starting_faction

--- a/code/datums/gamemodes/campaign/missions/patrol_mission.dm
+++ b/code/datums/gamemodes/campaign/missions/patrol_mission.dm
@@ -5,6 +5,7 @@
 	map_file = '_maps/map_files/desparity/desparity.dmm'
 	map_light_colours = list(COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	mission_icon = "combat_patrol"
 	starting_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
 	hostile_faction_objective_description = "Major Victory: Wipe out all hostiles in the AO or capture and hold the sensor towers for a points victory. Minor Victory: Eliminate more hostiles than you lose."
@@ -220,6 +221,7 @@
 	map_file = '_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm'
 	map_light_colours = list(COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW, COLOR_MISSION_YELLOW)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 
 /datum/campaign_mission/tdm/first_mission
 	name = "First Contact"
@@ -228,6 +230,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_RAIN = TRUE)
 	map_light_colours = list(LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN, LIGHT_COLOR_PALE_GREEN)
 	map_light_levels = list(200, 100, 75, 50)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	mission_start_delay = 3 MINUTES
 
 /datum/campaign_mission/tdm/first_mission/end_mission()

--- a/code/datums/gamemodes/campaign/missions/supply_raid.dm
+++ b/code/datums/gamemodes/campaign/missions/supply_raid.dm
@@ -8,6 +8,7 @@
 	map_traits = list(ZTRAIT_AWAY = TRUE, ZTRAIT_SNOWSTORM = TRUE)
 	map_light_colours = list(COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE, COLOR_MISSION_BLUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_ICE
 	objectives_total = 6
 	min_destruction_amount = 4
 	victory_point_rewards = list(
@@ -114,6 +115,7 @@
 	map_light_colours = list(COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED, COLOR_MISSION_RED)
 	map_traits = list(ZTRAIT_AWAY = TRUE)
 	map_light_levels = list(225, 150, 100, 75)
+	map_armor_color = MAP_ARMOR_STYLE_JUNGLE
 	objectives_total = 8
 	min_destruction_amount = 6
 	hostile_faction_additional_rewards = "Prevent the degradation of our attrition generation. B18 power armour available if you successfully protect this depot."

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -711,7 +711,9 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 	return
 
 /obj/item/proc/update_item_sprites()
-	switch(SSmapping.configs[GROUND_MAP].armor_style)
+	//we call the config directly for pregame where mode isn't set yet
+	var/armor_style = SSticker.mode ? SSticker.mode.get_map_color_variant() : SSmapping.configs[GROUND_MAP].armor_style
+	switch(armor_style)
 		if(MAP_ARMOR_STYLE_JUNGLE)
 			if(item_map_variant_flags & ITEM_JUNGLE_VARIANT)
 				if(colorable_allowed & PRESET_COLORS_ALLOWED)
@@ -745,9 +747,6 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 					greyscale_colors = ARMOR_PALETTE_DESERT
 				else if(colorable_allowed & ICON_STATE_VARIANTS_ALLOWED)
 					current_variant = DESERT_VARIANT
-
-	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD] && (item_map_variant_flags & ITEM_ICE_PROTECTION))
-		min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROTECTION_TEMPERATURE
 
 	if(!greyscale_colors)
 		return

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -218,7 +218,7 @@
 	item_flags = SYNTH_RESTRICTED
 	resistance_flags = UNACIDABLE
 	anti_hug = 6
-	item_map_variant_flags = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
+	item_map_variant_flags = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT)
 
 /obj/item/clothing/head/helmet/marine/grenadier
 	name = "\improper B17 helmet"
@@ -230,7 +230,7 @@
 	resistance_flags = UNACIDABLE
 	item_flags = SYNTH_RESTRICTED
 	anti_hug = 4
-	item_map_variant_flags = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
+	item_map_variant_flags = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT)
 
 /obj/item/clothing/head/helmet/marine/pilot
 	name = "\improper M30 tactical helmet"

--- a/code/modules/clothing/modular_armor/combat_robot.dm
+++ b/code/modules/clothing/modular_armor/combat_robot.dm
@@ -13,7 +13,7 @@
 	colorable_colors = ARMOR_PALETTES_LIST
 	colorable_allowed = PRESET_COLORS_ALLOWED
 	greyscale_config = /datum/greyscale_config/robot
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	attachments_allowed = list(
 		/obj/item/armor_module/module/better_shoulder_lamp,
@@ -90,7 +90,7 @@
 	colorable_colors = ARMOR_PALETTES_LIST
 	colorable_allowed = PRESET_COLORS_ALLOWED
 	greyscale_config = /datum/greyscale_config/robot
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	attachments_allowed = list(
 		/obj/item/armor_module/module/tyr_head,

--- a/code/modules/clothing/modular_armor/jaeger.dm
+++ b/code/modules/clothing/modular_armor/jaeger.dm
@@ -40,7 +40,7 @@
 	greyscale_config = /datum/greyscale_config/armor_mk2/infantry
 	colorable_allowed = PRESET_COLORS_ALLOWED
 	colorable_colors = ARMOR_PALETTES_LIST
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 
 	allowed_uniform_type = /obj/item/clothing/under

--- a/code/modules/clothing/modular_armor/mark_one.dm
+++ b/code/modules/clothing/modular_armor/mark_one.dm
@@ -35,7 +35,7 @@
 	)
 
 	greyscale_config = /datum/greyscale_config/armor_mk1/infantry
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 	colorable_colors = ARMOR_PALETTES_LIST
 	colorable_allowed = PRESET_COLORS_ALLOWED
 

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -247,7 +247,7 @@
 	greyscale_config = /datum/greyscale_config/exoskeleton
 	colorable_allowed = PRESET_COLORS_ALLOWED
 	colorable_colors = ARMOR_PALETTES_LIST
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 	allowed_uniform_type = /obj/item/clothing/under
 	attachments_allowed = list(
 
@@ -297,7 +297,7 @@
 	item_state_worn = TRUE
 
 	greyscale_config = /datum/greyscale_config/armor_mk1
-	greyscale_colors = ARMOR_PALETTE_DESERT
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	armor_protection_flags = HEAD
 	armor_features_flags = ARMOR_NO_DECAP
@@ -387,7 +387,7 @@
 	worn_icon_state = "gas_alt"
 	worn_icon_list = list(slot_wear_mask_str)
 	item_state_worn = TRUE
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	colorable_colors = ARMOR_PALETTES_LIST
 	colorable_allowed = PRESET_COLORS_ALLOWED

--- a/code/modules/clothing/modular_armor/xenonauten.dm
+++ b/code/modules/clothing/modular_armor/xenonauten.dm
@@ -41,7 +41,7 @@
 	greyscale_config = /datum/greyscale_config/xenonaut
 	colorable_allowed = PRESET_COLORS_ALLOWED
 	colorable_colors = ARMOR_PALETTES_LIST
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	allowed_uniform_type = /obj/item/clothing/under
 
@@ -310,7 +310,7 @@
 	item_map_variant_flags = ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_DESERT_VARIANT
 
 	greyscale_config = /datum/greyscale_config/xenonaut/helm
-	greyscale_colors = ARMOR_PALETTE_DRAB
+	greyscale_colors = ARMOR_PALETTE_BLACK
 
 	visorless_offset_y = 0
 


### PR DESCRIPTION

## About The Pull Request
Updated map colour variant selection so the gamemode can specify the variant to use.

Specifically, this means during campaign, the map variant will change with each mission.

Also changed the default colour (for groundmaps and missions that don't specify anything) to black, instead of drab or desert in some cases.
## Why It's Good For The Game
Muh realism or something.
## Changelog
:cl:
qol: Campaign: Map variant for colours updates with each mission
/:cl:
