### PR TITLE
The roomba no longer vaccums up ammunition after it fucking ate 7 of my pulse rifle mags holy fucking shit I hate the roomba

### DIFF
--- a/code/game/objects/machinery/bots/roomba.dm
+++ b/code/game/objects/machinery/bots/roomba.dm
@@ -50,7 +50,7 @@
 
 	var/sucked_one = FALSE
 	for(var/obj/item/sucker in loc)
-		if(sucker.anchored)
+		if(sucker.anchored || istype(sucker, /obj/item/ammo_magazine))
 			continue
 		sucked_one = TRUE
 


### PR DESCRIPTION
## About The Pull Request

The roomba no longer vaccums up ammunition after it fucking ate 7 of my pulse rifle mags holy fucking shit I hate the roomba

## Why It's Good For The Game

I love having no ammunition because I spent 70 points on pulse rifle mags and the roomba rolls over it when I open the crate

## Changelog
:cl:
qol: The roomba no longer vaccums up ammunition after it fucking ate 7 of my pulse rifle mags holy fucking shit I hate the roomba
/:cl:
