### PR TITLE
Spiderlings can now attack uncouncious marines

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -119,8 +119,6 @@
 	SIGNAL_HANDLER
 	if(!isliving(target))
 		return
-	if(target.stat != CONSCIOUS)
-		return
 	if(mob_parent?.get_xeno_hivenumber() == target.get_xeno_hivenumber())
 		return
 	atom_to_walk_to = target

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -133,9 +133,6 @@
 		return
 	if(isliving(atom_to_walk_to))
 		var/mob/living/victim = atom_to_walk_to
-		if(victim.stat != CONSCIOUS)
-			change_action(ESCORTING_ATOM, escorted_atom)
-			return
 	mob_parent.face_atom(atom_to_walk_to)
 	mob_parent.UnarmedAttack(atom_to_walk_to, mob_parent)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -131,8 +131,6 @@
 		return
 	if(Adjacent(atom_to_walk_to))
 		return
-	if(isliving(atom_to_walk_to))
-		var/mob/living/victim = atom_to_walk_to
 	mob_parent.face_atom(atom_to_walk_to)
 	mob_parent.UnarmedAttack(atom_to_walk_to, mob_parent)
 


### PR DESCRIPTION
## About The Pull Request

Spiderlings now ignore if the marine is incouncious and continue attacking them


https://github.com/tgstation/TerraGov-Marine-Corps/assets/32490372/0608a627-f672-4e7c-b364-0c2846758b35


https://github.com/tgstation/TerraGov-Marine-Corps/assets/32490372/5eaa9dfd-d0f7-4dd3-8cdc-8d3449a30e04



## Why It's Good For The Game

Spiderlings can now be attached to widow so if you want to crit drag a marine just put them on your back.
Also having to slash 10 times before to drain gave plenty of time for CAS to just murder your spiders.
You can also now finish a medded vali x2 nanite without them going up every ticks 

## Changelog
:cl:
add: Spiderlings can now attack uncouncious marines
/:cl:
