### PR TITLE
Gives vali machete campaign's sword lunge ability

### DIFF
--- a/code/game/objects/items/weapons/harvester.dm
+++ b/code/game/objects/items/weapons/harvester.dm
@@ -22,10 +22,12 @@
 /obj/item/weapon/sword/harvester/equipped(mob/user, slot)
 	. = ..()
 	toggle_item_bump_attack(user, TRUE)
+	special_attack.give_action(user)
 
 /obj/item/weapon/sword/harvester/dropped(mob/user)
 	. = ..()
 	toggle_item_bump_attack(user, FALSE)
+	special_attack.remove_action(user)
 
 //Vali Knife
 /obj/item/weapon/combat_knife/harvester


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin. Costs stamina to use.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ever since shield was killed from HvX, there has been no real reason to use machete. Claymore was objectively better, and even then machete was horribly underpowered. Might give it an interesting niche of movement (note: this dash does NOT go over xenos).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Vali machete has a small dash now that costs stamina
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
