### PR TITLE
Adds brake function to roller beds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -130,6 +130,18 @@
 
 	return ..()
 
+/obj/structure/bed/roller/attack_hand_alternate(mob/living/user)
+	. = ..()
+	if(!ishuman(user)) // Keep xenos from toggling the brake
+		return
+
+	if(anchored)
+		balloon_alert(user, "You release the brakes")
+		anchored = FALSE
+	else
+		balloon_alert(user, "You activate the brakes")
+		anchored = TRUE
+
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)
 	if(accepts_bodybag && !buckled_bodybag && !LAZYLEN(buckled_mobs) && istype(dropping,/obj/structure/closet/bodybag) && ishuman(user))
 		var/obj/structure/closet/bodybag/B = dropping
@@ -215,10 +227,10 @@
 */
 /obj/structure/bed/roller
 	name = "roller bed"
-	desc = "A basic cushioned leather board resting on a small frame. Not very comfortable at all, but allows the patient to rest lying down while moved to another location rapidly."
+	desc = "A basic cushioned leather board resting on a small frame. Not very comfortable at all, but allows the patient to rest lying down while moved to another location rapidly. Has brakes to prevent the patient from rolling away."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "roller_down"
-	anchored = FALSE
+	anchored = TRUE
 	buckle_flags = CAN_BUCKLE
 	drag_delay = 0 //Pulling something on wheels is easy
 	buckling_y = 6

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -136,10 +136,10 @@
 		return
 
 	if(!anchored)
-		balloon_alert(user, "You activate the brakes")
+		balloon_alert(user, "Brakes on")
 		anchored = TRUE
 	else
-		balloon_alert(user, "You release the brakes")
+		balloon_alert(user, "Brakes off")
 		anchored = FALSE
 
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -135,12 +135,12 @@
 	if(!ishuman(user)) // Keep xenos from toggling the brake
 		return
 
-	if(anchored)
-		balloon_alert(user, "You release the brakes")
-		anchored = FALSE
-	else
+	if(!anchored)
 		balloon_alert(user, "You activate the brakes")
 		anchored = TRUE
+	else
+		balloon_alert(user, "You release the brakes")
+		anchored = FALSE
 
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)
 	if(accepts_bodybag && !buckled_bodybag && !LAZYLEN(buckled_mobs) && istype(dropping,/obj/structure/closet/bodybag) && ishuman(user))
@@ -230,7 +230,7 @@
 	desc = "A basic cushioned leather board resting on a small frame. Not very comfortable at all, but allows the patient to rest lying down while moved to another location rapidly. Has brakes to prevent the patient from rolling away."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "roller_down"
-	anchored = TRUE
+	anchored = FALSE
 	buckle_flags = CAN_BUCKLE
 	drag_delay = 0 //Pulling something on wheels is easy
 	buckling_y = 6


### PR DESCRIPTION
## About The Pull Request
Adds a brake funtion to roller beds, allowing humans to toggle their anchor state on and off. Roller beds deploy with their anchor on by default.
## Why It's Good For The Game
Currently, using roller beds groundside carries the massive risk of a xeno coming by and kidnapping the patient, guaranteeing a perma. This will hopefully reduce the chances of this happening, and make roller beds much more useful for corpsmen.
## Changelog
:cl:
balance: Roller beds now have brakes that can be toggled with right click.
/:cl:
