### PR TITLE
Add SEE_OBJS and SEE_MOBS to the new_player mob type

### DIFF
--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -7,7 +7,7 @@
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	stat = DEAD // Keep hearing ghosts and other IFs
 	invisibility = INVISIBILITY_MAXIMUM
-	sight = SEE_MOBS|SEE_TURFS|SEE_OBJS
+	sight = SEE_MOBS|SEE_TURFS|SEE_OBJS|SEE_SELF
 	see_in_dark = 8
 	move_on_shuttle = TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -25,7 +25,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_invisible = SEE_INVISIBLE_LIVING
 	invisibility = INVISIBILITY_MAXIMUM
-	sight = SEE_MOBS|SEE_TURFS|SEE_OBJS
+	sight = SEE_MOBS|SEE_TURFS|SEE_OBJS|SEE_SELF
 	see_in_dark = 8
 	move_on_shuttle = TRUE
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -13,7 +13,7 @@
 	density = TRUE
 	canmove = FALSE
 	status_flags = CANSTUN|CANKNOCKOUT
-	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
+	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 	hud_type = /datum/hud/ai
 	buckle_flags = NONE
 	has_unlimited_silicon_privilege = TRUE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -15,7 +15,6 @@
 		hud_used.show_hud(hud_used.hud_version)
 
 	next_move = 1
-	sight |= SEE_SELF
 
 	// DO NOT CALL PARENT HERE
 	// BYOND's internal implementation of login does two things

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -1,5 +1,6 @@
 /mob/new_player
 	invisibility = INVISIBILITY_ABSTRACT
+	sight = SEE_MOBS|SEE_OBJS|SEE_TURFS
 	stat = DEAD
 	density = FALSE
 	canmove = FALSE


### PR DESCRIPTION
## About The Pull Request

Weirdly, players in the menu can't see anything except turfs and themselves. This PR also removes the `SEE_SELF` so you won't see the ghost mob in the context menu if you right click.

Moved `SEE_SELF` out of the `Login()` proc to the mobs that actually need them. Nothing out of the ordinary happened with humans and benos not having `SEE_SELF` (humans always lost it anyways since their sight is constantly updated). This seems to only really matter for camera-type mobs.

## Why It's Good For The Game

Fix.

## Changelog
:cl:
fix: Players in main menu can see mobs and objects if they make their way in, and no longer see themselves in the right click menu.
/:cl:
