### PR TITLE
Vehicle storage attachment refactor

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -18,7 +18,7 @@
 
 /datum/component/attachment_handler/Initialize(list/slots, list/attachables_allowed, list/attachment_offsets, list/starting_attachments, datum/callback/can_attach, datum/callback/on_attach, datum/callback/on_detach, list/overlays = list())
 	. = ..()
-	if(!isitem(parent))
+	if(!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.slots = slots
@@ -105,7 +105,8 @@
 	var/obj/parent_obj = parent
 	///The gun has another gun attached to it
 	if(isgun(attachment) && isgun(parent))
-		parent_obj:gunattachment = attachment
+		var/obj/item/weapon/gun/gun_parent = parent
+		gun_parent.gunattachment = attachment
 
 	on_attach?.Invoke(attachment, attacker)
 	if(attachment_data[ON_ATTACH])

--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -67,11 +67,12 @@
 	max_w_class = WEIGHT_CLASS_SMALL
 	max_storage_space = 8
 
-/datum/storage/internal/motorbike_pack/attempt_draw_object()
-	return //the sidecar upgrade is in parent.contents, so I have to limit this functionality
-
 /datum/storage/internal/motorbike_pack/on_ctrl_click()
 	return //We want to be able to grab the bike without pulling something out
+
+/datum/storage/internal/motorbike_pack/on_attackby(datum/source, obj/item/attacking_item, mob/user, params)
+	if(!params) //we're clicking directly on storage, not the sprite. Avoids accidental storing
+		return ..()
 
 /datum/storage/internal/webbing
 	max_w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1589,8 +1589,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 ///This is called when an attachment gun (src) attaches to a gun.
 /obj/item/weapon/gun/proc/on_attach(obj/item/attached_to, mob/user)
-	if(!istype(attached_to, /obj/item/weapon/gun))
+	if(!isgun(attached_to))
 		return
+	var/obj/item/weapon/gun/gun_attached_to = attached_to
+	gun_attached_to.gunattachment = src
 	master_gun = attached_to
 	master_gun.wield_delay					+= wield_delay_mod
 	if(gun_user)
@@ -1601,7 +1603,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/mob/living/living_user = user
 	if(master_gun == living_user.get_inactive_held_item() || master_gun == living_user.get_active_held_item())
 		new_action.give_action(living_user)
-	attached_to:gunattachment = src
 	activate(user)
 	new_action.set_toggle(TRUE)
 	update_icon()
@@ -1609,7 +1610,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 ///This is called when an attachment gun (src) detaches from a gun.
 /obj/item/weapon/gun/proc/on_detach(obj/item/attached_to, mob/user)
-	if(!istype(attached_to, /obj/item/weapon/gun))
+	if(!isgun(attached_to))
 		return
 	for(var/datum/action/action_to_delete AS in master_gun.actions)
 		if(action_to_delete.target != src)
@@ -1622,7 +1623,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.wield_delay					-= wield_delay_mod
 	UnregisterSignal(master_gun, COMSIG_ITEM_REMOVED_INVENTORY)
 	master_gun = null
-	attached_to:gunattachment = null
+	var/obj/item/weapon/gun/gun_attached_to = attached_to
+	gun_attached_to.gunattachment = null
 	update_icon()
 
 ///This activates the weapon for use.

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -176,6 +176,12 @@
 	STOP_PROCESSING(SSobj,src)
 	return ..()
 
+//internal storage
+/obj/item/vehicle_module/storage/motorbike
+	name = "internal storage"
+	desc = "A set of handy compartments to store things in."
+	storage_type = /datum/storage/internal/motorbike_pack
+
 /**
  * Sidecar that when attached lets you put two people on the bike
  */

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -14,6 +14,10 @@
 	allow_pass_flags = PASSABLE
 	coverage = 30	//It's just a bike, not hard to shoot over
 	buckle_flags = CAN_BUCKLE|BUCKLE_PREVENTS_PULL|BUCKLE_NEEDS_HAND
+	attachments_by_slot = list(ATTACHMENT_SLOT_STORAGE)
+	attachments_allowed = list(/obj/item/vehicle_module/storage/motorbike)
+	starting_attachments = list(/obj/item/vehicle_module/storage/motorbike)
+
 	///Mutable appearance overlay that covers up the mob with the bike as needed
 	var/mutable_appearance/motorbike_cover
 	///Fuel count, fuel usage is one per tile moved
@@ -27,7 +31,6 @@
 /obj/vehicle/ridden/motorbike/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/motorbike)
-	create_storage(/datum/storage/internal/motorbike_pack)
 	motorbike_cover = mutable_appearance(icon, "motorbike_cover", MOB_LAYER + 0.1)
 	fuel_count = fuel_max
 

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -4,7 +4,19 @@
 	max_buckled_mobs = 1
 	buckle_lying = -1
 	allow_pass_flags = PASS_LOW_STRUCTURE
+	///Assoc list of available slots. Since this keeps track of all currently equiped attachments per object, this cannot be a string_list()
+	var/list/attachments_by_slot = list()
+	///Typepath list of allowed attachment types.
+	var/list/attachments_allowed = list()
+	///Pixel offsets for specific attachment slots. Is not used currently.
+	var/list/attachment_offsets = list()
+	///List of attachment types that is attached to the object on initialize.
+	var/list/starting_attachments = list()
 	COOLDOWN_DECLARE(message_cooldown)
+
+/obj/vehicle/ridden/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachments_allowed, attachment_offsets, starting_attachments, null, null, null)
 
 /obj/vehicle/ridden/examine(mob/user)
 	. = ..()

--- a/code/modules/vehicles/vehicle_attachments/storage_attachments.dm
+++ b/code/modules/vehicles/vehicle_attachments/storage_attachments.dm
@@ -1,0 +1,35 @@
+/** Storage modules */
+/obj/item/vehicle_module/storage
+	icon = 'icons/mob/modular/modular_armor_modules.dmi'
+	icon_state = "mod_is_bag"
+	slot = ATTACHMENT_SLOT_STORAGE
+	w_class = WEIGHT_CLASS_BULKY
+	///Determines what subtype of storage is on our item, see datums\storage\subtypes
+	var/datum/storage/storage_type = /datum/storage
+
+/obj/item/vehicle_module/storage/Initialize(mapload)
+	. = ..()
+	create_storage(storage_type)
+	PopulateContents()
+
+/obj/item/vehicle_module/storage/on_attach(obj/item/attaching_to, mob/user)
+	. = ..()
+	storage_datum.register_storage_signals(attaching_to)
+
+/obj/item/vehicle_module/storage/on_detach(obj/item/detaching_from, mob/user)
+	storage_datum.unregister_storage_signals(detaching_from)
+	return ..()
+
+/obj/item/vehicle_module/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
+	return loc.Adjacent(neighbor, target, mover)
+
+///Use this to fill your storage with items. USE THIS INSTEAD OF NEW/INIT
+/obj/item/vehicle_module/storage/proc/PopulateContents()
+	return
+
+/obj/item/vehicle_module/storage/motorbike
+	name = "internal storage"
+	desc = "A set of handy compartments to store things in."
+	icon_state = ""
+	storage_type = /datum/storage/internal/motorbike_pack
+	attach_features_flags = NONE

--- a/code/modules/vehicles/vehicle_attachments/storage_attachments.dm
+++ b/code/modules/vehicles/vehicle_attachments/storage_attachments.dm
@@ -1,7 +1,6 @@
-/** Storage modules */
 /obj/item/vehicle_module/storage
-	icon = 'icons/mob/modular/modular_armor_modules.dmi'
-	icon_state = "mod_is_bag"
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = ""
 	slot = ATTACHMENT_SLOT_STORAGE
 	w_class = WEIGHT_CLASS_BULKY
 	///Determines what subtype of storage is on our item, see datums\storage\subtypes
@@ -26,10 +25,3 @@
 ///Use this to fill your storage with items. USE THIS INSTEAD OF NEW/INIT
 /obj/item/vehicle_module/storage/proc/PopulateContents()
 	return
-
-/obj/item/vehicle_module/storage/motorbike
-	name = "internal storage"
-	desc = "A set of handy compartments to store things in."
-	icon_state = ""
-	storage_type = /datum/storage/internal/motorbike_pack
-	attach_features_flags = NONE

--- a/code/modules/vehicles/vehicle_attachments/vehicle_modules.dm
+++ b/code/modules/vehicles/vehicle_attachments/vehicle_modules.dm
@@ -1,0 +1,105 @@
+/obj/item/vehicle_module
+	name = "vehicle module"
+	desc = "A proto-vehicle module. Call the coders if you see this."
+	icon = 'icons/mob/modular/modular_armor.dmi'
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0) // This is here to overwrite code over at objs.dm line 41. Marines don't get funny 200+ bio buff anymore.
+	appearance_flags = KEEP_APART|TILE_BOUND
+
+	///Reference to parent object.
+	var/obj/parent
+
+	///Slot the attachment is able to occupy.
+	var/slot
+	///Icon sheet of the attachment overlays
+	var/attach_icon = null
+	///Proc typepath that is called when this is attached to something.
+	var/on_attach = PROC_REF(on_attach)
+	///Proc typepath that is called when this is detached from something.
+	var/on_detach = PROC_REF(on_detach)
+	///Proc typepath that is called when this is item is being attached to something. Returns TRUE if it can attach.
+	var/can_attach = PROC_REF(can_attach)
+	///Pixel shift for the item overlay on the X axis.
+	var/pixel_shift_x = 0
+	///Pixel shift for the item overlay on the Y axis.
+	var/pixel_shift_y = 0
+	///Bitfield flags of various features.
+	var/attach_features_flags = NONE
+	///Time it takes to attach.
+	var/attach_delay = 1.5 SECONDS
+	///Time it takes to detach.
+	var/detach_delay = 1.5 SECONDS
+
+	///Layer for the attachment to be applied to.
+	var/attachment_layer
+	///Slot that is required for the action to appear to the equipper. If null the action will appear whenever the item is equiped to a slot.
+	var/prefered_slot = SLOT_WEAR_SUIT
+
+	///List of slots this attachment has.
+	var/list/attachments_by_slot = list()
+	///Starting attachments that are spawned with this.
+	var/list/starting_attachments = list()
+
+	///Allowed attachment types
+	var/list/attachments_allowed = list()
+
+	///The signal for this module if it can toggled
+	var/toggle_signal
+
+/obj/item/vehicle_module/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/attachment, slot, attach_icon, on_attach, on_detach, null, can_attach, pixel_shift_x, pixel_shift_y, attach_features_flags, attach_delay, detach_delay, attachment_layer = attachment_layer)
+	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachments_allowed, starting_attachments = starting_attachments)
+	update_icon()
+
+/// Called before a module is attached.
+/obj/item/vehicle_module/proc/can_attach(obj/item/attaching_to, mob/user)
+	return TRUE
+
+/// Called when the module is added to the armor.
+/obj/item/vehicle_module/proc/on_attach(obj/item/attaching_to, mob/user)
+	SEND_SIGNAL(attaching_to, COMSIG_ARMOR_MODULE_ATTACHING, user, src)
+	parent = attaching_to
+	parent.hard_armor = parent.hard_armor.attachArmor(hard_armor)
+	parent.soft_armor = parent.soft_armor.attachArmor(soft_armor)
+	//below applicable on buckle?
+	if(CHECK_BITFIELD(attach_features_flags, ATTACH_ACTIVATION))
+		RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, PROC_REF(on_buckle))
+		RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(on_unbuckle))
+
+/// Called when the module is removed from the armor.
+/obj/item/vehicle_module/proc/on_detach(obj/item/detaching_from, mob/user)
+	SEND_SIGNAL(detaching_from, COMSIG_ARMOR_MODULE_DETACHED, user, src)
+	parent.hard_armor = parent.hard_armor.detachArmor(hard_armor)
+	parent.soft_armor = parent.soft_armor.detachArmor(soft_armor)
+	UnregisterSignal(parent, COMSIG_MOVABLE_BUCKLE)
+	parent = null
+
+///Adds actions if the mob has the correct flag
+/obj/item/vehicle_module/proc/on_buckle(datum/source, mob/living/buckling_mob, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0, silent)
+	SIGNAL_HANDLER
+	var/obj/vehicle/parent_vehicle = source
+	if(!parent_vehicle.is_equipment_controller(buckling_mob))
+		return
+
+	LAZYADD(actions_types, /datum/action/item_action/toggle)
+	var/datum/action/item_action/toggle/new_action = new(src)
+	if(toggle_signal)
+		new_action.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
+	new_action.give_action(buckling_mob)
+
+///Removes actions if the mob had them
+/obj/item/vehicle_module/proc/on_unbuckle(datum/source, mob/living/unbuckled_mob, force = FALSE)
+	SIGNAL_HANDLER
+	if(!(src in unbuckled_mob.actions))
+		return
+	LAZYREMOVE(actions_types, /datum/action/item_action/toggle)
+	var/datum/action/item_action/toggle/old_action = locate(/datum/action/item_action/toggle) in actions
+	old_action?.remove_action(unbuckled_mob)
+	actions = null
+
+/obj/item/vehicle_module/ui_action_click(mob/user, datum/action/item_action/toggle/action)
+	action.set_toggle(activate(user))
+
+///Called on ui_action_click. Used for activating the module.
+/obj/item/vehicle_module/proc/activate(mob/living/user)
+	return

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2218,6 +2218,8 @@
 #include "code\modules\vehicles\unmanned\unmanned_turrets.dm"
 #include "code\modules\vehicles\unmanned\unmanned_vehicle.dm"
 #include "code\modules\vehicles\unmanned\unmanned_vehicle_remote.dm"
+#include "code\modules\vehicles\vehicle_attachments\storage_attachments.dm"
+#include "code\modules\vehicles\vehicle_attachments\vehicle_modules.dm"
 #include "code\modules\xenomorph\_xeno_structure.dm"
 #include "code\modules\xenomorph\acid_pools.dm"
 #include "code\modules\xenomorph\acidwell.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added attachment component support for vehicles.

To keep this PR simple, it's limited to vehicles/ridden and I have only set up storage attachments.

Specifically, this fixes a bug from the storage refactor where you can access the attached sidecar on a motorbike via storage and simply remove it and attach it to another bike.

Also cleaned up some funny old code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good.

Allows us to use the great attachment component behavior on vehicles for other attachment type stuff in future PR's.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a bug with motorbike sidecars
code: Added attachment component support to vehicles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
