### PR TITLE
Razorwires now shock charging xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -515,6 +515,7 @@
 	span_danger("The barbed wire slices into you!"), null, 5)
 	charger.Paralyze(0.5 SECONDS)
 	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, sharp = TRUE, updating_health = TRUE) //Armor is being ignored here.
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, charger) // To trigger egrill element, bump and shock if possible.
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	update_icon()
 	return PRECRUSH_ENTANGLED //Let's return this so that the charger may enter the turf in where it's entangled, if it survived the wounds without gibbing.


### PR DESCRIPTION
## About The Pull Request
Charging xenos now bump razorwires (assuming it wasn't killed in one hit). This means razorwires that are connected to the powernet will shock them.

## Why It's Good For The Game
It is kind of weird that slashing shocked razorwires is big owie, but charging face first into shocked razorwires doesn't. Feels like oversight. 

## Changelog
:cl:
balance: Xenomorphs that charge into shocked razorwires now bump into it and consequently get shocked.
/:cl: