### PR TITLE
Removes an egregious object fling trap in Slumbridge

### DIFF
--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -18,12 +18,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning,
 /area/slumbridge/outside/northwest/nearlz)
-"abi" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "abr" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/open/floor/prison/plate,
@@ -58,6 +52,14 @@
 /obj/effect/landmark/corpsespawner/engineer/regular,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
+"ado" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/slumbridge/landingzonetwo)
 "adG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/ammonia,
@@ -102,13 +104,6 @@
 "aeY" = (
 /turf/open/floor/prison/yellow,
 /area/slumbridge/inside/prison/innerring)
-"afi" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "afB" = (
 /turf/open/floor/plating/platebot,
 /area/slumbridge/inside/engi/south)
@@ -145,6 +140,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest/nearlz)
+"ahj" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -233,15 +235,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
-"alb" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "alt" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
@@ -269,6 +262,15 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/west)
+"amj" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/slumbridge/outside/southwest)
 "amS" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -295,6 +297,13 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
+"aoM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "aoP" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -382,6 +391,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/hangar)
+"arE" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "arG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -393,13 +408,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/dmg3,
 /area/slumbridge/caves/mining)
-"ass" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "asu" = (
 /turf/closed/wall/r_wall/prison,
 /area/slumbridge/inside/prison/outerringnorth)
@@ -413,19 +421,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
-"asF" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
-"asR" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "ata" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -553,21 +548,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
-"ayc" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
-"ayr" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
 "ayK" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -577,14 +557,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
-"azn" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 9
-	},
-/area/slumbridge/landingzonetwo)
 "azv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -697,12 +669,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
-"aDK" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "aDY" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -714,6 +680,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/landingzonetwo)
+"aEf" = (
+/obj/structure/platform/nondense{
+	dir = 6
+	},
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "aEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -723,15 +695,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red/corner,
 /area/slumbridge/inside/sombase/hangar)
-"aEQ" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 9
-	},
-/area/slumbridge/outside/southwest)
 "aFa" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/floor,
@@ -804,6 +767,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
+"aIx" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "aIE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
@@ -828,12 +798,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringnorth)
-"aJC" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "aJV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -909,6 +873,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"aMN" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "aMY" = (
 /turf/open/lavaland/basalt/dirt{
 	dir = 8
@@ -949,6 +917,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
+"aNZ" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/outside/northwest)
 "aOl" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/power/apc/drained{
@@ -957,6 +931,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery)
+"aOA" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "aOP" = (
 /obj/structure/inflatable/wall,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -974,6 +955,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/houses/dorms)
+"aPj" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "aPl" = (
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/dark,
@@ -1023,6 +1011,12 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
+"aRA" = (
+/obj/structure/platform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "aRF" = (
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -1067,11 +1061,6 @@
 "aSt" = (
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
-"aSx" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete,
-/area/slumbridge/outside/southwest)
 "aSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/gibspawner/human,
@@ -1093,6 +1082,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark/red2,
+/area/slumbridge/landingzoneone)
+"aTl" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating/mainship,
 /area/slumbridge/landingzoneone)
 "aTp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
@@ -1367,6 +1360,16 @@
 "bcU" = (
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
+"bdW" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs/seamless/edge{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "beg" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/tile/dark/green2,
@@ -1437,12 +1440,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner,
 /area/slumbridge/inside/colony/hydro)
-"bgE" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "bhd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -1487,6 +1484,13 @@
 /obj/machinery/light,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
+"bif" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/shuttle/drop2/lz2)
 "bim" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1507,6 +1511,12 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating/platebot,
 /area/slumbridge/landingzoneone)
+"biH" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "biM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -1553,13 +1563,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/innerring)
-"bkd" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "bkk" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -1753,13 +1756,6 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/drop1/lz1)
-"bpJ" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 10
-	},
-/area/slumbridge/outside/southwest)
 "bpU" = (
 /obj/machinery/door/airlock/mainship/medical/free_access{
 	name = "\improper Medical Clinic Morgue"
@@ -1857,6 +1853,9 @@
 /obj/effect/spawner/random/misc/structure/broken_window,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
+"buT" = (
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outerringnorth)
 "bvk" = (
 /obj/machinery/shower,
 /obj/effect/landmark/weed_node,
@@ -1914,14 +1913,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/central)
-"bwP" = (
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "bxk" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 9
@@ -1974,6 +1965,15 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
+"byL" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest/nearlz)
 "bzj" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -2122,6 +2122,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
+"bDe" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "bDi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
@@ -2148,6 +2155,12 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/south)
+"bEd" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2/corner,
+/area/slumbridge/landingzonetwo)
 "bEC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2207,12 +2220,6 @@
 	dir = 4
 	},
 /area/slumbridge/outside/northwest/nearlz)
-"bHk" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 4
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "bHo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -2288,11 +2295,6 @@
 	},
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/inside/zeta/south)
-"bIY" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/structure/fence/broken,
-/turf/open/floor/plating,
-/area/slumbridge/outside/northeast)
 "bJa" = (
 /obj/effect/turf_decal/warning_stripes/smallstripe,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2405,24 +2407,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
-"bLn" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "bLo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor/tile/dark/blue2/corner,
 /area/slumbridge/inside/colony/headoffice)
-"bLr" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "bLu" = (
 /obj/effect/ai_node,
 /turf/open/floor,
@@ -2439,15 +2429,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"bMb" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest/nearlz)
 "bNd" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -2573,12 +2554,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"bSw" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "bSF" = (
 /turf/open/floor/bcircuit,
 /area/slumbridge/inside/engi/engineroom)
@@ -2649,6 +2624,13 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/slumbridge/landingzonetwo)
+"bVu" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "bVF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
@@ -2828,10 +2810,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"cce" = (
-/obj/structure/platform_decoration,
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
+"cbY" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/shuttle/escapepod,
+/area/slumbridge/inside/zeta/entrance)
 "ccu" = (
 /obj/structure/prop/mainship/research/tankcompressor{
 	name = "tank transfer compressor"
@@ -2861,22 +2847,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"cdy" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines,
-/area/slumbridge/outside/southwest)
-"cdz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "cdK" = (
 /obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2901,6 +2871,14 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"cfg" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 9
+	},
+/area/slumbridge/landingzonetwo)
 "cfj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/gm/dense,
@@ -2939,11 +2917,21 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"chu" = (
+"chv" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/houses/car)
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
+"chQ" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/slumbridge/outside/southwest)
 "chT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/yellow{
@@ -3048,6 +3036,13 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/west)
+"clx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "clC" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -3143,12 +3138,13 @@
 	dir = 10
 	},
 /area/slumbridge/inside/houses/recreational)
-"cnV" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
+"cnv" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/inside/sombase/east)
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "coG" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3165,6 +3161,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/sombase/west)
+"cph" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/obj/structure/fence/broken,
+/turf/open/floor/plating,
+/area/slumbridge/outside/northeast)
 "cpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -3182,16 +3184,6 @@
 /obj/effect/turf_decal/riverdecal,
 /turf/open/liquid/water/river,
 /area/slumbridge/inside/hydrotreatment)
-"cpG" = (
-/obj/effect/turf_decal/trimline/purple/arrow_ccw,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery)
 "cpL" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/nwcargo)
@@ -3223,12 +3215,6 @@
 /obj/structure/bed/chair/sofa/corsat/left,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery)
-"cqj" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "cqo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -3319,13 +3305,6 @@
 /obj/effect/landmark/corpsespawner/miner/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
-"cun" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "cuu" = (
 /obj/machinery/light{
 	dir = 1
@@ -3339,11 +3318,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/prison/innerring)
-"cuX" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/outside/northeast)
 "cuY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3395,10 +3369,6 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
-"cxE" = (
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "cxI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -3462,13 +3432,6 @@
 	dir = 4
 	},
 /area/slumbridge/landingzonetwo)
-"cAw" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 6
-	},
-/area/slumbridge/outside/southwest)
 "cAA" = (
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
@@ -3510,10 +3473,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/houses/car)
-"cBH" = (
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery)
 "cCr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -3691,6 +3650,12 @@
 /obj/mecha_wreckage/ripley/lv624,
 /turf/open/floor/plating/ground/concrete/edge,
 /area/slumbridge/outside/southwest)
+"cIy" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "cIK" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
 	name = "Back Entry"
@@ -3746,24 +3711,6 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
-"cKW" = (
-/obj/structure/prop/mainship/mission_planning_system{
-	name = "\improper Miner Oversight";
-	pixel_x = -1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
-"cKZ" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "cLt" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
@@ -3857,6 +3804,13 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/outerringsouth)
+"cOp" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "cOs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -3879,6 +3833,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
+"cOZ" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/structure/prop/mainship/hangar_stencil,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "cPr" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -4086,11 +4047,6 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"cZr" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "cZG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/side{
@@ -4121,6 +4077,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
+"daf" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/slumbridge/landingzonetwo)
 "dal" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4128,21 +4092,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"daA" = (
-/obj/structure/flora/jungle/vines,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "daW" = (
 /obj/structure/table,
 /turf/open/floor/tile/yellow{
 	dir = 5
 	},
 /area/slumbridge/inside/engi/west)
-"dbK" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/mainship/ai,
-/area/slumbridge/inside/houses/recreational)
 "dbX" = (
 /obj/structure/table/mainship,
 /obj/structure/reagent_dispensers/fueltank,
@@ -4216,10 +4171,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/scorched,
 /area/slumbridge/inside/pmcdome)
-"ddG" = (
-/obj/structure/stairs/seamless/platform_vert,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "ddR" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -4262,9 +4213,18 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
+"dgj" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "dgF" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/zeta/north)
+"dgV" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/mainship/ai,
+/area/slumbridge/inside/houses/recreational)
 "dhf" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/weaponry/gun/sidearms,
@@ -4429,12 +4389,6 @@
 	},
 /turf/open/floor/tile/lightred/full,
 /area/slumbridge/inside/colony/southerndome)
-"dmE" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/outside/northeast)
 "dmJ" = (
 /obj/structure/barricade/wooden,
 /obj/structure/sign/safety/medical_supplies{
@@ -4512,6 +4466,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
+"dpc" = (
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "dpk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4536,6 +4498,12 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/caves/southeastcaves)
+"dqC" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "dqI" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4550,6 +4518,12 @@
 "dsd" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/medical/southern)
+"dsq" = (
+/obj/structure/lattice,
+/turf/open/liquid/lava/side{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "dsw" = (
 /obj/structure/cable,
 /turf/open/floor/tile/showroom,
@@ -4703,6 +4677,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkred/full,
 /area/slumbridge/inside/prison/outerringnorth)
+"dyC" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "dyD" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -4720,6 +4700,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
+"dzU" = (
+/obj/structure/prop/mainship/gelida/powerccable{
+	dir = 4
+	},
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "dAd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -4729,12 +4718,6 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery/garbledradio)
-"dAr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/misc/structure/chair_or_metal/east,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "dAM" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -4764,6 +4747,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
+"dBP" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "dBR" = (
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/sombase/east)
@@ -4801,12 +4793,6 @@
 	},
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
-"dDc" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "dDp" = (
 /obj/effect/mist,
 /turf/open/liquid/water/river/autosmooth,
@@ -4952,11 +4938,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
-"dIC" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
+"dIK" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "dIV" = (
 /obj/effect/spawner/random/misc/structure/wooden_table,
 /turf/open/floor/wood,
@@ -5031,13 +5019,12 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"dLz" = (
-/obj/effect/ai_node,
-/obj/structure/platform_decoration{
-	dir = 1
+"dLE" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
 	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "dLK" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -5066,14 +5053,6 @@
 "dNc" = (
 /turf/closed/gm,
 /area/slumbridge/inside/medical/storage)
-"dNf" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "dNm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -5101,10 +5080,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"dOw" = (
-/obj/effect/landmark/corpsespawner/PMC/regular,
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/outside/southwest)
 "dOP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5133,6 +5108,12 @@
 /obj/mecha_wreckage/ripley/lv624,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/southwest)
+"dQu" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "dQz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5206,10 +5187,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"dSd" = (
-/obj/structure/window/framed/prison/reinforced,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/outerringsouth)
 "dSm" = (
 /obj/item/spacecash/c20{
 	pixel_x = -11;
@@ -5291,10 +5268,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/slumbridge/outside/northwest)
-"dUf" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "dUn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -5349,6 +5322,14 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"dWF" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "dWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -5416,12 +5397,14 @@
 /obj/item/weapon/gun/shotgun/double,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/zeta/north)
-"dZF" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
+"dZz" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
 	},
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/slumbridge/landingzonetwo)
 "dZM" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /turf/open/floor,
@@ -5496,22 +5479,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
-"edg" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
-"edn" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "edw" = (
 /turf/open/floor/prison,
 /area/slumbridge/outside/southwest)
@@ -5522,6 +5489,12 @@
 	dir = 6
 	},
 /area/slumbridge/inside/zeta/north)
+"edT" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "eeH" = (
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/kitchen)
@@ -5532,18 +5505,6 @@
 "efd" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/outerringnorth)
-"efs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
-"efB" = (
-/obj/structure/flora/jungle/vines,
-/turf/closed/mineral/smooth/snowrock,
-/area/slumbridge/caves/rock)
 "efI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -5584,14 +5545,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
-"egI" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/slumbridge/landingzonetwo)
 "egR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -5624,12 +5577,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"ekp" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 9
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
+"ejB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/sombase/east)
+"ekj" = (
+/obj/structure/fence/broken,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "ekz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5843,21 +5799,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"etf" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
-"etk" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/slumbridge/outside/southwest)
 "etn" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -5999,11 +5940,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
-"exU" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "exY" = (
 /obj/structure/table/fancywoodentable,
 /turf/open/floor/tile/dark/green2{
@@ -6109,6 +6045,11 @@
 /obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/prison/whitegreen,
 /area/slumbridge/inside/prison/outerringsouth)
+"eEa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/green,
+/area/slumbridge/inside/houses/recreational)
 "eEu" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/vault{
@@ -6140,12 +6081,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/outside/northeast/bridges)
-"eGl" = (
-/obj/structure/sign/hydro{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "eGV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -6158,11 +6093,6 @@
 /obj/structure/flora/pottedplant/eighteen,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"eHB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/wood/broken,
-/area/slumbridge/inside/sombase/east)
 "eHL" = (
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/prison/red{
@@ -6237,6 +6167,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green,
 /area/slumbridge/inside/prison/innerring)
+"eLC" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "eLG" = (
 /turf/closed/shuttle/ert/engines/left{
 	dir = 1
@@ -6264,6 +6201,13 @@
 	dir = 10
 	},
 /area/slumbridge/outside/northwest)
+"eNi" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "eNl" = (
 /obj/machinery/science/analyser,
 /turf/open/floor/mainship/green/corner{
@@ -6329,6 +6273,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
+"eQb" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/slumbridge/inside/prison/outerringsouth)
 "eQj" = (
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/houses/car)
@@ -6363,13 +6311,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
-"eRV" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/outerringnorth)
 "eRY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6428,6 +6369,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"eUv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/houses/car)
 "eUy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6439,10 +6385,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
-"eUS" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/dark,
-/area/slumbridge/inside/colony/construction)
 "eUX" = (
 /obj/effect/turf_decal/tracks/claw1/bloody{
 	dir = 4
@@ -6453,6 +6395,14 @@
 	dir = 8
 	},
 /area/slumbridge/inside/zeta/south)
+"eUZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/sombase/west)
 "eVa" = (
 /obj/mecha_wreckage/mauler,
 /turf/open/floor/plating/platebotc,
@@ -6511,17 +6461,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/east)
-"eWG" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/mainship/ai,
-/area/slumbridge/inside/houses/recreational)
 "eWU" = (
 /obj/structure/cargo_container/green{
 	dir = 1
@@ -6570,6 +6509,10 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
+"eYV" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/dark,
+/area/slumbridge/inside/colony/construction)
 "eYY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -6642,13 +6585,6 @@
 "fdl" = (
 /turf/open/floor/cult,
 /area/slumbridge/inside/medical/morgue)
-"fdr" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 10
-	},
-/obj/structure/prop/mainship/hangar_stencil,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "fdv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6752,12 +6688,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/central)
-"fgf" = (
-/obj/structure/lattice,
-/turf/open/liquid/lava/side{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "fgu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/scorched,
@@ -6776,11 +6706,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"fip" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/grass,
-/area/slumbridge/caves/mining)
 "fiB" = (
 /obj/structure/coatrack,
 /obj/item/clothing/suit/storage/security/formal/senior_officer/tan{
@@ -6857,10 +6782,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
-"flm" = (
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
 "flD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/bunkbed,
@@ -6878,6 +6799,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/prison/innerring)
+"fmA" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
 "fmI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -6885,6 +6812,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
+"fmO" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "fmY" = (
 /obj/structure/cable,
 /turf/open/floor/tile/green/greentaupe,
@@ -6939,6 +6872,12 @@
 /obj/structure/prop/mainship/gelida/lightstick,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/outside/southwest)
+"foV" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/inside/sombase/east)
 "foY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/drained{
@@ -6996,10 +6935,6 @@
 "fqe" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/outside/northwest)
-"fqB" = (
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "fqI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /obj/structure/cable,
@@ -7090,15 +7025,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
-"ftu" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 6
-	},
-/area/slumbridge/outside/southwest)
 "ftJ" = (
 /obj/structure/barricade/snow{
 	dir = 4
@@ -7293,10 +7219,6 @@
 /obj/item/reagent_containers/glass/beaker/vial,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"fAZ" = (
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "fBj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -7351,6 +7273,11 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
+"fDx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "fDN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -7392,11 +7319,22 @@
 "fFo" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/engi/engineroom)
+"fFr" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/outside/northeast)
 "fFz" = (
 /obj/structure/closet/crate/secure/gear,
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/shuttle/blackfloor,
 /area/slumbridge/inside/pmcdome/weaponvault)
+"fFW" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "fFZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -7414,6 +7352,10 @@
 "fHu" = (
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
+"fHO" = (
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery)
 "fHS" = (
 /obj/structure/barricade/metal{
 	dir = 4
@@ -7431,12 +7373,6 @@
 "fIy" = (
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/surgery)
-"fIH" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "fJi" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner{
@@ -7458,10 +7394,6 @@
 /obj/structure/flora/stump,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"fKj" = (
-/obj/effect/landmark/corpsespawner/scientist/burst,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "fKx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7629,6 +7561,11 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/tile/blue/whiteblue,
 /area/slumbridge/inside/medical/foyer)
+"fPR" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/fence/broken,
+/turf/open/floor/plating,
+/area/slumbridge/outside/northeast)
 "fPU" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/tile/purple/taupepurple{
@@ -7758,13 +7695,6 @@
 /obj/effect/landmark/corpsespawner/chef/regular,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/prison/outerringsouth)
-"fTt" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "fTA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -7953,6 +7883,12 @@
 /obj/effect/spawner/random/engineering/glass,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"gaI" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
 "gaJ" = (
 /obj/structure/bed/chair/office/light/east,
 /obj/effect/landmark/corpsespawner/pmc,
@@ -8020,6 +7956,11 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
+"gdy" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/slumbridge/outside/southwest)
 "gdN" = (
 /obj/structure/desertdam/decals/road,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -8032,6 +7973,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
+"ger" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "gev" = (
 /obj/machinery/light{
 	dir = 1
@@ -8048,14 +7995,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
-"gfa" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
-/area/slumbridge/landingzonetwo)
 "gfg" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/decal/cleanable/dirt,
@@ -8095,12 +8034,13 @@
 /obj/structure/mine_structure/wooden/support_wall/broken/above,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
-"ggn" = (
-/obj/structure/platform/nondense{
-	dir = 6
+"ggx" = (
+/obj/effect/ai_node,
+/obj/structure/platform_decoration{
+	dir = 8
 	},
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "ggF" = (
 /obj/structure/window/framed/wood,
 /turf/open/floor/wood/variable/wide,
@@ -8164,6 +8104,11 @@
 	dir = 2
 	},
 /area/slumbridge/inside/medical/foyer)
+"gjG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/shuttle/escapepod,
+/area/slumbridge/inside/zeta/entrance)
 "gka" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/darkish,
@@ -8282,15 +8227,6 @@
 	},
 /turf/open/shuttle/blackfloor,
 /area/slumbridge/inside/prison/outerringsouth)
-"gmo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/nwcargo)
 "gnd" = (
 /obj/machinery/light{
 	dir = 4
@@ -8326,11 +8262,6 @@
 	},
 /turf/open/floor/engine,
 /area/slumbridge/inside/engi/engineroom)
-"goJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/sombase/east)
 "goL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -8442,6 +8373,11 @@
 /obj/structure/mine_structure/wooden/support_wall/beams/above,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
+"gtn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/nondense,
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "gto" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/ai_node,
@@ -8498,12 +8434,6 @@
 "gwm" = (
 /turf/closed/gm,
 /area/slumbridge/outside/northeast)
-"gwq" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/mosaic,
-/area/slumbridge/inside/houses/dorms)
 "gwM" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/prison/plate,
@@ -8543,12 +8473,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
-"gxv" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "gxB" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -8618,6 +8542,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"gzB" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/asteroidplating,
+/area/slumbridge/inside/zeta/south)
 "gzC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/jungle/vines,
@@ -8657,12 +8585,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/hangar)
-"gCy" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "gCC" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
@@ -8678,6 +8600,13 @@
 /obj/item/toy/plush/slime,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/engi/west)
+"gDu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/swcargo)
 "gDQ" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -8716,10 +8645,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/slumbridge/outside/northeast/bridges)
-"gEv" = (
-/obj/structure/fence/broken,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "gEy" = (
 /obj/item/ore/slag{
 	pixel_x = -6;
@@ -8856,10 +8781,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
-"gJm" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating,
-/area/slumbridge/caves/northeastcaves)
 "gJA" = (
 /obj/machinery/power/port_gen/pacman/mrs,
 /turf/open/floor/prison/darkbrown/full,
@@ -9009,6 +8930,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
+"gOk" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "gON" = (
 /obj/structure/safe,
 /turf/open/floor/prison/blackfloor,
@@ -9064,10 +8991,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
-"gRS" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "gSj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -9092,6 +9015,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/slumbridge/inside/colony/northerndome)
+"gTr" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "gTH" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -9144,6 +9073,10 @@
 	},
 /turf/open/floor/tile/green,
 /area/slumbridge/inside/houses/recreational)
+"gUW" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/dorms)
 "gVa" = (
 /turf/open/floor/tile/green/whitegreencorner{
 	dir = 1
@@ -9198,10 +9131,6 @@
 "gWV" = (
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/outside/northeast/bridges)
-"gXc" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "gXd" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/tile/bar,
@@ -9263,16 +9192,20 @@
 "gYL" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/surgery)
+"gYQ" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
 "gZD" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/heatinggrate,
 /area/slumbridge/inside/colony/dorms)
-"gZI" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/outerringsouth)
 "gZN" = (
 /turf/open/lavaland/basalt,
 /area/slumbridge/inside/prison/outside)
@@ -9294,10 +9227,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/orestorage)
-"har" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/stripesquare,
-/area/slumbridge/inside/sombase/hangar)
 "haw" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/light{
@@ -9339,6 +9268,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
+"hbx" = (
+/obj/structure/fence/broken,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 5
+	},
+/area/slumbridge/outside/southwest)
 "hbH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -9361,12 +9299,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/northeast)
-"hdk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "hdl" = (
 /obj/structure/cryofeed{
 	name = "\improper coolant feed"
@@ -9405,17 +9337,6 @@
 "heP" = (
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
-"hfc" = (
-/obj/effect/ai_node,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
-"hfm" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/asteroidplating,
-/area/slumbridge/inside/zeta/south)
 "hfq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -9428,14 +9349,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
-"hfO" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 5
-	},
-/area/slumbridge/landingzonetwo)
 "hge" = (
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
@@ -9490,6 +9403,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"hhy" = (
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
+"hhA" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "hhZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9566,6 +9488,11 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/slumbridge/landingzoneone)
+"hld" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "hly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9609,12 +9536,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
-"hmo" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "hmG" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
@@ -9724,12 +9645,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/pharmacy)
-"hqi" = (
-/obj/structure/platform_decoration/metalplatform_deco{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
 "hqD" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/machinery/light{
@@ -9738,14 +9653,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
-"hqE" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "hqT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/blue2{
@@ -9763,6 +9670,15 @@
 /obj/effect/spawner/random/misc/structure/directional_window/north,
 /turf/open/floor/mainship/ai,
 /area/slumbridge/inside/houses/recreational)
+"hro" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "hrr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9777,13 +9693,17 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
+"hrB" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating,
+/area/slumbridge/caves/northeastcaves)
 "hrD" = (
 /obj/structure/table,
 /obj/machinery/computer/security,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
 "hrM" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
 "hrQ" = (
@@ -9829,6 +9749,11 @@
 "hsZ" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/foyer)
+"htI" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "htL" = (
 /obj/item/trash/cigbutt,
 /obj/structure/table,
@@ -9840,6 +9765,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/south)
+"hul" = (
+/obj/structure/platform_decoration/metalplatform_deco{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
 "huS" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -9849,6 +9780,17 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/hangar)
+"huT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "hvj" = (
 /turf/open/liquid/lava/lpiece{
 	dir = 4
@@ -9949,6 +9891,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"hye" = (
+/obj/structure/platform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "hyh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -10026,6 +9976,13 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
+"hAT" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "hBo" = (
 /obj/structure/table/mainship,
 /obj/structure/prop/mainship/minigun_crate,
@@ -10065,6 +10022,12 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringsouth)
+"hBS" = (
+/obj/structure/platform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "hCl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -10172,10 +10135,6 @@
 /area/slumbridge/inside/colony/southerndome)
 "hFc" = (
 /turf/open/floor/prison,
-/area/slumbridge/outside/northwest)
-"hFn" = (
-/obj/structure/lattice,
-/turf/open/liquid/lava/side,
 /area/slumbridge/outside/northwest)
 "hFx" = (
 /obj/structure/barricade/snow{
@@ -10425,6 +10384,14 @@
 /obj/structure/xenoautopsy/tank,
 /turf/open/floor/iron/freezer,
 /area/slumbridge/inside/sombase/west)
+"hPu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "hPK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -10537,16 +10504,6 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/landingzoneone)
-"hTQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs/seamless/edge{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "hUh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -10681,6 +10638,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/broken,
 /area/slumbridge/inside/colony/bar)
+"hYA" = (
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "hYC" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -10710,10 +10671,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/slumbridge/inside/colony/southerndome)
-"hZB" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "hZH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/razorwire{
@@ -10721,6 +10678,13 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
+"hZL" = (
+/obj/structure/prop/mainship/mission_planning_system{
+	name = "\improper Miner Oversight";
+	pixel_x = -1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "hZM" = (
 /obj/machinery/faxmachine/warden,
 /obj/structure/table/reinforced,
@@ -10996,11 +10960,6 @@
 "ijf" = (
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
-"ijz" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "ijT" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -11031,14 +10990,6 @@
 	},
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
-"ikl" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/red2/corner{
-	dir = 4
-	},
-/area/slumbridge/landingzonetwo)
 "ikm" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -11215,13 +11166,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"ioZ" = (
-/obj/effect/ai_node,
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
 "ipe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -11249,11 +11193,6 @@
 /obj/effect/ai_node,
 /turf/open/lavaland/basalt/glowing,
 /area/slumbridge/outside/northwest)
-"ipA" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "ipI" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 9
@@ -11269,12 +11208,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/zeta/north)
-"ipX" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "iqF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -11282,6 +11215,12 @@
 	dir = 5
 	},
 /area/slumbridge/inside/engi/central)
+"iqP" = (
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "iqR" = (
 /obj/effect/decal/cleanable/molten_item,
 /turf/open/floor,
@@ -11437,13 +11376,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/outerringnorth)
-"ivx" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "ivS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -11748,20 +11680,16 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
-"iHB" = (
-/obj/structure/fence/broken,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
 "iHI" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"iHV" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "iHY" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/plating,
@@ -11973,31 +11901,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/houses/nwcargo)
-"iQa" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
-	dir = 6
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "iQb" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall/prison,
 /area/slumbridge/inside/prison/outerringnorth)
+"iQm" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/wide,
+/area/slumbridge/inside/houses/dorms)
 "iQo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engineroom)
-"iQu" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "iQz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -12039,6 +11957,10 @@
 	},
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
+"iSf" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "iSw" = (
 /obj/structure/window_frame/wood,
 /turf/open/floor/wood/variable,
@@ -12117,11 +12039,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"iVr" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "iVs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -12164,29 +12081,10 @@
 /obj/machinery/light,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"iWI" = (
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/engine,
-/area/slumbridge/inside/engi/engineroom)
 "iWJ" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/prison/whitegreen/full,
 /area/slumbridge/inside/prison/outerringsouth)
-"iWK" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
-"iWV" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 9
-	},
-/area/slumbridge/outside/southwest)
 "iXb" = (
 /obj/item/paper/brassnote,
 /turf/open/floor/cult,
@@ -12242,12 +12140,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"jaz" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "jaC" = (
 /obj/effect/decal/cleanable/glass/plastic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -12272,12 +12164,6 @@
 /obj/structure/curtain/open/temple,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
-"jbT" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "jcd" = (
 /obj/structure/window/reinforced/north,
 /obj/structure/window/reinforced/east,
@@ -12345,11 +12231,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
-"jeJ" = (
-/obj/structure/girder/displaced,
-/obj/structure/flora/jungle/vines,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "jfr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -12367,6 +12248,12 @@
 	dir = 5
 	},
 /area/slumbridge/inside/medical/foyer)
+"jfI" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/outside/northeast)
 "jfS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/blue,
@@ -12426,13 +12313,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
-"jil" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "jiD" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/marking/bot,
@@ -12466,12 +12346,6 @@
 	},
 /turf/open/floor/scorched,
 /area/slumbridge/inside/pmcdome)
-"jky" = (
-/obj/structure/platform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "jkR" = (
 /obj/machinery/computer/sleep_console,
 /turf/open/floor/tile/bar,
@@ -12501,6 +12375,17 @@
 	},
 /turf/open/floor/freezer,
 /area/slumbridge/inside/colony/kitchen)
+"jlH" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "jlM" = (
 /turf/open/liquid/lava/lpiece,
 /area/slumbridge/outside/northwest)
@@ -12718,6 +12603,12 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/innerring)
+"jsI" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "jsP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -12782,6 +12673,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/heatinggrate,
 /area/slumbridge/inside/colony/dorms)
+"jvi" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/mainship/ai,
+/area/slumbridge/inside/houses/recreational)
 "jvt" = (
 /obj/structure/prop/mainship/telecomms/bus,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -13059,6 +12961,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"jGM" = (
+/obj/structure/prop/turbine,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/engine,
+/area/slumbridge/inside/engi/engineroom)
 "jGO" = (
 /obj/structure/table,
 /obj/machinery/computer/atmos_alert{
@@ -13084,7 +12991,7 @@
 	name = "\improper turbine oversight system"
 	},
 /obj/effect/turf_decal/siding/dark,
-/turf/open/floor/bcircuit,
+/turf/open/floor/engine,
 /area/slumbridge/inside/engi/engineroom)
 "jHn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -13217,22 +13124,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
-"jLm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/swcargo)
-"jLn" = (
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "jLs" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -13321,13 +13212,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/sombase/east)
-"jPS" = (
-/obj/structure/sign/securearea{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "jQk" = (
 /obj/structure/table/black,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -13409,14 +13293,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/mono,
 /area/slumbridge/inside/colony/northerndome)
-"jSj" = (
-/obj/structure/platform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "jSq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/junction/yjunc{
@@ -13503,12 +13379,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/colony/pharmacy)
-"jWR" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "jXm" = (
 /obj/effect/ai_node,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -13560,6 +13430,13 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
+"jYQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "jZs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13676,6 +13553,13 @@
 "kdw" = (
 /turf/closed/wall,
 /area/slumbridge/caves/mining)
+"kdy" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 10
+	},
+/area/slumbridge/outside/southwest)
 "kdF" = (
 /obj/structure/prop/mainship/railing{
 	dir = 4
@@ -13824,13 +13708,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/innerring)
-"kjk" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "kjA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13980,6 +13857,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroidfloor,
 /area/slumbridge/outside/northeast/bridges)
+"koX" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "kph" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -14015,12 +13898,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
-"kry" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "krL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14112,6 +13989,12 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/vault,
 /area/slumbridge/inside/sombase/east)
+"kuR" = (
+/obj/structure/sign/hydro{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "kvg" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 6
@@ -14188,10 +14071,6 @@
 /obj/item/toy/plush/rouny,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/engi/west)
-"kyL" = (
-/obj/structure/platform/nondense,
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "kyP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/generic{
@@ -14451,6 +14330,15 @@
 	},
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
+"kKQ" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 10
+	},
+/area/slumbridge/outside/southwest)
 "kKX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass{
 	dir = 2
@@ -14538,6 +14426,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"kNG" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/houses/recreational)
 "kNJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -14559,11 +14451,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
-"kOq" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "kOG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -14660,6 +14547,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"kQL" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "kQS" = (
 /obj/machinery/light{
 	dir = 4
@@ -14702,6 +14594,12 @@
 "kRn" = (
 /turf/open/floor/rustyplating,
 /area/slumbridge/inside/prison/innerring)
+"kRt" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "kRv" = (
 /obj/effect/turf_decal/tracks/claw1/bloody{
 	dir = 4
@@ -14779,6 +14677,16 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"kTw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "kTH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red{
@@ -14832,6 +14740,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/ai,
 /area/slumbridge/inside/houses/recreational)
+"kVQ" = (
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "kVT" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/ai_node,
@@ -14853,6 +14765,10 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/storage)
+"kWD" = (
+/obj/effect/landmark/corpsespawner/PMC/regular,
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/outside/southwest)
 "kWF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/smooth/bigred,
@@ -14944,6 +14860,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
+"kZG" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "kZM" = (
 /obj/effect/spawner/random/misc/trash,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -14967,6 +14889,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/full,
 /area/slumbridge/inside/colony/southerndome)
+"lbl" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outerringsouth)
+"lbs" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/cult,
+/area/slumbridge/caves/northeastcaves)
 "lbv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15039,11 +14970,6 @@
 "leg" = (
 /turf/open/lavaland/basalt,
 /area/slumbridge/outside/northwest)
-"lel" = (
-/obj/effect/spawner/random/misc/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "leo" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
@@ -15054,6 +14980,16 @@
 	},
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
+"leQ" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
+"leW" = (
+/obj/structure/window/framed/prison/reinforced,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outerringsouth)
 "lff" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15085,10 +15021,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/houses/recreational)
-"lgx" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "lgJ" = (
 /obj/effect/landmark/patrol_point/tgmc_23,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -15104,6 +15036,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"lhc" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "lhd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -15175,6 +15114,9 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"ljt" = (
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "ljx" = (
 /obj/effect/turf_decal/riverdecal,
 /turf/open/liquid/water/river/autosmooth/deep,
@@ -15196,22 +15138,12 @@
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/sombase/east)
-"lkX" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/dorms)
 "llt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
-"llX" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "lms" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -15220,9 +15152,6 @@
 "lmC" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/ice,
-/area/slumbridge/landingzonetwo)
-"lmE" = (
-/turf/open/floor/plating/mainship,
 /area/slumbridge/landingzonetwo)
 "lmQ" = (
 /obj/structure/table/reinforced/flipped{
@@ -15332,6 +15261,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
+"lqs" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/wide,
+/area/slumbridge/inside/houses/dorms)
 "lqy" = (
 /obj/machinery/light{
 	dir = 8
@@ -15481,13 +15416,6 @@
 	dir = 6
 	},
 /area/slumbridge/inside/houses/recreational)
-"lwm" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
 "lwr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -15535,16 +15463,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/zeta/south)
-"lxP" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "lyo" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -15599,10 +15517,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/zeta/entrance)
-"lAy" = (
-/obj/effect/landmark/corpsespawner/PMC/regular,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "lAB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -15788,11 +15702,9 @@
 	dir = 10
 	},
 /area/slumbridge/inside/engi/west)
-"lGv" = (
-/obj/structure/platform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
+"lGq" = (
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
 "lGS" = (
 /turf/open/lavaland/basalt/dirt/corner,
@@ -15833,12 +15745,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/north)
-"lJw" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "lJC" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -15910,6 +15816,16 @@
 "lKR" = (
 /turf/open/floor/tile/brown,
 /area/slumbridge/inside/houses/dorms)
+"lKS" = (
+/obj/effect/turf_decal/trimline/purple/arrow_ccw,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery)
 "lKY" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/prison/red{
@@ -15975,10 +15891,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/prison/innerring)
-"lMU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/outside/northwest)
 "lNg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -16030,10 +15942,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
-"lNZ" = (
-/obj/structure/prop/vehicle/tank/east/armor,
-/turf/open/floor/mainship/stripesquare,
-/area/slumbridge/inside/sombase/hangar)
 "lOb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -16053,13 +15961,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"lOZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
+"lOv" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "lPH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -16096,6 +16003,12 @@
 	dir = 1
 	},
 /area/slumbridge/inside/zeta/entrance)
+"lQX" = (
+/obj/structure/sign/hydro/three{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "lRc" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -16167,12 +16080,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/car)
-"lUc" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/northeast)
 "lUg" = (
 /obj/structure/plasticflaps/mining,
 /turf/open/floor/plating/platebot,
@@ -16183,12 +16090,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/foyer)
-"lUi" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest/nearlz)
 "lUz" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
@@ -16215,6 +16116,10 @@
 	dir = 4
 	},
 /area/slumbridge/caves/mining)
+"lUO" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/mining)
 "lUS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -16234,10 +16139,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
-"lVx" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating,
-/area/slumbridge/inside/prison/outerringsouth)
 "lVB" = (
 /obj/structure/cargo_container/red,
 /turf/open/floor/asteroidfloor,
@@ -16245,6 +16146,12 @@
 "lVG" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
+"lVM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/sombase/west)
 "lWc" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -16298,15 +16205,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/hangar)
-"lZe" = (
-/obj/structure/fence/broken,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 5
-	},
-/area/slumbridge/outside/southwest)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
@@ -16388,10 +16286,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/northerndome)
-"mbY" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "mca" = (
 /turf/open/lavaland/basalt/glowing,
 /area/slumbridge/outside/northwest)
@@ -16409,9 +16303,6 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"mcs" = (
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/outerringnorth)
 "mcD" = (
 /obj/item/ore/slag{
 	pixel_x = -3;
@@ -16535,13 +16426,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringsouth)
-"mgG" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/swcargo)
 "mgJ" = (
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/mainship/red{
@@ -16571,15 +16455,6 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
-/area/slumbridge/outside/southwest)
-"mhz" = (
-/obj/structure/prop/mainship/gelida/powerccable{
-	dir = 4
-	},
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
 "mhV" = (
 /obj/structure/rock/basalt/alt3,
@@ -16654,10 +16529,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/recreational)
-"mjK" = (
-/obj/structure/lattice,
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "mjM" = (
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -16676,13 +16547,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"mkc" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "mkf" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/slumbridge/outside/northwest)
@@ -16707,6 +16571,10 @@
 /obj/structure/flora/jungle/vines,
 /turf/closed/gm,
 /area/slumbridge/caves/rock)
+"mkV" = (
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/plating,
+/area/slumbridge/inside/sombase/east)
 "mll" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -16755,6 +16623,13 @@
 /obj/item/ammo_casing,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/west)
+"mno" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "mnL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -16874,6 +16749,10 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating,
 /area/slumbridge/outside/southeast)
+"msm" = (
+/obj/effect/landmark/corpsespawner/PMC/regular,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "mtn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -16902,6 +16781,12 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/east)
+"muu" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "muU" = (
 /turf/open/liquid/lava/side{
 	dir = 4
@@ -16919,6 +16804,10 @@
 	dir = 4
 	},
 /area/slumbridge/outside/northeast/bridges)
+"mvy" = (
+/obj/structure/stairs/seamless/platform_vert,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "mvD" = (
 /obj/machinery/light{
 	dir = 4
@@ -16940,6 +16829,12 @@
 "mwo" = (
 /turf/closed/wall,
 /area/slumbridge/inside/medical/foyer)
+"mwq" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/mosaic,
+/area/slumbridge/inside/houses/dorms)
 "mwr" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor,
@@ -16996,15 +16891,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
-"mxR" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/slumbridge/outside/southwest)
 "mxS" = (
 /obj/structure/flora/jungle/vines,
 /obj/structure/fence,
@@ -17017,7 +16903,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
 "myx" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
 /obj/effect/turf_decal/sandytile/sandyplating,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
@@ -17044,6 +16930,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
+"mzs" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "mzF" = (
 /obj/structure/table/fancywoodentable,
 /obj/machinery/computer/crew,
@@ -17085,12 +16977,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/zeta/entrance)
-"mAI" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "mAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -17120,6 +17006,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
+"mCh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/wood/broken,
+/area/slumbridge/inside/sombase/east)
 "mCv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor/glass,
 /turf/open/floor/plating,
@@ -17129,6 +17020,12 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"mCR" = (
+/obj/structure/platform_decoration,
+/turf/open/liquid/lava/lpiece{
+	dir = 8
+	},
+/area/slumbridge/outside/northwest)
 "mCS" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/red/corner,
@@ -17186,13 +17083,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"mEC" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "mFf" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/tray,
@@ -17270,12 +17160,6 @@
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/storage)
-"mJi" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "mJo" = (
 /obj/machinery/landinglight/lz2,
 /turf/open/floor/tile/dark,
@@ -17322,6 +17206,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
+"mLW" = (
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "mLX" = (
 /obj/structure/flora/pottedplant/one,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -17477,6 +17367,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/northerndome)
+"mSk" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "mSv" = (
 /obj/effect/turf_decal/sandytile,
 /obj/effect/ai_node,
@@ -17512,6 +17408,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
+"mUL" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/mineral/smooth/bigred,
+/area/slumbridge/caves/rock)
 "mVc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -17532,6 +17432,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
+"mVH" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete,
+/area/slumbridge/outside/southwest)
 "mVO" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced,
@@ -17766,12 +17671,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
-"neO" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
 "neU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17879,6 +17778,10 @@
 "niQ" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/pmcdome/dorms)
+"niX" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "niY" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
@@ -18078,14 +17981,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"noc" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
+"nof" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "noy" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/sombase/hangar)
@@ -18126,6 +18026,12 @@
 /obj/effect/spawner/random/food_or_drink/sugary_snack,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/kitchen)
+"nrL" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "nrM" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/effect/ai_node,
@@ -18232,12 +18138,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"ntY" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "nuw" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 4
@@ -18256,11 +18156,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
-"nuW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/green,
-/area/slumbridge/inside/houses/recreational)
 "nva" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -18313,10 +18208,12 @@
 "nwg" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop1/lz1)
-"nwi" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
+"nwh" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "nwn" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1
@@ -18399,11 +18296,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
-"nyH" = (
-/obj/structure/prop/turbine,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/bcircuit,
-/area/slumbridge/inside/engi/engineroom)
 "nyQ" = (
 /obj/effect/spawner/random/misc/structure/directional_window/east,
 /obj/effect/decal/cleanable/dirt,
@@ -18489,12 +18381,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
-"nCf" = (
-/obj/structure/platform/metalplatform/nondense{
+"nBH" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
+"nBJ" = (
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outside)
 "nCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -18563,13 +18461,6 @@
 	},
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery/garbledradio)
-"nDG" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "nDL" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/dmg1,
@@ -18971,13 +18862,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/medical/southern)
-"nTu" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "nTY" = (
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
@@ -19167,11 +19051,9 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/headoffice)
-"nZF" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
+"nZy" = (
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "nZR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -19212,7 +19094,7 @@
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
 "obs" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/plating,
 /area/slumbridge/caves/northeastcaves)
 "obu" = (
@@ -19357,6 +19239,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"ogP" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "ohp" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -19452,15 +19341,6 @@
 	dir = 5
 	},
 /area/slumbridge/caves/northwestcaves)
-"okT" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 5
-	},
-/area/slumbridge/outside/southwest)
 "okV" = (
 /turf/open/ground/grass,
 /area/slumbridge/outside/southeast)
@@ -19599,6 +19479,14 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"opP" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "opT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -19679,6 +19567,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"ote" = (
+/obj/structure/platform/nondense,
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "otE" = (
 /obj/structure/largecrate/random/case,
 /obj/effect/turf_decal/sandytile,
@@ -19726,13 +19618,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/zeta/south)
-"ouI" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "ovd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -19795,11 +19680,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"oxZ" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "oyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -19848,6 +19728,11 @@
 "ozh" = (
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/slumbridge/outside/southeast)
+"ozr" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/slumbridge/outside/southwest)
 "ozE" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/mainship/silver{
@@ -19921,6 +19806,10 @@
 /obj/structure/cargo_container/hd_blue,
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/landingzoneone)
+"oCE" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "oCR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/floor,
@@ -19931,13 +19820,6 @@
 	dir = 1
 	},
 /area/slumbridge/outside/northwest/nearlz)
-"oEg" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "oEl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -19961,6 +19843,10 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/hangar)
+"oFn" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "oFB" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor,
@@ -20021,6 +19907,10 @@
 "oGR" = (
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/south)
+"oHg" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/houses/car)
 "oHh" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/marking/loadingarea,
@@ -20068,6 +19958,16 @@
 /obj/machinery/light,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
+"oJA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/slumbridge/inside/medical/foyer)
 "oJC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -20107,12 +20007,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/dorms)
-"oLq" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "oLs" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1;
@@ -20164,13 +20058,6 @@
 /obj/effect/spawner/random/engineering/radio,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"oNd" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8
-	},
-/obj/effect/turf_decal/riverdecal,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "oNl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -20348,11 +20235,9 @@
 	},
 /area/slumbridge/inside/prison/innerring)
 "oUU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/sombase/west)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/stripesquare,
+/area/slumbridge/inside/sombase/hangar)
 "oVn" = (
 /obj/item/weapon/sword/machete,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -20420,6 +20305,12 @@
 "oXX" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop2/lz2)
+"oYm" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "oYP" = (
 /obj/structure/table/mainship,
 /obj/machinery/light,
@@ -20605,6 +20496,13 @@
 /obj/effect/spawner/random/misc/cigar,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
+"pew" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "pff" = (
 /obj/item/shard,
 /obj/effect/ai_node,
@@ -20640,6 +20538,13 @@
 /obj/effect/spawner/random/food_or_drink/outdoors_snacks,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
+"phK" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "phV" = (
 /obj/structure/rack{
 	color = "#50617d"
@@ -20753,15 +20658,6 @@
 /obj/structure/closet/wardrobe/virology_white,
 /turf/open/floor/mainship/sterile,
 /area/slumbridge/inside/sombase/west)
-"pma" = (
-/obj/structure/prop/mainship/mission_planning_system{
-	name = "\improper Miner Oversight";
-	pixel_x = -1
-	},
-/turf/open/floor/plating/ground/snow/layer2{
-	dir = 6
-	},
-/area/slumbridge/outside/southwest)
 "pmA" = (
 /obj/effect/landmark/corpsespawner/engineer/regular,
 /turf/open/floor,
@@ -20857,6 +20753,13 @@
 /obj/item/reagent_containers/glass/bottle/tramadol,
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
+"pqB" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/colony/northerndome)
 "pqL" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 5
@@ -20925,13 +20828,6 @@
 	dir = 4
 	},
 /area/slumbridge/landingzonetwo)
-"psr" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "psz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20964,11 +20860,6 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/caves/mining)
-"ptl" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "ptr" = (
 /obj/structure/closet/bodybag,
 /turf/open/floor/tile/bar,
@@ -20985,16 +20876,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
-"ptF" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "ptO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/green2/corner,
@@ -21064,6 +20945,12 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringnorth)
+"pvF" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "pvH" = (
 /obj/machinery/door_control/old/unmeltable{
 	id = "NorthBaseSomArmory";
@@ -21149,6 +21036,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
+"pys" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/outside/northwest)
+"pyy" = (
+/obj/structure/prop/mainship/mission_planning_system{
+	name = "\improper Miner Oversight";
+	pixel_x = -1
+	},
+/turf/open/floor/plating/ground/snow/layer2{
+	dir = 6
+	},
+/area/slumbridge/outside/southwest)
 "pyW" = (
 /obj/effect/landmark/patrol_point/som/som_24,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -21157,9 +21058,9 @@
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass,
 /turf/open/floor/foamplating,
 /area/slumbridge/inside/prison/innerring)
-"pzv" = (
+"pzr" = (
 /obj/structure/platform/metalplatform/nondense{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/construction)
@@ -21216,6 +21117,10 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/marking/warning,
 /area/slumbridge/outside/northeast/bridges)
+"pBb" = (
+/obj/structure/lattice,
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "pBm" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/effect/decal/cleanable/dirt,
@@ -21245,10 +21150,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/slumbridge/inside/colony/southerndome)
-"pDK" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/slumbridge/inside/prison/outerringsouth)
 "pDT" = (
 /obj/structure/prop/mainship/research/tdoppler,
 /turf/open/floor/tile/yellow/full,
@@ -21415,6 +21316,9 @@
 	dir = 8
 	},
 /area/slumbridge/inside/medical/foyer)
+"pMp" = (
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outerringsouth)
 "pMs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21438,6 +21342,15 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/south)
+"pNt" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 6
+	},
+/area/slumbridge/outside/southwest)
 "pNw" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -21533,7 +21446,7 @@
 /area/slumbridge/inside/houses/dorms)
 "pPl" = (
 /obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
+/obj/item/reagent_containers/cup/glass/drinkingglass{
 	pixel_x = -7;
 	pixel_y = -1
 	},
@@ -21585,9 +21498,6 @@
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
-/area/slumbridge/inside/prison/outerringsouth)
-"pRV" = (
-/turf/open/lavaland/catwalk,
 /area/slumbridge/inside/prison/outerringsouth)
 "pSg" = (
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -21769,6 +21679,12 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
+"pYm" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/northeast)
 "pYB" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -21811,6 +21727,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/outside/northwest)
+"qal" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
+"qaF" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
 "qaJ" = (
 /obj/structure/safe/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -21892,6 +21823,10 @@
 "qcF" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/zeta/entrance)
+"qcM" = (
+/obj/effect/landmark/corpsespawner/scientist/burst,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "qcR" = (
 /obj/structure/prop/mainship/research/mechafab,
 /turf/open/floor/tile/yellow/full,
@@ -21904,13 +21839,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/slumbridge/outside/southwest)
-"qdz" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
+"qdC" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "qdH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -22008,13 +21940,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/zeta/north)
-"qhy" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/structure/platform_decoration,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "qhA" = (
 /obj/machinery/light{
 	dir = 4
@@ -22134,12 +22059,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
-"qkV" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
 "qll" = (
 /obj/structure/barricade/snow,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -22210,6 +22129,12 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/hangar)
+"qnT" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "qor" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -22231,6 +22156,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/vault,
 /area/slumbridge/inside/sombase/east)
+"qoE" = (
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "qoG" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -22248,12 +22176,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/minedrock)
-"qpP" = (
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "qqg" = (
 /obj/structure/table,
 /obj/item/bodybag,
@@ -22371,9 +22293,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/houses/surgery)
-"qtQ" = (
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "qug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/green/whitegreen,
@@ -22437,12 +22356,6 @@
 /obj/effect/spawner/random/misc/plushie/fiftyfifty,
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/inside/houses/dorms)
-"qwF" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "qxg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -22477,6 +22390,15 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"qxD" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 5
+	},
+/area/slumbridge/outside/southwest)
 "qxE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -22586,6 +22508,16 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
+"qCd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "qCL" = (
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest/nearlz)
@@ -22689,13 +22621,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
-"qFQ" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "qFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22830,18 +22755,17 @@
 "qKo" = (
 /turf/closed/wall/prison,
 /area/slumbridge/inside/prison/innerring)
-"qKr" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "qKX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"qLg" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 9
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "qLt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -22939,6 +22863,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
+"qNS" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
+"qNY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/swcargo)
 "qOc" = (
 /obj/machinery/light{
 	dir = 4
@@ -22964,26 +22904,10 @@
 /obj/machinery/space_heater,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
-"qPf" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "qPW" = (
 /obj/machinery/vending/marineFood/som,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
-"qPX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "qPY" = (
 /obj/structure/prop/mainship/sensor_computer1,
 /obj/machinery/light{
@@ -23327,12 +23251,14 @@
 /obj/structure/razorwire,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"rby" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 10
+"rbu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/safety/vacuum{
+	dir = 4
 	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "rbI" = (
 /obj/structure/bed/chair/wood/normal,
 /obj/effect/decal/cleanable/dirt,
@@ -23423,6 +23349,12 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
+"rfK" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "rgh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stairs/rampbottom{
@@ -23475,6 +23407,12 @@
 	dir = 9
 	},
 /area/slumbridge/caves/minedrock)
+"riM" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "riN" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -23497,13 +23435,6 @@
 	dir = 6
 	},
 /area/slumbridge/inside/sombase/hangar)
-"rjn" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/riverdecal,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "rjq" = (
 /obj/structure/cargo_container/red{
 	dir = 1
@@ -23644,17 +23575,6 @@
 "rok" = (
 /turf/open/floor/prison/sterilewhite,
 /area/slumbridge/inside/prison/outerringsouth)
-"ros" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/closed/mineral/smooth/snowrock,
-/area/slumbridge/caves/rock)
-"roy" = (
-/obj/machinery/floodlight/landing,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/shuttle/drop2/lz2)
 "roD" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /turf/open/floor/tile/showroom,
@@ -23748,32 +23668,12 @@
 	dir = 5
 	},
 /area/slumbridge/inside/prison/innerring)
-"rqt" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/wide,
-/area/slumbridge/inside/houses/dorms)
 "rqO" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
-"rqP" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/houses/car)
-"rrp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/tile/green/whitegreencorner{
-	dir = 8
-	},
-/area/slumbridge/inside/medical/foyer)
 "rrr" = (
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
@@ -23795,13 +23695,6 @@
 "rrK" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/zeta/south)
-"rsD" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "rsH" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -23809,6 +23702,12 @@
 /obj/effect/landmark/corpsespawner/doctor/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/pharmacy)
+"rsO" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
 "rtb" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -23845,6 +23744,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"ruH" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "ruN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23864,6 +23770,13 @@
 /obj/structure/ore_box,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/oreprocess)
+"ruY" = (
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "rvd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -23900,6 +23813,10 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"rwa" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/mineral/smooth/snowrock,
+/area/slumbridge/caves/rock)
 "rwr" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/decal/cleanable/dirt,
@@ -23936,18 +23853,17 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/south)
-"rxc" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/shuttle/escapepod,
-/area/slumbridge/inside/zeta/entrance)
 "rxl" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/west)
+"rxT" = (
+/obj/effect/ai_node,
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
 "ryG" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -23962,13 +23878,6 @@
 /obj/structure/flora/pottedplant/six,
 /turf/open/floor/mainship/plate,
 /area/slumbridge/inside/sombase/east)
-"rzd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "rzf" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/lavaland/basalt,
@@ -24100,6 +24009,22 @@
 /obj/structure/prop/mainship/gelida/planterboxsoilgrid/nondense,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/caves/mining)
+"rDt" = (
+/obj/structure/fence/broken,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
+"rDw" = (
+/obj/structure/sign/securearea{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "rDy" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -24113,12 +24038,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"rEK" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "rEO" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -24168,6 +24087,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
+"rGs" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "rGT" = (
 /turf/open/floor/prison/green/corner{
 	dir = 1
@@ -24178,6 +24103,16 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/west)
+"rHx" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "rHI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -24389,6 +24324,14 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/headoffice)
+"rPe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/nwcargo)
 "rPt" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -24443,26 +24386,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/north)
-"rQR" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/lavaland/catwalk,
-/area/slumbridge/outside/northwest)
+"rQV" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "rRm" = (
 /obj/effect/spawner/random/engineering/structure/tank_dispenser,
 /obj/effect/turf_decal/warning_stripes/box,
 /obj/effect/turf_decal/warning_stripes/linethick,
 /turf/open/floor/plating,
 /area/slumbridge/inside/pmcdome)
-"rRJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
+"rRz" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/slumbridge/inside/prison/outerringsouth)
 "rRL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/generic{
@@ -24548,17 +24487,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringsouth)
-"rVn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/ai_node,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/freezer,
-/area/slumbridge/inside/houses/recreational)
-"rVw" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "rVx" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/plating,
@@ -24588,6 +24516,13 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
+"rWs" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "rWw" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -24734,12 +24669,6 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"saO" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "sbk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24954,11 +24883,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/inside/colony/vault)
-"shb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/shuttle/escapepod,
-/area/slumbridge/inside/zeta/entrance)
 "shI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -24981,14 +24905,6 @@
 "sia" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
-"sih" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/sombase/west)
 "sip" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -25039,12 +24955,6 @@
 "skd" = (
 /turf/closed/mineral/smooth/bluefrostwall,
 /area/slumbridge/caves/rock)
-"skF" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/red2/corner,
-/area/slumbridge/landingzonetwo)
 "skH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -25289,6 +25199,12 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
+"swt" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "swv" = (
 /obj/structure/prop/mainship/gelida/powerccable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -25336,10 +25252,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/west)
-"sys" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "syw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody,
@@ -25404,15 +25316,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
-"sAW" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 10
-	},
-/area/slumbridge/outside/southwest)
 "sAX" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/attachable/bayonetknife/som,
@@ -25433,9 +25336,6 @@
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
-"sBB" = (
-/turf/open/lavaland/catwalk,
-/area/slumbridge/inside/prison/outside)
 "sBD" = (
 /obj/structure/sink/bathroom,
 /obj/effect/decal/cleanable/dirt,
@@ -25450,6 +25350,12 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/central)
+"sCj" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "sCk" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/zeta/entrance)
@@ -25469,12 +25375,6 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"sDb" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "sDd" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/grass,
@@ -25579,11 +25479,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"sGX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform/nondense,
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "sHv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -25605,14 +25500,6 @@
 "sHO" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/bar)
-"sHT" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "sHV" = (
 /obj/structure/inflatable/wall,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -25636,10 +25523,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"sJa" = (
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "sJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -25717,13 +25600,6 @@
 /obj/structure/flora/jungle/vines,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/caves/southeastcaves/garbledradio)
-"sMv" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "sMG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -25775,6 +25651,10 @@
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
 /area/slumbridge/inside/houses/surgery)
+"sPu" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/engine,
+/area/slumbridge/inside/engi/engineroom)
 "sPE" = (
 /obj/structure/inflatable/wall,
 /obj/effect/ai_node,
@@ -25895,6 +25775,11 @@
 /obj/effect/landmark/corpsespawner/colonist/regular,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
+"sSp" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "sSG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26018,12 +25903,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringsouth)
-"sXz" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "sXA" = (
 /obj/structure/cargo_container/nt,
 /turf/open/floor/tile/dark/purple2{
@@ -26059,10 +25938,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/houses/recreational)
-"sYp" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "sYP" = (
 /obj/structure/prop/mainship/gelida/powerccable,
 /obj/machinery/light{
@@ -26070,6 +25945,10 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining/dropship)
+"sYV" = (
+/obj/structure/platform_decoration,
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "sZa" = (
 /turf/open/liquid/lava/side{
 	dir = 4
@@ -26110,12 +25989,6 @@
 /obj/structure/rock/basalt/pile,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
-"taZ" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/lavaland/catwalk,
-/area/slumbridge/outside/northwest)
 "tbj" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -26535,6 +26408,12 @@
 	dir = 6
 	},
 /area/slumbridge/inside/zeta/south)
+"trZ" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "tsb" = (
 /obj/structure/cable,
 /turf/open/floor/tile/showroom,
@@ -26566,6 +26445,17 @@
 "tti" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/dorms)
+"ttT" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
+"ttW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/freezer,
+/area/slumbridge/inside/houses/recreational)
 "tuh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26635,6 +26525,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/prison/outerringsouth)
+"twZ" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "txe" = (
 /obj/structure/prop/mainship/gelida/powerconnector{
 	dir = 8
@@ -26662,12 +26558,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/colony/northerndome)
-"txJ" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "tyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -26712,6 +26602,9 @@
 	},
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/southeast)
+"tzx" = (
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/outside/northwest)
 "tzA" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
@@ -26768,10 +26661,6 @@
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
-"tBy" = (
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/plating,
-/area/slumbridge/inside/sombase/east)
 "tBz" = (
 /obj/effect/turf_decal/warning_stripes/linethick,
 /obj/effect/decal/cleanable/dirt,
@@ -26891,6 +26780,13 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/surgery)
+"tFk" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "tFo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
@@ -26905,12 +26801,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
-"tFR" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/effect/ai_node,
-/obj/structure/fence/broken,
-/turf/open/floor/plating,
-/area/slumbridge/outside/northeast)
 "tFX" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
@@ -26920,12 +26810,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery/garbledradio)
-"tGR" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "tGX" = (
 /obj/structure/rock/basalt/pile/alt,
 /obj/effect/ai_node,
@@ -27032,12 +26916,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/slumbridge/inside/sombase/west)
-"tKZ" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "tLY" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -27109,13 +26987,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/dmg1,
 /area/slumbridge/outside/southwest)
-"tOD" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/colony/northerndome)
 "tOF" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/bar)
@@ -27192,6 +27063,10 @@
 /obj/item/clothing/under/shorts/green,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
+"tSr" = (
+/obj/structure/lattice,
+/turf/open/liquid/lava/side,
+/area/slumbridge/outside/northwest)
 "tSt" = (
 /obj/structure/table/gamblingtable,
 /obj/effect/spawner/random/misc/trash,
@@ -27240,10 +27115,6 @@
 /obj/item/bedsheet/rd,
 /turf/open/floor/tile/dark/blue2/corner,
 /area/slumbridge/inside/colony/headoffice)
-"tUc" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/cult,
-/area/slumbridge/caves/northeastcaves)
 "tUf" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -27390,6 +27261,11 @@
 /obj/effect/spawner/random/misc/structure/suit_storage,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
+"tZi" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/grass,
+/area/slumbridge/caves/mining)
 "tZp" = (
 /obj/structure/table/fancywoodentable,
 /obj/effect/spawner/random/misc/paperbin,
@@ -27439,6 +27315,11 @@
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/outside/northwest/nearlz)
+"ubL" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "ucw" = (
 /obj/machinery/light{
 	dir = 8
@@ -27510,14 +27391,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/surgery)
+"ueV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "ueZ" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"ufd" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "ufz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -27592,6 +27475,12 @@
 	dir = 10
 	},
 /area/slumbridge/outside/southwest)
+"uiy" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "uiS" = (
 /obj/structure/inflatable/wall,
 /turf/open/floor/tile/dark,
@@ -27615,16 +27504,15 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
+"ujh" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "ujs" = (
 /obj/effect/spawner/random/misc/structure/broken_window,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
-"ujv" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 6
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "ujQ" = (
 /obj/structure/bed/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -27660,6 +27548,12 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/central)
+"ukz" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "ukA" = (
 /obj/machinery/light{
 	dir = 4
@@ -27920,12 +27814,6 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
-"uvx" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "uvY" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
@@ -28023,6 +27911,13 @@
 "uAZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
+/area/slumbridge/outside/southwest)
+"uBi" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 6
+	},
 /area/slumbridge/outside/southwest)
 "uBq" = (
 /obj/effect/spawner/random/misc/trash,
@@ -28190,6 +28085,13 @@
 	dir = 6
 	},
 /area/slumbridge/inside/engi/central)
+"uHr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/outerringnorth)
 "uHI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -28206,11 +28108,6 @@
 /obj/structure/cable,
 /turf/open/floor/dark2,
 /area/slumbridge/inside/engi/engineroom)
-"uIu" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "uIF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -28284,6 +28181,11 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
+"uMa" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "uMl" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/blackfloor,
@@ -28413,6 +28315,13 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/prison/red,
 /area/slumbridge/inside/prison/innerring)
+"uQg" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "uQn" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /obj/machinery/door/poddoor/shutters/opened{
@@ -28429,10 +28338,14 @@
 "uRv" = (
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"uRw" = (
+"uRH" = (
 /obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating/ground/concrete/lines,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
 /area/slumbridge/outside/southwest)
 "uRP" = (
 /obj/effect/spawner/random/misc/structure/securecloset/regular,
@@ -28467,6 +28380,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/slumbridge/inside/engi/south)
+"uSv" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/mineral/smooth/snowrock,
+/area/slumbridge/caves/rock)
 "uSw" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/ai_node,
@@ -28506,6 +28423,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/landingzonetwo)
+"uUn" = (
+/obj/effect/ai_node,
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "uUE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -28557,6 +28481,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"uWo" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "uWA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -28659,12 +28589,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
-"vbj" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "vbs" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
@@ -28672,10 +28596,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/southwest)
-"vbx" = (
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue/taupebluecorner,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "vbB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -28707,12 +28627,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engineroom)
-"vcm" = (
-/obj/structure/platform_decoration,
-/turf/open/liquid/lava/lpiece{
-	dir = 8
-	},
-/area/slumbridge/outside/northwest)
 "vdl" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -28859,15 +28773,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/houses/swcargo)
-"vhX" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
 "vie" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -28901,6 +28806,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile,
 /area/slumbridge/inside/medical/surgery)
+"vje" = (
+/obj/effect/spawner/random/misc/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "vjh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -28987,18 +28897,17 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
-"vmp" = (
-/obj/structure/sign/hydro/three{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "vmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"vmw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "vmx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white/warningstripe{
@@ -29037,9 +28946,20 @@
 	dir = 1
 	},
 /area/slumbridge/outside/northwest)
+"vns" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "vnL" = (
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/colony/northerndome)
+"vnM" = (
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "vnZ" = (
 /obj/structure/rack,
 /obj/item/explosive/plastique{
@@ -29108,6 +29028,10 @@
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
+"vpW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/outside/northwest)
 "vqn" = (
 /turf/open/floor/mainship/red{
 	dir = 6
@@ -29116,6 +29040,12 @@
 "vqW" = (
 /turf/open/floor/plating/ground/ice,
 /area/slumbridge/caves/southwestcaves)
+"vrb" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "vrd" = (
 /obj/item/spacecash/c1{
 	pixel_x = -8;
@@ -29146,6 +29076,12 @@
 /obj/structure/closet/toolcloset,
 /turf/open/shuttle/escapepod,
 /area/slumbridge/inside/zeta/entrance)
+"vrs" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "vrF" = (
 /obj/structure/sign/safety/vent{
 	dir = 1
@@ -29183,11 +29119,6 @@
 "vsE" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/surgery)
-"vsU" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "vtg" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/northerndome)
@@ -29329,6 +29260,12 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
+"vyt" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/outside/northwest)
 "vyM" = (
 /turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/slumbridge/caves/rock)
@@ -29357,14 +29294,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery/garbledradio)
-"vzT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/nwcargo)
 "vAf" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -29667,6 +29596,15 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"vJn" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/slumbridge/outside/southwest)
 "vJA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/warning{
@@ -29725,10 +29663,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/closed/wall/mainship/outer/canterbury,
 /area/slumbridge/caves/mining/dropship)
-"vMe" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/closed/gm,
-/area/slumbridge/caves/rock)
 "vME" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/normalweighted,
 /turf/open/floor/marking/bot,
@@ -29744,6 +29678,10 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating,
 /area/slumbridge/landingzonetwo)
+"vMN" = (
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "vNq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/kitchen,
@@ -29759,12 +29697,13 @@
 "vNL" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
-"vNM" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 10
+"vNU" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
 	},
-/turf/open/floor/plating/mainship,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 5
+	},
 /area/slumbridge/landingzonetwo)
 "vOb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29870,12 +29809,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/grass,
 /area/slumbridge/caves/mining)
-"vSc" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "vSo" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/light{
@@ -30042,6 +29975,20 @@
 "vVw" = (
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
+"vVz" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 4
+	},
+/area/slumbridge/landingzonetwo)
+"vVJ" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "vVK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -30120,12 +30067,6 @@
 "waa" = (
 /turf/open/floor/podhatch/floor,
 /area/slumbridge/inside/pmcdome/nukevault)
-"waz" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 6
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "waB" = (
 /turf/closed/wall,
 /area/slumbridge/outside/southwest/nearlz)
@@ -30280,18 +30221,19 @@
 /obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/slumbridge/inside/prison/innerring)
-"wfE" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/lavaland/catwalk,
-/area/slumbridge/outside/northwest)
 "wfI" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/misc/bedsheet,
 /obj/effect/landmark/corpsespawner/colonist/regular,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/dorms)
+"wfM" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "wfQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -30320,10 +30262,6 @@
 /obj/structure/mine_structure/wooden/support_wall/beams/above,
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
-"wgA" = (
-/obj/structure/flora/jungle/vines,
-/turf/closed/mineral/smooth/bigred,
-/area/slumbridge/caves/rock)
 "wgG" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small{
@@ -30366,6 +30304,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"whE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "whJ" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -30648,6 +30594,12 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/west)
+"wqO" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "wrd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -30655,6 +30607,12 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/pharmacy)
+"wrm" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "wrq" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -30717,15 +30675,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/colony/bar)
-"wtZ" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 4
-	},
-/area/slumbridge/outside/southwest)
 "wuc" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1
@@ -30762,9 +30711,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
-"wuS" = (
-/turf/open/lavaland/catwalk,
-/area/slumbridge/outside/northwest)
 "wvq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/folder/nooffset,
@@ -30961,12 +30907,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/asteroidwarning,
 /area/slumbridge/outside/northeast/bridges)
-"wCj" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "wCo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -31074,6 +31014,11 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/slumbridge/inside/colony/vault)
+"wGx" = (
+/obj/structure/girder/displaced,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "wGS" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -31101,6 +31046,13 @@
 	},
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
+"wHO" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "wHU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -31221,12 +31173,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
-"wLW" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "wLZ" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /turf/open/floor/tile/dark,
@@ -31305,6 +31251,14 @@
 /obj/structure/xenoautopsy/tank/alien,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/slumbridge/inside/colony/northerndome)
+"wOH" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "wOK" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/surgery/garbledradio)
@@ -31324,6 +31278,11 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/dorms)
+"wPu" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/mainship,
@@ -31378,6 +31337,15 @@
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"wSA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/nwcargo)
 "wSN" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 4
@@ -31436,6 +31404,10 @@
 	},
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/landingzonetwo)
+"wUB" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "wUD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -31638,6 +31610,12 @@
 	dir = 1
 	},
 /area/slumbridge/caves/mining/dropship)
+"xbB" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest/nearlz)
 "xbC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -31812,20 +31790,28 @@
 "xiI" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/sombase/west)
-"xiM" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
+"xiY" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "xjw" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"xks" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "xkx" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
 "xkI" = (
@@ -31875,13 +31861,6 @@
 "xmG" = (
 /turf/closed/mineral/smooth,
 /area/slumbridge/caves/northeastcaves)
-"xmJ" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "xmM" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
@@ -31935,6 +31914,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
+"xpQ" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "xpV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -31991,10 +31977,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/houses/surgery/garbledradio)
-"xrw" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/houses/recreational)
 "xry" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -32047,19 +32029,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"xuk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "xul" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/yellow{
 	dir = 8
 	},
 /area/slumbridge/inside/engi/south)
+"xun" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "xuA" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -32182,13 +32163,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/hydrotreatment)
-"xzZ" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/wide,
-/area/slumbridge/inside/houses/dorms)
 "xAb" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -32275,12 +32249,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/hangar)
-"xDz" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
 "xDF" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	color = "#ff6969"
@@ -32288,6 +32256,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
+"xDM" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "xDR" = (
 /obj/structure/flora/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -32304,6 +32278,15 @@
 	dir = 5
 	},
 /area/slumbridge/inside/sombase/east)
+"xEL" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/slumbridge/outside/southwest)
 "xEO" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/dirt,
@@ -32362,14 +32345,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/south)
-"xGq" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/slumbridge/landingzonetwo)
 "xGy" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
@@ -32404,6 +32379,15 @@
 	dir = 1
 	},
 /area/slumbridge/inside/pmcdome)
+"xGY" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
+	dir = 6
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "xHc" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -32423,6 +32407,12 @@
 	dir = 1
 	},
 /area/slumbridge/outside/southwest)
+"xHV" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "xIx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -32455,14 +32445,12 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"xKe" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/sign/safety/vacuum{
-	dir = 4
+"xJL" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
 	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "xKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -32546,6 +32534,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"xMO" = (
+/obj/structure/prop/vehicle/tank/east/armor,
+/turf/open/floor/mainship/stripesquare,
+/area/slumbridge/inside/sombase/hangar)
+"xNm" = (
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "xNr" = (
 /turf/open/floor/stairs/rampbottom,
 /area/slumbridge/outside/northwest)
@@ -32641,12 +32637,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"xQQ" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "xRH" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/decal/cleanable/dirt,
@@ -32717,16 +32707,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
+"xUx" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "xUC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
-"xUH" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/mining)
 "xUM" = (
 /obj/structure/prop/mainship/telecomms/broadcaster,
 /turf/open/floor/tile/dark,
@@ -32795,6 +32787,13 @@
 	dir = 8
 	},
 /area/slumbridge/landingzonetwo)
+"xWQ" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "xXj" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 1
@@ -32835,9 +32834,6 @@
 /obj/effect/landmark/corpsespawner/miner/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
-"xYH" = (
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "xYJ" = (
 /obj/structure/cargo_container/hd{
 	dir = 4
@@ -33043,6 +33039,12 @@
 	},
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
+"yfj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/liquid/lava/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "yfr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/stripesquare,
@@ -33056,6 +33058,13 @@
 	dir = 10
 	},
 /area/slumbridge/inside/colony/oreprocess)
+"yfK" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "yfQ" = (
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/dorms)
@@ -33084,12 +33093,6 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/slumbridge/inside/pmcdome)
-"yhc" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "yhj" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/engi/west)
@@ -33180,13 +33183,6 @@
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning,
 /area/slumbridge/outside/northwest)
-"yjC" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "yjO" = (
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/marking/warning{
@@ -33234,6 +33230,10 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/tile/dark/brown2,
 /area/slumbridge/inside/colony/orestorage)
+"ylg" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm,
+/area/slumbridge/caves/rock)
 "yll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -34328,8 +34328,8 @@ ooG
 ooG
 ooG
 ooG
-ioZ
-flm
+rxT
+hhy
 tvO
 ooG
 ooG
@@ -34498,22 +34498,22 @@ pjL
 pjL
 szu
 sfW
-azn
-xGq
-xGq
-xGq
-xGq
-xGq
-xGq
-xGq
-xGq
-xGq
-xGq
+cfg
+ado
+ado
+ado
+ado
+ado
+ado
+ado
+ado
+ado
+ado
 sfW
 sfW
-xGq
-xGq
-xGq
+ado
+ado
+ado
 pzJ
 ffG
 pzJ
@@ -34522,9 +34522,9 @@ pzJ
 ffG
 pzJ
 fBt
-lJw
-rRJ
-vNM
+muu
+hro
+ogP
 nCu
 pjL
 xvW
@@ -34703,9 +34703,9 @@ sfW
 sfW
 sfW
 sfW
-gCy
-lmE
-dUf
+rGs
+ljt
+oCE
 fVX
 pjL
 xvW
@@ -34860,7 +34860,7 @@ sfW
 sfW
 ooG
 aEa
-gfa
+dZz
 sfW
 tqd
 wia
@@ -34884,9 +34884,9 @@ wia
 wia
 wia
 wia
-roy
-aDK
-ujv
+bif
+qNS
+gOk
 yiz
 pjL
 xvW
@@ -35041,7 +35041,7 @@ ooG
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 gyK
@@ -35222,7 +35222,7 @@ ooG
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -35403,7 +35403,7 @@ ahF
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -35584,7 +35584,7 @@ ooG
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -35765,7 +35765,7 @@ ooG
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -35946,7 +35946,7 @@ ahF
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -36082,22 +36082,22 @@ uSb
 vyM
 vyM
 vyM
-jbT
-jbT
-bHk
-bHk
-bHk
-bHk
-bHk
-bHk
-bHk
-bHk
-bHk
-jbT
-jbT
-jbT
-bHk
-jbT
+dqC
+dqC
+leQ
+leQ
+leQ
+leQ
+leQ
+leQ
+leQ
+leQ
+leQ
+dqC
+dqC
+dqC
+leQ
+dqC
 vqW
 vqW
 vqW
@@ -36127,7 +36127,7 @@ sfW
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -36279,9 +36279,9 @@ bYo
 bYo
 bYo
 bYo
-bLr
-jbT
-jbT
+ger
+dqC
+dqC
 vqW
 vqW
 vqW
@@ -36308,7 +36308,7 @@ sfW
 ooG
 ooG
 aEa
-gfa
+dZz
 sfW
 mJo
 uek
@@ -36463,7 +36463,7 @@ uvc
 dkI
 dkI
 dkI
-bLr
+ger
 vqW
 vqW
 vqW
@@ -36489,7 +36489,7 @@ sfW
 ooG
 aEa
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -36601,10 +36601,10 @@ ewT
 hNa
 leg
 mca
-vcm
+mCR
 lLa
 hvj
-dDc
+uWo
 sFG
 drD
 mkf
@@ -36645,7 +36645,7 @@ nmr
 nmr
 dkI
 dkI
-bLr
+ger
 vqW
 vqW
 skd
@@ -36670,7 +36670,7 @@ sfW
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 uek
@@ -36715,9 +36715,9 @@ jso
 bYh
 bYh
 bXQ
-llX
-qwF
-fdr
+kRt
+gTr
+cOZ
 qKi
 qKi
 qKi
@@ -36734,9 +36734,9 @@ lKd
 qKi
 qKi
 qKi
-llX
-qwF
-fdr
+kRt
+gTr
+cOZ
 qKi
 qYu
 qKi
@@ -36783,8 +36783,8 @@ hNa
 leg
 leg
 leg
-taZ
-taZ
+aNZ
+aNZ
 leg
 leg
 qgS
@@ -36827,7 +36827,7 @@ nmr
 nmr
 dkI
 dkI
-tKZ
+vrs
 vqW
 skd
 skd
@@ -36851,7 +36851,7 @@ sfW
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 mJo
 qDh
@@ -36896,9 +36896,9 @@ jso
 bYh
 qKi
 qKi
-jil
-xYH
-sYp
+aIx
+nZy
+aTl
 qKi
 qKi
 qKi
@@ -36915,9 +36915,9 @@ tyh
 qKi
 qKi
 qKi
-vbj
-xYH
-sYp
+lOv
+nZy
+aTl
 qKi
 qYu
 qKi
@@ -36963,10 +36963,10 @@ uoT
 dok
 pOU
 wRn
-vsU
-rQR
-rQR
-rzd
+fDx
+pys
+pys
+pew
 wRn
 pOU
 pOU
@@ -37008,7 +37008,7 @@ nmr
 nmr
 nmr
 dkI
-tKZ
+vrs
 vqW
 skd
 skd
@@ -37032,7 +37032,7 @@ ooG
 ooG
 ooG
 ooG
-gfa
+dZz
 sfW
 tqd
 qWU
@@ -37077,9 +37077,9 @@ bYh
 bYh
 qKi
 qKi
-xQQ
-nDG
-waz
+xUx
+ahj
+oYm
 qKi
 qKi
 qKi
@@ -37096,9 +37096,9 @@ qKi
 qKi
 qKi
 gsR
-xQQ
-xiM
-waz
+xUx
+jsI
+oYm
 gsR
 qYu
 qKi
@@ -37145,8 +37145,8 @@ duU
 duU
 lBv
 xNr
-wuS
-lMU
+tzx
+vpW
 dsV
 duU
 lBv
@@ -37189,7 +37189,7 @@ wdb
 nmr
 nmr
 dkI
-tKZ
+vrs
 vqW
 vqW
 skd
@@ -37326,8 +37326,8 @@ mkf
 hNa
 leg
 leg
-wfE
-wfE
+vyt
+vyt
 leg
 mca
 leg
@@ -37370,7 +37370,7 @@ alt
 nmr
 bIq
 bYo
-tKZ
+vrs
 vqW
 vqW
 skd
@@ -37394,31 +37394,31 @@ ooG
 ooG
 ooG
 ooG
-hfO
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
+vNU
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
 sfW
 sfW
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
-egI
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
+daf
 nSK
 qFO
 qFO
@@ -37506,10 +37506,10 @@ nGK
 mkf
 hNa
 leg
-txJ
+twZ
 eSw
 fXD
-saO
+swt
 leg
 leg
 qgS
@@ -37551,7 +37551,7 @@ alt
 nmr
 oge
 bYo
-tKZ
+vrs
 vqW
 vqW
 vqW
@@ -37586,8 +37586,8 @@ fnu
 ooG
 ooG
 ooG
-skF
-ikl
+bEd
+vVz
 ooG
 ooG
 ooG
@@ -37600,7 +37600,7 @@ ooG
 ooG
 ooG
 ooG
-hqi
+hul
 ooG
 bPI
 pjL
@@ -37732,7 +37732,7 @@ bCz
 nmr
 lRi
 oge
-tKZ
+vrs
 vqW
 vqW
 vqW
@@ -37855,10 +37855,10 @@ lpM
 gzE
 swK
 lyP
-ouI
-ouI
-ouI
-qdz
+cOp
+cOp
+cOp
+bDe
 uhD
 feW
 buv
@@ -37913,7 +37913,7 @@ alt
 nmr
 uvc
 lRi
-tKZ
+vrs
 skd
 vqW
 vqW
@@ -38039,7 +38039,7 @@ lyP
 sVR
 sVR
 sVR
-uIu
+hhA
 uhD
 feW
 buv
@@ -38093,7 +38093,7 @@ vTh
 oSy
 nmr
 bIq
-ekp
+qLg
 vyM
 vyM
 skd
@@ -38220,7 +38220,7 @@ tuv
 sVR
 xYi
 sVR
-uIu
+hhA
 uhD
 feW
 buv
@@ -38274,7 +38274,7 @@ alt
 mmJ
 nmr
 lRi
-bSw
+fFW
 vyM
 vyM
 skd
@@ -38398,10 +38398,10 @@ oJH
 hAE
 bkN
 lyP
-oEg
-cKZ
-alb
-iQa
+mno
+jlH
+nBH
+xGY
 osQ
 tOw
 lyP
@@ -38455,7 +38455,7 @@ alt
 qNF
 nmr
 lRi
-abi
+edT
 vyM
 vyM
 vqW
@@ -38580,9 +38580,9 @@ xzI
 tZg
 lyP
 feW
-oNd
+ruY
 cpF
-rjn
+eNi
 uhD
 feW
 buv
@@ -38637,7 +38637,7 @@ qNF
 nmr
 uvc
 oge
-abi
+edT
 vyM
 vqW
 vqW
@@ -38819,9 +38819,9 @@ nmr
 uvc
 bIq
 lRi
-yhc
-jbT
-jbT
+arE
+dqC
+dqC
 vqW
 skd
 vyM
@@ -39003,8 +39003,8 @@ bIq
 bYo
 bYo
 bYo
-bLr
-bHk
+ger
+leQ
 vyM
 vyM
 skd
@@ -39186,7 +39186,7 @@ bYo
 bYo
 bYo
 bYo
-wCj
+xun
 vyM
 skd
 vqW
@@ -39215,9 +39215,9 @@ nxb
 fnu
 ooG
 aEa
-lJw
-mJi
-vNM
+muu
+wqO
+ogP
 ooG
 plp
 cgP
@@ -39367,7 +39367,7 @@ bYo
 bYo
 bYo
 bYo
-yhc
+arE
 vyM
 skd
 vqW
@@ -39396,9 +39396,9 @@ nxb
 fnu
 aEa
 ooG
-gCy
-lmE
-dUf
+rGs
+ljt
+oCE
 ooG
 plp
 cgP
@@ -39549,7 +39549,7 @@ bYo
 lFH
 bYo
 bYo
-bSw
+fFW
 skd
 vqW
 vqW
@@ -39577,9 +39577,9 @@ fnu
 fnu
 ooG
 ooG
-gxv
-aDK
-ujv
+xJL
+qNS
+gOk
 ooG
 ooG
 ooG
@@ -39611,9 +39611,9 @@ bYh
 bXQ
 qKi
 qKi
-llX
-qwF
-fdr
+kRt
+gTr
+cOZ
 qKi
 qKi
 qKi
@@ -39630,9 +39630,9 @@ qKi
 qKi
 qKi
 qKi
-llX
-qwF
-fdr
+kRt
+gTr
+cOZ
 qKi
 qYu
 qKi
@@ -39730,8 +39730,8 @@ dkI
 bYo
 bYo
 bYo
-yhc
-bHk
+arE
+leQ
 vyM
 vqW
 vqW
@@ -39792,9 +39792,9 @@ bYh
 qKi
 qKi
 qKi
-vbj
-xYH
-sYp
+lOv
+nZy
+aTl
 qKi
 qKi
 lVB
@@ -39811,9 +39811,9 @@ oCu
 qKi
 qKi
 qKi
-vbj
-xYH
-sYp
+lOv
+nZy
+aTl
 qKi
 qYu
 qKi
@@ -39913,7 +39913,7 @@ bYo
 bYo
 bYo
 bYo
-abi
+edT
 vqW
 vqW
 skd
@@ -39973,9 +39973,9 @@ bYh
 bYh
 gsR
 iIV
-xQQ
-nDG
-waz
+xUx
+ahj
+oYm
 qKi
 qKi
 rjq
@@ -39992,9 +39992,9 @@ uML
 qKi
 qKi
 qKi
-xQQ
-xiM
-waz
+xUx
+jsI
+oYm
 qKi
 qYu
 qKi
@@ -40073,10 +40073,10 @@ bIq
 rfs
 uvc
 mku
-sDb
-xmJ
-ntY
-rby
+rfK
+xWQ
+qal
+pvF
 bIq
 iZo
 nmr
@@ -40095,7 +40095,7 @@ lFH
 bYo
 bYo
 bYo
-bLr
+ger
 vqW
 skd
 vyM
@@ -40223,12 +40223,12 @@ nGK
 mkf
 hNa
 leg
-cce
-mjK
-hFn
-fgf
-mjK
-hfc
+sYV
+pBb
+tSr
+dsq
+pBb
+ggx
 sFG
 drD
 mkf
@@ -40254,10 +40254,10 @@ bIq
 bIq
 rfs
 rfs
-bgE
+trZ
 mNJ
 mNJ
-ufd
+wPu
 bIq
 rfs
 nmr
@@ -40277,7 +40277,7 @@ bYo
 bYo
 bYo
 qCL
-bLr
+ger
 skd
 skd
 vyM
@@ -40285,7 +40285,7 @@ vyM
 skd
 vqW
 vqW
-bHk
+leQ
 xvW
 pjL
 pjL
@@ -40405,10 +40405,10 @@ mkf
 jAA
 aUd
 leg
-fIH
-taZ
-taZ
-edn
+xHV
+aNZ
+aNZ
+dBP
 leg
 leg
 qgS
@@ -40434,12 +40434,12 @@ bIq
 bIq
 bIq
 bIq
-afi
+phK
 cvG
 mNJ
 tHG
 tbj
-nTu
+bVu
 qRS
 nmr
 nmr
@@ -40459,13 +40459,13 @@ bYo
 lFH
 qCL
 qCL
-abi
+edT
 skd
 vyM
 vyM
 vyM
 vqW
-rEK
+uiy
 qCL
 qFL
 mAd
@@ -40586,10 +40586,10 @@ mkf
 mkf
 hNa
 leg
-hmo
-wfE
-wfE
-sHT
+kZG
+vyt
+vyt
+xks
 lLC
 leg
 hvB
@@ -40615,16 +40615,16 @@ kWJ
 fMG
 oge
 oge
-kjk
+yfK
 aHR
 mNJ
 urt
 dDF
-oxZ
+uMa
 qRS
 lRi
 nmr
-ptF
+rHx
 nmr
 nmr
 nmr
@@ -40641,11 +40641,11 @@ bYo
 qCL
 qCL
 qCL
-yhc
+arE
 skd
 vyM
 vyM
-rEK
+uiy
 qCL
 qCL
 qCL
@@ -40766,12 +40766,12 @@ nGK
 mkf
 mkf
 hNa
-txJ
-mjK
-hFn
-fgf
-mjK
-saO
+twZ
+pBb
+tSr
+dsq
+pBb
+swt
 leg
 sFG
 mkf
@@ -40796,17 +40796,17 @@ oge
 vsz
 oge
 oge
-bgE
+trZ
 kNU
 ebJ
-eUS
+eYV
 xHy
 tbj
-mEC
-rsD
-ivx
+cnv
+rWs
+wHO
 dxR
-jWR
+pzr
 lRi
 lRi
 nmr
@@ -40823,9 +40823,9 @@ qCL
 qCL
 qCL
 qCL
-wCj
+xun
 vyM
-tGR
+dLE
 qCL
 qCL
 qCL
@@ -40977,7 +40977,7 @@ uvc
 uvc
 oge
 lRi
-cun
+lhc
 wAm
 mlv
 xbO
@@ -40987,7 +40987,7 @@ mlv
 uVV
 uqO
 nYF
-cZr
+sSp
 bIq
 afG
 nmr
@@ -40995,17 +40995,17 @@ iDq
 alt
 dkI
 dkI
-oLq
-oLq
-oLq
+biH
+biH
+biH
 dkI
 dkI
 qCL
 qCL
 qCL
 qCL
-yhc
-qPf
+arE
+qnT
 qCL
 qCL
 qCL
@@ -41158,7 +41158,7 @@ qRS
 oge
 oge
 lRi
-bkd
+dIK
 pff
 seb
 xQE
@@ -41168,18 +41168,18 @@ aHR
 kVT
 kmO
 iUL
-oxZ
+uMa
 lRi
 lRi
 nmr
 iDq
 alt
 nmr
-asR
+mSk
 alt
 alt
 alt
-fAZ
+hYA
 pZW
 qCL
 qCL
@@ -41339,7 +41339,7 @@ oge
 oge
 uvc
 lRi
-asF
+uQg
 oNv
 xHy
 seb
@@ -41349,18 +41349,18 @@ xPC
 aHR
 eOZ
 aHR
-ufd
+wPu
 bIq
 rfs
 nmr
 iDq
 alt
 nmr
-asR
+mSk
 alt
 lQq
 alt
-fAZ
+hYA
 bYo
 qCL
 qCL
@@ -41494,8 +41494,8 @@ wVJ
 wVJ
 wVJ
 wVJ
-dSd
-dSd
+leW
+leW
 wVJ
 wVJ
 wVJ
@@ -41521,23 +41521,23 @@ hNA
 uvc
 xlz
 bYo
-bLn
-qFQ
-edg
-sMv
-sMv
-nCf
-pzv
-dNf
-qFQ
-yjC
+dyC
+aPj
+vns
+ruH
+ruH
+koX
+mzs
+opP
+aPj
+xpQ
 bIq
 ppi
 nmr
 iDq
 wdb
 nmr
-asR
+mSk
 alt
 teE
 alt
@@ -41675,8 +41675,8 @@ lts
 lts
 bLR
 dwc
-pRV
-pRV
+pMp
+pMp
 lDI
 bLR
 pTC
@@ -41718,12 +41718,12 @@ nmr
 iDq
 alt
 nmr
-asR
+mSk
 alt
 wTz
 alt
-fAZ
-pma
+hYA
+pyy
 qCL
 iIa
 qCL
@@ -41856,8 +41856,8 @@ qNc
 sXv
 eUy
 oIJ
-gZI
-gZI
+lbl
+lbl
 lSj
 eUy
 gLI
@@ -41899,11 +41899,11 @@ nmr
 iDq
 alt
 nmr
-asR
+mSk
 alt
 cEu
 alt
-fAZ
+hYA
 aSe
 gIw
 gIw
@@ -42037,8 +42037,8 @@ xZH
 pNz
 qMS
 qMS
-dSd
-dSd
+leW
+leW
 qMS
 qMS
 hCt
@@ -42081,9 +42081,9 @@ iDq
 alt
 dkI
 dkI
-iWK
-mhz
-iWK
+ukz
+dzU
+ukz
 dkI
 dkI
 gIw
@@ -42624,9 +42624,9 @@ ygm
 xrd
 vTh
 oFW
-noc
+hPu
 cNE
-qhy
+wfM
 vTh
 oFW
 xee
@@ -42803,11 +42803,11 @@ vDC
 nmr
 iDq
 alt
-jky
-mAI
-vSc
-ipX
-jaz
+aRA
+riM
+nwh
+vVJ
+xiY
 nmr
 nmr
 iwe
@@ -42823,8 +42823,8 @@ iwe
 iwe
 iwe
 iwe
-lUi
-bMb
+xbB
+byL
 iwe
 iwe
 iwe
@@ -42959,10 +42959,10 @@ bYo
 bYo
 dkI
 dkI
-aEQ
-etk
-mxR
-sAW
+uRH
+vJn
+xEL
+kKQ
 dkI
 dkI
 jYP
@@ -42981,14 +42981,14 @@ riT
 nvH
 doH
 iBk
-vmp
+lQX
 iDq
 alt
-lGv
+hBS
 rFo
-ayc
+fmA
 eeH
-qkV
+rsO
 rFo
 rFo
 rFo
@@ -43139,12 +43139,12 @@ bYo
 bYo
 bYo
 pZW
-iWV
+amj
 urb
 gxe
 gxe
 thJ
-bpJ
+kdy
 fow
 rfs
 rfs
@@ -43162,11 +43162,11 @@ nDS
 nDS
 iXX
 nmf
-hqE
+wOH
 mWb
-dLz
-ddG
-ayc
+uUn
+mvy
+fmA
 eeH
 lSP
 dXL
@@ -43320,12 +43320,12 @@ bYo
 lFH
 bYo
 bYo
-vhX
+gYQ
 gxe
 dQp
 wpJ
 gxe
-uRw
+gdy
 uvc
 uvc
 rfs
@@ -43343,11 +43343,11 @@ oWX
 uOz
 fOo
 igQ
-jLn
+mLW
 bIw
-gRS
-qpP
-neO
+vnM
+iqP
+gaI
 eBo
 eBo
 eBo
@@ -43501,12 +43501,12 @@ bYo
 bYo
 bYo
 bYo
-vhX
+gYQ
 gxe
 vRu
 gxe
 qwi
-aSx
+mVH
 rfs
 nmr
 nmr
@@ -43524,7 +43524,7 @@ dym
 nvH
 doH
 iBk
-eGl
+kuR
 iDq
 alt
 nmr
@@ -43682,7 +43682,7 @@ bYo
 bYo
 bYo
 bYo
-ayr
+qaF
 dQp
 gxe
 aJV
@@ -43863,12 +43863,12 @@ bYo
 bYo
 bYo
 bYo
-iHB
+rDt
 gxe
 gxe
 pjp
 gxe
-aSx
+mVH
 uvc
 nmr
 nmr
@@ -44044,12 +44044,12 @@ bYo
 bYo
 bYo
 bYo
-iHB
+rDt
 gxe
 gxe
 rlX
 gxe
-cdy
+ozr
 rfs
 oge
 rfs
@@ -44225,12 +44225,12 @@ bYo
 lFH
 bYo
 pZW
-lZe
+hbx
 qkn
 aCj
 wpJ
 cIm
-cAw
+uBi
 dUW
 rfs
 lRi
@@ -44407,10 +44407,10 @@ bYo
 bYo
 dkI
 dkI
-okT
-wtZ
-wtZ
-ftu
+qxD
+chQ
+chQ
+pNt
 dkI
 dkI
 niO
@@ -44574,8 +44574,8 @@ knY
 vAq
 kzA
 qKo
-mkc
-qtQ
+clx
+qoE
 qKo
 qKl
 qMS
@@ -44926,8 +44926,8 @@ wlC
 uwN
 kXZ
 sXo
-qtQ
-qtQ
+qoE
+qoE
 rUk
 kRn
 kQp
@@ -45107,8 +45107,8 @@ kQp
 kQp
 wlC
 rUk
-qtQ
-lgx
+qoE
+niX
 rUk
 wlC
 kQp
@@ -45145,8 +45145,8 @@ bIq
 rfs
 bIq
 rfs
-lxP
-sJa
+qCd
+lGq
 rfs
 rfs
 rfs
@@ -45345,7 +45345,7 @@ nmr
 nmr
 nmr
 nmr
-qPX
+kTw
 nmr
 srG
 nmr
@@ -45681,7 +45681,7 @@ oge
 oge
 ppi
 oge
-lkX
+gUW
 wfI
 rIp
 uls
@@ -45695,7 +45695,7 @@ jXX
 uTW
 slo
 nhy
-lkX
+gUW
 nmr
 iDq
 alt
@@ -45824,8 +45824,8 @@ qKo
 qKo
 qKo
 qKo
-etf
-qtQ
+wrm
+qoE
 nzn
 rYY
 qTv
@@ -46367,8 +46367,8 @@ qKo
 qKo
 qKo
 qKo
-etf
-lel
+wrm
+vje
 qKo
 rYY
 qTv
@@ -46396,16 +46396,16 @@ wVJ
 bYo
 dkI
 dkI
-oLq
-oLq
-oLq
+biH
+biH
+biH
 dkI
 dkI
 uAZ
 qRS
 rfs
 rfs
-lkX
+gUW
 nhy
 rIp
 uTW
@@ -46419,7 +46419,7 @@ jXX
 uls
 nzf
 gkd
-lkX
+gUW
 nmr
 iDq
 alt
@@ -46537,8 +46537,8 @@ jlM
 vnq
 bqS
 asu
-mcs
-eRV
+buT
+uHr
 iAS
 sZa
 tmW
@@ -46576,11 +46576,11 @@ xOD
 wVJ
 bYo
 bYo
-asR
+mSk
 alt
 alt
 alt
-fAZ
+hYA
 fow
 qRS
 rfs
@@ -46718,8 +46718,8 @@ eSw
 bqS
 bqS
 asu
-mcs
-eRV
+buT
+uHr
 iAS
 hGQ
 hGQ
@@ -46757,11 +46757,11 @@ aIY
 wVJ
 lXi
 bYo
-asR
+mSk
 alt
 lQq
 alt
-fAZ
+hYA
 nmr
 nmr
 nmr
@@ -46910,8 +46910,8 @@ qKo
 qKo
 qKo
 qKo
-etf
-qtQ
+wrm
+qoE
 qKo
 gZN
 rYY
@@ -46938,7 +46938,7 @@ ppE
 wVJ
 lXi
 bYo
-asR
+mSk
 alt
 rfE
 pvh
@@ -47106,8 +47106,8 @@ qKo
 qKo
 nzn
 qKo
-qtQ
-mkc
+qoE
+clx
 qKo
 qKo
 qKo
@@ -47119,17 +47119,17 @@ gUz
 wVJ
 lXi
 lXi
-asR
+mSk
 alt
 jLZ
 tXx
-fAZ
-cKW
+hYA
+hZL
 nmr
 bCz
 tXx
 nmr
-lkX
+gUW
 nhy
 rIp
 uls
@@ -47143,7 +47143,7 @@ jXX
 uls
 slo
 wfI
-lkX
+gUW
 nmr
 iDq
 alt
@@ -47300,11 +47300,11 @@ hBM
 wVJ
 lXi
 lXi
-asR
+mSk
 alt
 cEu
 iVK
-fAZ
+hYA
 fow
 nmr
 alt
@@ -47482,9 +47482,9 @@ wVJ
 lXi
 lXi
 dkI
-iWK
-mhz
-iWK
+ukz
+dzU
+ukz
 dkI
 dkI
 nmr
@@ -47830,8 +47830,8 @@ gQT
 qKo
 nCW
 qKo
-qtQ
-mkc
+qoE
+clx
 qKo
 qKo
 qKo
@@ -47853,7 +47853,7 @@ ihH
 bCz
 tXx
 nmr
-lkX
+gUW
 nhy
 rIp
 uls
@@ -47867,7 +47867,7 @@ jXX
 uTW
 hRg
 iik
-lkX
+gUW
 nmr
 iDq
 alt
@@ -48364,13 +48364,13 @@ qKo
 qKo
 rfu
 uHI
-nZF
+ubL
 mzf
 cGs
-nZF
+ubL
 mzf
 cGs
-nZF
+ubL
 mzf
 aJo
 tKf
@@ -48403,8 +48403,8 @@ nmr
 nmr
 nmr
 nmr
-hTQ
-wLW
+bdW
+rQV
 nmr
 nmr
 nmr
@@ -48538,20 +48538,20 @@ cZS
 gZN
 nCW
 gZN
-sBB
-sBB
+nBJ
+nBJ
 gZN
 gZN
 qKo
 bxM
 lEV
-qtQ
+qoE
 lEV
 lEV
-hdk
+yfj
 lEV
 lEV
-qtQ
+qoE
 jsu
 wqa
 bjQ
@@ -48719,8 +48719,8 @@ ole
 gZN
 gZN
 gZN
-sBB
-sBB
+nBJ
+nBJ
 gZN
 nCW
 nzn
@@ -48900,8 +48900,8 @@ rUu
 gZN
 ove
 gZN
-sBB
-sBB
+nBJ
+nBJ
 gZN
 gZN
 nzn
@@ -49406,7 +49406,7 @@ bfJ
 fQU
 myy
 saE
-bSF
+xEm
 bSF
 jHh
 iZP
@@ -49589,7 +49589,7 @@ fvt
 saE
 xEm
 xEm
-iWI
+sPu
 whJ
 cqo
 hIf
@@ -49658,7 +49658,7 @@ lXi
 lXi
 dkI
 dkI
-dOw
+kWD
 bYo
 bYo
 bYo
@@ -49768,9 +49768,9 @@ ruq
 hTm
 rnC
 saE
+xEm
 bSF
-bSF
-nyH
+jGM
 mff
 car
 ith
@@ -49803,11 +49803,11 @@ fCq
 gZN
 gZN
 gZN
-sBB
-sBB
+nBJ
+nBJ
 gZN
-sBB
-sBB
+nBJ
+nBJ
 gZN
 iAS
 qFn
@@ -50373,7 +50373,7 @@ dlS
 mRZ
 kGn
 nwa
-pDK
+rRz
 kFd
 lJL
 lJL
@@ -50553,11 +50553,11 @@ oMS
 kFd
 fEr
 fEr
-pDK
-lVx
+rRz
+eQb
 pby
-jeJ
-wgA
+wGx
+mUL
 lXi
 lXi
 lXi
@@ -50734,12 +50734,12 @@ wVJ
 wVJ
 wVJ
 wVJ
-lVx
+eQb
 pby
 pby
 uxi
 pby
-efB
+uSv
 lXi
 lXi
 lXi
@@ -51101,9 +51101,9 @@ lJL
 uxi
 pby
 uxi
-mbY
-hZB
-ros
+wUB
+aMN
+rwa
 lXi
 lXi
 lXi
@@ -51282,8 +51282,8 @@ pRb
 wZU
 uxi
 uxi
-hZB
-hZB
+aMN
+aMN
 uxi
 mkO
 vJW
@@ -51462,12 +51462,12 @@ pRb
 pRb
 pRb
 wZU
-vMe
-hZB
+ylg
+aMN
 pby
 uxi
 pby
-vMe
+ylg
 vJW
 vJW
 vJW
@@ -51643,12 +51643,12 @@ pRb
 pRb
 pRb
 vJW
-vMe
+ylg
 vJW
 pby
 uxi
 pby
-hZB
+aMN
 pby
 pby
 vJW
@@ -51827,9 +51827,9 @@ vJW
 vJW
 vJW
 mkO
-mbY
-hZB
-hZB
+wUB
+aMN
+aMN
 pby
 pby
 pby
@@ -51948,8 +51948,8 @@ pRb
 gwm
 piv
 piv
-dmE
-fTt
+jfI
+hAT
 hDt
 hDt
 kRW
@@ -52009,7 +52009,7 @@ vJW
 vJW
 vJW
 vJW
-hZB
+aMN
 pby
 pby
 pby
@@ -52127,10 +52127,10 @@ pRb
 iFE
 xDR
 gqD
-cuX
+fFr
 piv
-dZF
-dZF
+cIy
+cIy
 hDt
 hDt
 bcU
@@ -52190,7 +52190,7 @@ vJW
 vJW
 vJW
 vJW
-vMe
+ylg
 pby
 uaX
 pby
@@ -52308,11 +52308,11 @@ lrN
 eaP
 fnR
 gqD
-daA
-cxE
-cxE
-cxE
-gEv
+iHV
+xNm
+xNm
+xNm
+ekj
 cpL
 cpL
 bNd
@@ -52459,7 +52459,7 @@ xiI
 elP
 uWn
 pEy
-sih
+eUZ
 bLT
 elP
 piZ
@@ -52487,7 +52487,7 @@ nHh
 lrN
 rbq
 eaP
-tFR
+cph
 eaP
 jTo
 ujT
@@ -52503,7 +52503,7 @@ bqP
 uNg
 cpL
 vNL
-fqB
+kVQ
 vNL
 wPU
 ezJ
@@ -52512,7 +52512,7 @@ vNL
 vNL
 vNL
 joq
-mgG
+gDu
 xxU
 kpZ
 voT
@@ -52668,7 +52668,7 @@ rfp
 lrN
 lrN
 uSw
-bIY
+fPR
 eaP
 nEV
 lrN
@@ -52677,7 +52677,7 @@ bcU
 bcU
 bNd
 sSK
-gmo
+wSA
 iPG
 tJB
 gcy
@@ -52849,7 +52849,7 @@ oFm
 pRb
 wZU
 eaP
-bIY
+fPR
 gqD
 gwm
 lrN
@@ -52875,7 +52875,7 @@ yik
 jMC
 sNy
 bNL
-jLm
+qNY
 gJA
 joq
 bcU
@@ -53073,7 +53073,7 @@ gpK
 nEZ
 kkh
 fPE
-dAr
+chv
 vzF
 eOA
 nvk
@@ -53220,7 +53220,7 @@ bcU
 bcU
 cpL
 mwj
-vzT
+rPe
 bkV
 cpL
 bcU
@@ -53258,7 +53258,7 @@ opz
 tUm
 eOA
 mNR
-eWG
+jvi
 fRk
 gpK
 qbc
@@ -53380,7 +53380,7 @@ elP
 yef
 pvH
 wZa
-oUU
+lVM
 viB
 dJJ
 nzv
@@ -53586,7 +53586,7 @@ bcU
 hDt
 hDt
 piv
-lUc
+pYm
 rFx
 nJW
 fUh
@@ -53615,7 +53615,7 @@ grH
 xle
 tSW
 wnA
-cdz
+huT
 gzI
 bAE
 eOW
@@ -53767,7 +53767,7 @@ bcU
 hDt
 hDt
 piv
-lUc
+pYm
 bhK
 kwK
 aYv
@@ -53800,12 +53800,12 @@ jqv
 sOo
 cYo
 ebW
-cqj
+nrL
 uyv
 gEk
 iTK
 pOx
-xrw
+kNG
 pOx
 cFM
 bcU
@@ -53946,8 +53946,8 @@ vNL
 vNL
 xtk
 vNL
-gXc
-gXc
+qdC
+qdC
 wPU
 tnA
 byE
@@ -54127,8 +54127,8 @@ grH
 grH
 ddR
 grH
-ijz
-kry
+hld
+xDM
 rMP
 jmQ
 byE
@@ -54141,7 +54141,7 @@ gvR
 rZW
 tMT
 gvR
-rqt
+lqs
 cpP
 gvR
 uuH
@@ -54164,7 +54164,7 @@ aqa
 uKe
 gXd
 hge
-efs
+whE
 fWF
 biM
 jjw
@@ -54291,7 +54291,7 @@ nYi
 bbU
 bbU
 bbU
-har
+oUU
 gVp
 pQi
 mKM
@@ -54308,8 +54308,8 @@ vNL
 vNL
 vNL
 vNL
-gXc
-gXc
+qdC
+qdC
 wPU
 tnA
 byE
@@ -54471,7 +54471,7 @@ rLj
 lDZ
 bbU
 bbU
-lNZ
+xMO
 bbU
 gVp
 mKM
@@ -54485,13 +54485,13 @@ bcU
 bcU
 bcU
 bcU
-lAy
+msm
 bcU
 bcU
 piv
 piv
 piv
-lUc
+pYm
 bhK
 byE
 bcU
@@ -54672,7 +54672,7 @@ kRW
 hDt
 piv
 piv
-lUc
+pYm
 bhK
 byE
 kRW
@@ -54691,7 +54691,7 @@ feL
 lKR
 kEt
 qwA
-gwq
+mwq
 kEt
 lDl
 bhK
@@ -54747,7 +54747,7 @@ ozh
 hJk
 hJk
 mwo
-rrp
+oJA
 bBR
 fQZ
 oEl
@@ -54834,7 +54834,7 @@ qlI
 bbU
 bbU
 bbU
-har
+oUU
 xnD
 hyr
 jFI
@@ -54852,7 +54852,7 @@ bcU
 bcU
 bcU
 hDt
-ipA
+dgj
 lDl
 tnA
 byE
@@ -54885,7 +54885,7 @@ nIo
 iXh
 qmF
 hUy
-rVn
+ttW
 nVJ
 gpK
 hPV
@@ -55033,7 +55033,7 @@ bcU
 uFN
 bcU
 ius
-kOq
+kQL
 lDl
 bhK
 byE
@@ -55071,7 +55071,7 @@ biE
 gpK
 sYo
 cqy
-nuW
+eEa
 mGX
 fOW
 cFM
@@ -55213,7 +55213,7 @@ cGN
 bcU
 bcU
 bcU
-ipA
+dgj
 hDt
 lDl
 bhK
@@ -55377,7 +55377,7 @@ huS
 bbU
 bbU
 yfr
-har
+oUU
 xnD
 pQi
 mKM
@@ -55395,8 +55395,8 @@ bcU
 bcU
 hDt
 hDt
-jPS
-lUc
+rDw
+pYm
 bhK
 byE
 ePP
@@ -55427,7 +55427,7 @@ iph
 xUZ
 qgT
 cmB
-dbK
+dgV
 xMp
 kVJ
 uGT
@@ -55538,7 +55538,7 @@ oLO
 qoC
 xvQ
 jsg
-goJ
+ejB
 wAO
 ltG
 tnB
@@ -55575,9 +55575,9 @@ kRW
 bcU
 bcU
 piv
-xKe
+rbu
 ogv
-lUc
+pYm
 tnA
 byE
 ogv
@@ -55951,7 +55951,7 @@ lrN
 nEV
 kEt
 sde
-xzZ
+iQm
 kEt
 vlt
 cni
@@ -56090,7 +56090,7 @@ oQJ
 rUY
 rSt
 fQA
-eHB
+mCh
 vtZ
 aeE
 dPQ
@@ -57537,7 +57537,7 @@ xvQ
 xvQ
 xvQ
 wDI
-tBy
+mkV
 etn
 mSv
 mXG
@@ -57592,19 +57592,19 @@ kRW
 bcU
 vbI
 bou
-cpG
+lKS
 wFt
 vbI
 lrN
 lrN
 lvS
-iQu
-bwP
+dWF
+dpc
 cjO
 rQw
 yjT
-jSj
-bwP
+hye
+dpc
 lrN
 lDl
 xPb
@@ -57785,7 +57785,7 @@ ksr
 bDl
 wPv
 gbC
-kyL
+ote
 lrN
 lDl
 xPb
@@ -57966,7 +57966,7 @@ uCt
 nRx
 eQj
 cax
-kyL
+ote
 lrN
 lDl
 jyW
@@ -58147,7 +58147,7 @@ eQj
 cBA
 ksr
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -58263,8 +58263,8 @@ xvQ
 xvQ
 xvQ
 xvQ
-cnV
-cnV
+foV
+foV
 xvQ
 xvQ
 pRb
@@ -58328,7 +58328,7 @@ eQj
 cBA
 eQj
 ooD
-kyL
+ote
 lrN
 lDl
 xPb
@@ -58488,7 +58488,7 @@ clP
 lCu
 shV
 kwx
-sXz
+sCj
 gOQ
 teB
 rLE
@@ -58505,11 +58505,11 @@ lrN
 lvS
 ykz
 ykz
-rqP
+oHg
 wkw
 bok
 fpk
-kyL
+ote
 lrN
 lDl
 bej
@@ -58667,7 +58667,7 @@ uSb
 uSb
 clP
 xrm
-fKj
+qcM
 nDv
 rEP
 hnw
@@ -58690,7 +58690,7 @@ glK
 cBA
 eQj
 ooD
-kyL
+ote
 lrN
 lDl
 xPb
@@ -58869,9 +58869,9 @@ lvS
 dEg
 dEg
 wkw
-chu
+eUv
 cax
-kyL
+ote
 lrN
 lDl
 jyW
@@ -59052,7 +59052,7 @@ dEg
 cBA
 eQj
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -59233,7 +59233,7 @@ cBA
 cBA
 eQj
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -59414,7 +59414,7 @@ dEg
 cBA
 ksr
 ooD
-ggn
+aEf
 lrN
 lDl
 jyW
@@ -59580,7 +59580,7 @@ loN
 oHY
 sOZ
 rrr
-cBH
+fHO
 hwj
 kdp
 eHU
@@ -59711,8 +59711,8 @@ pRb
 pRb
 lWc
 lWc
-ass
-aJC
+eLC
+vrb
 lWc
 lWc
 lWc
@@ -59753,7 +59753,7 @@ dAd
 imO
 vFl
 hLH
-vbx
+vMN
 imO
 kxD
 lCG
@@ -59919,7 +59919,7 @@ sfh
 xxD
 xxD
 xxD
-xUH
+lUO
 xxD
 xxD
 lVj
@@ -60060,7 +60060,7 @@ hHf
 hHf
 pRb
 lWc
-qKr
+tFk
 lWc
 kqR
 kqR
@@ -60138,7 +60138,7 @@ ykz
 ktW
 eQj
 cax
-xuk
+ueV
 lrN
 lDl
 jyW
@@ -60319,7 +60319,7 @@ xAV
 eQj
 eQj
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -60498,9 +60498,9 @@ nEV
 lvS
 pAj
 ykz
-rqP
+oHg
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -60681,7 +60681,7 @@ ktW
 ykz
 eQj
 ooD
-sGX
+gtn
 lrN
 lDl
 jyW
@@ -60862,7 +60862,7 @@ lvS
 xAV
 ksr
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -60980,7 +60980,7 @@ kqR
 kqR
 kqR
 rUn
-gJm
+hrB
 kWG
 pRb
 pRb
@@ -61043,7 +61043,7 @@ lvS
 dEg
 dEg
 cax
-kyL
+ote
 lrN
 lDl
 xPb
@@ -61224,7 +61224,7 @@ lvS
 eLS
 csZ
 ooD
-sGX
+gtn
 lrN
 lDl
 unB
@@ -61405,7 +61405,7 @@ lvS
 dQZ
 xPZ
 vlT
-kyL
+ote
 lrN
 lDl
 xPb
@@ -61551,7 +61551,7 @@ xxD
 vmm
 obR
 vdl
-fip
+tZi
 wlw
 obR
 fnD
@@ -61586,7 +61586,7 @@ lvS
 fRh
 dEg
 ksr
-sGX
+gtn
 lrN
 lDl
 xPb
@@ -61766,8 +61766,8 @@ kRW
 lvS
 eLS
 eLS
-rqP
-sGX
+oHg
+gtn
 lrN
 lDl
 xPb
@@ -61840,8 +61840,8 @@ lsi
 pEK
 oTq
 pRb
-xDz
-xDz
+fmO
+fmO
 wng
 wng
 wng
@@ -62254,8 +62254,8 @@ pRb
 pRb
 lWc
 lWc
-aJC
-aJC
+vrb
+vrb
 lWc
 pRb
 pRb
@@ -62469,7 +62469,7 @@ sfh
 tvN
 xxD
 xxD
-xUH
+lUO
 xxD
 bpu
 koR
@@ -62579,8 +62579,8 @@ cfj
 pRb
 pRb
 dqB
-psr
-uvx
+aoM
+dQu
 iof
 hHf
 hHf
@@ -62760,8 +62760,8 @@ oTq
 pRb
 pRb
 dqB
-uvx
-uvx
+dQu
+dQu
 iof
 hHf
 hHf
@@ -62955,9 +62955,9 @@ arg
 arg
 arg
 fkd
-lOZ
-lOZ
-lOZ
+jYQ
+jYQ
+jYQ
 fkd
 iof
 iof
@@ -63159,8 +63159,8 @@ pRb
 pRb
 pRb
 lWc
-aJC
-aJC
+vrb
+vrb
 lWc
 pRb
 pRb
@@ -63857,12 +63857,12 @@ hHf
 arg
 hHf
 hHf
-aJC
-aJC
+vrb
+vrb
 lWc
-aJC
+vrb
 lWc
-qKr
+tFk
 lWc
 pRb
 iof
@@ -63899,7 +63899,7 @@ pRb
 pRb
 kqR
 kqR
-nwi
+oFn
 kqR
 xxD
 pRb
@@ -64398,7 +64398,7 @@ hHf
 (173,1,1) = {"
 hHf
 arg
-ass
+eLC
 lWc
 lWc
 pRb
@@ -64430,8 +64430,8 @@ pRb
 pRb
 pRb
 lWc
-aJC
-aJC
+vrb
+vrb
 lWc
 lWc
 pRb
@@ -65123,7 +65123,7 @@ hHf
 hHf
 arg
 lWc
-aJC
+vrb
 pRb
 pRb
 pRb
@@ -65241,7 +65241,7 @@ jJM
 iBp
 vtg
 bbX
-tOD
+pqB
 ivc
 jOW
 vJW
@@ -65277,9 +65277,9 @@ pby
 oTq
 oTq
 pRb
-lwm
-xDz
-dIC
+aOA
+fmO
+htI
 oTq
 oTq
 hmM
@@ -65458,9 +65458,9 @@ pby
 oTq
 pRb
 pRb
-lwm
-xDz
-dIC
+aOA
+fmO
+htI
 oTq
 oTq
 hmM
@@ -65550,7 +65550,7 @@ xxD
 fnD
 fnD
 bIG
-hfm
+gzB
 rpi
 uoY
 uSb
@@ -65824,7 +65824,7 @@ sMt
 fyQ
 pWf
 mlq
-ptl
+nof
 mWu
 hmM
 mWu
@@ -65846,7 +65846,7 @@ hHf
 (181,1,1) = {"
 hHf
 fkd
-aJC
+vrb
 lWc
 pRb
 pRb
@@ -65933,7 +65933,7 @@ srl
 sDl
 oAB
 nyn
-shb
+gjG
 xtK
 enV
 qcC
@@ -66005,7 +66005,7 @@ eZH
 gwe
 vvK
 gwe
-rVw
+ujh
 nPC
 hmM
 iof
@@ -66186,7 +66186,7 @@ chZ
 gwe
 vvK
 vvK
-sys
+iSf
 nPC
 pRb
 iof
@@ -66367,7 +66367,7 @@ eZH
 gwe
 gwe
 gwe
-exU
+vmw
 mWu
 mWu
 iof
@@ -66474,7 +66474,7 @@ uSb
 sCk
 tmO
 cwS
-rxc
+cbY
 bfp
 bfp
 ydh
@@ -66571,7 +66571,7 @@ hHf
 hHf
 fkd
 lWc
-aJC
+vrb
 pRb
 pRb
 pRb
@@ -66752,7 +66752,7 @@ hHf
 hHf
 fkd
 lWc
-aJC
+vrb
 pRb
 pRb
 pRb
@@ -66789,8 +66789,8 @@ aWd
 lWc
 lWc
 lWc
-aJC
-aJC
+vrb
+vrb
 lWc
 lWc
 lWc
@@ -67058,8 +67058,8 @@ oTq
 pRb
 dqB
 dqB
-uvx
-uvx
+dQu
+dQu
 dqB
 dqB
 pRb
@@ -67119,13 +67119,13 @@ pRb
 pRb
 pRb
 lWc
-aJC
+vrb
 lWc
-aJC
-aJC
-aJC
+vrb
+vrb
+vrb
 lWc
-aJC
+vrb
 lWc
 lWc
 pRb
@@ -67483,9 +67483,9 @@ lWc
 kqR
 wgK
 lWc
-aJC
-aJC
-aJC
+vrb
+vrb
+vrb
 eqG
 wgK
 kqR
@@ -67661,7 +67661,7 @@ wgK
 kqR
 kqR
 lWc
-aJC
+vrb
 lWc
 lWc
 gwc
@@ -67669,7 +67669,7 @@ gwc
 wgK
 lWc
 lWc
-aJC
+vrb
 lWc
 kqR
 wgK
@@ -67865,7 +67865,7 @@ pRb
 pRb
 pRb
 fvf
-tUc
+lbs
 heP
 mgf
 heP
@@ -67881,8 +67881,8 @@ pRb
 kqR
 lWc
 lWc
-aJC
-aJC
+vrb
+vrb
 lWc
 lWc
 pRb
@@ -68385,7 +68385,7 @@ hHf
 kqR
 kqR
 lWc
-aJC
+vrb
 eqG
 lWc
 wgK
@@ -68393,7 +68393,7 @@ wgK
 wgK
 lWc
 lWc
-aJC
+vrb
 lWc
 tlS
 aWd
@@ -68569,9 +68569,9 @@ lWc
 kqR
 wgK
 lWc
-aJC
-aJC
-aJC
+vrb
+vrb
+vrb
 lWc
 wgK
 kqR
@@ -69078,7 +69078,7 @@ dqB
 vQG
 mWu
 mWu
-iVr
+ttT
 eSk
 mWu
 mWu

--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -18,6 +18,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning,
 /area/slumbridge/outside/northwest/nearlz)
+"abi" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "abr" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/open/floor/prison/plate,
@@ -52,14 +58,6 @@
 /obj/effect/landmark/corpsespawner/engineer/regular,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
-"ado" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/slumbridge/landingzonetwo)
 "adG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/ammonia,
@@ -104,6 +102,13 @@
 "aeY" = (
 /turf/open/floor/prison/yellow,
 /area/slumbridge/inside/prison/innerring)
+"afi" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "afB" = (
 /turf/open/floor/plating/platebot,
 /area/slumbridge/inside/engi/south)
@@ -140,13 +145,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest/nearlz)
-"ahj" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -235,6 +233,15 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
+"alb" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "alt" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
@@ -262,15 +269,6 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/west)
-"amj" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 9
-	},
-/area/slumbridge/outside/southwest)
 "amS" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -288,9 +286,8 @@
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
 "anT" = (
-/obj/structure/prop/mainship/missile_tube{
-	desc = "Metal rotary device spins to create power out of water.";
-	name = "\improper turbine oversight system"
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/slumbridge/inside/engi/engineroom)
@@ -298,13 +295,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
-"aoM" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "aoP" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -392,12 +382,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/hangar)
-"arE" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "arG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -409,6 +393,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/dmg3,
 /area/slumbridge/caves/mining)
+"ass" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "asu" = (
 /turf/closed/wall/r_wall/prison,
 /area/slumbridge/inside/prison/outerringnorth)
@@ -422,6 +413,19 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
+"asF" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
+"asR" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "ata" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -549,6 +553,21 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
+"ayc" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
+"ayr" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
 "ayK" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -558,6 +577,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
+"azn" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 9
+	},
+/area/slumbridge/landingzonetwo)
 "azv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -670,6 +697,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
+"aDK" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "aDY" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -681,12 +714,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/landingzonetwo)
-"aEf" = (
-/obj/structure/platform/nondense{
-	dir = 6
-	},
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "aEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -696,6 +723,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red/corner,
 /area/slumbridge/inside/sombase/hangar)
+"aEQ" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/slumbridge/outside/southwest)
 "aFa" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/floor,
@@ -768,13 +804,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
-"aIx" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "aIE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
@@ -799,6 +828,12 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringnorth)
+"aJC" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "aJV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -874,10 +909,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"aMN" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "aMY" = (
 /turf/open/lavaland/basalt/dirt{
 	dir = 8
@@ -918,12 +949,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
-"aNZ" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/outside/northwest)
 "aOl" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/power/apc/drained{
@@ -932,13 +957,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery)
-"aOA" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
 "aOP" = (
 /obj/structure/inflatable/wall,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -956,13 +974,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/houses/dorms)
-"aPj" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "aPl" = (
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/dark,
@@ -1012,12 +1023,6 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
-"aRA" = (
-/obj/structure/platform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "aRF" = (
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -1062,6 +1067,11 @@
 "aSt" = (
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
+"aSx" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete,
+/area/slumbridge/outside/southwest)
 "aSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/gibspawner/human,
@@ -1083,10 +1093,6 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark/red2,
-/area/slumbridge/landingzoneone)
-"aTl" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating/mainship,
 /area/slumbridge/landingzoneone)
 "aTp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
@@ -1361,16 +1367,6 @@
 "bcU" = (
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
-"bdW" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs/seamless/edge{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "beg" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/tile/dark/green2,
@@ -1441,6 +1437,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner,
 /area/slumbridge/inside/colony/hydro)
+"bgE" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "bhd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -1485,13 +1487,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
-"bif" = (
-/obj/machinery/floodlight/landing,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/shuttle/drop2/lz2)
 "bim" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1512,12 +1507,6 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating/platebot,
 /area/slumbridge/landingzoneone)
-"biH" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "biM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -1564,6 +1553,13 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/innerring)
+"bkd" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "bkk" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -1757,6 +1753,13 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/drop1/lz1)
+"bpJ" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 10
+	},
+/area/slumbridge/outside/southwest)
 "bpU" = (
 /obj/machinery/door/airlock/mainship/medical/free_access{
 	name = "\improper Medical Clinic Morgue"
@@ -1854,9 +1857,6 @@
 /obj/effect/spawner/random/misc/structure/broken_window,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
-"buT" = (
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outerringnorth)
 "bvk" = (
 /obj/machinery/shower,
 /obj/effect/landmark/weed_node,
@@ -1914,6 +1914,14 @@
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/central)
+"bwP" = (
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "bxk" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 9
@@ -1966,15 +1974,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
-"byL" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest/nearlz)
 "bzj" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -2123,13 +2122,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
-"bDe" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "bDi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
@@ -2156,12 +2148,6 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/south)
-"bEd" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/red2/corner,
-/area/slumbridge/landingzonetwo)
 "bEC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2221,6 +2207,12 @@
 	dir = 4
 	},
 /area/slumbridge/outside/northwest/nearlz)
+"bHk" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "bHo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -2296,6 +2288,11 @@
 	},
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/inside/zeta/south)
+"bIY" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/fence/broken,
+/turf/open/floor/plating,
+/area/slumbridge/outside/northeast)
 "bJa" = (
 /obj/effect/turf_decal/warning_stripes/smallstripe,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2408,12 +2405,24 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
+"bLn" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "bLo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor/tile/dark/blue2/corner,
 /area/slumbridge/inside/colony/headoffice)
+"bLr" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "bLu" = (
 /obj/effect/ai_node,
 /turf/open/floor,
@@ -2430,6 +2439,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"bMb" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest/nearlz)
 "bNd" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -2555,6 +2573,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"bSw" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "bSF" = (
 /turf/open/floor/bcircuit,
 /area/slumbridge/inside/engi/engineroom)
@@ -2625,13 +2649,6 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/slumbridge/landingzonetwo)
-"bVu" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "bVF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
@@ -2811,14 +2828,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"cbY" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/shuttle/escapepod,
-/area/slumbridge/inside/zeta/entrance)
+"cce" = (
+/obj/structure/platform_decoration,
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "ccu" = (
 /obj/structure/prop/mainship/research/tankcompressor{
 	name = "tank transfer compressor"
@@ -2848,6 +2861,22 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
+"cdy" = (
+/obj/structure/platform/metalplatform/nondense,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/slumbridge/outside/southwest)
+"cdz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "cdK" = (
 /obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2872,14 +2901,6 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"cfg" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 9
-	},
-/area/slumbridge/landingzonetwo)
 "cfj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/gm/dense,
@@ -2918,21 +2939,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"chv" = (
+"chu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
-"chQ" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 4
-	},
-/area/slumbridge/outside/southwest)
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/houses/car)
 "chT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/yellow{
@@ -3037,13 +3048,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/west)
-"clx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "clC" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -3139,13 +3143,12 @@
 	dir = 10
 	},
 /area/slumbridge/inside/houses/recreational)
-"cnv" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
+"cnV" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/inside/sombase/east)
 "coG" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3162,12 +3165,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/sombase/west)
-"cph" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/effect/ai_node,
-/obj/structure/fence/broken,
-/turf/open/floor/plating,
-/area/slumbridge/outside/northeast)
 "cpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -3185,6 +3182,16 @@
 /obj/effect/turf_decal/riverdecal,
 /turf/open/liquid/water/river,
 /area/slumbridge/inside/hydrotreatment)
+"cpG" = (
+/obj/effect/turf_decal/trimline/purple/arrow_ccw,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery)
 "cpL" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/nwcargo)
@@ -3216,6 +3223,12 @@
 /obj/structure/bed/chair/sofa/corsat/left,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery)
+"cqj" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "cqo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -3306,6 +3319,13 @@
 /obj/effect/landmark/corpsespawner/miner/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
+"cun" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "cuu" = (
 /obj/machinery/light{
 	dir = 1
@@ -3319,6 +3339,11 @@
 	dir = 5
 	},
 /area/slumbridge/inside/prison/innerring)
+"cuX" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/outside/northeast)
 "cuY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3370,6 +3395,10 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
+"cxE" = (
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "cxI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -3433,6 +3462,13 @@
 	dir = 4
 	},
 /area/slumbridge/landingzonetwo)
+"cAw" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 6
+	},
+/area/slumbridge/outside/southwest)
 "cAA" = (
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
@@ -3474,6 +3510,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/houses/car)
+"cBH" = (
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery)
 "cCr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -3651,12 +3691,6 @@
 /obj/mecha_wreckage/ripley/lv624,
 /turf/open/floor/plating/ground/concrete/edge,
 /area/slumbridge/outside/southwest)
-"cIy" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "cIK" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
 	name = "Back Entry"
@@ -3712,6 +3746,24 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
+"cKW" = (
+/obj/structure/prop/mainship/mission_planning_system{
+	name = "\improper Miner Oversight";
+	pixel_x = -1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
+"cKZ" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "cLt" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
@@ -3805,13 +3857,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/outerringsouth)
-"cOp" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "cOs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -3834,13 +3879,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"cOZ" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 10
-	},
-/obj/structure/prop/mainship/hangar_stencil,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "cPr" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -4048,6 +4086,11 @@
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"cZr" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "cZG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/side{
@@ -4078,14 +4121,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
-"daf" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/slumbridge/landingzonetwo)
 "dal" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4093,12 +4128,21 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
+"daA" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "daW" = (
 /obj/structure/table,
 /turf/open/floor/tile/yellow{
 	dir = 5
 	},
 /area/slumbridge/inside/engi/west)
+"dbK" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/mainship/ai,
+/area/slumbridge/inside/houses/recreational)
 "dbX" = (
 /obj/structure/table/mainship,
 /obj/structure/reagent_dispensers/fueltank,
@@ -4172,6 +4216,10 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/scorched,
 /area/slumbridge/inside/pmcdome)
+"ddG" = (
+/obj/structure/stairs/seamless/platform_vert,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "ddR" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -4214,18 +4262,9 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
-"dgj" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "dgF" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/zeta/north)
-"dgV" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/mainship/ai,
-/area/slumbridge/inside/houses/recreational)
 "dhf" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/weaponry/gun/sidearms,
@@ -4390,6 +4429,12 @@
 	},
 /turf/open/floor/tile/lightred/full,
 /area/slumbridge/inside/colony/southerndome)
+"dmE" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/outside/northeast)
 "dmJ" = (
 /obj/structure/barricade/wooden,
 /obj/structure/sign/safety/medical_supplies{
@@ -4467,14 +4512,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
-"dpc" = (
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "dpk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4499,12 +4536,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/caves/southeastcaves)
-"dqC" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "dqI" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4519,12 +4550,6 @@
 "dsd" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/medical/southern)
-"dsq" = (
-/obj/structure/lattice,
-/turf/open/liquid/lava/side{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "dsw" = (
 /obj/structure/cable,
 /turf/open/floor/tile/showroom,
@@ -4678,12 +4703,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkred/full,
 /area/slumbridge/inside/prison/outerringnorth)
-"dyC" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "dyD" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -4701,15 +4720,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"dzU" = (
-/obj/structure/prop/mainship/gelida/powerccable{
-	dir = 4
-	},
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "dAd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -4719,6 +4729,12 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery/garbledradio)
+"dAr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/misc/structure/chair_or_metal/east,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
 "dAM" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -4748,15 +4764,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
-"dBP" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "dBR" = (
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/sombase/east)
@@ -4794,6 +4801,12 @@
 	},
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
+"dDc" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "dDp" = (
 /obj/effect/mist,
 /turf/open/liquid/water/river/autosmooth,
@@ -4939,13 +4952,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
-"dIK" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
+"dIC" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "dIV" = (
 /obj/effect/spawner/random/misc/structure/wooden_table,
 /turf/open/floor/wood,
@@ -5020,12 +5031,13 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"dLE" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
+"dLz" = (
+/obj/effect/ai_node,
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "dLK" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -5054,6 +5066,14 @@
 "dNc" = (
 /turf/closed/gm,
 /area/slumbridge/inside/medical/storage)
+"dNf" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "dNm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -5081,6 +5101,10 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"dOw" = (
+/obj/effect/landmark/corpsespawner/PMC/regular,
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/outside/southwest)
 "dOP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5109,12 +5133,6 @@
 /obj/mecha_wreckage/ripley/lv624,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/southwest)
-"dQu" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
 "dQz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5188,6 +5206,10 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"dSd" = (
+/obj/structure/window/framed/prison/reinforced,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/outerringsouth)
 "dSm" = (
 /obj/item/spacecash/c20{
 	pixel_x = -11;
@@ -5269,6 +5291,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/slumbridge/outside/northwest)
+"dUf" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "dUn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -5323,14 +5349,6 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"dWF" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "dWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -5398,14 +5416,12 @@
 /obj/item/weapon/gun/shotgun/double,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/zeta/north)
-"dZz" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
+"dZF" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
 	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
-/area/slumbridge/landingzonetwo)
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "dZM" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /turf/open/floor,
@@ -5480,6 +5496,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
+"edg" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
+"edn" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "edw" = (
 /turf/open/floor/prison,
 /area/slumbridge/outside/southwest)
@@ -5490,12 +5522,6 @@
 	dir = 6
 	},
 /area/slumbridge/inside/zeta/north)
-"edT" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "eeH" = (
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/kitchen)
@@ -5506,6 +5532,18 @@
 "efd" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/outerringnorth)
+"efs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/bar,
+/area/slumbridge/inside/houses/recreational)
+"efB" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/mineral/smooth/snowrock,
+/area/slumbridge/caves/rock)
 "efI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -5546,6 +5584,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
+"egI" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/slumbridge/landingzonetwo)
 "egR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -5578,15 +5624,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"ejB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/sombase/east)
-"ekj" = (
-/obj/structure/fence/broken,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
+"ekp" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 9
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "ekz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5800,6 +5843,21 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"etf" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
+"etk" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/slumbridge/outside/southwest)
 "etn" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -5941,6 +5999,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
+"exU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "exY" = (
 /obj/structure/table/fancywoodentable,
 /turf/open/floor/tile/dark/green2{
@@ -6046,11 +6109,6 @@
 /obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/prison/whitegreen,
 /area/slumbridge/inside/prison/outerringsouth)
-"eEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/green,
-/area/slumbridge/inside/houses/recreational)
 "eEu" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/vault{
@@ -6082,6 +6140,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/outside/northeast/bridges)
+"eGl" = (
+/obj/structure/sign/hydro{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "eGV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -6094,6 +6158,11 @@
 /obj/structure/flora/pottedplant/eighteen,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
+"eHB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/wood/broken,
+/area/slumbridge/inside/sombase/east)
 "eHL" = (
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/prison/red{
@@ -6168,13 +6237,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green,
 /area/slumbridge/inside/prison/innerring)
-"eLC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "eLG" = (
 /turf/closed/shuttle/ert/engines/left{
 	dir = 1
@@ -6202,13 +6264,6 @@
 	dir = 10
 	},
 /area/slumbridge/outside/northwest)
-"eNi" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/riverdecal,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "eNl" = (
 /obj/machinery/science/analyser,
 /turf/open/floor/mainship/green/corner{
@@ -6274,10 +6329,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"eQb" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating,
-/area/slumbridge/inside/prison/outerringsouth)
 "eQj" = (
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/houses/car)
@@ -6312,6 +6363,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
+"eRV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/outerringnorth)
 "eRY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6370,11 +6428,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"eUv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/houses/car)
 "eUy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6386,6 +6439,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
+"eUS" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/dark,
+/area/slumbridge/inside/colony/construction)
 "eUX" = (
 /obj/effect/turf_decal/tracks/claw1/bloody{
 	dir = 4
@@ -6396,14 +6453,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/zeta/south)
-"eUZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/sombase/west)
 "eVa" = (
 /obj/mecha_wreckage/mauler,
 /turf/open/floor/plating/platebotc,
@@ -6462,6 +6511,17 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/east)
+"eWG" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/mainship/ai,
+/area/slumbridge/inside/houses/recreational)
 "eWU" = (
 /obj/structure/cargo_container/green{
 	dir = 1
@@ -6510,10 +6570,6 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
-"eYV" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/dark,
-/area/slumbridge/inside/colony/construction)
 "eYY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -6586,6 +6642,13 @@
 "fdl" = (
 /turf/open/floor/cult,
 /area/slumbridge/inside/medical/morgue)
+"fdr" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/structure/prop/mainship/hangar_stencil,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "fdv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6689,6 +6752,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/central)
+"fgf" = (
+/obj/structure/lattice,
+/turf/open/liquid/lava/side{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "fgu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/scorched,
@@ -6707,6 +6776,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"fip" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/grass,
+/area/slumbridge/caves/mining)
 "fiB" = (
 /obj/structure/coatrack,
 /obj/item/clothing/suit/storage/security/formal/senior_officer/tan{
@@ -6783,6 +6857,10 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
+"flm" = (
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
 "flD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/bunkbed,
@@ -6800,12 +6878,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/prison/innerring)
-"fmA" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
 "fmI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -6813,12 +6885,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
-"fmO" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
 "fmY" = (
 /obj/structure/cable,
 /turf/open/floor/tile/green/greentaupe,
@@ -6873,12 +6939,6 @@
 /obj/structure/prop/mainship/gelida/lightstick,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/outside/southwest)
-"foV" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/inside/sombase/east)
 "foY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/drained{
@@ -6936,6 +6996,10 @@
 "fqe" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/outside/northwest)
+"fqB" = (
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "fqI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /obj/structure/cable,
@@ -7026,6 +7090,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
+"ftu" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 6
+	},
+/area/slumbridge/outside/southwest)
 "ftJ" = (
 /obj/structure/barricade/snow{
 	dir = 4
@@ -7220,6 +7293,10 @@
 /obj/item/reagent_containers/glass/beaker/vial,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"fAZ" = (
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "fBj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -7274,11 +7351,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
-"fDx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "fDN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -7320,22 +7392,11 @@
 "fFo" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/engi/engineroom)
-"fFr" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/outside/northeast)
 "fFz" = (
 /obj/structure/closet/crate/secure/gear,
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/shuttle/blackfloor,
 /area/slumbridge/inside/pmcdome/weaponvault)
-"fFW" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "fFZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -7353,10 +7414,6 @@
 "fHu" = (
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
-"fHO" = (
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery)
 "fHS" = (
 /obj/structure/barricade/metal{
 	dir = 4
@@ -7374,6 +7431,12 @@
 "fIy" = (
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/surgery)
+"fIH" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "fJi" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner{
@@ -7395,6 +7458,10 @@
 /obj/structure/flora/stump,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"fKj" = (
+/obj/effect/landmark/corpsespawner/scientist/burst,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "fKx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7562,11 +7629,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/tile/blue/whiteblue,
 /area/slumbridge/inside/medical/foyer)
-"fPR" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/structure/fence/broken,
-/turf/open/floor/plating,
-/area/slumbridge/outside/northeast)
 "fPU" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/tile/purple/taupepurple{
@@ -7696,6 +7758,13 @@
 /obj/effect/landmark/corpsespawner/chef/regular,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/prison/outerringsouth)
+"fTt" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "fTA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -7884,12 +7953,6 @@
 /obj/effect/spawner/random/engineering/glass,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"gaI" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
 "gaJ" = (
 /obj/structure/bed/chair/office/light/east,
 /obj/effect/landmark/corpsespawner/pmc,
@@ -7957,11 +8020,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
-"gdy" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating/ground/concrete/lines,
-/area/slumbridge/outside/southwest)
 "gdN" = (
 /obj/structure/desertdam/decals/road,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7974,12 +8032,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"ger" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "gev" = (
 /obj/machinery/light{
 	dir = 1
@@ -7996,6 +8048,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
+"gfa" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/slumbridge/landingzonetwo)
 "gfg" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/decal/cleanable/dirt,
@@ -8035,13 +8095,12 @@
 /obj/structure/mine_structure/wooden/support_wall/broken/above,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
-"ggx" = (
-/obj/effect/ai_node,
-/obj/structure/platform_decoration{
-	dir = 8
+"ggn" = (
+/obj/structure/platform/nondense{
+	dir = 6
 	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "ggF" = (
 /obj/structure/window/framed/wood,
 /turf/open/floor/wood/variable/wide,
@@ -8105,11 +8164,6 @@
 	dir = 2
 	},
 /area/slumbridge/inside/medical/foyer)
-"gjG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/shuttle/escapepod,
-/area/slumbridge/inside/zeta/entrance)
 "gka" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/darkish,
@@ -8228,6 +8282,15 @@
 	},
 /turf/open/shuttle/blackfloor,
 /area/slumbridge/inside/prison/outerringsouth)
+"gmo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/nwcargo)
 "gnd" = (
 /obj/machinery/light{
 	dir = 4
@@ -8258,9 +8321,16 @@
 /turf/open/liquid/water/river,
 /area/slumbridge/inside/houses/recreational)
 "gow" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/slumbridge/inside/engi/engineroom)
+"goJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/sombase/east)
 "goL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -8372,11 +8442,6 @@
 /obj/structure/mine_structure/wooden/support_wall/beams/above,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/northwestcaves)
-"gtn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform/nondense,
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "gto" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/ai_node,
@@ -8433,6 +8498,12 @@
 "gwm" = (
 /turf/closed/gm,
 /area/slumbridge/outside/northeast)
+"gwq" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/mosaic,
+/area/slumbridge/inside/houses/dorms)
 "gwM" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/prison/plate,
@@ -8472,6 +8543,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
+"gxv" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "gxB" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -8541,10 +8618,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"gzB" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/asteroidplating,
-/area/slumbridge/inside/zeta/south)
 "gzC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/jungle/vines,
@@ -8584,6 +8657,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/hangar)
+"gCy" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "gCC" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
@@ -8599,13 +8678,6 @@
 /obj/item/toy/plush/slime,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/engi/west)
-"gDu" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/swcargo)
 "gDQ" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -8644,6 +8716,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/slumbridge/outside/northeast/bridges)
+"gEv" = (
+/obj/structure/fence/broken,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "gEy" = (
 /obj/item/ore/slag{
 	pixel_x = -6;
@@ -8780,6 +8856,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
+"gJm" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating,
+/area/slumbridge/caves/northeastcaves)
 "gJA" = (
 /obj/machinery/power/port_gen/pacman/mrs,
 /turf/open/floor/prison/darkbrown/full,
@@ -8929,12 +9009,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
-"gOk" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 6
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "gON" = (
 /obj/structure/safe,
 /turf/open/floor/prison/blackfloor,
@@ -8990,6 +9064,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/sombase/hangar)
+"gRS" = (
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "gSj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -9014,12 +9092,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/slumbridge/inside/colony/northerndome)
-"gTr" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "gTH" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -9072,10 +9144,6 @@
 	},
 /turf/open/floor/tile/green,
 /area/slumbridge/inside/houses/recreational)
-"gUW" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/dorms)
 "gVa" = (
 /turf/open/floor/tile/green/whitegreencorner{
 	dir = 1
@@ -9130,6 +9198,10 @@
 "gWV" = (
 /turf/open/floor/plating/asteroidplating,
 /area/slumbridge/outside/northeast/bridges)
+"gXc" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "gXd" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/tile/bar,
@@ -9191,20 +9263,16 @@
 "gYL" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/surgery)
-"gYQ" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
 "gZD" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/heatinggrate,
 /area/slumbridge/inside/colony/dorms)
+"gZI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/outerringsouth)
 "gZN" = (
 /turf/open/lavaland/basalt,
 /area/slumbridge/inside/prison/outside)
@@ -9226,6 +9294,10 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/orestorage)
+"har" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/stripesquare,
+/area/slumbridge/inside/sombase/hangar)
 "haw" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/light{
@@ -9267,15 +9339,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"hbx" = (
-/obj/structure/fence/broken,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 5
-	},
-/area/slumbridge/outside/southwest)
 "hbH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -9298,6 +9361,12 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/northeast)
+"hdk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "hdl" = (
 /obj/structure/cryofeed{
 	name = "\improper coolant feed"
@@ -9336,6 +9405,17 @@
 "heP" = (
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
+"hfc" = (
+/obj/effect/ai_node,
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
+"hfm" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/asteroidplating,
+/area/slumbridge/inside/zeta/south)
 "hfq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -9348,6 +9428,14 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
+"hfO" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 5
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 5
+	},
+/area/slumbridge/landingzonetwo)
 "hge" = (
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
@@ -9402,15 +9490,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"hhy" = (
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
-"hhA" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "hhZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9487,11 +9566,6 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/slumbridge/landingzoneone)
-"hld" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "hly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9535,6 +9609,12 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
+"hmo" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "hmG" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
@@ -9644,6 +9724,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/pharmacy)
+"hqi" = (
+/obj/structure/platform_decoration/metalplatform_deco{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
 "hqD" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /obj/machinery/light{
@@ -9652,6 +9738,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
+"hqE" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "hqT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/blue2{
@@ -9669,15 +9763,6 @@
 /obj/effect/spawner/random/misc/structure/directional_window/north,
 /turf/open/floor/mainship/ai,
 /area/slumbridge/inside/houses/recreational)
-"hro" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "hrr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9692,17 +9777,13 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
-"hrB" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating,
-/area/slumbridge/caves/northeastcaves)
 "hrD" = (
 /obj/structure/table,
 /obj/machinery/computer/security,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
 "hrM" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
 "hrQ" = (
@@ -9748,11 +9829,6 @@
 "hsZ" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/foyer)
-"htI" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves/garbledradio)
 "htL" = (
 /obj/item/trash/cigbutt,
 /obj/structure/table,
@@ -9764,12 +9840,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/south)
-"hul" = (
-/obj/structure/platform_decoration/metalplatform_deco{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
 "huS" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -9779,17 +9849,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/hangar)
-"huT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "hvj" = (
 /turf/open/liquid/lava/lpiece{
 	dir = 4
@@ -9890,14 +9949,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"hye" = (
-/obj/structure/platform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/slumbridge/inside/houses/car)
 "hyh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -9975,13 +10026,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"hAT" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "hBo" = (
 /obj/structure/table/mainship,
 /obj/structure/prop/mainship/minigun_crate,
@@ -10021,12 +10065,6 @@
 	},
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringsouth)
-"hBS" = (
-/obj/structure/platform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "hCl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -10134,6 +10172,10 @@
 /area/slumbridge/inside/colony/southerndome)
 "hFc" = (
 /turf/open/floor/prison,
+/area/slumbridge/outside/northwest)
+"hFn" = (
+/obj/structure/lattice,
+/turf/open/liquid/lava/side,
 /area/slumbridge/outside/northwest)
 "hFx" = (
 /obj/structure/barricade/snow{
@@ -10383,14 +10425,6 @@
 /obj/structure/xenoautopsy/tank,
 /turf/open/floor/iron/freezer,
 /area/slumbridge/inside/sombase/west)
-"hPu" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "hPK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -10503,6 +10537,16 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/landingzoneone)
+"hTQ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs/seamless/edge{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "hUh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -10637,10 +10681,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/broken,
 /area/slumbridge/inside/colony/bar)
-"hYA" = (
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "hYC" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -10670,6 +10710,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/slumbridge/inside/colony/southerndome)
+"hZB" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "hZH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/razorwire{
@@ -10677,13 +10721,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome)
-"hZL" = (
-/obj/structure/prop/mainship/mission_planning_system{
-	name = "\improper Miner Oversight";
-	pixel_x = -1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "hZM" = (
 /obj/machinery/faxmachine/warden,
 /obj/structure/table/reinforced,
@@ -10959,6 +10996,11 @@
 "ijf" = (
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
+"ijz" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "ijT" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -10989,6 +11031,14 @@
 	},
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
+"ikl" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 4
+	},
+/area/slumbridge/landingzonetwo)
 "ikm" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -11165,6 +11215,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"ioZ" = (
+/obj/effect/ai_node,
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow,
+/area/slumbridge/landingzonetwo)
 "ipe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -11192,6 +11249,11 @@
 /obj/effect/ai_node,
 /turf/open/lavaland/basalt/glowing,
 /area/slumbridge/outside/northwest)
+"ipA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "ipI" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 9
@@ -11207,6 +11269,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/zeta/north)
+"ipX" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "iqF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -11214,12 +11282,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/engi/central)
-"iqP" = (
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "iqR" = (
 /obj/effect/decal/cleanable/molten_item,
 /turf/open/floor,
@@ -11375,6 +11437,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/outerringnorth)
+"ivx" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "ivS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -11679,16 +11748,20 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
+"iHB" = (
+/obj/structure/fence/broken,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
 "iHI" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"iHV" = (
-/obj/structure/flora/jungle/vines,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "iHY" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/plating,
@@ -11900,21 +11973,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/houses/nwcargo)
+"iQa" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/riverdecal,
+/obj/structure/platform/nondense{
+	dir = 6
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "iQb" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall/prison,
 /area/slumbridge/inside/prison/outerringnorth)
-"iQm" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/wide,
-/area/slumbridge/inside/houses/dorms)
 "iQo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engineroom)
+"iQu" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "iQz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -11956,10 +12039,6 @@
 	},
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
-"iSf" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "iSw" = (
 /obj/structure/window_frame/wood,
 /turf/open/floor/wood/variable,
@@ -12038,6 +12117,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"iVr" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "iVs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -12080,10 +12164,29 @@
 /obj/machinery/light,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"iWI" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/engine,
+/area/slumbridge/inside/engi/engineroom)
 "iWJ" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/prison/whitegreen/full,
 /area/slumbridge/inside/prison/outerringsouth)
+"iWK" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
+"iWV" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/slumbridge/outside/southwest)
 "iXb" = (
 /obj/item/paper/brassnote,
 /turf/open/floor/cult,
@@ -12139,6 +12242,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"jaz" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "jaC" = (
 /obj/effect/decal/cleanable/glass/plastic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -12163,6 +12272,12 @@
 /obj/structure/curtain/open/temple,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
+"jbT" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "jcd" = (
 /obj/structure/window/reinforced/north,
 /obj/structure/window/reinforced/east,
@@ -12230,6 +12345,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
+"jeJ" = (
+/obj/structure/girder/displaced,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "jfr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -12247,12 +12367,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/medical/foyer)
-"jfI" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/outside/northeast)
 "jfS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/blue,
@@ -12312,6 +12426,13 @@
 	},
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringnorth)
+"jil" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "jiD" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/marking/bot,
@@ -12345,6 +12466,12 @@
 	},
 /turf/open/floor/scorched,
 /area/slumbridge/inside/pmcdome)
+"jky" = (
+/obj/structure/platform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "jkR" = (
 /obj/machinery/computer/sleep_console,
 /turf/open/floor/tile/bar,
@@ -12374,17 +12501,6 @@
 	},
 /turf/open/floor/freezer,
 /area/slumbridge/inside/colony/kitchen)
-"jlH" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "jlM" = (
 /turf/open/liquid/lava/lpiece,
 /area/slumbridge/outside/northwest)
@@ -12602,12 +12718,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/prison/innerring)
-"jsI" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "jsP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -12672,17 +12782,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/heatinggrate,
 /area/slumbridge/inside/colony/dorms)
-"jvi" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/mainship/ai,
-/area/slumbridge/inside/houses/recreational)
 "jvt" = (
 /obj/structure/prop/mainship/telecomms/bus,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -12980,8 +13079,12 @@
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/prison/outerringsouth)
 "jHh" = (
-/obj/structure/prop/turbine,
-/turf/open/floor/engine,
+/obj/structure/prop/mainship/missile_tube{
+	desc = "Metal rotary device spins to create power out of water.";
+	name = "\improper turbine oversight system"
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/bcircuit,
 /area/slumbridge/inside/engi/engineroom)
 "jHn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -13114,6 +13217,22 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
+"jLm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/swcargo)
+"jLn" = (
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "jLs" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -13202,6 +13321,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/sombase/east)
+"jPS" = (
+/obj/structure/sign/securearea{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "jQk" = (
 /obj/structure/table/black,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -13283,6 +13409,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/mono,
 /area/slumbridge/inside/colony/northerndome)
+"jSj" = (
+/obj/structure/platform/nondense{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/slumbridge/inside/houses/car)
 "jSq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/junction/yjunc{
@@ -13369,6 +13503,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/colony/pharmacy)
+"jWR" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "jXm" = (
 /obj/effect/ai_node,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -13420,13 +13560,6 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
-"jYQ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "jZs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13543,13 +13676,6 @@
 "kdw" = (
 /turf/closed/wall,
 /area/slumbridge/caves/mining)
-"kdy" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 10
-	},
-/area/slumbridge/outside/southwest)
 "kdF" = (
 /obj/structure/prop/mainship/railing{
 	dir = 4
@@ -13698,6 +13824,13 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/prison/innerring)
+"kjk" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "kjA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13847,12 +13980,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroidfloor,
 /area/slumbridge/outside/northeast/bridges)
-"koX" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "kph" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -13888,6 +14015,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
+"kry" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/slumbridge/outside/northeast)
 "krL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -13979,12 +14112,6 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/vault,
 /area/slumbridge/inside/sombase/east)
-"kuR" = (
-/obj/structure/sign/hydro{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "kvg" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 6
@@ -14061,6 +14188,10 @@
 /obj/item/toy/plush/rouny,
 /turf/open/floor/elevatorshaft,
 /area/slumbridge/inside/engi/west)
+"kyL" = (
+/obj/structure/platform/nondense,
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "kyP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/generic{
@@ -14320,15 +14451,6 @@
 	},
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
-"kKQ" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 10
-	},
-/area/slumbridge/outside/southwest)
 "kKX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass{
 	dir = 2
@@ -14416,10 +14538,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"kNG" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/houses/recreational)
 "kNJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -14441,6 +14559,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
+"kOq" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "kOG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -14537,11 +14660,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"kQL" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "kQS" = (
 /obj/machinery/light{
 	dir = 4
@@ -14584,12 +14702,6 @@
 "kRn" = (
 /turf/open/floor/rustyplating,
 /area/slumbridge/inside/prison/innerring)
-"kRt" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "kRv" = (
 /obj/effect/turf_decal/tracks/claw1/bloody{
 	dir = 4
@@ -14667,16 +14779,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"kTw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "kTH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/red{
@@ -14730,10 +14832,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/ai,
 /area/slumbridge/inside/houses/recreational)
-"kVQ" = (
-/obj/effect/landmark/corpsespawner/engineer/regular,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "kVT" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/ai_node,
@@ -14755,10 +14853,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/storage)
-"kWD" = (
-/obj/effect/landmark/corpsespawner/PMC/regular,
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/outside/southwest)
 "kWF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/smooth/bigred,
@@ -14850,12 +14944,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
-"kZG" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "kZM" = (
 /obj/effect/spawner/random/misc/trash,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -14879,15 +14967,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/full,
 /area/slumbridge/inside/colony/southerndome)
-"lbl" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outerringsouth)
-"lbs" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/cult,
-/area/slumbridge/caves/northeastcaves)
 "lbv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14960,6 +15039,11 @@
 "leg" = (
 /turf/open/lavaland/basalt,
 /area/slumbridge/outside/northwest)
+"lel" = (
+/obj/effect/spawner/random/misc/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "leo" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
@@ -14970,16 +15054,6 @@
 	},
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
-"leQ" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 4
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
-"leW" = (
-/obj/structure/window/framed/prison/reinforced,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outerringsouth)
 "lff" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15011,6 +15085,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/houses/recreational)
+"lgx" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "lgJ" = (
 /obj/effect/landmark/patrol_point/tgmc_23,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -15026,13 +15104,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"lhc" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "lhd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -15104,9 +15175,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"ljt" = (
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "ljx" = (
 /obj/effect/turf_decal/riverdecal,
 /turf/open/liquid/water/river/autosmooth/deep,
@@ -15128,12 +15196,22 @@
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/sombase/east)
+"lkX" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/dorms)
 "llt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
+"llX" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "lms" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -15142,6 +15220,9 @@
 "lmC" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/ice,
+/area/slumbridge/landingzonetwo)
+"lmE" = (
+/turf/open/floor/plating/mainship,
 /area/slumbridge/landingzonetwo)
 "lmQ" = (
 /obj/structure/table/reinforced/flipped{
@@ -15251,12 +15332,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/southern)
-"lqs" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/wide,
-/area/slumbridge/inside/houses/dorms)
 "lqy" = (
 /obj/machinery/light{
 	dir = 8
@@ -15406,6 +15481,13 @@
 	dir = 6
 	},
 /area/slumbridge/inside/houses/recreational)
+"lwm" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "lwr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -15453,6 +15535,16 @@
 	dir = 1
 	},
 /area/slumbridge/inside/zeta/south)
+"lxP" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "lyo" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -15507,6 +15599,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/zeta/entrance)
+"lAy" = (
+/obj/effect/landmark/corpsespawner/PMC/regular,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "lAB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -15692,9 +15788,11 @@
 	dir = 10
 	},
 /area/slumbridge/inside/engi/west)
-"lGq" = (
-/obj/structure/stairs/seamless/edge,
-/turf/open/floor/tile/dark,
+"lGv" = (
+/obj/structure/platform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
 /area/slumbridge/outside/southwest)
 "lGS" = (
 /turf/open/lavaland/basalt/dirt/corner,
@@ -15735,6 +15833,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/north)
+"lJw" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "lJC" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -15806,16 +15910,6 @@
 "lKR" = (
 /turf/open/floor/tile/brown,
 /area/slumbridge/inside/houses/dorms)
-"lKS" = (
-/obj/effect/turf_decal/trimline/purple/arrow_ccw,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery)
 "lKY" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/prison/red{
@@ -15881,6 +15975,10 @@
 	dir = 8
 	},
 /area/slumbridge/inside/prison/innerring)
+"lMU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/outside/northwest)
 "lNg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15932,6 +16030,10 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/inside/hydrotreatment)
+"lNZ" = (
+/obj/structure/prop/vehicle/tank/east/armor,
+/turf/open/floor/mainship/stripesquare,
+/area/slumbridge/inside/sombase/hangar)
 "lOb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -15951,12 +16053,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"lOv" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
+"lOZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
 	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "lPH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -15993,12 +16096,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/zeta/entrance)
-"lQX" = (
-/obj/structure/sign/hydro/three{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "lRc" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -16070,6 +16167,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/car)
+"lUc" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/northeast)
 "lUg" = (
 /obj/structure/plasticflaps/mining,
 /turf/open/floor/plating/platebot,
@@ -16080,6 +16183,12 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/foyer)
+"lUi" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest/nearlz)
 "lUz" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
@@ -16106,10 +16215,6 @@
 	dir = 4
 	},
 /area/slumbridge/caves/mining)
-"lUO" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/mining)
 "lUS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -16129,6 +16234,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
+"lVx" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/slumbridge/inside/prison/outerringsouth)
 "lVB" = (
 /obj/structure/cargo_container/red,
 /turf/open/floor/asteroidfloor,
@@ -16136,12 +16245,6 @@
 "lVG" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/orestorage)
-"lVM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/sombase/west)
 "lWc" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -16195,6 +16298,15 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/hangar)
+"lZe" = (
+/obj/structure/fence/broken,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 5
+	},
+/area/slumbridge/outside/southwest)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
@@ -16276,6 +16388,10 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/northerndome)
+"mbY" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/outside/southeast)
 "mca" = (
 /turf/open/lavaland/basalt/glowing,
 /area/slumbridge/outside/northwest)
@@ -16293,6 +16409,9 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
+"mcs" = (
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/outerringnorth)
 "mcD" = (
 /obj/item/ore/slag{
 	pixel_x = -3;
@@ -16416,6 +16535,13 @@
 /obj/machinery/light,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringsouth)
+"mgG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/assistant/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/swcargo)
 "mgJ" = (
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/mainship/red{
@@ -16445,6 +16571,15 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
+/area/slumbridge/outside/southwest)
+"mhz" = (
+/obj/structure/prop/mainship/gelida/powerccable{
+	dir = 4
+	},
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
 "mhV" = (
 /obj/structure/rock/basalt/alt3,
@@ -16519,6 +16654,10 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/recreational)
+"mjK" = (
+/obj/structure/lattice,
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "mjM" = (
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -16537,6 +16676,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
+"mkc" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "mkf" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/slumbridge/outside/northwest)
@@ -16561,10 +16707,6 @@
 /obj/structure/flora/jungle/vines,
 /turf/closed/gm,
 /area/slumbridge/caves/rock)
-"mkV" = (
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/plating,
-/area/slumbridge/inside/sombase/east)
 "mll" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -16613,13 +16755,6 @@
 /obj/item/ammo_casing,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/west)
-"mno" = (
-/obj/structure/catwalk,
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "mnL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -16701,6 +16836,7 @@
 /area/slumbridge/inside/medical/morgue)
 "mpw" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/engine,
 /area/slumbridge/inside/engi/engineroom)
 "mpI" = (
@@ -16738,10 +16874,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating,
 /area/slumbridge/outside/southeast)
-"msm" = (
-/obj/effect/landmark/corpsespawner/PMC/regular,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "mtn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -16770,12 +16902,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/east)
-"muu" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 9
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "muU" = (
 /turf/open/liquid/lava/side{
 	dir = 4
@@ -16793,10 +16919,6 @@
 	dir = 4
 	},
 /area/slumbridge/outside/northeast/bridges)
-"mvy" = (
-/obj/structure/stairs/seamless/platform_vert,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "mvD" = (
 /obj/machinery/light{
 	dir = 4
@@ -16818,12 +16940,6 @@
 "mwo" = (
 /turf/closed/wall,
 /area/slumbridge/inside/medical/foyer)
-"mwq" = (
-/obj/structure/bed/fancy,
-/obj/effect/spawner/random/misc/bedsheet,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/wood/variable/mosaic,
-/area/slumbridge/inside/houses/dorms)
 "mwr" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor,
@@ -16880,6 +16996,15 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
+"mxR" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/slumbridge/outside/southwest)
 "mxS" = (
 /obj/structure/flora/jungle/vines,
 /obj/structure/fence,
@@ -16892,7 +17017,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
 "myx" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/effect/turf_decal/sandytile/sandyplating,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
@@ -16919,12 +17044,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/slumbridge/inside/sombase/west)
-"mzs" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "mzF" = (
 /obj/structure/table/fancywoodentable,
 /obj/machinery/computer/crew,
@@ -16966,6 +17085,12 @@
 	dir = 5
 	},
 /area/slumbridge/inside/zeta/entrance)
+"mAI" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "mAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -16995,11 +17120,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
-"mCh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/som,
-/turf/open/floor/wood/broken,
-/area/slumbridge/inside/sombase/east)
 "mCv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor/glass,
 /turf/open/floor/plating,
@@ -17009,12 +17129,6 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"mCR" = (
-/obj/structure/platform_decoration,
-/turf/open/liquid/lava/lpiece{
-	dir = 8
-	},
-/area/slumbridge/outside/northwest)
 "mCS" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/red/corner,
@@ -17072,6 +17186,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
+"mEC" = (
+/obj/structure/window_frame/colony,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "mFf" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/tray,
@@ -17149,6 +17270,12 @@
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/storage)
+"mJi" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "mJo" = (
 /obj/machinery/landinglight/lz2,
 /turf/open/floor/tile/dark,
@@ -17195,12 +17322,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/cult,
 /area/slumbridge/caves/northeastcaves)
-"mLW" = (
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "mLX" = (
 /obj/structure/flora/pottedplant/one,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -17356,12 +17477,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/northerndome)
-"mSk" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "mSv" = (
 /obj/effect/turf_decal/sandytile,
 /obj/effect/ai_node,
@@ -17397,10 +17512,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
-"mUL" = (
-/obj/structure/flora/jungle/vines,
-/turf/closed/mineral/smooth/bigred,
-/area/slumbridge/caves/rock)
 "mVc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -17421,11 +17532,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/innerring)
-"mVH" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete,
-/area/slumbridge/outside/southwest)
 "mVO" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced,
@@ -17660,6 +17766,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/east)
+"neO" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
 "neU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -17767,10 +17879,6 @@
 "niQ" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/pmcdome/dorms)
-"niX" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "niY" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
@@ -17970,11 +18078,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"nof" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
+"noc" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "noy" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/sombase/hangar)
@@ -18015,12 +18126,6 @@
 /obj/effect/spawner/random/food_or_drink/sugary_snack,
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/kitchen)
-"nrL" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "nrM" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/effect/ai_node,
@@ -18127,6 +18232,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"ntY" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "nuw" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 4
@@ -18145,6 +18256,11 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
+"nuW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile/green,
+/area/slumbridge/inside/houses/recreational)
 "nva" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -18197,12 +18313,10 @@
 "nwg" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop1/lz1)
-"nwh" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
+"nwi" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "nwn" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1
@@ -18285,6 +18399,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/west)
+"nyH" = (
+/obj/structure/prop/turbine,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/bcircuit,
+/area/slumbridge/inside/engi/engineroom)
 "nyQ" = (
 /obj/effect/spawner/random/misc/structure/directional_window/east,
 /obj/effect/decal/cleanable/dirt,
@@ -18370,18 +18489,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
-"nBH" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
+"nCf" = (
+/obj/structure/platform/metalplatform/nondense{
 	dir = 4
 	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
-"nBJ" = (
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outside)
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "nCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -18450,6 +18563,13 @@
 	},
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery/garbledradio)
+"nDG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "nDL" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/dmg1,
@@ -18851,6 +18971,13 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/medical/southern)
+"nTu" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "nTY" = (
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
@@ -19040,9 +19167,11 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/headoffice)
-"nZy" = (
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
+"nZF" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "nZR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -19083,7 +19212,7 @@
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
 "obs" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plating,
 /area/slumbridge/caves/northeastcaves)
 "obu" = (
@@ -19228,13 +19357,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/ground/grass/weedable,
 /area/slumbridge/outside/southeast)
-"ogP" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 10
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "ohp" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -19330,6 +19452,15 @@
 	dir = 5
 	},
 /area/slumbridge/caves/northwestcaves)
+"okT" = (
+/obj/structure/fence,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 5
+	},
+/area/slumbridge/outside/southwest)
 "okV" = (
 /turf/open/ground/grass,
 /area/slumbridge/outside/southeast)
@@ -19468,14 +19599,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"opP" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "opT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -19556,10 +19679,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"ote" = (
-/obj/structure/platform/nondense,
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "otE" = (
 /obj/structure/largecrate/random/case,
 /obj/effect/turf_decal/sandytile,
@@ -19607,6 +19726,13 @@
 	dir = 5
 	},
 /area/slumbridge/inside/zeta/south)
+"ouI" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "ovd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -19669,6 +19795,11 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"oxZ" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "oyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -19717,11 +19848,6 @@
 "ozh" = (
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
 /area/slumbridge/outside/southeast)
-"ozr" = (
-/obj/structure/platform/metalplatform/nondense,
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines,
-/area/slumbridge/outside/southwest)
 "ozE" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/mainship/silver{
@@ -19795,10 +19921,6 @@
 /obj/structure/cargo_container/hd_blue,
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/landingzoneone)
-"oCE" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "oCR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/floor,
@@ -19809,6 +19931,13 @@
 	dir = 1
 	},
 /area/slumbridge/outside/northwest/nearlz)
+"oEg" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "oEl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -19832,10 +19961,6 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/slumbridge/inside/sombase/hangar)
-"oFn" = (
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "oFB" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor,
@@ -19896,10 +20021,6 @@
 "oGR" = (
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/south)
-"oHg" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/mainship,
-/area/slumbridge/inside/houses/car)
 "oHh" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/marking/loadingarea,
@@ -19947,16 +20068,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/colony/southerndome)
-"oJA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/tile/green/whitegreencorner{
-	dir = 8
-	},
-/area/slumbridge/inside/medical/foyer)
 "oJC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -19996,6 +20107,12 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/dorms)
+"oLq" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "oLs" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1;
@@ -20047,6 +20164,13 @@
 /obj/effect/spawner/random/engineering/radio,
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
+"oNd" = (
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "oNl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -20224,9 +20348,11 @@
 	},
 /area/slumbridge/inside/prison/innerring)
 "oUU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/stripesquare,
-/area/slumbridge/inside/sombase/hangar)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/sombase/west)
 "oVn" = (
 /obj/item/weapon/sword/machete,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -20294,12 +20420,6 @@
 "oXX" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop2/lz2)
-"oYm" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 6
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "oYP" = (
 /obj/structure/table/mainship,
 /obj/machinery/light,
@@ -20485,13 +20605,6 @@
 /obj/effect/spawner/random/misc/cigar,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
-"pew" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "pff" = (
 /obj/item/shard,
 /obj/effect/ai_node,
@@ -20527,13 +20640,6 @@
 /obj/effect/spawner/random/food_or_drink/outdoors_snacks,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/dorms)
-"phK" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "phV" = (
 /obj/structure/rack{
 	color = "#50617d"
@@ -20647,6 +20753,15 @@
 /obj/structure/closet/wardrobe/virology_white,
 /turf/open/floor/mainship/sterile,
 /area/slumbridge/inside/sombase/west)
+"pma" = (
+/obj/structure/prop/mainship/mission_planning_system{
+	name = "\improper Miner Oversight";
+	pixel_x = -1
+	},
+/turf/open/floor/plating/ground/snow/layer2{
+	dir = 6
+	},
+/area/slumbridge/outside/southwest)
 "pmA" = (
 /obj/effect/landmark/corpsespawner/engineer/regular,
 /turf/open/floor,
@@ -20742,13 +20857,6 @@
 /obj/item/reagent_containers/glass/bottle/tramadol,
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
-"pqB" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/security/regular,
-/turf/open/floor/mainship/floor,
-/area/slumbridge/inside/colony/northerndome)
 "pqL" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 5
@@ -20817,6 +20925,13 @@
 	dir = 4
 	},
 /area/slumbridge/landingzonetwo)
+"psr" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "psz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20849,6 +20964,11 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/caves/mining)
+"ptl" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "ptr" = (
 /obj/structure/closet/bodybag,
 /turf/open/floor/tile/bar,
@@ -20865,6 +20985,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
+"ptF" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "ptO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/green2/corner,
@@ -20934,12 +21064,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringnorth)
-"pvF" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "pvH" = (
 /obj/machinery/door_control/old/unmeltable{
 	id = "NorthBaseSomArmory";
@@ -21025,20 +21149,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/outside/southeast)
-"pys" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/outside/northwest)
-"pyy" = (
-/obj/structure/prop/mainship/mission_planning_system{
-	name = "\improper Miner Oversight";
-	pixel_x = -1
-	},
-/turf/open/floor/plating/ground/snow/layer2{
-	dir = 6
-	},
-/area/slumbridge/outside/southwest)
 "pyW" = (
 /obj/effect/landmark/patrol_point/som/som_24,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -21047,9 +21157,9 @@
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass,
 /turf/open/floor/foamplating,
 /area/slumbridge/inside/prison/innerring)
-"pzr" = (
+"pzv" = (
 /obj/structure/platform/metalplatform/nondense{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/construction)
@@ -21106,10 +21216,6 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/marking/warning,
 /area/slumbridge/outside/northeast/bridges)
-"pBb" = (
-/obj/structure/lattice,
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "pBm" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/effect/decal/cleanable/dirt,
@@ -21139,6 +21245,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/slumbridge/inside/colony/southerndome)
+"pDK" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/slumbridge/inside/prison/outerringsouth)
 "pDT" = (
 /obj/structure/prop/mainship/research/tdoppler,
 /turf/open/floor/tile/yellow/full,
@@ -21305,9 +21415,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/medical/foyer)
-"pMp" = (
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outerringsouth)
 "pMs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21331,15 +21438,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/south)
-"pNt" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 6
-	},
-/area/slumbridge/outside/southwest)
 "pNw" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -21435,7 +21533,7 @@
 /area/slumbridge/inside/houses/dorms)
 "pPl" = (
 /obj/structure/table/woodentable,
-/obj/item/reagent_containers/cup/glass/drinkingglass{
+/obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = -7;
 	pixel_y = -1
 	},
@@ -21487,6 +21585,9 @@
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
+/area/slumbridge/inside/prison/outerringsouth)
+"pRV" = (
+/turf/open/lavaland/catwalk,
 /area/slumbridge/inside/prison/outerringsouth)
 "pSg" = (
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -21668,12 +21769,6 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/south)
-"pYm" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/northeast)
 "pYB" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -21716,21 +21811,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/outside/northwest)
-"qal" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
-"qaF" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
 "qaJ" = (
 /obj/structure/safe/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -21812,10 +21892,6 @@
 "qcF" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/zeta/entrance)
-"qcM" = (
-/obj/effect/landmark/corpsespawner/scientist/burst,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "qcR" = (
 /obj/structure/prop/mainship/research/mechafab,
 /turf/open/floor/tile/yellow/full,
@@ -21828,10 +21904,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/slumbridge/outside/southwest)
-"qdC" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
+"qdz" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "qdH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21929,6 +22008,13 @@
 	dir = 4
 	},
 /area/slumbridge/inside/zeta/north)
+"qhy" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "qhA" = (
 /obj/machinery/light{
 	dir = 4
@@ -22048,6 +22134,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
+"qkV" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/slumbridge/inside/colony/kitchen)
 "qll" = (
 /obj/structure/barricade/snow,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -22118,12 +22210,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/hangar)
-"qnT" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "qor" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -22145,9 +22231,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/vault,
 /area/slumbridge/inside/sombase/east)
-"qoE" = (
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "qoG" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -22165,6 +22248,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/minedrock)
+"qpP" = (
+/obj/structure/stairs/seamless/platform_vert{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "qqg" = (
 /obj/structure/table,
 /obj/item/bodybag,
@@ -22282,6 +22371,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/inside/houses/surgery)
+"qtQ" = (
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/innerring)
 "qug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/green/whitegreen,
@@ -22345,6 +22437,12 @@
 /obj/effect/spawner/random/misc/plushie/fiftyfifty,
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/inside/houses/dorms)
+"qwF" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "qxg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -22379,15 +22477,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"qxD" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 5
-	},
-/area/slumbridge/outside/southwest)
 "qxE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -22497,16 +22586,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
-"qCd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "qCL" = (
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest/nearlz)
@@ -22610,6 +22689,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/slumbridge/landingzonetwo)
+"qFQ" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "qFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22744,17 +22830,18 @@
 "qKo" = (
 /turf/closed/wall/prison,
 /area/slumbridge/inside/prison/innerring)
+"qKr" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/northeastcaves)
 "qKX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"qLg" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 9
-	},
-/turf/closed/mineral/smooth/darkfrostwall/indestructible,
-/area/slumbridge/caves/rock)
 "qLt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -22852,22 +22939,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
-"qNS" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
-"qNY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/swcargo)
 "qOc" = (
 /obj/machinery/light{
 	dir = 4
@@ -22893,10 +22964,26 @@
 /obj/machinery/space_heater,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
+"qPf" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "qPW" = (
 /obj/machinery/vending/marineFood/som,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
+"qPX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "qPY" = (
 /obj/structure/prop/mainship/sensor_computer1,
 /obj/machinery/light{
@@ -23240,14 +23327,12 @@
 /obj/structure/razorwire,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"rbu" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/sign/safety/vacuum{
-	dir = 4
+"rby" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 10
 	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "rbI" = (
 /obj/structure/bed/chair/wood/normal,
 /obj/effect/decal/cleanable/dirt,
@@ -23338,12 +23423,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
-"rfK" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "rgh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stairs/rampbottom{
@@ -23396,12 +23475,6 @@
 	dir = 9
 	},
 /area/slumbridge/caves/minedrock)
-"riM" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/slumbridge/outside/southwest)
 "riN" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -23424,6 +23497,13 @@
 	dir = 6
 	},
 /area/slumbridge/inside/sombase/hangar)
+"rjn" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "rjq" = (
 /obj/structure/cargo_container/red{
 	dir = 1
@@ -23564,6 +23644,17 @@
 "rok" = (
 /turf/open/floor/prison/sterilewhite,
 /area/slumbridge/inside/prison/outerringsouth)
+"ros" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/mineral/smooth/snowrock,
+/area/slumbridge/caves/rock)
+"roy" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/shuttle/drop2/lz2)
 "roD" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /turf/open/floor/tile/showroom,
@@ -23657,12 +23748,32 @@
 	dir = 5
 	},
 /area/slumbridge/inside/prison/innerring)
+"rqt" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/wide,
+/area/slumbridge/inside/houses/dorms)
 "rqO" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"rqP" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/inside/houses/car)
+"rrp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/slumbridge/inside/medical/foyer)
 "rrr" = (
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
@@ -23684,6 +23795,13 @@
 "rrK" = (
 /turf/closed/wall/r_wall,
 /area/slumbridge/inside/zeta/south)
+"rsD" = (
+/obj/structure/girder/displaced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "rsH" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -23691,12 +23809,6 @@
 /obj/effect/landmark/corpsespawner/doctor/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/pharmacy)
-"rsO" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/slumbridge/inside/colony/kitchen)
 "rtb" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -23733,13 +23845,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"ruH" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "ruN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23759,13 +23864,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/colony/oreprocess)
-"ruY" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8
-	},
-/obj/effect/turf_decal/riverdecal,
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "rvd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -23802,10 +23900,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/west)
-"rwa" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/closed/mineral/smooth/snowrock,
-/area/slumbridge/caves/rock)
 "rwr" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/decal/cleanable/dirt,
@@ -23842,17 +23936,18 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/south)
+"rxc" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/shuttle/escapepod,
+/area/slumbridge/inside/zeta/entrance)
 "rxl" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/yellow,
 /area/slumbridge/inside/engi/west)
-"rxT" = (
-/obj/effect/ai_node,
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow,
-/area/slumbridge/landingzonetwo)
 "ryG" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -23867,6 +23962,13 @@
 /obj/structure/flora/pottedplant/six,
 /turf/open/floor/mainship/plate,
 /area/slumbridge/inside/sombase/east)
+"rzd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "rzf" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/lavaland/basalt,
@@ -23998,22 +24100,6 @@
 /obj/structure/prop/mainship/gelida/planterboxsoilgrid/nondense,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/caves/mining)
-"rDt" = (
-/obj/structure/fence/broken,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 1
-	},
-/area/slumbridge/outside/southwest)
-"rDw" = (
-/obj/structure/sign/securearea{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/grass/weedable/patch,
-/area/slumbridge/outside/northeast)
 "rDy" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -24027,6 +24113,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
+"rEK" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "rEO" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -24076,12 +24168,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
-"rGs" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "rGT" = (
 /turf/open/floor/prison/green/corner{
 	dir = 1
@@ -24092,16 +24178,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/west)
-"rHx" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "rHI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -24313,14 +24389,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/headoffice)
-"rPe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/nwcargo)
 "rPt" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -24375,22 +24443,26 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/north)
-"rQV" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
+"rQR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/lavaland/catwalk,
+/area/slumbridge/outside/northwest)
 "rRm" = (
 /obj/effect/spawner/random/engineering/structure/tank_dispenser,
 /obj/effect/turf_decal/warning_stripes/box,
 /obj/effect/turf_decal/warning_stripes/linethick,
 /turf/open/floor/plating,
 /area/slumbridge/inside/pmcdome)
-"rRz" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/slumbridge/inside/prison/outerringsouth)
+"rRJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "rRL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mainship/generic{
@@ -24476,6 +24548,17 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/outerringsouth)
+"rVn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/freezer,
+/area/slumbridge/inside/houses/recreational)
+"rVw" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "rVx" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/plating,
@@ -24505,13 +24588,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/prison/innerring)
-"rWs" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "rWw" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -24658,6 +24734,12 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
+"saO" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "sbk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24872,6 +24954,11 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/inside/colony/vault)
+"shb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer/regular,
+/turf/open/shuttle/escapepod,
+/area/slumbridge/inside/zeta/entrance)
 "shI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -24894,6 +24981,14 @@
 "sia" = (
 /turf/open/floor/tile/white,
 /area/slumbridge/inside/pmcdome/dorms)
+"sih" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/sombase/west)
 "sip" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -24944,6 +25039,12 @@
 "skd" = (
 /turf/closed/mineral/smooth/bluefrostwall,
 /area/slumbridge/caves/rock)
+"skF" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2/corner,
+/area/slumbridge/landingzonetwo)
 "skH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -25188,12 +25289,6 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery)
-"swt" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "swv" = (
 /obj/structure/prop/mainship/gelida/powerccable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -25241,6 +25336,10 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/west)
+"sys" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
+/area/slumbridge/caves/southeastcaves)
 "syw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody,
@@ -25305,6 +25404,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
+"sAW" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 10
+	},
+/area/slumbridge/outside/southwest)
 "sAX" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/attachable/bayonetknife/som,
@@ -25325,6 +25433,9 @@
 	},
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
+"sBB" = (
+/turf/open/lavaland/catwalk,
+/area/slumbridge/inside/prison/outside)
 "sBD" = (
 /obj/structure/sink/bathroom,
 /obj/effect/decal/cleanable/dirt,
@@ -25339,12 +25450,6 @@
 	},
 /turf/open/floor/tile/showroom,
 /area/slumbridge/inside/engi/central)
-"sCj" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "sCk" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/zeta/entrance)
@@ -25364,6 +25469,12 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"sDb" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/slumbridge/inside/colony/construction)
 "sDd" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/grass,
@@ -25468,6 +25579,11 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
+"sGX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/nondense,
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "sHv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -25489,6 +25605,14 @@
 "sHO" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/bar)
+"sHT" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/slumbridge/outside/northwest)
 "sHV" = (
 /obj/structure/inflatable/wall,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -25512,6 +25636,10 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"sJa" = (
+/obj/structure/stairs/seamless/edge,
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "sJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -25589,6 +25717,13 @@
 /obj/structure/flora/jungle/vines,
 /turf/open/floor/plating/ground/dirt,
 /area/slumbridge/caves/southeastcaves/garbledradio)
+"sMv" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "sMG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -25760,11 +25895,6 @@
 /obj/effect/landmark/corpsespawner/colonist/regular,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/bar)
-"sSp" = (
-/obj/structure/girder/displaced,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "sSG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25888,6 +26018,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/slumbridge/inside/prison/outerringsouth)
+"sXz" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "sXA" = (
 /obj/structure/cargo_container/nt,
 /turf/open/floor/tile/dark/purple2{
@@ -25923,6 +26059,10 @@
 	dir = 1
 	},
 /area/slumbridge/inside/houses/recreational)
+"sYp" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "sYP" = (
 /obj/structure/prop/mainship/gelida/powerccable,
 /obj/machinery/light{
@@ -25930,10 +26070,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining/dropship)
-"sYV" = (
-/obj/structure/platform_decoration,
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "sZa" = (
 /turf/open/liquid/lava/side{
 	dir = 4
@@ -25974,6 +26110,12 @@
 /obj/structure/rock/basalt/pile,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/slumbridge/caves/mining)
+"taZ" = (
+/obj/structure/platform/nondense{
+	dir = 8
+	},
+/turf/open/lavaland/catwalk,
+/area/slumbridge/outside/northwest)
 "tbj" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -26393,12 +26535,6 @@
 	dir = 6
 	},
 /area/slumbridge/inside/zeta/south)
-"trZ" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/slumbridge/inside/colony/construction)
 "tsb" = (
 /obj/structure/cable,
 /turf/open/floor/tile/showroom,
@@ -26430,17 +26566,6 @@
 "tti" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/dorms)
-"ttT" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/caves/southeastcaves)
-"ttW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/ai_node,
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/freezer,
-/area/slumbridge/inside/houses/recreational)
 "tuh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26510,12 +26635,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/prison/outerringsouth)
-"twZ" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "txe" = (
 /obj/structure/prop/mainship/gelida/powerconnector{
 	dir = 8
@@ -26543,6 +26662,12 @@
 	dir = 5
 	},
 /area/slumbridge/inside/colony/northerndome)
+"txJ" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/lavaland/basalt,
+/area/slumbridge/outside/northwest)
 "tyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -26587,9 +26712,6 @@
 	},
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/southeast)
-"tzx" = (
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/outside/northwest)
 "tzA" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
@@ -26646,6 +26768,10 @@
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
+"tBy" = (
+/obj/effect/landmark/corpsespawner/som,
+/turf/open/floor/plating,
+/area/slumbridge/inside/sombase/east)
 "tBz" = (
 /obj/effect/turf_decal/warning_stripes/linethick,
 /obj/effect/decal/cleanable/dirt,
@@ -26765,13 +26891,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/surgery)
-"tFk" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "tFo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
@@ -26786,6 +26905,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
+"tFR" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/obj/structure/fence/broken,
+/turf/open/floor/plating,
+/area/slumbridge/outside/northeast)
 "tFX" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
@@ -26795,6 +26920,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/houses/surgery/garbledradio)
+"tGR" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 6
+	},
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/slumbridge/caves/rock)
 "tGX" = (
 /obj/structure/rock/basalt/pile/alt,
 /obj/effect/ai_node,
@@ -26901,6 +27032,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/slumbridge/inside/sombase/west)
+"tKZ" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/ice,
+/area/slumbridge/caves/southwestcaves)
 "tLY" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -26972,6 +27109,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/dmg1,
 /area/slumbridge/outside/southwest)
+"tOD" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/security/regular,
+/turf/open/floor/mainship/floor,
+/area/slumbridge/inside/colony/northerndome)
 "tOF" = (
 /turf/open/floor/plating,
 /area/slumbridge/inside/colony/bar)
@@ -27048,10 +27192,6 @@
 /obj/item/clothing/under/shorts/green,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"tSr" = (
-/obj/structure/lattice,
-/turf/open/liquid/lava/side,
-/area/slumbridge/outside/northwest)
 "tSt" = (
 /obj/structure/table/gamblingtable,
 /obj/effect/spawner/random/misc/trash,
@@ -27100,6 +27240,10 @@
 /obj/item/bedsheet/rd,
 /turf/open/floor/tile/dark/blue2/corner,
 /area/slumbridge/inside/colony/headoffice)
+"tUc" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/cult,
+/area/slumbridge/caves/northeastcaves)
 "tUf" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -27246,11 +27390,6 @@
 /obj/effect/spawner/random/misc/structure/suit_storage,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/slumbridge/inside/hydrotreatment)
-"tZi" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/landmark/corpsespawner/miner/regular,
-/turf/open/floor/grass,
-/area/slumbridge/caves/mining)
 "tZp" = (
 /obj/structure/table/fancywoodentable,
 /obj/effect/spawner/random/misc/paperbin,
@@ -27300,11 +27439,6 @@
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/outside/northwest/nearlz)
-"ubL" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "ucw" = (
 /obj/machinery/light{
 	dir = 8
@@ -27376,16 +27510,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/slumbridge/inside/medical/surgery)
-"ueV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform/nondense{
-	dir = 10
-	},
-/turf/open/floor/plating/mainship/striped,
-/area/slumbridge/inside/houses/car)
 "ueZ" = (
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
+"ufd" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "ufz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -27460,12 +27592,6 @@
 	dir = 10
 	},
 /area/slumbridge/outside/southwest)
-"uiy" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "uiS" = (
 /obj/structure/inflatable/wall,
 /turf/open/floor/tile/dark,
@@ -27489,15 +27615,16 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
-"ujh" = (
-/obj/structure/flora/jungle/vines,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "ujs" = (
 /obj/effect/spawner/random/misc/structure/broken_window,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/central)
+"ujv" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzonetwo)
 "ujQ" = (
 /obj/structure/bed/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -27533,12 +27660,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/engi/central)
-"ukz" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "ukA" = (
 /obj/machinery/light{
 	dir = 4
@@ -27799,6 +27920,12 @@
 	dir = 8
 	},
 /area/slumbridge/outside/southwest)
+"uvx" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves)
 "uvY" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
@@ -27896,13 +28023,6 @@
 "uAZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/slumbridge/outside/southwest)
-"uBi" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 6
-	},
 /area/slumbridge/outside/southwest)
 "uBq" = (
 /obj/effect/spawner/random/misc/trash,
@@ -28070,13 +28190,6 @@
 	dir = 6
 	},
 /area/slumbridge/inside/engi/central)
-"uHr" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/outerringnorth)
 "uHI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -28093,6 +28206,11 @@
 /obj/structure/cable,
 /turf/open/floor/dark2,
 /area/slumbridge/inside/engi/engineroom)
+"uIu" = (
+/obj/structure/catwalk,
+/obj/structure/platform/nondense,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/hydrotreatment)
 "uIF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -28166,11 +28284,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/slumbridge/outside/northeast)
-"uMa" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "uMl" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/blackfloor,
@@ -28300,13 +28413,6 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/prison/red,
 /area/slumbridge/inside/prison/innerring)
-"uQg" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "uQn" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /obj/machinery/door/poddoor/shutters/opened{
@@ -28323,14 +28429,10 @@
 "uRv" = (
 /turf/open/floor/tile/cmo,
 /area/slumbridge/inside/medical/cmo)
-"uRH" = (
+"uRw" = (
 /obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 9
-	},
+/obj/structure/platform/metalplatform/nondense,
+/turf/open/floor/plating/ground/concrete/lines,
 /area/slumbridge/outside/southwest)
 "uRP" = (
 /obj/effect/spawner/random/misc/structure/securecloset/regular,
@@ -28365,10 +28467,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/slumbridge/inside/engi/south)
-"uSv" = (
-/obj/structure/flora/jungle/vines,
-/turf/closed/mineral/smooth/snowrock,
-/area/slumbridge/caves/rock)
 "uSw" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/ai_node,
@@ -28408,13 +28506,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/slumbridge/landingzonetwo)
-"uUn" = (
-/obj/effect/ai_node,
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "uUE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -28466,12 +28557,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"uWo" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/lavaland/basalt,
-/area/slumbridge/outside/northwest)
 "uWA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -28574,6 +28659,12 @@
 	dir = 1
 	},
 /area/slumbridge/inside/sombase/east)
+"vbj" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "vbs" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
@@ -28581,6 +28672,10 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/fake_space,
 /area/slumbridge/outside/southwest)
+"vbx" = (
+/obj/effect/landmark/corpsespawner/doctor/regular,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/slumbridge/inside/houses/surgery/garbledradio)
 "vbB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -28612,6 +28707,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engineroom)
+"vcm" = (
+/obj/structure/platform_decoration,
+/turf/open/liquid/lava/lpiece{
+	dir = 8
+	},
+/area/slumbridge/outside/northwest)
 "vdl" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -28758,6 +28859,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/slumbridge/inside/houses/swcargo)
+"vhX" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 1
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/slumbridge/outside/southwest)
 "vie" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -28791,11 +28901,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile,
 /area/slumbridge/inside/medical/surgery)
-"vje" = (
-/obj/effect/spawner/random/misc/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "vjh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -28882,17 +28987,18 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/slumbridge/caves/mining)
+"vmp" = (
+/obj/structure/sign/hydro/three{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/slumbridge/outside/southwest)
 "vmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/west)
-"vmw" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirtgrassborder/autosmooth/buildable,
-/area/slumbridge/caves/southeastcaves)
 "vmx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white/warningstripe{
@@ -28931,20 +29037,9 @@
 	dir = 1
 	},
 /area/slumbridge/outside/northwest)
-"vns" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "vnL" = (
 /turf/open/floor/mainship/red,
 /area/slumbridge/inside/colony/northerndome)
-"vnM" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "vnZ" = (
 /obj/structure/rack,
 /obj/item/explosive/plastique{
@@ -29013,10 +29108,6 @@
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/innerring)
-"vpW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/outside/northwest)
 "vqn" = (
 /turf/open/floor/mainship/red{
 	dir = 6
@@ -29025,12 +29116,6 @@
 "vqW" = (
 /turf/open/floor/plating/ground/ice,
 /area/slumbridge/caves/southwestcaves)
-"vrb" = (
-/obj/effect/landmark/xeno_resin_door{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/slumbridge/caves/northeastcaves)
 "vrd" = (
 /obj/item/spacecash/c1{
 	pixel_x = -8;
@@ -29061,12 +29146,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/shuttle/escapepod,
 /area/slumbridge/inside/zeta/entrance)
-"vrs" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/ice,
-/area/slumbridge/caves/southwestcaves)
 "vrF" = (
 /obj/structure/sign/safety/vent{
 	dir = 1
@@ -29104,6 +29183,11 @@
 "vsE" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/surgery)
+"vsU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/stairs/rampbottom,
+/area/slumbridge/outside/northwest)
 "vtg" = (
 /turf/closed/wall,
 /area/slumbridge/inside/colony/northerndome)
@@ -29245,12 +29329,6 @@
 	},
 /turf/open/floor/plating,
 /area/slumbridge/inside/engi/engine)
-"vyt" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/outside/northwest)
 "vyM" = (
 /turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/slumbridge/caves/rock)
@@ -29279,6 +29357,14 @@
 /obj/structure/table,
 /turf/open/floor/tile/barber,
 /area/slumbridge/inside/houses/surgery/garbledradio)
+"vzT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/prison,
+/area/slumbridge/inside/houses/nwcargo)
 "vAf" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -29581,15 +29667,6 @@
 	},
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"vJn" = (
-/obj/structure/fence,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/slumbridge/outside/southwest)
 "vJA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/warning{
@@ -29648,6 +29725,10 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/closed/wall/mainship/outer/canterbury,
 /area/slumbridge/caves/mining/dropship)
+"vMe" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm,
+/area/slumbridge/caves/rock)
 "vME" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/normalweighted,
 /turf/open/floor/marking/bot,
@@ -29663,10 +29744,6 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating,
 /area/slumbridge/landingzonetwo)
-"vMN" = (
-/obj/effect/landmark/corpsespawner/doctor/regular,
-/turf/open/floor/tile/blue/taupebluecorner,
-/area/slumbridge/inside/houses/surgery/garbledradio)
 "vNq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/kitchen,
@@ -29682,13 +29759,12 @@
 "vNL" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/slumbridge/outside/northeast)
-"vNU" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 5
+"vNM" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
 	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 5
-	},
+/turf/open/floor/plating/mainship,
 /area/slumbridge/landingzonetwo)
 "vOb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29794,6 +29870,12 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/grass,
 /area/slumbridge/caves/mining)
+"vSc" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "vSo" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/light{
@@ -29960,20 +30042,6 @@
 "vVw" = (
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
-"vVz" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/red2/corner{
-	dir = 4
-	},
-/area/slumbridge/landingzonetwo)
-"vVJ" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "vVK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -30052,6 +30120,12 @@
 "waa" = (
 /turf/open/floor/podhatch/floor,
 /area/slumbridge/inside/pmcdome/nukevault)
+"waz" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "waB" = (
 /turf/closed/wall,
 /area/slumbridge/outside/southwest/nearlz)
@@ -30206,19 +30280,18 @@
 /obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/slumbridge/inside/prison/innerring)
+"wfE" = (
+/obj/structure/platform/nondense{
+	dir = 4
+	},
+/turf/open/lavaland/catwalk,
+/area/slumbridge/outside/northwest)
 "wfI" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/misc/bedsheet,
 /obj/effect/landmark/corpsespawner/colonist/regular,
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/dorms)
-"wfM" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/structure/platform_decoration,
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "wfQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -30247,6 +30320,10 @@
 /obj/structure/mine_structure/wooden/support_wall/beams/above,
 /turf/open/floor/wood/variable/mosaic,
 /area/slumbridge/caves/southeastcaves/garbledradio)
+"wgA" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/mineral/smooth/bigred,
+/area/slumbridge/caves/rock)
 "wgG" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small{
@@ -30289,14 +30366,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"whE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/tile/bar,
-/area/slumbridge/inside/houses/recreational)
 "whJ" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -30579,12 +30648,6 @@
 	dir = 4
 	},
 /area/slumbridge/inside/sombase/west)
-"wqO" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
 "wrd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -30592,12 +30655,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/colony/pharmacy)
-"wrm" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "wrq" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -30660,6 +30717,15 @@
 	dir = 4
 	},
 /area/slumbridge/inside/colony/bar)
+"wtZ" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 4
+	},
+/obj/structure/fence/broken,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/slumbridge/outside/southwest)
 "wuc" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1
@@ -30696,6 +30762,9 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/slumbridge/inside/prison/outerringnorth)
+"wuS" = (
+/turf/open/lavaland/catwalk,
+/area/slumbridge/outside/northwest)
 "wvq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/folder/nooffset,
@@ -30892,6 +30961,12 @@
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/plating/asteroidwarning,
 /area/slumbridge/outside/northeast/bridges)
+"wCj" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "wCo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -30999,11 +31074,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/slumbridge/inside/colony/vault)
-"wGx" = (
-/obj/structure/girder/displaced,
-/obj/structure/flora/jungle/vines,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "wGS" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -31031,13 +31101,6 @@
 	},
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
-"wHO" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "wHU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -31158,6 +31221,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/medical/surgery)
+"wLW" = (
+/obj/structure/stairs/seamless/edge{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/slumbridge/outside/southwest)
 "wLZ" = (
 /obj/effect/spawner/random/misc/structure/stool,
 /turf/open/floor/tile/dark,
@@ -31236,14 +31305,6 @@
 /obj/structure/xenoautopsy/tank/alien,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/slumbridge/inside/colony/northerndome)
-"wOH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/structure/stairs/seamless/platform_vert{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
 "wOK" = (
 /turf/closed/wall,
 /area/slumbridge/inside/houses/surgery/garbledradio)
@@ -31263,11 +31324,6 @@
 	dir = 8
 	},
 /area/slumbridge/inside/houses/dorms)
-"wPu" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense,
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/mainship,
@@ -31322,15 +31378,6 @@
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/dark,
 /area/slumbridge/inside/zeta/south)
-"wSA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/assistant/regular,
-/turf/open/floor/prison,
-/area/slumbridge/inside/houses/nwcargo)
 "wSN" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 4
@@ -31389,10 +31436,6 @@
 	},
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/landingzonetwo)
-"wUB" = (
-/obj/effect/landmark/corpsespawner/colonist/regular,
-/turf/open/floor/plating/ground/dirt,
-/area/slumbridge/outside/southeast)
 "wUD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -31595,12 +31638,6 @@
 	dir = 1
 	},
 /area/slumbridge/caves/mining/dropship)
-"xbB" = (
-/obj/structure/stairs/seamless/edge{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest/nearlz)
 "xbC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -31775,28 +31812,20 @@
 "xiI" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/sombase/west)
-"xiY" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 8
+"xiM" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/slumbridge/outside/southwest)
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "xjw" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
-"xks" = (
-/obj/structure/platform/nondense{
-	dir = 4
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/slumbridge/outside/northwest)
 "xkx" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plating,
 /area/slumbridge/outside/northeast)
 "xkI" = (
@@ -31846,6 +31875,13 @@
 "xmG" = (
 /turf/closed/mineral/smooth,
 /area/slumbridge/caves/northeastcaves)
+"xmJ" = (
+/obj/structure/girder/reinforced,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "xmM" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
@@ -31899,13 +31935,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/ground/grass/weedable/patch,
 /area/slumbridge/outside/northeast)
-"xpQ" = (
-/obj/structure/girder,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "xpV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -31962,6 +31991,10 @@
 	dir = 1
 	},
 /area/slumbridge/inside/houses/surgery/garbledradio)
+"xrw" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/liquid/water/river,
+/area/slumbridge/inside/houses/recreational)
 "xry" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -32014,18 +32047,19 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
+"xuk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/nondense{
+	dir = 10
+	},
+/turf/open/floor/plating/mainship/striped,
+/area/slumbridge/inside/houses/car)
 "xul" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/yellow{
 	dir = 8
 	},
 /area/slumbridge/inside/engi/south)
-"xun" = (
-/obj/structure/platform/rockcliff/icycliff/nondense{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/slumbridge/caves/rock)
 "xuA" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -32148,6 +32182,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/green/greentaupe,
 /area/slumbridge/inside/hydrotreatment)
+"xzZ" = (
+/obj/structure/bed/fancy,
+/obj/effect/spawner/random/misc/bedsheet,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/wood/variable/wide,
+/area/slumbridge/inside/houses/dorms)
 "xAb" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -32234,6 +32275,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/hangar)
+"xDz" = (
+/obj/effect/landmark/xeno_resin_door{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/slumbridge/caves/southeastcaves/garbledradio)
 "xDF" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	color = "#ff6969"
@@ -32241,12 +32288,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/slumbridge/inside/sombase/east)
-"xDM" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "xDR" = (
 /obj/structure/flora/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -32263,15 +32304,6 @@
 	dir = 5
 	},
 /area/slumbridge/inside/sombase/east)
-"xEL" = (
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/slumbridge/outside/southwest)
 "xEO" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/dirt,
@@ -32330,6 +32362,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship_hull,
 /area/slumbridge/inside/zeta/south)
+"xGq" = (
+/obj/structure/platform/metalplatform/nondense{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/slumbridge/landingzonetwo)
 "xGy" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
@@ -32364,15 +32404,6 @@
 	dir = 1
 	},
 /area/slumbridge/inside/pmcdome)
-"xGY" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/riverdecal,
-/obj/structure/platform/nondense{
-	dir = 6
-	},
-/turf/open/liquid/water/river,
-/area/slumbridge/inside/hydrotreatment)
 "xHc" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -32392,12 +32423,6 @@
 	dir = 1
 	},
 /area/slumbridge/outside/southwest)
-"xHV" = (
-/obj/structure/platform/nondense{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom,
-/area/slumbridge/outside/northwest)
 "xIx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -32430,12 +32455,14 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
-"xJL" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
+"xKe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/safety/vacuum{
+	dir = 4
 	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzonetwo)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/grass/weedable/patch,
+/area/slumbridge/outside/northeast)
 "xKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -32519,14 +32546,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/slumbridge/inside/engi/engineroom)
-"xMO" = (
-/obj/structure/prop/vehicle/tank/east/armor,
-/turf/open/floor/mainship/stripesquare,
-/area/slumbridge/inside/sombase/hangar)
-"xNm" = (
-/obj/structure/fence/broken,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/slumbridge/outside/northeast)
 "xNr" = (
 /turf/open/floor/stairs/rampbottom,
 /area/slumbridge/outside/northwest)
@@ -32622,6 +32641,12 @@
 	},
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/medical/foyer)
+"xQQ" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "xRH" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/decal/cleanable/dirt,
@@ -32692,18 +32717,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow,
 /area/slumbridge/outside/southwest)
-"xUx" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/slumbridge/landingzoneone)
 "xUC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete,
 /area/slumbridge/outside/northeast)
+"xUH" = (
+/obj/effect/landmark/corpsespawner/miner/regular,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/slumbridge/caves/mining)
 "xUM" = (
 /obj/structure/prop/mainship/telecomms/broadcaster,
 /turf/open/floor/tile/dark,
@@ -32772,13 +32795,6 @@
 	dir = 8
 	},
 /area/slumbridge/landingzonetwo)
-"xWQ" = (
-/obj/structure/girder/reinforced,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "xXj" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 1
@@ -32819,6 +32835,9 @@
 /obj/effect/landmark/corpsespawner/miner/regular,
 /turf/open/floor/tile/dark,
 /area/slumbridge/outside/southwest)
+"xYH" = (
+/turf/open/floor/plating/mainship,
+/area/slumbridge/landingzoneone)
 "xYJ" = (
 /obj/structure/cargo_container/hd{
 	dir = 4
@@ -33024,12 +33043,6 @@
 	},
 /turf/open/floor/tile/blue,
 /area/slumbridge/inside/medical/chemistry)
-"yfj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/liquid/lava/catwalk,
-/area/slumbridge/inside/prison/innerring)
 "yfr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/stripesquare,
@@ -33043,13 +33056,6 @@
 	dir = 10
 	},
 /area/slumbridge/inside/colony/oreprocess)
-"yfK" = (
-/obj/structure/window_frame/colony,
-/obj/structure/platform/metalplatform/nondense{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/slumbridge/inside/colony/construction)
 "yfQ" = (
 /turf/open/floor/wood,
 /area/slumbridge/inside/colony/dorms)
@@ -33078,6 +33084,12 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/slumbridge/inside/pmcdome)
+"yhc" = (
+/obj/structure/platform/rockcliff/icycliff/nondense{
+	dir = 5
+	},
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/slumbridge/caves/rock)
 "yhj" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/slumbridge/inside/engi/west)
@@ -33168,6 +33180,13 @@
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning,
 /area/slumbridge/outside/northwest)
+"yjC" = (
+/obj/structure/girder,
+/obj/structure/platform/metalplatform/nondense{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/slumbridge/inside/colony/construction)
 "yjO" = (
 /obj/structure/prop/mainship/holobarrier/passthrough,
 /turf/open/floor/marking/warning{
@@ -33215,10 +33234,6 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/tile/dark/brown2,
 /area/slumbridge/inside/colony/orestorage)
-"ylg" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/closed/gm,
-/area/slumbridge/caves/rock)
 "yll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -34313,8 +34328,8 @@ ooG
 ooG
 ooG
 ooG
-rxT
-hhy
+ioZ
+flm
 tvO
 ooG
 ooG
@@ -34483,22 +34498,22 @@ pjL
 pjL
 szu
 sfW
-cfg
-ado
-ado
-ado
-ado
-ado
-ado
-ado
-ado
-ado
-ado
+azn
+xGq
+xGq
+xGq
+xGq
+xGq
+xGq
+xGq
+xGq
+xGq
+xGq
 sfW
 sfW
-ado
-ado
-ado
+xGq
+xGq
+xGq
 pzJ
 ffG
 pzJ
@@ -34507,9 +34522,9 @@ pzJ
 ffG
 pzJ
 fBt
-muu
-hro
-ogP
+lJw
+rRJ
+vNM
 nCu
 pjL
 xvW
@@ -34688,9 +34703,9 @@ sfW
 sfW
 sfW
 sfW
-rGs
-ljt
-oCE
+gCy
+lmE
+dUf
 fVX
 pjL
 xvW
@@ -34845,7 +34860,7 @@ sfW
 sfW
 ooG
 aEa
-dZz
+gfa
 sfW
 tqd
 wia
@@ -34869,9 +34884,9 @@ wia
 wia
 wia
 wia
-bif
-qNS
-gOk
+roy
+aDK
+ujv
 yiz
 pjL
 xvW
@@ -35026,7 +35041,7 @@ ooG
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 gyK
@@ -35207,7 +35222,7 @@ ooG
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -35388,7 +35403,7 @@ ahF
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -35569,7 +35584,7 @@ ooG
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -35750,7 +35765,7 @@ ooG
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -35931,7 +35946,7 @@ ahF
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -36067,22 +36082,22 @@ uSb
 vyM
 vyM
 vyM
-dqC
-dqC
-leQ
-leQ
-leQ
-leQ
-leQ
-leQ
-leQ
-leQ
-leQ
-dqC
-dqC
-dqC
-leQ
-dqC
+jbT
+jbT
+bHk
+bHk
+bHk
+bHk
+bHk
+bHk
+bHk
+bHk
+bHk
+jbT
+jbT
+jbT
+bHk
+jbT
 vqW
 vqW
 vqW
@@ -36112,7 +36127,7 @@ sfW
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -36264,9 +36279,9 @@ bYo
 bYo
 bYo
 bYo
-ger
-dqC
-dqC
+bLr
+jbT
+jbT
 vqW
 vqW
 vqW
@@ -36293,7 +36308,7 @@ sfW
 ooG
 ooG
 aEa
-dZz
+gfa
 sfW
 mJo
 uek
@@ -36448,7 +36463,7 @@ uvc
 dkI
 dkI
 dkI
-ger
+bLr
 vqW
 vqW
 vqW
@@ -36474,7 +36489,7 @@ sfW
 ooG
 aEa
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -36586,10 +36601,10 @@ ewT
 hNa
 leg
 mca
-mCR
+vcm
 lLa
 hvj
-uWo
+dDc
 sFG
 drD
 mkf
@@ -36630,7 +36645,7 @@ nmr
 nmr
 dkI
 dkI
-ger
+bLr
 vqW
 vqW
 skd
@@ -36655,7 +36670,7 @@ sfW
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 uek
@@ -36700,9 +36715,9 @@ jso
 bYh
 bYh
 bXQ
-kRt
-gTr
-cOZ
+llX
+qwF
+fdr
 qKi
 qKi
 qKi
@@ -36719,9 +36734,9 @@ lKd
 qKi
 qKi
 qKi
-kRt
-gTr
-cOZ
+llX
+qwF
+fdr
 qKi
 qYu
 qKi
@@ -36768,8 +36783,8 @@ hNa
 leg
 leg
 leg
-aNZ
-aNZ
+taZ
+taZ
 leg
 leg
 qgS
@@ -36812,7 +36827,7 @@ nmr
 nmr
 dkI
 dkI
-vrs
+tKZ
 vqW
 skd
 skd
@@ -36836,7 +36851,7 @@ sfW
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 mJo
 qDh
@@ -36881,9 +36896,9 @@ jso
 bYh
 qKi
 qKi
-aIx
-nZy
-aTl
+jil
+xYH
+sYp
 qKi
 qKi
 qKi
@@ -36900,9 +36915,9 @@ tyh
 qKi
 qKi
 qKi
-lOv
-nZy
-aTl
+vbj
+xYH
+sYp
 qKi
 qYu
 qKi
@@ -36948,10 +36963,10 @@ uoT
 dok
 pOU
 wRn
-fDx
-pys
-pys
-pew
+vsU
+rQR
+rQR
+rzd
 wRn
 pOU
 pOU
@@ -36993,7 +37008,7 @@ nmr
 nmr
 nmr
 dkI
-vrs
+tKZ
 vqW
 skd
 skd
@@ -37017,7 +37032,7 @@ ooG
 ooG
 ooG
 ooG
-dZz
+gfa
 sfW
 tqd
 qWU
@@ -37062,9 +37077,9 @@ bYh
 bYh
 qKi
 qKi
-xUx
-ahj
-oYm
+xQQ
+nDG
+waz
 qKi
 qKi
 qKi
@@ -37081,9 +37096,9 @@ qKi
 qKi
 qKi
 gsR
-xUx
-jsI
-oYm
+xQQ
+xiM
+waz
 gsR
 qYu
 qKi
@@ -37130,8 +37145,8 @@ duU
 duU
 lBv
 xNr
-tzx
-vpW
+wuS
+lMU
 dsV
 duU
 lBv
@@ -37174,7 +37189,7 @@ wdb
 nmr
 nmr
 dkI
-vrs
+tKZ
 vqW
 vqW
 skd
@@ -37311,8 +37326,8 @@ mkf
 hNa
 leg
 leg
-vyt
-vyt
+wfE
+wfE
 leg
 mca
 leg
@@ -37355,7 +37370,7 @@ alt
 nmr
 bIq
 bYo
-vrs
+tKZ
 vqW
 vqW
 skd
@@ -37379,31 +37394,31 @@ ooG
 ooG
 ooG
 ooG
-vNU
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
+hfO
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
 sfW
 sfW
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
-daf
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
+egI
 nSK
 qFO
 qFO
@@ -37491,10 +37506,10 @@ nGK
 mkf
 hNa
 leg
-twZ
+txJ
 eSw
 fXD
-swt
+saO
 leg
 leg
 qgS
@@ -37536,7 +37551,7 @@ alt
 nmr
 oge
 bYo
-vrs
+tKZ
 vqW
 vqW
 vqW
@@ -37571,8 +37586,8 @@ fnu
 ooG
 ooG
 ooG
-bEd
-vVz
+skF
+ikl
 ooG
 ooG
 ooG
@@ -37585,7 +37600,7 @@ ooG
 ooG
 ooG
 ooG
-hul
+hqi
 ooG
 bPI
 pjL
@@ -37717,7 +37732,7 @@ bCz
 nmr
 lRi
 oge
-vrs
+tKZ
 vqW
 vqW
 vqW
@@ -37840,10 +37855,10 @@ lpM
 gzE
 swK
 lyP
-cOp
-cOp
-cOp
-bDe
+ouI
+ouI
+ouI
+qdz
 uhD
 feW
 buv
@@ -37898,7 +37913,7 @@ alt
 nmr
 uvc
 lRi
-vrs
+tKZ
 skd
 vqW
 vqW
@@ -38024,7 +38039,7 @@ lyP
 sVR
 sVR
 sVR
-hhA
+uIu
 uhD
 feW
 buv
@@ -38078,7 +38093,7 @@ vTh
 oSy
 nmr
 bIq
-qLg
+ekp
 vyM
 vyM
 skd
@@ -38205,7 +38220,7 @@ tuv
 sVR
 xYi
 sVR
-hhA
+uIu
 uhD
 feW
 buv
@@ -38259,7 +38274,7 @@ alt
 mmJ
 nmr
 lRi
-fFW
+bSw
 vyM
 vyM
 skd
@@ -38383,10 +38398,10 @@ oJH
 hAE
 bkN
 lyP
-mno
-jlH
-nBH
-xGY
+oEg
+cKZ
+alb
+iQa
 osQ
 tOw
 lyP
@@ -38440,7 +38455,7 @@ alt
 qNF
 nmr
 lRi
-edT
+abi
 vyM
 vyM
 vqW
@@ -38565,9 +38580,9 @@ xzI
 tZg
 lyP
 feW
-ruY
+oNd
 cpF
-eNi
+rjn
 uhD
 feW
 buv
@@ -38622,7 +38637,7 @@ qNF
 nmr
 uvc
 oge
-edT
+abi
 vyM
 vqW
 vqW
@@ -38804,9 +38819,9 @@ nmr
 uvc
 bIq
 lRi
-arE
-dqC
-dqC
+yhc
+jbT
+jbT
 vqW
 skd
 vyM
@@ -38988,8 +39003,8 @@ bIq
 bYo
 bYo
 bYo
-ger
-leQ
+bLr
+bHk
 vyM
 vyM
 skd
@@ -39171,7 +39186,7 @@ bYo
 bYo
 bYo
 bYo
-xun
+wCj
 vyM
 skd
 vqW
@@ -39200,9 +39215,9 @@ nxb
 fnu
 ooG
 aEa
-muu
-wqO
-ogP
+lJw
+mJi
+vNM
 ooG
 plp
 cgP
@@ -39352,7 +39367,7 @@ bYo
 bYo
 bYo
 bYo
-arE
+yhc
 vyM
 skd
 vqW
@@ -39381,9 +39396,9 @@ nxb
 fnu
 aEa
 ooG
-rGs
-ljt
-oCE
+gCy
+lmE
+dUf
 ooG
 plp
 cgP
@@ -39534,7 +39549,7 @@ bYo
 lFH
 bYo
 bYo
-fFW
+bSw
 skd
 vqW
 vqW
@@ -39562,9 +39577,9 @@ fnu
 fnu
 ooG
 ooG
-xJL
-qNS
-gOk
+gxv
+aDK
+ujv
 ooG
 ooG
 ooG
@@ -39596,9 +39611,9 @@ bYh
 bXQ
 qKi
 qKi
-kRt
-gTr
-cOZ
+llX
+qwF
+fdr
 qKi
 qKi
 qKi
@@ -39615,9 +39630,9 @@ qKi
 qKi
 qKi
 qKi
-kRt
-gTr
-cOZ
+llX
+qwF
+fdr
 qKi
 qYu
 qKi
@@ -39715,8 +39730,8 @@ dkI
 bYo
 bYo
 bYo
-arE
-leQ
+yhc
+bHk
 vyM
 vqW
 vqW
@@ -39777,9 +39792,9 @@ bYh
 qKi
 qKi
 qKi
-lOv
-nZy
-aTl
+vbj
+xYH
+sYp
 qKi
 qKi
 lVB
@@ -39796,9 +39811,9 @@ oCu
 qKi
 qKi
 qKi
-lOv
-nZy
-aTl
+vbj
+xYH
+sYp
 qKi
 qYu
 qKi
@@ -39898,7 +39913,7 @@ bYo
 bYo
 bYo
 bYo
-edT
+abi
 vqW
 vqW
 skd
@@ -39958,9 +39973,9 @@ bYh
 bYh
 gsR
 iIV
-xUx
-ahj
-oYm
+xQQ
+nDG
+waz
 qKi
 qKi
 rjq
@@ -39977,9 +39992,9 @@ uML
 qKi
 qKi
 qKi
-xUx
-jsI
-oYm
+xQQ
+xiM
+waz
 qKi
 qYu
 qKi
@@ -40058,10 +40073,10 @@ bIq
 rfs
 uvc
 mku
-rfK
-xWQ
-qal
-pvF
+sDb
+xmJ
+ntY
+rby
 bIq
 iZo
 nmr
@@ -40080,7 +40095,7 @@ lFH
 bYo
 bYo
 bYo
-ger
+bLr
 vqW
 skd
 vyM
@@ -40208,12 +40223,12 @@ nGK
 mkf
 hNa
 leg
-sYV
-pBb
-tSr
-dsq
-pBb
-ggx
+cce
+mjK
+hFn
+fgf
+mjK
+hfc
 sFG
 drD
 mkf
@@ -40239,10 +40254,10 @@ bIq
 bIq
 rfs
 rfs
-trZ
+bgE
 mNJ
 mNJ
-wPu
+ufd
 bIq
 rfs
 nmr
@@ -40262,7 +40277,7 @@ bYo
 bYo
 bYo
 qCL
-ger
+bLr
 skd
 skd
 vyM
@@ -40270,7 +40285,7 @@ vyM
 skd
 vqW
 vqW
-leQ
+bHk
 xvW
 pjL
 pjL
@@ -40390,10 +40405,10 @@ mkf
 jAA
 aUd
 leg
-xHV
-aNZ
-aNZ
-dBP
+fIH
+taZ
+taZ
+edn
 leg
 leg
 qgS
@@ -40419,12 +40434,12 @@ bIq
 bIq
 bIq
 bIq
-phK
+afi
 cvG
 mNJ
 tHG
 tbj
-bVu
+nTu
 qRS
 nmr
 nmr
@@ -40444,13 +40459,13 @@ bYo
 lFH
 qCL
 qCL
-edT
+abi
 skd
 vyM
 vyM
 vyM
 vqW
-uiy
+rEK
 qCL
 qFL
 mAd
@@ -40571,10 +40586,10 @@ mkf
 mkf
 hNa
 leg
-kZG
-vyt
-vyt
-xks
+hmo
+wfE
+wfE
+sHT
 lLC
 leg
 hvB
@@ -40600,16 +40615,16 @@ kWJ
 fMG
 oge
 oge
-yfK
+kjk
 aHR
 mNJ
 urt
 dDF
-uMa
+oxZ
 qRS
 lRi
 nmr
-rHx
+ptF
 nmr
 nmr
 nmr
@@ -40626,11 +40641,11 @@ bYo
 qCL
 qCL
 qCL
-arE
+yhc
 skd
 vyM
 vyM
-uiy
+rEK
 qCL
 qCL
 qCL
@@ -40751,12 +40766,12 @@ nGK
 mkf
 mkf
 hNa
-twZ
-pBb
-tSr
-dsq
-pBb
-swt
+txJ
+mjK
+hFn
+fgf
+mjK
+saO
 leg
 sFG
 mkf
@@ -40781,17 +40796,17 @@ oge
 vsz
 oge
 oge
-trZ
+bgE
 kNU
 ebJ
-eYV
+eUS
 xHy
 tbj
-cnv
-rWs
-wHO
+mEC
+rsD
+ivx
 dxR
-pzr
+jWR
 lRi
 lRi
 nmr
@@ -40808,9 +40823,9 @@ qCL
 qCL
 qCL
 qCL
-xun
+wCj
 vyM
-dLE
+tGR
 qCL
 qCL
 qCL
@@ -40962,7 +40977,7 @@ uvc
 uvc
 oge
 lRi
-lhc
+cun
 wAm
 mlv
 xbO
@@ -40972,7 +40987,7 @@ mlv
 uVV
 uqO
 nYF
-sSp
+cZr
 bIq
 afG
 nmr
@@ -40980,17 +40995,17 @@ iDq
 alt
 dkI
 dkI
-biH
-biH
-biH
+oLq
+oLq
+oLq
 dkI
 dkI
 qCL
 qCL
 qCL
 qCL
-arE
-qnT
+yhc
+qPf
 qCL
 qCL
 qCL
@@ -41143,7 +41158,7 @@ qRS
 oge
 oge
 lRi
-dIK
+bkd
 pff
 seb
 xQE
@@ -41153,18 +41168,18 @@ aHR
 kVT
 kmO
 iUL
-uMa
+oxZ
 lRi
 lRi
 nmr
 iDq
 alt
 nmr
-mSk
+asR
 alt
 alt
 alt
-hYA
+fAZ
 pZW
 qCL
 qCL
@@ -41324,7 +41339,7 @@ oge
 oge
 uvc
 lRi
-uQg
+asF
 oNv
 xHy
 seb
@@ -41334,18 +41349,18 @@ xPC
 aHR
 eOZ
 aHR
-wPu
+ufd
 bIq
 rfs
 nmr
 iDq
 alt
 nmr
-mSk
+asR
 alt
 lQq
 alt
-hYA
+fAZ
 bYo
 qCL
 qCL
@@ -41479,8 +41494,8 @@ wVJ
 wVJ
 wVJ
 wVJ
-leW
-leW
+dSd
+dSd
 wVJ
 wVJ
 wVJ
@@ -41506,23 +41521,23 @@ hNA
 uvc
 xlz
 bYo
-dyC
-aPj
-vns
-ruH
-ruH
-koX
-mzs
-opP
-aPj
-xpQ
+bLn
+qFQ
+edg
+sMv
+sMv
+nCf
+pzv
+dNf
+qFQ
+yjC
 bIq
 ppi
 nmr
 iDq
 wdb
 nmr
-mSk
+asR
 alt
 teE
 alt
@@ -41660,8 +41675,8 @@ lts
 lts
 bLR
 dwc
-pMp
-pMp
+pRV
+pRV
 lDI
 bLR
 pTC
@@ -41703,12 +41718,12 @@ nmr
 iDq
 alt
 nmr
-mSk
+asR
 alt
 wTz
 alt
-hYA
-pyy
+fAZ
+pma
 qCL
 iIa
 qCL
@@ -41841,8 +41856,8 @@ qNc
 sXv
 eUy
 oIJ
-lbl
-lbl
+gZI
+gZI
 lSj
 eUy
 gLI
@@ -41884,11 +41899,11 @@ nmr
 iDq
 alt
 nmr
-mSk
+asR
 alt
 cEu
 alt
-hYA
+fAZ
 aSe
 gIw
 gIw
@@ -42022,8 +42037,8 @@ xZH
 pNz
 qMS
 qMS
-leW
-leW
+dSd
+dSd
 qMS
 qMS
 hCt
@@ -42066,9 +42081,9 @@ iDq
 alt
 dkI
 dkI
-ukz
-dzU
-ukz
+iWK
+mhz
+iWK
 dkI
 dkI
 gIw
@@ -42609,9 +42624,9 @@ ygm
 xrd
 vTh
 oFW
-hPu
+noc
 cNE
-wfM
+qhy
 vTh
 oFW
 xee
@@ -42788,11 +42803,11 @@ vDC
 nmr
 iDq
 alt
-aRA
-riM
-nwh
-vVJ
-xiY
+jky
+mAI
+vSc
+ipX
+jaz
 nmr
 nmr
 iwe
@@ -42808,8 +42823,8 @@ iwe
 iwe
 iwe
 iwe
-xbB
-byL
+lUi
+bMb
 iwe
 iwe
 iwe
@@ -42944,10 +42959,10 @@ bYo
 bYo
 dkI
 dkI
-uRH
-vJn
-xEL
-kKQ
+aEQ
+etk
+mxR
+sAW
 dkI
 dkI
 jYP
@@ -42966,14 +42981,14 @@ riT
 nvH
 doH
 iBk
-lQX
+vmp
 iDq
 alt
-hBS
+lGv
 rFo
-fmA
+ayc
 eeH
-rsO
+qkV
 rFo
 rFo
 rFo
@@ -43124,12 +43139,12 @@ bYo
 bYo
 bYo
 pZW
-amj
+iWV
 urb
 gxe
 gxe
 thJ
-kdy
+bpJ
 fow
 rfs
 rfs
@@ -43147,11 +43162,11 @@ nDS
 nDS
 iXX
 nmf
-wOH
+hqE
 mWb
-uUn
-mvy
-fmA
+dLz
+ddG
+ayc
 eeH
 lSP
 dXL
@@ -43305,12 +43320,12 @@ bYo
 lFH
 bYo
 bYo
-gYQ
+vhX
 gxe
 dQp
 wpJ
 gxe
-gdy
+uRw
 uvc
 uvc
 rfs
@@ -43328,11 +43343,11 @@ oWX
 uOz
 fOo
 igQ
-mLW
+jLn
 bIw
-vnM
-iqP
-gaI
+gRS
+qpP
+neO
 eBo
 eBo
 eBo
@@ -43486,12 +43501,12 @@ bYo
 bYo
 bYo
 bYo
-gYQ
+vhX
 gxe
 vRu
 gxe
 qwi
-mVH
+aSx
 rfs
 nmr
 nmr
@@ -43509,7 +43524,7 @@ dym
 nvH
 doH
 iBk
-kuR
+eGl
 iDq
 alt
 nmr
@@ -43667,7 +43682,7 @@ bYo
 bYo
 bYo
 bYo
-qaF
+ayr
 dQp
 gxe
 aJV
@@ -43848,12 +43863,12 @@ bYo
 bYo
 bYo
 bYo
-rDt
+iHB
 gxe
 gxe
 pjp
 gxe
-mVH
+aSx
 uvc
 nmr
 nmr
@@ -44029,12 +44044,12 @@ bYo
 bYo
 bYo
 bYo
-rDt
+iHB
 gxe
 gxe
 rlX
 gxe
-ozr
+cdy
 rfs
 oge
 rfs
@@ -44210,12 +44225,12 @@ bYo
 lFH
 bYo
 pZW
-hbx
+lZe
 qkn
 aCj
 wpJ
 cIm
-uBi
+cAw
 dUW
 rfs
 lRi
@@ -44392,10 +44407,10 @@ bYo
 bYo
 dkI
 dkI
-qxD
-chQ
-chQ
-pNt
+okT
+wtZ
+wtZ
+ftu
 dkI
 dkI
 niO
@@ -44559,8 +44574,8 @@ knY
 vAq
 kzA
 qKo
-clx
-qoE
+mkc
+qtQ
 qKo
 qKl
 qMS
@@ -44911,8 +44926,8 @@ wlC
 uwN
 kXZ
 sXo
-qoE
-qoE
+qtQ
+qtQ
 rUk
 kRn
 kQp
@@ -45092,8 +45107,8 @@ kQp
 kQp
 wlC
 rUk
-qoE
-niX
+qtQ
+lgx
 rUk
 wlC
 kQp
@@ -45130,8 +45145,8 @@ bIq
 rfs
 bIq
 rfs
-qCd
-lGq
+lxP
+sJa
 rfs
 rfs
 rfs
@@ -45330,7 +45345,7 @@ nmr
 nmr
 nmr
 nmr
-kTw
+qPX
 nmr
 srG
 nmr
@@ -45666,7 +45681,7 @@ oge
 oge
 ppi
 oge
-gUW
+lkX
 wfI
 rIp
 uls
@@ -45680,7 +45695,7 @@ jXX
 uTW
 slo
 nhy
-gUW
+lkX
 nmr
 iDq
 alt
@@ -45809,8 +45824,8 @@ qKo
 qKo
 qKo
 qKo
-wrm
-qoE
+etf
+qtQ
 nzn
 rYY
 qTv
@@ -46352,8 +46367,8 @@ qKo
 qKo
 qKo
 qKo
-wrm
-vje
+etf
+lel
 qKo
 rYY
 qTv
@@ -46381,16 +46396,16 @@ wVJ
 bYo
 dkI
 dkI
-biH
-biH
-biH
+oLq
+oLq
+oLq
 dkI
 dkI
 uAZ
 qRS
 rfs
 rfs
-gUW
+lkX
 nhy
 rIp
 uTW
@@ -46404,7 +46419,7 @@ jXX
 uls
 nzf
 gkd
-gUW
+lkX
 nmr
 iDq
 alt
@@ -46522,8 +46537,8 @@ jlM
 vnq
 bqS
 asu
-buT
-uHr
+mcs
+eRV
 iAS
 sZa
 tmW
@@ -46561,11 +46576,11 @@ xOD
 wVJ
 bYo
 bYo
-mSk
+asR
 alt
 alt
 alt
-hYA
+fAZ
 fow
 qRS
 rfs
@@ -46703,8 +46718,8 @@ eSw
 bqS
 bqS
 asu
-buT
-uHr
+mcs
+eRV
 iAS
 hGQ
 hGQ
@@ -46742,11 +46757,11 @@ aIY
 wVJ
 lXi
 bYo
-mSk
+asR
 alt
 lQq
 alt
-hYA
+fAZ
 nmr
 nmr
 nmr
@@ -46895,8 +46910,8 @@ qKo
 qKo
 qKo
 qKo
-wrm
-qoE
+etf
+qtQ
 qKo
 gZN
 rYY
@@ -46923,7 +46938,7 @@ ppE
 wVJ
 lXi
 bYo
-mSk
+asR
 alt
 rfE
 pvh
@@ -47091,8 +47106,8 @@ qKo
 qKo
 nzn
 qKo
-qoE
-clx
+qtQ
+mkc
 qKo
 qKo
 qKo
@@ -47104,17 +47119,17 @@ gUz
 wVJ
 lXi
 lXi
-mSk
+asR
 alt
 jLZ
 tXx
-hYA
-hZL
+fAZ
+cKW
 nmr
 bCz
 tXx
 nmr
-gUW
+lkX
 nhy
 rIp
 uls
@@ -47128,7 +47143,7 @@ jXX
 uls
 slo
 wfI
-gUW
+lkX
 nmr
 iDq
 alt
@@ -47285,11 +47300,11 @@ hBM
 wVJ
 lXi
 lXi
-mSk
+asR
 alt
 cEu
 iVK
-hYA
+fAZ
 fow
 nmr
 alt
@@ -47467,9 +47482,9 @@ wVJ
 lXi
 lXi
 dkI
-ukz
-dzU
-ukz
+iWK
+mhz
+iWK
 dkI
 dkI
 nmr
@@ -47815,8 +47830,8 @@ gQT
 qKo
 nCW
 qKo
-qoE
-clx
+qtQ
+mkc
 qKo
 qKo
 qKo
@@ -47838,7 +47853,7 @@ ihH
 bCz
 tXx
 nmr
-gUW
+lkX
 nhy
 rIp
 uls
@@ -47852,7 +47867,7 @@ jXX
 uTW
 hRg
 iik
-gUW
+lkX
 nmr
 iDq
 alt
@@ -48349,13 +48364,13 @@ qKo
 qKo
 rfu
 uHI
-ubL
+nZF
 mzf
 cGs
-ubL
+nZF
 mzf
 cGs
-ubL
+nZF
 mzf
 aJo
 tKf
@@ -48388,8 +48403,8 @@ nmr
 nmr
 nmr
 nmr
-bdW
-rQV
+hTQ
+wLW
 nmr
 nmr
 nmr
@@ -48523,20 +48538,20 @@ cZS
 gZN
 nCW
 gZN
-nBJ
-nBJ
+sBB
+sBB
 gZN
 gZN
 qKo
 bxM
 lEV
-qoE
+qtQ
 lEV
 lEV
-yfj
+hdk
 lEV
 lEV
-qoE
+qtQ
 jsu
 wqa
 bjQ
@@ -48704,8 +48719,8 @@ ole
 gZN
 gZN
 gZN
-nBJ
-nBJ
+sBB
+sBB
 gZN
 nCW
 nzn
@@ -48885,8 +48900,8 @@ rUu
 gZN
 ove
 gZN
-nBJ
-nBJ
+sBB
+sBB
 gZN
 gZN
 nzn
@@ -49029,9 +49044,9 @@ hNv
 vJd
 emb
 jBa
-xEm
-gow
-xEm
+oyU
+mwr
+oyU
 whJ
 lhV
 ith
@@ -49210,8 +49225,8 @@ fBA
 jSt
 whJ
 saE
-xEm
-bSF
+gow
+gow
 anT
 whJ
 wpR
@@ -49391,7 +49406,7 @@ bfJ
 fQU
 myy
 saE
-xEm
+bSF
 bSF
 jHh
 iZP
@@ -49573,8 +49588,8 @@ ezl
 fvt
 saE
 xEm
-bSF
-jHh
+xEm
+iWI
 whJ
 cqo
 hIf
@@ -49643,7 +49658,7 @@ lXi
 lXi
 dkI
 dkI
-kWD
+dOw
 bYo
 bYo
 bYo
@@ -49753,9 +49768,9 @@ ruq
 hTm
 rnC
 saE
-xEm
 bSF
-jHh
+bSF
+nyH
 mff
 car
 ith
@@ -49788,11 +49803,11 @@ fCq
 gZN
 gZN
 gZN
-nBJ
-nBJ
+sBB
+sBB
 gZN
-nBJ
-nBJ
+sBB
+sBB
 gZN
 iAS
 qFn
@@ -50358,7 +50373,7 @@ dlS
 mRZ
 kGn
 nwa
-rRz
+pDK
 kFd
 lJL
 lJL
@@ -50538,11 +50553,11 @@ oMS
 kFd
 fEr
 fEr
-rRz
-eQb
+pDK
+lVx
 pby
-wGx
-mUL
+jeJ
+wgA
 lXi
 lXi
 lXi
@@ -50719,12 +50734,12 @@ wVJ
 wVJ
 wVJ
 wVJ
-eQb
+lVx
 pby
 pby
 uxi
 pby
-uSv
+efB
 lXi
 lXi
 lXi
@@ -51086,9 +51101,9 @@ lJL
 uxi
 pby
 uxi
-wUB
-aMN
-rwa
+mbY
+hZB
+ros
 lXi
 lXi
 lXi
@@ -51267,8 +51282,8 @@ pRb
 wZU
 uxi
 uxi
-aMN
-aMN
+hZB
+hZB
 uxi
 mkO
 vJW
@@ -51447,12 +51462,12 @@ pRb
 pRb
 pRb
 wZU
-ylg
-aMN
+vMe
+hZB
 pby
 uxi
 pby
-ylg
+vMe
 vJW
 vJW
 vJW
@@ -51628,12 +51643,12 @@ pRb
 pRb
 pRb
 vJW
-ylg
+vMe
 vJW
 pby
 uxi
 pby
-aMN
+hZB
 pby
 pby
 vJW
@@ -51812,9 +51827,9 @@ vJW
 vJW
 vJW
 mkO
-wUB
-aMN
-aMN
+mbY
+hZB
+hZB
 pby
 pby
 pby
@@ -51933,8 +51948,8 @@ pRb
 gwm
 piv
 piv
-jfI
-hAT
+dmE
+fTt
 hDt
 hDt
 kRW
@@ -51994,7 +52009,7 @@ vJW
 vJW
 vJW
 vJW
-aMN
+hZB
 pby
 pby
 pby
@@ -52112,10 +52127,10 @@ pRb
 iFE
 xDR
 gqD
-fFr
+cuX
 piv
-cIy
-cIy
+dZF
+dZF
 hDt
 hDt
 bcU
@@ -52175,7 +52190,7 @@ vJW
 vJW
 vJW
 vJW
-ylg
+vMe
 pby
 uaX
 pby
@@ -52293,11 +52308,11 @@ lrN
 eaP
 fnR
 gqD
-iHV
-xNm
-xNm
-xNm
-ekj
+daA
+cxE
+cxE
+cxE
+gEv
 cpL
 cpL
 bNd
@@ -52444,7 +52459,7 @@ xiI
 elP
 uWn
 pEy
-eUZ
+sih
 bLT
 elP
 piZ
@@ -52472,7 +52487,7 @@ nHh
 lrN
 rbq
 eaP
-cph
+tFR
 eaP
 jTo
 ujT
@@ -52488,7 +52503,7 @@ bqP
 uNg
 cpL
 vNL
-kVQ
+fqB
 vNL
 wPU
 ezJ
@@ -52497,7 +52512,7 @@ vNL
 vNL
 vNL
 joq
-gDu
+mgG
 xxU
 kpZ
 voT
@@ -52653,7 +52668,7 @@ rfp
 lrN
 lrN
 uSw
-fPR
+bIY
 eaP
 nEV
 lrN
@@ -52662,7 +52677,7 @@ bcU
 bcU
 bNd
 sSK
-wSA
+gmo
 iPG
 tJB
 gcy
@@ -52834,7 +52849,7 @@ oFm
 pRb
 wZU
 eaP
-fPR
+bIY
 gqD
 gwm
 lrN
@@ -52860,7 +52875,7 @@ yik
 jMC
 sNy
 bNL
-qNY
+jLm
 gJA
 joq
 bcU
@@ -53058,7 +53073,7 @@ gpK
 nEZ
 kkh
 fPE
-chv
+dAr
 vzF
 eOA
 nvk
@@ -53205,7 +53220,7 @@ bcU
 bcU
 cpL
 mwj
-rPe
+vzT
 bkV
 cpL
 bcU
@@ -53243,7 +53258,7 @@ opz
 tUm
 eOA
 mNR
-jvi
+eWG
 fRk
 gpK
 qbc
@@ -53365,7 +53380,7 @@ elP
 yef
 pvH
 wZa
-lVM
+oUU
 viB
 dJJ
 nzv
@@ -53571,7 +53586,7 @@ bcU
 hDt
 hDt
 piv
-pYm
+lUc
 rFx
 nJW
 fUh
@@ -53600,7 +53615,7 @@ grH
 xle
 tSW
 wnA
-huT
+cdz
 gzI
 bAE
 eOW
@@ -53752,7 +53767,7 @@ bcU
 hDt
 hDt
 piv
-pYm
+lUc
 bhK
 kwK
 aYv
@@ -53785,12 +53800,12 @@ jqv
 sOo
 cYo
 ebW
-nrL
+cqj
 uyv
 gEk
 iTK
 pOx
-kNG
+xrw
 pOx
 cFM
 bcU
@@ -53931,8 +53946,8 @@ vNL
 vNL
 xtk
 vNL
-qdC
-qdC
+gXc
+gXc
 wPU
 tnA
 byE
@@ -54112,8 +54127,8 @@ grH
 grH
 ddR
 grH
-hld
-xDM
+ijz
+kry
 rMP
 jmQ
 byE
@@ -54126,7 +54141,7 @@ gvR
 rZW
 tMT
 gvR
-lqs
+rqt
 cpP
 gvR
 uuH
@@ -54149,7 +54164,7 @@ aqa
 uKe
 gXd
 hge
-whE
+efs
 fWF
 biM
 jjw
@@ -54276,7 +54291,7 @@ nYi
 bbU
 bbU
 bbU
-oUU
+har
 gVp
 pQi
 mKM
@@ -54293,8 +54308,8 @@ vNL
 vNL
 vNL
 vNL
-qdC
-qdC
+gXc
+gXc
 wPU
 tnA
 byE
@@ -54456,7 +54471,7 @@ rLj
 lDZ
 bbU
 bbU
-xMO
+lNZ
 bbU
 gVp
 mKM
@@ -54470,13 +54485,13 @@ bcU
 bcU
 bcU
 bcU
-msm
+lAy
 bcU
 bcU
 piv
 piv
 piv
-pYm
+lUc
 bhK
 byE
 bcU
@@ -54657,7 +54672,7 @@ kRW
 hDt
 piv
 piv
-pYm
+lUc
 bhK
 byE
 kRW
@@ -54676,7 +54691,7 @@ feL
 lKR
 kEt
 qwA
-mwq
+gwq
 kEt
 lDl
 bhK
@@ -54732,7 +54747,7 @@ ozh
 hJk
 hJk
 mwo
-oJA
+rrp
 bBR
 fQZ
 oEl
@@ -54819,7 +54834,7 @@ qlI
 bbU
 bbU
 bbU
-oUU
+har
 xnD
 hyr
 jFI
@@ -54837,7 +54852,7 @@ bcU
 bcU
 bcU
 hDt
-dgj
+ipA
 lDl
 tnA
 byE
@@ -54870,7 +54885,7 @@ nIo
 iXh
 qmF
 hUy
-ttW
+rVn
 nVJ
 gpK
 hPV
@@ -55018,7 +55033,7 @@ bcU
 uFN
 bcU
 ius
-kQL
+kOq
 lDl
 bhK
 byE
@@ -55056,7 +55071,7 @@ biE
 gpK
 sYo
 cqy
-eEa
+nuW
 mGX
 fOW
 cFM
@@ -55198,7 +55213,7 @@ cGN
 bcU
 bcU
 bcU
-dgj
+ipA
 hDt
 lDl
 bhK
@@ -55362,7 +55377,7 @@ huS
 bbU
 bbU
 yfr
-oUU
+har
 xnD
 pQi
 mKM
@@ -55380,8 +55395,8 @@ bcU
 bcU
 hDt
 hDt
-rDw
-pYm
+jPS
+lUc
 bhK
 byE
 ePP
@@ -55412,7 +55427,7 @@ iph
 xUZ
 qgT
 cmB
-dgV
+dbK
 xMp
 kVJ
 uGT
@@ -55523,7 +55538,7 @@ oLO
 qoC
 xvQ
 jsg
-ejB
+goJ
 wAO
 ltG
 tnB
@@ -55560,9 +55575,9 @@ kRW
 bcU
 bcU
 piv
-rbu
+xKe
 ogv
-pYm
+lUc
 tnA
 byE
 ogv
@@ -55936,7 +55951,7 @@ lrN
 nEV
 kEt
 sde
-iQm
+xzZ
 kEt
 vlt
 cni
@@ -56075,7 +56090,7 @@ oQJ
 rUY
 rSt
 fQA
-mCh
+eHB
 vtZ
 aeE
 dPQ
@@ -57522,7 +57537,7 @@ xvQ
 xvQ
 xvQ
 wDI
-mkV
+tBy
 etn
 mSv
 mXG
@@ -57577,19 +57592,19 @@ kRW
 bcU
 vbI
 bou
-lKS
+cpG
 wFt
 vbI
 lrN
 lrN
 lvS
-dWF
-dpc
+iQu
+bwP
 cjO
 rQw
 yjT
-hye
-dpc
+jSj
+bwP
 lrN
 lDl
 xPb
@@ -57770,7 +57785,7 @@ ksr
 bDl
 wPv
 gbC
-ote
+kyL
 lrN
 lDl
 xPb
@@ -57951,7 +57966,7 @@ uCt
 nRx
 eQj
 cax
-ote
+kyL
 lrN
 lDl
 jyW
@@ -58132,7 +58147,7 @@ eQj
 cBA
 ksr
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -58248,8 +58263,8 @@ xvQ
 xvQ
 xvQ
 xvQ
-foV
-foV
+cnV
+cnV
 xvQ
 xvQ
 pRb
@@ -58313,7 +58328,7 @@ eQj
 cBA
 eQj
 ooD
-ote
+kyL
 lrN
 lDl
 xPb
@@ -58473,7 +58488,7 @@ clP
 lCu
 shV
 kwx
-sCj
+sXz
 gOQ
 teB
 rLE
@@ -58490,11 +58505,11 @@ lrN
 lvS
 ykz
 ykz
-oHg
+rqP
 wkw
 bok
 fpk
-ote
+kyL
 lrN
 lDl
 bej
@@ -58652,7 +58667,7 @@ uSb
 uSb
 clP
 xrm
-qcM
+fKj
 nDv
 rEP
 hnw
@@ -58675,7 +58690,7 @@ glK
 cBA
 eQj
 ooD
-ote
+kyL
 lrN
 lDl
 xPb
@@ -58854,9 +58869,9 @@ lvS
 dEg
 dEg
 wkw
-eUv
+chu
 cax
-ote
+kyL
 lrN
 lDl
 jyW
@@ -59037,7 +59052,7 @@ dEg
 cBA
 eQj
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -59218,7 +59233,7 @@ cBA
 cBA
 eQj
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -59399,7 +59414,7 @@ dEg
 cBA
 ksr
 ooD
-aEf
+ggn
 lrN
 lDl
 jyW
@@ -59565,7 +59580,7 @@ loN
 oHY
 sOZ
 rrr
-fHO
+cBH
 hwj
 kdp
 eHU
@@ -59696,8 +59711,8 @@ pRb
 pRb
 lWc
 lWc
-eLC
-vrb
+ass
+aJC
 lWc
 lWc
 lWc
@@ -59738,7 +59753,7 @@ dAd
 imO
 vFl
 hLH
-vMN
+vbx
 imO
 kxD
 lCG
@@ -59904,7 +59919,7 @@ sfh
 xxD
 xxD
 xxD
-lUO
+xUH
 xxD
 xxD
 lVj
@@ -60045,7 +60060,7 @@ hHf
 hHf
 pRb
 lWc
-tFk
+qKr
 lWc
 kqR
 kqR
@@ -60123,7 +60138,7 @@ ykz
 ktW
 eQj
 cax
-ueV
+xuk
 lrN
 lDl
 jyW
@@ -60304,7 +60319,7 @@ xAV
 eQj
 eQj
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -60483,9 +60498,9 @@ nEV
 lvS
 pAj
 ykz
-oHg
+rqP
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -60666,7 +60681,7 @@ ktW
 ykz
 eQj
 ooD
-gtn
+sGX
 lrN
 lDl
 jyW
@@ -60847,7 +60862,7 @@ lvS
 xAV
 ksr
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -60965,7 +60980,7 @@ kqR
 kqR
 kqR
 rUn
-hrB
+gJm
 kWG
 pRb
 pRb
@@ -61028,7 +61043,7 @@ lvS
 dEg
 dEg
 cax
-ote
+kyL
 lrN
 lDl
 xPb
@@ -61209,7 +61224,7 @@ lvS
 eLS
 csZ
 ooD
-gtn
+sGX
 lrN
 lDl
 unB
@@ -61390,7 +61405,7 @@ lvS
 dQZ
 xPZ
 vlT
-ote
+kyL
 lrN
 lDl
 xPb
@@ -61536,7 +61551,7 @@ xxD
 vmm
 obR
 vdl
-tZi
+fip
 wlw
 obR
 fnD
@@ -61571,7 +61586,7 @@ lvS
 fRh
 dEg
 ksr
-gtn
+sGX
 lrN
 lDl
 xPb
@@ -61751,8 +61766,8 @@ kRW
 lvS
 eLS
 eLS
-oHg
-gtn
+rqP
+sGX
 lrN
 lDl
 xPb
@@ -61825,8 +61840,8 @@ lsi
 pEK
 oTq
 pRb
-fmO
-fmO
+xDz
+xDz
 wng
 wng
 wng
@@ -62239,8 +62254,8 @@ pRb
 pRb
 lWc
 lWc
-vrb
-vrb
+aJC
+aJC
 lWc
 pRb
 pRb
@@ -62454,7 +62469,7 @@ sfh
 tvN
 xxD
 xxD
-lUO
+xUH
 xxD
 bpu
 koR
@@ -62564,8 +62579,8 @@ cfj
 pRb
 pRb
 dqB
-aoM
-dQu
+psr
+uvx
 iof
 hHf
 hHf
@@ -62745,8 +62760,8 @@ oTq
 pRb
 pRb
 dqB
-dQu
-dQu
+uvx
+uvx
 iof
 hHf
 hHf
@@ -62940,9 +62955,9 @@ arg
 arg
 arg
 fkd
-jYQ
-jYQ
-jYQ
+lOZ
+lOZ
+lOZ
 fkd
 iof
 iof
@@ -63144,8 +63159,8 @@ pRb
 pRb
 pRb
 lWc
-vrb
-vrb
+aJC
+aJC
 lWc
 pRb
 pRb
@@ -63842,12 +63857,12 @@ hHf
 arg
 hHf
 hHf
-vrb
-vrb
+aJC
+aJC
 lWc
-vrb
+aJC
 lWc
-tFk
+qKr
 lWc
 pRb
 iof
@@ -63884,7 +63899,7 @@ pRb
 pRb
 kqR
 kqR
-oFn
+nwi
 kqR
 xxD
 pRb
@@ -64383,7 +64398,7 @@ hHf
 (173,1,1) = {"
 hHf
 arg
-eLC
+ass
 lWc
 lWc
 pRb
@@ -64415,8 +64430,8 @@ pRb
 pRb
 pRb
 lWc
-vrb
-vrb
+aJC
+aJC
 lWc
 lWc
 pRb
@@ -65108,7 +65123,7 @@ hHf
 hHf
 arg
 lWc
-vrb
+aJC
 pRb
 pRb
 pRb
@@ -65226,7 +65241,7 @@ jJM
 iBp
 vtg
 bbX
-pqB
+tOD
 ivc
 jOW
 vJW
@@ -65262,9 +65277,9 @@ pby
 oTq
 oTq
 pRb
-aOA
-fmO
-htI
+lwm
+xDz
+dIC
 oTq
 oTq
 hmM
@@ -65443,9 +65458,9 @@ pby
 oTq
 pRb
 pRb
-aOA
-fmO
-htI
+lwm
+xDz
+dIC
 oTq
 oTq
 hmM
@@ -65535,7 +65550,7 @@ xxD
 fnD
 fnD
 bIG
-gzB
+hfm
 rpi
 uoY
 uSb
@@ -65809,7 +65824,7 @@ sMt
 fyQ
 pWf
 mlq
-nof
+ptl
 mWu
 hmM
 mWu
@@ -65831,7 +65846,7 @@ hHf
 (181,1,1) = {"
 hHf
 fkd
-vrb
+aJC
 lWc
 pRb
 pRb
@@ -65918,7 +65933,7 @@ srl
 sDl
 oAB
 nyn
-gjG
+shb
 xtK
 enV
 qcC
@@ -65990,7 +66005,7 @@ eZH
 gwe
 vvK
 gwe
-ujh
+rVw
 nPC
 hmM
 iof
@@ -66171,7 +66186,7 @@ chZ
 gwe
 vvK
 vvK
-iSf
+sys
 nPC
 pRb
 iof
@@ -66352,7 +66367,7 @@ eZH
 gwe
 gwe
 gwe
-vmw
+exU
 mWu
 mWu
 iof
@@ -66459,7 +66474,7 @@ uSb
 sCk
 tmO
 cwS
-cbY
+rxc
 bfp
 bfp
 ydh
@@ -66556,7 +66571,7 @@ hHf
 hHf
 fkd
 lWc
-vrb
+aJC
 pRb
 pRb
 pRb
@@ -66737,7 +66752,7 @@ hHf
 hHf
 fkd
 lWc
-vrb
+aJC
 pRb
 pRb
 pRb
@@ -66774,8 +66789,8 @@ aWd
 lWc
 lWc
 lWc
-vrb
-vrb
+aJC
+aJC
 lWc
 lWc
 lWc
@@ -67043,8 +67058,8 @@ oTq
 pRb
 dqB
 dqB
-dQu
-dQu
+uvx
+uvx
 dqB
 dqB
 pRb
@@ -67104,13 +67119,13 @@ pRb
 pRb
 pRb
 lWc
-vrb
+aJC
 lWc
-vrb
-vrb
-vrb
+aJC
+aJC
+aJC
 lWc
-vrb
+aJC
 lWc
 lWc
 pRb
@@ -67468,9 +67483,9 @@ lWc
 kqR
 wgK
 lWc
-vrb
-vrb
-vrb
+aJC
+aJC
+aJC
 eqG
 wgK
 kqR
@@ -67646,7 +67661,7 @@ wgK
 kqR
 kqR
 lWc
-vrb
+aJC
 lWc
 lWc
 gwc
@@ -67654,7 +67669,7 @@ gwc
 wgK
 lWc
 lWc
-vrb
+aJC
 lWc
 kqR
 wgK
@@ -67850,7 +67865,7 @@ pRb
 pRb
 pRb
 fvf
-lbs
+tUc
 heP
 mgf
 heP
@@ -67866,8 +67881,8 @@ pRb
 kqR
 lWc
 lWc
-vrb
-vrb
+aJC
+aJC
 lWc
 lWc
 pRb
@@ -68370,7 +68385,7 @@ hHf
 kqR
 kqR
 lWc
-vrb
+aJC
 eqG
 lWc
 wgK
@@ -68378,7 +68393,7 @@ wgK
 wgK
 lWc
 lWc
-vrb
+aJC
 lWc
 tlS
 aWd
@@ -68554,9 +68569,9 @@ lWc
 kqR
 wgK
 lWc
-vrb
-vrb
-vrb
+aJC
+aJC
+aJC
 lWc
 wgK
 kqR
@@ -69063,7 +69078,7 @@ dqB
 vQG
 mWu
 mWu
-ttT
+iVr
 eSk
 mWu
 mWu


### PR DESCRIPTION
## About The Pull Request
Yeah no, this is not a good thing and needs to be quickly removed
Replaced it with this:
![slumbridge](https://github.com/tgstation/TerraGov-Marine-Corps/assets/80391698/e2b44cef-f2e8-440b-bc9a-b7aad1ed83cc)

## Why It's Good For The Game
* Less unfair deaths
* This shouldn't happen anymore

https://github.com/tgstation/TerraGov-Marine-Corps/assets/80391698/e28af98d-8b04-4aeb-8391-e4daa281bb38


## Changelog
:cl:
fix: fixes a object fling trap in Slumbridge engineering
/:cl:
