### PR TITLE
Tank AOE damage stuff

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -182,7 +182,10 @@
 	return root.take_damage(arglist(args))
 
 /obj/hitbox/ex_act(severity)
-	return
+	root.ex_act(severity)
+
+/obj/hitbox/lava_act()
+	root.lava_act()
 
 ///2x2 hitbox version
 /obj/hitbox/medium

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -35,3 +35,18 @@
 	if(!.)
 		return
 	return (loc_override || (entering_mob.loc in enter_locations(entering_mob)))
+
+/obj/vehicle/sealed/armored/multitile/ex_act(severity)
+	if(QDELETED(src))
+		return
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			take_damage(INFINITY, BRUTE, BOMB, 0)
+		if(EXPLODE_HEAVY)
+			take_damage(80, BRUTE, BOMB, 0)
+		if(EXPLODE_LIGHT)
+			take_damage(10, BRUTE, BOMB, 0)
+		//weak explosions do nothing
+
+/obj/vehicle/sealed/armored/multitile/lava_act()
+	take_damage(30, BURN, FIRE)

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -49,4 +49,6 @@
 		//weak explosions do nothing
 
 /obj/vehicle/sealed/armored/multitile/lava_act()
+	if(QDELETED(src))
+		return
 	take_damage(30, BURN, FIRE)


### PR DESCRIPTION

## About The Pull Request
Make ex_act/lava_act consistant for multitile vehicles.

Currently both these effects are very strange for tanks.
Explosions do nothing unless they hit the middle turf (the tank object itself) while lava hits it for EVERY tile in lava.

Made them both consistant in this behavior - the more vehicle turfs in an explosion/lava, the more damage.
Reduced the damage for both of these to take this into account.

Weak explosions simply do nothing to tanks, while light does very little and heavy does a fair bit (dev still qdels)
Lava does 30 instead of 50 per tile, but considering the speed of a tank, trying to traverse an actual lava lake is still a sure fire why to lose your ride.

This also means you essentially get bonus damage if you catch the centre of the tank in lava or an explosion.

The numbers are kinda whatever, since it only really applies for FF, but this does notably mean tanks shooting 1 tile in front of them are now going to hurt themselves a lot more.
## Why It's Good For The Game
Consistant/clearer damage application from explosions and lava.
Less benefit to blowing yourself up with the tank cannon.
## Changelog
:cl:
balance: Explosions now effect tanks for every tile of tank impacted, but the damage per tile has been reduced to compensate
/:cl:
