### PR TITLE
Increases QB for Gelida

### DIFF
--- a/_maps/gelida_iv.json
+++ b/_maps/gelida_iv.json
@@ -12,7 +12,7 @@
 		"set4": 2
 	},
     "armor": "ice",
-	"quickbuilds": 1600,
+	"quickbuilds": 1900,
 	"announce_text": "Our comms array has detected an automated emergency signal broadcasting over a frequency reserved for the highest level of emergencies. The message was traced to the northern reaches of the research colony Gelida IV. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",
 	"traits":[{
 		"weather_snowstorm": true


### PR DESCRIPTION

## About The Pull Request
1600 is quite low for a full sized map and it seems xenos always run out of QB before even mazing all of the disks. This increases QB to 1900, still less than some other maps.
## Why It's Good For The Game
Marines can move very fast when unobstructed, and this map isnt as linear as most so marines can usually find a path without any maze.
## Changelog
:cl:
balance: Increased QB points on Gelida to 1900.
/:cl:
