### PR TITLE
Fix hugger bounce for real

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -390,7 +390,6 @@
 		if(!Attach(carbon_victim))
 			go_idle()
 	else
-		step(src, REVERSE_DIR(dir))
 		if(!issamexenohive(carbon_victim))
 			carbon_victim.adjust_stagger(3 SECONDS)
 			carbon_victim.add_slowdown(3)


### PR DESCRIPTION

## About The Pull Request
Fixed huggers bouncing off mobs for real.

Turns out there was a funny 2nd snowflake bounce call.

:cl:
fix: fixed huggers bouncing off mobs (again)
/:cl:
