### PR TITLE
Attrition fix

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -322,10 +322,11 @@
 		return
 
 	if(current_mission.mission_state == MISSION_STATE_ACTIVE)
-		if(stat_list[job_datum.faction].active_attrition_points < job_datum.job_cost)
+		var/active_attrition = stat_list[job_datum.faction].active_attrition_points
+		if(active_attrition < job_datum.job_cost)
 			to_chat(usr, "<span class='warning'>Unable to spawn. Insufficient attrition.<spawn>")
 			return
-		stat_list[job_datum.faction].active_attrition_points -= job_datum.job_cost
+		active_attrition -= job_datum.job_cost
 	LateSpawn(ready_candidate)
 	return TRUE
 

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -70,7 +70,7 @@
 
 	var/respawn_delay = CAMPAIGN_RESPAWN_TIME + stat_list[respawnee.faction]?.respawn_delay_modifier
 	if((player_death_times[respawnee.ckey] + respawn_delay) > world.time)
-		to_chat(respawnee, "<span class='warning'>Respawn timer has [round((player_death_times[respawnee.ckey] + respawn_delay - world.time) / 10)] seconds remaining.<spawn>")
+		to_chat(respawnee, span_warning("Respawn timer has [round((player_death_times[respawnee.ckey] + respawn_delay - world.time) / 10)] seconds remaining."))
 		return
 
 	attempt_attrition_respawn(respawnee)
@@ -309,22 +309,22 @@
 ///Actually respawns the player, if still able
 /datum/game_mode/hvh/campaign/proc/attrition_respawn(mob/new_player/ready_candidate, datum/job/job_datum)
 	if(!ready_candidate.IsJobAvailable(job_datum, TRUE))
-		to_chat(usr, "<span class='warning'>Selected job is not available.<spawn>")
+		to_chat(usr, span_warning("Selected job is not available."))
 		return
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
-		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished!<spawn>")
+		to_chat(usr,span_warning("The round is either not ready, or has already finished!"))
 		return
 	if(!GLOB.enter_allowed)
-		to_chat(usr, "<span class='warning'>Spawning currently disabled, please observe.<spawn>")
+		to_chat(usr, span_warning("Spawning currently disabled, please observe."))
 		return
 	if(!SSjob.AssignRole(ready_candidate, job_datum, TRUE))
-		to_chat(usr, "<span class='warning'>Failed to assign selected role.<spawn>")
+		to_chat(usr, span_warning("Failed to assign selected role."))
 		return
 
 	if(current_mission.mission_state == MISSION_STATE_ACTIVE)
 		var/active_attrition = stat_list[job_datum.faction].active_attrition_points
 		if(active_attrition < job_datum.job_cost)
-			to_chat(usr, "<span class='warning'>Unable to spawn. Insufficient attrition.<spawn>")
+			to_chat(usr, span_warning("Unable to spawn. Insufficient attrition."))
 			return
 		active_attrition -= job_datum.job_cost
 	LateSpawn(ready_candidate)

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -322,6 +322,9 @@
 		return
 
 	if(current_mission.mission_state == MISSION_STATE_ACTIVE)
+		if(stat_list[job_datum.faction].active_attrition_points < job_datum.job_cost)
+			to_chat(usr, "<span class='warning'>Unable to spawn. Insufficient attrition.<spawn>")
+			return
 		stat_list[job_datum.faction].active_attrition_points -= job_datum.job_cost
 	LateSpawn(ready_candidate)
 	return TRUE

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -444,10 +444,10 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	switch(action)
 		if("set_attrition_points")
 			if(!is_leadership_role(user))
-				to_chat(user, "<span class='warning'>Only leadership roles can do this.")
+				to_chat(user, span_warning("Only leadership roles can do this."))
 				return
 			if((current_mode.current_mission?.mission_state != MISSION_STATE_NEW) && (current_mode.current_mission?.mission_state != MISSION_STATE_LOADED))
-				to_chat(user, "<span class='warning'>Current mission already ongoing, unable to assign more personnel at this time.")
+				to_chat(user, span_warning("Current mission already ongoing, unable to assign more personnel at this time."))
 				return
 			var/combined_attrition = total_attrition_points + active_attrition_points
 			var/choice = tgui_input_number(user, "How much manpower would you like to dedicate to this mission?", "Attrition Point selection", 0, combined_attrition, 0, 60 SECONDS)
@@ -457,13 +457,13 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 			active_attrition_points = choice
 			for(var/mob/living/carbon/human/faction_member AS in GLOB.alive_human_list_faction[faction])
 				faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
-				to_chat(faction_member, "<span class='warning'>[user] has assigned [choice] attrition points for the next mission.")
+				to_chat(faction_member, span_warning("[user] has assigned [choice] attrition points for the next mission."))
 			update_static_data_for_all_viewers()
 			return TRUE
 
 		if("set_next_mission")
 			if(user != faction_leader)
-				to_chat(user, "<span class='warning'>Only your faction's commander can do this.")
+				to_chat(user, span_warning("Only your faction's commander can do this."))
 				return
 			var/new_mission = text2path(params["new_mission"])
 			if(!new_mission)
@@ -472,10 +472,10 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 				return
 			var/datum/campaign_mission/choice = available_missions[new_mission]
 			if(current_mode.current_mission?.mission_state != MISSION_STATE_FINISHED)
-				to_chat(user, "<span class='warning'>Current mission still ongoing!")
+				to_chat(user, span_warning("Current mission still ongoing!"))
 				return
 			if(!(stats_flags & MISSION_SELECTION_ALLOWED))
-				to_chat(user, "<span class='warning'>The opposing side has the initiative, win a mission to regain it.")
+				to_chat(user, span_warning("The opposing side has the initiative, win a mission to regain it."))
 				return
 			current_mode.load_new_mission(choice)
 			available_missions -= new_mission
@@ -491,10 +491,10 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 			var/datum/campaign_asset/choice = faction_assets[selected_asset]
 			if(!is_leadership_role(user))
 				if(!(choice.asset_flags & ASSET_SL_AVAILABLE))
-					to_chat(user, "<span class='warning'>Only leadership roles can do this.")
+					to_chat(user, span_warning("Only leadership roles can do this."))
 					return
 				if(!(ismarineleaderjob(user.job) || issommarineleaderjob(user.job)))
-					to_chat(user, "<span class='warning'>Only squad leaders and above can do this.")
+					to_chat(user, span_warning("Only squad leaders and above can do this."))
 					return
 			if(!choice.attempt_activatation(user))
 				return
@@ -502,12 +502,12 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 				faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
 				var/portrait = choice.asset_portrait ? choice.asset_portrait : faction_portrait
 				faction_member.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[choice.name] asset activated", portrait)
-				to_chat(faction_member, "<span class='warning'>[user] has activated the [choice.name] campaign asset.")
+				to_chat(faction_member, span_warning("[user] has activated the [choice.name] campaign asset."))
 			return TRUE
 
 		if("purchase_reward")
 			if(!is_leadership_role(user))
-				to_chat(user, "<span class='warning'>Only leadership roles can do this.")
+				to_chat(user, span_warning("Only leadership roles can do this."))
 				return
 			var/datum/campaign_asset/selected_asset = text2path(params["selected_reward"])
 			if(!selected_asset)
@@ -515,13 +515,13 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 			if(!(selected_asset in purchasable_assets))
 				return
 			if(initial(selected_asset.cost) > total_attrition_points)
-				to_chat(user, "<span class='warning'>[initial(selected_asset.cost) - total_attrition_points] more attrition points required.")
+				to_chat(user, span_warning("[initial(selected_asset.cost) - total_attrition_points] more attrition points required."))
 				return
 			add_asset(selected_asset)
 			total_attrition_points -= initial(selected_asset.cost)
 			for(var/mob/living/carbon/human/faction_member AS in GLOB.alive_human_list_faction[faction])
 				faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
-				to_chat(faction_member, "<span class='warning'>[user] has purchased the [initial(selected_asset.name)] campaign asset.")
+				to_chat(faction_member, span_warning("[user] has purchased the [initial(selected_asset.name)] campaign asset."))
 			update_static_data_for_all_viewers()
 			return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fixes a bug with attrition, where it only checks attrition when you first open the spawn window. So if multiple people open it at the same time (most commonly when rapid reserves is used), more people could spawn than you had attrition for.

This led to negative attrition in some cases, and is also what would break ally spawns (as even though they have zero attrition cost, once you're in the negatives, you're below that cost)
## Why It's Good For The Game
bug fix.
## Changelog
:cl:
fix: Campaign: Fixed an issue with attrition going into the negatives, allowing for more respawns than intended, and breaking allied spawns
/:cl:
