### PR TITLE
Map fixes

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -14281,10 +14281,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical)
-"lNQ" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "lOu" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -22333,12 +22329,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
-"sqK" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "sqT" = (
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -27241,12 +27231,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
-"wDJ" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "wDK" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -27948,10 +27932,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
-"xkA" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "xlh" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/cargo/arrow{
@@ -36402,7 +36382,7 @@ vAL
 mGC
 jfL
 jcy
-lNQ
+mGC
 mGC
 mGC
 mGC
@@ -36504,7 +36484,7 @@ vAL
 rik
 rik
 bHy
-xkA
+mGC
 mGC
 mGC
 mGC
@@ -37116,7 +37096,7 @@ vAL
 uST
 uST
 uhS
-xkA
+mGC
 mGC
 mGC
 mGC
@@ -37218,7 +37198,7 @@ vAL
 mGC
 jfL
 jcy
-lNQ
+mGC
 mGC
 mGC
 mGC
@@ -39365,7 +39345,7 @@ krc
 bHy
 mGC
 fjj
-sqK
+mGC
 mGC
 mGC
 mGC
@@ -40385,7 +40365,7 @@ mtP
 uhS
 mGC
 fjj
-wDJ
+mGC
 mGC
 mGC
 mGC

--- a/_maps/map_files/Campaign maps/orion_2/orionoutpost_2.dmm
+++ b/_maps/map_files/Campaign maps/orion_2/orionoutpost_2.dmm
@@ -7014,14 +7014,6 @@
 /obj/machinery/vending/security,
 /turf/open/floor/mainship/red,
 /area/orion_outpost/surface/building/monitor)
-"HG" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/orion_outpost/surface/landing_pad_2)
 "HJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -7364,10 +7356,6 @@
 /obj/structure/window/framed/mainship/gray,
 /turf/open/floor/wood,
 /area/orion_outpost/surface/building/barracks)
-"Ju" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad_2)
 "Jw" = (
 /turf/open/floor/mainship/orange,
 /area/orion_outpost/surface/building/cargo)
@@ -10209,10 +10197,6 @@
 /obj/structure/stairs/seamless/edge,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/vehicledepot)
-"WH" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad_2)
 "WI" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -12526,7 +12510,7 @@ Gx
 Gx
 Gx
 Gx
-HG
+Gx
 Gx
 Gx
 Kz
@@ -12654,7 +12638,7 @@ EJ
 IH
 ft
 rS
-WH
+ft
 ft
 ft
 ft
@@ -12786,7 +12770,7 @@ nQ
 IH
 ft
 ft
-Ju
+ft
 ft
 ft
 ft
@@ -13578,7 +13562,7 @@ EJ
 IH
 ft
 ft
-Ju
+ft
 ft
 ft
 ft
@@ -13710,7 +13694,7 @@ EJ
 IH
 ft
 rS
-WH
+ft
 ft
 ft
 ft

--- a/_maps/map_files/Campaign maps/som_base/sombase.dmm
+++ b/_maps/map_files/Campaign maps/som_base/sombase.dmm
@@ -2297,10 +2297,6 @@
 	dir = 8
 	},
 /area/rocinante_base/ground/base_se)
-"dfF" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/ground/concrete,
-/area/rocinante_base/surface/landing/landing_pad_one)
 "dfT" = (
 /turf/open/floor/plating,
 /area/rocinante_base/surface/building/mining_construction)
@@ -2669,14 +2665,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/rocinante_base/surface/building/medical)
-"dJI" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/rocinante_base/surface/landing/landing_pad_two)
 "dJQ" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -11075,10 +11063,6 @@
 /obj/effect/landmark/corpsespawner/som,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/ground/base_cent)
-"pBb" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/ground/concrete,
-/area/rocinante_base/surface/landing/landing_pad_two)
 "pBj" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/red/corner{
@@ -12953,10 +12937,6 @@
 	dir = 4
 	},
 /area/rocinante_base/surface/building/security/command_sec)
-"sma" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/ground/concrete,
-/area/rocinante_base/surface/landing/landing_pad_one)
 "smb" = (
 /obj/structure/cable,
 /turf/open/floor/scorched,
@@ -13536,10 +13516,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/rocinante_base/ground/base_se)
-"sWJ" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/ground/concrete,
-/area/rocinante_base/surface/landing/landing_pad_two)
 "sWR" = (
 /turf/closed/shuttle/dropship_regular/interior_wall{
 	dir = 1
@@ -14684,14 +14660,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/red,
 /area/rocinante_base/surface/building/living/laundromat)
-"uya" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/rocinante_base/surface/landing/landing_pad_one)
 "uyb" = (
 /obj/structure/window/framed/mainship/gray,
 /turf/open/floor/plating/ground/concrete,
@@ -18485,7 +18453,7 @@ gtL
 gtL
 gtL
 gtL
-dJI
+gtL
 gtL
 gtL
 qkG
@@ -18633,7 +18601,7 @@ rfF
 xTt
 erF
 amw
-sWJ
+erF
 erF
 erF
 erF
@@ -18785,7 +18753,7 @@ rfF
 xTt
 erF
 erF
-pBb
+erF
 erF
 erF
 erF
@@ -19697,7 +19665,7 @@ rfF
 xTt
 erF
 erF
-pBb
+erF
 erF
 erF
 erF
@@ -19849,7 +19817,7 @@ rfF
 xTt
 erF
 amw
-sWJ
+erF
 erF
 erF
 erF
@@ -22357,7 +22325,7 @@ edx
 edx
 edx
 edx
-uya
+edx
 edx
 edx
 vAH
@@ -22505,7 +22473,7 @@ vJY
 aJl
 bjX
 iEn
-dfF
+bjX
 bjX
 bjX
 bjX
@@ -22657,7 +22625,7 @@ vJY
 aJl
 bjX
 bjX
-sma
+bjX
 bjX
 bjX
 bjX
@@ -23569,7 +23537,7 @@ vJY
 aJl
 bjX
 bjX
-sma
+bjX
 bjX
 bjX
 bjX
@@ -23721,7 +23689,7 @@ vJY
 aJl
 bjX
 iEn
-dfF
+bjX
 bjX
 bjX
 bjX

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -22149,14 +22149,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/medical/hallway/garbledradio)
-"iDS" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/ice_colony/exterior/surface/landing_pad2)
 "iEz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -29174,10 +29166,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/bball/garbledradio)
-"rUI" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/ice_colony/exterior/surface/landing_pad2)
 "rVU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -30738,10 +30726,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
 /area/ice_colony/surface/garage/three)
-"tQj" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/ice_colony/exterior/surface/landing_pad2)
 "tQt" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -37026,7 +37010,7 @@ cTP
 cTP
 cTP
 cTP
-iDS
+cTP
 cTP
 cTP
 acU
@@ -37234,7 +37218,7 @@ aay
 dWh
 afd
 tkL
-tQj
+afd
 afd
 afd
 afd
@@ -37446,7 +37430,7 @@ aay
 dWh
 afd
 afd
-rUI
+afd
 afd
 afd
 afd
@@ -38718,7 +38702,7 @@ aay
 dWh
 afd
 afd
-rUI
+afd
 afd
 afd
 afd
@@ -38930,7 +38914,7 @@ aay
 dWh
 afd
 tkL
-tQj
+afd
 afd
 afd
 afd

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -7719,10 +7719,6 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/river2)
-"hem" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "hes" = (
 /turf/closed/wall,
 /area/lv624/lazarus/quartstorage)
@@ -10222,14 +10218,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
-"jRU" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/shuttle/drop1/lz1)
 "jSi" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
@@ -20050,10 +20038,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"vfY" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "vgb" = (
 /obj/structure/flora/jungle/vines,
 /turf/closed/gm/dense,
@@ -58673,7 +58657,7 @@ wVT
 wVT
 wVT
 wVT
-jRU
+wVT
 wVT
 wVT
 pFJ
@@ -58851,7 +58835,7 @@ kLN
 wvz
 ydT
 ycR
-hem
+ydT
 ydT
 ydT
 ydT
@@ -59033,7 +59017,7 @@ kLN
 wvz
 ydT
 ydT
-vfY
+ydT
 ydT
 ydT
 ydT
@@ -60125,7 +60109,7 @@ kLN
 wvz
 ydT
 ydT
-vfY
+ydT
 ydT
 ydT
 ydT
@@ -60307,7 +60291,7 @@ kLN
 wvz
 ydT
 ycR
-hem
+ydT
 ydT
 ydT
 ydT

--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -1240,10 +1240,6 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/marshalls)
-"aZU" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "aZV" = (
 /obj/effect/spawner/random/misc/structure/girder,
 /turf/open/floor/plating/ground/dirt,
@@ -1386,10 +1382,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/colony/operations_hall)
-"bhj" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "bhR" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -2257,10 +2249,6 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/marshalls)
-"bTK" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "bTL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18491,10 +18479,6 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/recdorms)
-"plm" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "plA" = (
 /obj/structure/fence,
 /obj/structure/cable,
@@ -73750,7 +73734,7 @@ bwI
 vON
 jts
 pxc
-bTK
+jts
 jts
 jts
 jts
@@ -73924,7 +73908,7 @@ xiR
 ojM
 jsZ
 prl
-bhj
+jsZ
 cGD
 jsZ
 jsZ
@@ -73967,7 +73951,7 @@ bwI
 vON
 jts
 jts
-plm
+jts
 jts
 jts
 jts
@@ -74141,7 +74125,7 @@ xiR
 ojM
 jsZ
 jsZ
-aZU
+jsZ
 jsZ
 jsZ
 jsZ
@@ -75269,7 +75253,7 @@ bwI
 vON
 jts
 jts
-plm
+jts
 jts
 jts
 jts
@@ -75443,7 +75427,7 @@ xiR
 ojM
 jsZ
 jsZ
-aZU
+jsZ
 jsZ
 jsZ
 jsZ
@@ -75486,7 +75470,7 @@ bwI
 vON
 jts
 pxc
-bTK
+jts
 jts
 jts
 jts
@@ -75660,7 +75644,7 @@ xiR
 ojM
 jsZ
 prl
-bhj
+jsZ
 jsZ
 jsZ
 jsZ

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -9236,10 +9236,6 @@
 	dir = 8
 	},
 /area/magmoor/volcano)
-"gsi" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/magmoor/landing/two)
 "gsk" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
@@ -13064,10 +13060,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/southeast)
-"jkz" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/magmoor/landing/two)
 "jkK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -17136,10 +17128,6 @@
 /obj/structure/sign/greencross,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/magmoor/compound/northeast)
-"lYz" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/magmoor/landing)
 "lYC" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/blue/taupeblue,
@@ -31719,10 +31707,6 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/carpet,
 /area/magmoor/command/conference)
-"wAo" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/magmoor/landing)
 "wAt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44984,7 +44968,7 @@ jET
 dzo
 nlP
 gsk
-lYz
+nlP
 nlP
 nlP
 nlP
@@ -45217,7 +45201,7 @@ jET
 dzo
 nlP
 nlP
-wAo
+nlP
 nlP
 nlP
 nlP
@@ -46615,7 +46599,7 @@ rtV
 dzo
 nlP
 nlP
-wAo
+nlP
 nlP
 nlP
 nlP
@@ -46848,7 +46832,7 @@ jET
 dzo
 nlP
 gsk
-lYz
+nlP
 nlP
 nlP
 nlP
@@ -72420,7 +72404,7 @@ kRR
 afM
 ogT
 kqp
-jkz
+ogT
 ogT
 ogT
 ogT
@@ -72653,7 +72637,7 @@ kRR
 afM
 ogT
 ogT
-gsi
+ogT
 ogT
 ogT
 ogT
@@ -74051,7 +74035,7 @@ kRR
 afM
 ogT
 ogT
-gsi
+ogT
 ogT
 ogT
 ogT
@@ -74284,7 +74268,7 @@ kRR
 afM
 ogT
 kqp
-jkz
+ogT
 ogT
 ogT
 ogT

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -104,10 +104,6 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/orion_outpost/ground/outpostsw)
-"aK" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad)
 "aM" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -6587,14 +6583,6 @@
 	dir = 5
 	},
 /area/orion_outpost/surface/building/administration)
-"FL" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/orion_outpost/surface/landing_pad)
 "FM" = (
 /obj/machinery/power/monitor{
 	name = "Main Power Grid Monitoring"
@@ -6964,14 +6952,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostse)
-"HG" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/orion_outpost/surface/landing_pad_2)
 "HJ" = (
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/ground/underground/caveS/garbledradio)
@@ -7300,10 +7280,6 @@
 /obj/structure/window/framed/mainship/gray,
 /turf/open/floor/wood,
 /area/orion_outpost/surface/building/barracks)
-"Ju" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad_2)
 "Jw" = (
 /turf/open/floor/mainship/orange,
 /area/orion_outpost/surface/building/cargo)
@@ -9556,10 +9532,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/underground/caveS)
-"TW" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad)
 "TX" = (
 /obj/structure/inflatable/popped/door,
 /turf/open/floor/mainship/mono,
@@ -10150,10 +10122,6 @@
 	dir = 8
 	},
 /area/orion_outpost/ground/underground/caveN)
-"WH" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/orion_outpost/surface/landing_pad_2)
 "WI" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -12444,7 +12412,7 @@ Gx
 Gx
 Gx
 Gx
-HG
+Gx
 Gx
 Gx
 Kz
@@ -12572,7 +12540,7 @@ EJ
 IH
 ft
 rS
-WH
+ft
 ft
 ft
 ft
@@ -12704,7 +12672,7 @@ nQ
 IH
 ft
 ft
-Ju
+ft
 ft
 ft
 ft
@@ -13496,7 +13464,7 @@ EJ
 IH
 ft
 ft
-Ju
+ft
 ft
 ft
 ft
@@ -13628,7 +13596,7 @@ EJ
 IH
 ft
 rS
-WH
+ft
 ft
 ft
 ft
@@ -13977,7 +13945,7 @@ bl
 bl
 bl
 bl
-FL
+bl
 bl
 bl
 ET
@@ -14105,7 +14073,7 @@ fj
 GQ
 gg
 SA
-TW
+gg
 gg
 gg
 gg
@@ -14237,7 +14205,7 @@ fj
 GQ
 gg
 gg
-aK
+gg
 gg
 gg
 gg
@@ -15029,7 +14997,7 @@ fj
 GQ
 gg
 gg
-aK
+gg
 gg
 gg
 gg
@@ -15161,7 +15129,7 @@ fj
 GQ
 gg
 SA
-TW
+gg
 gg
 gg
 gg

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1790,12 +1790,6 @@
 "cjC" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
-"cjU" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "ckd" = (
 /obj/machinery/door/airlock/mainship/medical{
 	dir = 1;
@@ -2062,12 +2056,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"cEZ" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "cFk" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/mainship/tcomms,
@@ -4044,10 +4032,6 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"fbT" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "fcu" = (
 /obj/effect/landmark/corpsespawner/chef/regular,
 /turf/open/floor/mainship/mono,
@@ -6986,10 +6970,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"iMu" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "iMF" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
@@ -47438,7 +47418,7 @@ xyA
 kDx
 kDx
 cfw
-fbT
+kDx
 kDx
 kDx
 kDx
@@ -47695,7 +47675,7 @@ xyA
 csW
 csW
 nzB
-iMu
+kDx
 kDx
 kDx
 kDx
@@ -49237,7 +49217,7 @@ cPE
 xDq
 xDq
 qWy
-iMu
+kDx
 kDx
 kDx
 kDx
@@ -49494,7 +49474,7 @@ cPE
 kDx
 kDx
 cfw
-fbT
+kDx
 kDx
 kDx
 kDx
@@ -52325,7 +52305,7 @@ tHk
 nzB
 kDx
 cxw
-cjU
+kDx
 kDx
 kDx
 kDx
@@ -54895,7 +54875,7 @@ nbW
 qWy
 kDx
 cxw
-cEZ
+kDx
 kDx
 kDx
 kDx

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -41698,14 +41698,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
-"gSs" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/prison/hangar/civilian)
 "gTa" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/broken,
@@ -43620,10 +43612,6 @@
 	dir = 4
 	},
 /area/prison/hangar/civilian)
-"lXn" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/prison/hangar/civilian)
 "lXO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -44575,10 +44563,6 @@
 "ogg" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/space)
-"ogM" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/prison/hangar/civilian)
 "oho" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
@@ -46524,10 +46508,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
-"sLV" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/prison/hangar/main)
 "sMp" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -47578,10 +47558,6 @@
 /obj/effect/spawner/random/weaponry/shiv,
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/maxsec/south)
-"vAB" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/prison/hangar/main)
 "vBj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data,
@@ -48238,14 +48214,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
-"xgV" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/prison/hangar/main)
 "xhv" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/misc/paperbin{
@@ -50611,7 +50579,7 @@ bcJ
 bcJ
 bcJ
 bcJ
-gSs
+bcJ
 bcJ
 bcJ
 szH
@@ -50864,7 +50832,7 @@ qWN
 sqF
 qhf
 fRl
-lXn
+qhf
 qhf
 qhf
 qhf
@@ -51121,7 +51089,7 @@ qWN
 sqF
 qhf
 qhf
-ogM
+qhf
 qhf
 qhf
 qhf
@@ -52663,7 +52631,7 @@ qWN
 sqF
 qhf
 qhf
-ogM
+qhf
 qhf
 qhf
 qhf
@@ -52920,7 +52888,7 @@ qWN
 sqF
 qhf
 fRl
-lXn
+qhf
 qhf
 qhf
 qhf
@@ -108435,7 +108403,7 @@ uHL
 uHL
 uHL
 uHL
-xgV
+uHL
 uHL
 uHL
 ndS
@@ -108688,7 +108656,7 @@ baF
 wwv
 nTj
 lPJ
-vAB
+nTj
 nTj
 nTj
 nTj
@@ -108945,7 +108913,7 @@ baF
 wwv
 nTj
 nTj
-sLV
+nTj
 nTj
 nTj
 nTj
@@ -110487,7 +110455,7 @@ baF
 wwv
 nTj
 nTj
-sLV
+nTj
 nTj
 nTj
 nTj
@@ -110744,7 +110712,7 @@ baF
 wwv
 nTj
 lPJ
-vAB
+nTj
 nTj
 nTj
 nTj

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -11140,12 +11140,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
-"dKl" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "dKT" = (
 /obj/machinery/vending/nanomed{
 	pixel_y = 25
@@ -17488,12 +17482,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"lxI" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/sulaco/hangar/cas)
 "lyd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
@@ -22347,10 +22335,6 @@
 	dir = 1
 	},
 /area/sulaco/cargo/prep)
-"rFe" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/sulaco/hangar)
 "rFM" = (
 /obj/structure/droppod,
 /obj/structure/drop_pod_launcher,
@@ -24701,10 +24685,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
-"uvn" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/sulaco/hangar)
 "uvN" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -57418,7 +57398,7 @@ lJm
 fsb
 pwv
 jIo
-dKl
+pwv
 kJu
 dal
 pwv
@@ -59988,7 +59968,7 @@ qES
 ylS
 pwv
 jIo
-lxI
+pwv
 pwv
 pwv
 pwv
@@ -62819,7 +62799,7 @@ igo
 aPZ
 aPZ
 eQF
-rFe
+aPZ
 aPZ
 aPZ
 aPZ
@@ -63076,7 +63056,7 @@ igo
 dtI
 dtI
 npe
-uvn
+aPZ
 aPZ
 aPZ
 aPZ
@@ -64618,7 +64598,7 @@ bYh
 sMl
 sMl
 ger
-uvn
+aPZ
 aPZ
 aPZ
 aPZ
@@ -64875,7 +64855,7 @@ igo
 aPZ
 aPZ
 eQF
-rFe
+aPZ
 aPZ
 aPZ
 aPZ

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -7547,12 +7547,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
-"cIT" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "cJu" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/cmo_office)
@@ -7665,12 +7659,6 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"cTc" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "cTo" = (
 /obj/structure/closet,
 /obj/item/toy/plush/lizard,
@@ -8513,10 +8501,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
-"ehi" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "ehv" = (
 /obj/machinery/vending/tool,
 /obj/machinery/camera/autoname/mainship,
@@ -13074,10 +13058,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
-"lBc" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "lBr" = (
 /obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/ai,
@@ -41599,7 +41579,7 @@ car
 aPL
 blA
 hHM
-cTc
+blA
 blA
 blA
 blA
@@ -44169,7 +44149,7 @@ hOA
 fgc
 blA
 hHM
-cIT
+blA
 blA
 blA
 blA
@@ -46991,7 +46971,7 @@ uGB
 blA
 blA
 qNu
-ehi
+blA
 blA
 blA
 blA
@@ -47248,7 +47228,7 @@ uGB
 srb
 srb
 aPL
-lBc
+blA
 blA
 blA
 blA
@@ -48790,7 +48770,7 @@ uGB
 xUV
 xUV
 fgc
-lBc
+blA
 blA
 blA
 blA
@@ -49047,7 +49027,7 @@ uGB
 blA
 blA
 qNu
-ehi
+blA
 blA
 blA
 blA

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -6896,7 +6896,6 @@
 	},
 /area/whiskey_outpost/outside/east)
 "Pk" = (
-/obj/effect/attach_point/electronics/dropship1,
 /obj/structure/dropship_piece/one/weapon/rightleft,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
@@ -7128,7 +7127,6 @@
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "RP" = (
-/obj/effect/attach_point/electronics/dropship1,
 /obj/structure/dropship_piece/one/weapon/leftright,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -1193,18 +1193,6 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/mainship,
 /area/mainship/command/cic)
-"afC" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
-"afD" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "afE" = (
 /obj/machinery/computer/ordercomp,
 /obj/structure/cable,
@@ -5190,7 +5178,7 @@ bOu
 bOu
 bOu
 bOu
-afC
+bOu
 bOu
 bOu
 bOu
@@ -5790,7 +5778,7 @@ bOu
 bOu
 bOu
 bOu
-afD
+bOu
 bOu
 bOu
 bOu

--- a/_maps/map_files/deltastation/deltastation.dmm
+++ b/_maps/map_files/deltastation/deltastation.dmm
@@ -60266,10 +60266,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/deltastation/hallway/primary/central/aft)
-"mmf" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "mmr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63911,10 +63907,6 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/iron,
 /area/deltastation/maintenance/disposal/incinerator)
-"nbj" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "nbo" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/spawner/random/machinery/random_broken_computer/crewmonitor,
@@ -74172,14 +74164,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/deltastation/command/heads_quarters/hos)
-"phF" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/shuttle/drop1/lz1)
 "phG" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/transparent/neutral/fourcorners,
@@ -167646,7 +167630,7 @@ wVi
 wVi
 wVi
 wVi
-phF
+wVi
 wVi
 wVi
 rLQ
@@ -167899,7 +167883,7 @@ guZ
 hao
 qgB
 mMC
-mmf
+qgB
 qgB
 qgB
 qgB
@@ -168156,7 +168140,7 @@ fyi
 hao
 qgB
 qgB
-nbj
+qgB
 qgB
 qgB
 qgB
@@ -169698,7 +169682,7 @@ fyi
 hao
 qgB
 qgB
-nbj
+qgB
 qgB
 qgB
 qgB
@@ -169955,7 +169939,7 @@ fyi
 hao
 qgB
 mMC
-mmf
+qgB
 qgB
 qgB
 qgB

--- a/_maps/map_files/oscar_outpost/oscar_outpost.dmm
+++ b/_maps/map_files/oscar_outpost/oscar_outpost.dmm
@@ -17,10 +17,6 @@
 /obj/effect/landmark/start/job/captain,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost/base)
-"ak" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "ao" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -8784,10 +8780,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/oscar_outpost/village/central)
-"UQ" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "UR" = (
 /obj/machinery/computer/camera_advanced/overwatch{
 	dir = 4
@@ -15855,7 +15847,7 @@ IV
 IV
 IV
 wE
-ak
+IV
 IV
 IV
 IV
@@ -16107,7 +16099,7 @@ IV
 IV
 IV
 IV
-UQ
+IV
 IV
 IV
 IV
@@ -17619,7 +17611,7 @@ IV
 IV
 IV
 IV
-UQ
+IV
 IV
 IV
 IV
@@ -17871,7 +17863,7 @@ IV
 IV
 IV
 wE
-ak
+IV
 IV
 IV
 IV

--- a/_maps/modularmaps/EORG/original.dmm
+++ b/_maps/modularmaps/EORG/original.dmm
@@ -388,9 +388,6 @@
 /turf/open/floor/tile/bar,
 /area/deathmatch)
 "bN" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8
-	},
 /obj/structure/dropship_piece/one/wing/left/bottom,
 /obj/structure/dropship_piece/one/wing/left/bottom,
 /turf/open/ground/coast{
@@ -506,18 +503,12 @@
 	},
 /area/deathmatch)
 "ck" = (
-/obj/effect/attach_point/electronics/dropship1{
-	dir = 1
-	},
 /obj/structure/dropship_piece/one/weapon/rightleft,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
 /area/deathmatch)
 "cl" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 1
-	},
 /obj/structure/dropship_piece/one/weapon/rightright,
 /turf/open/ground/grass,
 /area/deathmatch)
@@ -621,9 +612,6 @@
 /turf/closed/shuttle/dropship1/finright,
 /area/deathmatch)
 "cJ" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 4
-	},
 /obj/structure/dropship_piece/one/wing/right/bottom,
 /turf/open/ground/grass,
 /area/deathmatch)

--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -284,7 +284,7 @@
 "bk" = (
 /obj/structure/dropship_piece/one/wing/left/bottom,
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 4
+	dir = 8
 	},
 /turf/template_noop,
 /area/shuttle/dropship/alamo)


### PR DESCRIPTION

## About The Pull Request
Removes a bucket load of equipment attachment points from maps which are basically invisible blockers that have been copy pasted from map to map like a virus.

Also fixed one alalmo sentry point facing the wrong way.

:cl:
fix: fixed an alamo sentry facing the wrong way
fix: Removed various invisible blockers on some maps
/:cl:
