### PR TITLE
Fixes transport crewman and assault crewman orbit menu icons

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -106,6 +106,8 @@ GLOBAL_LIST_INIT(playable_icons, list(
 	"medical",
 	"pilot",
 	"transportofficer",
+	"transport_crew",
+	"assault_crew",
 	"praetorian",
 	"private",
 	"puppeteer",


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
Bug bad.
## Changelog
:cl:
fix: Fixed transport crewman and assault crewman orbit menu icons.
/:cl:
