### PR TITLE
Makes Gelida IV an HVH only map

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///If the gamemode has a whitelist of valid ground maps. Whitelist overrides the blacklist
 	var/list/whitelist_ground_maps
 	///If the gamemode has a blacklist of disallowed ground maps
-	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_RESEARCH_OUTPOST, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS)
+	var/list/blacklist_ground_maps = list(MAP_DELTA_STATION, MAP_RESEARCH_OUTPOST, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_GELIDA_IV)
 	///if fun tads are enabled by default
 	var/enable_fun_tads = FALSE
 


### PR DESCRIPTION

## About The Pull Request

Kills gelida in HvX.

## Why It's Good For The Game

In my 300 hours playing this server, i have never seen a single person say they like this map, this shit is so annoying to play as xeno that they dont bother anymore, it's comically easy to silo rush since it has no caves, and for marines, the big long hallways and chokes makes them a gas fest if they are doing it properly.
## Changelog

:cl:
config: Disables gelida in HvX
/:cl: