### PR TITLE
Removes an extra plat miner from big red – west Eta

### DIFF
--- a/_maps/modularmaps/big_red/bigredsouthwestetavar5.dmm
+++ b/_maps/modularmaps/big_red/bigredsouthwestetavar5.dmm
@@ -258,10 +258,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"Av" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/south)
 "Ay" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -2103,7 +2099,7 @@ WV
 WV
 WV
 WV
-Av
+WV
 WV
 tq
 WV


### PR DESCRIPTION

## About The Pull Request
In this one module there's just an extra plat miner sitting in a hall. All of the other module equivalents only have 1 miner. This one has two, for some reason.

one day I will kill all modulars
## Why It's Good For The Game
Mfw rng marine buff
## Changelog
:cl:
balance: removes an extra plat miner from a big red modular variant that was not present on any other variants.
/:cl:
