### PR TITLE
Pyrogen Fire Charge description correction

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -1142,7 +1142,7 @@
 /datum/keybinding/xeno/firecharge
 	name = "Fire Charge"
 	full_name = "Pyrogen: Fire Charge"
-	description = "Charge with the power of the fire , burn the first marine you come across."
+	description = "Charge forward and attack a marine, extinguishing them if they're on fire, but dealing extra burn damage depending on how many firestacks they have."
 	keybind_signal = COMSIG_XENOABILITY_FIRECHARGE
 
 /datum/keybinding/xeno/firenado

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -4,7 +4,7 @@
 /datum/action/ability/activable/xeno/charge/fire_charge
 	name = "Fire Charge"
 	action_icon_state = "fireslash"
-	desc = "Charge up to 3 tiles, inflicting a stack of melting flame and slashing them with a fiery claw. "
+	desc = "Charge up to 3 tiles, attacking any organic you come across. Extinguishes the target if they were set on fire, but deals extra damage depending on how many fire stacks they have."
 	cooldown_duration = 4 SECONDS
 	ability_cost = 30
 	keybinding_signals = list(


### PR DESCRIPTION

## About The Pull Request

The description implies that the ability adds a stack of melting flame - It doesn't. What the ability actually does is extinguish the target, and deal extra damage depending on how many firestacks they have.

## Why It's Good For The Game

Less pyrogens charging a guy on fire and wondering - WHY HE NO SET ON FIRE AND WHY HE EXTINGUISH

## Changelog
:cl:
spellcheck: Pyrogen Fire Charge ability now accurately describes what it does - Extinguish the target and deal extra damage depending on their fire stacks
/:cl:
