### PR TITLE
Keybinds misc fixes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -220,6 +220,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	random_character()
 	menuoptions = list()
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
+	save_keybinds()
 	for(var/i in 1 to CUSTOM_EMOTE_SLOTS)
 		var/datum/custom_emote/emote = new
 		emote.id = i

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -223,6 +223,9 @@
 	volume_tts = sanitize_integer(volume_tts, 1, 100, initial(volume_tts))
 
 	key_bindings = sanitize_islist(key_bindings, list())
+	if (!length(key_bindings))
+		key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key)
+
 	custom_emotes = sanitize_is_full_emote_list(custom_emotes)
 	chem_macros = sanitize_islist(chem_macros, list())
 	quick_equip = sanitize_islist(quick_equip, QUICK_EQUIP_ORDER, MAX_QUICK_EQUIP_SLOTS, TRUE, VALID_EQUIP_SLOTS)

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -787,7 +787,7 @@
 			emote.spoken_emote = !emote.spoken_emote
 
 		if("reset-keybindings")
-			key_bindings = GLOB.hotkey_keybinding_list_by_key
+			key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key)
 			current_client.set_macros()
 			save_keybinds()
 


### PR DESCRIPTION
## About The Pull Request
1) If a player joined, then ghosted or did nothing, and then another round started, they would have no keybinds because the new player code would create a save file, save the defaults into the file, **then** load the default keybinds, meaning the savefile would still have blank keybinds which would get loaded next round.

2) If the keybind list was for any other reason invalid, it would load a blank keybindings list.

3) If a player hit reset-keybinds, the default keybind list would get loaded into their preference datum *by reference*. See the 3rd commit for more info.

## Why It's Good For The Game

Players getting blank keybinds, joining the game, and being unable to move are only 40% likely to mentor help to ask why, and 60% likely to just go to some other server.