### PR TITLE
Reduces Behemoth's Ability Damage Against Vehicles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1451,10 +1451,10 @@
 					continue
 				if(isvehicle(affected_atom))
 					var/obj/vehicle/veh_victim = affected_atom
-					var/damage_mult = 1
+					var/damage_add = 0
 					if(ismecha(veh_victim))
-						damage_mult = 5.55
-					veh_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER * damage_mult), MELEE)
+						damage_add = 8.2
+					veh_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER + damage_add), MELEE)
 					continue
 				if(istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
 					var/obj/structure/reagent_dispensers/fueltank/affected_tank = affected_atom

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1404,7 +1404,7 @@
 // ***************************************
 // *********** Global Procs
 // ***************************************
-#define AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER 10
+#define AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER 1.8
 
 /**
  * Checks for any atoms caught in the attack's range, and applies several effects based on the atom's type.

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1451,7 +1451,10 @@
 					continue
 				if(isvehicle(affected_atom))
 					var/obj/vehicle/veh_victim = affected_atom
-					veh_victim.take_damage(attack_damage * AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER, MELEE)
+					var/damage_mult = 1
+					if(ismecha(veh_victim))
+						damage_mult = 5.55
+					veh_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER * damage_mult), MELEE)
 					continue
 				if(istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
 					var/obj/structure/reagent_dispensers/fueltank/affected_tank = affected_atom


### PR DESCRIPTION

## About The Pull Request
Reduces Behemoth's ability damage against vehicles to a 1.8 multiplier, down from a 10 multiplier.
## Why It's Good For The Game
Behemoth is doing an absurd amount of damage against tanks and apcs right now, doing over 800 damage if he charges his rocks into a vehicle, or around 350 if he stomps in the middle of a vehicle. This pr changes it so each charged rock hit will do about 50 damage, totaling 150 damage, and stomp doing 63 damage. Primal wrath's earth pillars do the equivilant of 3 charged rocks.
## Changelog
:cl:
balance: Reduced the damage multiplier of behemoth's abilities against vehicles from 10 to 1.8
/:cl:
