### PR TITLE
Removes evo fade in for xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -205,8 +205,6 @@
 	qdel(src)
 	INVOKE_ASYNC(new_xeno, TYPE_PROC_REF(/atom, do_jitter_animation), 1000)
 
-	new_xeno.overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
-
 ///Check if the xeno is currently able to evolve
 /mob/living/carbon/xenomorph/proc/generic_evolution_checks()
 	if(do_actions)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -345,6 +345,11 @@
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
 
+
+/mob/living/carbon/xenomorph/on_spawn(mob/new_player/summoner)
+	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", atom/movable/screen/fullscreen/black)
+	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", atom/movable/screen/fullscreen/spawning_in)
+
 /mob/new_player/proc/transfer_character()
 	. = new_character
 	if(.)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -345,10 +345,6 @@
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
 
-/mob/living/carbon/xenomorph/on_spawn(mob/new_player/summoner)
-	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
-	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
-
 /mob/new_player/proc/transfer_character()
 	. = new_character
 	if(.)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -347,8 +347,8 @@
 
 
 /mob/living/carbon/xenomorph/on_spawn(mob/new_player/summoner)
-	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", atom/movable/screen/fullscreen/black)
-	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", atom/movable/screen/fullscreen/spawning_in)
+	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
+	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
 
 /mob/new_player/proc/transfer_character()
 	. = new_character

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -345,7 +345,6 @@
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)
 
-
 /mob/living/carbon/xenomorph/on_spawn(mob/new_player/summoner)
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)
 	overlay_fullscreen_timer(2 SECONDS, 20, "roundstart2", /atom/movable/screen/fullscreen/spawning_in)


### PR DESCRIPTION
## About The Pull Request
This feature doesn't really do anything but mildly annoy the xeno for 2 seconds upon spawning or evolving. I'm tired of being mildly annoyed.

in gh#14149 the fade in was advertised as both a way to remove xeno hitlag and as an immersion thing. The xeno hitlag was proved to be false, but it was merged because of the immersion thing. I don't think the immersion thing is worth it, hence the removal
## Why It's Good For The Game
All minor inconveniences must be destroyed. Immersion isn't real
## Changelog
:cl:
del: Xenos evolution fade-in effect removed
/:cl:
