### PR TITLE
Fixes an attachment component bug

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -83,10 +83,8 @@
 		return
 	attacher.temporarilyRemoveItemFromInventory(attachment)
 
-	//Re-try putting old attachment into hands, now that we've cleared them
-	if(old_attachment)
+	if(old_attachment && isturf(old_attachment.loc)) //if we didn't have space in our hands earlier, we try put the old attachment in hand now
 		attacher.put_in_hands(old_attachment)
-
 
 ///Finishes setting up the attachment. This is where the attachment actually attaches. This can be called directly to bypass any checks to directly attach an object.
 /datum/component/attachment_handler/proc/finish_handle_attachment(obj/item/attachment, list/attachment_data, mob/attacker)


### PR DESCRIPTION

## About The Pull Request
Fixes #15365

Swapping out attachments would put the old attachment in your hand when removing it, but then put it in hand AGAIN after the new attachment was successfully added, leading to an invisible phantom attachment. This only occured while you had a free hand (i.e. swapping webbings since you don't have to hold the item to do so).

:cl:
fix: fixed a phantom attachment bug when swapping attachments in some cases.
/:cl:
