### PR TITLE
Fix stacks in backpacks breaking

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -724,7 +724,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(isitem(parent))
 		var/obj/item/parent_storage = parent
 		if(item_to_insert.w_class >= parent_storage.w_class && istype(item_to_insert, /obj/item/storage) && !is_type_in_typecache(item_to_insert.type, typecacheof(storage_type_limits)))
-			if(!istype(src, /obj/item/storage/backpack/holding))	//bohs should be able to hold backpacks again. The override for putting a boh in a boh is in backpack.dm.
+			if(!istype(src, /obj/item/storage/backpack/holding)) //bohs should be able to hold backpacks again. The override for putting a boh in a boh is in backpack.dm.
 				if(warning)
 					to_chat(user, span_notice("[parent.name] cannot hold [item_to_insert] as it's a storage item of the same size."))
 				return FALSE //To prevent the stacking of same sized storage items.
@@ -780,10 +780,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  * such as when picking up all the items on a tile with one click.
  * user can be null, it refers to the potential mob doing the insertion.
  */
-/datum/storage/proc/handle_item_insertion(obj/item/item, prevent_warning = 0, mob/user)
+/datum/storage/proc/handle_item_insertion(obj/item/item, prevent_warning = FALSE, mob/user)
 	if(!istype(item))
 		return FALSE
-	if(!handle_access_delay(item, user, taking_out=FALSE))
+	if(!handle_access_delay(item, user, taking_out = FALSE))
 		item.forceMove(item.drop_location())
 		return FALSE
 	if(user && item.loc == user)
@@ -820,12 +820,21 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 						span_notice("You put \the [item] into \the [parent.name]."),\
 						null, visidist)
 
-///Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
-/datum/storage/proc/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/**
+ * Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
+ *
+ * Arguments:
+ * * item: the item that is getting removed
+ * * new_location: where the item is being sent to
+ * * user: whoever/whatever is calling this proc
+ * * silent: defaults to FALSE, on subtypes this is used to prevent a sound from being played
+ * * bypass_delay: if TRUE, will bypass draw delay
+ */
+/datum/storage/proc/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	if(!istype(item))
 		return FALSE
 
-	if(!handle_access_delay(item, user))
+	if(!bypass_delay && !handle_access_delay(item, user))
 		return FALSE
 
 	for(var/mob/M AS in can_see_content())
@@ -978,7 +987,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/handle_atom_del(datum/source, atom/movable/movable_atom)
 	SIGNAL_HANDLER
 	if(isitem(movable_atom))
-		INVOKE_ASYNC(src, PROC_REF(remove_from_storage), movable_atom, movable_atom.loc, usr, TRUE)
+		INVOKE_ASYNC(src, PROC_REF(remove_from_storage), movable_atom, null, usr, silent = TRUE, bypass_delay = TRUE)
 
 ///signal sent from /atom/proc/max_stack_merging()
 /datum/storage/proc/max_stack_merging(datum/source, obj/item/stack/stacks)

--- a/code/datums/storage/subtypes/bag.dm
+++ b/code/datums/storage/subtypes/bag.dm
@@ -152,7 +152,7 @@
 		show_to(user)
 	sheetsnatcher.update_icon()
 
-/datum/storage/bag/sheetsnatcher/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE) // Instead of removing
+/datum/storage/bag/sheetsnatcher/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE) // Instead of removing
 	var/obj/item/stack/sheet/S = item
 	if(!istype(S))
 		return FALSE

--- a/code/datums/storage/subtypes/box.dm
+++ b/code/datums/storage/subtypes/box.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	set_holdable(list(/obj/item/reagent_containers/food/snacks/packaged_meal))
 
-/datum/storage/box/mre/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/box/mre/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	if(. && !length(parent.contents) && !gc_destroyed)
 		qdel(parent)

--- a/code/datums/storage/subtypes/holster.dm
+++ b/code/datums/storage/subtypes/holster.dm
@@ -28,7 +28,7 @@
 	holster.update_icon() //So that the icon actually updates after we've assigned our holstered_item
 	playsound(parent, sheathe_sound, 15, 1)
 
-/datum/storage/holster/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/holster/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	var/obj/item/storage/holster/holster = parent
 	if(!. || !is_type_in_list(item, holster.holsterable_allowed)) //check to see if the item being removed is the snowflake item

--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -51,7 +51,7 @@
 	var/obj/master_item = parent.loc
 	master_item?.update_icon()
 
-/datum/storage/internal/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/internal/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	var/obj/master_item = parent.loc
 	if(isturf(master_item) || ismob(master_item))

--- a/code/datums/storage/subtypes/pill_bottle.dm
+++ b/code/datums/storage/subtypes/pill_bottle.dm
@@ -15,7 +15,7 @@
 		/obj/item/paper,
 	))
 
-/datum/storage/pill_bottle/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/pill_bottle/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	if(!silent && . && user)
 		playsound(user, 'sound/items/pills.ogg', 15, 1)
@@ -37,7 +37,7 @@
 	. = ..()
 	set_holdable(cant_hold_list = list(/obj/item/reagent_containers/pill)) //Nada. Once you take the pills out. They don't come back in.
 
-/datum/storage/pill_bottle/packet/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/pill_bottle/packet/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	if(!.)
 		return

--- a/code/datums/storage/subtypes/wallet.dm
+++ b/code/datums/storage/subtypes/wallet.dm
@@ -25,7 +25,7 @@
 		/obj/item/tool/stamp,
 	))
 
-/datum/storage/wallet/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE)
+/datum/storage/wallet/remove_from_storage(obj/item/item, atom/new_location, mob/user, silent = FALSE, bypass_delay = FALSE)
 	. = ..()
 	var/obj/item/storage/wallet/parent_wallet = parent
 	if(item == parent_wallet.front_id)


### PR DESCRIPTION
## About The Pull Request
2 bugfixes:
Fix stacks breaking when you try merging stacks together
fix deleting an item inside a storage not properly removing it from the storage

Fixes #15910, #15879
## Why It's Good For The Game
bugfix
## Changelog
:cl:
fix: Merging stacks inside a backpack will no longer break
fix: Deleting something inside a storage will no longer break
/:cl:
