### PR TITLE
Shipside rank overhaul

### DIFF
--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -187,16 +187,34 @@
 	switch(paygrade)
 		if("C")
 			. = size ? "" : "Civilian"
-		if("CD")
-			. = size ? "Dr." : "Doctor"
+		if("MS")
+			. = size ? "MS" : "Medical Student"
+		if("JR")
+			. = size ? "JR" : "Junior Resident"
+		if("SR")
+			. = size ? "SR" : "Senior Resident"
+		if("GP")
+			. = size ? "GP" : "General Practitioner"
+		if("AP")
+			. = size ? "AP" : "Attending Physician"
+		if("SP")
+			. = size ? "SP" : "Senior Physician"
+		if("HP")
+			. = size ? "HP" : "Head Physician"
+		if("MSPVR")
+			. = size ? "MSPVR" : "Medical Supervisor"
+		if("MDR")
+			. = size ? "MDR" : "Medical Director"
+		if("RSRA")
+			. = size ? "RSRA" : "Research Assistant"
+		if("RSR")
+			. = size ? "RSR" : "Researcher"
+		if("LECT")
+			. = size ? "LECT" : "Lecturer"
+		if("APROF")
+			. = size ? "APROF" : "Associate Professor"
 		if("PROF")
-			. = size ? "Prof." : "Professor"
-		if("RES")
-			. = size ? "RES" : "Medical Resident"
-		if("MD")
-			. = size ? "MD" : "Medical Doctor"
-		if("CHO")
-			. = size ? "CHO" : "Chief Health Officer"
+			. = size ? "PROF" : "Professor"
 		if("CMO")
 			. = size ? "CMO" : "Chief Medical Officer"
 		if("CMN")
@@ -285,6 +303,8 @@
 			. = size ? "PO1" : "Petty Officer First Class"
 		if("CPO")
 			. = size ? "CPO" : "Chief Petty Officer"
+		if("SCPO")
+			. = size ? "SCPO" : "Senior Chief Petty Officer"
 		if("MO4")
 			. = size ? "MAJ" : "Major"
 		if("MO5")
@@ -413,6 +433,10 @@
 			. = size ? "MERC" : "MERC Engineer"
 		if("VM")
 			. = size ? "VAT" : "VatGrown Marine"
+		if("Mk.V")
+			. = size ? "Mk.V" : "Mark V"
+		if("Mk.IV")
+			. = size ? "Mk.IV" : "Mark IV"
 		if("Mk.III")
 			. = size ? "Mk.III" : "Mark III"
 		if("Mk.II")

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -61,12 +61,16 @@ Godspeed, captain! And remember, you are not above the law."})
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500) // starting
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "O6"
-		if(1501 to 7500) // 25hrs
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "O7"
-		if(7501 to INFINITY) //125 hrs
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "O8"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "O9"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "10"
 
 /datum/job/terragov/command/captain/campaign
 	outfit = /datum/outfit/job/command/captain_campaign
@@ -209,7 +213,7 @@ Make the TGMC proud!"})
 //Staff Officer
 /datum/job/terragov/command/staffofficer
 	title = STAFF_OFFICER
-	paygrade = "O3"
+	paygrade = "O1"
 	comm_title = "SO"
 	total_positions = 4
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ALPHA, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_DELTA)
@@ -255,11 +259,15 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500) // starting
+		if(0 to 600) // starting
+			new_human.wear_id.paygrade = "O1"
+		if(601 to 1500) // 10hrs
+			new_human.wear_id.paygrade = "O2"
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "O3"
-		if(1501 to 3000) // 25 hrs
+		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
-		if(3001 to INFINITY) // 50 hrs
+		if(180001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/command/staffofficer/campaign
@@ -377,7 +385,7 @@ You are to ensure the Tadpole's survival and to transport marines around, acting
 //Pilot Officer
 /datum/job/terragov/command/pilot
 	title = PILOT_OFFICER
-	paygrade = "WO"
+	paygrade = "O1"
 	comm_title = "PO"
 	total_positions = 1
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
@@ -413,19 +421,21 @@ You are to ensure the Tadpole's survival and to transport marines around, acting
 		return
 	switch(playtime_mins)
 		if(0 to 600) // starting
-			new_human.wear_id.paygrade = "WO"
-		if(601 to 3000) // 10 hrs
-			new_human.wear_id.paygrade = "CWO"
-		if(3001 to 6000) // 50 hrs
 			new_human.wear_id.paygrade = "O1"
-		if(6001 to INFINITY) // 100 hrs
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "O2"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "O3"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "O4"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/command/pilot/radio_help_message(mob/M)
 	. = ..()
 	to_chat(M, {"Your job is to support marines with either close air support via the Condor.
 You are expected to use the Condor as the Alamo is able to be ran automatically, though at some points you will be required to take control of the Alamo for the operation's success, though highly unlikey.
-Though you are a warrant officer, your authority is limited to the dropship and the Condor, where you have authority over the enlisted personnel.
+Though you are an officer, your authority is limited to the dropship and the Condor, where you have authority over the enlisted personnel.
 "})
 
 
@@ -677,7 +687,7 @@ You can serve your Division in a variety of roles, so choose carefully."})
 //Chief Ship Engineer
 /datum/job/terragov/engineering/chief
 	title = CHIEF_SHIP_ENGINEER
-	paygrade = "O2"
+	paygrade = "O1"
 	comm_title = "CSE"
 	selection_color = "#ffeeaa"
 	total_positions = 1
@@ -713,12 +723,16 @@ You can serve your Division in a variety of roles, so choose carefully."})
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500) // starting
+		if(0 to 600) // starting
+			new_human.wear_id.paygrade = "O1"
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "O2"
 		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "O3"
-		if(6001 to INFINITY) // 100 hrs
+		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/engineering/chief/radio_help_message(mob/M)
 	. = ..()
@@ -788,13 +802,16 @@ You are also next in the chain of command, should the bridge crew fall in the li
 		return
 	switch(playtime_mins)
 		if(0 to 600) // starting
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "PO3"
-		if(601 to 3000) // 10 hrs
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "PO2"
-		if(3001 to 6000) // 50 hrs
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "PO1"
-		if(6001 to INFINITY) // 100 hrs
+		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "CPO"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "SCPO"
 
 /datum/job/terragov/engineering/tech/radio_help_message(mob/M)
 	. = ..()
@@ -829,7 +846,7 @@ requisitions line and later on to be ready to send supplies for marines who are 
 /datum/job/terragov/requisitions/officer
 	title = REQUISITIONS_OFFICER
 	req_admin_notify = TRUE
-	paygrade = "CPO"
+	paygrade = "O1"
 	comm_title = "RO"
 	selection_color = "#9990B2"
 	total_positions = 1
@@ -867,13 +884,15 @@ requisitions line and later on to be ready to send supplies for marines who are 
 		return
 	switch(playtime_mins)
 		if(0 to 600) // starting
-			new_human.wear_id.paygrade = "CPO"
-		if(601 to 1500) // 10 hrs
-			new_human.wear_id.paygrade = "WO"
-		if(1501 to 6000) // 50 hrs
-			new_human.wear_id.paygrade = "CWO"
-		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "O1"
+		if(601 to 1500) // 10hrs
+			new_human.wear_id.paygrade = "O2"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "O3"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "O4"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/requisitions/officer/radio_help_message(mob/M)
 	. = ..()
@@ -911,7 +930,7 @@ A happy ship is a well-functioning ship."})
 	title = CHIEF_MEDICAL_OFFICER
 	req_admin_notify = TRUE
 	comm_title = "CMO"
-	paygrade = "CHO"
+	paygrade = "SP"
 	total_positions = 1
 	supervisors = "the acting captain"
 	selection_color = "#99FF99"
@@ -959,9 +978,15 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000) // starting
-			new_human.wear_id.paygrade = "CHO"
-		if(3001 to INFINITY) // 50 hrs
+		if(0 to 600) // starting
+			new_human.wear_id.paygrade = "SP"
+		if(601 to 1500) // 10hrs
+			new_human.wear_id.paygrade = "HP"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "MSPVR"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "MDR"
+		if(180001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "CMO"
 
 /datum/outfit/job/medical/professor
@@ -998,7 +1023,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 /datum/job/terragov/medical/medicalofficer
 	title = MEDICAL_DOCTOR
 	comm_title = "MD"
-	paygrade = "RES"
+	paygrade = "MS"
 	total_positions = 4
 	supervisors = "the chief medical officer"
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY)
@@ -1036,10 +1061,16 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000) // starting
-			new_human.wear_id.paygrade = "RES"
-		if(3001 to INFINITY) // 50 hrs
-			new_human.wear_id.paygrade = "MD"
+		if(0 to 600) // starting
+			new_human.wear_id.paygrade = "MS"
+		if(601 to 1500) // 10hrs
+			new_human.wear_id.paygrade = "JR"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "SR"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "GP"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "AP"
 
 /datum/job/terragov/medical/medicalofficer/radio_help_message(mob/M)
 	. = ..()
@@ -1084,7 +1115,7 @@ You are also an expert when it comes to medication and treatment. If you do not 
 /datum/job/terragov/medical/researcher
 	title = MEDICAL_RESEARCHER
 	comm_title = "Rsr"
-	paygrade = "CD"
+	paygrade = "RSRA"
 	total_positions = 2
 	supervisors = "the NT corporate office"
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_ENGINEERING, ACCESS_CIVILIAN_ENGINEERING)
@@ -1131,9 +1162,15 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000) // starting
-			new_human.wear_id.paygrade = "CD"
-		if(3001 to INFINITY) // 50 hrs
+		if(0 to 600) // starting
+			new_human.wear_id.paygrade = "RSRA"
+		if(601 to 1500) // 10hrs
+			new_human.wear_id.paygrade = "RSR"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "LECT"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "APROF"
+		if(180001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "PROF"
 
 
@@ -1174,7 +1211,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 //Liaison
 /datum/job/terragov/civilian/liaison
 	title = CORPORATE_LIAISON
-	paygrade = "NT"
+	paygrade = "NT1"
 	comm_title = "CL"
 	supervisors = "the NT corporate office"
 	total_positions = 1
@@ -1209,15 +1246,15 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600) // 0 to 10 hours
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "NT1"
-		if(601 to 1500) // 10 to 25 hours
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "NT2"
-		if(1501 to 3000) // 25 to 50 hours
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "NT3"
-		if(3001 to 6000) // 50 to 100 hours
+		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "NT4"
-		if(6000 to INFINITY) // Above 100 hours
+		if(180001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "NT5"
 
 /datum/job/terragov/civilian/liaison/radio_help_message(mob/M)
@@ -1295,12 +1332,16 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600) //up to 10 hours
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "Mk.I"
-		if(601 to 3000) // 10 to 50 hrs
+		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "Mk.II"
-		if(3001 to INFINITY) // more than 50 hrs
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "Mk.III"
+		if(6001 to 18000) // 100 hrs
+			new_human.wear_id.paygrade = "Mk.IV"
+		if(180001 to INFINITY) // 300 hrs
+			new_human.wear_id.paygrade = "Mk.V"
 
 /datum/job/terragov/silicon/synthetic/radio_help_message(mob/M)
 	. = ..()

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -802,7 +802,6 @@ You are also next in the chain of command, should the bridge crew fall in the li
 		return
 	switch(playtime_mins)
 		if(0 to 600) // starting
-		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "PO3"
 		if(601 to 1500) // 10hrs
 			new_human.wear_id.paygrade = "PO2"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -69,7 +69,7 @@ Godspeed, captain! And remember, you are not above the law."})
 			new_human.wear_id.paygrade = "O8"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O9"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "10"
 
 /datum/job/terragov/command/captain/campaign
@@ -267,7 +267,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 			new_human.wear_id.paygrade = "O3"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/command/staffofficer/campaign
@@ -428,7 +428,7 @@ You are to ensure the Tadpole's survival and to transport marines around, acting
 			new_human.wear_id.paygrade = "O3"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/command/pilot/radio_help_message(mob/M)
@@ -731,7 +731,7 @@ You can serve your Division in a variety of roles, so choose carefully."})
 			new_human.wear_id.paygrade = "O3"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/engineering/chief/radio_help_message(mob/M)
@@ -809,7 +809,7 @@ You are also next in the chain of command, should the bridge crew fall in the li
 			new_human.wear_id.paygrade = "PO1"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "CPO"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "SCPO"
 
 /datum/job/terragov/engineering/tech/radio_help_message(mob/M)
@@ -890,7 +890,7 @@ requisitions line and later on to be ready to send supplies for marines who are 
 			new_human.wear_id.paygrade = "O3"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/job/terragov/requisitions/officer/radio_help_message(mob/M)
@@ -985,7 +985,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 			new_human.wear_id.paygrade = "MSPVR"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "MDR"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "CMO"
 
 /datum/outfit/job/medical/professor
@@ -1068,7 +1068,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 			new_human.wear_id.paygrade = "SR"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "GP"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "AP"
 
 /datum/job/terragov/medical/medicalofficer/radio_help_message(mob/M)
@@ -1169,7 +1169,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 			new_human.wear_id.paygrade = "LECT"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "APROF"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "PROF"
 
 
@@ -1253,7 +1253,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 			new_human.wear_id.paygrade = "NT3"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "NT4"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "NT5"
 
 /datum/job/terragov/civilian/liaison/radio_help_message(mob/M)
@@ -1339,7 +1339,7 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 			new_human.wear_id.paygrade = "Mk.III"
 		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "Mk.IV"
-		if(180001 to INFINITY) // 300 hrs
+		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "Mk.V"
 
 /datum/job/terragov/silicon/synthetic/radio_help_message(mob/M)


### PR DESCRIPTION
## About The Pull Request
New shipside ranks
Starting > 10hrs > 25 hours > 100 hours > 300 hours (5 ranks in total)

Captain
Captain > Commodore > Rear Admiral > Vice Admiral > Admiral

Staff Officer
Ensign > Lieutenant Junior Grade > Lieutenant > Lieutenant Commander > Commander

Chief Engineer
Ensign > Lieutenant Junior Grade > Lieutenant > Lieutenant Commander > Commander

Chief Medical Officer
Senior Physician > Head Physician > Medical Supervisor > Medical Director > Chief Medical Officer

Requistions Officer
Ensign > Lieutenant Junior Grade > Lieutenant > Lieutenant Commander > Commander

Synthetic
Mark I > Mark II > Mark III > Mark IV > Mark V

Pilot Officer
Ensign > Lieutenant Junior Grade > Lieutenant > Lieutenant Commander > Commander

Medical Doctor
Medical Student > Junior Resident > Senior Resident > General Practitioner > Attending Physician

Ship Technician
Petty Officer Third Class > Petty Officer Second Class > Petty Officer First Class > Chief Petty Officer > Senior Chief Petty Officer

Researcher
Research Assistant > Researcher > Lecturer > Asscoiate Professor > Professor

Liaison
Corporate Intern > Corporate Associate > Corporate Partner > Corporate Analyst > Corporate Supervisor
## Why It's Good For The Game
Shipside ranks were wildly inconsistent especially in time; every rank now has the same times and ranks up to 300 hours (I won't make 1000 hour ranks because I am not cruel enough to subject someone to 1000 hours of a shipside role, I have standards.)
Some of the ranks were sort of hacked together since maintainers requested that CMO, MD and RSR remain civilian roles. If anyone has suggestions regarding those and their acronyms please throw them in the comments and I will see what I can do.
## Changelog
:cl:
spellcheck: New shipside role rank structure
/:cl:
