### PR TITLE
Clarifies that Behemoth rolling ram deals no damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -81,7 +81,7 @@
 
 /datum/action/ability/xeno_action/ready_charge/behemoth_roll
 	name = "Roll"
-	desc = "Toggles Rolling on or off. This can be used to damage talls but won't deal much damage."
+	desc = "Toggles Rolling on or off. This can be used to displace talls but won't deal ANY damage."
 	charge_type = CHARGE_BEHEMOTH
 	speed_per_step = 0.35
 	steps_for_charge = 4

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -81,7 +81,7 @@
 
 /datum/action/ability/xeno_action/ready_charge/behemoth_roll
 	name = "Roll"
-	desc = "Toggles Rolling on or off."
+	desc = "Toggles Rolling on or off. This can be used to damage talls but won't deal much damage."
 	charge_type = CHARGE_BEHEMOTH
 	speed_per_step = 0.35
 	steps_for_charge = 4

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -81,7 +81,7 @@
 
 /datum/action/ability/xeno_action/ready_charge/behemoth_roll
 	name = "Roll"
-	desc = "Toggles Rolling on or off. This can be used to displace talls but won't deal ANY damage."
+	desc = "Toggles Rolling on or off. This can be used to displace talls but won't deal any damage."
 	charge_type = CHARGE_BEHEMOTH
 	speed_per_step = 0.35
 	steps_for_charge = 4


### PR DESCRIPTION
## About The Pull Request
Changes behemoth rolling description to desc = "Toggles Rolling on or off. This can be used to displace talls but won't deal any damage."
## Why It's Good For The Game
I've seen behemoths use it offensively without knowing it's doing nothing, this will let them know it's a traversal ability and not a damaging tool.
## Changelog
:cl:
qol: clarifies that behemoth roll deals 0 damage in the ability description
/:cl:
