### PR TITLE
Adds a ton of digsites to Riptide, Magmoor, and Lawanka

### DIFF
--- a/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
+++ b/_maps/map_files/Lawanka_Outpost/LawankaOutpost.dmm
@@ -149,6 +149,7 @@
 /area/lawankaoutpost/outside/east)
 "aeX" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
 	},
@@ -257,6 +258,10 @@
 /obj/structure/bed/chair/sofa/right,
 /turf/open/floor/wood/variable,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"ajm" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/lawankaoutpost/colony/mining)
 "ajO" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -276,6 +281,10 @@
 /obj/item/clothing/head/helmet/riot,
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/caves/nukestorage)
+"aln" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/operations_meeting)
 "alq" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/campaign_structure/barricade/sandbags/asat,
@@ -393,6 +402,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"aoo" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/lawankaoutpost/colony/robotics)
 "aoH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2268,6 +2281,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/marshalls)
+"bUV" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/blue/taupeblue,
+/area/lawankaoutpost/colony/biologics)
 "bUZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/structure/cable,
@@ -2609,6 +2626,7 @@
 /area/lawankaoutpost/colony/atmos)
 "chC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 5
 	},
@@ -3454,6 +3472,13 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/southdorms)
+"cTp" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/lawankaoutpost/colony/operations_kitchen)
 "cTE" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -4523,6 +4548,10 @@
 	dir = 1
 	},
 /area/lawankaoutpost/colony/biologics)
+"dOB" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/lawankaoutpost/caves/nukestorage)
 "dOH" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -4667,6 +4696,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/east)
+"dWg" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lawankaoutpost/colony/medbay)
 "dWk" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/kitchenknife/butcherweighted,
@@ -4881,6 +4914,10 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/engineering)
+"eff" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lawankaoutpost/colony/chapel)
 "efh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -5140,6 +5177,7 @@
 /area/lawankaoutpost/caves/nanotrasen_lab)
 "epG" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/mining)
 "epK" = (
@@ -5484,14 +5522,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
-"eEV" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/table/woodentable,
-/turf/open/floor/wood,
-/area/lawankaoutpost/colony/bar)
 "eFc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -5779,10 +5809,6 @@
 	},
 /area/lawankaoutpost/caves/nanotrasen_lab)
 "eQN" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /obj/structure/table/woodentable,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -6994,6 +7020,13 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/white,
 /area/lawankaoutpost/colony/operations_hall)
+"fLo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/lawankaoutpost/colony/biologics)
 "fLw" = (
 /obj/effect/landmark/xeno_tunnel_spawn,
 /obj/structure/flora/grass/tallgrass/hideable{
@@ -7483,6 +7516,7 @@
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/engineering)
 "gff" = (
@@ -7855,6 +7889,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/lawankaoutpost/colony/robotics)
+"gse" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/ground/grass/weedable,
+/area/lawankaoutpost/colony/hydroponics)
 "gsE" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_x = -11;
@@ -7871,6 +7910,10 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
 /area/lawankaoutpost/outside/east)
+"gtd" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/cult,
+/area/lawankaoutpost/caves/southwest)
 "gtg" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_y = -3
@@ -7941,6 +7984,12 @@
 "gwF" = (
 /turf/open/floor/mainship/orange/full,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"gwX" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/engineering)
 "gxn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8218,6 +8267,11 @@
 	dir = 8
 	},
 /area/lawankaoutpost/colony/cargo)
+"gJU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lawankaoutpost/caves/nanotrasen_lab)
 "gJW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -10881,6 +10935,10 @@
 /obj/item/mecha_parts/part/phazon_head,
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"jdq" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/full,
+/area/lawankaoutpost/colony/biologics)
 "jei" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/yellow2{
@@ -11426,6 +11484,12 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/tile/dark/yellow2,
 /area/lawankaoutpost/colony/engineering)
+"jxF" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lawankaoutpost/colony/mining)
 "jyC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -12612,6 +12676,10 @@
 /obj/machinery/prop/r_n_d/server,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"kDf" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/white,
+/area/lawankaoutpost/colony/medbay)
 "kDt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
@@ -14222,6 +14290,12 @@
 	},
 /turf/open/floor,
 /area/lawankaoutpost/colony/recdorms)
+"lPQ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/lawankaoutpost/colony/marshalls)
 "lPS" = (
 /obj/machinery/door/airlock/science{
 	name = "\improper RnD Servers"
@@ -14610,6 +14684,10 @@
 "miV" = (
 /turf/closed/wall,
 /area/lawankaoutpost/colony/chapel)
+"mje" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/red/whitered/full,
+/area/lawankaoutpost/colony/medbay)
 "mjf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -16928,6 +17006,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/full,
 /area/lawankaoutpost/colony/hydroponics)
+"nYF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/lawankaoutpost/colony/engineering)
 "nYJ" = (
 /obj/structure/table,
 /obj/effect/spawner/random/machinery/random_broken_computer/small,
@@ -17427,6 +17510,10 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/biologics)
+"otd" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/lawankaoutpost/colony/engineering)
 "otm" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/campaign_structure/barricade/sandbags/asat{
@@ -20980,6 +21067,11 @@
 	},
 /turf/open/floor/tile/green/greentaupe,
 /area/lawankaoutpost/colony/southdorms)
+"rlr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/chapel,
+/area/lawankaoutpost/colony/chapel)
 "rls" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/ai_node,
@@ -21020,6 +21112,10 @@
 	dir = 4
 	},
 /area/lawankaoutpost/colony/operations_meeting)
+"rmP" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lawankaoutpost/colony/operations_storage)
 "rnf" = (
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/tile/green/full,
@@ -21736,6 +21832,7 @@
 /turf/open/floor,
 /area/lawankaoutpost/colony/biologics)
 "rRT" = (
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
 /area/lawankaoutpost/colony/marshalls)
 "rRZ" = (
@@ -22535,6 +22632,10 @@
 	},
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/lawankaoutpost/outside/southeast)
+"sAc" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/lawankaoutpost/caves/nanotrasen_lab)
 "sBa" = (
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/ground/grass/weedable,
@@ -22708,6 +22809,11 @@
 	dir = 6
 	},
 /area/lawankaoutpost/colony/medbay)
+"sGo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/purple/taupepurple/corner,
+/area/lawankaoutpost/colony/biologics)
 "sGE" = (
 /turf/open/floor/tile/purple/taupepurple{
 	dir = 6
@@ -23213,6 +23319,10 @@
 "tbM" = (
 /turf/open/floor,
 /area/lawankaoutpost/colony/recdorms)
+"tbN" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/lawankaoutpost/colony/hydroponics)
 "tbS" = (
 /obj/structure/flora/grass/tallgrass/hideable/tallgrasscorner{
 	color = "#7a8c54";
@@ -23513,6 +23623,11 @@
 /obj/effect/spawner/random/misc/structure/crate,
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/mining)
+"tnT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/lawankaoutpost/colony/operations_administration)
 "tnW" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light,
@@ -24742,6 +24857,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lawankaoutpost/colony/operations_storage)
+"ups" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/bcircuit/off,
+/area/lawankaoutpost/colony/biologics)
 "upy" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -24887,6 +25006,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/east)
+"uwX" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark/red2/corner,
+/area/lawankaoutpost/colony/marshalls)
 "uxb" = (
 /obj/effect/decal/remains/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -25789,6 +25912,15 @@
 	dir = 9
 	},
 /area/lawankaoutpost/colony/operations_administration)
+"vig" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/lawankaoutpost/caves/nanotrasen_lab)
 "vii" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -26887,10 +27019,15 @@
 	dir = 9
 	},
 /area/lawankaoutpost/colony/chapel)
+"wdK" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/lawankaoutpost/colony/biologics_storage)
 "wdL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/red/full,
 /area/lawankaoutpost/caves/nanotrasen_lab)
 "wdR" = (
@@ -27510,6 +27647,11 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lawankaoutpost/colony/engineering)
+"wzh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/lawankaoutpost/colony/hydroponics)
 "wzt" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor,
@@ -27581,6 +27723,10 @@
 	},
 /turf/open/floor/wood/variable,
 /area/lawankaoutpost/caves/nanotrasen_lab)
+"wEc" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lawankaoutpost/caves/nanotrasen_lab)
 "wEi" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/tool/crowbar/red,
@@ -27632,6 +27778,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/ground/dirt,
 /area/lawankaoutpost/outside/west)
+"wGy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood,
+/area/lawankaoutpost/colony/bar)
 "wHa" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/tile/dark2,
@@ -27866,6 +28018,7 @@
 /area/lawankaoutpost/outside/central)
 "wRa" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/lawankaoutpost/colony/medbay)
 "wRe" = (
@@ -29304,6 +29457,10 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/wood,
 /area/lawankaoutpost/colony/chapel)
+"xXs" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/lawankaoutpost/caves/nanotrasen_lab)
 "xXt" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/landmark/weed_node,
@@ -31644,7 +31801,7 @@ flP
 flP
 flP
 nUt
-flP
+foQ
 flP
 flP
 flP
@@ -31964,7 +32121,7 @@ uDr
 rRZ
 rRZ
 evx
-rRZ
+upD
 rRZ
 rRZ
 rRZ
@@ -32002,7 +32159,7 @@ xGW
 bKe
 bKe
 bKe
-bKe
+pgD
 bKe
 bKe
 wpA
@@ -32065,7 +32222,7 @@ uDr
 flP
 qqN
 flP
-flP
+foQ
 flP
 flP
 flP
@@ -32528,7 +32685,7 @@ xGW
 flP
 flP
 nDG
-flP
+foQ
 flP
 nDG
 flP
@@ -33907,7 +34064,7 @@ rRZ
 rRZ
 nKA
 rRZ
-rRZ
+upD
 rRZ
 rRZ
 rRZ
@@ -33968,7 +34125,7 @@ bKe
 bKe
 bKe
 bKe
-bKe
+pgD
 bKe
 bKe
 ipr
@@ -34498,7 +34655,7 @@ xGW
 xGW
 fHP
 flP
-flP
+foQ
 fHP
 flP
 flP
@@ -35108,7 +35265,7 @@ xGW
 oqq
 oqq
 fVT
-wUp
+sAc
 qQq
 jqb
 sML
@@ -35119,7 +35276,7 @@ unA
 nBv
 ark
 tOX
-wmc
+vig
 blJ
 tbh
 kVm
@@ -35838,7 +35995,7 @@ rRZ
 rRZ
 rRZ
 xqw
-rRZ
+upD
 rRZ
 rRZ
 xqw
@@ -35867,7 +36024,7 @@ rRZ
 rRZ
 nKA
 rRZ
-rRZ
+upD
 rRZ
 rRZ
 rRZ
@@ -36343,7 +36500,7 @@ bKe
 bKe
 bKe
 bKe
-bKe
+pgD
 bKe
 phF
 xGW
@@ -36543,7 +36700,7 @@ xqw
 rRZ
 bKe
 bKe
-bKe
+pgD
 bKe
 wpA
 bKe
@@ -37658,7 +37815,7 @@ ipr
 ipr
 bKe
 bKe
-bKe
+pgD
 bKe
 bKe
 bKe
@@ -37677,7 +37834,7 @@ xGW
 bKe
 wpA
 bKe
-bKe
+pgD
 phF
 wpA
 wpA
@@ -37713,7 +37870,7 @@ xGW
 oqq
 fVT
 bbZ
-nwW
+wEc
 nwW
 qZm
 nwW
@@ -37852,7 +38009,7 @@ pxb
 pxb
 vfW
 pxb
-pxb
+gtd
 pxb
 waq
 pxb
@@ -38223,7 +38380,7 @@ flP
 rRZ
 uDc
 rRZ
-rRZ
+upD
 rRZ
 rRZ
 rRZ
@@ -38395,7 +38552,7 @@ rrz
 rOj
 knt
 knt
-knt
+jTd
 knt
 hxH
 hxH
@@ -39506,7 +39663,7 @@ oqq
 oqq
 xGW
 flP
-flP
+foQ
 fHP
 flP
 xGW
@@ -39542,7 +39699,7 @@ rRZ
 xqw
 rRZ
 rRZ
-rRZ
+upD
 xqw
 rRZ
 xGW
@@ -39583,7 +39740,7 @@ bKe
 bKe
 dun
 pxb
-pxb
+gtd
 pxb
 shs
 pxb
@@ -40423,7 +40580,7 @@ oqq
 xGW
 rRZ
 rRZ
-rRZ
+upD
 rRZ
 rRZ
 vNG
@@ -40965,7 +41122,7 @@ oqq
 oqq
 xGW
 flP
-flP
+foQ
 flP
 flP
 nDG
@@ -41198,7 +41355,7 @@ qQS
 fVT
 tMM
 qIt
-kvd
+gJU
 mkd
 jpt
 uPI
@@ -41502,7 +41659,7 @@ rRZ
 rRZ
 xqw
 rRZ
-rRZ
+upD
 rRZ
 rRZ
 rRZ
@@ -43085,7 +43242,7 @@ xGW
 bKe
 bKe
 bKe
-bKe
+pgD
 bKe
 bKe
 bKe
@@ -43438,7 +43595,7 @@ xGW
 rRZ
 rRZ
 rRZ
-rRZ
+upD
 rRZ
 vNG
 vNG
@@ -43689,7 +43846,7 @@ gLG
 rIc
 rIc
 gLG
-gLG
+cte
 fEu
 gLG
 gLG
@@ -44585,7 +44742,7 @@ gLG
 fKw
 wWw
 gLG
-gLG
+cte
 gLG
 fEu
 bKe
@@ -45855,7 +46012,7 @@ xGW
 xGW
 xGW
 gLG
-gLG
+cte
 gLG
 gLG
 rIc
@@ -45867,7 +46024,7 @@ gQO
 uIY
 hfL
 ycc
-nva
+otd
 jLV
 lFW
 pxk
@@ -46143,7 +46300,7 @@ bKe
 bKe
 bKe
 bKe
-bKe
+pgD
 bKe
 bKe
 phF
@@ -47269,7 +47426,7 @@ oqq
 fVT
 mOx
 isK
-isK
+xXs
 ybP
 qKV
 ybP
@@ -48041,7 +48198,7 @@ tRS
 tRS
 pvY
 hPj
-nva
+otd
 tdT
 nva
 nva
@@ -48122,7 +48279,7 @@ oqq
 xGW
 xGW
 knt
-knt
+jTd
 knt
 knt
 rrz
@@ -48245,7 +48402,7 @@ nPA
 bMm
 tRS
 skU
-nva
+otd
 nva
 nva
 skU
@@ -48917,7 +49074,7 @@ whJ
 fOi
 ntc
 nva
-tdT
+nYF
 nva
 wcC
 dLr
@@ -49236,7 +49393,7 @@ knt
 knt
 knt
 knt
-knt
+jTd
 knt
 xGW
 oqq
@@ -49531,7 +49688,7 @@ rqO
 eQN
 gKg
 pGg
-eEV
+xIU
 hfd
 qsJ
 uxA
@@ -49657,7 +49814,7 @@ knt
 rrz
 rrz
 knt
-knt
+jTd
 knt
 rrz
 knt
@@ -49773,7 +49930,7 @@ tAI
 biZ
 jjo
 seh
-pfg
+gwX
 vzb
 gEk
 mWe
@@ -50051,7 +50208,7 @@ hoj
 xGW
 pWO
 pWO
-pWO
+nwi
 pWO
 xGW
 xGW
@@ -50137,7 +50294,7 @@ vXr
 hHv
 sZf
 hUw
-sZf
+dWg
 sZf
 pSX
 sZf
@@ -50149,7 +50306,7 @@ vXr
 rYL
 jMG
 hNz
-hBF
+mje
 vXr
 bMm
 odh
@@ -50179,7 +50336,7 @@ pGg
 tJs
 tJs
 tJs
-onE
+wGy
 tJs
 wuD
 tJs
@@ -50262,7 +50419,7 @@ lTQ
 rDc
 lTQ
 hoj
-xsy
+dOB
 ihN
 hoj
 xGW
@@ -51123,7 +51280,7 @@ oqq
 xGW
 pWO
 pWO
-pWO
+nwi
 pWO
 xGW
 xGW
@@ -53358,7 +53515,7 @@ hSX
 mCl
 cHR
 tEb
-dtO
+jxF
 svr
 gkQ
 gkQ
@@ -53389,7 +53546,7 @@ uaK
 mHu
 qnh
 jEj
-qyO
+kDf
 qML
 vXr
 lfB
@@ -54109,7 +54266,7 @@ wrN
 eSx
 miV
 mVs
-mVs
+eff
 eAO
 mVs
 miV
@@ -54579,7 +54736,7 @@ mtm
 ezB
 sHv
 gtK
-qqj
+wzh
 xwF
 cIE
 qqj
@@ -54996,7 +55153,7 @@ gTp
 fKE
 dPG
 gEU
-dPG
+rlr
 gEU
 dPG
 bKq
@@ -55535,7 +55692,7 @@ cSf
 eZQ
 msh
 gbZ
-eAy
+ajm
 lTg
 eAy
 nXN
@@ -55724,7 +55881,7 @@ iDa
 ela
 aIQ
 ukc
-aIQ
+fLo
 aIQ
 ukc
 aIQ
@@ -56029,7 +56186,7 @@ peq
 lDH
 lDH
 vLk
-hvT
+tnT
 cNe
 cLk
 cLk
@@ -56697,7 +56854,7 @@ qUw
 ooU
 peu
 cYc
-cYc
+aln
 qIw
 gTl
 ooU
@@ -57476,7 +57633,7 @@ iDa
 iDa
 ekV
 izK
-hLs
+bUV
 oWW
 cmy
 sVx
@@ -58050,7 +58207,7 @@ qqj
 mnO
 hkB
 ezB
-gtK
+tbN
 ozX
 ils
 gtK
@@ -58820,7 +58977,7 @@ oDd
 hpU
 yaw
 oHy
-oDd
+aoo
 mBy
 sfP
 fAt
@@ -59630,7 +59787,7 @@ oqq
 oqq
 jTQ
 mcj
-mcj
+wdK
 wwj
 oNy
 lvL
@@ -60391,7 +60548,7 @@ sWy
 pmn
 kDt
 qoa
-qoa
+rmP
 ldb
 cmM
 xWk
@@ -61018,7 +61175,7 @@ ech
 mKu
 kpF
 eJh
-kpF
+cTp
 mKu
 xFg
 ach
@@ -61747,7 +61904,7 @@ fOX
 gtK
 kJr
 trV
-hWF
+gse
 kWr
 vVy
 hWF
@@ -62158,7 +62315,7 @@ kDH
 sob
 bnR
 kUK
-lAx
+uwX
 fgH
 nIH
 dce
@@ -62455,7 +62612,7 @@ xGW
 iDa
 dWk
 vOA
-yib
+jdq
 mNW
 wSZ
 spr
@@ -63334,7 +63491,7 @@ mLL
 xZc
 mfE
 nCz
-xZc
+sGo
 mLL
 nGs
 mLL
@@ -64192,7 +64349,7 @@ iDa
 ank
 lfM
 mVi
-qpP
+ups
 mVi
 qpP
 tMc
@@ -64549,7 +64706,7 @@ uIE
 psm
 eKO
 ugS
-izy
+lPQ
 jad
 qrS
 iQc

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -17225,13 +17225,13 @@
 /area/magmoor/engi/thermal)
 "lZs" = (
 /obj/structure/table/mainship,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 6;
-	pixel_y = 13
-	},
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice{
 	pixel_x = -2;
 	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 13;
+	pixel_x = 9
 	},
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/jani)

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -1593,6 +1593,10 @@
 	dir = 4
 	},
 /area/magmoor/engi/storage)
+"bcl" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/mono,
+/area/magmoor/mining)
 "bcF" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/tile/purple/taupepurple{
@@ -2459,7 +2463,7 @@
 /area/magmoor/compound/west)
 "bGT" = (
 /obj/structure/table/gamblingtable,
-/obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda,
+/obj/item/reagent_containers/food/drinks/drinkingglass/soda,
 /turf/open/floor/wood,
 /area/magmoor/civilian/gambling)
 "bHh" = (
@@ -2993,6 +2997,10 @@
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/carpet/side,
 /area/magmoor/command/conference)
+"caK" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/cult,
+/area/magmoor/cave/northwest)
 "caN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -3098,6 +3106,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/magmoor/civilian/arrival/east)
+"cfb" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/magmoor/compound/northwest)
 "cfh" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/ai_node,
@@ -5043,6 +5055,10 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/compound)
+"dwI" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/cargo,
+/area/magmoor/cargo/storage/south)
 "dwS" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/southwest)
@@ -5479,6 +5495,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
+"dJz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/mono,
+/area/magmoor/cargo/storage/secure/south)
 "dKc" = (
 /obj/structure/closet/open,
 /turf/open/floor/mainship/purple{
@@ -6162,6 +6183,10 @@
 	dir = 5
 	},
 /area/magmoor/hydroponics/north)
+"ent" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/mainship,
+/area/magmoor/mining)
 "env" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile,
@@ -6892,6 +6917,10 @@
 	dir = 4
 	},
 /area/magmoor/compound/east)
+"eIY" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/magmoor/mining/garage)
 "eJo" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -7190,6 +7219,10 @@
 	dir = 9
 	},
 /area/magmoor/cargo/processing/south)
+"eSF" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing/two)
 "eSN" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/freezer,
@@ -7653,6 +7686,10 @@
 	dir = 5
 	},
 /area/magmoor/compound/west)
+"fkU" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/orange/full,
+/area/magmoor/engi/thermal)
 "fkW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9283,6 +9320,10 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/landing)
+"gtZ" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/northwest)
 "gud" = (
 /turf/open/floor/mainship/orange{
 	dir = 4
@@ -10790,6 +10831,10 @@
 	dir = 8
 	},
 /area/magmoor/engi)
+"hDs" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/magmoor/engi/garage)
 "hDy" = (
 /obj/structure/rock/basalt/pile/alt3,
 /obj/effect/ai_node,
@@ -11957,6 +12002,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/plating_catwalk,
 /area/magmoor/mining/storage)
 "iui" = (
@@ -13568,6 +13614,10 @@
 	dir = 1
 	},
 /area/magmoor/compound/east)
+"jBb" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/mono,
+/area/magmoor/engi/power)
 "jBI" = (
 /turf/open/floor/mainship/blue/corner{
 	dir = 1
@@ -16566,6 +16616,10 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/magmoor/civilian/pool)
+"lEu" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/freezer,
+/area/magmoor/cargo/freezer)
 "lEB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -17171,7 +17225,7 @@
 /area/magmoor/engi/thermal)
 "lZs" = (
 /obj/structure/table/mainship,
-/obj/item/reagent_containers/cup/glass/drinkingglass{
+/obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 6;
 	pixel_y = 13
 	},
@@ -17681,6 +17735,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/power)
 "mxa" = (
@@ -18490,7 +18545,7 @@
 /obj/structure/table/woodentable{
 	flipped = 1
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda,
+/obj/item/reagent_containers/food/drinks/drinkingglass/soda,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
 "naZ" = (
@@ -24594,6 +24649,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
+"ruM" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/cult,
+/area/magmoor/cave/northeast)
 "ruR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -24712,6 +24771,12 @@
 	dir = 5
 	},
 /area/magmoor/civilian/mosque)
+"rAU" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/magmoor/command/lobby)
 "rBm" = (
 /turf/closed/wall/r_wall,
 /area/magmoor/command/conference)
@@ -25602,6 +25667,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound)
+"siC" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/west)
 "siQ" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
@@ -27290,6 +27359,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/cult,
 /area/magmoor/cave/north)
+"tqS" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/magmoor/cave/northeast)
 "tqZ" = (
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/northeast)
@@ -30182,6 +30255,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/clean)
+"vtY" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/cult,
+/area/magmoor/cave/north)
 "vud" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
@@ -30543,6 +30620,10 @@
 /obj/structure/coatrack,
 /turf/open/floor/wood,
 /area/magmoor/command/office)
+"vJc" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/red/full,
+/area/magmoor/security/infocenter)
 "vJq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -31881,6 +31962,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/power)
 "wEH" = (
@@ -32263,6 +32345,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
+"wSl" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing/two)
 "wSt" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	name = "Server Room"
@@ -33171,6 +33257,10 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/carpet/side,
 /area/magmoor/command/conference)
+"xud" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing)
 "xuf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
@@ -33673,6 +33763,10 @@
 	dir = 4
 	},
 /area/magmoor/civilian/arrival/east)
+"xJy" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/sterile/dark,
+/area/magmoor/research/containment)
 "xJC" = (
 /obj/structure/closet/crate/secure,
 /turf/open/floor/mainship/floor,
@@ -33853,6 +33947,10 @@
 /obj/machinery/navbeacon,
 /turf/open/floor/marking/delivery,
 /area/magmoor/civilian/bar)
+"xPR" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing)
 "xPY" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/mainship/orange,
@@ -35935,7 +36033,7 @@ efw
 efw
 efw
 efw
-efw
+gtZ
 efw
 efw
 efw
@@ -36201,7 +36299,7 @@ rxl
 efw
 lfn
 efw
-efw
+gtZ
 efw
 efw
 sUk
@@ -36478,7 +36576,7 @@ rxl
 rxl
 aZd
 aZd
-aZd
+siC
 aZd
 aZd
 fVB
@@ -36694,7 +36792,7 @@ efw
 efw
 efw
 efw
-efw
+gtZ
 efw
 qDf
 efw
@@ -36914,7 +37012,7 @@ sUk
 efw
 lfn
 efw
-efw
+gtZ
 efw
 efw
 efw
@@ -36963,7 +37061,7 @@ aZd
 aZd
 aZd
 aZd
-aZd
+siC
 aZd
 rxl
 rxl
@@ -37089,7 +37187,7 @@ rxl
 efw
 efw
 efw
-efw
+gtZ
 efw
 lfn
 lST
@@ -37652,7 +37750,7 @@ aZd
 aZd
 aZd
 aZd
-aZd
+siC
 aZd
 fVB
 jHZ
@@ -38055,7 +38153,7 @@ efw
 efw
 efw
 efw
-efw
+gtZ
 efw
 efw
 efw
@@ -38510,7 +38608,7 @@ efw
 hko
 sUk
 efw
-efw
+gtZ
 lfn
 qDf
 efw
@@ -38727,7 +38825,7 @@ mFF
 wVz
 wVz
 gok
-mXv
+caK
 mXv
 mXv
 gok
@@ -38802,7 +38900,7 @@ mlB
 mlB
 ojW
 dPK
-dPK
+cfb
 dPK
 dPK
 dPK
@@ -39466,7 +39564,7 @@ qDf
 efw
 efw
 efw
-efw
+gtZ
 efw
 efw
 lfn
@@ -39650,7 +39748,7 @@ rxl
 rxl
 efw
 efw
-efw
+gtZ
 efw
 efw
 rxl
@@ -39972,7 +40070,7 @@ mOt
 vaO
 rtj
 xru
-rDJ
+vJc
 tZy
 gVO
 aap
@@ -40419,7 +40517,7 @@ qDf
 sUk
 sUk
 qDf
-efw
+gtZ
 efw
 vgf
 tYu
@@ -40594,7 +40692,7 @@ efw
 efw
 lfn
 efw
-efw
+gtZ
 efw
 efw
 efw
@@ -40619,7 +40717,7 @@ efw
 qDf
 efw
 efw
-efw
+gtZ
 lfn
 efw
 qDf
@@ -42444,7 +42542,7 @@ rxl
 rxl
 rxl
 efw
-efw
+gtZ
 efw
 efw
 lfn
@@ -43396,7 +43494,7 @@ rxl
 rxl
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 rxl
@@ -44105,7 +44203,7 @@ kcd
 kcd
 rxl
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -44776,7 +44874,7 @@ rxl
 rxl
 rxl
 kxx
-kcd
+qUy
 kcd
 kcd
 rxl
@@ -44968,7 +45066,7 @@ jET
 dzo
 nlP
 gsk
-nlP
+xud
 nlP
 nlP
 nlP
@@ -45201,7 +45299,7 @@ jET
 dzo
 nlP
 nlP
-nlP
+xPR
 nlP
 nlP
 nlP
@@ -45792,7 +45890,7 @@ bKW
 nlz
 bMF
 jnd
-uHK
+rAU
 hym
 rBm
 yla
@@ -46418,7 +46516,7 @@ mBf
 jkR
 lxN
 lxN
-lxN
+vtY
 lxN
 mBf
 jkR
@@ -46599,7 +46697,7 @@ rtV
 dzo
 nlP
 nlP
-nlP
+xPR
 nlP
 nlP
 nlP
@@ -46832,7 +46930,7 @@ jET
 dzo
 nlP
 gsk
-nlP
+xud
 nlP
 nlP
 nlP
@@ -47126,7 +47224,7 @@ kcd
 kcd
 iXx
 kcd
-kcd
+qUy
 kcd
 iXx
 kcd
@@ -47612,7 +47710,7 @@ tMF
 xaU
 wmc
 kaV
-kaV
+bcl
 nXN
 cmn
 xeB
@@ -47803,7 +47901,7 @@ kcd
 kcd
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -48550,7 +48648,7 @@ dzU
 tMF
 fcp
 nrM
-nrM
+ent
 sze
 ebG
 uZb
@@ -48768,7 +48866,7 @@ rxl
 rxl
 try
 kcd
-kcd
+qUy
 kcd
 kcd
 kxx
@@ -49447,7 +49545,7 @@ rxl
 kcd
 iXx
 kcd
-kcd
+qUy
 kcd
 kxx
 kcd
@@ -49498,7 +49596,7 @@ ctB
 cpY
 lCx
 lCx
-ibS
+hDs
 glt
 ibS
 lMP
@@ -50173,7 +50271,7 @@ kcd
 tNH
 iEk
 iEk
-iEk
+eIY
 iEk
 aUs
 itf
@@ -50474,7 +50572,7 @@ tPd
 axT
 eiy
 eLp
-eiy
+dwI
 eiy
 wJz
 sBQ
@@ -50837,7 +50935,7 @@ rxl
 rxl
 rxl
 kcd
-kcd
+qUy
 kcd
 kxx
 kcd
@@ -51316,7 +51414,7 @@ kcd
 kcd
 jkR
 jkR
-lxN
+vtY
 lxN
 fCN
 lxN
@@ -52476,7 +52574,7 @@ kcd
 kcd
 kcd
 kcd
-kcd
+qUy
 uUg
 sBd
 sBd
@@ -52961,7 +53059,7 @@ kxx
 kcd
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -53022,7 +53120,7 @@ hji
 hHp
 gaa
 xeC
-xeC
+dJz
 xeC
 qhn
 mgE
@@ -53170,7 +53268,7 @@ lxN
 lxN
 lxN
 lxN
-lxN
+vtY
 lxN
 lxN
 jkR
@@ -53883,7 +53981,7 @@ kcd
 kcd
 kxx
 kcd
-kcd
+qUy
 kcd
 kxx
 kcd
@@ -54149,7 +54247,7 @@ cdc
 fmq
 cal
 laS
-cdc
+jBb
 fmq
 hLK
 ksj
@@ -55090,7 +55188,7 @@ njq
 xdD
 ylq
 guR
-pyN
+fkU
 sRP
 oZS
 oZS
@@ -56244,7 +56342,7 @@ hJR
 xmI
 yhF
 cdc
-cdc
+jBb
 uRD
 nWI
 nWI
@@ -56673,7 +56771,7 @@ kcd
 gnd
 sBd
 kcd
-kcd
+qUy
 kcd
 iXx
 pUu
@@ -56897,7 +56995,7 @@ jkR
 lxN
 xeb
 rcX
-lxN
+vtY
 lxN
 lxN
 lxN
@@ -57625,7 +57723,7 @@ jkR
 rQK
 rxl
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -57687,7 +57785,7 @@ iyf
 kdG
 uIj
 kOi
-noB
+lEu
 owv
 tlb
 kdG
@@ -58772,7 +58870,7 @@ kcd
 rxl
 kcd
 cFc
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -59961,7 +60059,7 @@ kcd
 kcd
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -60154,7 +60252,7 @@ rxl
 mFF
 jkR
 lxN
-lxN
+vtY
 lxN
 jkR
 jkR
@@ -62044,7 +62142,7 @@ sIO
 kcd
 kcd
 kcd
-kcd
+qUy
 kcd
 sBd
 sBd
@@ -62294,7 +62392,7 @@ kcd
 kcd
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 kcd
@@ -64137,7 +64235,7 @@ pUu
 pUu
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 azV
@@ -65800,7 +65898,7 @@ rxl
 kcd
 kcd
 kcd
-kcd
+qUy
 iXx
 kxx
 kcd
@@ -65993,7 +66091,7 @@ rxl
 iXx
 kcd
 kcd
-kcd
+qUy
 kcd
 kcd
 rIR
@@ -68137,7 +68235,7 @@ lwH
 lwH
 lwH
 lwH
-lwH
+tqS
 lwH
 xaR
 lwH
@@ -68785,7 +68883,7 @@ rxl
 rxl
 kcd
 iXx
-kcd
+qUy
 kcd
 kcd
 rxl
@@ -69285,7 +69383,7 @@ kKI
 dKc
 dFa
 kcd
-kcd
+qUy
 kcd
 rxl
 rxl
@@ -69972,7 +70070,7 @@ hFZ
 fSa
 qlb
 hFZ
-hFZ
+xJy
 hFZ
 dDT
 ghh
@@ -71874,7 +71972,7 @@ lwH
 bZr
 lwH
 lwH
-lwH
+tqS
 lwH
 bZr
 lwH
@@ -72283,7 +72381,7 @@ lwH
 lwH
 bZr
 lwH
-lwH
+tqS
 lwH
 lwH
 bZr
@@ -72404,7 +72502,7 @@ kRR
 afM
 ogT
 kqp
-ogT
+eSF
 ogT
 ogT
 ogT
@@ -72637,7 +72735,7 @@ kRR
 afM
 ogT
 ogT
-ogT
+wSl
 ogT
 ogT
 ogT
@@ -73923,7 +74021,7 @@ lwH
 tIF
 vTR
 nnf
-vTR
+ruM
 vTR
 vTR
 vTR
@@ -73955,7 +74053,7 @@ rxl
 rxl
 rxl
 lwH
-lwH
+tqS
 xaR
 lwH
 lwH
@@ -74035,7 +74133,7 @@ kRR
 afM
 ogT
 ogT
-ogT
+wSl
 ogT
 ogT
 ogT
@@ -74268,7 +74366,7 @@ kRR
 afM
 ogT
 kqp
-ogT
+eSF
 ogT
 ogT
 ogT
@@ -75098,7 +75196,7 @@ lwH
 rEV
 rEV
 lwH
-lwH
+tqS
 lwH
 lwH
 rxl
@@ -76544,7 +76642,7 @@ lwH
 bZr
 lwH
 lwH
-lwH
+tqS
 bZr
 lwH
 rxl
@@ -76948,7 +77046,7 @@ lwH
 lwH
 rEV
 rEV
-lwH
+tqS
 lwH
 rEV
 rxl
@@ -76998,7 +77096,7 @@ rxl
 rxl
 rxl
 lwH
-lwH
+tqS
 lwH
 xaR
 rxl
@@ -78149,7 +78247,7 @@ rxl
 rxl
 lwH
 lwH
-lwH
+tqS
 lwH
 lwH
 lwH
@@ -78366,7 +78464,7 @@ rEV
 rEV
 lwH
 lwH
-lwH
+tqS
 lwH
 rxl
 rxl
@@ -78589,7 +78687,7 @@ rEV
 rEV
 lwH
 lwH
-lwH
+tqS
 lwH
 lwH
 rEV

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -2461,11 +2461,6 @@
 	dir = 1
 	},
 /area/magmoor/compound/west)
-"bGT" = (
-/obj/structure/table/gamblingtable,
-/obj/item/reagent_containers/food/drinks/drinkingglass/soda,
-/turf/open/floor/wood,
-/area/magmoor/civilian/gambling)
 "bHh" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 5
@@ -17229,10 +17224,6 @@
 	pixel_x = -2;
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 13;
-	pixel_x = 9
-	},
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/jani)
 "mad" = (
@@ -18545,7 +18536,6 @@
 /obj/structure/table/woodentable{
 	flipped = 1
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/soda,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
 "naZ" = (
@@ -47127,7 +47117,7 @@ eNf
 roE
 kfI
 kfI
-bGT
+kfI
 jeO
 ucS
 roE

--- a/_maps/map_files/riptide/riptide.dmm
+++ b/_maps/map_files/riptide/riptide.dmm
@@ -250,7 +250,6 @@
 /turf/open/floor/wood/alt_seven,
 /area/riptide/outside/westbeach)
 "akQ" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/liquid/water/river/desertdam/clean/shallow_edge{
 	dir = 4
 	},
@@ -553,6 +552,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/sandtemple,
 /area/riptide/caves/pmc/warehouse)
 "auy" = (
@@ -1289,6 +1289,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/ground,
 /area/riptide/outside/southislands)
+"aVJ" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood/fancy,
+/area/riptide/inside/luxurybar)
 "aVR" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -3238,6 +3242,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/riptide/inside/medical/offices)
+"cpz" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/lavaland/basalt,
+/area/riptide/outside/volcano)
 "cpG" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -3447,7 +3455,6 @@
 /obj/structure/platform_decoration{
 	dir = 5
 	},
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "cvL" = (
@@ -3462,6 +3469,11 @@
 	},
 /turf/open/floor/prison/plate,
 /area/riptide/caves/pmc/prison)
+"cvZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/concrete,
+/area/riptide/inside/warehouse)
 "cwb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -3499,7 +3511,6 @@
 	},
 /area/riptide/caves/south)
 "cwH" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /obj/structure/platform_decoration{
 	dir = 8
 	},
@@ -3780,6 +3791,11 @@
 	},
 /turf/open/floor/tile/bar,
 /area/riptide/inside/medical)
+"cGw" = (
+/obj/effect/turf_decal/riverdecal,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/riptide/caves/piratecove)
 "cGz" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/wood/alt_six,
@@ -3962,6 +3978,11 @@
 	dir = 6
 	},
 /area/riptide/outside/westislands)
+"cOv" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/rustyplating,
+/area/riptide/caves/pmc/warehouse)
 "cOS" = (
 /obj/item/weapon/brick,
 /turf/open/ground,
@@ -4401,6 +4422,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/riptide/caves/pmc/lobby)
+"ddi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/iron/dark/textured_large,
+/area/riptide/caves/pmc/toxins)
 "ddx" = (
 /obj/structure/table/black,
 /obj/effect/spawner/random/engineering/tool,
@@ -4701,7 +4727,13 @@
 	},
 /turf/open/floor/prison,
 /area/riptide/inside/syndicatehead)
+"dpt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark2,
+/area/riptide/inside/southtower)
 "dpA" = (
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/redfloor,
 /area/riptide/inside/warehouse)
 "dpK" = (
@@ -5791,9 +5823,6 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -6
-	},
 /turf/open/floor/tile/vault,
 /area/riptide/inside/luxurybar)
 "eaT" = (
@@ -6264,10 +6293,6 @@
 	},
 /turf/open/ground,
 /area/riptide/outside/eastbeach)
-"erY" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/liquid/water/river/desertdam/clean/shallow_edge/corner,
-/area/riptide/outside/southislands)
 "ese" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/liquid/water/river,
@@ -7620,13 +7645,6 @@
 "fqz" = (
 /obj/structure/table/fancywoodentable,
 /obj/item/reagent_containers/food/drinks/bottle/limejuice,
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
 /turf/open/floor/wood/variable,
 /area/riptide/outside/northjungle)
 "fqA" = (
@@ -7808,10 +7826,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/riptide/inside/hydroponics)
-"fyC" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/closed/mineral/smooth/indestructible,
-/area/riptide/caves/rock)
 "fyI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -8378,7 +8392,6 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "fOg" = (
@@ -8663,6 +8676,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/concrete,
 /area/riptide/caves/tram)
+"gaI" = (
+/obj/structure/mine_structure/wooden/support_wall/t_bar,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/central)
 "gaU" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/gun/shotgun/pump/trenchgun,
@@ -8859,11 +8877,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
 /area/riptide/caves/pmc/rnd)
-"ghP" = (
-/obj/structure/rock/basalt,
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "ghQ" = (
 /obj/structure/flora/drought/shroom/glow,
 /turf/open/floor/plating/ground/dirt_alt/random,
@@ -9016,7 +9029,6 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "goj" = (
@@ -9068,6 +9080,10 @@
 	dir = 1
 	},
 /area/riptide/inside/medical)
+"gpr" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/concrete,
+/area/riptide/caves/tram)
 "gpN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood/alt_six,
@@ -10069,7 +10085,6 @@
 	},
 /area/riptide/caves/north)
 "hfI" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /obj/structure/platform_decoration{
 	dir = 4
 	},
@@ -10124,11 +10139,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/riptide/inside/engineering/cave)
 "hil" = (
 /obj/structure/rock/basalt/pile,
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "hin" = (
@@ -10196,6 +10211,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/open,
 /area/riptide/inside/engineering/bridge)
+"hkn" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/north2/garbledradio)
 "hkz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10251,6 +10270,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/grimy,
 /area/riptide/caves/central/garbledradio)
+"hmf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/riptide/caves/pmc/lobby)
 "hmp" = (
 /turf/open/floor/prison/plate,
 /area/riptide/caves/pmc/prison)
@@ -10512,6 +10536,10 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/riptide/outside/beachlzone)
+"hub" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/north)
 "huw" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood/thatch,
@@ -10736,7 +10764,6 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/riptide/caves/syndicatemining)
 "hDT" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/liquid/water/river/desertdam/clean/shallow_edge/corner2{
 	dir = 4
 	},
@@ -11065,6 +11092,12 @@
 /obj/structure/rack,
 /turf/open/floor/tile/brown,
 /area/riptide/inside/engineering)
+"hPe" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker{
+	dir = 4
+	},
+/area/riptide/caves/north)
 "hPE" = (
 /obj/effect/landmark/corpsespawner/colonist/burst,
 /obj/effect/decal/cleanable/blood,
@@ -11286,6 +11319,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/riptide/caves/syndicatemining)
+"hZu" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating,
+/area/riptide/inside/tikihut)
 "iaz" = (
 /obj/structure/window_frame/wood,
 /obj/effect/turf_decal/sandytile,
@@ -11784,6 +11822,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/dark2,
 /area/riptide/inside/warehouse)
+"isK" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood/alt_two,
+/area/riptide/caves/checkpoint)
 "itb" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
@@ -12126,6 +12168,12 @@
 	},
 /turf/open/floor/prison/plate,
 /area/riptide/inside/syndicatefoyer)
+"iIL" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirtgrassborder2{
+	dir = 4
+	},
+/area/riptide/outside/southjungle)
 "iJE" = (
 /obj/item/reagent_containers/food/drinks/bottle/kahlua,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -12806,10 +12854,6 @@
 /obj/effect/decal/cleanable/mucus,
 /turf/open/floor/tile/bar,
 /area/riptide/inside/medical)
-"jie" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/liquid/water/river/desertdam/clean/shallow_edge/corner2,
-/area/riptide/outside/southislands)
 "jih" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood/darker,
@@ -13055,6 +13099,7 @@
 "jqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/igniter,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/scorched,
 /area/riptide/inside/syndicategen)
 "jqG" = (
@@ -13123,6 +13168,11 @@
 "juD" = (
 /turf/open/floor/wood,
 /area/riptide/caves/north2)
+"juN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/kitchen,
+/area/riptide/inside/syndicateport)
 "jve" = (
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/wood,
@@ -14097,6 +14147,16 @@
 	dir = 8
 	},
 /area/riptide/outside/volcano)
+"kdP" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood/thatch,
+/area/riptide/inside/tikihut)
+"kec" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/central)
 "ked" = (
 /obj/machinery/door/poddoor/shutters/opened{
 	dir = 8
@@ -16381,6 +16441,7 @@
 "lCu" = (
 /obj/machinery/light,
 /obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/desertdam/asphalt/open,
 /area/riptide/inside/engineering/cave)
 "lCB" = (
@@ -16728,11 +16789,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/alt_two,
 /area/riptide/inside/recroom)
-"lPx" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/obj/structure/platform_decoration,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "lPG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16895,6 +16951,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/wood/thatch,
 /area/riptide/inside/canteen/two)
 "lTr" = (
@@ -16963,6 +17020,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/riptide/caves/central)
+"lVU" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/plate,
+/area/riptide/caves/syndicatemining)
 "lVW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_resin_wall,
@@ -16972,6 +17033,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/riptide/caves/central/garbledradio)
+"lXd" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker{
+	dir = 1
+	},
+/area/riptide/caves/south)
 "lXp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -17017,12 +17084,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/riptide/outside/beachlzone)
-"lZy" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/ground/coast{
-	dir = 10
-	},
-/area/riptide/outside/southislands)
 "lZS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/open,
@@ -17329,6 +17390,12 @@
 "mlU" = (
 /turf/open/floor/wood/variable/wide,
 /area/riptide/inside/beachmotel)
+"mmj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/kitchen,
+/area/riptide/caves/syndicatemining)
 "mmt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/cable,
@@ -17509,13 +17576,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/riptide/outside/beachlzone)
-"msu" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "msE" = (
 /obj/structure/prop/vehicle/truck/truckcargo/destructible,
 /turf/open/floor/plating/ground/concrete,
@@ -18338,12 +18398,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/darker,
 /area/riptide/inside/beachbar)
-"mVb" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/liquid/water/river/desertdam/clean/shallow_edge/corner2{
-	dir = 1
-	},
-/area/riptide/outside/southislands)
 "mVd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
 	dir = 1
@@ -18402,6 +18456,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/tcomms,
 /area/riptide/caves/pmc/rnd)
 "mXL" = (
@@ -18782,6 +18837,10 @@
 	},
 /turf/closed/wall/mainship/gray,
 /area/riptide/inside/engineering/bridge)
+"nlH" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/central)
 "nlK" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
@@ -18841,7 +18900,6 @@
 /obj/structure/platform_decoration{
 	dir = 6
 	},
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "nno" = (
@@ -19002,12 +19060,6 @@
 /obj/structure/flora/jungle/large_bush,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner,
 /area/riptide/outside/southjungle)
-"nsL" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/ground/coast{
-	dir = 6
-	},
-/area/riptide/outside/southislands)
 "nsZ" = (
 /obj/effect/landmark/corpsespawner/colonist/regular,
 /obj/effect/decal/cleanable/dirt,
@@ -19945,6 +19997,11 @@
 	},
 /turf/open/ground/grass/weedable,
 /area/riptide/outside/southbeach)
+"nZt" = (
+/obj/effect/turf_decal/riverdecal,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/riptide/caves/north2)
 "nZv" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/gun_ammo,
@@ -20078,6 +20135,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/alt_two,
 /area/riptide/inside/cargoboat)
+"ofI" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood/thatch,
+/area/riptide/inside/tikihut)
 "ofV" = (
 /obj/effect/decal/cleanable/molten_item,
 /obj/effect/decal/cleanable/dirt,
@@ -20149,10 +20210,6 @@
 /obj/item/reagent_containers/food/drinks/cans/lemon_lime{
 	pixel_x = -9;
 	pixel_y = -2
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/filled/cola{
-	pixel_x = 9;
-	pixel_y = 4
 	},
 /obj/structure/platform/adobe{
 	dir = 1
@@ -20288,12 +20345,6 @@
 	dir = 4
 	},
 /area/riptide/outside/beachlzone)
-"ooe" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/liquid/water/river/desertdam/clean/shallow_edge{
-	dir = 1
-	},
-/area/riptide/outside/southislands)
 "oom" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/dmg3,
@@ -20461,6 +20512,11 @@
 "ouy" = (
 /turf/open/floor/prison/sterilewhite,
 /area/riptide/inside/syndicatestarboard)
+"ouD" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/riptide/inside/syndicatecheckpoint)
 "ouO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20805,6 +20861,11 @@
 /obj/effect/turf_decal/sandytile,
 /turf/open/floor/plating/dmg3,
 /area/riptide/inside/engineering/bridge)
+"oEC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/desertdam/asphalt/open,
+/area/riptide/inside/engineering/cave)
 "oEK" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -20991,6 +21052,11 @@
 	dir = 1
 	},
 /area/riptide/outside/southjungle)
+"oKY" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/bar,
+/area/riptide/inside/medical/surgery)
 "oLj" = (
 /obj/structure/window/framed/wood,
 /obj/structure/curtain/open/temple,
@@ -21230,6 +21296,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/riptide/caves/piratecove)
+"oSN" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/iron/herringbone,
+/area/riptide/caves/pmc/rnd)
 "oSZ" = (
 /obj/item/ammo_casing/shell{
 	dir = 6
@@ -21476,6 +21547,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship,
 /area/riptide/inside/breachedfob)
 "pdG" = (
@@ -22155,11 +22227,6 @@
 /obj/structure/table,
 /turf/open/floor/wood/alt_nine,
 /area/riptide/outside/beachlzone)
-"pBH" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "pBI" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/plating/ground/dirtgrassborder2{
@@ -22608,7 +22675,6 @@
 /turf/open/floor/wood,
 /area/riptide/inside/southtower)
 "pPr" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
@@ -23046,6 +23112,10 @@
 	dir = 8
 	},
 /area/riptide/outside/westislands)
+"qbS" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/north2)
 "qct" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags{
@@ -23426,6 +23496,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/riptide/caves/south)
+"qng" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood/alt_nine,
+/area/riptide/inside/arena)
 "qnr" = (
 /obj/structure/table/mainship,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24258,7 +24332,6 @@
 	dir = 8
 	},
 /obj/structure/platform_decoration,
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "qQq" = (
@@ -24683,6 +24756,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/carpet/side{
 	dir = 10
 	},
@@ -25298,6 +25372,10 @@
 	},
 /turf/open/floor/tile/bar,
 /area/riptide/inside/medical)
+"ryE" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/ground/grass/weedable,
+/area/riptide/outside/southjungle)
 "ryF" = (
 /obj/effect/decal/remains/robot,
 /obj/machinery/light{
@@ -25404,7 +25482,6 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "rAY" = (
@@ -26203,6 +26280,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/riptide/caves/central/garbledradio)
+"sbl" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/pmc/prison)
 "sbD" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/plating,
@@ -26502,6 +26583,10 @@
 	},
 /turf/open/floor/wood/alt_three,
 /area/riptide/inside/beachmotel)
+"slX" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood,
+/area/riptide/inside/syndicateport)
 "sml" = (
 /turf/open/floor/iron/dark/diagonal,
 /area/riptide/caves/pmc/toxins)
@@ -26816,13 +26901,6 @@
 "suj" = (
 /turf/open/floor/marking,
 /area/riptide/inside/engineering/bridge)
-"sul" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "sut" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -27461,6 +27539,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/brown,
 /area/riptide/inside/engineering)
+"sSY" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/riptide/caves/north/garbledradio)
 "sTa" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/benchpress,
@@ -27536,7 +27618,6 @@
 /area/riptide/outside/beachlzone)
 "sVu" = (
 /obj/structure/platform_decoration,
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
 "sVO" = (
@@ -27698,6 +27779,10 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating/ground/dirt_alt/random,
 /area/riptide/caves/north)
+"tbj" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow,
+/area/riptide/caves/syndicatemining)
 "tbo" = (
 /obj/effect/landmark/patrol_point/som/som_22,
 /turf/open/ground,
@@ -27724,11 +27809,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/riptide/inside/syndicatestarboard)
-"tcv" = (
-/obj/item/fishing/lure,
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "tcy" = (
 /obj/structure/table,
 /obj/item/storage/surgical_tray,
@@ -28005,11 +28085,6 @@
 	},
 /turf/open/floor/plating/ground/dirt_alt/random,
 /area/riptide/caves/north)
-"tlp" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/obj/structure/flora/jungle/vines,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "tlx" = (
 /obj/effect/landmark/corpsespawner/syndicatesoldier,
 /obj/effect/decal/cleanable/blood,
@@ -28073,11 +28148,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/open,
 /area/riptide/inside/engineering/bridge)
-"top" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "tou" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -28127,10 +28197,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside/regular,
 /area/riptide/outside/volcano)
-"tql" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/ground/coast,
-/area/riptide/outside/southislands)
 "tqK" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/dirt,
@@ -28376,10 +28442,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/redfloor,
 /area/riptide/inside/warehouse)
-"tyY" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "tzb" = (
 /turf/open/liquid/water/river/desertdam/clean/shallow_edge/corner{
 	dir = 1
@@ -28443,6 +28505,10 @@
 	},
 /obj/structure/cable,
 /turf/open/ground,
+/area/riptide/outside/southjungle)
+"tCN" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirtgrassborder2,
 /area/riptide/outside/southjungle)
 "tCX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29064,11 +29130,6 @@
 /obj/structure/prop/mainship/brokengen,
 /turf/open/floor/tile/caution,
 /area/riptide/inside/engineering)
-"tWc" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "tWm" = (
 /obj/structure/mineral_door/wood,
 /obj/structure/cable,
@@ -29447,7 +29508,6 @@
 	},
 /area/riptide/outside/beachlzone)
 "ulQ" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/space/sea,
 /area/riptide/caves/sea)
@@ -29542,6 +29602,16 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/plate,
 /area/riptide/inside/abandonedsec)
+"upJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/brown{
+	dir = 4
+	},
+/area/riptide/inside/engineering)
 "uqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -30213,10 +30283,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grimy,
 /area/riptide/outside/northislands)
-"uPS" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/closed/mineral/smooth/outdoor,
-/area/riptide/caves/rock)
 "uQg" = (
 /turf/closed/wall,
 /area/riptide/caves/north)
@@ -30875,13 +30941,6 @@
 	dir = 8
 	},
 /area/riptide/inside/chapel)
-"vor" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/space/sea,
-/area/riptide/caves/sea)
 "vot" = (
 /obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 1
@@ -31760,6 +31819,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood/thatch,
 /area/riptide/inside/tikihut)
+"vUX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/mainship/red/full,
+/area/riptide/caves/north)
 "vVn" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	dir = 1
@@ -31908,6 +31972,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/plate,
 /area/riptide/inside/abandonedsec)
 "vYP" = (
@@ -31956,12 +32021,6 @@
 	dir = 1
 	},
 /area/riptide/outside/beachlzone)
-"waT" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/open/liquid/water/river/desertdam/clean/shallow_edge{
-	dir = 4
-	},
-/area/riptide/outside/southislands)
 "wbd" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship,
@@ -33221,10 +33280,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass/weedable,
 /area/riptide/outside/northjungle)
-"wXY" = (
-/obj/effect/forcefield/allow_bullet_travel,
-/turf/closed/mineral/smooth/outdoor,
-/area/riptide/caves/sea)
 "wYy" = (
 /obj/structure/fence,
 /obj/structure/platform/nondense,
@@ -34105,6 +34160,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/bar,
 /area/riptide/inside/engineering)
+"xCf" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/cave/darker{
+	dir = 8
+	},
+/area/riptide/caves/north)
 "xCu" = (
 /turf/closed/gm/dense,
 /area/riptide/caves/rock)
@@ -34426,7 +34487,6 @@
 /turf/open/floor/plating/ground/dirt,
 /area/riptide/outside/volcano)
 "xRv" = (
-/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/mineral/smooth/indestructible,
 /area/riptide/caves/sea)
 "xRJ" = (
@@ -34741,6 +34801,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/riptide/inside/engineering/cave)
+"yeN" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/white,
+/area/riptide/inside/hydroponics)
 "yfb" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1
@@ -34968,21 +35032,19 @@
 
 (1,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 lhB
 cQc
-tyY
+bfg
 cQc
 bjE
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -35002,47 +35064,29 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 rNB
 eTW
 dQr
 uyR
 uVx
 rNB
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -35085,8 +35129,28 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 mKA
 rkg
 lXK
@@ -35100,10 +35164,10 @@ mDj
 mDj
 hxI
 kLp
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35147,21 +35211,19 @@ bfg
 "}
 (2,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 cQc
 cQc
 bqj
 cQc
 cQc
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -35181,7 +35243,9 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
+bfg
+bfg
 ulQ
 ulQ
 ulQ
@@ -35221,7 +35285,6 @@ ulQ
 ulQ
 ulQ
 ulQ
-tyY
 bfg
 bfg
 bfg
@@ -35264,8 +35327,9 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 cNT
 lXK
 lNd
@@ -35280,9 +35344,9 @@ hHX
 gxv
 tzb
 pKd
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35326,21 +35390,19 @@ bfg
 "}
 (3,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 cQc
 rAx
 mzH
 cNl
 cQc
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -35360,7 +35422,9 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
+bfg
+bfg
 pPr
 rNB
 rNB
@@ -35400,7 +35464,6 @@ aCL
 rNB
 rNB
 pPr
-tyY
 bfg
 bfg
 bfg
@@ -35429,22 +35492,23 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 cNT
 rgm
 bQo
@@ -35460,8 +35524,8 @@ qzz
 hxI
 tzb
 pKd
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35505,23 +35569,23 @@ bfg
 "}
 (4,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 bqj
 thU
 wTU
 oft
 bqj
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35539,7 +35603,7 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
 pPr
 rNB
 mzP
@@ -35579,51 +35643,51 @@ ggO
 alc
 rNB
 pPr
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
 bfg
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sVu
-tyY
-sul
-tyY
-tyY
-tyY
-tyY
+bfg
+cwH
+bfg
+bfg
+bfg
+bfg
 sVu
-tyY
-tyY
-sul
-tyY
-tyY
+bfg
+bfg
+cwH
+bfg
+bfg
 cNT
 rgm
 bQo
@@ -35639,26 +35703,26 @@ bQo
 qzz
 hxI
 kLp
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35684,23 +35748,23 @@ bfg
 "}
 (5,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 bqj
 sEq
 pkz
 kQq
 bqj
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35718,7 +35782,7 @@ bfg
 bfg
 sEG
 bfg
-tyY
+bfg
 pPr
 aCL
 uyR
@@ -35758,37 +35822,37 @@ vwF
 otY
 aCL
 pPr
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 euz
 tfs
 pSN
@@ -35818,28 +35882,28 @@ bQo
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 sVu
-tyY
-tyY
-tyY
-sul
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+cwH
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -35863,14 +35927,14 @@ bfg
 "}
 (6,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 bqj
 jdf
 kzn
@@ -35878,8 +35942,6 @@ jqk
 bqj
 xnV
 njz
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -35888,16 +35950,18 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tcv
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+sEG
+bfg
+bfg
+bfg
+bfg
 pPr
 aCL
 uyR
@@ -35937,8 +36001,8 @@ vwF
 otY
 aCL
 pPr
-tyY
-tyY
+bfg
+bfg
 nyt
 gPY
 gPY
@@ -35946,8 +36010,8 @@ gPY
 gPY
 gPY
 iZT
-tyY
-tyY
+bfg
+bfg
 nyt
 gPY
 gPY
@@ -35955,18 +36019,18 @@ gPY
 gPY
 gPY
 iZT
-tyY
+bfg
 euz
 tfs
 tfs
 tfs
 tfs
 wFf
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 euz
 eMW
 sro
@@ -35997,7 +36061,7 @@ aaS
 bQo
 mWe
 kLp
-sul
+cwH
 sVu
 nnn
 gCL
@@ -36005,20 +36069,20 @@ vdZ
 gEr
 rAN
 qQo
-tyY
-tyY
-tyY
-tyY
-sul
+bfg
+bfg
+bfg
+bfg
+cwH
 mKA
 vzs
 vzs
 vzs
 pKd
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -36042,14 +36106,14 @@ bfg
 "}
 (7,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 ykD
 pkz
 geI
@@ -36057,8 +36121,7 @@ rwX
 puJ
 cwb
 xnV
-sul
-tyY
+cwH
 bfg
 bfg
 bfg
@@ -36067,16 +36130,17 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 pPr
 rNB
 uyR
@@ -36156,11 +36220,11 @@ lSh
 tzb
 pKd
 fNW
-tyY
-tyY
-vor
-tyY
-tyY
+bfg
+bfg
+hfI
+bfg
+bfg
 cNT
 rgm
 hHX
@@ -36196,9 +36260,9 @@ hxI
 tzb
 vzs
 pKd
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 sQM
@@ -36221,14 +36285,14 @@ bfg
 "}
 (8,1,1) = {"
 wCv
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
 cQc
 dxO
 fpG
@@ -36236,8 +36300,6 @@ rFr
 kDF
 vSm
 pVH
-tyY
-tyY
 bfg
 bfg
 bfg
@@ -36246,16 +36308,18 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 nhu
 nrq
 nrq
 nrq
 nrq
 jKC
-tyY
-tyY
+bfg
+bfg
 pPr
 aCL
 fHJ
@@ -36334,12 +36398,12 @@ wex
 rBR
 rBR
 kLp
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 cNT
 rgm
 bQo
@@ -36375,9 +36439,9 @@ qzz
 mDj
 hxI
 kLp
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 sQM
@@ -36400,14 +36464,14 @@ bfg
 "}
 (9,1,1) = {"
 wCv
-tyY
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 cQc
 fIE
 oIS
@@ -36415,26 +36479,26 @@ fIE
 kDF
 wqC
 pVH
-tyY
-tyY
-tyY
-tyY
-tyY
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 uFg
 oGZ
 rwz
 rwz
 oGZ
 uFg
-tyY
-tyY
+bfg
+bfg
 pPr
 aCL
 nHt
@@ -36517,8 +36581,8 @@ tfs
 tfs
 tfs
 wFf
-tyY
-tyY
+bfg
+bfg
 cNT
 mce
 vFQ
@@ -36555,8 +36619,8 @@ bQo
 gxv
 tzb
 pKd
-tyY
-tyY
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -36579,33 +36643,33 @@ bfg
 "}
 (10,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 fIE
 fIE
 fIE
 nrq
 vSm
 njz
-vor
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+hfI
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 uFg
 uij
 wuk
@@ -36613,7 +36677,7 @@ jMa
 ioh
 uFg
 uFg
-tyY
+bfg
 pPr
 aCL
 fTa
@@ -36697,7 +36761,7 @@ rBR
 rBR
 epC
 wFf
-tyY
+bfg
 cNT
 lSh
 rgm
@@ -36713,14 +36777,14 @@ bQo
 bQo
 jMW
 kLp
-vor
+hfI
 fNW
 goh
 iwx
 giD
 bLC
 cvu
-vor
+hfI
 cTA
 hhI
 xnY
@@ -36734,8 +36798,8 @@ bQo
 qzz
 hxI
 kLp
-tyY
-tyY
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -36758,10 +36822,10 @@ bfg
 "}
 (11,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 nhu
 nrq
 nrq
@@ -36776,13 +36840,13 @@ njz
 nrq
 nrq
 jKC
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 kQu
 cqi
 uFg
@@ -36792,7 +36856,7 @@ uQP
 uQP
 uQP
 uFg
-tyY
+bfg
 pPr
 rNB
 ejD
@@ -36892,14 +36956,14 @@ bQo
 iZm
 cOo
 kLp
-tyY
-tyY
+bfg
+bfg
 fNW
 spE
 fQS
-tyY
-vor
-tyY
+bfg
+hfI
+bfg
 olb
 fYQ
 pND
@@ -36913,8 +36977,8 @@ bQo
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -36937,7 +37001,7 @@ bfg
 "}
 (12,1,1) = {"
 wCv
-tyY
+bfg
 nhu
 nrq
 nrq
@@ -36971,7 +37035,7 @@ ppO
 uQP
 amU
 oGZ
-tyY
+bfg
 pPr
 aCL
 fsz
@@ -37071,17 +37135,17 @@ iZm
 cOo
 pZJ
 wRN
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 fwT
 bDN
-tyY
-tyY
+bfg
+bfg
 fNW
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 hDT
 fzz
 rgm
@@ -37092,8 +37156,8 @@ bQo
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 sTP
 sTP
@@ -37116,7 +37180,7 @@ bfg
 "}
 (13,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 tLj
 quK
@@ -37150,7 +37214,7 @@ emu
 cuP
 wgz
 oGZ
-tyY
+bfg
 pPr
 aCL
 fsz
@@ -37249,19 +37313,19 @@ sWp
 cOo
 pZJ
 wRN
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 fwT
 fwT
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 cNT
 mce
 vFQ
@@ -37271,8 +37335,8 @@ bKC
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 sTP
@@ -37317,9 +37381,9 @@ rXt
 pWv
 ajh
 anO
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 kQu
 cqi
 uFg
@@ -37329,7 +37393,7 @@ aUf
 uQP
 xJo
 uFg
-tyY
+bfg
 pPr
 aCL
 fsz
@@ -37427,20 +37491,20 @@ kBz
 kBz
 kBz
 wRN
-tyY
+bfg
 sVu
-tyY
-sul
-tyY
+bfg
+cwH
+bfg
 fwT
 fwT
-tyY
-uPS
+bfg
+sTP
 bfg
 bfg
 sEG
-tyY
-tyY
+bfg
+bfg
 fPz
 qbN
 rgm
@@ -37450,9 +37514,9 @@ bQo
 iZm
 cOo
 kLp
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -37496,11 +37560,11 @@ pdT
 pdT
 iWe
 anO
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 uFg
 uFg
 uFg
@@ -37508,7 +37572,7 @@ wgS
 wgE
 uFg
 uFg
-tyY
+bfg
 pPr
 rNB
 dih
@@ -37601,26 +37665,26 @@ kTg
 wex
 lSh
 kLp
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 pSN
 fwT
 fwT
 fps
 fwT
-sul
-uPS
+cwH
+sTP
 sTP
 bfg
 bfg
-tyY
-tcv
-tyY
+bfg
+sEG
+bfg
 cNT
 mce
 sWp
@@ -37629,14 +37693,14 @@ sWp
 cOo
 lSh
 kLp
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-uPS
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+sTP
 sTP
 sTP
 sTP
@@ -37676,17 +37740,17 @@ nZz
 bDJ
 anO
 sVu
-tyY
-tyY
-sul
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+cwH
+bfg
+bfg
+bfg
+bfg
 hkz
 lTa
-tyY
-tyY
+bfg
+bfg
 sVu
 pPr
 rNB
@@ -37781,25 +37845,25 @@ wex
 rBR
 epC
 wFf
-tyY
-uPS
-uPS
-uPS
-uPS
+bfg
+sTP
+sTP
+sTP
+sTP
 fNW
 fwT
 bDN
 fwT
 fwT
 uig
-tyY
-uPS
+bfg
+sTP
 sTP
 sEG
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 fPz
 kBz
 kBz
@@ -37809,17 +37873,17 @@ lSh
 lSh
 tzb
 pKd
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-uPS
-uPS
-uPS
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+sTP
+sTP
+sTP
 sTP
 bfg
 bfg
@@ -37960,29 +38024,29 @@ vZW
 bqZ
 rBR
 qiF
-tyY
-uPS
-uPS
-tyY
-tyY
-tyY
+bfg
+sTP
+sTP
+bfg
+bfg
+bfg
 fps
 fwT
-tyY
+bfg
 fNW
-tyY
-vor
-tyY
+bfg
+hfI
+bfg
 sTP
 bfg
 sTP
 sTP
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 cNT
 nSe
 oZN
@@ -37993,16 +38057,16 @@ wsl
 wsl
 wsl
 eCH
-tyY
-tyY
-tyY
-tyY
-tyY
-uPS
-uPS
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+sTP
+sTP
+bfg
+bfg
+bfg
 bfg
 bfg
 bfg
@@ -38139,29 +38203,29 @@ kTg
 wex
 rBR
 qiF
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 euz
 tfs
 eGc
 eGc
 tfs
 wFf
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 sTP
 sTP
-uPS
-tyY
-tyY
-tyY
-tyY
-tyY
+sTP
+bfg
+bfg
+bfg
+bfg
+bfg
 mqQ
 gVk
 bQo
@@ -38176,12 +38240,12 @@ wsl
 wsl
 wsl
 eCH
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 bfg
 elM
 bfg
@@ -38329,18 +38393,18 @@ eGc
 rBR
 epC
 wFf
-tyY
-tyY
-tyY
 bfg
 bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
 sTP
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 mqQ
 rgm
 bQo
@@ -38359,9 +38423,9 @@ wsl
 wsl
 wsl
 eCH
-tyY
-tyY
-wXY
+bfg
+bfg
+elM
 elM
 bfg
 bfg
@@ -38508,18 +38572,18 @@ eGc
 bqZ
 rBR
 qiF
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 bfg
 sTP
 sTP
 sTP
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 mqQ
 rgm
 hHX
@@ -38538,9 +38602,9 @@ mDj
 mDj
 hxI
 vXw
-tyY
-tyY
-wXY
+bfg
+bfg
+elM
 elM
 elM
 elM
@@ -38582,7 +38646,7 @@ aUf
 uQP
 rnj
 oGZ
-tyY
+bfg
 pPr
 aCL
 fsz
@@ -38688,16 +38752,16 @@ wex
 rBR
 epC
 wFf
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
-tyY
-tyY
+bfg
+bfg
 dAL
 ieK
 rgm
@@ -38718,9 +38782,9 @@ lTs
 gxv
 uSA
 eCH
-tyY
-wXY
-wXY
+bfg
+elM
+elM
 elM
 elM
 bfg
@@ -38761,7 +38825,7 @@ aUf
 uQP
 fQT
 oGZ
-tyY
+bfg
 pPr
 aCL
 eIo
@@ -38869,14 +38933,14 @@ rBR
 epC
 tfs
 wFf
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 bfg
 sTP
-tyY
-tyY
+bfg
+bfg
 mqQ
 lXK
 lNd
@@ -38897,10 +38961,10 @@ bQo
 qzz
 hxI
 vXw
-tyY
-tyY
-wXY
-wXY
+bfg
+bfg
+elM
+elM
 elM
 elM
 "}
@@ -38940,7 +39004,7 @@ aUf
 uQP
 fiR
 uFg
-tyY
+bfg
 pPr
 aCL
 sXP
@@ -39050,12 +39114,12 @@ rBR
 epC
 tfs
 wFf
-tyY
-tyY
+bfg
+bfg
 bfg
 sTP
-tyY
-tyY
+bfg
+bfg
 mqQ
 rgm
 vDg
@@ -39077,9 +39141,9 @@ bQo
 gxv
 uSA
 eCH
-tyY
-tyY
-wXY
+bfg
+bfg
+elM
 elM
 elM
 "}
@@ -39119,7 +39183,7 @@ njR
 uVh
 pBD
 uFg
-tyY
+bfg
 sKJ
 uUt
 sXP
@@ -39229,12 +39293,12 @@ rBR
 rBR
 rBR
 qiF
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 mqQ
 rgm
 bQo
@@ -39257,8 +39321,8 @@ qzz
 hxI
 uSA
 eCH
-tyY
-wXY
+bfg
+elM
 elM
 elM
 "}
@@ -39408,12 +39472,12 @@ sVO
 bqZ
 gao
 qiF
-tyY
-sul
-tyY
+bfg
+cwH
+bfg
 sVu
-tyY
-tyY
+bfg
+bfg
 eVa
 rgm
 mpc
@@ -39436,8 +39500,8 @@ bQo
 qzz
 hxI
 vXw
-tyY
-wXY
+bfg
+elM
 elM
 elM
 "}
@@ -39615,8 +39679,8 @@ bQo
 bQo
 gxv
 vXw
-tyY
-wXY
+bfg
+elM
 elM
 bfg
 "}
@@ -39794,8 +39858,8 @@ bQo
 bQo
 gxv
 vXw
-tyY
-wXY
+bfg
+elM
 elM
 bfg
 "}
@@ -39973,8 +40037,8 @@ hHX
 bQo
 gxv
 vXw
-tyY
-wXY
+bfg
+elM
 bfg
 bfg
 "}
@@ -40124,12 +40188,12 @@ bCN
 dwf
 sro
 qiF
-tyY
-vor
-tyY
+bfg
+hfI
+bfg
 fNW
-tyY
-tyY
+bfg
+bfg
 oCh
 rgm
 bQo
@@ -40152,8 +40216,8 @@ bQo
 bQo
 gxv
 vXw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
@@ -40303,12 +40367,12 @@ rBR
 rBR
 rBR
 qiF
-tyY
-tyY
-uPS
-uPS
-tyY
-tyY
+bfg
+bfg
+sTP
+sTP
+bfg
+bfg
 mqQ
 rgm
 bQo
@@ -40331,14 +40395,14 @@ bQo
 bQo
 gxv
 vXw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
 (31,1,1) = {"
 wCv
-tyY
+bfg
 jnd
 ftZ
 cgU
@@ -40482,12 +40546,12 @@ rBR
 rBR
 rBR
 qiF
-tyY
-uPS
-uPS
-uPS
-uPS
-tyY
+bfg
+sTP
+sTP
+sTP
+sTP
+bfg
 mqQ
 mce
 vFQ
@@ -40510,16 +40574,16 @@ bQo
 bQo
 gxv
 vXw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
 (32,1,1) = {"
 wCv
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 jnd
 ftZ
 ftZ
@@ -40661,12 +40725,12 @@ bqZ
 rBR
 rBR
 qiF
-tyY
-uPS
-uPS
-tyY
-tyY
-tyY
+bfg
+sTP
+sTP
+bfg
+bfg
+bfg
 mqQ
 lSh
 rgm
@@ -40689,21 +40753,21 @@ bQo
 bQo
 gxv
 vXw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
 (33,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 jnd
 ftZ
 xnV
@@ -40840,10 +40904,10 @@ wex
 rBR
 rBR
 qiF
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 euz
 tfs
 ieK
@@ -40868,23 +40932,23 @@ bQo
 iZm
 cOo
 vXw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
 (34,1,1) = {"
 wCv
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 xnV
 cYz
 xnV
@@ -41047,8 +41111,8 @@ iZm
 cOo
 qRF
 ejV
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
@@ -41060,10 +41124,10 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 xnV
 xDK
 xnV
@@ -41225,9 +41289,9 @@ fwT
 cOo
 qRF
 ejV
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 bfg
 "}
@@ -41241,8 +41305,8 @@ wCv
 wCv
 bse
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xDK
 xnV
@@ -41405,9 +41469,9 @@ jOu
 uSA
 vzs
 pKd
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 "}
 (37,1,1) = {"
@@ -41420,8 +41484,8 @@ aNL
 cQC
 wCv
 bfg
-tyY
-lPx
+bfg
+sVu
 xnV
 qSv
 xnV
@@ -41584,9 +41648,9 @@ enM
 mDj
 hxI
 kLp
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 bfg
 "}
 (38,1,1) = {"
@@ -41599,8 +41663,8 @@ qRW
 dEq
 wCv
 bfg
-tyY
-tyY
+bfg
+bfg
 nqA
 xDK
 pVH
@@ -41745,13 +41809,13 @@ rBR
 rBR
 sta
 exC
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 mKA
 rkg
 lXK
@@ -41764,8 +41828,8 @@ bQo
 gxv
 tzb
 pKd
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (39,1,1) = {"
@@ -41778,8 +41842,8 @@ cev
 dWz
 wCv
 bfg
-tyY
-tyY
+bfg
+bfg
 nqA
 xDK
 pVH
@@ -41923,14 +41987,14 @@ lMd
 uAj
 uAj
 mql
-tyY
-tyY
-fyC
-fyC
-fyC
-tyY
-tyY
-tyY
+bfg
+bfg
+ngS
+ngS
+ngS
+bfg
+bfg
+bfg
 cNT
 lXK
 lNd
@@ -41943,8 +42007,8 @@ bQo
 qzz
 hxI
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (40,1,1) = {"
@@ -41957,8 +42021,8 @@ wCv
 wCv
 bWI
 bfg
-tyY
-msu
+bfg
+fNW
 xnV
 cYz
 xnV
@@ -42102,14 +42166,14 @@ jJS
 lMd
 uAj
 mql
-tyY
-tyY
-fyC
-fyC
-fyC
-tyY
-tyY
-tyY
+bfg
+bfg
+ngS
+ngS
+ngS
+bfg
+bfg
+bfg
 cNT
 rgm
 bQo
@@ -42122,8 +42186,8 @@ bQo
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (41,1,1) = {"
@@ -42136,8 +42200,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 qSv
 xnV
@@ -42281,14 +42345,14 @@ sir
 mJn
 uAj
 mql
-tyY
-tyY
-fyC
-fyC
-fyC
-fyC
-tyY
-tyY
+bfg
+bfg
+ngS
+ngS
+ngS
+ngS
+bfg
+bfg
 cNT
 rgm
 hHX
@@ -42301,8 +42365,8 @@ hHX
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (42,1,1) = {"
@@ -42315,8 +42379,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xDK
 xnV
@@ -42461,12 +42525,12 @@ mJn
 uAj
 muZ
 oph
-tyY
-fyC
-fyC
-fyC
-fyC
-fyC
+bfg
+ngS
+ngS
+ngS
+ngS
+ngS
 xRv
 rkg
 mce
@@ -42480,8 +42544,8 @@ bQo
 bQo
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (43,1,1) = {"
@@ -42494,8 +42558,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xDK
 xnV
@@ -42640,12 +42704,12 @@ jJS
 lMd
 uAj
 mql
-tyY
-tyY
-fyC
-fyC
-fyC
-fyC
+bfg
+bfg
+ngS
+ngS
+ngS
+ngS
 xRv
 lSh
 bfp
@@ -42659,8 +42723,8 @@ bQo
 qpP
 gxv
 kLp
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (44,1,1) = {"
@@ -42672,8 +42736,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 sVu
 bzD
 ivi
@@ -42838,8 +42902,8 @@ kHe
 kHe
 opA
 hKz
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (45,1,1) = {"
@@ -42851,7 +42915,7 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
 sVu
 nnn
 hON
@@ -43017,8 +43081,8 @@ bfp
 bfp
 bfp
 hKz
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (46,1,1) = {"
@@ -43030,8 +43094,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 guE
 fno
 xKQ
@@ -43196,8 +43260,8 @@ bfp
 bfp
 bfp
 hKz
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (47,1,1) = {"
@@ -43209,8 +43273,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 hON
 fno
 lpd
@@ -43375,8 +43439,8 @@ bfp
 bfp
 bfp
 hKz
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (48,1,1) = {"
@@ -43388,8 +43452,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 ikC
 fno
 aoS
@@ -43554,8 +43618,8 @@ bfp
 tmu
 bfp
 hKz
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (49,1,1) = {"
@@ -43567,7 +43631,7 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
 fNW
 goh
 hON
@@ -43734,7 +43798,7 @@ bfp
 bfp
 hKz
 cwH
-tyY
+bfg
 bfg
 "}
 (50,1,1) = {"
@@ -43746,8 +43810,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 fNW
 bzD
 ivi
@@ -43912,8 +43976,8 @@ iDi
 iTu
 iTu
 hEe
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (51,1,1) = {"
@@ -43926,8 +43990,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xDK
 xnV
@@ -44091,8 +44155,8 @@ rEK
 rEK
 rEK
 rEK
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (52,1,1) = {"
@@ -44102,11 +44166,11 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 xnV
 cYz
 xnV
@@ -44271,7 +44335,7 @@ hyd
 sQD
 rEK
 kNN
-tyY
+bfg
 bfg
 "}
 (53,1,1) = {"
@@ -44279,13 +44343,13 @@ wCv
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 xnV
 qSv
 xnV
@@ -44458,10 +44522,10 @@ wCv
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 rbW
 oaO
 oaO
@@ -44636,9 +44700,9 @@ kNN
 wCv
 bfg
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 rbW
 oaO
 mjf
@@ -44813,11 +44877,11 @@ hLr
 "}
 (56,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 wHS
 tLj
 quK
@@ -44992,10 +45056,10 @@ hLr
 "}
 (57,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 rbW
 mjf
 eyC
@@ -45171,8 +45235,8 @@ hLr
 "}
 (58,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 rbW
 oaO
 mjf
@@ -45350,8 +45414,8 @@ kNN
 "}
 (59,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 tLj
 quK
@@ -45529,8 +45593,8 @@ hLr
 "}
 (60,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -45708,8 +45772,8 @@ hLr
 "}
 (61,1,1) = {"
 aEL
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 nNS
@@ -45875,7 +45939,7 @@ aBC
 xsR
 pCJ
 rDy
-hyd
+dpt
 gaf
 hyd
 pYq
@@ -45887,8 +45951,8 @@ hLr
 "}
 (62,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -46066,8 +46130,8 @@ kNN
 "}
 (63,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -46245,7 +46309,7 @@ hLr
 "}
 (64,1,1) = {"
 wCv
-tyY
+bfg
 rbW
 mjf
 eyC
@@ -46424,7 +46488,7 @@ hLr
 "}
 (65,1,1) = {"
 wCv
-ghP
+bzd
 wHS
 tLj
 gfQ
@@ -46603,7 +46667,7 @@ hLr
 "}
 (66,1,1) = {"
 wCv
-tyY
+bfg
 wHS
 eyC
 pdT
@@ -46678,7 +46742,7 @@ mSy
 sAh
 exs
 aBu
-mBY
+slX
 mBY
 aYH
 lMA
@@ -46782,7 +46846,7 @@ kNN
 "}
 (67,1,1) = {"
 wCv
-tyY
+bfg
 wHS
 eyC
 pdT
@@ -46961,7 +47025,7 @@ bfg
 "}
 (68,1,1) = {"
 wCv
-tyY
+bfg
 wHS
 eyC
 pdT
@@ -47050,7 +47114,7 @@ fzb
 iEm
 uvw
 wKs
-nOc
+juN
 uVo
 nOc
 qbI
@@ -47135,12 +47199,12 @@ gaf
 rVV
 rEK
 kNN
-tyY
+bfg
 bfg
 "}
 (69,1,1) = {"
 wCv
-tyY
+bfg
 wHS
 eyC
 pdT
@@ -47313,13 +47377,13 @@ ejK
 mlI
 ejK
 rEK
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (70,1,1) = {"
 wCv
-tyY
+bfg
 wHS
 nxn
 ugD
@@ -47352,7 +47416,7 @@ etb
 dCV
 dzH
 npY
-hTS
+oKY
 cSS
 dCV
 hHO
@@ -47492,13 +47556,13 @@ vfg
 bVN
 iNw
 iqb
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (71,1,1) = {"
 wCv
-tyY
+bfg
 xBP
 ute
 eyC
@@ -47671,14 +47735,14 @@ eRH
 vfg
 nsa
 iqb
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (72,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -47850,14 +47914,14 @@ vfg
 uUq
 vfg
 iqb
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (73,1,1) = {"
 wCv
 hil
-tyY
+bfg
 wHS
 nxn
 ugD
@@ -48029,14 +48093,14 @@ uUq
 mcM
 wSN
 rHY
-tyY
-tyY
+bfg
+bfg
 bfg
 "}
 (74,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 xBP
 ute
 eyC
@@ -48209,14 +48273,14 @@ jIS
 iLn
 hKz
 hfI
-tyY
-tyY
+bfg
+bfg
 "}
 (75,1,1) = {"
 wCv
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 wHS
 eyC
 soJ
@@ -48387,14 +48451,14 @@ unw
 iNw
 iNw
 hKz
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 "}
 (76,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 rbW
 mjf
 eyC
@@ -48568,12 +48632,12 @@ iNw
 dyT
 hdZ
 tVU
-tyY
+bfg
 "}
 (77,1,1) = {"
 wCv
-ghP
-tyY
+bzd
+bfg
 wHS
 tLj
 gfQ
@@ -48747,12 +48811,12 @@ uUq
 cIX
 cUT
 dyT
-waT
+hdZ
 "}
 (78,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -48926,12 +48990,12 @@ iqb
 pwP
 kwa
 rMJ
-lZy
+cUT
 "}
 (79,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -49105,12 +49169,12 @@ iqb
 pwP
 pwP
 pwP
-tql
+gDI
 "}
 (80,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 nNS
@@ -49284,12 +49348,12 @@ iNw
 pCf
 pwP
 pwP
-tql
+gDI
 "}
 (81,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -49463,12 +49527,12 @@ iNw
 pwP
 pwP
 pwP
-tql
+gDI
 "}
 (82,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -49642,12 +49706,12 @@ iNw
 pwP
 pwP
 qqb
-nsL
+opA
 "}
 (83,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 nNS
@@ -49821,12 +49885,12 @@ iNw
 iCW
 qqb
 opA
-erY
+txa
 "}
 (84,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -50000,12 +50064,12 @@ iqb
 qqb
 opA
 txa
-jie
+uCJ
 "}
 (85,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 pdT
@@ -50179,12 +50243,12 @@ iqb
 opA
 txa
 uCJ
-tyY
+bfg
 "}
 (86,1,1) = {"
 bDF
-tyY
-tyY
+bfg
+bfg
 wHS
 eyC
 sBK
@@ -50298,7 +50362,7 @@ kjQ
 eKa
 vaV
 nTO
-vaV
+iIL
 vaV
 hTw
 udO
@@ -50357,13 +50421,13 @@ iNw
 iNw
 lri
 hKz
-tyY
-tyY
+bfg
+bfg
 "}
 (87,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 wHS
 nxn
 ugD
@@ -50537,12 +50601,12 @@ iNw
 cUT
 dyT
 tVU
-tyY
+bfg
 "}
 (88,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 xBP
 ute
 nxn
@@ -50716,13 +50780,13 @@ iNw
 kwa
 cUT
 hKz
-tyY
+bfg
 "}
 (89,1,1) = {"
 wCv
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 xBP
 ute
 nxn
@@ -50816,7 +50880,7 @@ krQ
 geK
 mSy
 mSy
-mSy
+cpz
 lZU
 mSy
 mSy
@@ -50895,14 +50959,14 @@ pwP
 pwP
 gDI
 hKz
-tyY
+bfg
 "}
 (90,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 xBP
 gOy
 gOy
@@ -51074,17 +51138,17 @@ fEO
 pwP
 gDI
 dyT
-mVb
+tVU
 "}
 (91,1,1) = {"
 wCv
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 qSv
 xnV
 eoN
@@ -51253,17 +51317,17 @@ hNS
 pwP
 kwa
 cUT
-ooe
+hKz
 "}
 (92,1,1) = {"
 wCv
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 xDK
 xnV
 eoN
@@ -51432,7 +51496,7 @@ hNS
 pwP
 pwP
 gDI
-ooe
+hKz
 "}
 (93,1,1) = {"
 wCv
@@ -51441,8 +51505,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xDK
 qOE
 eoN
@@ -51611,7 +51675,7 @@ hNS
 hNS
 pwP
 gDI
-ooe
+hKz
 "}
 (94,1,1) = {"
 wCv
@@ -51619,9 +51683,9 @@ bfg
 bfg
 bzd
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 qSv
 xnV
 eoN
@@ -51668,7 +51732,7 @@ kOZ
 xCu
 lPP
 oiY
-bAh
+hZu
 vUh
 cyw
 sLg
@@ -51790,17 +51854,17 @@ oIJ
 hNS
 pwP
 gDI
-ooe
+hKz
 "}
 (95,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 sVu
-tyY
+bfg
 ivi
 bzD
 eoN
@@ -51969,16 +52033,16 @@ tee
 hNS
 pwP
 gDI
-ooe
+hKz
 "}
 (96,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
+bfg
 sVu
-tyY
+bfg
 guE
 buj
 tsE
@@ -52121,7 +52185,7 @@ xCu
 xCu
 xCu
 skr
-oyS
+ryE
 oyS
 mmH
 sTP
@@ -52148,15 +52212,15 @@ hRa
 hNS
 pwP
 gDI
-ooe
+hKz
 "}
 (97,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 guE
 arM
 jgc
@@ -52193,7 +52257,7 @@ edg
 nQZ
 edg
 fHD
-bLx
+upJ
 thT
 azQ
 kOZ
@@ -52286,7 +52350,7 @@ oyS
 oyS
 oyS
 oyS
-oyS
+ryE
 oyS
 oyS
 oyS
@@ -52327,15 +52391,15 @@ hNS
 hNS
 fEO
 gDI
-ooe
+hKz
 "}
 (98,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 hON
 fno
 htz
@@ -52506,15 +52570,15 @@ hNS
 pwP
 qqb
 opA
-ooe
+hKz
 "}
 (99,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 ikC
 bok
 aoS
@@ -52685,16 +52749,16 @@ fEO
 pwP
 gDI
 txa
-jie
+uCJ
 "}
 (100,1,1) = {"
 wCv
 bfg
 bfg
 bfg
-tyY
+bfg
 fNW
-tyY
+bfg
 ikC
 buj
 sXo
@@ -52864,17 +52928,17 @@ kHe
 kHe
 opA
 hKz
-tyY
+bfg
 "}
 (101,1,1) = {"
 wCv
 boV
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 fNW
-tyY
+bfg
 ivi
 iny
 eoN
@@ -52926,7 +52990,7 @@ ctJ
 cyw
 hxe
 bRM
-xyR
+ofI
 lPP
 joI
 eFe
@@ -53043,7 +53107,7 @@ njg
 njg
 njg
 uCJ
-tyY
+bfg
 "}
 (102,1,1) = {"
 wCv
@@ -53051,9 +53115,9 @@ bfg
 bfg
 bfg
 bRx
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 xDK
 xnV
 eoN
@@ -53096,7 +53160,7 @@ mpj
 eUY
 qyW
 hBc
-vUh
+kdP
 xeh
 vmI
 fJc
@@ -53214,25 +53278,25 @@ ldU
 ldU
 qwM
 aCB
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 "}
 (103,1,1) = {"
 wCv
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 xDK
 wvI
 eoN
@@ -53347,7 +53411,7 @@ rJn
 mxX
 xUp
 tJi
-oyS
+ryE
 oyS
 wUL
 wUL
@@ -53393,25 +53457,25 @@ ldU
 ldU
 ldU
 aCB
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 "}
 (104,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 xDK
 xnV
 eoN
@@ -53514,7 +53578,7 @@ kOZ
 kOZ
 xCu
 fWt
-oyS
+ryE
 xCu
 xCu
 lQo
@@ -53572,8 +53636,8 @@ jKT
 jdP
 jKT
 aCB
-tyY
-tyY
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -53584,9 +53648,9 @@ bfg
 "}
 (105,1,1) = {"
 wCv
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 nhu
 nrq
 nrq
@@ -53751,9 +53815,9 @@ jKT
 tPd
 jKT
 aCB
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -53763,8 +53827,8 @@ bfg
 "}
 (106,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 nhu
 boN
 tLj
@@ -53853,7 +53917,7 @@ eqc
 lfd
 ifo
 cGB
-kOr
+ouD
 jXW
 efY
 gDW
@@ -53930,10 +53994,10 @@ kVr
 kVr
 kVr
 aCB
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -53942,7 +54006,7 @@ bfg
 "}
 (107,1,1) = {"
 wCv
-tyY
+bfg
 nhu
 boN
 tLj
@@ -54110,18 +54174,18 @@ koz
 jWa
 vCR
 cqQ
-tyY
-tyY
-tyY
-tyY
-tyY
-uPS
+bfg
+bfg
+bfg
+bfg
+bfg
+sTP
 sTP
 bfg
 "}
 (108,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 tLj
 gfQ
@@ -54290,17 +54354,17 @@ dUt
 vjZ
 okX
 tpU
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 bfg
 "}
 (109,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -54429,7 +54493,7 @@ kOZ
 kOZ
 oyS
 oyS
-oyS
+ryE
 oyS
 oyS
 oyS
@@ -54472,14 +54536,14 @@ xJK
 xJK
 xJK
 vtG
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 "}
 (110,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -54652,13 +54716,13 @@ rMJ
 cUT
 dZW
 vtG
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
 "}
 (111,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -54832,12 +54896,12 @@ poz
 cUT
 dZW
 vtG
-tyY
-tyY
+bfg
+bfg
 "}
 (112,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -55011,12 +55075,12 @@ pwP
 kwa
 cUT
 lxo
-tyY
-tyY
+bfg
+bfg
 "}
 (113,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 nxn
 ugD
@@ -55191,11 +55255,11 @@ pwP
 gDI
 dZW
 vtG
-tyY
+bfg
 "}
 (114,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eoN
 eyC
@@ -55342,7 +55406,7 @@ xCu
 xCu
 oyS
 mXZ
-oyS
+ryE
 oyS
 oyS
 lNa
@@ -55374,7 +55438,7 @@ vtG
 "}
 (115,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 tLj
 gfQ
@@ -55439,7 +55503,7 @@ nUE
 rOl
 sBV
 dIu
-nUE
+aVJ
 uCg
 ecK
 nxc
@@ -55553,7 +55617,7 @@ lxo
 "}
 (116,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -55667,7 +55731,7 @@ sir
 iRE
 oyS
 oyS
-xUp
+tCN
 ayK
 kOZ
 kOZ
@@ -55675,7 +55739,7 @@ kOZ
 kOZ
 iRE
 oyS
-oyS
+ryE
 iRE
 iRE
 sir
@@ -55732,7 +55796,7 @@ lxo
 "}
 (117,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -55911,7 +55975,7 @@ lxo
 "}
 (118,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56090,7 +56154,7 @@ lxo
 "}
 (119,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56269,7 +56333,7 @@ lxo
 "}
 (120,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56448,7 +56512,7 @@ lxo
 "}
 (121,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56627,7 +56691,7 @@ lxo
 "}
 (122,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56806,7 +56870,7 @@ lxo
 "}
 (123,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 eyC
 pdT
@@ -56985,7 +57049,7 @@ lxo
 "}
 (124,1,1) = {"
 wCv
-tyY
+bfg
 dsf
 nxn
 ugD
@@ -57164,7 +57228,7 @@ lxo
 "}
 (125,1,1) = {"
 wCv
-tyY
+bfg
 jnd
 cgU
 eyC
@@ -57343,8 +57407,8 @@ lxo
 "}
 (126,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 dsf
 nxn
 ihk
@@ -57522,8 +57586,8 @@ lxo
 "}
 (127,1,1) = {"
 wCv
-tyY
-tyY
+bfg
+bfg
 jnd
 ftZ
 ftZ
@@ -57701,13 +57765,13 @@ hKz
 "}
 (128,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sVu
 bzD
 ivi
@@ -57880,14 +57944,14 @@ uCJ
 "}
 (129,1,1) = {"
 wCv
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 kXQ
 jgc
 fno
@@ -58055,7 +58119,7 @@ iNw
 opA
 txa
 uCJ
-tyY
+bfg
 "}
 (130,1,1) = {"
 wCv
@@ -58065,8 +58129,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-msu
+bfg
+fNW
 fno
 htz
 xuN
@@ -58233,8 +58297,8 @@ iNw
 iNw
 njg
 uCJ
-tyY
-tyY
+bfg
+bfg
 "}
 (131,1,1) = {"
 wCv
@@ -58244,8 +58308,8 @@ bfg
 bfg
 bXC
 bfg
-tyY
-lPx
+bfg
+sVu
 fno
 ibZ
 evp
@@ -58326,7 +58390,7 @@ wJG
 wJG
 vAG
 bpV
-iGr
+qng
 aPE
 wFH
 rWg
@@ -58410,10 +58474,10 @@ pwP
 pwP
 iNw
 iqb
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 "}
 (132,1,1) = {"
 wCv
@@ -58423,8 +58487,8 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 kXQ
 bmc
 cGz
@@ -58589,10 +58653,10 @@ pwP
 pwP
 jIS
 iqb
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 "}
 (133,1,1) = {"
 wCv
@@ -58602,18 +58666,18 @@ bfg
 bfg
 bfg
 bfg
-tyY
+bfg
 fNW
 bzD
 bzD
 hNm
-tyY
-vor
-tyY
-tyY
+bfg
+hfI
+bfg
+bfg
 fNW
-tyY
-tyY
+bfg
+bfg
 hfI
 iVI
 bHO
@@ -58713,7 +58777,7 @@ pbh
 kSh
 kIx
 hvV
-kIx
+cvZ
 kIx
 avd
 wOb
@@ -58768,8 +58832,8 @@ pwP
 pwP
 iNw
 iNw
-vor
-tyY
+hfI
+bfg
 bfg
 bfg
 "}
@@ -58781,19 +58845,19 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xnV
 xnV
 hfI
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 iVI
 bHO
 qlA
@@ -58947,8 +59011,8 @@ pwP
 pwP
 iNw
 iNw
-tyY
-tyY
+bfg
+bfg
 bfg
 bfg
 "}
@@ -58960,19 +59024,19 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xnV
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 wpl
 dnd
 bHO
@@ -59126,10 +59190,10 @@ xqf
 pwP
 iNw
 iNw
-sul
-tyY
-tyY
-tyY
+cwH
+bfg
+bfg
+bfg
 "}
 (136,1,1) = {"
 wCv
@@ -59139,20 +59203,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 wvI
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 iVI
 bHO
 bHO
@@ -59305,10 +59369,10 @@ pwP
 pwP
 iNw
 iqb
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 "}
 (137,1,1) = {"
 wCv
@@ -59318,20 +59382,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 qOE
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 wpl
 nvJ
 dnd
@@ -59486,8 +59550,8 @@ lMn
 hdN
 ngS
 ngS
-tyY
-tyY
+bfg
+bfg
 "}
 (138,1,1) = {"
 wCv
@@ -59497,22 +59561,22 @@ bfg
 bfg
 bfg
 bfg
-tyY
-lPx
+bfg
+sVu
 xnV
 xnV
 xnV
-sul
-tyY
+cwH
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 wpl
 nvJ
 nvJ
@@ -59666,7 +59730,7 @@ hdN
 hdN
 ngS
 ngS
-tyY
+bfg
 "}
 (139,1,1) = {"
 wCv
@@ -59676,23 +59740,23 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 nqA
 xnV
 pVH
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -59855,21 +59919,21 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 nqA
 wvI
 pVH
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -59909,7 +59973,7 @@ sTP
 sTP
 nyr
 lZZ
-nyr
+hub
 nyr
 sTP
 sTP
@@ -60034,21 +60098,21 @@ bfg
 bfg
 bfg
 bfg
-tyY
-msu
+bfg
+fNW
 xnV
 xnV
 xnV
-vor
-tyY
+hfI
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 sTP
 xKn
 xKn
@@ -60099,7 +60163,7 @@ iqk
 gqq
 gqq
 gqq
-gqq
+nlH
 gqq
 gqq
 gqq
@@ -60213,20 +60277,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xnV
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 xKn
@@ -60392,20 +60456,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 wvI
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 xKn
@@ -60530,7 +60594,7 @@ wiF
 sIp
 sXu
 sIp
-oQL
+yeN
 xZS
 daU
 tdi
@@ -60571,20 +60635,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 qOE
 xnV
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 xKn
@@ -60750,20 +60814,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xnV
 xnV
-tyY
-tyY
-tyY
 bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 xKn
@@ -60773,7 +60837,7 @@ lCu
 xKn
 bjk
 nnQ
-lZS
+oEC
 nes
 fla
 xKn
@@ -60792,7 +60856,7 @@ jtJ
 rNV
 jtJ
 jtJ
-jtJ
+sSY
 jtJ
 gtN
 rNV
@@ -60929,20 +60993,20 @@ bfg
 bfg
 bfg
 bfg
-tyY
-tyY
+bfg
+bfg
 xnV
 xnV
 xnV
-tyY
-tlp
-pBH
+bfg
+mPZ
+mPZ
 mPZ
 bfg
 bfg
 mPZ
-pBH
-tyY
+mPZ
+bfg
 sTP
 sTP
 xKn
@@ -61114,14 +61178,14 @@ dXf
 dXf
 dXf
 ngS
-tlp
-pBH
 mPZ
 mPZ
 mPZ
 mPZ
-pBH
-tlp
+mPZ
+mPZ
+mPZ
+mPZ
 sTP
 sTP
 xKn
@@ -61137,7 +61201,7 @@ lZS
 doH
 dZV
 dZV
-lZS
+oEC
 dZV
 xKn
 per
@@ -61293,14 +61357,14 @@ dXf
 nQs
 dXf
 ngS
-tlp
-pBH
 mPZ
 mPZ
 mPZ
 mPZ
-pBH
-tlp
+mPZ
+mPZ
+mPZ
+mPZ
 sTP
 sTP
 xKn
@@ -61321,7 +61385,7 @@ iDz
 xKn
 nyr
 nyr
-aWy
+xCf
 fim
 jtJ
 jtJ
@@ -61472,14 +61536,14 @@ nHg
 dXf
 dXf
 ngS
-tWc
-top
-top
 kgK
 kgK
 kgK
-top
-tWc
+kgK
+kgK
+kgK
+kgK
+kgK
 sTP
 sTP
 xKn
@@ -61651,14 +61715,14 @@ dXf
 lsm
 dXf
 ngS
-tlp
-tlp
-pBH
 mPZ
 mPZ
 mPZ
-pBH
-tlp
+mPZ
+mPZ
+mPZ
+mPZ
+mPZ
 sTP
 sTP
 xKn
@@ -61705,7 +61769,7 @@ gqq
 ncD
 gqq
 hpw
-gqq
+nlH
 gqq
 gqq
 gqq
@@ -61734,7 +61798,7 @@ vYj
 vyD
 uBZ
 iAg
-wmk
+isK
 vqT
 leU
 bdm
@@ -61831,13 +61895,13 @@ dXf
 dXf
 ngS
 ngS
-tlp
-pBH
-pBH
 mPZ
 mPZ
-pBH
-tlp
+mPZ
+mPZ
+mPZ
+mPZ
+mPZ
 sTP
 sTP
 sTP
@@ -61871,7 +61935,7 @@ sTP
 sTP
 nyr
 nyr
-nyr
+hub
 nyr
 nyr
 sTP
@@ -61902,7 +61966,7 @@ wEj
 gqq
 gqq
 bHs
-gqq
+nlH
 gqq
 sTP
 bdm
@@ -62010,14 +62074,14 @@ dXf
 dXf
 ngS
 ngS
-tyY
-tyY
-pBH
+bfg
+bfg
 mPZ
 mPZ
-tyY
-tyY
-tyY
+mPZ
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -62190,13 +62254,13 @@ ngS
 ngS
 ngS
 ngS
-tyY
-tyY
-tyY
 bfg
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -62345,7 +62409,7 @@ wqW
 aqo
 aqo
 aqo
-aqo
+bRG
 apW
 sTP
 sTP
@@ -62369,13 +62433,13 @@ ngS
 ngS
 ngS
 ngS
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
-tyY
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
+bfg
 sTP
 sTP
 sTP
@@ -63047,7 +63111,7 @@ ngS
 ngS
 sTP
 sTP
-aqo
+bRG
 aqo
 aqo
 sTP
@@ -63187,7 +63251,7 @@ sTP
 oll
 oll
 uyJ
-rCd
+oSN
 nMl
 olw
 cRF
@@ -63297,7 +63361,7 @@ sTP
 sTP
 sTP
 tTZ
-nyr
+hub
 nyr
 nyr
 lZZ
@@ -63465,7 +63529,7 @@ sTP
 sTP
 nUU
 nyr
-aWy
+xCf
 nyr
 nyr
 sTP
@@ -63485,7 +63549,7 @@ nyr
 nyr
 ebs
 nyr
-nyr
+hub
 nyr
 ebs
 nyr
@@ -63535,7 +63599,7 @@ oUY
 hIn
 cQm
 cQm
-pGI
+hmf
 xxo
 cGd
 cTZ
@@ -63806,7 +63870,7 @@ kfX
 wpy
 wpy
 wpy
-wpy
+nZt
 wpy
 wpy
 wpy
@@ -63875,7 +63939,7 @@ xin
 xin
 xin
 qXs
-xin
+sbl
 xin
 rgV
 jIe
@@ -64037,7 +64101,7 @@ gqq
 gqq
 gqq
 gqq
-gqq
+nlH
 gqq
 bHs
 gqq
@@ -64066,7 +64130,7 @@ qzJ
 qCv
 bmA
 pGI
-pGI
+hmf
 cGd
 mwZ
 mwZ
@@ -64473,7 +64537,7 @@ sTP
 sTP
 sTP
 dwl
-aqo
+bRG
 aqo
 aqo
 hBF
@@ -65081,7 +65145,7 @@ nyr
 nyr
 nyr
 nyr
-nyr
+hub
 nyr
 xGO
 nyr
@@ -65225,7 +65289,7 @@ dXf
 dXf
 dXf
 dYI
-dXf
+hkn
 ngS
 ngS
 sTP
@@ -65607,7 +65671,7 @@ tTZ
 fbD
 pXO
 jKM
-nyr
+hub
 nyr
 ngq
 ngq
@@ -65698,7 +65762,7 @@ sml
 sPr
 iUX
 ajq
-iUX
+ddi
 iUX
 hqK
 dlw
@@ -65805,7 +65869,7 @@ nyr
 nyr
 nyr
 lZZ
-nUU
+hPe
 nyr
 nyr
 nyr
@@ -66207,7 +66271,7 @@ kRU
 kRU
 gqq
 gqq
-gqq
+nlH
 gqq
 gqq
 mOc
@@ -66224,7 +66288,7 @@ bvr
 bhR
 bhR
 byk
-pGI
+hmf
 nOs
 jBe
 sYf
@@ -66371,7 +66435,7 @@ duN
 hpw
 tro
 oSH
-dlI
+gpr
 wlc
 wlc
 gwb
@@ -66618,7 +66682,7 @@ ngS
 sTP
 sTP
 sAq
-aqo
+bRG
 aqo
 sTP
 ngS
@@ -66851,7 +66915,7 @@ ltQ
 wpy
 wpy
 wpy
-wpy
+nZt
 wpy
 aIx
 ngq
@@ -66953,7 +67017,7 @@ sTP
 hpw
 gqq
 gqq
-gqq
+nlH
 krk
 gqq
 gqq
@@ -67144,7 +67208,7 @@ gqq
 gqq
 aqo
 sAq
-aqo
+bRG
 aqo
 aqo
 aqo
@@ -67452,7 +67516,7 @@ jat
 ueo
 wFs
 uYX
-gqq
+nlH
 gqq
 gqq
 gqq
@@ -67468,7 +67532,7 @@ bfm
 kYQ
 nBJ
 lza
-vkA
+cOv
 vkA
 fpU
 dtG
@@ -67766,7 +67830,7 @@ ngS
 sTP
 sTP
 nyr
-nyr
+hub
 nyr
 nyr
 sTP
@@ -67837,7 +67901,7 @@ rPN
 mHZ
 wZE
 jqK
-jpU
+kjZ
 gqq
 gqq
 sTP
@@ -67897,7 +67961,7 @@ ngS
 sTP
 sTP
 aqo
-aqo
+bRG
 aqo
 ngS
 ngS
@@ -68112,7 +68176,7 @@ sTP
 sTP
 ivV
 nyr
-nyr
+hub
 oHz
 sTP
 ngS
@@ -68532,7 +68596,7 @@ gqq
 gqq
 duN
 duN
-gqq
+nlH
 hpw
 duN
 duN
@@ -68593,7 +68657,7 @@ cDu
 aqo
 aqo
 aqo
-aqo
+bRG
 aqo
 aqo
 jtf
@@ -68625,7 +68689,7 @@ sTP
 sTP
 sTP
 rip
-rip
+qbS
 rip
 rip
 rip
@@ -68674,7 +68738,7 @@ sTP
 uFp
 eyg
 nyr
-nyr
+hub
 nyr
 nyr
 eyg
@@ -68738,7 +68802,7 @@ fJY
 gqq
 duN
 sTP
-gqq
+nlH
 gqq
 hpw
 wEj
@@ -68817,7 +68881,7 @@ sTP
 rip
 rip
 wpy
-wpy
+nZt
 tEz
 juD
 jFR
@@ -69082,7 +69146,7 @@ gqq
 gqq
 gqq
 gqq
-gqq
+nlH
 jpU
 gqq
 gqq
@@ -69653,7 +69717,7 @@ aqo
 aqo
 sAq
 aqo
-apW
+lXd
 aqo
 aqo
 pCz
@@ -69821,7 +69885,7 @@ ncD
 gqq
 gqq
 gqq
-gqq
+nlH
 jHS
 gqq
 jBi
@@ -70102,7 +70166,7 @@ nMN
 mpv
 rtO
 xuO
-kFo
+vUX
 rMf
 xuO
 mpv
@@ -70111,7 +70175,7 @@ sTP
 uFp
 nyr
 nyr
-gqq
+nlH
 gqq
 hpw
 sTP
@@ -70201,7 +70265,7 @@ sTP
 sTP
 oax
 qKz
-qKz
+mxM
 qKz
 qKz
 nLc
@@ -70267,7 +70331,7 @@ ngS
 ngS
 sTP
 sTP
-nyr
+hub
 nyr
 ovm
 nyr
@@ -70399,7 +70463,7 @@ qJo
 sRw
 xCL
 sRw
-mdT
+mmj
 mdT
 bNZ
 dLi
@@ -70526,7 +70590,7 @@ gqq
 gqq
 gqq
 xjF
-geH
+kec
 gqq
 rFY
 hpw
@@ -70861,7 +70925,7 @@ sTP
 gqq
 gqq
 gqq
-gqq
+nlH
 gqq
 gqq
 sTP
@@ -71074,7 +71138,7 @@ ncD
 jBi
 gqq
 gqq
-gqq
+nlH
 gqq
 ncD
 gqq
@@ -71136,7 +71200,7 @@ rip
 aQL
 iDQ
 rip
-rip
+qbS
 rip
 rip
 sTP
@@ -71635,7 +71699,7 @@ pCz
 oax
 gwc
 szj
-paE
+lVU
 eot
 szj
 paE
@@ -71802,7 +71866,7 @@ sTP
 htU
 igs
 aqo
-aqo
+bRG
 aqo
 aqo
 aqo
@@ -71878,7 +71942,7 @@ ngS
 ngS
 sTP
 nyr
-nyr
+hub
 nyr
 nyr
 rjV
@@ -72808,7 +72872,7 @@ hpw
 gqq
 jBi
 gqq
-gqq
+nlH
 gqq
 hpw
 gqq
@@ -72847,7 +72911,7 @@ gqq
 duN
 duN
 gqq
-gqq
+nlH
 gqq
 gqq
 duN
@@ -72975,7 +73039,7 @@ nyr
 luV
 nyr
 ebs
-gqq
+nlH
 hpw
 gqq
 ncD
@@ -73236,7 +73300,7 @@ cDu
 wqW
 aqo
 njb
-aqo
+bRG
 aqo
 wqW
 aqo
@@ -73404,7 +73468,7 @@ gqq
 gqq
 jBi
 hpw
-nND
+gaI
 gqq
 gqq
 sAq
@@ -73431,7 +73495,7 @@ yjK
 xSc
 iMp
 rJR
-rJR
+tbj
 rJR
 rJR
 nLc
@@ -73652,7 +73716,7 @@ xCu
 wBN
 aXV
 nxR
-aWa
+cGw
 iho
 kse
 nRB


### PR DESCRIPTION

## About The Pull Request
Each of these maps have less than 40 digsites, with Riptide having only 12 (compared to 80+ on other maps). This increases the number on each of these maps to ~100.
## Why It's Good For The Game
Digsites are a very good side objective for making money that naturally gets harder during a round as the freebies are taken and more respawn in harder to reach areas. Maps with few of these harder ones make it very easy to just wait the 5 minutes for them to respawn in the easy areas, so this PR adds a lot more variance on the areas and potential difficulty of digsites.
## Changelog
:cl:
add: Added a ton of researcher digsites to Riptide, Magmoor, and Lawanka.
/:cl:
