### PR TITLE
Makes Evade cancel timer 0.3 seconds instead of 1 second

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -147,7 +147,7 @@
 	RegisterSignal(owner, COMSIG_LIVING_PRE_THROW_IMPACT, PROC_REF(evasion_throw_dodge))
 	GLOB.round_statistics.runner_evasions++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_evasions")
-	TIMER_COOLDOWN_START(src, COOLDOWN_EVASION_ACTIVATION, 0.1 SECONDS)
+	TIMER_COOLDOWN_START(src, COOLDOWN_EVASION_ACTIVATION, 0.3 SECONDS)
 
 /datum/action/ability/xeno_action/evasion/ai_should_start_consider()
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -147,7 +147,7 @@
 	RegisterSignal(owner, COMSIG_LIVING_PRE_THROW_IMPACT, PROC_REF(evasion_throw_dodge))
 	GLOB.round_statistics.runner_evasions++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_evasions")
-	TIMER_COOLDOWN_START(src, COOLDOWN_EVASION_ACTIVATION, 1 SECONDS)
+	TIMER_COOLDOWN_START(src, COOLDOWN_EVASION_ACTIVATION, 0.1 SECONDS)
 
 /datum/action/ability/xeno_action/evasion/ai_should_start_consider()
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
As the title says it lets you cancel evade faster, I'd make it 0 but on the off chance someone double taps really fast this will help them, kinda.
## Why It's Good For The Game
You can now slash that shotgunner (1) more time while their fire delay is still up, jokes aside earlier evasion cancel gives more control over being unable to slash for a whole second.
## Changelog
:cl:
balance: Runner evasion can now be canceled at 0.3 seconds, instead of 1 second. (1 --> 0.3) 
/:cl:
