### PR TITLE
Scaling loadouts for campaign

### DIFF
--- a/code/__DEFINES/campaign.dm
+++ b/code/__DEFINES/campaign.dm
@@ -20,6 +20,12 @@
 #define CAMPAIGN_LOSS_BONUS 0.15
 ///Max losing bonus
 #define CAMPAIGN_MAX_LOSS_BONUS 0.45
+///Limited loadout items can be multiplied by up to this mult, based on pop
+#define CAMPAIGN_LOADOUT_MULT_MAX 3
+///Pop floor to for base loadout amount
+#define CAMPAIGN_LOADOUT_POP_MIN 40
+///Pop required to reach max loadout mult
+#define CAMPAIGN_LOADOUT_POP_MAX 100
 
 //mission defines
 ///Mission has not been loaded

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -45,11 +45,12 @@
 		stat_list[faction] = new /datum/faction_stats(faction)
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_PLAYER_ROUNDSTART_SPAWNED, COMSIG_GLOB_PLAYER_LATE_SPAWNED), PROC_REF(register_faction_member))
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_MOB_DEATH, COMSIG_MOB_GHOSTIZE), PROC_REF(set_death_time))
-	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, PROC_REF(cut_death_list_timer))
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, PROC_REF(end_mission))
 	addtimer(CALLBACK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode/hvh/campaign, intro_sequence)), SSticker.round_start_time + 1 MINUTES)
 
 /datum/game_mode/hvh/campaign/post_setup()
 	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(scale_loadouts)) //load_new_mission delays other proc calls in this proc both before and after it for whatever reason
 	for(var/obj/effect/landmark/patrol_point/exit_point AS in GLOB.patrol_point_list) //som 'ship' map is now ground, but this ensures we clean up exit points if this changes in the future
 		qdel(exit_point)
 	load_new_mission(new /datum/campaign_mission/tdm/first_mission(factions[1])) //this is the 'roundstart' mission
@@ -221,10 +222,22 @@
 		player_respawn(player)
 		return
 
-///Wrapper for cutting the deathlist via timer due to the players not immediately returning to base
-/datum/game_mode/hvh/campaign/proc/cut_death_list_timer(datum/source)
+///Handles post mission cleanup
+/datum/game_mode/hvh/campaign/proc/end_mission(datum/source)
 	SIGNAL_HANDLER
 	addtimer(CALLBACK(src, PROC_REF(cut_death_list)), AFTER_MISSION_TELEPORT_DELAY + 1)
+	scale_loadouts()
+
+///Limited loadout quantities scale by pop
+/datum/game_mode/hvh/campaign/proc/scale_loadouts(pop_override)
+	if(!isnum(pop_override))
+		pop_override = length(GLOB.clients)
+	var/loadout_ratio = clamp((pop_override - CAMPAIGN_LOADOUT_POP_MIN) / (CAMPAIGN_LOADOUT_POP_MAX - CAMPAIGN_LOADOUT_POP_MIN), 0, 1)
+	for(var/job in GLOB.campaign_loadout_items_by_role)
+		for(var/datum/loadout_item/loadout_item AS in GLOB.campaign_loadout_items_by_role[job])
+			if(loadout_item.quantity == -1)
+				continue
+			loadout_item.quantity = floor(LERP(initial(loadout_item.quantity), initial(loadout_item.quantity) * CAMPAIGN_LOADOUT_MULT_MAX, loadout_ratio))
 
 ///cuts the death time and respawn_timers list at mission end
 /datum/game_mode/hvh/campaign/proc/cut_death_list(datum/source)

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -337,18 +337,11 @@
 	apply_outcome()
 	play_outro()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAMPAIGN_MISSION_ENDED, src, winning_faction)
-	for(var/i in GLOB.quick_loadouts)
-		var/datum/outfit/quick/outfit = GLOB.quick_loadouts[i]
-		outfit.quantity = initial(outfit.quantity)
-	for(var/job in GLOB.campaign_loadout_items_by_role)
-		for(var/datum/loadout_item/loadout_item AS in GLOB.campaign_loadout_items_by_role[job])
-			loadout_item.quantity = initial(loadout_item.quantity)
 	for(var/mob/living/carbon/human/corpse AS in GLOB.dead_human_list) //clean up all the bodies and refund normal roles if required
 		if(corpse.z != mission_z_level.z_value)
 			continue
 		if(!HAS_TRAIT(corpse, TRAIT_UNDEFIBBABLE) && corpse?.job?.job_cost)
 			corpse.job.free_job_positions(1)
-
 		qdel(corpse)
 
 ///Unregisters all signals when the mission finishes

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
@@ -154,7 +154,7 @@
 	A powerful ranged weapon with a wide area of effect, the recoiless rifle is a powerful support weapon that can severely wound whole groups of opponents in a single shot. Has a draw delay."
 	ui_icon = "t160"
 	purchase_cost = 100
-	quantity = 2
+	quantity = 3
 	item_typepath = /obj/item/storage/holster/backholster/rpg/low_impact
 	jobs_supported = list(SQUAD_ENGINEER)
 


### PR DESCRIPTION

## About The Pull Request
Limited loadouts now scaling in quantity, based on pop.
40 and under = current min quantity.
100 pop = x3 normal quantity.

Also made the engie RR loadout limit 3 instead of 2, since its weaker than the SOM version.
## Why It's Good For The Game
More limited loadouts at higher pop is more interesting.
## Changelog
:cl:
add: Campaign limited loadout quantities scale with pop
balance: Campaign: LE RR loadout limit increased to 3 from 2
/:cl:
