### PR TITLE
Adds PR-412 incendiary mags to Requisition

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1675,6 +1675,11 @@ Imports
 	contains = list(/obj/item/ammo_magazine/rifle)
 	cost = 3
 
+/datum/supply_packs/imports/m41a2/ammo
+	name = "PR-412 Pulse Rifle Incendiary Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/incendiary)
+	cost = 8
+
 /datum/supply_packs/imports/m412l1
 	name = "PR-412L1 Heavy Pulse Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/m412l1_hpr)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1675,10 +1675,10 @@ Imports
 	contains = list(/obj/item/ammo_magazine/rifle)
 	cost = 3
 
-/datum/supply_packs/imports/m41a2/ammo
+/datum/supply_packs/imports/m41a2/ammo/incendiary
 	name = "PR-412 Pulse Rifle Incendiary Ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/incendiary)
-	cost = 8
+	cost = 25
 
 /datum/supply_packs/imports/m412l1
 	name = "PR-412L1 Heavy Pulse Rifle"


### PR DESCRIPTION
## About The Pull Request
You can now buy the incend mags for the PR412 for 25 points each.

/datum/ammo/bullet/rifle/incendiary
    name = "incendiary rifle bullet"
    hud_state = "rifle_fire"
    damage_type = BURN
    shrapnel_chance = 0
    ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
    accuracy = -10

## Why It's Good For The Game
Currently unused and not found anywhere else in the game, but remains in the files. This makes them used.
## Changelog
:cl:
add: You can now purchase the PR-412 incend mags from req
/:cl:
