### PR TITLE
Lava and fire jumping

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -187,12 +187,13 @@
 		return FALSE
 	if(status_flags & GODMODE)
 		return TRUE //while godmode will stop the damage, we don't want the process to stop in case godmode is removed
+	if(pass_flags & PASS_FIRE) //Pass fire allow to cross lava without being affected.
+		return FALSE
 
 	var/lava_damage = 20
 	take_overall_damage(max(modify_by_armor(lava_damage, FIRE), lava_damage * 0.3), BURN, updating_health = TRUE, max_limbs = 3) //snowflakey interaction to stop complete lava immunity
-	if(!CHECK_BITFIELD(pass_flags, PASS_FIRE))//Pass fire allow to cross lava without igniting
-		adjust_fire_stacks(20)
-		IgniteMob()
+	adjust_fire_stacks(20)
+	IgniteMob()
 	return TRUE
 
 /mob/living/fire_act(burn_level)
@@ -203,12 +204,11 @@
 	if(hard_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return FALSE
+	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being affected.
+		return FALSE
 
 	take_overall_damage(rand(10, burn_level), BURN, FIRE, updating_health = TRUE, max_limbs = 4)
 	to_chat(src, span_warning("You are burned!"))
-
-	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being ignited
-		return FALSE
 
 	. = TRUE
 	adjust_fire_stacks(burn_level)


### PR DESCRIPTION
## About The Pull Request
Lava and fire will now not deal damage when jumped over, previously not igniting but still dealing the damage.
## Why It's Good For The Game
Jumping over fire shouldnt still apply half of the effects.
## Changelog
:cl:
balance: Lava and fire no longer deal damage when jumped over.
/:cl:
