### PR TITLE
Changes Intel computers to now be a loot box reward event.

### DIFF
--- a/code/game/objects/items/loot_box.dm
+++ b/code/game/objects/items/loot_box.dm
@@ -677,3 +677,244 @@
 	new /obj/item/weapon/gun/launcher/rocket/sadar(src)
 	new /obj/item/storage/backpack/marine/satchel/scout_cloak(src)
 	new /obj/item/ammo_magazine/rocket/sadar/ap(src)
+
+
+
+// Lootbox for New intel computer.
+
+/obj/item/loot_box/securelootcrate
+	name = "Specialised loot crate"
+	desc = "A crate filled with all sorts of potential goodies that someone like you wouldnt normally be able to get for operations."
+	icon = 'icons/obj/items/items.dmi'
+	icon_state = "lootbox"
+	worn_icon_state = "lootbox"
+
+	legendary_list = list(
+		/obj/item/storage/box/crate/loot/heavy_pack,
+		/obj/item/storage/box/crate/loot/b18classic_pack,
+		/obj/item/storage/box/crate/loot/sadarclassic_pack,
+	)
+	rare_list = list(
+		/obj/item/storage/box/crate/loot/sentry_pack,
+		/obj/item/storage/box/crate/loot/agl_pack,
+	)
+	uncommon_list = list(
+		/obj/item/storage/box/crate/loot/railgun_pack,
+		/obj/item/storage/box/crate/loot/scoutrifle_pack,
+		/obj/item/storage/box/crate/loot/recoilless_pack,
+	)
+	common_list = list(
+		/obj/item/storage/box/crate/loot/autosniper_pack,
+		/obj/item/storage/box/crate/loot/thermobaric_pack,
+		/obj/item/storage/box/crate/loot/tesla_pack,
+		/obj/item/storage/box/crate/loot/tx54_pack,
+	)
+
+// Boxes the lootbox uses.
+
+/obj/item/storage/box/crate/loot
+	name = "Specialised equipment crate"
+	desc = "A large secure crate that contains specialised equipment hold it in your hand and click its icon use it"
+	icon_state = "smartgun_case"
+	w_class = WEIGHT_CLASS_HUGE
+
+/obj/item/storage/box/crate/loot/Initialize(mapload)
+	. = ..()
+	storage_datum.storage_slots = 100
+	storage_datum.max_storage_space = 100
+	storage_datum.max_w_class = 0
+
+/obj/item/storage/box/crate/loot/PopulateContents()
+	new /obj/item/weapon/banhammer(src)
+
+
+/obj/structure/closet/crate/loot
+	name = "Specialised equipment crate"
+	desc = "A large crate containing Specialised equipment."
+	icon = 'icons/obj/structures/crates.dmi'
+	icon_state = "closed_basic"
+	icon_opened = "open_basic"
+	icon_closed = "closed_basic"
+
+/obj/structure/closet/crate/loot/PopulateContents()
+	new /obj/item/weapon/banhammer(src)
+
+// Common
+
+/obj/item/storage/box/crate/loot/autosniper_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
+	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
+	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src) //180 total and common, fine considering 3 autos is really strong.
+
+/obj/item/storage/box/crate/loot/thermobaric_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/launcher/rocket/m57a4/t57(src)
+	new /obj/item/weapon/gun/launcher/rocket/m57a4/t57(src)
+	new /obj/item/weapon/gun/launcher/rocket/m57a4/t57(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src)
+	new /obj/item/ammo_magazine/rocket/m57a4(src) // three launchers and 10 arrays. Common. 200.
+
+/obj/item/storage/box/crate/loot/tesla_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/energy/lasgun/lasrifle/tesla(src)
+	new /obj/item/weapon/gun/energy/lasgun/lasrifle/tesla(src)
+	new /obj/item/weapon/gun/energy/lasgun/lasrifle/tesla(src) // 180 and nothing else. Have fun.
+
+/obj/item/storage/box/crate/loot/tx54_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/rifle/tx54(src)
+	new /obj/item/weapon/gun/rifle/tx54(src)
+	new /obj/item/weapon/gun/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+
+// Uncommon
+
+/obj/item/storage/box/crate/loot/materials_pack/PopulateContents()
+	. = ..()
+	new /obj/item/stack/sheet/plasteel/large_stack(src)
+	new /obj/item/stack/sheet/plasteel/large_stack(src)
+	new /obj/item/stack/sheet/metal/large_stack(src)
+	new /obj/item/stack/sheet/metal/large_stack(src)
+	new /obj/item/stack/sheet/metal/large_stack(src)
+	new /obj/item/stack/sheet/metal/large_stack(src)
+	new /obj/item/stack/sandbags_empty/full(src)
+	new /obj/item/stack/sandbags_empty/full(src)
+	new /obj/item/stack/sandbags_empty/full(src)
+	new /obj/item/stack/sandbags_empty/full(src)
+	new /obj/item/tool/shovel/etool(src)
+	new /obj/item/tool/shovel/etool(src)
+	new /obj/item/tool/shovel/etool(src)
+	new /obj/item/tool/shovel/etool(src)
+
+/obj/item/storage/box/crate/loot/recoilless_pack/PopulateContents()
+	. = ..()
+	new /obj/item/storage/holster/backholster/rpg/full(src)
+	new /obj/item/storage/holster/backholster/rpg/full(src)
+	new /obj/item/storage/holster/backholster/rpg/full(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+	new /obj/item/ammo_magazine/rocket/recoilless/heat(src)
+
+/obj/item/storage/box/crate/loot/railgun_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/rifle/railgun(src)
+	new /obj/item/weapon/gun/rifle/railgun(src)
+	new /obj/item/weapon/gun/rifle/railgun(src)
+	new /obj/item/ammo_magazine/railgun/smart(src)
+	new /obj/item/ammo_magazine/railgun/smart(src)
+	new /obj/item/ammo_magazine/railgun/smart(src)
+	new /obj/item/ammo_magazine/railgun/smart(src)
+	new /obj/item/ammo_magazine/railgun/hvap(src)
+	new /obj/item/ammo_magazine/railgun/hvap(src)
+	new /obj/item/ammo_magazine/railgun/hvap(src)
+	new /obj/item/ammo_magazine/railgun/hvap(src)
+	new /obj/item/ammo_magazine/railgun(src)
+	new /obj/item/ammo_magazine/railgun(src)
+	new /obj/item/ammo_magazine/railgun(src)
+	new /obj/item/ammo_magazine/railgun(src)
+
+/obj/item/storage/box/crate/loot/scoutrifle_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/rifle/tx8(src)
+	new /obj/item/weapon/gun/rifle/tx8(src)
+	new /obj/item/weapon/gun/rifle/tx8(src)
+	new /obj/item/ammo_magazine/packet/scout_rifle(src)
+	new /obj/item/ammo_magazine/packet/scout_rifle(src)
+	new /obj/item/ammo_magazine/packet/scout_rifle(src)
+	new /obj/item/ammo_magazine/packet/scout_rifle(src)
+	new /obj/item/ammo_magazine/rifle/tx8
+	new /obj/item/ammo_magazine/rifle/tx8
+	new /obj/item/ammo_magazine/rifle/tx8
+	new /obj/item/ammo_magazine/rifle/tx8
+	new /obj/item/ammo_magazine/rifle/tx8
+	new /obj/item/ammo_magazine/rifle/tx8
+
+
+// Rares
+
+/obj/item/storage/box/crate/loot/agl_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/standard_agls(src)
+	new /obj/item/ammo_magazine/standard_agls(src)
+	new /obj/item/ammo_magazine/standard_agls(src)
+	new /obj/item/ammo_magazine/standard_agls(src)
+	new /obj/item/ammo_magazine/standard_agls(src)
+	new /obj/item/ammo_magazine/standard_agls/fragmentation(src)
+	new /obj/item/ammo_magazine/standard_agls/fragmentation(src)
+	new /obj/item/ammo_magazine/standard_agls/fragmentation(src)
+	new /obj/item/ammo_magazine/standard_agls/fragmentation(src)
+
+/obj/item/storage/box/crate/loot/sentry_pack/PopulateContents()
+	. = ..()
+	new /obj/item/storage/box/crate/sentry(src)
+	new /obj/item/storage/box/crate/sentry(src)
+	new /obj/item/storage/box/crate/sentry(src)
+	new /obj/item/storage/box/crate/minisentry(src)
+
+// Legendaries
+
+/obj/item/storage/box/crate/loot/operator_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/rifle/m412/elite
+	new /obj/item/ammo_magazine/rifle
+	new /obj/item/ammo_magazine/rifle
+	new /obj/item/ammo_magazine/rifle
+	new /obj/item/ammo_magazine/rifle
+	new /obj/item/clothing/glasses/night/tx8
+
+/obj/item/storage/box/crate/loot/b18classic_pack/PopulateContents()
+	. = ..()
+	new /obj/item/clothing/suit/storage/marine/specialist(src)
+	new /obj/item/clothing/head/helmet/marine/specialist(src)
+	new /obj/item/clothing/gloves/marine/specialist(src)
+	new /obj/item/weapon/gun/minigun(src)
+	new /obj/item/ammo_magazine/minigun_powerpack(src)
+	new /obj/item/ammo_magazine/minigun_powerpack(src)
+
+/obj/item/storage/box/crate/loot/heavy_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/minigun(src)
+	new /obj/item/weapon/gun/minigun(src)
+	new /obj/item/ammo_magazine/minigun_powerpack(src)
+	new /obj/item/ammo_magazine/minigun_powerpack(src)
+	new /obj/item/armor_module/module/tyr_extra_armor(src)
+	new /obj/item/armor_module/module/tyr_extra_armor(src)
+
+/obj/item/storage/box/crate/loot/sadarclassic_pack/PopulateContents()
+	. = ..()
+	new /obj/item/weapon/gun/launcher/rocket/sadar(src)
+	new /obj/item/storage/backpack/marine/satchel/scout_cloak(src)
+	new /obj/item/ammo_magazine/rocket/sadar/ap(src)

--- a/code/game/objects/machinery/computer/intel_computer.dm
+++ b/code/game/objects/machinery/computer/intel_computer.dm
@@ -2,10 +2,9 @@
 	name = "circuit board (intel computer)"
 	build_path = /obj/machinery/computer/intel_computer
 
-
 /obj/machinery/computer/intel_computer
-	name = "Intelligence computer"
-	desc = "A computer used to access the colonies central database. TGMC Intel division will occasionally request remote data retrieval from these computers"
+	name = "Secured equipment computer"
+	desc = "A computer used to access specialised equipment. TGMC Intel division will occasionally report the location of active computers"
 	icon_state = "intel_computer"
 	screen_overlay = "intel_computer_screen"
 	circuit = /obj/item/circuitboard/computer/intel_computer
@@ -15,10 +14,6 @@
 
 	///Whether this computer is activated by the event yet
 	var/active = FALSE
-	///How much supply points you get for completing the terminal
-	var/supply_reward = 600
-	///How much dropship points you get for completing the terminal
-	var/dropship_reward = 60
 
 	///How much progress we get every tick, up to 100
 	var/progress_interval = 1
@@ -35,7 +30,6 @@
 	///What faction has launched the intel process
 	var/faction = FACTION_TERRAGOV
 
-
 /obj/machinery/computer/intel_computer/Initialize(mapload)
 	. = ..()
 	GLOB.intel_computers += src
@@ -51,9 +45,8 @@
 		STOP_PROCESSING(SSmachines, src)
 		printing = FALSE
 		printing_complete = TRUE
-		SSpoints.supply_points[faction] += supply_reward
-		SSpoints.dropship_points += dropship_reward
-		minor_announce("Classified transmission recieved from [get_area(src)]. Bonus delivered as [supply_reward] supply points and [dropship_reward] dropship points.", title = "TGMC Intel Division")
+		new /obj/item/loot_box/securelootcrate(get_turf(src))
+		visible_message(span_notice("[src] beeps as it finishes bypassing security protocols, the secure compartment opens up to reveal its contents"))
 		SSminimaps.remove_marker(src)
 
 /obj/machinery/computer/intel_computer/Destroy()
@@ -62,7 +55,7 @@
 
 /obj/machinery/computer/intel_computer/interact(mob/user)
 	if(!active)
-		to_chat(user, span_notice("This terminal has nothing of use on it."))
+		to_chat(user, span_notice("you aren't able to bypass the security protocols to use this terminal."))
 		return
 	return ..()
 

--- a/code/modules/events/intel_computer.dm
+++ b/code/modules/events/intel_computer.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/intel_computer
 	name = "Intel computer activation"
 	typepath = /datum/round_event/intel_computer
-	weight = 25
+	weight = 30
 
 	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture")
 


### PR DESCRIPTION
## About The Pull Request

This gives heavy incentive to doing the event when it occurs, instead of marines ignoring them, while rewarding them for their effort. this requires marines to be careful as xenos might use this to pick off loners, so risk reward.

EDIT: upon completion, it will generate a loot box at the intel disk. the contents dont have anything new, except deplorables being removed from the loot table, more or less. intel computer can only be used once.

## Changelog

:cl:
add: loot box event reward system instead of intel req point reward event system.
balance: updates event weight from 25 to 30
/:cl:


