### PR TITLE
Click catcher fix

### DIFF
--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -141,9 +141,11 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/atom_hud, list(
 	return
 
 
+///Sets up the click_catcher for the client
 /mob/proc/add_click_catcher()
-	client.screen += client.void
-
+	if(!client)
+		return
+	client.apply_clickcatcher()
 
 /mob/new_player/add_click_catcher()
 	return

--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -143,9 +143,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/atom_hud, list(
 
 ///Sets up the click_catcher for the client
 /mob/proc/add_click_catcher()
-	if(!client)
-		return
-	client.apply_clickcatcher()
+	client?.apply_clickcatcher()
 
 /mob/new_player/add_click_catcher()
 	return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -302,7 +302,6 @@
 
 	send_resources()
 
-	generate_clickcatcher()
 	apply_clickcatcher()
 
 	if(prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
@@ -903,15 +902,11 @@
 	winset(src, "mainwindow", "is-maximized=true")
 
 
-/client/proc/generate_clickcatcher()
-	if(void)
-		return
-	void = new()
-	screen += void
-
-
+///Creates and applies a clickcatcher
 /client/proc/apply_clickcatcher()
-	generate_clickcatcher()
+	if(!void)
+		void = new()
+	screen |= void
 	var/list/actualview = getviewsize(view)
 	void.UpdateGreed(actualview[1], actualview[2])
 


### PR DESCRIPTION

## About The Pull Request
Thanks to @Notamaniac in #15860 who narrowed down the issue on this long standing bug.

Fixed the click catcher not working in some circumstances (such as after using revive()).

The way the proc was setup meant the click catcher was being created but not applied. Changed it so it now should apply correctly no matter what.

:cl:
fix: fixed the blackscreen click catcher not working under some conditions
/:cl:
