### PR TITLE
Trying to undeploy mortar refunds any chambered items

### DIFF
--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -154,11 +154,6 @@
 		sentry?.set_on(TRUE)
 		return
 
-	if(istype(deployed_machine, /obj/machinery/deployable/mortar))
-		var/obj/machinery/deployable/mortar/mortar = deployed_machine
-		for(var/obj/loaded_item in mortar.chamber_items)
-			loaded_item.forceMove(get_turf(deployed_machine))
-
 	undeployed_item.toggle_deployment_flag()
 
 	user.unset_interaction()

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -154,6 +154,11 @@
 		sentry?.set_on(TRUE)
 		return
 
+	if(istype(deployed_machine, /obj/machinery/deployable/mortar))
+		var/obj/machinery/deployable/mortar/mortar = deployed_machine
+		for(var/obj/loaded_item in mortar.chamber_items)
+			loaded_item.forceMove(get_turf(deployed_machine))
+
 	undeployed_item.toggle_deployment_flag()
 
 	user.unset_interaction()

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -113,7 +113,7 @@
 	for(var/obj/loaded_item in chamber_items)
 		chamber_items -= loaded_item
 		loaded_item.forceMove(get_turf(src))
-	. = ..()
+	return ..()
 
 /obj/machinery/deployable/mortar/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -109,6 +109,11 @@
 
 	ui_interact(user)
 
+/obj/machinery/deployable/mortar/disassemble(mob/user)
+	for(var/obj/loaded_item in chamber_items)
+		chamber_items -= loaded_item
+		loaded_item.forceMove(get_turf(src))
+	. = ..()
 
 /obj/machinery/deployable/mortar/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
## About The Pull Request
Trying to undeploying a mortar deployment now returns/dumps any chambered items onto the floor.

Fixes #15938

## Why It's Good For The Game
Bugfix. The mortar shell that I didn't launch or use shouldn't delete itself when I pack up my mortar to move it elsewhere.

## Changelog
:cl:
fix: Mortar's chambered items now drop onto the floor (instead of deleting itself) when undeployment attempt is made.
/:cl:
