### PR TITLE
Tier fours cannot deevolve if they are the only hive leader. Aka, Shrike.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -281,6 +281,9 @@
 			to_chat(src, span_warning("[get_exp_format(xenojob.required_playtime_remaining(client))] as [xenojob.get_exp_req_type()] required to play queen like roles."))
 			return FALSE
 
+	if(regression && tier == XENO_TIER_FOUR && length(hive.xenos_by_tier[XENO_TIER_FOUR]) == 1) //Evolving xeno is the only hive leader.
+		to_chat(src, span_warning("We cannot regress right now, our hive would collapse!"))
+		return FALSE
 	var/min_xenos = new_caste.evolve_min_xenos
 	if(min_xenos && (hive.total_xenos_for_evolving() < min_xenos))
 		balloon_alert(src, "[min_xenos] xenos needed to become a [initial(new_caste.display_name)]")


### PR DESCRIPTION

## About The Pull Request
Title. This makes it so tier four castes cannot deevolve if they are the only tier four (aka, they are the only one stopping a hive collapse).
(Assumes all tier fours are potential leaders which is the case at the moment and I do not foresee changing in the future. Could be checked for differently but would be a lot more verbose code. Request as change if wanted anyways).

Directed at Shrikes in particular, as those are the only leader caste capable of regressing at this time.
## Why It's Good For The Game
Shrike is an edge case caste that while it can stop hive collapses by being a hive leader, is also capable of deevolving at any time, and has zero evo tick requirements to evolve into.
This, combined with the recent changes to add caste swapping and evolving from any caste into any higher tier, made Shrike a prime target for non-fun gameplay, e.g. evolving shrike just to immediately devo into whatever other caste instead, then repeating once the collapse timer is very low.

I have considered this change a while ago when I watched someone delay for a long time via this technique, but now that I've had an even more annoying take reported to me (involving ventcrawling), it is time to stop.
## Changelog
:cl:
balance: Shrikes cannot deevolve if they are the only tier four (aka Leader) xenomorph in the hive.
/:cl:
