### PR TITLE
LTB tank cannon rebalancing

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -77,7 +77,7 @@
 	penetration = 50
 	damage = 85
 	hud_state = "bigshell_he"
-	sundering = 40
+	sundering = 50
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, 0, 3, 5, 0, 3)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -75,12 +75,12 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 200
+	damage = 100
 	hud_state = "bigshell_he"
-	sundering = 20
+	sundering = 40
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3)
+	explosion(T, 0, 3, 5, 0, 3)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/victim, obj/projectile/proj)
 	drop_nade(get_turf(victim))

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -84,8 +84,6 @@
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/victim, obj/projectile/proj)
 	drop_nade(get_turf(victim))
-	if(!isxeno(victim))
-		victim.gib()
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -75,7 +75,7 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 100
+	damage = 85
 	hud_state = "bigshell_he"
 	sundering = 40
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -838,7 +838,7 @@ WEAPONS
 /datum/supply_packs/weapons/ltb_shells
 	name = "LTB tank shell"
 	contains = list(/obj/item/ammo_magazine/tank/ltb_cannon)
-	cost = 10
+	cost = 30
 
 /datum/supply_packs/weapons/ltaap_rounds
 	name = "LTAAP tank magazine"


### PR DESCRIPTION
## About The Pull Request
Rebalances the LTB tank cannon round, with it being a net nerf.
Projectile damage reduced from 200 to 85.
Price in Requisitions increased from 10 to 30.
Sundering increased from 20 to 50.
Heavy impact range increased from 2 to 3.
Removes gibbing of non-xeno targets.

## Why It's Good For The Game
As it stands right now, the tank is basically a death sentence most of the times, and can solo a vast majority of the xeno castes. I believe it is healthier for the tank to require more support, instead of being able to just instantly crit everything that dares challenge it. Considering I'm pushing it in that direction, I figured I'd compensate by adding more sunder, explosion range, and outright removing gibbing; if it's meant to be more supportive, then this should enable that.

Double also, gibbing permanently removes people from rounds and that's very stinky.

## Changelog
:cl: Lewdcifer
balance: LTB tank cannon round rebalanced;
del: Projectile damage reduced from 200 to 85.
del: Requisitions price increased from 10 to 30.
del: No longer gibs non-xeno targets.
add: Sundering increased from 20 to 50.
add: Heavy impact range increased from 2 to 3.
/:cl: