### PR TITLE
Fix cursed vehicle to vehicle movement

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -85,12 +85,18 @@
 	SIGNAL_HANDLER
 	if(!HAS_TRAIT(AM, TRAIT_TANK_DESANT))
 		return
-	if(locate(src) in AM.loc) //Î'd cut the locate but for some reason it wdoesnt work lol
+	if(AM.loc in locs)
 		return
-	REMOVE_TRAIT(AM, TRAIT_TANK_DESANT, VEHICLE_TRAIT)
 	AM.layer = LAZYACCESS(tank_desants, AM)
 	LAZYREMOVE(tank_desants, AM)
 	UnregisterSignal(AM, COMSIG_QDELETING)
+	var/obj/hitbox/new_hitbox = locate(/obj/hitbox) in AM.loc //walking onto another vehicle
+	if(!new_hitbox)
+		REMOVE_TRAIT(AM, TRAIT_TANK_DESANT, VEHICLE_TRAIT)
+		return
+	LAZYSET(new_hitbox.tank_desants, AM, AM.layer)
+	new_hitbox.RegisterSignal(AM, COMSIG_QDELETING, PROC_REF(on_desant_del))
+	AM.layer = ABOVE_MOB_PLATFORM_LAYER //we set it separately so the original layer is recorded
 
 ///cleanup riders on deletion
 /obj/hitbox/proc/on_desant_del(datum/source)


### PR DESCRIPTION
## About The Pull Request
Day 7485 of Tivi's plan to ignore multitile bugs until I get annoyed enough to fix them.

You will no longer be cursed to fly into space/out of the alamo if you walk between two vehicles.

Fixes #15945, #15799

:cl:
fix: fixed walking between multitile vehicles causing issues
/:cl:
