### PR TITLE
Fixes missing alamo consoles on Lawanka and Daedalus

### DIFF
--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -987,6 +987,11 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/southmeetingroom)
+"aOv" = (
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/obj/structure/table/mainship,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/lv624/lazarus/console)
 "aOR" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/air_alarm{
@@ -73255,7 +73260,7 @@ gfH
 mYW
 gfH
 gfH
-gfH
+aOv
 gfH
 gfH
 gfH

--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -20061,6 +20061,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/marshalls)
+"qym" = (
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/obj/structure/table,
+/turf/open/floor,
+/area/lv624/lazarus/console)
 "qyn" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -76738,7 +76743,7 @@ uty
 wEk
 wEk
 wEk
-wEk
+qym
 wEk
 wEk
 uty
@@ -76791,7 +76796,7 @@ rac
 nFU
 nFU
 nFU
-nFU
+qym
 nFU
 nFU
 rac


### PR DESCRIPTION

## About The Pull Request
Adds the dropship consoles to both landing zones in Lawanka and the landing zone in Daedalus
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: Fixes missing alamo consoles on Lawanka and Daedalus
/:cl:
