### PR TITLE
Som ERT breacher skills

### DIFF
--- a/code/datums/emergency_calls/sons_of_mars_breachers.dm
+++ b/code/datums/emergency_calls/sons_of_mars_breachers.dm
@@ -1,6 +1,6 @@
 //Sons of Mars
 /datum/emergency_call/som_breachers
-	name = "Sons of Mars Squad"
+	name = "Sons of Mars breacher squad"
 	base_probability = 13
 	alignement_factor = 0
 	///number of available special weapon dudes
@@ -15,7 +15,7 @@
 	to_chat(H, "<B>Eliminate the TerraGov personnel onboard, capture the ship. If there are fellow ICC contingents such as the ICCAF, then work with them in this goal. Take no prisoners. Take back what was once lost.</B>")
 
 /datum/emergency_call/som_breachers/do_activate(announce = TRUE)
-	max_specialists = round(mob_max * 0.2)
+	max_specialists = floor(mob_max * 0.2)
 	return ..()
 
 /datum/emergency_call/som_breachers/create_member(datum/mind/M)

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -58,8 +58,10 @@ GLOBAL_PROTECT(exp_specialmap)
 	var/multiple_outfits = FALSE
 	///list of outfit variants
 	var/list/datum/outfit/job/outfits = list()
-
+	///Skills for this job
 	var/skills_type = /datum/skills
+	///Any special traits that are assigned for this job
+	var/list/job_traits
 
 	var/display_order = JOB_DISPLAY_ORDER_DEFAULT
 	var/job_flags = NONE
@@ -292,6 +294,8 @@ GLOBAL_PROTECT(exp_specialmap)
 /mob/living/proc/apply_assigned_role_to_spawn(datum/job/assigned_role, client/player, datum/squad/assigned_squad, admin_action = FALSE)
 	job = assigned_role
 	set_skills(getSkillsType(job.return_skills_type(player?.prefs)))
+	if(islist(job.job_traits))
+		add_traits(job.job_traits, INNATE_TRAIT)
 	faction = job.faction
 	job.announce(src)
 	GLOB.round_statistics.total_humans_created[faction]++

--- a/code/datums/jobs/job/sons_of_mars_ert.dm
+++ b/code/datums/jobs/job/sons_of_mars_ert.dm
@@ -271,6 +271,7 @@
 /datum/job/som/ert/veteran
 	title = "SOM Veteran"
 	paygrade = "SOM_S1"
+	skills_type = /datum/skills/som_veteran
 	outfit = /datum/outfit/job/som/ert/veteran/charger
 	multiple_outfits = TRUE
 	outfits = list(
@@ -342,6 +343,8 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_vet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
@@ -506,6 +509,7 @@
 /datum/job/som/ert/specialist
 	title = "SOM Specialist"
 	paygrade = "SOM_S2"
+	skills_type = /datum/skills/som_veteran
 	outfit = /datum/outfit/job/som/ert/veteran/culverin
 	multiple_outfits = TRUE
 	outfits = list(
@@ -520,7 +524,7 @@
 	job_category = JOB_CAT_COMMAND
 	title = "SOM Leader"
 	paygrade = "SOM_S4"
-	skills_type = /datum/skills/sl
+	skills_type = /datum/skills/som_veteran/sl
 	outfit = /datum/outfit/job/som/ert/leader/charger
 	multiple_outfits = TRUE
 	outfits = list(
@@ -649,6 +653,7 @@
 /datum/job/som/ert/breacher
 	title = "SOM Breacher"
 	paygrade = "SOM_S2"
+	skills_type = /datum/skills/som_veteran
 	outfit = /datum/outfit/job/som/ert/veteran/breacher_melee
 	multiple_outfits = TRUE
 	outfits = list(
@@ -664,6 +669,8 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som, SLOT_IN_BACKPACK)
@@ -714,6 +721,8 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_rpg/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
@@ -744,6 +753,8 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_flamer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
@@ -763,6 +774,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_culverin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
 
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
@@ -774,6 +786,7 @@
 /datum/job/som/ert/medic/breacher
 	title = "SOM Breacher Medic"
 	paygrade = "SOM_E5"
+	skills_type = /datum/skills/som_veteran/medic
 	outfit = /datum/outfit/job/som/ert/medic/breacher
 	multiple_outfits = FALSE
 
@@ -785,6 +798,7 @@
 
 /datum/outfit/job/som/ert/medic/breacher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
 
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_BACKPACK)
@@ -822,6 +836,8 @@
 
 /datum/outfit/job/som/ert/leader/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som/extended, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som/extended, SLOT_IN_BACKPACK)
@@ -855,6 +871,8 @@
 
 /datum/outfit/job/som/ert/leader/breacher_ranged/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)

--- a/code/datums/jobs/job/sons_of_mars_ert.dm
+++ b/code/datums/jobs/job/sons_of_mars_ert.dm
@@ -343,7 +343,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_vet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)
@@ -669,7 +669,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som, SLOT_IN_BACKPACK)
@@ -721,7 +721,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_rpg/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
@@ -753,7 +753,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_flamer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
@@ -774,7 +774,7 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_culverin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
@@ -798,7 +798,7 @@
 
 /datum/outfit/job/som/ert/medic/breacher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_BACKPACK)
@@ -836,7 +836,7 @@
 
 /datum/outfit/job/som/ert/leader/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som/extended, SLOT_IN_BACKPACK)
@@ -871,7 +871,7 @@
 
 /datum/outfit/job/som/ert/leader/breacher_ranged/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), TRAIT_GENERIC)
+	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
 
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)

--- a/code/datums/jobs/job/sons_of_mars_ert.dm
+++ b/code/datums/jobs/job/sons_of_mars_ert.dm
@@ -272,6 +272,7 @@
 	title = "SOM Veteran"
 	paygrade = "SOM_S1"
 	skills_type = /datum/skills/som_veteran
+	job_traits = list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT)
 	outfit = /datum/outfit/job/som/ert/veteran/charger
 	multiple_outfits = TRUE
 	outfits = list(
@@ -343,8 +344,6 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_vet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
@@ -525,6 +524,7 @@
 	title = "SOM Leader"
 	paygrade = "SOM_S4"
 	skills_type = /datum/skills/som_veteran/sl
+	job_traits = list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT)
 	outfit = /datum/outfit/job/som/ert/leader/charger
 	multiple_outfits = TRUE
 	outfits = list(
@@ -654,6 +654,7 @@
 	title = "SOM Breacher"
 	paygrade = "SOM_S2"
 	skills_type = /datum/skills/som_veteran
+	job_traits = list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT)
 	outfit = /datum/outfit/job/som/ert/veteran/breacher_melee
 	multiple_outfits = TRUE
 	outfits = list(
@@ -669,8 +670,6 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som, SLOT_IN_BACKPACK)
@@ -721,8 +720,6 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_rpg/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/som, SLOT_IN_BELT)
@@ -753,8 +750,6 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_flamer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/large/som, SLOT_IN_BELT)
@@ -774,8 +769,6 @@
 
 /datum/outfit/job/som/ert/veteran/breacher_culverin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_ACCESSORY)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar/red, SLOT_IN_ACCESSORY)
@@ -787,6 +780,7 @@
 	title = "SOM Breacher Medic"
 	paygrade = "SOM_E5"
 	skills_type = /datum/skills/som_veteran/medic
+	job_traits = list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT)
 	outfit = /datum/outfit/job/som/ert/medic/breacher
 	multiple_outfits = FALSE
 
@@ -798,8 +792,6 @@
 
 /datum/outfit/job/som/ert/medic/breacher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/cell/lasgun/volkite, SLOT_IN_BACKPACK)
@@ -836,8 +828,6 @@
 
 /datum/outfit/job/som/ert/leader/breacher_melee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som/extended, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/som/extended, SLOT_IN_BACKPACK)
@@ -871,8 +861,6 @@
 
 /datum/outfit/job/som/ert/leader/breacher_ranged/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.add_traits(list(TRAIT_AXE_EXPERT, TRAIT_SWORD_EXPERT), INNATE_TRAIT)
-
 	H.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/weldingtool/largetank, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -802,3 +802,32 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = "Skeleton"
 	cqc = SKILL_CQC_TRAINED
 	melee_weapons = SKILL_MELEE_TRAINED
+
+//SOM veterans
+/datum/skills/som_veteran
+	name = "SOM Veteran"
+	leadership = SKILL_LEAD_BEGINNER
+	cqc = SKILL_CQC_TRAINED
+	melee_weapons = SKILL_MELEE_TRAINED
+	construction = SKILL_CONSTRUCTION_METAL
+	engineer = SKILL_ENGINEER_METAL
+	firearms = SKILL_FIREARMS_TRAINED
+	pistols = SKILL_PISTOLS_TRAINED
+	smgs = SKILL_SMGS_TRAINED
+	rifles = SKILL_RIFLES_TRAINED
+	shotguns = SKILL_SHOTGUNS_TRAINED
+	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
+	medical = SKILL_MEDICAL_NOVICE
+	surgery = SKILL_SURGERY_AMATEUR
+	stamina = SKILL_STAMINA_TRAINED
+
+/datum/skills/som_veteran/sl
+	name = "SOM Leader"
+	construction = SKILL_CONSTRUCTION_PLASTEEL
+	engineer = SKILL_ENGINEER_PLASTEEL
+	leadership = SKILL_LEAD_EXPERT
+
+/datum/skills/som_veteran/medic
+	name = "SOM Medic"
+	medical = SKILL_MEDICAL_PRACTICED
+	surgery = SKILL_SURGERY_TRAINED


### PR DESCRIPTION

## About The Pull Request
Adds some skills to the SOM breacher ert/the SOM SL, including the axe sweep ability.
Actually gives them their own name so its not just a copy paste.
## Why It's Good For The Game
Big more interesting variety, makes the breacher variant a little better considering they have a strong focus on melee with axes.
## Changelog
:cl:
balance: SOM breacher ERTs have undergone more advanced training
/:cl:
