### PR TITLE
Removes walking grenades

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -99,13 +99,6 @@
 /obj/item/explosive/grenade/fire_act(burn_level)
 	activate()
 
-/obj/item/explosive/grenade/attack_hand(mob/living/user)
-	. = ..()
-	if(.)
-		return
-	walk(src, null, null)
-	return
-
 ///Adjusts det time, used for grenade launchers
 /obj/item/explosive/grenade/proc/launched_det_time()
 	det_time = min(10, det_time)


### PR DESCRIPTION

## About The Pull Request
Grenades do not walk. Stop that.

Removes some random old CM code that doesn't do anything.

I would remove walk stuff entirely but simple mobs still use it. Someone totally should unfuck it though, TG made a movement SS.
:cl:
code: Removed some dead code
/:cl:
