### PR TITLE
Reduces Puppet Damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
@@ -9,7 +9,7 @@
 
 	tier = XENO_TIER_MINION
 	upgrade = XENO_UPGRADE_BASETYPE
-	melee_damage = 15
+	melee_damage = 12
 	accuracy_malus = 65
 	speed = -0.8
 	plasma_max = 2


### PR DESCRIPTION

## About The Pull Request
Reduces puppet damage from 15 to 12, effectively reducing the damage of max puppets from 45 to 36.
## Why It's Good For The Game
Currently, puppets have stats equivalent to 2 spiderlings. This means that they do a shit ton of damage per minion compared to spiderlings, and are more tanky as well. This change aims to make puppets less "insta-death" and more "deadly wall" by reducing their damage but keeping their health the same.
## Changelog
:cl:
balance: Reduce puppet damage from 15 to 12
/:cl:
