### PR TITLE
Fixes revive() causing you to be unable to shoot at unseen tiles

### DIFF
--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -320,6 +320,7 @@
 	handle_regular_hud_updates()
 	reload_fullscreens()
 	hud_used?.show_hud(hud_used.hud_version)
+	add_click_catcher()
 
 	SSmobs.start_processing(src)
 	SEND_SIGNAL(src, COMSIG_LIVING_POST_FULLY_HEAL, admin_revive)


### PR DESCRIPTION

## About The Pull Request

Allows mobs to shoot at unseen tiles when revive() gets called on them. I'm going to admit, this was more of a game of 'call the missing proc that wasn't called in login()'. I don't fully understand why this works, and my only guess that is that the screenmob.client.screen = list() call in the show_hud() deletes these voids that can be shot at, and that calling add_click_catcher() readds them. This is me talking out of my ass though. No immediate bugs from testing though.

Fixes #15550

## Why It's Good For The Game

You no longer need to reconnect when leaving robotic cradles or entering EORD from the round ending to shoot at unseen tiles.

## Changelog
:cl:
fix: Admin revives, the robotic cradle, and entering EORD via round end prefs should no longer cause you to be unable to shoot at unseen tiles
/:cl:
