### PR TITLE
Ravager Rage Screenshake no longer effects the ravager

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -379,7 +379,7 @@
 		affected_tiles.Shake(duration = 1 SECONDS) //SFX
 
 	for(var/mob/living/affected_mob in cheap_get_humans_near(X, rage_power_radius) + cheap_get_xenos_near(X, rage_power_radius)) //Roar that applies cool SFX
-		if(affected_mob.stat) //We don't care about the dead/unconsious
+		if(affected_mob.stat || affected_mob == X) //We don't care about the dead/unconsious
 			continue
 
 		shake_camera(affected_mob, 1 SECONDS, 1)


### PR DESCRIPTION

## About The Pull Request
see title
## Why It's Good For The Game
Getting such heavy screenshake when you pop rage is very disrupting, and can lead to you getting killed if you try and use it to make advantage of the damage and speed boost. An earlier PR for this was closed so the screenshake could be "Reduced to fluff levels," but no such PR has been made and I don't think there's an amount of screenshake low enough to be considered "fluff"
## Changelog
:cl:
balance: Ravager's Rage no longer shakes the screen of the ravager who used the ability
/:cl:
