### PR TITLE
SL enabled rapid reserves

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/reserves.dm
+++ b/code/datums/gamemodes/campaign/rewards/reserves.dm
@@ -36,6 +36,7 @@
 	ui_icon = "respawn"
 	uses = 1
 	cost = 5
+	asset_flags = ASSET_ACTIVATED_EFFECT|ASSET_SL_AVAILABLE
 
 /datum/campaign_asset/tactical_reserves/activation_checks()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
SL's can activate the rapid reserve's asset in campaign.
## Why It's Good For The Game
Often when you need to turn this asset on, your faction leader could already be dead, and you might have no command staff.
## Changelog
:cl:
balance: Campaign: SL's can activate the Rapid Reserves asset
/:cl:
