### PR TITLE
Make King Roar's armored vehicle damage depend on how much is hit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -264,9 +264,12 @@
 			shake_camera(carbon_victim, 3 * severity, 3 * severity)
 			carbon_victim.apply_effect(1 SECONDS, WEAKEN)
 			to_chat(carbon_victim, "You are smashed to the ground!")
-		else if(isvehicle(victim))
+		else if(isvehicle(victim) || ishitbox(victim))
 			var/obj/vehicle/veh_victim = victim
-			veh_victim.take_damage(SHATTERING_ROAR_DAMAGE * 5 * severity, BRUTE, MELEE)
+			var/armored_vehicle_penalty = 0
+			if(ishitbox(victim))
+				armored_vehicle_penalty = 20
+			veh_victim.take_damage((SHATTERING_ROAR_DAMAGE - armored_vehicle_penalty) * 5 * severity, BRUTE, MELEE)
 		else if(istype(victim, /obj/structure/window))
 			var/obj/structure/window/window_victim = victim
 			if(window_victim.damageable)


### PR DESCRIPTION
## About The Pull Request
Title, makes it so King's roar deals damage depending on how much of the vehicle is hit, up to 120 damage if the king is right next to it.
## Why It's Good For The Game
Currently, King's roar only deals 80 damage if it hits the center of the tank. This is very unintuitive, and isn't much considering it requires the King to sit there and stare at the tank while winding up his roar. This makes it so that even if the roar only grazes the tank, it will at least do something, rather than literally nothing, and will reward the king for hitting more of the tank.
## Changelog
:cl:
balance: King's roar now deals damage to all parts of the tank instead of just the center. Damage is 12 per tile at close range, 10 per tile at farther distances. 

/:cl:
