### PR TITLE
Deconstructing upgraded metal cade refunds full cost

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -515,6 +515,7 @@
 			resistance_flags |= UNACIDABLE
 
 	barricade_upgrade_type = choice
+	stack_amount += 1
 
 	balloon_alert_to_viewers("[choice] attached")
 
@@ -688,6 +689,7 @@
 
 			new /obj/item/stack/sheet/metal(loc, CADE_UPGRADE_REQUIRED_SHEETS)
 			barricade_upgrade_type = null
+			stack_amount -= 1
 			update_icon()
 			return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Deconstructing an upgraded metal barricade automatically factors in the metal used to upgrade it. This means deconstructing an upgraded metal barricade should return 5 sheets of metal (actual cost) instead of 4 (not upgraded cost).

## Why It's Good For The Game
Bug fix. Makes deconstructing more convenient since you don't have to degrade and then deconstruct to get the full refund.

## Changelog
:cl:
fix: Deconstructing an upgraded metal barricade now returns the actual cost of 5 sheets instead of 4.
/:cl: