### PR TITLE
Tank minigun changes

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -8,7 +8,6 @@
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)
 	name = "machinegun bullet"
 	icon_state = "bullet" // Keeping it bog standard with the turret but allows it to be changed.
-	ammo_behavior_flags = AMMO_BALLISTIC
 	hud_state = "minigun"
 	hud_state_empty = "smartgun_empty"
 	accurate_range = 12
@@ -22,7 +21,6 @@
 	name = "minigun bullet"
 	hud_state = "minigun"
 	hud_state_empty = "smartgun_empty"
-	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	accurate_range = 5
@@ -33,12 +31,12 @@
 
 /datum/ammo/bullet/minigun/ltaap
 	name = "chaingun bullet"
-	damage = 30
+	damage = 25
 	penetration = 15
-	sundering = 0
-	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_IFF
-	damage_falloff = 2
-	accuracy = 80
+	sundering = 1
+	accuracy = -15
+	accurate_range = 12
+	damage_falloff = 0.75
 
 /datum/ammo/bullet/auto_cannon
 	name = "autocannon high-velocity bullet"


### PR DESCRIPTION

## About The Pull Request
Changes tank minigun from a simple IFF damage dealing spam cannon that sucks balls at range, to a more balanced and useful gun that can sunder and be effective at range, but without the IFF crutch.

- Damage falloff Reduced from 2 to 0.75
- Base damage reduced from 30 to 25
- Sunder increased from 0 to 1
- Accurate range changed from 5 to 12
- Accuracy bonus changed from +80(wtf, I am pretty sure Kuro assumed this meant 80% acc, not +80) to -15
- Removed IFF
## Why It's Good For The Game
IFF made the minigun really powerful, and completely idiot proof and far less interesting to both fight with and against, as xenos could not mitigate the damage with positioning.

The changes make the gun overall noticably stronger, especially at range (currently its very high falloff makes it absurdly high damage at close range where xenos are trying to slash the tank, but terrible at range), to compensate for no IFF.

Over all should be a more interesting and balanced option.
## Changelog
:cl:
balance: Rebalanced tank minigun for better performance but no IFF
/:cl:
