### PR TITLE
Increase crusher charge damage against tanks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -260,6 +260,7 @@
 		else
 			return NONE
 
+
 // Charge is divided into two acts: before and after the crushed thing taking damage, as that can cause it to be deleted.
 /datum/action/ability/xeno_action/ready_charge/proc/do_crush(datum/source, atom/crushed)
 	SIGNAL_HANDLER
@@ -308,7 +309,10 @@
 			return precrush2signal(crushed_obj.post_crush_act(charger, src))
 		playsound(crushed_obj.loc, SFX_PUNCH, 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
-		crushed_obj.take_damage(precrush, BRUTE, MELEE)
+		var/vehicle_damage_mult = 1
+		if(isarmoredvehicle(crushed) || ishitbox(crushed))
+			vehicle_damage_mult = 5
+		crushed_obj.take_damage(precrush * vehicle_damage_mult, BRUTE, MELEE)
 		if(QDELETED(crushed_obj))
 			charger.visible_message(span_danger("[charger] crushes [preserved_name]!"),
 			span_xenodanger("We crush [preserved_name]!"))

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -260,7 +260,6 @@
 		else
 			return NONE
 
-
 // Charge is divided into two acts: before and after the crushed thing taking damage, as that can cause it to be deleted.
 /datum/action/ability/xeno_action/ready_charge/proc/do_crush(datum/source, atom/crushed)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Title, increases to be between 50-100, depending how long the crusher was charging.
## Why It's Good For The Game
Currently, crusher does about 20 damage max if it charges into the tank. This is abysmal, especially considering the crusher has to get in the tanks face to do this damage. This hopefully helps crushers actually do damage to the tank, outside of sitting on it and smacking it.
## Changelog
:cl:
balance: Crusher's charge now does more damage to tanks and apcs (from between 18-21 to between 50-100) depending on the charge distance.
/:cl:
