### PR TITLE
Bull rework part 2

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -28,7 +28,7 @@
 /datum/action/ability/activable/xeno/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
-	desc = "When you hit a host, stops your charge while piercing and injecting them with Neurotoxin."
+	desc = "When you hit a host, stops your charge while piercing and injecting them with Ozelomelon."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLGORE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -28,7 +28,7 @@
 /datum/action/ability/activable/xeno/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
-	desc = "When you hit a host, stops your charge while piercing and injecting them with Ozelomelon."
+	desc = "When you hit a host, stops your charge while piercing and injecting them with Ozelomelyn."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLGORE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -28,7 +28,7 @@
 /datum/action/ability/activable/xeno/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
-	desc = "When you hit a host, stops your charge while piercing them for a large amount of damage where you are targeting, in addition to injecting the Ozelomelyn toxin."
+	desc = "When you hit a host, stops your charge while piercing and injecting them with Neurotoxin."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLGORE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/bull.dm
@@ -10,7 +10,6 @@
 	plasma_stored = 200
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_NORMAL
-	mob_size = MOB_SIZE_BIG
 
 	pixel_x = -16
 	pixel_y = -3

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -12,7 +12,7 @@
 	melee_damage = 21
 
 	// *** Speed *** //
-	speed = -0.8
+	speed = -0.9
 
 	// *** Plasma *** //
 	plasma_max = 270 //High plasma is need for charging

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -9,17 +9,20 @@
 	wound_type = "bull" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 24
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 270 //High plasma is need for charging
-	plasma_gain = 18
+	plasma_max = 340 //High plasma is need for charging
+	plasma_gain = 24
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 450
+
+	// *** Sunder *** //
+	sunder_multiplier = 0.9
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -33,7 +36,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 40, BULLET = 50, LASER = 40, ENERGY = 40, BOMB = 0, BIO = 35, FIRE = 50, ACID = 35)
+	soft_armor = list(MELEE = 50, BULLET = 55, LASER = 55, ENERGY = 55, BOMB = 20, BIO = 35, FIRE = 50, ACID = 35)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "bull"

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -570,7 +570,7 @@
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
 			adjust_slowdown(CHARGE_SPEED(charge_datum) * 1)
-			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 25)
+			reagents.add_reagent(/datum/reagent/toxin/xeno_ozelomelyn, 10)
 			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 
 	if(anchored)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -570,7 +570,7 @@
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
 			adjust_slowdown(CHARGE_SPEED(charge_datum) * 1)
-			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 30)
+			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 25)
 			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 
 	if(anchored)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -569,6 +569,7 @@
 			Paralyze(CHARGE_SPEED(charge_datum) * 0.2 SECONDS)
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
+			adjust_slowdown(CHARGE_SPEED(charge_datum) * 1)
 			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 15)
 			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -570,7 +570,7 @@
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
 			adjust_slowdown(CHARGE_SPEED(charge_datum) * 1)
-			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 15)
+			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 30)
 			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 
 	if(anchored)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -29,7 +29,7 @@
 	var/charge_ability_on = FALSE
 	var/valid_steps_taken = 0
 	var/crush_sound = SFX_PUNCH
-	var/speed_per_step = 0.13
+	var/speed_per_step = 0.15
 	var/steps_for_charge = 7
 	var/max_steps_buildup = 14
 	var/crush_living_damage = 20

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -342,7 +342,7 @@
 	speed_per_step = 0.15
 	steps_for_charge = 5
 	max_steps_buildup = 10
-	crush_living_damage = 32
+	crush_living_damage = 37
 	plasma_use_multiplier = 2
 
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -29,7 +29,7 @@
 	var/charge_ability_on = FALSE
 	var/valid_steps_taken = 0
 	var/crush_sound = SFX_PUNCH
-	var/speed_per_step = 0.15
+	var/speed_per_step = 0.13
 	var/steps_for_charge = 7
 	var/max_steps_buildup = 14
 	var/crush_living_damage = 20
@@ -342,7 +342,7 @@
 	speed_per_step = 0.15
 	steps_for_charge = 5
 	max_steps_buildup = 10
-	crush_living_damage = 15
+	crush_living_damage = 32
 	plasma_use_multiplier = 2
 
 
@@ -564,12 +564,12 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 2 SECONDS)
+			Paralyze(CHARGE_SPEED(charge_datum) * 1.5 SECONDS)
 		if(CHARGE_BULL)
 			Paralyze(CHARGE_SPEED(charge_datum) * 0.2 SECONDS)
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
-			reagents.add_reagent(/datum/reagent/toxin/xeno_ozelomelyn, 10)
+			reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 15)
 			playsound(charger,'sound/effects/spray3.ogg', 15, TRUE)
 
 	if(anchored)
@@ -603,8 +603,6 @@
 		if(CHARGE_BULL_GORE)
 			if(world.time > charge_datum.next_special_attack)
 				charge_datum.next_special_attack = world.time + 2 SECONDS
-				attack_alien_harm(charger, charger.xeno_caste.melee_damage * charger.xeno_melee_damage_modifier, charger.zone_selected, FALSE, TRUE, TRUE) //Free gore attack.
-				emote_gored()
 				var/turf/destination = get_step(loc, charger.dir)
 				if(destination)
 					throw_at(destination, 1, 1, charger, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -566,7 +566,7 @@
 		if(CHARGE_BULL_HEADBUTT)
 			Paralyze(CHARGE_SPEED(charge_datum) * 1.5 SECONDS)
 		if(CHARGE_BULL)
-			Paralyze(CHARGE_SPEED(charge_datum) * 0.2 SECONDS)
+			Paralyze(0.2 SECONDS)
 		if(CHARGE_BULL_GORE)
 			adjust_stagger(CHARGE_SPEED(charge_datum) * 1 SECONDS)
 			adjust_slowdown(CHARGE_SPEED(charge_datum) * 1)


### PR DESCRIPTION
## About The Pull Request

Tl;dr Bull is no longer stun and knockback immune. All charges now deal 48 damage (2 slashes) exactly. Headbutt has even less stun. Bull's walking speed very slightly increased.

Stun immunity: **Gone**. It can be stunned by buckshot/slugs again, and knocked around by explosives.
Gore: 62 > **48 damage**. It now also does 1 second of slow alongside the stagger. Also also removed it's extra slash that (I think) made it more likely to frac and IB due to wacky code.
Headbutt: 20 > **48 damage**. 2 > **1.5 second stun**.
Plow: 20 > **48 damage**.

## Why It's Good For The Game

**Stun immunity:** This was given to bull as a sort of bandaid for being a terrible caste that couldn't accomplish anything worthwhile with its abilities. Now that its abilities are actually good, its no longer needed. Stun immunity makes Bull too safe in the hands of a good player.

**Gore:** It had a little too much damage, so it's been reduced. The 1 second slow addition doesn't really do much, I'm just adding it for consistencies sake.

**Headbutt:** The stun felt mostly balanced before. But since damage is being increased, stun is being decreased.

**Plow:** This did too little damage to be worth using before, so damage increased.

**Speed:** Slightly increased walking speed is there to compensate for no stun immunity. Should make getting stunned out of a charge less cbt.

Also, gore charging someone now longer makes the "*Gore" sound effect. It mislead marines into thinking they got organ damage, when really it was just a wacky sound effect. This should also make the injection sound effect easier to hear, letting the marine know they've been injected with Neuro. I haven't deleted the sound files themselves as they do sound cool and could be used for something else.

## Changelog

:cl:
balance: All of Bull's charges now deal exactly the same damage (2 slashes).
balance: Gore now also deals 1 sec of slow in addition to the 1 sec of stagger.
balance: Decreased Headbutt charges stun from 2 seconds to 1.5 seconds.
balance: Slightly increased Bulls walking speed.
sounddel: Removed the *gore emote from Bulls gore charge
spellcheck: Updated Bulls ability descriptions
/:cl:

