### PR TITLE
Truck fix

### DIFF
--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -1254,22 +1254,22 @@
 	icon_state = "truck_enclosed_wrecked"
 
 /obj/structure/prop/vehicle/big_truck/tread
-	icon_state = "truck_flat"
+	icon_state = "truck_treads"
 
 /obj/structure/prop/vehicle/big_truck/flat_tread
-	icon_state = "truck_flat"
+	icon_state = "truck_flat_treads"
 
 /obj/structure/prop/vehicle/big_truck/enclosed_tread
-	icon_state = "truck_enclosed"
+	icon_state = "truck_enclosed_treads"
 
 /obj/structure/prop/vehicle/big_truck/wrecked_tread
-	icon_state = "truck_wrecked"
+	icon_state = "truck_treads_wrecked"
 
 /obj/structure/prop/vehicle/big_truck/flat_wrecked_tread
-	icon_state = "truck_flat_wrecked"
+	icon_state = "truck_flat_treads_wrecked"
 
 /obj/structure/prop/vehicle/big_truck/enclosed_wrecked_tread
-	icon_state = "truck_enclosed_wrecked"
+	icon_state = "truck_enclosed_treads_wrecked"
 
 
 /obj/structure/prop/vehicle/tank


### PR DESCRIPTION

## About The Pull Request
Treaded trucks will now use the correct sprites.
## Why It's Good For The Game
Correct sprites good
## Changelog
:cl:
fix: Treaded trucks now use the correct sprites.
/:cl:
