### PR TITLE
Explosive pouch fix

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -416,7 +416,7 @@
 	. = ..()
 	storage_datum.sprite_slots = 2
 	storage_datum.storage_slots = 4
-	storage_datum.max_w_class = WEIGHT_CLASS_NORMAL
+	storage_datum.max_w_class = WEIGHT_CLASS_BULKY
 	storage_datum.set_holdable(can_hold_list = list(
 		/obj/item/explosive/plastique,
 		/obj/item/explosive/mine,


### PR DESCRIPTION
## About The Pull Request

Fixes the explosive pouch not being able to hold 67mm rockets

## Why It's Good For The Game

Fix good, Closes #14633

## Changelog

:cl:
fix: Fixes explosive pouch not being able to hold 67mm rockets
/:cl: