### PR TITLE
Nerf MG-27, HMG, and HSG's scope to slightly less than mini scope

### DIFF
--- a/code/modules/projectiles/gun_attachables/scope.dm
+++ b/code/modules/projectiles/gun_attachables/scope.dm
@@ -154,7 +154,7 @@
 	desc = "An unremovable set of long range ironsights for an HMG-08 machinegun."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
-	zoom_tile_offset = 5
+	zoom_tile_offset = 4
 
 /obj/item/attachable/scope/unremovable/mmg
 	name = "MG-27 rail scope"
@@ -164,7 +164,7 @@
 	aim_speed_mod = 0.2
 	scoped_accuracy_mod = SCOPE_RAIL_MINI
 	zoom_slowdown = 0.3
-	zoom_tile_offset = 5
+	zoom_tile_offset = 4
 	zoom_viewsize = 0
 
 /obj/item/attachable/scope/unremovable/standard_atgun
@@ -179,7 +179,7 @@
 	desc = "An unremovable smart sight built for use with the HSG-102, it does nearly all the aiming work for the gun's integrated IFF systems."
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
-	zoom_tile_offset = 5
+	zoom_tile_offset = 4
 	deployed_scope_rezoom = TRUE
 
 //all mounted guns with a nest use this


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/6610922/953325a6-d351-47d5-9446-0a08535c8a6c)

Supreme Leader Kurt's Will,

"We're removing offscreen gameplay since its uninteractive and heavily stacked for marines, mounted weapons are also culprits of off screening tho less so than the other stuff that is getting a nerf, since boiler is having his range reduced I don't think mounted weapons need mini scope range anymore"

## Changelog

:cl:
balance: Nerf MG-27, HMG, and HSG's scope to slightly less than mini scope
/:cl:

