### PR TITLE
See Through sprite opacity QOL change

### DIFF
--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -17,7 +17,7 @@
 	///This component's personal uid
 	var/personal_uid
 
-/datum/component/seethrough_mob/Initialize(target_alpha = 155, animation_time = 0.5 SECONDS, clickthrough = TRUE)
+/datum/component/seethrough_mob/Initialize(target_alpha = 170, animation_time = 0.5 SECONDS, clickthrough = TRUE)
 	. = ..()
 
 	if(!ismob(parent))

--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -17,7 +17,7 @@
 	///This component's personal uid
 	var/personal_uid
 
-/datum/component/seethrough_mob/Initialize(target_alpha = 100, animation_time = 0.5 SECONDS, clickthrough = TRUE)
+/datum/component/seethrough_mob/Initialize(target_alpha = 155, animation_time = 0.5 SECONDS, clickthrough = TRUE)
 	. = ..()
 
 	if(!ismob(parent))


### PR DESCRIPTION
## About The Pull Request

Changes the alpha value of See Through when active from 100 to 170.

## Why It's Good For The Game

See Through, as of right now, lowers your character's sprite more than it needs to. It can be hard to see where you are while also trying to look around you. This is worse if you are playing a caste with a dark color palette and you're on top of weeds, which makes you nearly invisible if you're not looking directly at the sprite.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/156480604/2767761b-f0e6-44b8-9160-0154d6bb90a2)
This value increase mostly fixes this issue while still allowing you to see things under your sprite.
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/156480604/f394380d-0475-4565-9348-f36a00a22b48)
For reference, See Through off:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/156480604/963d4357-2b51-4dca-84cf-05ac85358506)

## Changelog

:cl:
qol: Changed See Through's sprite alpha from 100 to 170.
/:cl: