### PR TITLE
Adds a dedicated AC and TC bunk bed to Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -1654,16 +1654,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo/prep)
-"aiT" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
 "aiW" = (
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -2098,11 +2088,9 @@
 	},
 /area/sulaco/research)
 "alR" = (
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
-	},
-/turf/closed/wall/mainship/gray,
-/area/sulaco/hangar/storage)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "alW" = (
 /obj/structure/sign/prop2,
 /turf/open/floor/plating,
@@ -3387,6 +3375,10 @@
 /obj/machinery/door/poddoor/opened/port,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"atj" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "atk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
@@ -9214,6 +9206,13 @@
 /obj/item/clothing/mask/balaclava,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"beR" = (
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "bfC" = (
 /obj/structure/closet/crate/medical,
 /turf/open/floor/prison,
@@ -9716,16 +9715,15 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/hangar)
 "bPy" = (
-/obj/machinery/door/poddoor/mainship/mech{
-	dir = 1;
-	id = "mech_shutters_3"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
+	},
 /turf/open/floor/mainship_hull/gray,
-/area/sulaco/hangar/storage)
+/area/mainship/living/tankerbunks)
 "bPL" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -10690,6 +10688,11 @@
 /obj/structure/ship_ammo/cas/bomb/fourhundred,
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
+"dbk" = (
+/obj/effect/landmark/start/job/assault_crewman,
+/obj/structure/bed/bunkbed,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "dde" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/prison/bright_clean,
@@ -11071,15 +11074,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/platebotc,
 /area/mainship/shipboard/weapon_room)
-"dDW" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/vending/engivend,
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
 "dEd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -11404,12 +11398,18 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
 "ebs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
+"ebF" = (
+/obj/structure/table/woodentable,
+/obj/effect/spawner/random/misc/cigarettes,
+/obj/effect/spawner/random/misc/soap,
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/machinery/light/mainship/small,
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "ecj" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/prison/bright_clean,
@@ -11568,12 +11568,8 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "ema" = (
-/obj/machinery/door_control/mainship/mech{
-	dir = 1;
-	id = "mech_shutters_3"
-	},
-/turf/open/floor/prison/bright_clean,
-/area/sulaco/hangar)
+/turf/closed/wall/mainship/gray/outer,
+/area/mainship/living/tankerbunks)
 "emj" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -11803,16 +11799,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/evac)
-"eAJ" = (
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
-	},
-/obj/machinery/door/poddoor/mainship/mech{
-	id = "mech_shutters_3"
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
 "eAL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/prison,
@@ -11822,6 +11808,13 @@
 /obj/item/explosive/grenade/flare/civilian,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"eBa" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "eBK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/mainship{
@@ -12277,6 +12270,10 @@
 	dir = 4
 	},
 /area/sulaco/medbay)
+"fba" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "fbS" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -12308,6 +12305,10 @@
 "fdF" = (
 /turf/closed/wall/mainship/gray,
 /area/sulaco/cryosleep)
+"fdV" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "fel" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -12332,6 +12333,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
+"ffg" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "fgg" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -12626,13 +12631,12 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "fAk" = (
-/obj/machinery/door/poddoor/mainship/mech{
-	dir = 1;
-	id = "mech_shutters_3"
-	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
+	},
 /turf/open/floor/mainship_hull/gray,
-/area/sulaco/hangar/storage)
+/area/mainship/living/tankerbunks)
 "fBA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
@@ -13219,6 +13223,16 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
+"gpt" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/gear/vehicle,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "gpO" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -13412,18 +13426,18 @@
 	},
 /area/sulaco/medbay/west)
 "gGS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
 	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
+"gHp" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "gHU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
@@ -13570,6 +13584,11 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/marine)
+"gRZ" = (
+/obj/structure/bed/chair/wood/wings,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "gSo" = (
 /obj/machinery/door/airlock/mainship/engineering,
 /obj/machinery/door/firedoor/mainship,
@@ -13738,21 +13757,6 @@
 /obj/structure/rack,
 /obj/item/circuitboard/machine/batteryrack,
 /obj/item/circuitboard/machine/smes,
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
-"hbA" = (
-/obj/machinery/power/apc/mainship,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "vehicle_elevator_railing"
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "hbH" = (
@@ -14136,16 +14140,12 @@
 	},
 /area/sulaco/medbay/west)
 "hAn" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/tank_part_fabricator,
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "hAO" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -14284,6 +14284,18 @@
 	dir = 8
 	},
 /area/sulaco/medbay/storage)
+"hGh" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "hGE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -15437,6 +15449,12 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/prison/sterilewhite,
 /area/mainship/living/starboard_garden)
+"iWf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "iWz" = (
 /obj/machinery/firealarm,
 /obj/vehicle/ridden/powerloader,
@@ -15541,6 +15559,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"jcm" = (
+/obj/effect/spawner/random/misc/plant,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "jdD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -16309,6 +16331,12 @@
 	dir = 10
 	},
 /area/space)
+"jYm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "jYs" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -17426,6 +17454,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
+"lwZ" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "lxu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -17557,6 +17592,13 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/cas)
+"lEb" = (
+/obj/structure/table/woodentable,
+/obj/item/paper,
+/obj/effect/spawner/random/misc/cigarettes,
+/obj/effect/spawner/random/misc/cigar,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "lEm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -17597,8 +17639,12 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "lFo" = (
-/turf/open/floor/mainship/empty,
-/area/sulaco/hangar/storage)
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/gear/vehicle,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "lFQ" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -17699,17 +17745,15 @@
 /turf/open/floor/plating,
 /area/sulaco/hangar)
 "lML" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/structure/rack,
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
 	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "lMO" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -18407,6 +18451,9 @@
 "mDu" = (
 /turf/open/floor/mainship_hull/gray,
 /area/space)
+"mEj" = (
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "mEE" = (
 /turf/open/floor/prison/red{
 	dir = 6
@@ -18646,11 +18693,10 @@
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
 "mYh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "mYA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18844,6 +18890,17 @@
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/plate,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"nnz" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "nob" = (
 /obj/effect/landmark/start/job/synthetic,
 /obj/effect/ai_node,
@@ -19082,15 +19139,9 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "nGd" = (
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/mainship/mech{
-	id = "mech_shutters_3"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "nGG" = (
 /obj/machinery/door_control/mainship/tcomms{
 	dir = 8;
@@ -19900,15 +19951,16 @@
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "oEr" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
 	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "oEw" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /turf/open/floor/prison,
@@ -20160,6 +20212,10 @@
 /obj/item/radio/intercom/general,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
+"oRe" = (
+/obj/docking_port/stationary/supply/vehicle,
+/turf/open/floor/mainship/empty,
+/area/mainship/living/tankerbunks)
 "oRM" = (
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -21315,14 +21371,12 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "qwj" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
 	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "qxr" = (
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
@@ -21640,6 +21694,12 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"qRM" = (
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "qSg" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -22224,12 +22284,9 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "rCY" = (
-/obj/machinery/door/poddoor/mainship/mech{
-	dir = 1;
-	id = "mech_shutters_3"
-	},
+/obj/structure/window/framed/mainship/gray/toughened,
 /turf/open/floor/mainship_hull/gray,
-/area/sulaco/hangar/storage)
+/area/mainship/living/tankerbunks)
 "rDx" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/surgical_tray,
@@ -22372,17 +22429,6 @@
 	dir = 8
 	},
 /area/mainship/living/basketball)
-"rNf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
 "rNq" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -22479,6 +22525,18 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"rQp" = (
+/obj/structure/mirror{
+	dir = 8
+	},
+/obj/structure/table/woodentable,
+/obj/item/paper,
+/obj/effect/spawner/random/misc/clipboard,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "rSe" = (
 /obj/item/radio/intercom/general{
 	dir = 8
@@ -22571,6 +22629,10 @@
 	dir = 1
 	},
 /area/sulaco/research)
+"saI" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull,
+/turf/open/floor/plating/platebotc,
+/area/mainship/living/tankerbunks)
 "saZ" = (
 /obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/chapel{
@@ -22701,6 +22763,14 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/wood,
 /area/sulaco/bridge/office)
+"sfh" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "sft" = (
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/prison,
@@ -23128,12 +23198,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "sDv" = (
-/obj/machinery/door_control/mainship/mech{
-	dir = 4;
-	id = "mech_shutters_3"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/machinery/tank_part_fabricator,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "sDU" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/prison/whitegreen/corner{
@@ -23211,6 +23278,16 @@
 	dir = 6
 	},
 /area/sulaco/bridge)
+"sKu" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "sKG" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/disk/botany,
@@ -23282,6 +23359,12 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"sNp" = (
+/obj/structure/table/woodentable,
+/obj/effect/spawner/random/misc/table_lighting,
+/obj/effect/spawner/random/misc/hand_labeler,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "sNK" = (
 /obj/machinery/light/mainship,
 /obj/machinery/holopad{
@@ -23400,13 +23483,10 @@
 "sUF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 1
+	dir = 6
 	},
-/obj/machinery/light/mainship/small{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "sUP" = (
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/briefing)
@@ -23464,6 +23544,14 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"sXB" = (
+/obj/effect/landmark/start/job/transport_crewman,
+/obj/structure/bed/bunkbed,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "sZo" = (
 /obj/machinery/holopad,
 /turf/open/floor/prison,
@@ -23696,6 +23784,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"tlP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "tmj" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -24293,6 +24387,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
+"ucf" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "udt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -24415,12 +24513,15 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "uiA" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "vehicle_elevator_railing"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/gear/vehicle,
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "uiN" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/rifle/m412,
@@ -24528,14 +24629,8 @@
 /turf/open/floor/plating,
 /area/sulaco/hangar)
 "uoJ" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/vending/tool,
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "uoT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -24659,6 +24754,10 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/cargo/office)
+"uyv" = (
+/obj/structure/window/framed/mainship/gray/toughened,
+/turf/open/floor/plating/platebotc,
+/area/mainship/living/tankerbunks)
 "uyz" = (
 /turf/open/floor/prison/sterilewhite,
 /area/mainship/living/starboard_garden)
@@ -24685,6 +24784,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
+"uAA" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "uAS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -24807,6 +24912,16 @@
 	dir = 8
 	},
 /area/sulaco/medbay)
+"uJa" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "uJg" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/mainship/small{
@@ -24857,6 +24972,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"uNx" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "uNQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -25269,6 +25388,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "vrP" = (
@@ -25527,6 +25647,16 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/storage)
+"vDm" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/vending/engivend,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "vDU" = (
 /turf/open/floor/mainship_hull/gray/dir{
 	dir = 4
@@ -26422,14 +26552,14 @@
 /turf/open/floor/prison/arrow/clean,
 /area/mainship/command/self_destruct)
 "wTy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
 	},
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/obj/machinery/gear/vehicle,
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "wTC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -26670,9 +26800,8 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
 "xiF" = (
-/obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
-/area/sulaco/hangar/storage)
+/area/mainship/living/tankerbunks)
 "xjl" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
@@ -26874,6 +27003,9 @@
 /obj/item/weapon/gun/energy/taser,
 /turf/open/floor/prison,
 /area/sulaco/security)
+"xzr" = (
+/turf/closed/wall/mainship/gray,
+/area/mainship/living/tankerbunks)
 "xzB" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clipboard,
@@ -26996,6 +27128,15 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/prison,
 /area/sulaco/marine)
+"xIb" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "xIz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -27064,14 +27205,13 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_main_hall)
 "xLQ" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
 	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "xMC" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/opened{
@@ -68823,11 +68963,11 @@ sKM
 aPF
 aPF
 aPF
-aRQ
 aPF
 aPF
 aPF
-ema
+aPF
+aPF
 bYM
 eRL
 uwV
@@ -69072,22 +69212,22 @@ bFa
 bFa
 bFa
 bFa
-bFa
-bFa
-bFa
-bFa
-bFa
-bFa
-kOr
-bYM
+ema
+xzr
+xzr
+xzr
+xzr
+xzr
+xzr
+eBa
 alR
-alR
+uoJ
 nGd
-nGd
-eAJ
-bYM
-bYM
-bYM
+uoJ
+uoJ
+xzr
+xzr
+xzr
 iZD
 aUS
 iZD
@@ -69328,23 +69468,23 @@ tZr
 vDU
 vDU
 vDU
-vDU
-vDU
-vDU
-vDU
-vDU
-vDU
 mDu
-kOr
+ema
+dbk
+mEj
+sXB
+mEj
+fba
+gHp
 uoJ
 lFo
-lFo
-lFo
-lFo
+qRM
+qRM
+beR
 lFo
 hAn
 sDv
-bYM
+xzr
 qpD
 mCT
 pWS
@@ -69585,23 +69725,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nzi
-ykt
+saI
+uNx
+mEj
+mEj
+gRZ
+lEb
+uyv
 qwj
-lFo
-lFo
-lFo
-lFo
-lFo
+xiF
+xiF
+xiF
+xiF
+xiF
 oEr
-lEr
-bYM
+uoJ
+xzr
 aeL
 qTF
 pMx
@@ -69842,23 +69982,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nzi
-ykt
+saI
+ffg
+mEj
+mEj
+mEj
+sNp
+uyv
 xLQ
-lFo
-lFo
 xiF
-lFo
-lFo
-oEr
+xiF
+xiF
+xiF
+xiF
+sKu
 ebs
-bYM
+xzr
 jYO
 wTC
 jJa
@@ -70099,21 +70239,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nzi
-ykt
-dDW
-lFo
-lFo
-lFo
-lFo
-lFo
-oEr
+saI
+ucf
+mEj
+uAA
+mEj
+iWf
+uyv
+qwj
+xiF
+xiF
+oRe
+xiF
+xiF
+nnz
 mYh
 fAk
 kzO
@@ -70356,22 +70496,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nzi
-kOr
+ema
+fdV
+ebF
+rQp
+jcm
+jYm
+lwZ
 lML
-lFo
-lFo
-lFo
-lFo
-lFo
+xiF
+xiF
+xiF
+xiF
+xiF
 gGS
-pWS
+atj
 rCY
 tkV
 gRI
@@ -70613,20 +70753,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nzi
-kOr
+ema
+ema
+ema
+ema
+ema
+ema
+ema
 uiA
-aiT
-aiT
-aiT
-hbA
-rNf
+xiF
+xiF
+xiF
+xiF
+xiF
 wTy
 sUF
 bPy
@@ -70870,23 +71010,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 tZr
-cyv
-cyv
-kOr
-kOr
-kOr
-kOr
-ykt
-ykt
-kOr
-kOr
+vDU
+vDU
+vDU
+vDU
+vDU
+mDu
+ema
+sfh
+gpt
+uJa
+xIb
+hGh
+gpt
+tlP
+vDm
+xzr
 pWS
 hlB
 jYO
@@ -71133,17 +71273,17 @@ aaa
 aaa
 aaa
 aaa
-tZr
-vDU
-vDU
-vDU
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-ykt
+nzi
+ema
+ema
+ema
+ema
+ema
+ema
+saI
+saI
+ema
+ema
 aeL
 bWI
 dQF
@@ -71390,11 +71530,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-nzi
+tZr
+vDU
+vDU
+vDU
+mDu
 mDu
 mDu
 mDu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the AC and TC a proper spawn instead of spawning them at cryo roundstart, gives them a room and makes them able to access their lift without breaking through shutters.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/80391698/cdec6ea8-c6ec-4825-822f-ff65e5362a92)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, Sulaco lacks a proper AC+TC room. This PR:
* makes it so AC and TC don't have to break through several shutters and doors in order to get to their lift.
* Gives AC and TC their own room in which they spawn in and have several vendors much like on Pillar of Spring.
* Widens the room because currently the walls touch the platforms and it looks uggo as the walls try to connect to the platforms
* Fixes the outside decor plating near the ACTC room
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a proper room for AC and TC in Sulaco.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
