### PR TITLE
Campaign loadout fixes

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
@@ -48,11 +48,32 @@
 	ui_icon = "lorica"
 	item_typepath = /obj/item/clothing/head/modular/som/lorica
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN)
-	item_whitelist = list(/obj/item/clothing/suit/modular/som/heavy/lorica = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/som/heavy/lorica = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/som/heavy/lorica/medic = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/som/heavy/lorica/engineer = ITEM_SLOT_OCLOTHING,
+	)
+
+/datum/loadout_item/helmet/som_tyr/medic
+	jobs_supported = list(SOM_SQUAD_CORPSMAN)
+	loadout_item_flags = NONE
+
+/datum/loadout_item/helmet/som_tyr/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/russian_red, SLOT_IN_HEAD)
+
+/datum/loadout_item/helmet/som_tyr/engineer
+	jobs_supported = list(SOM_SQUAD_ENGINEER)
+	loadout_item_flags = NONE
+
+/datum/loadout_item/helmet/som_tyr/engineer/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_HEAD)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_HEAD)
 
 /datum/loadout_item/helmet/som_tyr/universal
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	loadout_item_flags = NONE
+
 /datum/loadout_item/helmet/som_mimir
 	name = "Biohazard helmet"
 	desc = "A standard combat helmet with a Mithridatius 'Mith' environmental protection module."

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
@@ -60,7 +60,7 @@
 	desc = "A pouch specialized for holding shotgun ammo. Contains buckshot shells."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/shotgun/som
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
 
 /datum/loadout_item/r_pocket/som_shotgun/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_R_POUCH)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/pockets.dm
@@ -60,7 +60,7 @@
 	desc = "A pouch specialized for holding shotgun ammo. Contains buckshot shells."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/shotgun/som
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
 
 /datum/loadout_item/r_pocket/som_shotgun/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_R_POUCH)
@@ -174,7 +174,7 @@
 	desc = "A pouch specialized for holding shotgun ammo. Contains Flechette shells."
 	ui_icon = "grenade"
 	item_typepath = /obj/item/storage/pouch/shotgun/som
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
 
 /datum/loadout_item/l_pocket/som_shotgun/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_L_POUCH)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -131,11 +131,22 @@
 	loadout_item_flags = null
 	item_whitelist = null
 
+/datum/loadout_item/suit_slot/som_heavy_tyr/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+
 /datum/loadout_item/suit_slot/som_heavy_tyr/engineer
 	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/engineer
 	jobs_supported = list(SOM_SQUAD_ENGINEER)
 	loadout_item_flags = null
 	item_whitelist = null
+
+/datum/loadout_item/suit_slot/som_heavy_tyr/engineer/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/circuitboard/apc, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/cell/high, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/medium_stack, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/large_stack, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/barbed_wire/half_stack, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/som_heavy_tyr/universal
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -126,7 +126,7 @@
 	item_whitelist = list(/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/charger/somvet = ITEM_SLOT_SUITSTORE)
 
 /datum/loadout_item/suit_slot/som_heavy_tyr/medic
-	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/general
+	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/medic
 	jobs_supported = list(SOM_SQUAD_CORPSMAN)
 	loadout_item_flags = null
 	item_whitelist = null

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -125,8 +125,20 @@
 	jobs_supported = list(SOM_SQUAD_VETERAN)
 	item_whitelist = list(/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/charger/somvet = ITEM_SLOT_SUITSTORE)
 
+/datum/loadout_item/suit_slot/som_heavy_tyr/medic
+	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/general
+	jobs_supported = list(SOM_SQUAD_CORPSMAN)
+	loadout_item_flags = null
+	item_whitelist = null
+
+/datum/loadout_item/suit_slot/som_heavy_tyr/engineer
+	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/engineer
+	jobs_supported = list(SOM_SQUAD_ENGINEER)
+	loadout_item_flags = null
+	item_whitelist = null
+
 /datum/loadout_item/suit_slot/som_heavy_tyr/universal
-	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
+	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER)
 	loadout_item_flags = null
 	item_whitelist = null
 

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/medic.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/medic.dm
@@ -112,7 +112,7 @@
 	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus, SLOT_IN_BACKPACK)
 
-/datum/loadout_item/suit_store/main_gun/som_marine/smg/enhanced
+/datum/loadout_item/suit_store/main_gun/som_medic/smg/enhanced
 	name = "V-21+"
 	desc = "Equipped with a mag harness, recoil compensator and vertical grip. The V-21 is the principal submachinegun used by the Sons of Mars, with a variable rate of fire. \
 	Has outstanding mobility and handling and can be comfortably fired one handed on its lower fire rate mode. \

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/head.dm
@@ -60,14 +60,34 @@
 	ui_icon = "tyr"
 	item_typepath = /obj/item/clothing/head/modular/m10x/tyr
 	jobs_supported = list(SQUAD_MARINE)
-	item_whitelist = list(/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two = ITEM_SLOT_OCLOTHING)
+	item_whitelist = list(
+		/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/corpsman = ITEM_SLOT_OCLOTHING,
+		/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/engineer = ITEM_SLOT_OCLOTHING,
+	)
 
 /datum/loadout_item/helmet/tyr/smartgunner
 	jobs_supported = list(SQUAD_SMARTGUNNER)
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 
+/datum/loadout_item/helmet/tyr/corpsman
+	jobs_supported = list(SQUAD_CORPSMAN)
+	loadout_item_flags = NONE
+
+/datum/loadout_item/helmet/tyr/corpsman/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/neuraline, SLOT_IN_HEAD)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/neuraline, SLOT_IN_HEAD)
+
+/datum/loadout_item/helmet/tyr/engineer
+	jobs_supported = list(SQUAD_ENGINEER)
+	loadout_item_flags = NONE
+
+/datum/loadout_item/helmet/tyr/engineer/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_HEAD)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_HEAD)
+
 /datum/loadout_item/helmet/tyr/universal
-	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 	loadout_item_flags = NONE
 
 /datum/loadout_item/helmet/white_dress

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/pockets.dm
@@ -59,7 +59,7 @@
 	item_typepath = /obj/item/storage/pouch/grenade/standard
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
-/datum/loadout_item/r_pocket/som_emp_grenades
+/datum/loadout_item/r_pocket/emp_grenades
 	name = "EMP nades"
 	desc = "A pouch carrying a set of six EMP grenades. Effective against electronic systems including mechs."
 	purchase_cost = 30
@@ -181,7 +181,7 @@
 	item_typepath = /obj/item/storage/pouch/grenade/standard
 	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 
-/datum/loadout_item/l_pocket/som_emp_grenades
+/datum/loadout_item/l_pocket/emp_grenades
 	name = "EMP nades"
 	desc = "A pouch carrying a set of six EMP grenades. Effective against electronic systems including mechs."
 	purchase_cost = 30

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -137,8 +137,20 @@
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_OPTION|LOADOUT_ITEM_DEFAULT_CHOICE
 	item_whitelist = null
 
+/datum/loadout_item/suit_slot/heavy_tyr/medic
+	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/corpsman
+	jobs_supported = list(SQUAD_CORPSMAN)
+	loadout_item_flags = null
+	item_whitelist = null
+
+/datum/loadout_item/suit_slot/heavy_tyr/engineer
+	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/engineer
+	jobs_supported = list(SQUAD_ENGINEER)
+	loadout_item_flags = null
+	item_whitelist = null
+
 /datum/loadout_item/suit_slot/heavy_tyr/universal
-	jobs_supported = list(SQUAD_MARINE, SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
+	jobs_supported = list(SQUAD_MARINE, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)
 	loadout_item_flags = NONE
 	item_whitelist = null
 

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -143,11 +143,22 @@
 	loadout_item_flags = null
 	item_whitelist = null
 
+/datum/loadout_item/suit_slot/heavy_tyr/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+
 /datum/loadout_item/suit_slot/heavy_tyr/engineer
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/engineer
 	jobs_supported = list(SQUAD_ENGINEER)
 	loadout_item_flags = null
 	item_whitelist = null
+
+/datum/loadout_item/suit_slot/heavy_tyr/engineer/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
+	wearer.equip_to_slot_or_del(new /obj/item/circuitboard/apc, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/cell/high, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/medium_stack, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/large_stack, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/stack/barbed_wire/half_stack, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/heavy_tyr/universal
 	jobs_supported = list(SQUAD_MARINE, SQUAD_SMARTGUNNER, SQUAD_LEADER, FIELD_COMMANDER)

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -132,14 +132,21 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 /datum/perk/trait/hp_boost/unlock_bonus(mob/living/carbon/owner, datum/individual_stats/owner_stats)
 	if(owner_stats.faction == FACTION_TERRAGOV)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/heavy_tyr/universal, /datum/loadout_item/suit_slot/heavy_tyr, SQUAD_MARINE)
-		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/heavy_tyr/universal, list(SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_LEADER, FIELD_COMMANDER), owner)
-		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/tyr/universal, list(SQUAD_CORPSMAN, SQUAD_ENGINEER, SQUAD_LEADER, FIELD_COMMANDER), owner)
-
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/heavy_tyr/universal, list(SQUAD_LEADER, FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/tyr/universal, list(SQUAD_LEADER, FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/heavy_tyr/medic, list(SQUAD_CORPSMAN), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/tyr/corpsman, list(SQUAD_CORPSMAN), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/heavy_tyr/engineer, list(SQUAD_ENGINEER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/tyr/engineer, list(SQUAD_ENGINEER), owner)
 	else if(owner_stats.faction == FACTION_SOM)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, /datum/loadout_item/suit_slot/som_heavy_tyr, SOM_SQUAD_MARINE)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, /datum/loadout_item/suit_slot/som_heavy_tyr/veteran, SOM_SQUAD_VETERAN)
-		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, list(SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
-		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/som_tyr/universal, list(SOM_SQUAD_CORPSMAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/som_heavy_tyr/universal, list(SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/som_tyr/universal, list(SOM_SQUAD_LEADER, SOM_FIELD_COMMANDER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/som_heavy_tyr/medic, list(SOM_SQUAD_CORPSMAN), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/som_tyr/medic, list(SOM_SQUAD_CORPSMAN), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/suit_slot/som_heavy_tyr/engineer, list(SOM_SQUAD_ENGINEER), owner)
+		owner_stats.unlock_loadout_item(/datum/loadout_item/helmet/som_tyr/engineer, list(SOM_SQUAD_ENGINEER), owner)
 
 /datum/perk/trait/hp_boost/two
 	name = "Extreme constitution"

--- a/code/modules/clothing/modular_armor/som.dm
+++ b/code/modules/clothing/modular_armor/som.dm
@@ -144,6 +144,18 @@
 		/obj/item/armor_module/storage/medical/som,
 	)
 
+/obj/item/clothing/suit/modular/som/heavy/lorica/medic
+	starting_attachments = list(
+		/obj/item/armor_module/module/tyr_extra_armor/som,
+		/obj/item/armor_module/storage/general/som,
+	)
+
+/obj/item/clothing/suit/modular/som/heavy/lorica/engineer
+	starting_attachments = list(
+		/obj/item/armor_module/module/tyr_extra_armor/som,
+		/obj/item/armor_module/storage/engineering/som,
+	)
+
 /obj/item/clothing/suit/modular/som/heavy/mithridatius
 	starting_attachments = list(
 		/obj/item/armor_module/module/mimir_environment_protection/som,

--- a/code/modules/clothing/modular_armor/xenonauten.dm
+++ b/code/modules/clothing/modular_armor/xenonauten.dm
@@ -179,10 +179,16 @@
 		/obj/item/armor_module/storage/medical,
 	)
 
-/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two
+/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/corpsman
 	starting_attachments = list(
 		/obj/item/armor_module/module/tyr_extra_armor,
-		/obj/item/armor_module/storage/medical,
+		/obj/item/armor_module/storage/general,
+	)
+
+/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/engineer
+	starting_attachments = list(
+		/obj/item/armor_module/module/tyr_extra_armor,
+		/obj/item/armor_module/storage/engineering,
 	)
 
 /obj/item/clothing/suit/modular/xenonauten/heavy/grenadier //Literally grenades

--- a/code/modules/clothing/modular_armor/xenonauten.dm
+++ b/code/modules/clothing/modular_armor/xenonauten.dm
@@ -179,6 +179,12 @@
 		/obj/item/armor_module/storage/medical,
 	)
 
+/obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two
+	starting_attachments = list(
+		/obj/item/armor_module/module/tyr_extra_armor,
+		/obj/item/armor_module/storage/medical,
+	)
+
 /obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/corpsman
 	starting_attachments = list(
 		/obj/item/armor_module/module/tyr_extra_armor,


### PR DESCRIPTION
## About The Pull Request
Fixed some incorrect access to EMP pouches (for marines) and shotgun shell pouches  (for SOM)
Fixed tyr/lorica armour for medics/engies having the wrong storage stuff
Fixed SOM medics not getting the upgrade V21 loadout with the SMG perk

:cl:
fix: Campaign: Fixed loadout issues
/:cl:
