### PR TITLE
Fixes overwatch being unable to select targets to OB

### DIFF
--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -482,6 +482,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 		if("back")
 			state = OW_MAIN
 		if("use_cam")
+			selected_target = locate(href_list["selected_target"])
 			var/atom/cam_target = locate(href_list["cam_target"])
 			if(!cam_target)
 				return


### PR DESCRIPTION

## About The Pull Request
#15598 broke the ability to select laser targets for OB's
This probably needs a more comprehensive fix, alas staring at html makes my head ache.
And no, this doesn't let you OB on a marine cam, the selected_target var is checked to see whether it's an orbital beacon (bring back orbital beacons pls) or laser target

## Why It's Good For The Game

I won't get yelled at by Alan or other FC's for not firing the OB as an AI

## Changelog

:cl:
fix: Overwatch can select laser targets to fire OB's again
/:cl:
