### PR TITLE
Fixes bug preventing tangle mortar shells from being ordered

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1034,12 +1034,12 @@ EXPLOSIVES
 	contains = list(/obj/item/mortal_shell/howitzer/incendiary)
 	cost = 40
 
-/datum/supply_packs/explosives/mortar_ammo_wp
+/datum/supply_packs/explosives/howitzer_ammo_wp
 	name = "MG-100Y howitzer white phosporous smoke shell"
 	contains = list(/obj/item/mortal_shell/howitzer/white_phos)
 	cost = 60
 
-/datum/supply_packs/explosives/mortar_ammo_plasmaloss
+/datum/supply_packs/explosives/howitzer_ammo_plasmaloss
 	name = "MG-100Y howitzer tanglefoot shell"
 	contains = list(/obj/item/mortal_shell/howitzer/plasmaloss)
 	cost = 60


### PR DESCRIPTION
## About The Pull Request
I swear I remember there being some discussion on this being a balance thing with the howitzer only getting tangle, but I might've mixed this up with WP. Anyways howitzer tangle shells were sharing the same datum as the mortar shells, hence you couldn't order them.
I also renamed the howitzer wp, in the rare case mortar WP gets added

Fixes #15900

## Why It's Good For The Game

Tangle mortar shells are slightly less condemmed to reqtorio hell

## Changelog
:cl:
fix: After two years - Tangle mortar shells can be ordered again
/:cl:
