### PR TITLE
Reduce AMR's on-hit slowdown

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -155,7 +155,7 @@
 //Define sniper laser multipliers
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
-#define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
+#define SNIPER_LASER_SLOWDOWN_STACKS 2.25 // Slowdown applied on hit vs the aimed target.
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20


### PR DESCRIPTION
## About The Pull Request
Reduces AMRs on-hit slowdown from 3 to 2.25
## Why It's Good For The Game
AMR currently has some of the highest slowdown of any gun, on par with a sadar. Unlike a sadar, you can have a whole magazine to use to cause this slowdown and do this from miles away. Combine this with the 50 AP and 135 damage, and whatever gets hit becomes a easy to attack target. 
## Changelog
:cl:
balance: Reduced the slowdown of the amr from 3 to 2.25
/:cl:
