### PR TITLE
Boiler Tweaks

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -375,20 +375,19 @@
 
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro
-	alpha = 120
-	opacity = FALSE
+	alpha = 255
+	opacity = TRUE
 	color = "#ffbf58" //Mustard orange?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
 ///Xeno neurotox smoke for Defilers; doesn't extinguish
 /obj/effect/particle_effect/smoke/xeno/neuro/medium
-	alpha = 255
-	opacity = TRUE
-	color = "#ffbf58" //Mustard orange?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
 ///Xeno neurotox smoke for neurospit; doesn't extinguish or blind
 /obj/effect/particle_effect/smoke/xeno/neuro/light
+	alpha = 120
+	opacity = FALSE
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/toxic

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -368,6 +368,7 @@
 /obj/effect/particle_effect/smoke/xeno/burn/opaque
 	alpha = 255
 	opacity = TRUE
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
 //Xeno light acid smoke.for acid huggers
 /obj/effect/particle_effect/smoke/xeno/burn/light

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -33,7 +33,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LONG_RANGE_SIGHT,
 	)
+	/// The offset in a direction for zoom_in
 	var/tile_offset = 5
+	/// The size of the zoom for zoom_in
 	var/view_size = 4
 
 /datum/action/ability/xeno_action/toggle_long_range/bull
@@ -49,8 +51,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	else
 		X.visible_message(span_notice("[X] starts looking off into the distance."), \
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
-		if(X.xeno_flags & XENO_ZOOMED)
-			return
 		X.zoom_in(tile_offset, view_size)
 		..()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -51,6 +51,8 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	else
 		X.visible_message(span_notice("[X] starts looking off into the distance."), \
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
+		if(!do_after(X, 1 SECONDS, IGNORE_HELD_ITEM, null, BUSY_ICON_GENERIC) || (X.xeno_flags & XENO_ZOOMED))
+			return
 		X.zoom_in(tile_offset, view_size)
 		..()
 
@@ -266,11 +268,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	if(!isturf(T) || T.z != S.z)
 		if(!silent)
 			boiler_owner.balloon_alert(boiler_owner, "Invalid target.")
-		return FALSE
-
-	if(get_dist(T, S) <= 5) //Magic number
-		if(!silent)
-			boiler_owner.balloon_alert(boiler_owner, "Too close!")
 		return FALSE
 
 /datum/action/ability/activable/xeno/bombard/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -33,6 +33,12 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LONG_RANGE_SIGHT,
 	)
+	var/tile_offset = 5
+	var/view_size = 4
+
+/datum/action/ability/xeno_action/toggle_long_range/bull
+	tile_offset = 11
+	view_size = 12
 
 /datum/action/ability/xeno_action/toggle_long_range/action_activate()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
@@ -43,9 +49,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	else
 		X.visible_message(span_notice("[X] starts looking off into the distance."), \
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
-		if(!do_after(X, 1 SECONDS, IGNORE_HELD_ITEM, null, BUSY_ICON_GENERIC) || (X.xeno_flags & XENO_ZOOMED))
+		if(X.xeno_flags & XENO_ZOOMED)
 			return
-		X.zoom_in(11)
+		X.zoom_in(tile_offset, view_size)
 		..()
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -44,7 +44,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/boiler/Initialize(mapload)
 	. = ..()
-	smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
+	smoke = new /datum/effect_system/smoke_spread/xeno/acid/opaque(src)
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
 	update_boiler_glow()
 	RegisterSignal(src, COMSIG_XENOMORPH_GIBBING, PROC_REF(gib_explode))

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -46,7 +46,7 @@
 		/datum/action/ability/activable/xeno/bull_charge,
 		/datum/action/ability/activable/xeno/bull_charge/headbutt,
 		/datum/action/ability/activable/xeno/bull_charge/gore,
-		/datum/action/ability/xeno_action/toggle_long_range,
+		/datum/action/ability/xeno_action/toggle_long_range/bull,
 	)
 
 /datum/xeno_caste/bull/normal

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -30,7 +30,7 @@
 	///On a direct hit, how much drowsyness gets added to the target?
 	var/hit_drowsyness = 12
 	///Base spread range
-	var/fixed_spread_range = 4
+	var/fixed_spread_range = 3
 	///Which type is the smoke we leave on passed tiles, provided the projectile has AMMO_LEAVE_TURF enabled?
 	var/passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/neuro/light
 	///We're going to reuse one smoke spread system repeatedly to cut down on processing.

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -160,7 +160,7 @@
 	///As opposed to normal globs, this will pass by the target tile if they hit nothing.
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_LEAVE_TURF
 	danger_message = span_danger("A pressurized glob of acid lands with a nasty splat and explodes into noxious fumes!")
-	max_range = 25
+	max_range = 14
 	damage = 75
 	penetration = 70
 	reagent_transfer_amount = 55
@@ -180,7 +180,7 @@
 	///As opposed to normal globs, this will pass by the target tile if they hit nothing.
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_LEAVE_TURF
 	danger_message = span_danger("A pressurized glob of acid lands with a concerning hissing sound and explodes into corrosive bile!")
-	max_range = 25
+	max_range = 14
 	damage = 75
 	penetration = 70
 	passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/acid/light

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -143,7 +143,7 @@
 	if(!do_after(user_xeno, 3 SECONDS, NONE, trap))
 		return FALSE
 	trap.set_trap_type(TRAP_SMOKE_ACID)
-	trap.smoke = new /datum/effect_system/smoke_spread/xeno/acid
+	trap.smoke = new /datum/effect_system/smoke_spread/xeno/acid/opaque
 	trap.smoke.set_up(1, get_turf(trap))
 	return TRUE
 
@@ -151,7 +151,7 @@
 	airburst(victim, proj)
 
 /datum/ammo/xeno/boiler_gas/corrosive/set_smoke()
-	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid()
+	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid/opaque()
 
 /datum/ammo/xeno/boiler_gas/lance
 	name = "pressurized glob of gas"


### PR DESCRIPTION
## About The Pull Request
Basically puts boiler alot closer to CM boiler now that we are starting to take down offscreens.
Zoom reduced to about miniscope range (4 tiles)
Opaque gas is back
Boiler gas radius reduced from 4 to 3 tile radius
Able to shoot within 5 tiles of yourself
## Why It's Good For The Game
Boiler was a lot less toxic without opaque gas but did lack the utility a smokescreen gave. The toxicity was mostly because you literally could not interact with boiler at sniper range, even with root. This makes boiler have a good more deal risk/reward as they are much, much closer to marines but have the smokescreen. Additionally no zoom windup as that felt quite arbitrary.
## Changelog
:cl:
balance: Boiler - Zoom reduced to about miniscope range (4 tiles)
balance: Boiler - Opaque gas is back
balance: Boiler - Boiler gas radius reduced from 4 to 3 tile radius
balance: Boiler - Able to shoot within 5 tiles of yourself
/:cl:
