### PR TITLE
Allows AI to get coords from weeds

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -207,6 +207,9 @@
 	var/turf/firedturf = get_turf(src)
 	firedturf.AICtrlShiftClick(user)
 
+/obj/alien/weeds/AICtrlClick(mob/living/silicon/ai/user)
+	var/turf/firedturf = get_turf(src)
+	firedturf.AICtrlClick(user)
 /* Xenos */
 /mob/living/carbon/xenomorph/AIMiddleClick(mob/living/silicon/ai/user)
 	user.ai_ping(src, COOLDOWN_AI_PING_NORMAL)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -210,6 +210,7 @@
 /obj/alien/weeds/AICtrlClick(mob/living/silicon/ai/user)
 	var/turf/firedturf = get_turf(src)
 	firedturf.AICtrlClick(user)
+
 /* Xenos */
 /mob/living/carbon/xenomorph/AIMiddleClick(mob/living/silicon/ai/user)
 	user.ai_ping(src, COOLDOWN_AI_PING_NORMAL)


### PR DESCRIPTION

## About The Pull Request

AI couldn't get coords on weeded tiles, this fixes that

## Why It's Good For The Game

AI has one less excuse for giving mortar/howtizer coords

## Changelog

:cl:
fix: AI can now use Ctrl Click on weeded tiles to get coordinates
/:cl:
