### PR TITLE
Alamo doors unlock on hijacking the console

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -514,6 +514,7 @@
 		shuttle.set_idle()
 		shuttle.set_hijack_state(HIJACK_STATE_CALLED_DOWN)
 		shuttle.do_start_hijack_timer()
+		shuttle.unlock_all()
 	interact(xeno_attacker) //Open the UI
 
 /obj/machinery/computer/shuttle/marine_dropship/ui_state(mob/user)


### PR DESCRIPTION
## About The Pull Request

There might be either some spaghetti here, or someone just forgot to readd this line when doing a refactor
Fixes #15741

## Why It's Good For The Game

Queen/King/Shrike can no longer be theorectically trapped by locking all the doors as soon as it's inside

## Changelog

:cl:
fix: Alamo now unlocks itself when a T4 touches the console (as it used to)
/:cl:
