### PR TITLE
Hypos no longer open pill bottles

### DIFF
--- a/code/datums/storage/subtypes/pill_bottle.dm
+++ b/code/datums/storage/subtypes/pill_bottle.dm
@@ -20,6 +20,10 @@
 	if(!silent && . && user)
 		playsound(user, 'sound/items/pills.ogg', 15, 1)
 
+/datum/storage/pill_bottle/on_attackby(datum/source, obj/item/attacking_item, mob/user, params)
+	if(!istype(attacking_item, /obj/item/reagent_containers/hypospray))
+		return ..()
+
 /datum/storage/pill_bottle/packet
 	storage_slots = 8
 	max_w_class = 0


### PR DESCRIPTION

## About The Pull Request
Makes hypos not open pill bottles when you click on it to liquify a pill.
## Why It's Good For The Game
QOL
## Changelog
:cl:
qol: Liquifying a pill with a hypo no longer opens the pill bottle
/:cl:
