### PR TITLE
Nerfs digsites/research

### DIFF
--- a/code/game/objects/effects/landmarks/excavation_site_spawner.dm
+++ b/code/game/objects/effects/landmarks/excavation_site_spawner.dm
@@ -30,9 +30,9 @@
 ///Excavation rewards buckets
 /datum/excavation_rewards
 	///Min amount of rewards
-	var/rewards_min = 2
+	var/rewards_min = 1
 	///Max amount of rewards
-	var/rewards_max = 4
+	var/rewards_max = 2
 	///Minimaps icon name of the excavation site
 	var/map_icon = "excav_money"
 	///List of rewards for the excavation
@@ -48,8 +48,8 @@
 		new typepath(excav_site.loc)
 
 /datum/excavation_rewards/xeno
-	rewards_min = 2
-	rewards_max = 4
+	rewards_min = 1
+	rewards_max = 2
 	map_icon = "excav_xeno"
 	rewards = list(
 		/obj/item/research_resource/xeno,

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -38,7 +38,6 @@
 	var/static/list/rewards_lists = list(
 		RES_MONEY = list(
 			RES_TIER_BASIC = list(
-				/obj/item/research_product/money/basic,
 				/obj/item/research_product/money/common,
 			),
 			RES_TIER_COMMON = list(
@@ -55,7 +54,6 @@
 		),
 		RES_XENO = list(
 			RES_TIER_BASIC = list(
-				/obj/item/research_product/money/basic,
 				/obj/item/research_product/money/common,
 			),
 			RES_TIER_COMMON = list(


### PR DESCRIPTION
## About The Pull Request
Reduces the amount of samples dug per site from 2-4 to 1-2.
Reduces the minimum point reward from 200 to 150.
<details>
<summary> How many points before and after? </summary>
<img width="739" alt="samplesold" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/fa6a6a64-229f-41c1-aa2e-67f0c4459c92">

Money digsites give a minimum of 400 points with an average of 1230 points, while xeno digsites are fairly close behind with an average of 789 per digsite.
This change will reduce the expected value of digsites to 540 points for money digsites with a minimum of 150, and xeno digsites to 319.5 with a minimum of 150.

</details>

## Why It's Good For The Game
<img width="177" alt="research" src="https://github.com/tgstation/TerraGov-Marine-Corps/assets/106282690/7cf4bef7-c60e-45fb-a043-639ae834a3e9">

Research gets points way too easily, invalidating any semblance of economy in req. 
Currently a single yellow digsite is on average worth more than a queen kill.
Research will still be profitable but wont be giving the insane numbers that it currently gives.
## Changelog
:cl:
balance: Nerfed researcher digsite rewards.
/:cl:
