### PR TITLE
Tank cannon buff

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -80,12 +80,7 @@
 	sundering = 20
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3)
-
-/datum/ammo/rocket/ltb/on_hit_mob(mob/victim, obj/projectile/proj)
-	drop_nade(get_turf(victim))
-	if(!isxeno(victim))
-		victim.gib()
+	explosion(T, 1, 2, 5, 0, 3)
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"


### PR DESCRIPTION

## About The Pull Request
Adds 1 dev back to the  tank cannon.
## Why It's Good For The Game
Removing devastate explosion from the tank cannon because of gib wasn't entirely thought through.
The change also reduced the damage, stagger, slow and sunder applied by a direct hit, significantly weakening it.

Now that tank sunder was reduced from 100(!) to 20, the tank will no longer be able to just qdel xenos regardless of their armour, so the original issue shouldn't be a problem, barring a couple of xenos without bomb armour, which would also need to not have warding.
## Changelog
:cl:
balance: Readd devastate back to the tank cannon
/:cl:
