### PR TITLE
Reduces Pop Lock Requirement For Tank

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -526,7 +526,7 @@ You can serve your Division in a variety of roles, so choose carefully."})
 /datum/outfit/job/command/mech_pilot/fallen
 	ears = null
 
-#define ASSAULT_CREWMAN_POPLOCK 50
+#define ASSAULT_CREWMAN_POPLOCK 45
 //tank/arty driver+gunner
 /datum/job/terragov/command/assault_crewman
 	title = ASSAULT_CREWMAN


### PR DESCRIPTION

## About The Pull Request
Reduces the pop needed for assault crewman to spawn from 50 to 45. This does not touch how many marines are needed for the roles spawn, just the players on the server round-start
## Why It's Good For The Game
Considering tad FOB is no more, letting the tank become the spearhead more often should help them with pushing to areas they need to go to.
## Changelog
:cl:
balance: Reduce pop needed round-start for tank from 50 to 45
/:cl:
