### PR TITLE
Hugger throw fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -398,6 +398,11 @@
 
 	leaping = FALSE
 
+/obj/item/clothing/mask/facehugger/throw_bounce(atom/hit_atom, turf/old_throw_source)
+	if(ismob(hit_atom))
+		return
+	return ..()
+
 /obj/item/clothing/mask/facehugger/stop_throw(flying, original_layer)
 	. = ..()
 	update_icon()


### PR DESCRIPTION
## About The Pull Request
Huggers will no longer bounce if thrown into a mob.
Fixes #13686

:cl:
fix: Huggers will no longer bounce if thrown into a mob
/:cl:
