### PR TITLE
Hivemind buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -14,8 +14,8 @@
 	speed = 0
 
 	// *** Plasma *** //
-	plasma_max = 600 //  75 is the cost of plant_weeds
-	plasma_gain = 60
+	plasma_max = 1000 //  75 is the cost of plant_weeds
+	plasma_gain = 120
 
 	// *** Health *** //
 	max_health = 100


### PR DESCRIPTION

## About The Pull Request

Hivemind buff in plasma.

Plasma max goes from 600 to 1000
Plasma regen goes from 60 to 120

## Why It's Good For The Game

Hivemind feels like a subpar caste into its most important job, weeding and mazing, those changes are meant to provide said caste a better time with wall building in the backline giving other support castes the spotlight at front.

## Changelog


:cl:

balance: Hivemind plasma from 600 to 1000
balance: Hivemind plasma regen from 60 to 120

/:cl:


