### PR TITLE
Implement more uses of PopulateContents()

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -443,8 +443,7 @@
 	new /obj/item/explosive/grenade/chem_grenade/razorburn_small(src)
 	new /obj/item/explosive/grenade/chem_grenade/razorburn_large(src)
 
-/obj/item/storage/pouch/explosive/antigas/Initialize(mapload)
-	. = ..()
+/obj/item/storage/pouch/explosive/antigas/PopulateContents()
 	new /obj/item/explosive/grenade/smokebomb/antigas(src)
 	new /obj/item/explosive/grenade/smokebomb/antigas(src)
 	new /obj/item/explosive/grenade/smokebomb/antigas(src)
@@ -496,8 +495,7 @@
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 	new /obj/item/explosive/grenade/flashbang/stun(src)
 
-/obj/item/storage/pouch/grenade/standard/Initialize(mapload)
-	. = ..()
+/obj/item/storage/pouch/grenade/standard/PopulateContents()
 	new /obj/item/explosive/grenade(src)
 	new /obj/item/explosive/grenade(src)
 	new /obj/item/explosive/grenade(src)
@@ -505,14 +503,9 @@
 	new /obj/item/explosive/grenade/bullet/laser(src)
 	new /obj/item/explosive/grenade/incendiary(src)
 
-/obj/item/storage/pouch/grenade/emp/Initialize(mapload)
-	. = ..()
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
+/obj/item/storage/pouch/grenade/emp
+	fill_type = /obj/item/explosive/grenade/emp
+	fill_number = 6
 
 /obj/item/storage/pouch/grenade/som
 	desc = "It can contain grenades. This one looks to be made out of traditional SOM leather."
@@ -538,8 +531,7 @@
 	new /obj/item/explosive/grenade/som(src)
 	new /obj/item/explosive/grenade/som(src)
 
-/obj/item/storage/pouch/grenade/som/standard/Initialize(mapload)
-	. = ..()
+/obj/item/storage/pouch/grenade/som/standard/PopulateContents()
 	new /obj/item/explosive/grenade/som(src)
 	new /obj/item/explosive/grenade/som(src)
 	new /obj/item/explosive/grenade/som(src)
@@ -547,14 +539,9 @@
 	new /obj/item/explosive/grenade/incendiary/som(src)
 	new /obj/item/explosive/grenade/incendiary/som(src)
 
-/obj/item/storage/pouch/grenade/som/emp/Initialize(mapload)
-	. = ..()
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
-	new /obj/item/explosive/grenade/emp(src)
+/obj/item/storage/pouch/grenade/som/emp
+	fill_type = /obj/item/explosive/grenade/emp
+	fill_number = 6
 
 /obj/item/storage/pouch/medkit
 	name = "medkit pouch"

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -128,8 +128,7 @@
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/secure/briefcase/Initialize(mapload)
-	. = ..()
+/obj/item/storage/secure/briefcase/PopulateContents()
 	new /obj/item/paper(src)
 	new /obj/item/tool/pen(src)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -82,7 +82,7 @@
 	return ..()
 
 
-//USE THIS TO FILL IT, NOT INITIALIZE OR NEW
+///USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -4,8 +4,7 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/athletic_mixed/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/athletic_mixed/PopulateContents()
 	new /obj/item/clothing/under/shorts/grey(src)
 	new /obj/item/clothing/under/shorts/black(src)
 	new /obj/item/clothing/under/shorts/red(src)
@@ -27,8 +26,7 @@
 	name = "boxing gloves"
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
-/obj/structure/closet/boxinggloves/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/boxinggloves/PopulateContents()
 	new /obj/item/clothing/gloves/heldgloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/heldgloves/boxing/green(src)
 	new /obj/item/clothing/gloves/heldgloves/boxing/yellow(src)
@@ -39,8 +37,7 @@
 	name = "mask closet"
 	desc = "IT'S A STORAGE UNIT FOR FIGHTER MASKS OLE!"
 
-/obj/structure/closet/masks/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/masks/PopulateContents()
 	new /obj/item/clothing/mask/luchador(src)
 	new /obj/item/clothing/mask/luchador/rudos(src)
 	new /obj/item/clothing/mask/luchador/tecnicos(src)
@@ -52,8 +49,7 @@
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/lasertag/red/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/lasertag/red/PopulateContents()
 	new /obj/item/clothing/suit/redtag(src)
 	new /obj/item/clothing/suit/redtag(src)
 
@@ -64,8 +60,7 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lasertag/blue/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/lasertag/blue/PopulateContents()
 	new /obj/item/clothing/suit/bluetag(src)
 	new /obj/item/clothing/suit/bluetag(src)
 
@@ -75,8 +70,7 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/basketball/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/basketball/PopulateContents()
 	new /obj/item/clothing/under/shorts/grey(src)
 	new /obj/item/clothing/under/shorts/black(src)
 	new /obj/item/clothing/under/shorts/red(src)
@@ -89,8 +83,7 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/swimsuit/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/swimsuit/PopulateContents()
 	new /obj/item/clothing/under/swimsuit/red(src)
 	new /obj/item/clothing/under/swimsuit/black(src)
 	new /obj/item/clothing/under/swimsuit/blue(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -14,8 +14,7 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/gmcloset/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/gmcloset/PopulateContents()
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/clothing/head/hairflower
@@ -38,8 +37,7 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/jcloset/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/jcloset/PopulateContents()
 	new /obj/item/clothing/under/rank/janitor(src)
 	new /obj/item/clothing/gloves/black(src)
 	new /obj/item/clothing/head/soft/purple(src)
@@ -62,8 +60,7 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lawcloset/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/lawcloset/PopulateContents()
 	new /obj/item/clothing/under/lawyer/female(src)
 	new /obj/item/clothing/under/lawyer/black(src)
 	new /obj/item/clothing/under/lawyer/red(src)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -5,8 +5,7 @@
 	icon_closed = "bio"
 	icon_opened = "bioopen"
 
-/obj/structure/closet/l3closet/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/l3closet/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit( src )
 	new /obj/item/clothing/head/bio_hood( src )
 
@@ -16,9 +15,7 @@
 	icon_closed = "bio_general"
 	icon_opened = "bio_generalopen"
 
-/obj/structure/closet/l3closet/general/Initialize(mapload)
-	. = ..()
-	contents = list()
+/obj/structure/closet/l3closet/general/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit( src )
 	new /obj/item/clothing/head/bio_hood( src )
 
@@ -28,9 +25,7 @@
 	icon_closed = "bio_virology"
 	icon_opened = "bio_virologyopen"
 
-/obj/structure/closet/l3closet/virology/Initialize(mapload)
-	. = ..()
-	contents = list()
+/obj/structure/closet/l3closet/virology/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit/virology( src )
 	new /obj/item/clothing/head/bio_hood/virology( src )
 	new /obj/item/clothing/mask/breath(src)
@@ -42,9 +37,7 @@
 	icon_closed = "bio_security"
 	icon_opened = "bio_securityopen"
 
-/obj/structure/closet/l3closet/security/Initialize(mapload)
-	. = ..()
-	contents = list()
+/obj/structure/closet/l3closet/security/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit/security( src )
 	new /obj/item/clothing/head/bio_hood/security( src )
 
@@ -54,9 +47,7 @@
 	icon_closed = "bio_janitor"
 	icon_opened = "bio_janitoropen"
 
-/obj/structure/closet/l3closet/janitor/Initialize(mapload)
-	. = ..()
-	contents = list()
+/obj/structure/closet/l3closet/janitor/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit/janitor( src )
 	new /obj/item/clothing/head/bio_hood/janitor( src )
 
@@ -66,8 +57,6 @@
 	icon_closed = "bio_scientist"
 	icon_opened = "bio_scientistopen"
 
-/obj/structure/closet/l3closet/scientist/Initialize(mapload)
-	. = ..()
-	contents = list()
+/obj/structure/closet/l3closet/scientist/PopulateContents()
 	new /obj/item/clothing/suit/bio_suit/scientist( src )
 	new /obj/item/clothing/head/bio_hood/scientist( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -9,8 +9,7 @@
 	icon_off = "cabinetdetective_broken"
 
 
-/obj/structure/closet/secure_closet/bar/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/bar/PopulateContents()
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -9,8 +9,7 @@
 	icon_off = "secureceoff"
 
 
-/obj/structure/closet/secure_closet/engineering_chief/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/engineering_chief/PopulateContents()
 	new /obj/item/armor_module/storage/uniform/webbing(src)
 	new /obj/item/armor_module/storage/uniform/brown_vest(src)
 	new /obj/item/clothing/head/hardhat/white(src)
@@ -46,8 +45,7 @@
 	icon_off = "secureengelecoff"
 
 
-/obj/structure/closet/secure_closet/engineering_electrical/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/engineering_electrical/PopulateContents()
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/clothing/gloves/insulated(src)
@@ -73,8 +71,7 @@
 	icon_off = "secureengweldoff"
 
 
-/obj/structure/closet/secure_closet/engineering_welding/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/engineering_welding/PopulateContents()
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
@@ -95,8 +92,7 @@
 	icon_broken = "secureengbroken"
 	icon_off = "secureengoff"
 
-/obj/structure/closet/secure_closet/engineering_personal/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/engineering_personal/PopulateContents()
 	new /obj/item/armor_module/storage/uniform/brown_vest(src)
 	new /obj/item/storage/toolbox/mechanical(src)
 	if(!is_ground_level(z))
@@ -136,8 +132,7 @@
 	icon_off = "secureatmoff"
 
 
-/obj/structure/closet/secure_closet/atmos_personal/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/secure_closet/atmos_personal/PopulateContents()
 	if (prob(70))
 		new /obj/item/armor_module/storage/uniform/brown_vest(src)
 	else

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -92,8 +92,7 @@
 	icon_opened = "open_explosives"
 	icon_closed = "closed_explosives"
 
-/obj/structure/closet/crate/explosives/whiskeyoutpost/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/explosives/whiskeyoutpost/PopulateContents()
 	new /obj/item/explosive/grenade/stick(src)
 	new /obj/item/explosive/grenade/stick(src)
 	new /obj/item/explosive/grenade/stick(src)
@@ -112,8 +111,7 @@
 	new /obj/item/explosive/grenade/phosphorus/upp(src)
 	new /obj/item/explosive/grenade/phosphorus/upp(src)
 
-/obj/structure/closet/crate/explosives/whiskeyoutposttwo/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/explosives/whiskeyoutposttwo/PopulateContents()
 	new /obj/structure/closet/crate/explosives(src)
 	new /obj/item/storage/box/visual/grenade/razorburn(src)
 	new /obj/item/storage/box/visual/grenade/razorburn(src)
@@ -139,8 +137,7 @@
 	icon_opened = "open_hydro"
 	icon_closed = "closed_hydro"
 
-/obj/structure/closet/crate/hydroponics/prespawned/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/hydroponics/prespawned/PopulateContents()
 	new /obj/item/reagent_containers/spray/plantbgone(src)
 	new /obj/item/reagent_containers/spray/plantbgone(src)
 	new /obj/item/tool/minihoe(src)
@@ -171,8 +168,7 @@
 	name = "RCD crate"
 	desc = "A crate for the storage of the RCD."
 
-/obj/structure/closet/crate/rcd/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/rcd/PopulateContents()
 	new /obj/item/ammo_rcd(src)
 	new /obj/item/ammo_rcd(src)
 	new /obj/item/ammo_rcd(src)
@@ -186,8 +182,7 @@
 	desc = "A crate of emergency rations."
 	name = "Emergency Rations"
 
-/obj/structure/closet/crate/freezer/rations/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/freezer/rations/PopulateContents()
 	new /obj/item/storage/box/donkpockets(src)
 	new /obj/item/storage/box/donkpockets(src)
 
@@ -198,8 +193,7 @@
 	icon_opened = "open_radioactive"
 	icon_closed = "closed_radioactive"
 
-/obj/structure/closet/crate/radiation/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/crate/radiation/PopulateContents()
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)


### PR DESCRIPTION

## About The Pull Request
Implement more uses of PopulateContents()
## Why It's Good For The Game
Storage + lockers both call PopulateContents() right after initialize. Please use this proc to fill these items instead of tying it directly on to Initialize().
This makes it easier for us to make subtypes call parent on initialize since this proc is easier to override.
## Changelog
:cl:
code: Implement more uses of PopulateContents()
/:cl:
