### PR TITLE
Sentinel Drain Sting Now Respects Acid Armour

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -163,7 +163,7 @@
 		xeno_target.emote("scream")
 		xeno_owner.apply_status_effect(STATUS_EFFECT_DRAIN_SURGE)
 		new /obj/effect/temp_visual/drain_sting_crit(get_turf(xeno_target))
-	xeno_target.adjustFireLoss(drain_potency / 5)
+	xeno_target.adjustFireLoss(drain_potency / 5, armor_type = ACID)
 	xeno_target.AdjustKnockdown(max(0.1 SECONDS, debuff.stacks - 10))
 	HEAL_XENO_DAMAGE(xeno_owner, drain_potency, FALSE)
 	xeno_owner.gain_plasma(drain_potency * 3.5)


### PR DESCRIPTION
## About The Pull Request

Sentinel Drain ability now respects acid armour

## Why It's Good For The Game
I saw a B18 user get owned by a sentinel and laughed at them, then the sentinel owned me and now I'm crying.

Drain sting ignores all armour, below is a video of a sentinel owning a deathsquad guy.

It should probably respect acid armour because currently it hurts my feelings

---

Videos:

Current drain sting:
https://github.com/tgstation/TerraGov-Marine-Corps/assets/70779744/9f594713-db61-4568-a89a-f8bd61c4249b

"Fixed" drain sting:
https://github.com/tgstation/TerraGov-Marine-Corps/assets/70779744/c67a4f8f-848c-4f24-9647-c1cd37054c9a


## Changelog
:cl:
balance: Sentinel Drain Sting now respects acid armour.
/:cl:
