### PR TITLE
Jerrycans show correct amount of fuel when examined

### DIFF
--- a/code/modules/reagents/reagent_containers/jerrycan.dm
+++ b/code/modules/reagents/reagent_containers/jerrycan.dm
@@ -16,7 +16,7 @@
 	if(get_dist(user,src) > 2)
 		. += span_warning("You're too far away to see [src]'s reagent amount!")
 		return
-	. += "There is [volume] units of fuel remaining."
+	. += "There is [reagents.reagent_list ? reagents.total_volume : 0] units of fuel remaining."
 
 /obj/item/reagent_containers/jerrycan/attack_turf(turf/A, mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Examining jerrycans correctly show how much fuel is inside of it.
## Why It's Good For The Game
Bugfix. There isn't 200 units of fuel in a jerrycan when it is empty.
## Changelog
:cl:
fix: Jerrycans correctly show how much fuel is inside of it when examined.
/:cl:
