### PR TITLE
Magmoor tweaks

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -14370,10 +14370,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/northeast)
-"kaC" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/magmoor/medical/chemistry)
 "kaF" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -21004,11 +21000,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/rnd)
-"oRO" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/magmoor/medical/chemistry)
 "oRP" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 4
@@ -64691,8 +64682,8 @@ aXa
 dSo
 lUh
 lUh
-kaC
-kaC
+lUh
+lUh
 lUh
 lUh
 lUh
@@ -65155,7 +65146,7 @@ lGa
 lTp
 oGw
 dSo
-kaC
+lUh
 rKG
 lmZ
 bbG
@@ -65388,7 +65379,7 @@ wUY
 trh
 oGw
 dSo
-oRO
+lUh
 sBF
 ihH
 kAT
@@ -65621,7 +65612,7 @@ dXE
 cXr
 oGw
 dSo
-kaC
+lUh
 jlm
 xZH
 eHt

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1224,7 +1224,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "aSR" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3402,7 +3402,7 @@
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/cave/north)
+/area/magmoor/engi/garage)
 "cqc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -3562,6 +3562,9 @@
 	dir = 4
 	},
 /area/magmoor/compound/north)
+"ctB" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/engi/garage)
 "ctE" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -4388,7 +4391,7 @@
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "dcP" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/machinery/light,
@@ -6845,6 +6848,10 @@
 	dir = 4
 	},
 /area/magmoor/compound/east)
+"eJo" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/engi/garage)
 "eJu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -8998,7 +9005,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "glK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -9913,7 +9920,7 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "gWk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -11099,7 +11106,7 @@
 "hWc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "hWC" = (
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/magmoor/civilian/arrival/east)
@@ -11283,6 +11290,9 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/west)
+"ibS" = (
+/turf/open/floor/plating,
+/area/magmoor/engi/garage)
 "ice" = (
 /obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
@@ -13185,7 +13195,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "jto" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -15447,7 +15457,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "kWl" = (
 /obj/structure/lattice,
 /obj/structure/window/framed/colony/reinforced,
@@ -16252,7 +16262,7 @@
 "lAV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "lBd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -16281,7 +16291,7 @@
 "lCx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "lCA" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 1
@@ -16519,7 +16529,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "lNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -18872,10 +18882,6 @@
 	dir = 1
 	},
 /area/magmoor/command/conference)
-"nDD" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/magmoor/cave/north)
 "nDE" = (
 /obj/machinery/door/airlock/medical{
 	name = "\improper Changing Room"
@@ -19213,7 +19219,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "nSX" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
@@ -19603,7 +19609,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "oif" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -19998,7 +20004,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "owv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -21060,7 +21066,7 @@
 	name = "\improper Power Management"
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "pfg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/edge,
@@ -22610,7 +22616,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "qhU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22646,7 +22652,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "qjx" = (
 /obj/machinery/science/isolator/inserted,
 /turf/open/floor/mainship/sterile/purple,
@@ -22912,7 +22918,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/mainship,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "qtg" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -23902,7 +23908,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "rhG" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -24111,7 +24117,7 @@
 	on = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "rpI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -24124,7 +24130,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/magmoor/cave/north)
+/area/magmoor/engi/garage)
 "rpV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -24192,7 +24198,7 @@
 "rtB" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "rtK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -26027,7 +26033,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/magmoor/cave/north)
+/area/magmoor/engi/garage)
 "sMJ" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 8
@@ -27799,7 +27805,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/mainship,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "uaU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -29615,7 +29621,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/magmoor/cave/north)
+/area/magmoor/engi/garage)
 "vpf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -29850,7 +29856,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "vye" = (
 /obj/structure/rock/basalt/alt,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -29937,7 +29943,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "vBG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/side{
@@ -30632,7 +30638,7 @@
 "vZv" = (
 /obj/structure/prop/vehicle/crawler/crawler_fuel,
 /turf/open/floor/plating,
-/area/magmoor/cave/north)
+/area/magmoor/engi/garage)
 "vZF" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/side{
@@ -31160,9 +31166,6 @@
 	dir = 9
 	},
 /area/magmoor/medical/treatment)
-"wvq" = (
-/turf/closed/wall/r_wall,
-/area/magmoor/cave/rock)
 "wvH" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -31724,7 +31727,7 @@
 	name = "\improper Engineering Garage"
 	},
 /turf/open/floor/plating,
-/area/magmoor/compound/north)
+/area/magmoor/engi/garage)
 "wOk" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/tile/cmo,
@@ -47624,7 +47627,7 @@ vRc
 xyy
 xyy
 xyy
-aWO
+ctB
 xyy
 pDq
 pDq
@@ -47855,11 +47858,11 @@ vRc
 vRc
 xyy
 xyy
-aWO
-aWO
-aWO
-aWO
-gxb
+ctB
+ctB
+ctB
+ctB
+ctB
 pDq
 lqI
 lqI
@@ -48088,12 +48091,12 @@ vRc
 xyy
 xyy
 xyy
-ego
-kSy
+eJo
+ibS
 voh
 vxQ
-gxb
-gxb
+ctB
+ctB
 lqI
 lqI
 lqI
@@ -48320,14 +48323,14 @@ kcd
 vRc
 xyy
 xyy
-aWO
-aWO
+ctB
+ctB
 rpK
-kSy
+ibS
 owq
 ohW
-gxb
-gxb
+ctB
+ctB
 lqI
 lqI
 oPq
@@ -48553,12 +48556,12 @@ kxx
 vRc
 xyy
 xyy
-aWO
+ctB
 sLM
-cFH
-cFH
+ibS
+ibS
 dcL
-cFH
+ibS
 lMP
 wOh
 iha
@@ -48785,9 +48788,9 @@ kcd
 vRc
 vRc
 xyy
-aWO
-aWO
-kSy
+ctB
+ctB
+ibS
 lCx
 lCx
 qhG
@@ -49018,13 +49021,13 @@ kcd
 vRc
 xyy
 xyy
-aWO
+ctB
 cpY
-nDD
 lCx
-cFH
+lCx
+ibS
 glt
-cFH
+ibS
 gVu
 wOh
 kGc
@@ -49251,15 +49254,15 @@ vRc
 vRc
 xyy
 xyy
-aWO
-aWO
+ctB
+ctB
 vZv
 hWc
-cFH
+ibS
 rpH
 aSB
-gxb
-wvq
+ctB
+ctB
 lqI
 lqI
 lqI
@@ -49485,13 +49488,13 @@ xyy
 xyy
 xyy
 xyy
-aWO
-kSy
-cFH
+ctB
+ibS
+ibS
 kWk
 vxQ
 qsN
-gxb
+ctB
 pDq
 pDq
 pDq
@@ -49718,14 +49721,14 @@ ymj
 ymj
 ymj
 ymj
-aSp
-aSp
-cFH
-cFH
+ctB
+ctB
+ibS
+ibS
 vxQ
 rtB
-gxb
-wvq
+ctB
+ctB
 pDq
 lqI
 lqI
@@ -49952,13 +49955,13 @@ ymj
 ymj
 ymj
 ymj
-leZ
-tJb
+eJo
+ibS
 jtk
 rgO
 uaN
 lAV
-ybx
+eJo
 lqI
 lqI
 lqI
@@ -50185,13 +50188,13 @@ ymj
 ymj
 ymj
 ymj
-aSp
-aSp
-gxb
+ctB
+ctB
+ctB
 peW
-gxb
+ctB
 peW
-gxb
+ctB
 lqI
 lqI
 lqI

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -49491,7 +49491,7 @@ xyy
 ctB
 ibS
 ibS
-kWk
+ibS
 vxQ
 qsN
 ctB
@@ -49723,7 +49723,7 @@ ymj
 ymj
 ctB
 ctB
-ibS
+kWk
 ibS
 vxQ
 rtB

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1214,6 +1214,17 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/cult,
 /area/magmoor/cave/northwest)
+"aSB" = (
+/obj/machinery/door_control{
+	id = "engi_garage";
+	name = "Engineering Garage";
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/compound/north)
 "aSR" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2264,6 +2275,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/northwest)
+"bAS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete/edge{
+	dir = 1
+	},
+/area/magmoor/compound/north)
 "bBC" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3374,6 +3397,12 @@
 	dir = 5
 	},
 /area/magmoor/cargo/storage/south)
+"cpY" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/cave/north)
 "cqc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -4353,6 +4382,13 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi)
+"dcL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "dcP" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/machinery/light,
@@ -4938,6 +4974,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
 	},
@@ -6834,16 +6873,14 @@
 /turf/open/floor/plating,
 /area/magmoor/cave/north)
 "eJT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable,
-/turf/open/floor/plating/ground/concrete/edge{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/north)
 "eKc" = (
 /obj/structure/table/mainship,
@@ -7442,6 +7479,18 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/command/office/main)
+"fht" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/magmoor/compound/north)
 "fhx" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -8943,6 +8992,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
+"glt" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "glK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -9851,8 +9907,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
 "gVu" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/concrete/edge,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
 /area/magmoor/compound/north)
 "gWk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -11354,16 +11414,19 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/atmos)
-"igA" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/magmoor/volcano)
 "igV" = (
 /obj/machinery/door/window/secure,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/magmoor/hydroponics/south)
+"iha" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/magmoor/compound/north)
 "ihH" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/chemistry)
@@ -13117,6 +13180,12 @@
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"jtk" = (
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "jto" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -13931,6 +14000,9 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/concrete/lines{
@@ -14938,6 +15010,14 @@
 	dir = 1
 	},
 /area/magmoor/medical/lobby)
+"kGc" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/magmoor/compound/north)
 "kGs" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -15252,6 +15332,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
 	},
@@ -15359,6 +15442,12 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/magmoor/landing)
+"kWk" = (
+/obj/structure/prop/vehicle/big_truck{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "kWl" = (
 /obj/structure/lattice,
 /obj/structure/window/framed/colony/reinforced,
@@ -16160,6 +16249,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
+"lAV" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/magmoor/compound/north)
 "lBd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -16185,6 +16278,10 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
+"lCx" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "lCA" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 1
@@ -16416,6 +16513,13 @@
 	dir = 1
 	},
 /area/magmoor/civilian/arrival/east)
+"lMP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "lNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -16945,12 +17049,12 @@
 /turf/open/floor/mainship/tcomms,
 /area/magmoor/research/serverroom)
 "mef" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/concrete/edge{
@@ -17031,12 +17135,6 @@
 /obj/item/mecha_parts/part/durand_armor,
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi)
-"miE" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/magmoor/compound/north)
 "miM" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -18774,6 +18872,10 @@
 	dir = 1
 	},
 /area/magmoor/command/conference)
+"nDD" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/magmoor/cave/north)
 "nDE" = (
 /obj/machinery/door/airlock/medical{
 	name = "\improper Changing Room"
@@ -19105,6 +19207,13 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/basket)
+"nSH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "nSX" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
@@ -19489,6 +19598,12 @@
 "ohT" = (
 /turf/closed/wall,
 /area/magmoor/civilian/bar)
+"ohW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/compound/north)
 "oif" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -19872,6 +19987,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/research)
+"owq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/compound/north)
 "owv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -20928,6 +21055,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/lavaland/catwalk,
 /area/magmoor/compound)
+"peW" = (
+/obj/machinery/door/airlock/mainship/engineering{
+	name = "\improper Power Management"
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "pfg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/edge,
@@ -22468,6 +22601,16 @@
 	dir = 8
 	},
 /area/magmoor/civilian/clean)
+"qhG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "qhU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22498,6 +22641,12 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/shower)
+"qjc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "qjx" = (
 /obj/machinery/science/isolator/inserted,
 /turf/open/floor/mainship/sterile/purple,
@@ -22758,6 +22907,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
+"qsN" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/magmoor/compound/north)
 "qtg" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -23741,6 +23896,13 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/command/lobby)
+"rgO" = (
+/obj/effect/ai_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/compound/north)
 "rhG" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -23937,6 +24099,19 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
+"rpH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/compound/north)
 "rpI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -23944,6 +24119,12 @@
 /obj/structure/sign/examroom,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/lobby)
+"rpK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/magmoor/cave/north)
 "rpV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -24008,6 +24189,10 @@
 "rtA" = (
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/civilian/jani)
+"rtB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/mainship,
+/area/magmoor/compound/north)
 "rtK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -25837,6 +26022,12 @@
 	dir = 4
 	},
 /area/magmoor/engi)
+"sLM" = (
+/obj/structure/prop/vehicle/crawler/crawler_red{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/magmoor/cave/north)
 "sMJ" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 8
@@ -27603,6 +27794,12 @@
 	dir = 1
 	},
 /area/magmoor/compound/north)
+"uaN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/magmoor/compound/north)
 "uaU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -28248,6 +28445,15 @@
 	dir = 1
 	},
 /area/magmoor/cargo/processing/south)
+"utS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete,
+/area/magmoor/compound/north)
 "utT" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 4
@@ -29404,6 +29610,12 @@
 	dir = 4
 	},
 /area/magmoor/security/infocenter)
+"voh" = (
+/obj/structure/prop/vehicle/crane/cranecargo/destructible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/magmoor/cave/north)
 "vpf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -29628,9 +29840,16 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
 	},
+/area/magmoor/compound/north)
+"vxQ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/magmoor/compound/north)
 "vye" = (
 /obj/structure/rock/basalt/alt,
@@ -29707,6 +29926,17 @@
 "vBC" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/edge,
+/area/magmoor/compound/north)
+"vBE" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	id = "engi_garage";
+	name = "\improper Engineering Garage"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/magmoor/compound/north)
 "vBG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30399,6 +30629,10 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/mosque)
+"vZv" = (
+/obj/structure/prop/vehicle/crawler/crawler_fuel,
+/turf/open/floor/plating,
+/area/magmoor/cave/north)
 "vZF" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/side{
@@ -30926,6 +31160,9 @@
 	dir = 9
 	},
 /area/magmoor/medical/treatment)
+"wvq" = (
+/turf/closed/wall/r_wall,
+/area/magmoor/cave/rock)
 "wvH" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -31480,6 +31717,14 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/northwest)
+"wOh" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	id = "engi_garage";
+	name = "\improper Engineering Garage"
+	},
+/turf/open/floor/plating,
+/area/magmoor/compound/north)
 "wOk" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/tile/cmo,
@@ -32588,6 +32833,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 5
 	},
@@ -47147,7 +47395,7 @@ xyy
 xyy
 pDq
 pDq
-lqI
+pDq
 oPq
 lqI
 lqI
@@ -47376,11 +47624,11 @@ vRc
 xyy
 xyy
 xyy
+aWO
 xyy
-xyy
-vBZ
 pDq
-lqI
+pDq
+pDq
 lqI
 lqI
 lqI
@@ -47607,12 +47855,12 @@ vRc
 vRc
 xyy
 xyy
-xyy
-xyy
-xyy
-xyy
-xfT
-lqI
+aWO
+aWO
+aWO
+aWO
+gxb
+pDq
 lqI
 lqI
 lqI
@@ -47840,12 +48088,12 @@ vRc
 xyy
 xyy
 xyy
-xyy
-xyy
-xyy
-xfT
-xfT
-lqI
+ego
+kSy
+voh
+vxQ
+gxb
+gxb
 lqI
 lqI
 lqI
@@ -48072,14 +48320,14 @@ kcd
 vRc
 xyy
 xyy
-xyy
-xyy
-xyy
-xyy
-xfT
-lqI
-oPq
-lqI
+aWO
+aWO
+rpK
+kSy
+owq
+ohW
+gxb
+gxb
 lqI
 lqI
 oPq
@@ -48305,19 +48553,19 @@ kxx
 vRc
 xyy
 xyy
-xyy
-xyy
-vBZ
-xfT
-lqI
-lqI
-lqI
-lqI
-lqI
-lqI
-lqI
-dXE
-lQy
+aWO
+sLM
+cFH
+cFH
+dcL
+cFH
+lMP
+wOh
+iha
+qHR
+qHR
+qHR
+khH
 vyy
 iks
 lqI
@@ -48537,19 +48785,19 @@ kcd
 vRc
 vRc
 xyy
-xyy
-xyy
-xyy
-xfT
-lqI
-fJD
-qHR
-qHR
-qHR
-qHR
-qHR
-qHR
-qHR
+aWO
+aWO
+kSy
+lCx
+lCx
+qhG
+qjc
+nSH
+vBE
+utS
+kLr
+kLr
+kLr
 eJT
 hNM
 gwg
@@ -48770,16 +49018,16 @@ kcd
 vRc
 xyy
 xyy
-xyy
-xyy
-xyy
-xfT
-lqI
-trh
-jKH
+aWO
+cpY
+nDD
+lCx
+cFH
+glt
+cFH
 gVu
-lGa
-lGa
+wOh
+kGc
 gNd
 lGa
 lGa
@@ -49003,15 +49251,15 @@ vRc
 vRc
 xyy
 xyy
-xyy
-xyy
-xyy
-xfT
-lqI
-trh
-iNL
-vyy
-pDq
+aWO
+aWO
+vZv
+hWc
+cFH
+rpH
+aSB
+gxb
+wvq
 lqI
 lqI
 lqI
@@ -49237,13 +49485,13 @@ xyy
 xyy
 xyy
 xyy
-xyy
-xyy
-vBZ
-lqI
-trh
-iNL
-vyy
+aWO
+kSy
+cFH
+kWk
+vxQ
+qsN
+gxb
 pDq
 pDq
 pDq
@@ -49470,14 +49718,14 @@ ymj
 ymj
 ymj
 ymj
-ymj
-ymj
-xfT
-xfT
-trh
-iNL
-vyy
-pDq
+aSp
+aSp
+cFH
+cFH
+vxQ
+rtB
+gxb
+wvq
 pDq
 lqI
 lqI
@@ -49704,18 +49952,18 @@ ymj
 ymj
 ymj
 ymj
-ymj
-ymj
-xfT
-trh
-jKH
-vyy
-lqI
+leZ
+tJb
+jtk
+rgO
+uaN
+lAV
+ybx
 lqI
 lqI
 lqI
 oPq
-lqI
+iwE
 lqI
 lqI
 xfT
@@ -49937,13 +50185,13 @@ ymj
 ymj
 ymj
 ymj
-ymj
-ymj
-xfT
-trh
-iNL
-vyy
-iKT
+aSp
+aSp
+gxb
+peW
+gxb
+peW
+gxb
 lqI
 lqI
 lqI
@@ -50172,11 +50420,11 @@ ymj
 ymj
 ymj
 ymj
-gxb
-miE
-gAp
-mOw
-gxb
+aSp
+kxw
+kVa
+frD
+aSp
 oPq
 lqI
 lqI
@@ -50405,11 +50653,11 @@ ymj
 ymj
 ymj
 ymj
-evt
-hWc
-fVX
-cFH
-puq
+rbw
+pgJ
+ktt
+tJb
+vzP
 mPq
 mPq
 xfT
@@ -50430,7 +50678,7 @@ bQv
 rWR
 dSo
 dSo
-nUF
+fht
 vyy
 dSo
 jIN
@@ -50663,7 +50911,7 @@ dSo
 dSo
 dSo
 dSo
-nUF
+fht
 vyy
 dSo
 dSo
@@ -50896,7 +51144,7 @@ gGI
 uyR
 uyR
 uyR
-rSY
+bAS
 wXX
 uyR
 kyY
@@ -51105,9 +51353,9 @@ ymj
 ymj
 ymj
 sBc
+xja
 tJb
-tJb
-igA
+pgJ
 eFU
 rxl
 ymj
@@ -55086,7 +55334,7 @@ ybx
 ybx
 gxb
 gxb
-nUF
+fht
 oLH
 lGa
 uSM
@@ -55319,7 +55567,7 @@ ymj
 ymj
 ymj
 vEO
-nUF
+fht
 vyy
 dSo
 fwM
@@ -55785,7 +56033,7 @@ rxl
 ymj
 ymj
 vEO
-nUF
+fht
 vyy
 dSo
 joN
@@ -56018,7 +56266,7 @@ ymj
 ymj
 ymj
 vEO
-nUF
+fht
 vyy
 dSo
 joN
@@ -56251,7 +56499,7 @@ ymj
 ymj
 ymj
 vEO
-nUF
+fht
 vyy
 dSo
 dSo
@@ -56484,7 +56732,7 @@ ymj
 ymj
 ymj
 xfT
-nUF
+fht
 vyy
 lZb
 dSo
@@ -57188,7 +57436,7 @@ iyf
 iyf
 iyf
 iyf
-nUF
+fht
 iNL
 vyy
 som

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1,16 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
+/obj/machinery/door/window/secure{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "aab" = (
@@ -776,10 +768,11 @@
 /area/magmoor/compound/southeast)
 "aAC" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/weaponry/ammo/shotgun,
-/turf/open/floor/tile/red/redtaupe{
+/obj/item/ashtray/bronze,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "aAG" = (
 /obj/structure/stairs/seamless/edge_vert,
@@ -934,6 +927,18 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"aGB" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/magmoor/security/storage)
 "aHi" = (
 /obj/machinery/air_alarm{
 	dir = 8
@@ -966,10 +971,6 @@
 	dir = 4
 	},
 /area/magmoor/civilian/arrival/east)
-"aJE" = (
-/obj/structure/bed/bunkbed,
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "aJH" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 6
@@ -980,7 +981,10 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/magmoor/compound/south)
 "aKn" = (
-/obj/structure/closet/secure_closet/security,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
 	},
@@ -1202,7 +1206,8 @@
 /turf/open/floor/grass,
 /area/magmoor/hydroponics/south)
 "aSm" = (
-/obj/structure/closet/secure_closet/security,
+/obj/structure/table/reinforced,
+/obj/machinery/faxmachine/brig,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -1304,12 +1309,6 @@
 "aUQ" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/command/office/main)
-"aUR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/infocenter)
 "aUW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1338,6 +1337,13 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/magmoor/civilian/rnr)
+"aWK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "aWO" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/cave/north)
@@ -1668,6 +1674,10 @@
 	dir = 1
 	},
 /area/magmoor/compound)
+"beD" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/tile/dark/red2,
+/area/magmoor/security/storage)
 "beH" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/grass,
@@ -1699,13 +1709,13 @@
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/jani)
 "bfs" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 8
-	},
-/area/magmoor/security/infocenter)
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "bfN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/window/framed/colony/reinforced,
@@ -1757,15 +1767,8 @@
 	},
 /area/magmoor/compound/northwest)
 "bhF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/turf/open/floor/tile/red/redtaupe{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark/red2{
-	dir = 1
 	},
 /area/magmoor/security/infocenter)
 "bhS" = (
@@ -1825,12 +1828,8 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
 "bky" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/syndicate,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
+/obj/structure/closet/bombclosetsecurity,
+/turf/open/floor/tile/red/redtaupecorner,
 /area/magmoor/security/infocenter)
 "bkD" = (
 /obj/machinery/conveyor{
@@ -1874,6 +1873,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 1
 	},
@@ -1968,13 +1968,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
 "bpz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1;
-	welded = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/open/floor/tile/red/redtaupe{
@@ -2769,8 +2764,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival)
 "bQc" = (
-/obj/machinery/vending/security,
-/turf/open/floor/tile/red/redtaupe,
+/turf/open/floor/tile/red/redtaupecorner,
 /area/magmoor/security/infocenter)
 "bQv" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -3154,6 +3148,15 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
+"cgC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	welded = 1
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/magmoor/security/infocenter)
 "cgW" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -3616,6 +3619,10 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/side,
 /area/magmoor/command/conference)
+"cvm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "cvp" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -3769,20 +3776,6 @@
 	dir = 4
 	},
 /area/magmoor/engi/storage)
-"cEE" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 1
-	},
-/area/magmoor/security/infocenter)
-"cEF" = (
-/obj/effect/landmark/corpsespawner/prisoner/burst,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1;
-	welded = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "cEM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -3925,6 +3918,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
+"cJf" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "cJq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -4373,6 +4374,24 @@
 	dir = 10
 	},
 /area/magmoor/compound/north)
+"dby" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
+"dbA" = (
+/obj/effect/landmark/corpsespawner/prisoner/burst,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "dcg" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -4481,12 +4500,14 @@
 /turf/closed/wall,
 /area/magmoor/hydroponics/north)
 "dfE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/tile/red/redtaupecorner,
-/area/magmoor/security/infocenter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "dgj" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mainship/cargo,
@@ -4568,13 +4589,7 @@
 /area/magmoor/landing/two)
 "din" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "dio" = (
@@ -4728,11 +4743,6 @@
 	dir = 1
 	},
 /area/magmoor/engi/atmos)
-"dob" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/secure_data,
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/lobby)
 "doh" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/hydroponics/south)
@@ -4744,7 +4754,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/magmoor/engi/thermal)
 "doD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "doR" = (
@@ -5003,6 +5020,9 @@
 	dir = 1
 	},
 /area/magmoor/compound/north)
+"dwm" = (
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/storage)
 "dwo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -5704,6 +5724,9 @@
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/mainship/cargo,
 /area/magmoor/cargo/storage/secure/south)
+"dUN" = (
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/storage)
 "dVc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -5743,10 +5766,8 @@
 /turf/open/floor/mainship/red,
 /area/magmoor/security/storage)
 "dWD" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
+/obj/structure/closet/bombclosetsecurity,
+/turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/infocenter)
 "dWH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -5811,11 +5832,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/cargo/processing/south)
-"dYn" = (
-/obj/structure/table/reinforced,
-/obj/item/flash,
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/infocenter)
 "dYD" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -6012,6 +6028,14 @@
 "ehQ" = (
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"ehW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/magmoor/security/storage)
 "ein" = (
 /obj/structure/disposalpipe/down{
 	dir = 1
@@ -6168,9 +6192,7 @@
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
 "enT" = (
-/obj/machinery/door/airlock/mainship/security{
-	name = "\improper Security Lobby"
-	},
+/obj/machinery/computer/forensic_scanning,
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
 	},
@@ -6194,6 +6216,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/rnd)
+"eqA" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/magmoor/security/infocenter)
 "eqF" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -6210,16 +6240,13 @@
 	},
 /area/magmoor/civilian/pool)
 "erD" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/cleanable/blood/gibs/xeno/core,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "erJ" = (
@@ -6274,20 +6301,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
 /area/magmoor/civilian/cryostasis)
-"etJ" = (
-/obj/machinery/door/airlock/mainship/security{
-	dir = 8;
-	name = "\improper Security Breakroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile,
-/area/magmoor/security/lobby)
 "etK" = (
 /obj/machinery/science/pathogenic_incubator/open,
 /obj/machinery/light{
@@ -6343,13 +6356,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/patient)
-"euu" = (
-/obj/machinery/faxmachine/brig,
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 8
-	},
-/area/magmoor/security/infocenter)
 "euH" = (
 /obj/machinery/light{
 	dir = 4
@@ -6455,18 +6461,13 @@
 	},
 /area/magmoor/medical/storage)
 "exF" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Holding Cell"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/detective,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "eyg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6539,6 +6540,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
+"eAw" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "eAy" = (
 /obj/effect/landmark/patrol_point/tgmc_23,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -6570,11 +6576,13 @@
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
 "eBh" = (
-/obj/structure/bed/chair,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/area/magmoor/security/infocenter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "eBl" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/mainship/blue{
@@ -6620,6 +6628,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
+"eCE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "eCK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6635,13 +6655,6 @@
 	dir = 1
 	},
 /area/magmoor/civilian/rnr)
-"eDc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "eDq" = (
 /obj/structure/table/mainship,
 /obj/structure/rock/basalt/pile/alt3,
@@ -6756,6 +6769,18 @@
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/mainship/blue,
 /area/magmoor/command/lobby)
+"eGW" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "eHj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small{
@@ -7146,6 +7171,17 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
+"eSf" = (
+/obj/machinery/door/airlock/mainship/security{
+	dir = 1;
+	name = "\improper Warden's Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red,
+/area/magmoor/security/storage)
 "eSj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -7236,6 +7272,12 @@
 	dir = 4
 	},
 /area/magmoor/engi/power)
+"eWb" = (
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "eWt" = (
 /turf/closed/wall/indestructible/bulkhead,
 /area/magmoor/landing)
@@ -8318,6 +8360,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"fLn" = (
+/obj/structure/table/reinforced,
+/obj/item/flash,
+/turf/open/floor/tile/dark/red2,
+/area/magmoor/security/storage)
 "fLr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8391,16 +8438,6 @@
 	dir = 4
 	},
 /area/magmoor/compound/southwest)
-"fNe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "fNf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8418,6 +8455,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/southwest)
+"fNw" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "fOm" = (
 /turf/open/floor/wood,
 /area/magmoor/civilian/jani)
@@ -8441,6 +8483,12 @@
 	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/northwest)
+"fQa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/storage)
 "fQg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8736,6 +8784,16 @@
 	dir = 6
 	},
 /area/magmoor/compound)
+"gaM" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "gaP" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/landmark/weed_node,
@@ -8841,6 +8899,14 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi)
+"geK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/storage)
 "geP" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/gun/rifle/m16,
@@ -9235,8 +9301,6 @@
 	},
 /area/magmoor/compound/northeast)
 "guy" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/gun/energy/taser,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 1
 	},
@@ -9492,6 +9556,13 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/shower)
+"gCi" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/lobby)
 "gCk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -9541,18 +9612,11 @@
 	},
 /area/magmoor/compound/west)
 "gEe" = (
-/obj/item/explosive/plastique{
-	pixel_x = 3;
-	pixel_y = 7
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/item/explosive/plastique{
-	pixel_y = 4
-	},
-/obj/structure/rack,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "gEB" = (
 /obj/structure/bed/stool,
@@ -9714,6 +9778,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/magmoor/compound/north)
+"gKu" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/item/shard{
+	pixel_x = -9
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/west)
 "gKI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -9914,12 +9985,6 @@
 	},
 /turf/open/floor/mainship/orange,
 /area/magmoor/cargo/storage/secure/south)
-"gUI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/red2{
-	dir = 1
-	},
-/area/magmoor/security/infocenter)
 "gUT" = (
 /obj/machinery/landinglight/lz2{
 	dir = 4
@@ -9932,6 +9997,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
+"gVO" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/infocenter)
 "gWk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -9940,16 +10012,6 @@
 	dir = 1
 	},
 /area/magmoor/cargo/storage/secure/south)
-"gWS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/security{
-	dir = 1;
-	name = "\improper Security Breakroom"
-	},
-/turf/open/floor/tile,
-/area/magmoor/security/infocenter)
 "gXo" = (
 /obj/machinery/air_alarm{
 	dir = 8
@@ -10019,6 +10081,15 @@
 /obj/item/shard,
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
+"hbE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	welded = 1
+	},
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 1
+	},
+/area/magmoor/security/infocenter)
 "hbM" = (
 /obj/structure/table/mainship,
 /obj/item/healthanalyzer,
@@ -10376,6 +10447,17 @@
 	dir = 8
 	},
 /area/magmoor/research/rnd)
+"hrb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 8
+	},
+/area/magmoor/security/storage)
 "hrd" = (
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/cave/north)
@@ -10390,6 +10472,13 @@
 "hrv" = (
 /turf/open/floor/tile/dark2,
 /area/magmoor/civilian/mosque)
+"hrF" = (
+/obj/item/shard{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/west)
 "hrH" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison/kitchen,
@@ -10491,6 +10580,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/landing)
+"huH" = (
+/obj/item/weapon/gun/revolver/cmb{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "hvH" = (
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -10704,6 +10803,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/orange,
 /area/magmoor/cargo/processing/south)
+"hDB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "hDZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10718,6 +10826,12 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi)
+"hEg" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/infocenter)
 "hEl" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -11030,6 +11144,12 @@
 	dir = 1
 	},
 /area/magmoor/compound/east)
+"hSR" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 2
+	},
+/area/magmoor/security/lobby)
 "hTt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11371,6 +11491,13 @@
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival/east)
+"ieq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	welded = 1
+	},
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "ier" = (
 /obj/machinery/light{
 	dir = 8
@@ -11418,6 +11545,16 @@
 	dir = 8
 	},
 /area/magmoor/cargo/processing/south)
+"ifh" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/storage)
 "ifp" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -11723,12 +11860,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/power)
-"iqN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "iqO" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
@@ -11794,6 +11925,24 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
+"itD" = (
+/obj/structure/closet/gimmick{
+	anchored = 1;
+	name = "Riot gear"
+	},
+/obj/item/weapon/shield/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/magmoor/security/storage)
 "itH" = (
 /obj/structure/curtain/open/medical,
 /turf/open/floor/mainship/sterile/dark,
@@ -12266,9 +12415,8 @@
 /turf/open/floor/grass,
 /area/magmoor/civilian/clean)
 "iNr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
@@ -12469,6 +12617,16 @@
 	dir = 1
 	},
 /area/magmoor/compound/northwest)
+"iUC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "iUD" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/mainship/blue{
@@ -12479,8 +12637,9 @@
 /turf/closed/wall,
 /area/magmoor/medical/cmo)
 "iVe" = (
-/obj/machinery/vending/nanomed,
-/turf/open/floor/tile/red/redtaupecorner,
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/infocenter)
 "iVV" = (
 /obj/structure/largecrate/supply/medicine/iv,
@@ -12563,6 +12722,15 @@
 /obj/effect/spawner/random/food_or_drink/kitchenknife,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
+"iZN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "jaj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -12753,13 +12921,6 @@
 	dir = 4
 	},
 /area/magmoor/compound/east)
-"jfI" = (
-/obj/machinery/door/airlock/mainship/security{
-	dir = 1;
-	name = "\improper Security Breakroom"
-	},
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "jfW" = (
 /obj/item/shard/phoron,
 /turf/open/floor/mainship/sterile/dark,
@@ -12794,19 +12955,6 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating,
 /area/magmoor/cave/north)
-"jhh" = (
-/obj/effect/decal/cleanable/blood/six,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
-	},
-/area/magmoor/security/lobby)
 "jho" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -13099,6 +13247,16 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival)
+"jpn" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 1
+	},
+/area/magmoor/security/infocenter)
 "jps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/cult,
@@ -13222,8 +13380,10 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
 "jtC" = (
-/turf/open/floor/tile,
-/area/magmoor/security/infocenter)
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "jtD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13497,6 +13657,22 @@
 	dir = 10
 	},
 /area/magmoor/compound/northeast)
+"jEi" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	pixel_y = 11
+	},
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/infocenter)
 "jEv" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -13599,6 +13775,18 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/storage)
+"jHk" = (
+/obj/machinery/door/airlock/mainship/security{
+	name = "\improper Armoury"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red,
+/area/magmoor/security/storage)
 "jHK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13687,21 +13875,17 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
 "jJJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 8
 	},
 /area/magmoor/security/infocenter)
-"jJW" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/lobby)
 "jKf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13714,6 +13898,19 @@
 	dir = 4
 	},
 /area/magmoor/compound)
+"jKr" = (
+/obj/machinery/door/airlock/mainship/security/glass{
+	name = "\improper Holding Cell";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/lobby)
 "jKu" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13772,11 +13969,14 @@
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
 "jMh" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/area/magmoor/security/infocenter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/lobby)
 "jMi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13863,6 +14063,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival/east)
+"jQa" = (
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "jQe" = (
 /obj/machinery/light{
 	dir = 4
@@ -13935,6 +14138,16 @@
 	dir = 1
 	},
 /area/magmoor/civilian/dorms)
+"jSe" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "jSk" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -14092,7 +14305,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/red/redtaupe{
 	dir = 8
 	},
@@ -14291,17 +14503,6 @@
 /obj/structure/table/gamblingtable,
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
-"kfY" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "kgb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14816,6 +15017,15 @@
 /obj/item/tool/stamp,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/commandroom)
+"kzv" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/corpsespawner/prison_security,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/storage)
 "kzB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -14965,6 +15175,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/lobby)
+"kEw" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/infocenter)
 "kEA" = (
 /obj/item/lightstick/anchored,
 /obj/effect/ai_node,
@@ -15071,6 +15289,13 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/magmoor/mining/garage)
+"kHP" = (
+/obj/machinery/door/airlock/mainship/security{
+	dir = 8;
+	name = "\improper Security Breakroom"
+	},
+/turf/open/floor/tile/red,
+/area/magmoor/security/infocenter)
 "kIw" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 6
@@ -15150,18 +15375,6 @@
 	dir = 8
 	},
 /area/magmoor/research/rnd/lobby)
-"kLd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark/red2{
-	dir = 1
-	},
-/area/magmoor/security/infocenter)
 "kLm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -15265,6 +15478,17 @@
 	dir = 1
 	},
 /area/magmoor/research/containment)
+"kPM" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "kPP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15549,6 +15773,10 @@
 	dir = 10
 	},
 /area/magmoor/compound/southwest)
+"kYM" = (
+/obj/machinery/vending/security,
+/turf/open/floor/tile/red,
+/area/magmoor/security/infocenter)
 "kZC" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -15559,17 +15787,29 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/magmoor/command/office/main)
+"kZG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/computer/intel_computer,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/magmoor/security/storage)
+"kZZ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/gun/energy/taser,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/magmoor/security/infocenter)
 "laA" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/research)
-"laM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	welded = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "laS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -15930,12 +16170,6 @@
 	},
 /turf/open/floor/mainship/green,
 /area/magmoor/hydroponics/north)
-"loi" = (
-/obj/machinery/computer/forensic_scanning,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 2
-	},
-/area/magmoor/security/lobby)
 "lop" = (
 /obj/structure/prop/oresilo,
 /turf/open/floor/plating/mainship,
@@ -15964,10 +16198,10 @@
 /area/magmoor/research)
 "lpe" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/tile/red/redtaupe{
@@ -16131,10 +16365,6 @@
 	dir = 1
 	},
 /area/magmoor/civilian/dorms)
-"lvJ" = (
-/obj/item/ammo_casing,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/lobby)
 "lvP" = (
 /obj/structure/cargo_container/nt{
 	dir = 1
@@ -16302,6 +16532,16 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/basket)
+"lCe" = (
+/obj/machinery/vending/nanomed,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/storage)
 "lCx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16362,6 +16602,14 @@
 	dir = 1
 	},
 /area/magmoor/command/lobby/east)
+"lFu" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "lFD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16738,10 +16986,6 @@
 	dir = 9
 	},
 /area/magmoor/compound/north)
-"lSS" = (
-/obj/structure/bed/chair,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "lST" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -16812,11 +17056,15 @@
 /turf/open/floor/wood,
 /area/magmoor/command/office)
 "lUZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/weaponry/ammo/shotgun,
-/obj/effect/spawner/random/weaponry/ammo/shotgun,
-/obj/effect/spawner/random/weaponry/gun/shotgun,
-/turf/open/floor/tile/dark/red2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
 /area/magmoor/security/infocenter)
 "lVp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -16826,6 +17074,11 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
+"lVv" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/magmoor/security/storage)
 "lVE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -16969,10 +17222,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/mainship/mono,
 /area/magmoor/research/rnd/lobby)
-"maL" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "maS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -17236,6 +17485,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
+"mlU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "mlZ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
@@ -17270,6 +17523,16 @@
 	},
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound)
+"moe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "mow" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17425,6 +17688,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/landing/two)
+"mwG" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/magmoor/security/storage)
 "mwM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -17438,6 +17705,10 @@
 	dir = 5
 	},
 /area/magmoor/civilian/arrival)
+"mxr" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/red,
+/area/magmoor/security/infocenter)
 "mxC" = (
 /turf/open/floor/tile/red/redtaupe{
 	dir = 8
@@ -17541,8 +17812,14 @@
 /turf/open/floor/mainship/silver,
 /area/magmoor/civilian/arrival/east)
 "mCp" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/mainship/mono,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/red/redtaupecorner,
 /area/magmoor/security/infocenter)
 "mCt" = (
 /obj/machinery/power/apc/drained{
@@ -17642,11 +17919,9 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
-"mFm" = (
+"mFf" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 1
-	},
+/turf/open/floor/tile/red,
 /area/magmoor/security/infocenter)
 "mFv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17930,6 +18205,12 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/research/rnd/lobby)
+"mPT" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "mPW" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -18252,17 +18533,6 @@
 	dir = 10
 	},
 /area/magmoor/medical/treatment)
-"nbR" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "nbS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -18647,6 +18917,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/basket)
+"nsc" = (
+/obj/effect/decal/cleanable/blood/six,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "nsr" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/silver,
@@ -18853,7 +19128,12 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/atmos)
 "nBs" = (
-/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
 /turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/lobby)
 "nBx" = (
@@ -18924,14 +19204,14 @@
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
 "nEg" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "nEn" = (
@@ -19176,11 +19456,16 @@
 	},
 /area/magmoor/civilian/clean)
 "nQY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
 /area/magmoor/security/infocenter)
 "nRj" = (
 /obj/machinery/floodlight/colony{
@@ -19316,12 +19601,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/wood,
 /area/magmoor/command/office/main)
-"nWl" = (
-/obj/effect/landmark/corpsespawner,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
-	},
-/area/magmoor/security/lobby)
 "nWx" = (
 /turf/open/floor/mainship/silver{
 	dir = 4
@@ -19809,6 +20088,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
+"opN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/storage)
 "oqh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -20318,12 +20604,6 @@
 	dir = 4
 	},
 /area/magmoor/civilian/clean/shower)
-"oEN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/infocenter)
 "oFF" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -20586,6 +20866,9 @@
 	},
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound/south)
+"oOi" = (
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "oOw" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -20810,12 +21093,15 @@
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing/two)
 "oVR" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 4
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/infocenter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "oWD" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 4
@@ -21292,7 +21578,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/security{
-	name = "\improper Armoury"
+	name = "\improper Security Office"
 	},
 /turf/open/floor/tile,
 /area/magmoor/security/infocenter)
@@ -21315,6 +21601,12 @@
 	},
 /turf/open/floor/tile/white,
 /area/magmoor/civilian/pool)
+"pne" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "pnC" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -21334,23 +21626,9 @@
 	},
 /area/magmoor/compound/northwest)
 "pok" = (
-/obj/item/shard{
-	pixel_x = -9
-	},
-/obj/item/shard{
-	pixel_x = 12;
-	pixel_y = 7
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark/red2{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/security_space_law,
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "poC" = (
 /obj/machinery/hydroponics,
@@ -21512,6 +21790,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean)
+"ptJ" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/lobby)
 "ptS" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/emerald{
@@ -21826,13 +22110,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
 "pEz" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "pEF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -21982,7 +22264,9 @@
 /turf/open/floor/mainship/sterile,
 /area/magmoor/medical/lobby)
 "pLU" = (
-/obj/machinery/vending/cigarette,
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 8
 	},
@@ -22238,11 +22522,12 @@
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/magmoor/compound/south)
 "pTv" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/area/magmoor/security/infocenter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "pUd" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
@@ -22345,14 +22630,9 @@
 	},
 /area/magmoor/command/conference)
 "pXw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
+/obj/structure/bed/bunkbed,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "pXX" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/mainship/mono,
@@ -22372,12 +22652,6 @@
 	},
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/magmoor/compound/east)
-"pZr" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/magmoor/security/infocenter)
 "pZu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22689,6 +22963,16 @@
 /obj/structure/cable,
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/dorms)
+"qkm" = (
+/obj/item/ammo_casing/shell,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/storage)
 "qkn" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -22881,6 +23165,13 @@
 	dir = 8
 	},
 /area/magmoor/engi/atmos)
+"qrK" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/security_space_law,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/magmoor/security/infocenter)
 "qrL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23228,6 +23519,13 @@
 	dir = 6
 	},
 /area/magmoor/compound/north)
+"qCx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "qDc" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/cigar,
@@ -23245,10 +23543,6 @@
 /obj/structure/table/woodentable,
 /turf/open/floor/mainship/floor,
 /area/magmoor/hydroponics/south)
-"qFf" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/lobby)
 "qFr" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/storage)
@@ -23334,6 +23628,12 @@
 	dir = 4
 	},
 /area/magmoor/command/commandroom)
+"qIK" = (
+/obj/machinery/light,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/lobby)
 "qIT" = (
 /turf/open/floor/mainship/black,
 /area/magmoor/landing)
@@ -23491,13 +23791,15 @@
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/power)
 "qQZ" = (
-/obj/structure/bed/chair{
+/obj/machinery/door/airlock/mainship/security{
 	dir = 1;
-	pixel_y = 11
+	name = "\improper Security Breakroom"
 	},
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red,
 /area/magmoor/security/infocenter)
 "qRH" = (
 /turf/open/floor/plating/ground/concrete/lines{
@@ -23539,6 +23841,11 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/magmoor/medical/cmo)
+"qUk" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "qUy" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23976,6 +24283,23 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/purple/taupepurple,
 /area/magmoor/civilian/dorms)
+"rjR" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/explosive/plastique{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/explosive/plastique{
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "rjZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -24073,6 +24397,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship,
 /area/magmoor/cargo/processing/south)
+"rou" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "roE" = (
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
@@ -24178,6 +24506,15 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
 /area/magmoor/engi/atmos)
+"rtj" = (
+/obj/structure/table/reinforced,
+/obj/item/ashtray/bronze,
+/obj/item/trash/cigbutt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "rtk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24359,14 +24696,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi)
-"ryW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/red/redtaupe{
-	dir = 1
-	},
-/area/magmoor/security/infocenter)
 "rzj" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -24444,6 +24773,12 @@
 	},
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound/north)
+"rCo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/magmoor/security/lobby)
 "rCt" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side,
@@ -24461,6 +24796,13 @@
 	dir = 10
 	},
 /area/magmoor/civilian/cryostasis)
+"rDe" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/infocenter)
 "rDp" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/emerald{
@@ -24500,6 +24842,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
 	},
@@ -24763,6 +25108,16 @@
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/mainship/orange,
 /area/magmoor/cargo/processing/south)
+"rOv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "rOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -24878,6 +25233,15 @@
 	dir = 1
 	},
 /area/magmoor/compound/north)
+"rTL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "rTX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -25033,6 +25397,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/corner,
 /area/magmoor/medical/patient)
+"rZD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "sac" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -25272,9 +25644,18 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
 "sjy" = (
-/turf/open/floor/tile/red/redtaupe{
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor/glass{
+	dir = 1;
+	name = "\improper Security Lobby"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "skh" = (
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -25282,6 +25663,14 @@
 	dir = 4
 	},
 /area/magmoor/compound/north)
+"skx" = (
+/obj/structure/toilet,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "skK" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/structure/table/reinforced/flipped{
@@ -25308,6 +25697,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/southeast)
+"skX" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "sle" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -25383,6 +25776,10 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/mainship/red,
 /area/magmoor/security/arrivals/east)
+"snF" = (
+/obj/machinery/vending/security,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/storage)
 "sod" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25550,10 +25947,16 @@
 	},
 /area/magmoor/compound/north)
 "stY" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	welded = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/tile/dark/red2,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
 /area/magmoor/security/infocenter)
 "sue" = (
 /obj/structure/cable,
@@ -25662,6 +26065,14 @@
 "syD" = (
 /turf/open/liquid/lava/autosmoothing,
 /area/magmoor/compound)
+"syH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light,
+/turf/open/floor/tile/dark/red2,
+/area/magmoor/security/storage)
 "syN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25819,6 +26230,14 @@
 	dir = 4
 	},
 /area/magmoor/command/lobby/east)
+"sDK" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "sEf" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26125,9 +26544,6 @@
 	dir = 8
 	},
 /area/magmoor/command/office/main)
-"sPW" = (
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/security/infocenter)
 "sQh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -27576,15 +27992,15 @@
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi)
 "tRG" = (
-/obj/structure/rack,
-/obj/item/weapon/gun/smg/m25,
-/obj/item/weapon/gun/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/tile/dark/red2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
 /area/magmoor/security/infocenter)
 "tRM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -27612,6 +28028,17 @@
 "tSL" = (
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/cryostasis)
+"tSV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "tTH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
@@ -27721,11 +28148,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/west)
-"tXP" = (
-/obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "tYc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -27754,6 +28176,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/landing/two)
+"tZy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "tZz" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -28032,13 +28460,6 @@
 	dir = 1
 	},
 /area/magmoor/compound/south)
-"ugU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	welded = 1
-	},
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "ugW" = (
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/arrivals/east)
@@ -28144,6 +28565,17 @@
 /obj/item/contraband/poster,
 /turf/open/floor/mainship/cargo,
 /area/magmoor/cargo/storage/south)
+"ujF" = (
+/obj/machinery/door/airlock/mainship/security/glass{
+	name = "\improper Holding Cell";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "ujR" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -28179,6 +28611,12 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/medical/cmo)
+"ukE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/infocenter)
 "ukL" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -28260,14 +28698,13 @@
 /turf/open/lavaland/catwalk,
 /area/magmoor/compound/north)
 "umZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/turf/open/floor/tile/red/redtaupe{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "unF" = (
 /obj/structure/barricade/guardrail{
@@ -28394,6 +28831,12 @@
 	dir = 8
 	},
 /area/magmoor/security/arrivals/east)
+"urA" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
+/area/magmoor/security/infocenter)
 "urG" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -28517,6 +28960,14 @@
 	dir = 1
 	},
 /area/magmoor/compound/southeast)
+"uwD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "uwE" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
@@ -28526,14 +28977,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/north)
-"uwQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/lobby)
 "uwV" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -28779,6 +29222,11 @@
 	dir = 1
 	},
 /area/magmoor/command/commandroom)
+"uEu" = (
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/storage)
 "uFP" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -29113,13 +29561,6 @@
 	dir = 4
 	},
 /area/magmoor/mining)
-"uTl" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
 "uTu" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/orange,
@@ -29211,8 +29652,11 @@
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/dorms)
 "uUU" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "uVi" = (
@@ -29258,13 +29702,8 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
 "uWg" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/infocenter)
 "uXf" = (
 /turf/open/floor/carpet,
@@ -29393,6 +29832,12 @@
 "vaD" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/medical/storage)
+"vaO" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/corpsespawner/prison_security/burst,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/infocenter)
 "vaW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -29547,6 +29992,12 @@
 	},
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
+"vjK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "vjN" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
@@ -29610,23 +30061,19 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
-"vnG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
-	},
-/area/magmoor/security/infocenter)
 "voh" = (
 /obj/structure/prop/vehicle/crane/cranecargo/destructible{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/magmoor/engi/garage)
+"voC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/tile/red,
+/area/magmoor/security/infocenter)
 "vpf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -30397,14 +30844,6 @@
 	dir = 4
 	},
 /area/magmoor/compound/south)
-"vRX" = (
-/obj/structure/closet/walllocker/hydrant/extinguisher{
-	dir = 4
-	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 4
-	},
-/area/magmoor/security/lobby)
 "vRZ" = (
 /obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30753,14 +31192,11 @@
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/north)
 "wdP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/machinery/light,
 /obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "weq" = (
@@ -31227,6 +31663,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/chemistry)
+"wxl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/lobby)
 "wxp" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -31250,11 +31696,6 @@
 	dir = 4
 	},
 /area/magmoor/compound)
-"wyz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/lobby)
 "wyD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -31554,6 +31995,11 @@
 /area/magmoor/mining)
 "wIz" = (
 /obj/structure/cable,
+/obj/machinery/vending/nanomed,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/infocenter)
 "wIA" = (
@@ -31909,10 +32355,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/lobby)
-"wUC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber,
-/turf/open/floor/tile/red/redtaupe,
-/area/magmoor/security/lobby)
 "wUD" = (
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/mainship/orange{
@@ -31944,6 +32386,14 @@
 /obj/structure/lattice,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/north)
+"wWe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/magmoor/security/storage)
 "wWk" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -32646,6 +33096,12 @@
 /obj/structure/rock/basalt/alt,
 /turf/open/lavaland/basalt/dirt/autosmoothing,
 /area/magmoor/compound/north)
+"xru" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "xrx" = (
 /obj/structure/rack,
 /obj/item/storage/box/masks,
@@ -32900,14 +33356,13 @@
 	},
 /area/magmoor/engi/atmos)
 "xxT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/full,
 /area/magmoor/security/lobby)
 "xxY" = (
@@ -32961,8 +33416,17 @@
 /turf/open/lavaland/basalt/cave/autosmooth,
 /area/magmoor/volcano)
 "xzL" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/tile/dark/red2,
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
 /area/magmoor/security/infocenter)
 "xzO" = (
 /obj/structure/table/mainship,
@@ -33030,6 +33494,11 @@
 	},
 /turf/open/floor/mainship/blue,
 /area/magmoor/civilian/arrival/east)
+"xBP" = (
+/obj/structure/rack,
+/obj/item/weapon/combat_knife,
+/turf/open/floor/tile/dark,
+/area/magmoor/security/storage)
 "xBS" = (
 /obj/structure/rack,
 /obj/effect/landmark/weed_node,
@@ -33491,11 +33960,9 @@
 	},
 /area/magmoor/cargo/processing/south)
 "xSw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/red/full,
-/area/magmoor/security/infocenter)
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/mainship/mono,
+/area/magmoor/security/lobby)
 "xSI" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -33711,6 +34178,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/chemistry)
+"xZM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/red/redtaupe,
+/area/magmoor/security/lobby)
 "yan" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33941,6 +34417,19 @@
 "yhW" = (
 /turf/open/floor/wood,
 /area/magmoor/command/office/main)
+"yia" = (
+/obj/machinery/door/airlock/mainship/security{
+	dir = 8;
+	name = "\improper Warden's Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/red,
+/area/magmoor/security/infocenter)
 "yip" = (
 /obj/structure/rack,
 /obj/item/clothing/under/shorts/red,
@@ -38805,14 +39294,14 @@ dPK
 dPK
 ojW
 dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-rxl
-rxl
-rxl
+mOt
+mOt
+mOt
+eQl
+mOt
+mOt
+mOt
+aap
 rxl
 rxl
 rxl
@@ -39032,27 +39521,27 @@ rxl
 rxl
 rxl
 rxl
-mlB
-ojW
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
+pvQ
+pvQ
+pvQ
+pvQ
+vEo
+vEo
+mOt
+bQc
+cgC
+bhF
+kZZ
+qrK
+urA
+aap
+aap
+aap
+aap
+aap
+aap
+aap
+aap
 rxl
 rxl
 rxl
@@ -39265,27 +39754,27 @@ rxl
 rxl
 rxl
 rxl
-rxl
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-ojW
-dPK
-dPK
-dPK
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
-rxl
+pvQ
+pXw
+xSw
+pvQ
+hSR
+dhx
+mOt
+rDe
+lFu
+fNw
+rDJ
+rZD
+hEg
+aap
+snF
+kZG
+qUk
+kPM
+xBP
+beD
+aap
 rxl
 rxl
 rxl
@@ -39498,27 +39987,27 @@ rxl
 rxl
 rxl
 rxl
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-ojW
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-rxl
-rxl
-rxl
-rxl
-rxl
+pvQ
+dbA
+cJf
+jKr
+xZM
+qIK
+mOt
+vaO
+rtj
+xru
+rDJ
+tZy
+gVO
+aap
+dwm
+ehW
+ieq
+jQa
+rou
+fLn
+aap
 rxl
 rxl
 rxl
@@ -39731,27 +40220,27 @@ rxl
 rxl
 rxl
 mlB
-ojW
-dPK
-dPK
-ojW
-dPK
-ojW
-dPK
+pvQ
+cvm
+gaM
+pvQ
+hDB
+rCo
 mOt
-mOt
-syO
-mOt
-mOt
-dPK
-ojW
-dPK
-dPK
-dPK
-dPK
-dPK
-rxl
-rxl
+huH
+eCE
+ukE
+ukE
+eGW
+jpn
+eSf
+ifh
+aGB
+rjR
+jSe
+pne
+syH
+aap
 rxl
 rxl
 rxl
@@ -39964,28 +40453,28 @@ rxl
 tYu
 mlB
 dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
+pvQ
+pvQ
+pvQ
+pvQ
+hDB
+yej
 mOt
-aJE
-cEF
-pZr
 mOt
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-dPK
-ojW
-dPK
-dze
+mOt
+mOt
+mOt
+yia
+mOt
+aap
+lCe
+opN
+qkm
+kzv
+geK
+dUN
+lVv
+gKu
 rxl
 rxl
 rxl
@@ -40197,28 +40686,28 @@ tYu
 mlB
 ffI
 dPK
+vEo
+skX
+vjK
+ieA
+rTL
+yej
 mOt
-mOt
-syO
-mOt
-mOt
-syO
-mOt
-mOt
+wOk
 mCp
-kfY
-laM
-mOt
-dPK
-dPK
-dPK
-ojW
-dPK
-dPK
-dPK
-dPK
-dPK
-dze
+bhF
+bhF
+tRG
+mFf
+aap
+hrb
+wWe
+uEu
+uEu
+uEu
+fQa
+mwG
+hrF
 dze
 dze
 dze
@@ -40430,21 +40919,21 @@ mlB
 mlB
 dPK
 cKB
-mOt
-pUA
+cSt
+oOi
 dfE
 eBh
-jMh
+iZN
 jMh
 qQZ
-mOt
-syO
+voC
+kEw
 exF
-syO
+dby
+jEi
 mOt
-mOt
-syO
-mOt
+aap
+jHk
 aap
 aap
 aap
@@ -40663,19 +41152,19 @@ ffI
 dPK
 xMR
 fCK
-eQl
-woV
-aUR
-lSS
+pvQ
+oOi
+rTL
+pvQ
+pvQ
+pvQ
+mOt
+pUA
+iVe
 hed
-tXP
+aAC
 eKG
 mOt
-iVe
-vnG
-aAC
-mOt
-gUI
 bky
 tRG
 aap
@@ -40896,19 +41385,19 @@ dPK
 dPK
 xMR
 fCK
-jfI
+pvQ
 jtC
 oVR
-nbR
+pvQ
 xSw
 pXw
-ryW
-gWS
-oEN
-eDc
-hed
 mOt
-cEE
+woV
+aqn
+akY
+tSV
+hbE
+mOt
 dWD
 xzL
 aap
@@ -41129,19 +41618,19 @@ dPK
 dPK
 rfA
 fCK
-mOt
-wOk
-aqn
-jJJ
+pvQ
+oOi
+iUC
+ujF
 pTv
 bfs
-mFm
 mOt
-qKe
-fNe
-maL
 mOt
-kLd
+kHP
+mOt
+mOt
+mOt
+mOt
 uWg
 nQY
 oXd
@@ -41363,17 +41852,17 @@ dPK
 dPK
 plZ
 pvQ
+mlU
+oVR
 pvQ
+skx
+kWP
 pvQ
-etJ
-cSt
-pvQ
-pvQ
-mOt
+mxr
 bQc
 umZ
-ugU
-mOt
+bhF
+eqA
 bhF
 gEe
 lUZ
@@ -41596,17 +42085,17 @@ dPK
 dPK
 xMR
 pvQ
-loi
+oOi
 sjy
-jhh
-nWl
-vRX
-dhx
-mOt
-dRY
-fNe
-rDJ
-mOt
+pvQ
+pvQ
+pvQ
+pvQ
+kYM
+qKe
+tZy
+eAw
+qCx
 pok
 pEz
 stY
@@ -41828,24 +42317,24 @@ dPK
 dPK
 dPK
 xMR
-vEo
-dob
-jJW
+pvQ
+oOi
+oVR
 aaa
-lvJ
 ieA
-yej
+eWb
+pvQ
 mOt
-bWX
+dRY
 wdP
-iqN
-iqN
-uTl
+mOt
+mOt
+mOt
 wIz
 rEa
 aap
 lbB
-pxb
+itD
 pxb
 hMZ
 aap
@@ -42065,16 +42554,16 @@ pvQ
 nBs
 uUU
 din
-rCK
-pvQ
+nsc
+sDK
 enT
 mOt
-dYn
+bWX
 iNr
-rDJ
-rDJ
+uwD
+rOv
 erD
-rDJ
+moe
 aKn
 aap
 aap
@@ -42294,20 +42783,20 @@ dPK
 dPK
 dPK
 xMR
-vEo
-wUC
+pvQ
+skX
 doD
-uwQ
-ieA
-qFf
-yej
+pvQ
+aWK
+rCK
+gCi
 mOt
 aSm
 rDX
-euu
+akY
 pLU
 jJJ
-akY
+mPT
 guy
 mOt
 dPK
@@ -42527,12 +43016,12 @@ ojW
 dPK
 dPK
 xMR
-cSt
+pvQ
 byD
-ieA
+wxl
 nEg
 xxT
-wyz
+ieA
 bpz
 mOt
 mOt
@@ -42762,7 +43251,7 @@ dPK
 xMR
 pvQ
 nqJ
-mxC
+ptJ
 mxC
 lpe
 jYa
@@ -42776,7 +43265,7 @@ pIQ
 fCK
 sYz
 dPK
-sPW
+dPK
 dPK
 dPK
 dPK

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -3317,6 +3317,9 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing/two)
+"cmO" = (
+/turf/open/floor/plating/mainship,
+/area/magmoor/engi/garage)
 "cna" = (
 /obj/structure/rock/basalt/pile/alt2,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -3613,6 +3616,15 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/side,
 /area/magmoor/command/conference)
+"cvp" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/magmoor/engi/garage)
 "cvs" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
@@ -4367,6 +4379,13 @@
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
 	},
+/area/magmoor/compound/north)
+"dck" = (
+/obj/machinery/door_control{
+	id = "engi_garage";
+	name = "Engineering Garage"
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/north)
 "dcn" = (
 /obj/machinery/vending/coffee,
@@ -9913,14 +9932,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
-"gVu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/magmoor/engi/garage)
 "gWk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -13194,7 +13205,10 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/magmoor/engi/garage)
 "jto" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -16524,9 +16538,6 @@
 	},
 /area/magmoor/civilian/arrival/east)
 "lMP" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/magmoor/engi/garage)
@@ -23902,13 +23913,6 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/command/lobby)
-"rgO" = (
-/obj/effect/ai_node,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/magmoor/engi/garage)
 "rhG" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -24106,9 +24110,6 @@
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
 "rpH" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -28371,6 +28372,10 @@
 	dir = 4
 	},
 /area/magmoor/compound)
+"urn" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/magmoor/engi/garage)
 "urs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33808,6 +33813,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/commandroom)
+"ydX" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/plating/mainship,
+/area/magmoor/engi/garage)
 "yej" = (
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
@@ -48559,7 +48568,7 @@ xyy
 ctB
 sLM
 ibS
-ibS
+urn
 dcL
 ibS
 lMP
@@ -49028,7 +49037,7 @@ lCx
 ibS
 glt
 ibS
-gVu
+lMP
 wOh
 kGc
 gNd
@@ -49258,12 +49267,12 @@ ctB
 ctB
 vZv
 hWc
-ibS
+cvp
 rpH
 aSB
 ctB
 ctB
-lqI
+dck
 lqI
 lqI
 lqI
@@ -49491,8 +49500,8 @@ xyy
 ctB
 ibS
 ibS
-ibS
 vxQ
+ydX
 qsN
 ctB
 pDq
@@ -49724,8 +49733,8 @@ ymj
 ctB
 ctB
 kWk
-ibS
 vxQ
+cmO
 rtB
 ctB
 ctB
@@ -49958,7 +49967,7 @@ ymj
 eJo
 ibS
 jtk
-rgO
+lAV
 uaN
 lAV
 eJo

--- a/code/game/area/magmoor_digsite.dm
+++ b/code/game/area/magmoor_digsite.dm
@@ -192,6 +192,12 @@
 	name = "Engineering Lobby & Storage"
 	icon_state = "lava_engi_storage"
 
+/area/magmoor/engi/garage
+	name = "Engineering Garage"
+	ceiling = CEILING_DEEP_UNDERGROUND_METAL
+	icon_state = "lava_eng1"
+	minimap_color = MINIMAP_AREA_ENGI_CAVE
+
 //Security
 
 /area/magmoor/security


### PR DESCRIPTION
## About The Pull Request

- Added a new garage above admin
- Revamped security to have more cover for xenos
- Removed a few windows from pharmacy
- Fixed a few missing pipes

<details>
<img width="560" alt="garage3" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/2facb0c0-b938-4892-af86-36521a0dd450">
<img width="361" alt="magsec" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/22dcc19b-39d4-49fd-aa13-04a073b38b32">
</details>

## Why It's Good For The Game
Admin disk tends to be very marine sided as long as they have enough maze clear because there isnt a ton of cover for xenos to heal under. Pharmacy also tends to be a dead zone due to it having many sightlines through it while being blocked by machinery. This should make the two 2nd disks a bit easier to siege for xenos.
## Changelog
:cl:
add: Added more cover for xenos on the 2nd disks of Magmoor.
fix: Fixed a few missing pipes on Magmoor.
/:cl:
