### PR TITLE
Makes OBs cost the same (solid fuel-wise)

### DIFF
--- a/code/datums/marine_main_ship.dm
+++ b/code/datums/marine_main_ship.dm
@@ -4,7 +4,6 @@ GLOBAL_DATUM_INIT(marine_main_ship, /datum/marine_main_ship, new)
 /datum/marine_main_ship
 
 	var/obj/structure/orbital_cannon/orbital_cannon
-	var/list/ob_type_fuel_requirements
 
 	var/obj/structure/ship_rail_gun/rail_gun
 

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -1,7 +1,7 @@
 #define WARHEAD_FLY_TIME 1 SECONDS
 #define RG_FLY_TIME 1 SECONDS
 #define WARHEAD_FALLING_SOUND_RANGE 15
-
+#define WARHEAD_FUEL_REQUIREMENT 6
 /obj/structure/orbital_cannon
 	name = "\improper Orbital Cannon"
 	desc = "The TGMC Orbital Cannon System. Used for shooting large targets on the planet that is orbited. It accelerates its payload with solid fuel for devastating results upon impact."
@@ -24,14 +24,6 @@
 	. = ..()
 	if(!GLOB.marine_main_ship.orbital_cannon)
 		GLOB.marine_main_ship.orbital_cannon = src
-
-	if(!GLOB.marine_main_ship.ob_type_fuel_requirements)
-		GLOB.marine_main_ship.ob_type_fuel_requirements = list()
-		var/list/L = list(3,4,5,6)
-		var/amt
-		for(var/i in 1 to 4)
-			amt = pick_n_take(L)
-			GLOB.marine_main_ship?.ob_type_fuel_requirements += amt
 
 	var/turf/T = locate(x+1,y+1,z)
 	var/obj/structure/orbital_tray/O = new(T)
@@ -200,16 +192,7 @@
 	ob_cannon_busy = TRUE
 
 	var/inaccurate_fuel = 0
-
-	switch(tray.warhead.warhead_kind)
-		if("explosive")
-			inaccurate_fuel = abs(GLOB.marine_main_ship?.ob_type_fuel_requirements[1] - tray.fuel_amt)
-		if("incendiary")
-			inaccurate_fuel = abs(GLOB.marine_main_ship?.ob_type_fuel_requirements[2] - tray.fuel_amt)
-		if("cluster")
-			inaccurate_fuel = abs(GLOB.marine_main_ship?.ob_type_fuel_requirements[3] - tray.fuel_amt)
-		if("plasma")
-			inaccurate_fuel = abs(GLOB.marine_main_ship?.ob_type_fuel_requirements[4] - tray.fuel_amt)
+	inaccurate_fuel = WARHEAD_FUEL_REQUIREMENT - tray.fuel_amt
 
 	// Give marines a warning if misfuelled.
 	var/fuel_warning = "Warhead fuel level: safe."
@@ -479,10 +462,7 @@
 	else
 		if(orbital_window_page == 1)
 			dat += "<font size=3>Warhead Fuel Requirements:</font><BR>"
-			dat += "- HE Orbital Warhead: <b>[GLOB.marine_main_ship.ob_type_fuel_requirements[1]] Solid Fuel blocks.</b><BR>"
-			dat += "- Incendiary Orbital Warhead: <b>[GLOB.marine_main_ship.ob_type_fuel_requirements[2]] Solid Fuel blocks.</b><BR>"
-			dat += "- Cluster Orbital Warhead: <b>[GLOB.marine_main_ship?.ob_type_fuel_requirements[3]] Solid Fuel blocks.</b><BR>"
-			dat += "- Plasma drain Orbital Warhead: <b>[GLOB.marine_main_ship?.ob_type_fuel_requirements[4]] Solid Fuel blocks.</b><BR>"
+			dat += "All orbital warheads require <b>[WARHEAD_FUEL_REQUIREMENT] Solid Fuel blocks.</b><BR>"
 
 			dat += "<BR><BR><A href='?src=[text_ref(src)];back=1'><font size=3>Back</font></A><BR>"
 		else

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -2,6 +2,7 @@
 #define RG_FLY_TIME 1 SECONDS
 #define WARHEAD_FALLING_SOUND_RANGE 15
 #define WARHEAD_FUEL_REQUIREMENT 6
+
 /obj/structure/orbital_cannon
 	name = "\improper Orbital Cannon"
 	desc = "The TGMC Orbital Cannon System. Used for shooting large targets on the planet that is orbited. It accelerates its payload with solid fuel for devastating results upon impact."
@@ -192,7 +193,7 @@
 	ob_cannon_busy = TRUE
 
 	var/inaccurate_fuel = 0
-	inaccurate_fuel = WARHEAD_FUEL_REQUIREMENT - tray.fuel_amt
+	inaccurate_fuel = abs(WARHEAD_FUEL_REQUIREMENT - tray.fuel_amt)
 
 	// Give marines a warning if misfuelled.
 	var/fuel_warning = "Warhead fuel level: safe."


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/65325586/ea4e8ffd-d73d-4918-8f45-20a0cf08eca7)
## Why It's Good For The Game
Although OBs have penalties for loading an incorrect amount of solid fuel, the severity of this is calculated by subtracting the amount of fuel you have loaded from the required amount of fuel.
This means that if you have a requirement of 2 solid fuel for a tanglefoot OB, you can only ever get a penalty of 4 seconds due to inadequate fuel
On the other hand, if you get a requirement of 6 solid fuel, you can incur a penalty of up to 20 seconds of tanglefoot hang time due to inadequate fuel

letting something as important as OB innacuracy rely purely on RNG doesn't sit right with me
this also means you can do gamble obs every round instead of waiting for them to cost a bunch :^)
## Changelog
:cl:
balance: ALL Orbital Bombardment types cost 6 solid fuel
/:cl:
