### PR TITLE
Tad can land on lavaland tiles

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -30,7 +30,7 @@
 	/// Vertical offset from the console of the origin tile when using it
 	var/y_offset = 0
 	/// Turfs that can be landed on
-	var/list/whitelist_turfs = list(/turf/open/ground, /turf/open/floor, /turf/open/liquid/water)
+	var/list/whitelist_turfs = list(/turf/open/ground, /turf/open/floor, /turf/open/liquid/water, /turf/open/lavaland)
 	/// Are we able to see hidden ports when using the console
 	var/see_hidden = FALSE
 	/// Delay of the place_action


### PR DESCRIPTION

## About The Pull Request
Allows tad to land on lavaland tiles, this does not include lava itself.
## Why It's Good For The Game
Maps like metnal and barrenquilla use this tileset and so tad cant even land on 99% of the map. Futureproofing for when this tileset becomes more common than just a few spots on Slumbridge
## Changelog
:cl:
fix: Tad can now land on lavaland tilesets.
/:cl:
