### PR TITLE
Pyrogen Buffs and damage type rework

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -643,7 +643,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 /// How fast the pyrogen moves when charging using fire charge
 #define PYROGEN_CHARGESPEED 3
 /// Maximum charge distance.
-#define PYROGEN_CHARGEDISTANCE 3
+#define PYROGEN_CHARGEDISTANCE 5
 /// Damage on hitting a mob using fire charge
 #define PYROGEN_FIRECHARGE_DAMAGE 10
 /// Bonus damage per fire stack

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -612,7 +612,7 @@
 	if(debuff_owner.stat == DEAD || debuff_owner.status_flags & GODMODE)
 		qdel(src)
 		return
-	debuff_owner.take_overall_damage(PYROGEN_DAMAGE_PER_STACK * stacks, BURN, ACID, updating_health = TRUE)
+	debuff_owner.take_overall_damage(PYROGEN_DAMAGE_PER_STACK * stacks, BURN, FIRE, updating_health = TRUE)
 	if(stacks > 4)
 		visual_fire.icon_state = "melting_high_stacks"
 	else

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -62,7 +62,7 @@
 		var/datum/status_effect/stacking/melting_fire/debuff = living_target.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
 		fire_damage += debuff.stacks * PYROGEN_FIRECHARGE_DAMAGE_PER_STACK
 		living_target.remove_status_effect(STATUS_EFFECT_MELTING_FIRE)
-	living_target.take_overall_damage(fire_damage, BURN, ACID, max_limbs = 2)
+	living_target.take_overall_damage(fire_damage, BURN, FIRE, max_limbs = 2)
 	living_target.hitby(owner)
 
 
@@ -88,7 +88,7 @@
 /datum/action/ability/activable/xeno/fireball/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/pyrogen/xeno = owner
 	playsound(get_turf(xeno), 'sound/effects/wind.ogg', 50)
-	if(!do_after(xeno, 1 SECONDS, IGNORE_HELD_ITEM, target, BUSY_ICON_DANGER))
+	if(!do_after(xeno, 0.6 SECONDS, IGNORE_HELD_ITEM, target, BUSY_ICON_DANGER))
 		return fail_activate()
 
 	if(!can_use_ability(target, FALSE, ABILITY_IGNORE_PLASMA))
@@ -179,7 +179,7 @@
 		debuff.add_stacks(PYROGEN_TORNADO_MELTING_FIRE_STACKS)
 	else
 		target.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_TORNADO_MELTING_FIRE_STACKS)
-	target.take_overall_damage(PYROGEN_TORNADE_HIT_DAMAGE, BURN, ACID, max_limbs = 2)
+	target.take_overall_damage(PYROGEN_TORNADE_HIT_DAMAGE, BURN, FIRE, max_limbs = 2)
 
 ///Effects applied to a mob that crosses a burning turf
 /obj/effect/xenomorph/firenado/proc/on_cross(datum/source, mob/living/carbon/human/target, oldloc, oldlocs)
@@ -241,7 +241,7 @@
 /datum/action/ability/activable/xeno/firestorm/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/pyrogen/xeno = owner
 
-	if(!do_after(xeno, 1 SECONDS, IGNORE_HELD_ITEM, target, BUSY_ICON_DANGER))
+	if(!do_after(xeno, 0.6 SECONDS, IGNORE_HELD_ITEM, target, BUSY_ICON_DANGER))
 		return fail_activate()
 
 	if(!can_use_ability(target, FALSE, ABILITY_IGNORE_PLASMA))
@@ -351,13 +351,13 @@
 				if(debuff)
 					damage += debuff.stacks * PYROGEN_HEATRAY_BONUS_DAMAGE_PER_MELTING_STACK
 
-				human_victim.take_overall_damage(damage, BURN, ACID, updating_health = TRUE, max_limbs = 2)
+				human_victim.take_overall_damage(damage, BURN, FIRE, updating_health = TRUE, max_limbs = 2)
 
 				human_victim.flash_weak_pain()
 				animation_flash_color(human_victim)
 			else if(isvehicle(victim))
 				var/obj/vehicle/veh_victim = victim
-				veh_victim.take_damage(PYROGEN_HEATRAY_HIT_DAMAGE, BURN, ACID)
+				veh_victim.take_damage(PYROGEN_HEATRAY_HIT_DAMAGE, BURN, FIRE)
 	if(world.time - started_firing > PYROGEN_HEATRAY_MAXDURATION)
 		stop_beaming()
 		return


### PR DESCRIPTION

## About The Pull Request
Reduces the ability delay of pyro's tornado and fireball ability to 0.6 seconds, down from 1 second. Increases the charge range by 2 tiles (5 tiles range), and changes the damage of pyros abilities from acid to fire.
## Why It's Good For The Game
Pyro is currently a very weak caste, being a squishy frontliner with sluggish abilities and a short range charge meant to combo with it's other abilities to do damage. These buffs aim to help make it be better at front-lining while keeping it as a squishy caste. The fire change is due to the caste dealing acid damage being incredibly unintuitive. Also 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/7e877f90-5098-452d-9825-c7f7152d9c1c)
## Changelog
:cl:
balance: Reduced the ability delay on pyrogens fireball and fire tornado to 0.6 seconds, down from 1 second.
balance: Increased the fire charge range by 2 tiles (from 3 tiles to 5 tiles)
balance: Changed pyros damage from acid to fire
/:cl:
