### PR TITLE
Fixes behemoth's earth pillar and AoE attacks not damaging vehicles outside of the middle

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -250,6 +250,8 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 
 #define isarmoredvehicle(A) (istype(A, /obj/vehicle/sealed/armored))
 
+#define ishitbox(A) (istype(A, /obj/hitbox))
+
 #define isorgan(A) (istype(A, /datum/limb))
 
 #define isidcard(A) (istype(A, /obj/item/card/id))

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1366,6 +1366,8 @@
 	if(istype(hit_object, /obj/structure/reagent_dispensers/fueltank))
 		var/obj/structure/reagent_dispensers/fueltank/hit_tank = hit_object
 		hit_tank.explode()
+	if(istype(hit_object, /obj/hitbox)) // These don't hit the vehicles, but rather their hitboxes, so isarmored will not work here
+		return on_hit_anything(get_turf(hit_object), proj)
 	return rock_broke(get_turf(hit_object), proj)
 
 /datum/ammo/xeno/earth_pillar/on_hit_mob(mob/hit_mob, obj/projectile/proj)

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1366,7 +1366,7 @@
 	if(istype(hit_object, /obj/structure/reagent_dispensers/fueltank))
 		var/obj/structure/reagent_dispensers/fueltank/hit_tank = hit_object
 		hit_tank.explode()
-	if(istype(hit_object, /obj/hitbox)) // These don't hit the vehicles, but rather their hitboxes, so isarmored will not work here
+	if(ishitbox(hit_object) || ismecha(hit_object)) // These don't hit the vehicles, but rather their hitboxes, so isarmored will not work here
 		return on_hit_anything(get_turf(hit_object), proj)
 	return rock_broke(get_turf(hit_object), proj)
 
@@ -1406,7 +1406,7 @@
 // ***************************************
 // *********** Global Procs
 // ***************************************
-#define AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER 1.8
+#define AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER 0.4
 
 /**
  * Checks for any atoms caught in the attack's range, and applies several effects based on the atom's type.
@@ -1437,7 +1437,7 @@
 				shake_camera(affected_living, 1, 0.8)
 				affected_living.Paralyze(paralyze_duration)
 				affected_living.apply_damage(attack_damage, BRUTE, blocked = MELEE)
-			else if(isearthpillar(affected_atom) || isvehicle(affected_atom) || istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
+			else if(isearthpillar(affected_atom) || isvehicle(affected_atom) || ishitbox(affected_atom) || istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
 				affected_atom.do_jitter_animation()
 				new /obj/effect/temp_visual/behemoth/landslide/hit(affected_atom.loc)
 				playsound(affected_atom.loc, SFX_BEHEMOTH_EARTH_PILLAR_HIT, 40)
@@ -1451,11 +1451,11 @@
 					do_warning(xeno_owner, spread_turfs, wind_up_duration)
 					addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(behemoth_area_attack), xeno_owner, spread_turfs, enhanced), wind_up_duration)
 					continue
-				if(isvehicle(affected_atom))
+				if(isvehicle(affected_atom) || ishitbox(affected_atom))
 					var/obj/vehicle/veh_victim = affected_atom
 					var/damage_add = 0
 					if(ismecha(veh_victim))
-						damage_add = 8.2
+						damage_add = 9.5
 					veh_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER + damage_add), MELEE)
 					continue
 				if(istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))


### PR DESCRIPTION
## About The Pull Request
Title, specifically them not doing damage to vehicles if they are tossed rather than rammed with landslide. Also makes it so the AoE attacks don't have to hit the center in order to do damage, rather they can hit any part of the tank.
## Why It's Good For The Game
Bugs bad
## Changelog
:cl:
fix: Behemoth's earth pillars should do damage to vehicles now if they are tossed at them
fix: Behemoth's AoE attacks will now damage all parts of the tank (previously only damaged it's center)
balance: Adjusted Behemoth's ability damage to compensate for attacks like meteor doing damage per vehicle tile hit
/:cl:
