### PR TITLE
Prevents Crusher from crest tossing vehicles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -105,6 +105,9 @@
 		for(var/obj/effect/forcefield/fog/fog in throw_origin)
 			A.balloon_alert(X, "Cannot, fog")
 			return fail_activate()
+	if(isvehicle(A))
+		A.balloon_alert(X, "Too heavy!")
+		return fail_activate()
 	if(isliving(A))
 		var/mob/living/L = A
 		if(L.mob_size >= MOB_SIZE_BIG) //Penalize toss distance for big creatures

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -105,7 +105,7 @@
 		for(var/obj/effect/forcefield/fog/fog in throw_origin)
 			A.balloon_alert(X, "Cannot, fog")
 			return fail_activate()
-	if(isvehicle(A))
+	if(isarmoredvehicle(A))
 		A.balloon_alert(X, "Too heavy!")
 		return fail_activate()
 	if(isliving(A))


### PR DESCRIPTION
## About The Pull Request
Prevents crusher from crest tossing armored vehicles, aka the APC and tank
## Why It's Good For The Game
Considering how slow they are, being able to just get instantly displaced several tiles makes it difficult for tank to safely be near the front line. also prevents bugs like this

https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/38e2a7ea-3a4c-424f-a32b-65976d6384e2
## Changelog
:cl:
balance: Crusher can no longer crest toss armored vehicles (such as the apc and tank)
/:cl:
