### PR TITLE
fixes proper args in playsound_local()

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -155,18 +155,18 @@ SUBSYSTEM_DEF(explosions)
 					far_explosion_sound = SFX_EXPLOSION_SMALL_DISTANT
 				// If inside the blast radius + world.view - 2
 				if(dist <= round(max_range + world.view - 2, 1))
-					M.playsound_local(epicenter, null, 75, 1, frequency, falloff = 5, sound_to_use = explosion_sound)
+					M.playsound_local(epicenter, explosion_sound, 75, 1, frequency, falloff = 5)
 					if(is_mainship_level(epicenter.z))
-						M.playsound_local(epicenter, null, 40, 1, frequency, falloff = 5, sound_to_use = creak_sound)//ship groaning under explosion effect
+						M.playsound_local(epicenter, creak_sound, 40, 1, frequency, falloff = 5)//ship groaning under explosion effect
 					if(baseshakeamount > 0)
 						shake_camera(M, 15, clamp(baseshakeamount, 0, 5))
 				// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 				else if(dist <= far_dist)
 					var/far_volume = clamp(far_dist, 30, 60) // Volume is based on explosion size and dist
 					far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
-					M.playsound_local(epicenter, null, far_volume, 1, frequency, falloff = 5, sound_to_use = far_explosion_sound)
+					M.playsound_local(epicenter, far_explosion_sound, far_volume, 1, frequency, falloff = 5)
 					if(is_mainship_level(epicenter.z))
-						M.playsound_local(epicenter, null, far_volume*3, 1, frequency, falloff = 5, sound_to_use = creak_sound)//ship groaning under explosion effect
+						M.playsound_local(epicenter, creak_sound, far_volume*3, 1, frequency, falloff = 5)//ship groaning under explosion effect
 					if(baseshakeamount > 0)
 						shake_camera(M, 7, clamp(baseshakeamount*0.15, 0, 1.5))
 

--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -125,15 +125,10 @@ SUBSYSTEM_DEF(tts)
 		if(get_dist(listening_mob, turf_source) <= range)
 			listening_mob.playsound_local(
 				turf_source,
+				soundin = audio_to_use,
 				vol = sound_volume,
-//				falloff_exponent = SOUND_FALLOFF_EXPONENT,
 				channel = channel,
-//				pressure_affected = TRUE,
-				sound_to_use = audio_to_use,
-//				max_distance = SOUND_RANGE,
-//				falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE,
 				distance_multiplier = 1,
-//				use_reverb = TRUE
 			)
 
 // Need to wait for all HTTP requests to complete here because of a rustg crash bug that causes crashes when dd restarts whilst HTTP requests are ongoing.

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 				target.playsound_local(source, SFX_ALIEN_CLAW_FLESH, 25, TRUE)
 				sleep(rand(CLICK_CD_RANGE, CLICK_CD_RANGE + 6))
 				if(hits >= 4 && prob(70))
-					target.playsound_local(source, get_sfx(pick(SFX_MALE_SCREAM, SFX_FEMALE_SCREAM)), 35, TRUE)
+					target.playsound_local(source, pick(SFX_MALE_SCREAM, SFX_FEMALE_SCREAM), 35, TRUE)
 					break
 	qdel(src)
 
@@ -284,7 +284,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		if("hugged")
 			target.playsound_local(source, 'sound/effects/alien_egg_move.ogg', 35, TRUE)
 			sleep(1 SECONDS)
-			target.playsound_local(source, get_sfx("[pick("male", "female")]_hugged"), 35, TRUE)
+			target.playsound_local(source, pick(SFX_MALE_HUGGED, SFX_FEMALE_HUGGED), 35, TRUE)
 		if("weed placed")
 			target.playsound_local(source, SFX_ALIEN_RESIN_BUILD, 35, TRUE)
 		if("gunshots")

--- a/code/modules/instruments/songs/play_legacy.dm
+++ b/code/modules/instruments/songs/play_legacy.dm
@@ -84,5 +84,5 @@
 		var/mob/M = i
 		if(M?.client?.prefs?.toggles_sound & SOUND_INSTRUMENTS_OFF)
 			continue
-		M.playsound_local(source, null, volume * using_instrument.volume_multiplier, sound_to_use = music_played)
+		M.playsound_local(source, music_played, volume * using_instrument.volume_multiplier)
 		// Could do environment and echo later but not for now

--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -64,7 +64,7 @@
 		var/mob/M = i
 		if(M?.client?.prefs?.toggles_sound & SOUND_INSTRUMENTS_OFF)
 			continue
-		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, FALSE, channel, copy)
+		M.playsound_local(get_turf(parent), copy, volume, FALSE, K.frequency, null, FALSE, channel)
 		// Could do environment and echo later but not for now
 
 /**

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -36,7 +36,7 @@
 	deadchat_broadcast(" has messaged the hive: \"[input]\"", Q, Q)
 	var/queens_word = "<span class='maptext' style=font-size:18pt;text-align:center valign='top'><u>HIVE MESSAGE:</u><br></span>" + input
 
-	var/sound/queen_sound = sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS)
+	var/sound/queen_sound = sound(get_sfx(SFX_QUEEN), channel = CHANNEL_ANNOUNCEMENTS)
 	var/sound/king_sound = sound('sound/voice/xenos_roaring.ogg', channel = CHANNEL_ANNOUNCEMENTS)
 	for(var/mob/living/carbon/xenomorph/X AS in Q.hive.get_all_xenos())
 		to_chat(X, assemble_alert(


### PR DESCRIPTION

## About The Pull Request
Fix some sounds I broke
They were passing the sound as ``sound_to_use`` instead of ``soundin``

BTW we still have 2 broken sounds, idk what they are supposed to be.
cas/heavygun/proc/strage_turfs is calling ``get_sfx("explosion")``
ammo/xeno/web/on_hit_mob is calling ``get_sfx("snap")``
Neither of these SFX have ever existed and idk if they had sound files somewhere, but idk where to find out so Im just leaving it.
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: fix some broken playsound_local (notably nades and TTS)
/:cl:
