### PR TITLE
Renames chestburster prefs

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -194,8 +194,8 @@
 	)
 
 #define BE_SPECIAL_FLAGS list(\
-	"Latejoin Xenomorph" = BE_ALIEN,\
-	"Xenomorph when unrevivable" = BE_ALIEN_UNREVIVABLE,\
+	"Join as Chestburster" = BE_ALIEN,\
+	"Take Own Chestburster" = BE_ALIEN_UNREVIVABLE,\
 	"End of Round Deathmatch" = BE_DEATHMATCH,\
 	"Prefer Squad over Role" = BE_SQUAD_STRICT\
 	)


### PR DESCRIPTION

## About The Pull Request
Renames the two chestburster prefs from "Latejoin Xenomorph" and "Xenomorph When Unrevivable" to "Join as Chestburster" and "Take Own Chestburster"
## Why It's Good For The Game
Clarifies when these are actually used to hopefully encourage people to turn these on instead of leaving every burst SSD to die.
## Changelog
:cl:
spellcheck: Renamed chestburster preferences.
/:cl:
