### PR TITLE
Prevent deployable shields on the tad and alamo

### DIFF
--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -75,9 +75,10 @@
 
 		var/area/area = get_area(location)
 		var/turf/open/placement_loc = location
-		if(restricted_deployment && (!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION)) // long ass check to prevent things like deployable shields on alamo
-			user.balloon_alert(user, "Can't deploy here")
-			return
+		if(restricted_deployment)
+			if(!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION) // long ass series of checks to prevent things like deployable shields on alamo
+				user.balloon_alert(user, "Can't deploy here")
+				return
 
 		if(LinkBlocked(get_turf(user), location))
 			location.balloon_alert(user, "No room to deploy")

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -8,8 +8,6 @@
 	var/obj/deploy_type
 	///Any extra checks required when trying to deploy this item
 	var/datum/callback/deploy_check_callback
-	///Helps to determine if the item should be deployable in areas like the tad and alamo
-	var/restricted_deployment = FALSE
 
 /datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback, _restricted_deployment = FALSE)
 	if(!isitem(parent))

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -73,9 +73,9 @@
 		if(!ishuman(user) || HAS_TRAIT(item_to_deploy, TRAIT_NODROP))
 			return
 
-		var/area/area = get_area(location)
-		var/turf/open/placement_loc = location
 		if(restricted_deployment)
+			var/area/area = get_area(location)
+			var/turf/open/placement_loc = location
 			if(!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION) // long ass series of checks to prevent things like deployable shields on alamo
 				user.balloon_alert(user, "Can't deploy here")
 				return

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -70,6 +70,12 @@
 		if(!ishuman(user) || HAS_TRAIT(item_to_deploy, TRAIT_NODROP))
 			return
 
+		var/area/area = get_area(location)
+		var/turf/open/placement_loc = location
+		if(istype(item_to_deploy, /obj/item/weapon/shield/riot/marine/deployable) && (!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION)) // long ass check to prevent things like deployable shields on alamo
+			user.balloon_alert(user, "Can't deploy here")
+			return
+
 		if(LinkBlocked(get_turf(user), location))
 			location.balloon_alert(user, "No room to deploy")
 			return

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -8,13 +8,16 @@
 	var/obj/deploy_type
 	///Any extra checks required when trying to deploy this item
 	var/datum/callback/deploy_check_callback
+	///Helps to determine if the item should be deployable in areas like the tad and alamo
+	var/restricted_deployment = FALSE
 
-/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback)
+/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _restricted_deployment, _deploy_check_callback)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	deploy_type = _deploy_type
 	deploy_time = _deploy_time
 	undeploy_time = _undeploy_time
+	restricted_deployment = _restricted_deployment
 	deploy_check_callback = _deploy_check_callback
 
 	var/obj/item/attached_item = parent
@@ -72,7 +75,7 @@
 
 		var/area/area = get_area(location)
 		var/turf/open/placement_loc = location
-		if(istype(item_to_deploy, /obj/item/weapon/shield/riot/marine/deployable) && (!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION)) // long ass check to prevent things like deployable shields on alamo
+		if(restricted_deployment && (!placement_loc.allow_construction || area.area_flags & NO_CONSTRUCTION)) // long ass check to prevent things like deployable shields on alamo
 			user.balloon_alert(user, "Can't deploy here")
 			return
 

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -8,6 +8,8 @@
 	var/obj/deploy_type
 	///Any extra checks required when trying to deploy this item
 	var/datum/callback/deploy_check_callback
+	///Helps to determine if the item should be deployable in areas like the tad and alamo
+	var/restricted_deployment
 
 /datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback, _restricted_deployment = FALSE)
 	if(!isitem(parent))

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -11,14 +11,14 @@
 	///Helps to determine if the item should be deployable in areas like the tad and alamo
 	var/restricted_deployment = FALSE
 
-/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _restricted_deployment, _deploy_check_callback)
+/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback, _restricted_deployment)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	deploy_type = _deploy_type
 	deploy_time = _deploy_time
 	undeploy_time = _undeploy_time
-	restricted_deployment = _restricted_deployment
 	deploy_check_callback = _deploy_check_callback
+	restricted_deployment = _restricted_deployment
 
 	var/obj/item/attached_item = parent
 	if(CHECK_BITFIELD(attached_item.item_flags, DEPLOY_ON_INITIALIZE))

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -11,7 +11,7 @@
 	///Helps to determine if the item should be deployable in areas like the tad and alamo
 	var/restricted_deployment = FALSE
 
-/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback, _restricted_deployment)
+/datum/component/deployable_item/Initialize(_deploy_type, _deploy_time, _undeploy_time, _deploy_check_callback, _restricted_deployment = FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	deploy_type = _deploy_type

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -160,7 +160,7 @@
 
 /obj/item/weapon/shield/riot/marine/deployable/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time, restricted_deployment)
+	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time, null, restricted_deployment)
 
 /obj/item/weapon/shield/riot/marine/deployable/set_shield()
 	AddComponent(/datum/component/shield, SHIELD_PARENT_INTEGRITY, list(MELEE = 40, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 40, BIO = 15, FIRE = 30, ACID = 35))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -155,12 +155,10 @@
 	var/undeploy_time = 1 SECONDS
 	///Whether it is wired
 	var/is_wired = FALSE
-	///Wether it can be deployed on the tad/alamo
-	var/restricted_deployment = TRUE
 
 /obj/item/weapon/shield/riot/marine/deployable/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time, null, restricted_deployment)
+	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time, null, TRUE)
 
 /obj/item/weapon/shield/riot/marine/deployable/set_shield()
 	AddComponent(/datum/component/shield, SHIELD_PARENT_INTEGRITY, list(MELEE = 40, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 40, BIO = 15, FIRE = 30, ACID = 35))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -155,10 +155,12 @@
 	var/undeploy_time = 1 SECONDS
 	///Whether it is wired
 	var/is_wired = FALSE
+	///Wether it can be deployed on the tad/alamo
+	var/restricted_deployment = TRUE
 
 /obj/item/weapon/shield/riot/marine/deployable/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time)
+	AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time, restricted_deployment)
 
 /obj/item/weapon/shield/riot/marine/deployable/set_shield()
 	AddComponent(/datum/component/shield, SHIELD_PARENT_INTEGRITY, list(MELEE = 40, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 40, BIO = 15, FIRE = 30, ACID = 35))


### PR DESCRIPTION

## About The Pull Request
Prevents deployable shields from being deployed on the alamo and the tad.
## Why It's Good For The Game
Helps reduce ahelps for these things, and prevents an exploit
## Changelog
:cl:
fix: Deployable shields can no longer be deployed on the alamo and the tad
/:cl:
