### PR TITLE
Tank Desant projectile fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -303,7 +303,7 @@
 	if(ammo.bonus_projectiles_amount && !recursivity) //Recursivity check in case the bonus projectiles have bonus projectiles of their own. Let's not loop infinitely.
 		ammo.fire_bonus_projectiles(src, shooter, source, range, speed, dir_angle, target)
 
-	if(source.Adjacent(target) && PROJECTILE_HIT_CHECK(target, src, null, FALSE, null))
+	if(source.Adjacent(target) && PROJECTILE_HIT_CHECK(target, src, null, FALSE, hit_atoms))
 		target.do_projectile_hit(src)
 		if((!ismob(target) || !(ammo.ammo_behavior_flags & AMMO_PASS_THROUGH_MOB)) && !(ammo.ammo_behavior_flags & AMMO_PASS_THROUGH_MOVABLE))
 			qdel(src)
@@ -971,7 +971,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		if(ammo.bonus_projectiles_amount)
 			ammo.fire_bonus_projectiles(src, shooter, source, range, speed, dir_angle, target)
 
-	if(source.Adjacent(target) && PROJECTILE_HIT_CHECK(target, src, null, FALSE, null))
+	if(source.Adjacent(target) && PROJECTILE_HIT_CHECK(target, src, null, FALSE, hit_atoms))
 		target.do_projectile_hit(src)
 		if((!ismob(target) || !(ammo.ammo_behavior_flags & AMMO_PASS_THROUGH_MOB)) && !(ammo.ammo_behavior_flags & AMMO_PASS_THROUGH_MOVABLE))
 			qdel(src)


### PR DESCRIPTION

## About The Pull Request
Vehicles are not intended to be able to hit mobs on top of them.

Fixes this to actually work.
## Why It's Good For The Game
Significant balance fix for vehicles.
## Changelog
:cl:
fix: fixed vehicles being able to shoot mobs on top of them when they shouldn't have been able to
/:cl:
