### PR TITLE
Makes the hypos in the NTMed default to being empty

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -173,12 +173,7 @@
 		"Hypospray" = list (
 			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 10,
-			/obj/item/reagent_containers/hypospray/advanced = 5,
-			/obj/item/reagent_containers/hypospray/advanced/bicaridine = 5,
-			/obj/item/reagent_containers/hypospray/advanced/kelotane = 5,
-			/obj/item/reagent_containers/hypospray/advanced/tramadol = 5,
-			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 5,
-			/obj/item/reagent_containers/hypospray/advanced/dylovene = 5,
+			/obj/item/reagent_containers/hypospray/advanced = 30,
 		),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = -1,


### PR DESCRIPTION

## About The Pull Request
Makes the hypos in the NTMed default to being empty
## Why It's Good For The Game
This should make prep slightly less annoying now.
There never was a lack of hyposprays in the vendor, but people get annoyed when they have to vend a bicaridine hypo, just to empty it in order to fill it with what they want.
## Changelog
:cl:
qol: All the hyposprays in the NTMed are empty by default
/:cl:
