### PR TITLE
Adds logging to LZ Containment Shutters

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -145,7 +145,7 @@
 	icon_state = "[initial(icon_state)]1"
 
 	alarm_played = TRUE
-	playsound_z(z, 'sound/effects/shutters_alarm.ogg', 15) // woop woop, shutters opening.]
+	playsound_z(z, 'sound/effects/shutters_alarm.ogg', 15) // woop woop, shutters opening.
 	log_game("[key_name(user)] has opened the LZ Containment Shutters.")
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, update_icon)), 1.5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(pulsed)), 185)

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -145,7 +145,8 @@
 	icon_state = "[initial(icon_state)]1"
 
 	alarm_played = TRUE
-	playsound_z(z, 'sound/effects/shutters_alarm.ogg', 15) // woop woop, shutters opening.
+	playsound_z(z, 'sound/effects/shutters_alarm.ogg', 15) // woop woop, shutters opening.]
+	log_game("[key_name(user)] has opened the LZ Containment Shutters.")
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, update_icon)), 1.5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(pulsed)), 185)
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
Fingerprints seem to not work on this, no more Guess Who for the admins on who opened shutters against FC's or Captain's orders.
## Changelog
:cl:
admin: Added logging to LZ Containment Shutters
/:cl:
