### PR TITLE
Fixes bar signs

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -5,6 +5,7 @@
 
 /obj/structure/sign/double/barsign/Initialize(mapload)
 	. = ..()
+	icon = 'icons/obj/structures/barsigns.dmi'
 	ChangeSign(pick(
 	"pinkflamingo",
 	"magmasea",

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -2,10 +2,10 @@
 	icon = 'icons/obj/structures/barsigns.dmi'
 	icon_state = "off"
 	anchored = TRUE
+	directional = FALSE
 
 /obj/structure/sign/double/barsign/Initialize(mapload)
 	. = ..()
-	icon = 'icons/obj/structures/barsigns.dmi'
 	ChangeSign(pick(
 	"pinkflamingo",
 	"magmasea",

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -5,12 +5,13 @@
 	density = FALSE
 	layer = WALL_OBJ_LAYER
 	var/directional = TRUE //if true init to a given x/y offset on a wall, if not leave floating in space. used for multiple signs on a wall to prevent them all from moving to the same offset and overlapping/becoming unreadable
+	var/unmodified_icon = 'icons/obj/decals.dmi' // the clean version of the sprite, which we replace in initialize when the sign loads in game
 
 /obj/structure/sign/Initialize(mapload)
 	. = ..()
 	if(!directional) //if not directional do not initialize to a x or y offset
 		return
-	icon = 'icons/obj/decals.dmi' // replace the modified decal sprites with normal ones without an arrow
+	icon = unmodified_icon
 	switch(dir)
 		if(NORTH)
 			pixel_y = 32

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -1,5 +1,5 @@
 /obj/structure/sign
-	icon = 'icons/obj/decals_arrow.dmi'
+	icon = 'icons/obj/decals_arrow.dmi' // a copy of icons/obj/decals.dmi with directional arrows on the sprites, so a mapper knows which way a sign is facing
 	anchored = TRUE
 	opacity = FALSE
 	density = FALSE
@@ -8,9 +8,9 @@
 
 /obj/structure/sign/Initialize(mapload)
 	. = ..()
-	icon = 'icons/obj/decals.dmi'
 	if(!directional) //if not directional do not initialize to a x or y offset
 		return
+	icon = 'icons/obj/decals.dmi' // replace the modified decal sprites with normal ones without an arrow
 	switch(dir)
 		if(NORTH)
 			pixel_y = 32

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -5,13 +5,14 @@
 	density = FALSE
 	layer = WALL_OBJ_LAYER
 	var/directional = TRUE //if true init to a given x/y offset on a wall, if not leave floating in space. used for multiple signs on a wall to prevent them all from moving to the same offset and overlapping/becoming unreadable
-	var/unmodified_icon = 'icons/obj/decals.dmi' // the clean version of the sprite, which we replace in initialize when the sign loads in game
+	/// The clean version of the sprite, which we replace in initialize when the sign loads in game
+	var/base_icon = 'icons/obj/decals.dmi' 
 
 /obj/structure/sign/Initialize(mapload)
 	. = ..()
 	if(!directional) //if not directional do not initialize to a x or y offset
 		return
-	icon = unmodified_icon
+	icon = base_icon
 	switch(dir)
 		if(NORTH)
 			pixel_y = 32


### PR DESCRIPTION

## About The Pull Request
Turns out /obj/structure/sign/ changes the icon var on initialize, which barsigns inherit from.

## Why It's Good For The Game
Less error signs

## Changelog
:cl:
fix: Barsigns should no longer show up as errors
/:cl:
