### PR TITLE
Roomba no longer permanently curses storages that get vacuumed

### DIFF
--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -141,7 +141,7 @@
 	updateUsrDialog()
 
 	if(href_list["item"])
-		var/obj/item/I 
+		var/obj/item/I
 		switch(state)
 			if(STATE_GUN)
 				I = locate(href_list["item"]) in GLOB.cryoed_item_list_gun
@@ -354,6 +354,10 @@
 		if(!QDELETED(src))
 			qdel(src)
 		return
+	if(storage_datum)
+		for(var/obj/item/item_in_storage AS in src)
+			storage_datum.remove_from_storage(item_in_storage)
+			item_in_storage.store_in_cryo()
 	moveToNullspace()
 	if(istype(src, /obj/item/weapon/gun))
 		GLOB.cryoed_item_list_gun += src
@@ -373,11 +377,6 @@
 		GLOB.cryoed_item_list_containers += src
 	else
 		GLOB.cryoed_item_list_other += src
-
-/obj/item/storage/store_in_cryo()
-	for(var/obj/item/I AS in src)
-		I.store_in_cryo()
-	return ..()
 
 /obj/machinery/cryopod/grab_interact(obj/item/grab/grab, mob/user, base_damage = BASE_OBJ_SLAM_DAMAGE, is_sharp = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Roomba no longer permanently curses storages that get vacuumed
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14884
## Why It's Good For The Game
bugfix
## Changelog
:cl:
fix: Roomba no longer curses your storage if it sends it to cryo
/:cl:
