### PR TITLE
projectile fixes and cleanup

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1356,13 +1356,13 @@
 	damage_type = BRUTE
 	armor_type = MELEE
 
-/datum/ammo/xeno/earth_pillar/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return rock_broke(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return rock_broke(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(istype(hit_object, /obj/structure/reagent_dispensers/fueltank))
 		var/obj/structure/reagent_dispensers/fueltank/hit_tank = hit_object
 		hit_tank.explode()
@@ -1370,7 +1370,7 @@
 		return on_hit_anything(get_turf(hit_object), proj)
 	return rock_broke(get_turf(hit_object), proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isxeno(proj.firer) || !isliving(hit_mob))
 		return
 	var/mob/living/carbon/xenomorph/xeno_firer = proj.firer
@@ -1392,13 +1392,13 @@
 	var/list/turf/affected_turfs = filled_turfs(hit_turf, EARTH_PILLAR_SPREAD_RADIUS, include_edge = FALSE, bypass_window = TRUE, projectile = TRUE)
 	behemoth_area_attack(proj.firer, affected_turfs, damage_multiplier = EARTH_PILLAR_SPREAD_DAMAGE_MULTIPLIER)
 
-/datum/ammo/xeno/earth_pillar/landslide/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return on_hit_anything(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/landslide/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return on_hit_anything(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/landslide/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	. = ..()
 	return on_hit_anything(get_turf(hit_object), proj)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1357,28 +1357,28 @@
 	armor_type = MELEE
 
 /datum/ammo/xeno/earth_pillar/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	return rock_broke(hit_turf, proj)
+	return rock_broke(target_turf, proj)
 
 /datum/ammo/xeno/earth_pillar/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	return rock_broke(hit_turf, proj)
+	return rock_broke(target_turf, proj)
 
 /datum/ammo/xeno/earth_pillar/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	if(istype(hit_object, /obj/structure/reagent_dispensers/fueltank))
-		var/obj/structure/reagent_dispensers/fueltank/hit_tank = hit_object
+	if(istype(target_obj, /obj/structure/reagent_dispensers/fueltank))
+		var/obj/structure/reagent_dispensers/fueltank/hit_tank = target_obj
 		hit_tank.explode()
-	if(ishitbox(hit_object) || ismecha(hit_object)) // These don't hit the vehicles, but rather their hitboxes, so isarmored will not work here
-		return on_hit_anything(get_turf(hit_object), proj)
-	return rock_broke(get_turf(hit_object), proj)
+	if(ishitbox(target_obj) || ismecha(target_obj)) // These don't hit the vehicles, but rather their hitboxes, so isarmored will not work here
+		return on_hit_anything(get_turf(target_obj), proj)
+	return rock_broke(get_turf(target_obj), proj)
 
 /datum/ammo/xeno/earth_pillar/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isxeno(proj.firer) || !isliving(hit_mob))
+	if(!isxeno(proj.firer) || !isliving(target_mob))
 		return
 	var/mob/living/carbon/xenomorph/xeno_firer = proj.firer
-	var/mob/living/hit_living = hit_mob
+	var/mob/living/hit_living = target_mob
 	if(xeno_firer.issamexenohive(hit_living) || hit_living.stat == DEAD)
-		return on_hit_anything(get_turf(hit_mob), proj)
+		return on_hit_anything(get_turf(target_mob), proj)
 	step_away(hit_living, proj, 1, 1)
-	return on_hit_anything(get_turf(hit_mob), proj)
+	return on_hit_anything(get_turf(target_mob), proj)
 
 /// VFX + SFX for when the rock doesn't hit anything.
 /datum/ammo/xeno/earth_pillar/proc/rock_broke(turf/hit_turf, obj/projectile/proj)
@@ -1393,14 +1393,14 @@
 	behemoth_area_attack(proj.firer, affected_turfs, damage_multiplier = EARTH_PILLAR_SPREAD_DAMAGE_MULTIPLIER)
 
 /datum/ammo/xeno/earth_pillar/landslide/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	return on_hit_anything(hit_turf, proj)
+	return on_hit_anything(target_turf, proj)
 
 /datum/ammo/xeno/earth_pillar/landslide/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	return on_hit_anything(hit_turf, proj)
+	return on_hit_anything(target_turf, proj)
 
 /datum/ammo/xeno/earth_pillar/landslide/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	. = ..()
-	return on_hit_anything(get_turf(hit_object), proj)
+	return on_hit_anything(get_turf(target_obj), proj)
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1356,13 +1356,13 @@
 	damage_type = BRUTE
 	armor_type = MELEE
 
-/datum/ammo/xeno/earth_pillar/do_at_max_range(turf/hit_turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/do_at_max_range(turf/turf, obj/projectile/proj)
 	return rock_broke(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_turf(turf/hit_turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_turf(turf/turf, obj/projectile/proj)
 	return rock_broke(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_obj(obj/hit_object, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_obj(obj/obj, obj/projectile/proj)
 	if(istype(hit_object, /obj/structure/reagent_dispensers/fueltank))
 		var/obj/structure/reagent_dispensers/fueltank/hit_tank = hit_object
 		hit_tank.explode()
@@ -1370,7 +1370,7 @@
 		return on_hit_anything(get_turf(hit_object), proj)
 	return rock_broke(get_turf(hit_object), proj)
 
-/datum/ammo/xeno/earth_pillar/on_hit_mob(mob/hit_mob, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isxeno(proj.firer) || !isliving(hit_mob))
 		return
 	var/mob/living/carbon/xenomorph/xeno_firer = proj.firer
@@ -1392,13 +1392,13 @@
 	var/list/turf/affected_turfs = filled_turfs(hit_turf, EARTH_PILLAR_SPREAD_RADIUS, include_edge = FALSE, bypass_window = TRUE, projectile = TRUE)
 	behemoth_area_attack(proj.firer, affected_turfs, damage_multiplier = EARTH_PILLAR_SPREAD_DAMAGE_MULTIPLIER)
 
-/datum/ammo/xeno/earth_pillar/landslide/do_at_max_range(turf/hit_turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/do_at_max_range(turf/turf, obj/projectile/proj)
 	return on_hit_anything(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/landslide/on_hit_turf(turf/hit_turf, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/on_hit_turf(turf/turf, obj/projectile/proj)
 	return on_hit_anything(hit_turf, proj)
 
-/datum/ammo/xeno/earth_pillar/landslide/on_hit_obj(obj/hit_object, obj/projectile/proj)
+/datum/ammo/xeno/earth_pillar/landslide/on_hit_obj(obj/obj, obj/projectile/proj)
 	. = ..()
 	return on_hit_anything(get_turf(hit_object), proj)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -18,7 +18,7 @@
 	/// The amount of stacks applied on hit.
 	var/intoxication_stacks = 5
 
-/datum/ammo/xeno/acid/toxic_spit/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/acid/toxic_spit/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
 		if(C.issamexenohive(P.firer))

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -18,7 +18,7 @@
 	/// The amount of stacks applied on hit.
 	var/intoxication_stacks = 5
 
-/datum/ammo/xeno/acid/toxic_spit/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/acid/toxic_spit/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
 		if(C.issamexenohive(P.firer))

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -19,16 +19,17 @@
 	var/intoxication_stacks = 5
 
 /datum/ammo/xeno/acid/toxic_spit/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(istype(M,/mob/living/carbon))
-		var/mob/living/carbon/C = M
-		if(C.issamexenohive(P.firer))
-			return
-		if(HAS_TRAIT(C, TRAIT_INTOXICATION_IMMUNE))
-			return
-		if(C.has_status_effect(STATUS_EFFECT_INTOXICATED))
-			var/datum/status_effect/stacking/intoxicated/debuff = C.has_status_effect(STATUS_EFFECT_INTOXICATED)
-			debuff.add_stacks(intoxication_stacks)
-		C.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxication_stacks)
+	if(!iscarbon(target_mob))
+		return
+	var/mob/living/carbon/target_carbon = target_mob
+	if(target_carbon.issamexenohive(proj.firer))
+		return
+	if(HAS_TRAIT(target_carbon, TRAIT_INTOXICATION_IMMUNE))
+		return
+	if(target_carbon.has_status_effect(STATUS_EFFECT_INTOXICATED))
+		var/datum/status_effect/stacking/intoxicated/debuff = target_carbon.has_status_effect(STATUS_EFFECT_INTOXICATED)
+		debuff.add_stacks(intoxication_stacks)
+	target_carbon.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxication_stacks)
 
 // ***************************************
 // *********** Toxic Slash

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -258,7 +258,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		new_proj.fire_at(target, shooter, source, range, speed, new_angle, TRUE, loc_override = origin_override)
 
 ///A variant of Fire_bonus_projectiles without fixed scatter and no link between gun and bonus_projectile accuracy
-/datum/ammo/proc/fire_directionalburst(obj/projectile/main_proj, mob/living/shooter, atom/source, projectile_amount, range, speed, angle, target)
+/datum/ammo/proc/fire_directionalburst(obj/projectile/main_proj, mob/living/shooter, atom/source, projectile_amount, range, speed, angle, target, loc_override = main_proj.loc)
 	var/effect_icon = ""
 	var/proj_type = /obj/projectile
 	if(istype(main_proj, /obj/projectile/hitscan))
@@ -266,7 +266,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		var/obj/projectile/hitscan/main_proj_hitscan = main_proj
 		effect_icon = main_proj_hitscan.effect_icon
 	for(var/i = 1 to projectile_amount) //Want to run this for the number of bonus projectiles.
-		var/obj/projectile/new_proj = new proj_type(main_proj.loc, effect_icon)
+		var/obj/projectile/new_proj = new proj_type(loc_override, effect_icon)
 		if(bonus_projectiles_type)
 			new_proj.generate_bullet(bonus_projectiles_type)
 		else //If no bonus type is defined then the extra projectiles are the same as the main one.
@@ -283,7 +283,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			new_angle += 360
 		if(new_angle > 360)
 			new_angle -= 360
-		new_proj.fire_at(target, shooter, main_proj.loc, range, speed, new_angle, TRUE)
+		new_proj.fire_at(target, shooter, loc_override, range, speed, new_angle, TRUE)
 
 /datum/ammo/proc/drop_flame(turf/T)
 	if(!istype(T))

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -93,27 +93,27 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	///Base fire stacks added on hit if the projectile has AMMO_INCENDIARY
 	var/incendiary_strength = 10
 
-/datum/ammo/proc/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/proc/do_at_max_range(turf/turf, obj/projectile/proj)
 	return
 
 ///Does it do something special when shield blocked? Ie. a flare or grenade that still blows up.
-/datum/ammo/proc/on_shield_block(mob/M, obj/projectile/proj)
+/datum/ammo/proc/on_shield_block(mob/mob, obj/projectile/proj)
 	return
 
 ///Special effects when hitting dense turfs.
-/datum/ammo/proc/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/proc/on_hit_turf(turf/turf, obj/projectile/proj)
 	return
 
 ///Special effects when hitting mobs.
-/datum/ammo/proc/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/proc/on_hit_mob(mob/mob, obj/projectile/proj)
 	return
 
 ///Special effects when hitting objects.
-/datum/ammo/proc/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/proc/on_hit_obj(obj/obj, obj/projectile/proj)
 	return
 
 ///Special effects for leaving a turf. Only called if the projectile has AMMO_LEAVE_TURF enabled
-/datum/ammo/proc/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/proc/on_leave_turf(turf/turf, obj/projectile/proj)
 	return
 
 ///Handles CC application on the victim

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -93,27 +93,27 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	///Base fire stacks added on hit if the projectile has AMMO_INCENDIARY
 	var/incendiary_strength = 10
 
-/datum/ammo/proc/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/proc/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return
 
 ///Does it do something special when shield blocked? Ie. a flare or grenade that still blows up.
-/datum/ammo/proc/on_shield_block(mob/mob, obj/projectile/proj)
+/datum/ammo/proc/on_shield_block(mob/target_mob, obj/projectile/proj)
 	return
 
 ///Special effects when hitting dense turfs.
-/datum/ammo/proc/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/proc/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return
 
 ///Special effects when hitting mobs.
-/datum/ammo/proc/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/proc/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	return
 
 ///Special effects when hitting objects.
-/datum/ammo/proc/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/proc/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	return
 
 ///Special effects for leaving a turf. Only called if the projectile has AMMO_LEAVE_TURF enabled
-/datum/ammo/proc/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/proc/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	return
 
 ///Handles CC application on the victim

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -27,20 +27,24 @@
 
 
 /datum/ammo/ags_shrapnel/on_hit_mob(mob/M, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, M) )
+	var/turf/det_turf = get_turf(M)
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, M), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_obj(obj/O, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, O) )
+	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, O), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_turf(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, T) )
+	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, T), det_turf)
 
 /datum/ammo/ags_shrapnel/do_at_max_range(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)) )
+	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 
 /datum/ammo/ags_shrapnel/incendiary
 	name = "white phosphorous grenade"

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -27,22 +27,22 @@
 
 
 /datum/ammo/ags_shrapnel/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/det_turf = get_turf(M)
+	var/turf/det_turf = get_turf(target_mob)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, M), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_mob), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, O), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, T), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/ags_shrapnel/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 
@@ -71,16 +71,16 @@
 	damage_falloff = 0
 
 /datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_flame(get_turf(M))
+	drop_flame(get_turf(target_mob))
 
 /datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_flame(get_turf(O))
+	drop_flame(get_turf(target_obj))
 
 /datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_flame(get_turf(T))
+	drop_flame(get_turf(target_turf))
 
 /datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_flame(get_turf(T))
+	drop_flame(get_turf(target_turf))
 
 /datum/ammo/bullet/ags_spread/incendiary/drop_flame(turf/T)
 	if(!istype(T))

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -26,22 +26,22 @@
 	var/bonus_projectile_quantity = 15
 
 
-/datum/ammo/ags_shrapnel/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, M), det_turf)
 
-/datum/ammo/ags_shrapnel/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/ags_shrapnel/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/ags_shrapnel/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
@@ -70,16 +70,16 @@
 	sundering = 1.5
 	damage_falloff = 0
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_flame(get_turf(M))
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_flame(get_turf(O))
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
-/datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
 /datum/ammo/bullet/ags_spread/incendiary/drop_flame(turf/T)

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -26,22 +26,22 @@
 	var/bonus_projectile_quantity = 15
 
 
-/datum/ammo/ags_shrapnel/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, M), det_turf)
 
-/datum/ammo/ags_shrapnel/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/ags_shrapnel/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/on_hit_turf(turf/turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/ags_shrapnel/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/ags_shrapnel/do_at_max_range(turf/turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
@@ -70,16 +70,16 @@
 	sundering = 1.5
 	damage_falloff = 0
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_flame(get_turf(M))
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_flame(get_turf(O))
 
-/datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/ags_spread/incendiary/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
-/datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/bullet/ags_spread/incendiary/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
 /datum/ammo/bullet/ags_spread/incendiary/drop_flame(turf/T)

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -32,17 +32,17 @@
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_mob), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/ags_shrapnel/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/ags_shrapnel/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 2, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -39,7 +39,7 @@
 	accurate_range = 10
 	bullet_color = COLOR_VIVID_YELLOW
 
-/datum/ammo/energy/taser/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/taser/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stun = 20 SECONDS)
 
 /datum/ammo/energy/tesla
@@ -67,7 +67,7 @@
 	zap_beam(proj, 3, damage)
 
 
-/datum/ammo/energy/tesla/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/tesla/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(M)) //need 1 second more than the actual effect time
 		var/mob/living/carbon/xenomorph/X = M
 		X.use_plasma(0.3 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) //Drains 30% of max plasma on hit
@@ -155,7 +155,7 @@
 	damage_type = STAMINA
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/M43/disabler/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/M43/disabler/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/pulsebolt
@@ -178,7 +178,7 @@
 	ammo_behavior_flags = AMMO_ENERGY
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/M43/practice/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/M43/practice/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(ishuman(mob))
 		return
 	var/mob/living/carbon/human/human_victim = mob
@@ -220,7 +220,7 @@
 	///plasma drained per hit
 	var/plasma_drain = 25
 
-/datum/ammo/energy/lasgun/marine/weakening/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/weakening/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 6, slowdown = 1)
 
 	if(!isxeno(M))
@@ -240,7 +240,7 @@
 	///number of microwave stacks to apply when hitting mobvs
 	var/microwave_stacks = 1
 
-/datum/ammo/energy/lasgun/marine/microwave/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/microwave/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -283,7 +283,7 @@
 	hitscan_effect_icon = "pu_laser"
 	bullet_color = LIGHT_COLOR_PURPLE
 
-/datum/ammo/energy/lasgun/marine/impact/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/impact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/knockback_dist = round(LERP(3, 1, proj.distance_travelled / 6), 1)
 	staggerstun(M, proj, max_range = 6, knockback = knockback_dist)
 
@@ -297,7 +297,7 @@
 	hitscan_effect_icon = "blue_beam"
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/marine/cripple/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/cripple/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, slowdown = 1.5)
 
 /datum/ammo/energy/lasgun/marine/autolaser
@@ -320,7 +320,7 @@
 	hitscan_effect_icon = "beam_heavy"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_PASS_THROUGH_MOB
 
-/datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
 		wall_victim.take_damage(proj.damage, proj.damtype, proj.armor_type)
@@ -336,7 +336,7 @@
 	///number of melting stacks to apply when hitting mobs
 	var/melt_stacks = 2
 
-/datum/ammo/energy/lasgun/marine/autolaser/melting/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/autolaser/melting/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -385,7 +385,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 5 SECONDS
 
-/datum/ammo/energy/lasgun/marine/shatter/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/shatter/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -424,10 +424,10 @@
 	damage = 40
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/three
 
-/datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	reflect(T, proj, 5)
 
-/datum/ammo/energy/lasgun/marine/ricochet/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/ricochet/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	reflect(get_turf(O), proj, 5)
 
 /datum/ammo/energy/lasgun/marine/pistol
@@ -460,7 +460,7 @@
 	hitscan_effect_icon = "beam_incen"
 	bullet_color = COLOR_LASER_RED
 
-/datum/ammo/energy/lasgun/pistol/disabler/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/pistol/disabler/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/marine/xray
@@ -498,16 +498,16 @@
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
 	flame_radius(radius, T, 3, 3, 3, 3)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step_towards(O, P) : O, P)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/heavy_laser/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T)
 
 /datum/ammo/energy/plasma
@@ -535,7 +535,7 @@
 	damage_falloff = 0.5
 	accurate_range = 25
 
-/datum/ammo/energy/plasma/rifle_marksman/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/plasma/rifle_marksman/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 	var/mob/living/living_victim = M
@@ -555,16 +555,16 @@
 /datum/ammo/energy/plasma/blast/drop_nade(turf/T)
 	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
 
-/datum/ammo/energy/plasma/blast/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/plasma/blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/energy/plasma/blast/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma/blast/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/energy/plasma/blast/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma/blast/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/energy/plasma/blast/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/plasma/blast/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(M.loc)
 
 /datum/ammo/energy/plasma/blast/melting
@@ -620,7 +620,7 @@
 	penetration = 40
 	sundering = 10
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/damage_mult = 1
 	switch(M.mob_size)
 		if(MOB_SIZE_BIG)
@@ -636,7 +636,7 @@
 	staggerstun(living_victim, proj, PLASMA_CANNON_INNER_STAGGERSTUN_RANGE, weaken = 0.5 SECONDS, knockback = 1, hard_size_threshold = 1)
 	staggerstun(living_victim, proj, PLASMA_CANNON_STAGGERSTUN_RANGE, stagger = PLASMA_CANNON_STAGGER_DURATION, slowdown = 2, knockback = 1, hard_size_threshold = 2)
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/damage_mult = 3
 	if(isvehicle(O))
 		var/obj/vehicle/vehicle_target = O
@@ -648,7 +648,7 @@
 				to_chat(living_victim, "You are knocked about by the impact, staggering you!")
 	proj.damage *= damage_mult
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	proj.damage *= 5
 
 #undef PLASMA_CANNON_INNER_STAGGERSTUN_RANGE
@@ -674,7 +674,7 @@
 /datum/ammo/energy/plasma/smg_standard/four
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/three
 
-/datum/ammo/energy/plasma/smg_standard/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma/smg_standard/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	reflect(T, proj, 5)
 
 // Plasma //
@@ -723,14 +723,14 @@
 		mob_caught.adjust_fire_stacks(burn_damage)
 		mob_caught.IgniteMob()
 
-/datum/ammo/energy/plasma_pistol/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_fire(T, proj)
 
-/datum/ammo/energy/plasma_pistol/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_fire(M, proj)
 
-/datum/ammo/energy/plasma_pistol/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_fire(O, proj)
 
-/datum/ammo/energy/plasma_pistol/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_fire(T, proj)

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -556,13 +556,13 @@
 	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
 
 /datum/ammo/energy/plasma/blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/energy/plasma/blast/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/plasma/blast/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/plasma/blast/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(target_mob.loc)

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -39,7 +39,7 @@
 	accurate_range = 10
 	bullet_color = COLOR_VIVID_YELLOW
 
-/datum/ammo/energy/taser/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/energy/taser/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stun = 20 SECONDS)
 
 /datum/ammo/energy/tesla
@@ -67,7 +67,7 @@
 	zap_beam(proj, 3, damage)
 
 
-/datum/ammo/energy/tesla/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/energy/tesla/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(isxeno(M)) //need 1 second more than the actual effect time
 		var/mob/living/carbon/xenomorph/X = M
 		X.use_plasma(0.3 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) //Drains 30% of max plasma on hit
@@ -155,7 +155,7 @@
 	damage_type = STAMINA
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/M43/disabler/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/energy/lasgun/M43/disabler/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/pulsebolt
@@ -178,16 +178,11 @@
 	ammo_behavior_flags = AMMO_ENERGY
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/M43/practice/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
-	if(!istype(C) || C.stat == DEAD || C.issamexenohive(P.firer) )
+/datum/ammo/energy/lasgun/M43/practice/on_hit_mob(mob/mob, obj/projectile/proj)
+	if(ishuman(mob))
 		return
-
-	if(isnestedhost(C))
-		return
-
-	staggerstun(C, P, stagger = 2 SECONDS, slowdown = 1) //Staggers and slows down briefly
-
-	return ..()
+	var/mob/living/carbon/human/human_victim = mob
+	staggerstun(human_victim, proj, stagger = 2 SECONDS, slowdown = 1) //Staggers and slows down briefly
 
 // TE Lasers //
 
@@ -225,7 +220,7 @@
 	///plasma drained per hit
 	var/plasma_drain = 25
 
-/datum/ammo/energy/lasgun/marine/weakening/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/weakening/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 6, slowdown = 1)
 
 	if(!isxeno(M))
@@ -245,7 +240,7 @@
 	///number of microwave stacks to apply when hitting mobvs
 	var/microwave_stacks = 1
 
-/datum/ammo/energy/lasgun/marine/microwave/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/microwave/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -288,7 +283,7 @@
 	hitscan_effect_icon = "pu_laser"
 	bullet_color = LIGHT_COLOR_PURPLE
 
-/datum/ammo/energy/lasgun/marine/impact/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/impact/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/knockback_dist = round(LERP(3, 1, proj.distance_travelled / 6), 1)
 	staggerstun(M, proj, max_range = 6, knockback = knockback_dist)
 
@@ -302,7 +297,7 @@
 	hitscan_effect_icon = "blue_beam"
 	bullet_color = COLOR_DISABLER_BLUE
 
-/datum/ammo/energy/lasgun/marine/cripple/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/cripple/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, slowdown = 1.5)
 
 /datum/ammo/energy/lasgun/marine/autolaser
@@ -325,7 +320,7 @@
 	hitscan_effect_icon = "beam_heavy"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_PASS_THROUGH_MOB
 
-/datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/turf, obj/projectile/proj)
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
 		wall_victim.take_damage(proj.damage, proj.damtype, proj.armor_type)
@@ -341,7 +336,7 @@
 	///number of melting stacks to apply when hitting mobs
 	var/melt_stacks = 2
 
-/datum/ammo/energy/lasgun/marine/autolaser/melting/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/autolaser/melting/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -390,7 +385,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 5 SECONDS
 
-/datum/ammo/energy/lasgun/marine/shatter/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/shatter/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -429,10 +424,10 @@
 	damage = 40
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/three
 
-/datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/turf, obj/projectile/proj)
 	reflect(T, proj, 5)
 
-/datum/ammo/energy/lasgun/marine/ricochet/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/energy/lasgun/marine/ricochet/on_hit_obj(obj/obj, obj/projectile/proj)
 	reflect(get_turf(O), proj, 5)
 
 /datum/ammo/energy/lasgun/marine/pistol
@@ -465,7 +460,7 @@
 	hitscan_effect_icon = "beam_incen"
 	bullet_color = COLOR_LASER_RED
 
-/datum/ammo/energy/lasgun/pistol/disabler/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/energy/lasgun/pistol/disabler/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/marine/xray
@@ -503,16 +498,16 @@
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
 	flame_radius(radius, T, 3, 3, 3, 3)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step_towards(O, P) : O, P)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T)
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/energy/lasgun/marine/heavy_laser/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T)
 
 /datum/ammo/energy/plasma
@@ -540,7 +535,7 @@
 	damage_falloff = 0.5
 	accurate_range = 25
 
-/datum/ammo/energy/plasma/rifle_marksman/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/plasma/rifle_marksman/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 	var/mob/living/living_victim = M
@@ -560,16 +555,16 @@
 /datum/ammo/energy/plasma/blast/drop_nade(turf/T)
 	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
 
-/datum/ammo/energy/plasma/blast/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/energy/plasma/blast/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/energy/plasma/blast/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/energy/plasma/blast/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/energy/plasma/blast/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/energy/plasma/blast/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/energy/plasma/blast/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/plasma/blast/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(M.loc)
 
 /datum/ammo/energy/plasma/blast/melting
@@ -625,7 +620,7 @@
 	penetration = 40
 	sundering = 10
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/damage_mult = 1
 	switch(M.mob_size)
 		if(MOB_SIZE_BIG)
@@ -641,7 +636,7 @@
 	staggerstun(living_victim, proj, PLASMA_CANNON_INNER_STAGGERSTUN_RANGE, weaken = 0.5 SECONDS, knockback = 1, hard_size_threshold = 1)
 	staggerstun(living_victim, proj, PLASMA_CANNON_STAGGERSTUN_RANGE, stagger = PLASMA_CANNON_STAGGER_DURATION, slowdown = 2, knockback = 1, hard_size_threshold = 2)
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/damage_mult = 3
 	if(isvehicle(O))
 		var/obj/vehicle/vehicle_target = O
@@ -653,7 +648,7 @@
 				to_chat(living_victim, "You are knocked about by the impact, staggering you!")
 	proj.damage *= damage_mult
 
-/datum/ammo/energy/plasma/cannon_heavy/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/energy/plasma/cannon_heavy/on_hit_turf(turf/turf, obj/projectile/proj)
 	proj.damage *= 5
 
 #undef PLASMA_CANNON_INNER_STAGGERSTUN_RANGE
@@ -679,7 +674,7 @@
 /datum/ammo/energy/plasma/smg_standard/four
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/three
 
-/datum/ammo/energy/plasma/smg_standard/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/energy/plasma/smg_standard/on_hit_turf(turf/turf, obj/projectile/proj)
 	reflect(T, proj, 5)
 
 // Plasma //
@@ -728,14 +723,14 @@
 		mob_caught.adjust_fire_stacks(burn_damage)
 		mob_caught.IgniteMob()
 
-/datum/ammo/energy/plasma_pistol/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_fire(T, proj)
 
-/datum/ammo/energy/plasma_pistol/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_fire(M, proj)
 
-/datum/ammo/energy/plasma_pistol/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_fire(O, proj)
 
-/datum/ammo/energy/plasma_pistol/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/energy/plasma_pistol/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_fire(T, proj)

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -561,13 +561,13 @@
 	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
 
 /datum/ammo/energy/plasma/blast/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : O.loc)
+	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
 /datum/ammo/energy/plasma/blast/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/energy/plasma/blast/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/energy/plasma/blast/on_hit_mob(mob/M, obj/projectile/proj)
 	drop_nade(M.loc)

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -40,7 +40,7 @@
 	bullet_color = COLOR_VIVID_YELLOW
 
 /datum/ammo/energy/taser/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stun = 20 SECONDS)
+	staggerstun(target_mob, proj, stun = 20 SECONDS)
 
 /datum/ammo/energy/tesla
 	name = "energy ball"
@@ -68,8 +68,8 @@
 
 
 /datum/ammo/energy/tesla/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(isxeno(M)) //need 1 second more than the actual effect time
-		var/mob/living/carbon/xenomorph/X = M
+	if(isxeno(target_mob)) //need 1 second more than the actual effect time
+		var/mob/living/carbon/xenomorph/X = target_mob
 		X.use_plasma(0.3 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) //Drains 30% of max plasma on hit
 
 /datum/ammo/energy/lasburster
@@ -156,7 +156,7 @@
 	bullet_color = COLOR_DISABLER_BLUE
 
 /datum/ammo/energy/lasgun/M43/disabler/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
+	staggerstun(target_mob, proj, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/pulsebolt
 	name = "pulse bolt"
@@ -179,9 +179,9 @@
 	bullet_color = COLOR_DISABLER_BLUE
 
 /datum/ammo/energy/lasgun/M43/practice/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(ishuman(mob))
+	if(ishuman(target_mob))
 		return
-	var/mob/living/carbon/human/human_victim = mob
+	var/mob/living/carbon/human/human_victim = target_mob
 	staggerstun(human_victim, proj, stagger = 2 SECONDS, slowdown = 1) //Staggers and slows down briefly
 
 // TE Lasers //
@@ -221,11 +221,11 @@
 	var/plasma_drain = 25
 
 /datum/ammo/energy/lasgun/marine/weakening/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, max_range = 6, slowdown = 1)
+	staggerstun(target_mob, proj, max_range = 6, slowdown = 1)
 
-	if(!isxeno(M))
+	if(!isxeno(target_mob))
 		return
-	var/mob/living/carbon/xenomorph/xeno_victim = M
+	var/mob/living/carbon/xenomorph/xeno_victim = target_mob
 	xeno_victim.use_plasma(plasma_drain * xeno_victim.xeno_caste.plasma_regen_limit)
 
 /datum/ammo/energy/lasgun/marine/microwave
@@ -241,10 +241,10 @@
 	var/microwave_stacks = 1
 
 /datum/ammo/energy/lasgun/marine/microwave/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
 
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	var/datum/status_effect/stacking/microwave/debuff = living_victim.has_status_effect(STATUS_EFFECT_MICROWAVE)
 
 	if(debuff)
@@ -285,7 +285,7 @@
 
 /datum/ammo/energy/lasgun/marine/impact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/knockback_dist = round(LERP(3, 1, proj.distance_travelled / 6), 1)
-	staggerstun(M, proj, max_range = 6, knockback = knockback_dist)
+	staggerstun(target_mob, proj, max_range = 6, knockback = knockback_dist)
 
 /datum/ammo/energy/lasgun/marine/cripple
 	name = "impact laser blast"
@@ -298,7 +298,7 @@
 	bullet_color = COLOR_DISABLER_BLUE
 
 /datum/ammo/energy/lasgun/marine/cripple/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, slowdown = 1.5)
+	staggerstun(target_mob, proj, slowdown = 1.5)
 
 /datum/ammo/energy/lasgun/marine/autolaser
 	name = "machine laser bolt"
@@ -321,8 +321,8 @@
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_PASS_THROUGH_MOB
 
 /datum/ammo/energy/lasgun/marine/autolaser/charge/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	if(istype(T, /turf/closed/wall))
-		var/turf/closed/wall/wall_victim = T
+	if(istype(target_turf, /turf/closed/wall))
+		var/turf/closed/wall/wall_victim = target_turf
 		wall_victim.take_damage(proj.damage, proj.damtype, proj.armor_type)
 
 /datum/ammo/energy/lasgun/marine/autolaser/melting
@@ -337,10 +337,10 @@
 	var/melt_stacks = 2
 
 /datum/ammo/energy/lasgun/marine/autolaser/melting/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
 
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	var/datum/status_effect/stacking/melting/debuff = living_victim.has_status_effect(STATUS_EFFECT_MELTING)
 
 	if(debuff)
@@ -386,10 +386,10 @@
 	var/shatter_duration = 5 SECONDS
 
 /datum/ammo/energy/lasgun/marine/shatter/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
 
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)
 
 /datum/ammo/energy/lasgun/marine/shatter/heavy_laser
@@ -425,10 +425,10 @@
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/three
 
 /datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	reflect(T, proj, 5)
+	reflect(target_turf, proj, 5)
 
 /datum/ammo/energy/lasgun/marine/ricochet/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	reflect(get_turf(O), proj, 5)
+	reflect(get_turf(target_obj), proj, 5)
 
 /datum/ammo/energy/lasgun/marine/pistol
 	name = "pistol laser bolt"
@@ -461,7 +461,7 @@
 	bullet_color = COLOR_LASER_RED
 
 /datum/ammo/energy/lasgun/pistol/disabler/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 0.75)
+	staggerstun(target_mob, proj, stagger = 1 SECONDS, slowdown = 0.75)
 
 /datum/ammo/energy/lasgun/marine/xray
 	name = "xray heat bolt"
@@ -499,16 +499,16 @@
 	flame_radius(radius, T, 3, 3, 3, 3)
 
 /datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step_towards(O, P) : O, P)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj, proj)
 
 /datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step_towards(T, P) : T)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/lasgun/marine/heavy_laser/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step_towards(T, P) : T)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/plasma
 	name = "superheated plasma"
@@ -536,9 +536,9 @@
 	accurate_range = 25
 
 /datum/ammo/energy/plasma/rifle_marksman/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, 2 SECONDS)
 
 /datum/ammo/energy/plasma/blast
@@ -556,16 +556,16 @@
 	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
 
 /datum/ammo/energy/plasma/blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : O.loc)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/energy/plasma/blast/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/plasma/blast/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/energy/plasma/blast/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(M.loc)
+	drop_nade(target_mob.loc)
 
 /datum/ammo/energy/plasma/blast/melting
 	damage = 40
@@ -622,24 +622,24 @@
 
 /datum/ammo/energy/plasma/cannon_heavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/damage_mult = 1
-	switch(M.mob_size)
+	switch(target_mob.mob_size)
 		if(MOB_SIZE_BIG)
 			damage_mult = 2
 		if(MOB_SIZE_XENO)
 			damage_mult = 1.5
 
 	proj.damage *= damage_mult
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, PLASMA_CANNON_SHATTER_DURATION)
 	staggerstun(living_victim, proj, PLASMA_CANNON_INNER_STAGGERSTUN_RANGE, weaken = 0.5 SECONDS, knockback = 1, hard_size_threshold = 1)
 	staggerstun(living_victim, proj, PLASMA_CANNON_STAGGERSTUN_RANGE, stagger = PLASMA_CANNON_STAGGER_DURATION, slowdown = 2, knockback = 1, hard_size_threshold = 2)
 
 /datum/ammo/energy/plasma/cannon_heavy/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/damage_mult = 3
-	if(isvehicle(O))
-		var/obj/vehicle/vehicle_target = O
+	if(isvehicle(target_obj))
+		var/obj/vehicle/vehicle_target = target_obj
 		if(ismecha(vehicle_target) || isarmoredvehicle(vehicle_target))
 			damage_mult = 4
 		if(get_dist_euclidean(proj.starting_turf, vehicle_target) <= PLASMA_CANNON_STAGGERSTUN_RANGE) //staggerstun will fail on tank occupants if we just use staggerstun
@@ -675,7 +675,7 @@
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/three
 
 /datum/ammo/energy/plasma/smg_standard/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	reflect(T, proj, 5)
+	reflect(target_turf, proj, 5)
 
 // Plasma //
 /datum/ammo/energy/sectoid_plasma
@@ -724,13 +724,13 @@
 		mob_caught.IgniteMob()
 
 /datum/ammo/energy/plasma_pistol/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_fire(T, proj)
+	drop_fire(target_turf, proj)
 
 /datum/ammo/energy/plasma_pistol/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_fire(M, proj)
+	drop_fire(target_mob, proj)
 
 /datum/ammo/energy/plasma_pistol/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_fire(O, proj)
+	drop_fire(target_obj, proj)
 
 /datum/ammo/energy/plasma_pistol/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_fire(T, proj)
+	drop_fire(target_turf, proj)

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -56,18 +56,18 @@
 	var/autocannon_wall_bonus = 50
 
 /datum/ammo/bullet/auto_cannon/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	P.proj_max_range -= 20
+	proj.proj_max_range -= 20
 
-	if(istype(T, /turf/closed/wall))
-		var/turf/closed/wall/wall_victim = T
-		wall_victim.take_damage(autocannon_wall_bonus, P.damtype, P.armor_type)
+	if(istype(target_turf, /turf/closed/wall))
+		var/turf/closed/wall/wall_victim = target_turf
+		wall_victim.take_damage(autocannon_wall_bonus, proj.damtype, proj.armor_type)
 
 /datum/ammo/bullet/auto_cannon/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	P.proj_max_range -= 5
-	staggerstun(M, P, max_range = 20, slowdown = 1)
+	proj.proj_max_range -= 5
+	staggerstun(target_mob, proj, max_range = 20, slowdown = 1)
 
 /datum/ammo/bullet/auto_cannon/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	P.proj_max_range -= 5
+	proj.proj_max_range -= 5
 
 /datum/ammo/bullet/auto_cannon/flak
 	name = "autocannon smart-detonating bullet"
@@ -81,10 +81,10 @@
 	autocannon_wall_bonus = 25
 
 /datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	airburst(mob, proj)
+	airburst(target_mob, proj)
 
 /datum/ammo/bullet/auto_cannon/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	airburst(turf, proj)
+	airburst(target_turf, proj)
 
 /datum/ammo/bullet/railgun
 	name = "armor piercing railgun slug"
@@ -100,10 +100,10 @@
 	on_pierce_multiplier = 0.75
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, slowdown = 2, knockback = 2)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 4 SECONDS, slowdown = 2, knockback = 2)
 
 /datum/ammo/bullet/railgun/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	P.proj_max_range -= 3
+	proj.proj_max_range -= 3
 
 /datum/ammo/bullet/railgun/hvap
 	name = "high velocity railgun slug"
@@ -115,7 +115,7 @@
 	sundering = 50
 
 /datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 2 SECONDS, knockback = 3)
+	staggerstun(target_mob, proj, stagger = 2 SECONDS, knockback = 3)
 
 /datum/ammo/bullet/railgun/smart
 	name = "smart armor piercing railgun slug"
@@ -126,7 +126,7 @@
 	sundering = 20
 
 /datum/ammo/bullet/railgun/smart/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 3 SECONDS, slowdown = 3)
+	staggerstun(target_mob, proj, stagger = 3 SECONDS, slowdown = 3)
 
 /datum/ammo/bullet/apfsds
 	name = "\improper APFSDS round"
@@ -155,4 +155,4 @@
 	on_pierce_multiplier = 0.85
 
 /datum/ammo/bullet/coilgun/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 0.2 SECONDS, slowdown = 1, knockback = 3)
+	staggerstun(target_mob, proj, weaken = 0.2 SECONDS, slowdown = 1, knockback = 3)

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -55,18 +55,18 @@
 	///Bonus flat damage to walls, balanced around resin walls.
 	var/autocannon_wall_bonus = 50
 
-/datum/ammo/bullet/auto_cannon/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/auto_cannon/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	P.proj_max_range -= 20
 
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
 		wall_victim.take_damage(autocannon_wall_bonus, P.damtype, P.armor_type)
 
-/datum/ammo/bullet/auto_cannon/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/auto_cannon/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	P.proj_max_range -= 5
 	staggerstun(M, P, max_range = 20, slowdown = 1)
 
-/datum/ammo/bullet/auto_cannon/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/bullet/auto_cannon/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/bullet/auto_cannon/flak
@@ -80,10 +80,10 @@
 	airburst_multiplier = 1
 	autocannon_wall_bonus = 25
 
-/datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	airburst(mob, proj)
 
-/datum/ammo/bullet/auto_cannon/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/auto_cannon/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	airburst(turf, proj)
 
 /datum/ammo/bullet/railgun
@@ -99,10 +99,10 @@
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.75
 
-/datum/ammo/bullet/railgun/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/railgun/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, slowdown = 2, knockback = 2)
 
-/datum/ammo/bullet/railgun/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/railgun/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	P.proj_max_range -= 3
 
 /datum/ammo/bullet/railgun/hvap
@@ -114,7 +114,7 @@
 	penetration = 30
 	sundering = 50
 
-/datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, knockback = 3)
 
 /datum/ammo/bullet/railgun/smart
@@ -125,7 +125,7 @@
 	penetration = 20
 	sundering = 20
 
-/datum/ammo/bullet/railgun/smart/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/railgun/smart/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 3 SECONDS, slowdown = 3)
 
 /datum/ammo/bullet/apfsds
@@ -154,5 +154,5 @@
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.85
 
-/datum/ammo/bullet/coilgun/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/coilgun/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 0.2 SECONDS, slowdown = 1, knockback = 3)

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -55,18 +55,18 @@
 	///Bonus flat damage to walls, balanced around resin walls.
 	var/autocannon_wall_bonus = 50
 
-/datum/ammo/bullet/auto_cannon/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/auto_cannon/on_hit_turf(turf/turf, obj/projectile/proj)
 	P.proj_max_range -= 20
 
 	if(istype(T, /turf/closed/wall))
 		var/turf/closed/wall/wall_victim = T
 		wall_victim.take_damage(autocannon_wall_bonus, P.damtype, P.armor_type)
 
-/datum/ammo/bullet/auto_cannon/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/auto_cannon/on_hit_mob(mob/mob, obj/projectile/proj)
 	P.proj_max_range -= 5
 	staggerstun(M, P, max_range = 20, slowdown = 1)
 
-/datum/ammo/bullet/auto_cannon/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/bullet/auto_cannon/on_hit_obj(obj/obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/bullet/auto_cannon/flak
@@ -80,11 +80,11 @@
 	airburst_multiplier = 1
 	autocannon_wall_bonus = 25
 
-/datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/victim, obj/projectile/proj)
-	airburst(victim, proj)
+/datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/mob, obj/projectile/proj)
+	airburst(mob, proj)
 
-/datum/ammo/bullet/auto_cannon/do_at_max_range(turf/T, obj/projectile/proj)
-	airburst(T, proj)
+/datum/ammo/bullet/auto_cannon/do_at_max_range(turf/turf, obj/projectile/proj)
+	airburst(turf, proj)
 
 /datum/ammo/bullet/railgun
 	name = "armor piercing railgun slug"
@@ -99,10 +99,10 @@
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.75
 
-/datum/ammo/bullet/railgun/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/railgun/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, slowdown = 2, knockback = 2)
 
-/datum/ammo/bullet/railgun/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/railgun/on_hit_turf(turf/turf, obj/projectile/proj)
 	P.proj_max_range -= 3
 
 /datum/ammo/bullet/railgun/hvap
@@ -114,7 +114,7 @@
 	penetration = 30
 	sundering = 50
 
-/datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, knockback = 3)
 
 /datum/ammo/bullet/railgun/smart
@@ -125,7 +125,7 @@
 	penetration = 20
 	sundering = 20
 
-/datum/ammo/bullet/railgun/smart/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/railgun/smart/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 3 SECONDS, slowdown = 3)
 
 /datum/ammo/bullet/apfsds
@@ -154,5 +154,5 @@
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.85
 
-/datum/ammo/bullet/coilgun/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/coilgun/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 0.2 SECONDS, slowdown = 1, knockback = 3)

--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -20,7 +20,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/tx54_spread/mech/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, max_range = 3, slowdown = 0.2)
+	staggerstun(target_mob, proj, max_range = 3, slowdown = 0.2)
 
 /*
 //================================================
@@ -112,7 +112,7 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/mech/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/energy/lasgun/marine/mech
 	name = "superheated laser bolt"

--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -19,7 +19,7 @@
 	penetration = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/tx54_spread/mech/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/mech/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 3, slowdown = 0.2)
 
 /*
@@ -111,7 +111,7 @@
 	damage = 75
 	damage_falloff = 4
 
-/datum/ammo/bullet/shotgun/mech/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/mech/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/energy/lasgun/marine/mech

--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -19,7 +19,7 @@
 	penetration = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/tx54_spread/mech/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/mech/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 3, slowdown = 0.2)
 
 /*
@@ -111,7 +111,7 @@
 	damage = 75
 	damage_falloff = 4
 
-/datum/ammo/bullet/shotgun/mech/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/mech/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/energy/lasgun/marine/mech

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -194,7 +194,7 @@
 	drop_nade(get_turf(P))
 
 /datum/ammo/smoke_burst/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/smoke_burst/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -21,7 +21,7 @@
 	///projectile speed for the bonus projectiles
 	var/bonus_projectile_speed = 3
 
-/datum/ammo/bullet/micro_rail/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	var/datum/effect_system/smoke_spread/smoke = new
@@ -77,7 +77,7 @@
 	sundering = 3
 	damage_falloff = 1
 
-/datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, stagger = 1 SECONDS, slowdown = 0.5)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary
@@ -88,7 +88,7 @@
 	sundering = 1.5
 	max_range = 6
 
-/datum/ammo/bullet/micro_rail_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, stagger = 0.4 SECONDS, slowdown = 0.2)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary/drop_flame(turf/T)
@@ -96,7 +96,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/micro_rail_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	if(prob(40))
 		drop_flame(T)
 
@@ -145,22 +145,22 @@
 				var/obj/obj_victim = target
 				obj_victim.take_damage(explosion_damage, BRUTE, BOMB)
 
-/datum/ammo/micro_rail_cluster/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	///chance to detonate early, scales with distance and capped, to avoid lots of immediate detonations, and nothing reach max range respectively.
 	var/detonate_probability = min(proj.distance_travelled * 4, 16)
 	if(prob(detonate_probability))
 		proj.proj_max_range = proj.distance_travelled
 
-/datum/ammo/micro_rail_cluster/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	detonate(get_turf(P), P)
 
-/datum/ammo/micro_rail_cluster/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	detonate(get_turf(P), P)
 
-/datum/ammo/micro_rail_cluster/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	detonate(T.density ? P.loc : T, P)
 
-/datum/ammo/micro_rail_cluster/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	detonate(T.density ? P.loc : T, P)
 
 /datum/ammo/smoke_burst
@@ -187,14 +187,14 @@
 	smoke.set_up(smokeradius, T, rand(5,9))
 	smoke.start()
 
-/datum/ammo/smoke_burst/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/smoke_burst/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/smoke_burst/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/smoke_burst/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/smoke_burst/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/smoke_burst/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/smoke_burst/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/smoke_burst/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -191,10 +191,10 @@
 	drop_nade(get_turf(target_mob))
 
 /datum/ammo/smoke_burst/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(get_turf(target_obj))
+	drop_nade(target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : get_turf(target_obj))
 
 /datum/ammo/smoke_burst/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/smoke_burst/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -21,7 +21,7 @@
 	///projectile speed for the bonus projectiles
 	var/bonus_projectile_speed = 3
 
-/datum/ammo/bullet/micro_rail/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail/do_at_max_range(turf/turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	var/datum/effect_system/smoke_spread/smoke = new
@@ -77,7 +77,7 @@
 	sundering = 3
 	damage_falloff = 1
 
-/datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, stagger = 1 SECONDS, slowdown = 0.5)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary
@@ -88,7 +88,7 @@
 	sundering = 1.5
 	max_range = 6
 
-/datum/ammo/bullet/micro_rail_spread/incendiary/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, stagger = 0.4 SECONDS, slowdown = 0.2)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary/drop_flame(turf/T)
@@ -96,7 +96,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/micro_rail_spread/incendiary/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/micro_rail_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
 	if(prob(40))
 		drop_flame(T)
 
@@ -145,22 +145,22 @@
 				var/obj/obj_victim = target
 				obj_victim.take_damage(explosion_damage, BRUTE, BOMB)
 
-/datum/ammo/micro_rail_cluster/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/micro_rail_cluster/on_leave_turf(turf/turf, obj/projectile/proj)
 	///chance to detonate early, scales with distance and capped, to avoid lots of immediate detonations, and nothing reach max range respectively.
 	var/detonate_probability = min(proj.distance_travelled * 4, 16)
 	if(prob(detonate_probability))
 		proj.proj_max_range = proj.distance_travelled
 
-/datum/ammo/micro_rail_cluster/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/micro_rail_cluster/on_hit_mob(mob/mob, obj/projectile/proj)
 	detonate(get_turf(P), P)
 
-/datum/ammo/micro_rail_cluster/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/micro_rail_cluster/on_hit_obj(obj/obj, obj/projectile/proj)
 	detonate(get_turf(P), P)
 
-/datum/ammo/micro_rail_cluster/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/micro_rail_cluster/on_hit_turf(turf/turf, obj/projectile/proj)
 	detonate(T.density ? P.loc : T, P)
 
-/datum/ammo/micro_rail_cluster/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/micro_rail_cluster/do_at_max_range(turf/turf, obj/projectile/proj)
 	detonate(T.density ? P.loc : T, P)
 
 /datum/ammo/smoke_burst
@@ -187,14 +187,14 @@
 	smoke.set_up(smokeradius, T, rand(5,9))
 	smoke.start()
 
-/datum/ammo/smoke_burst/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/smoke_burst/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/smoke_burst/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/smoke_burst/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/smoke_burst/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/smoke_burst/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/smoke_burst/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/smoke_burst/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -22,7 +22,7 @@
 	var/bonus_projectile_speed = 3
 
 /datum/ammo/bullet/micro_rail/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(0, det_turf, 1)
@@ -78,7 +78,7 @@
 	damage_falloff = 1
 
 /datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, stagger = 1 SECONDS, slowdown = 0.5)
+	staggerstun(target_mob, proj, stagger = 1 SECONDS, slowdown = 0.5)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary
 	name = "incendiary flechette"
@@ -89,7 +89,7 @@
 	max_range = 6
 
 /datum/ammo/bullet/micro_rail_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, stagger = 0.4 SECONDS, slowdown = 0.2)
+	staggerstun(target_mob, proj, stagger = 0.4 SECONDS, slowdown = 0.2)
 
 /datum/ammo/bullet/micro_rail_spread/incendiary/drop_flame(turf/T)
 	if(!istype(T))
@@ -98,7 +98,7 @@
 
 /datum/ammo/bullet/micro_rail_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	if(prob(40))
-		drop_flame(T)
+		drop_flame(target_turf)
 
 /datum/ammo/micro_rail_cluster
 	name = "bomblet"
@@ -152,16 +152,16 @@
 		proj.proj_max_range = proj.distance_travelled
 
 /datum/ammo/micro_rail_cluster/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	detonate(get_turf(P), P)
+	detonate(get_turf(target_mob), proj)
 
 /datum/ammo/micro_rail_cluster/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	detonate(get_turf(P), P)
+	detonate(get_turf(target_obj), proj)
 
 /datum/ammo/micro_rail_cluster/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	detonate(T.density ? P.loc : T, P)
+	detonate(target_turf.density ? proj.loc : target_turf, proj)
 
 /datum/ammo/micro_rail_cluster/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	detonate(T.density ? P.loc : T, P)
+	detonate(target_turf.density ? proj.loc : target_turf, proj)
 
 /datum/ammo/smoke_burst
 	name = "micro smoke canister"
@@ -188,13 +188,13 @@
 	smoke.start()
 
 /datum/ammo/smoke_burst/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(P))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/smoke_burst/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(get_turf(P))
+	drop_nade(get_turf(target_obj))
 
 /datum/ammo/smoke_burst/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/smoke_burst/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -22,7 +22,7 @@
 	var/bonus_projectile_speed = 3
 
 /datum/ammo/bullet/micro_rail/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(0, det_turf, 1)

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -22,11 +22,12 @@
 	var/bonus_projectile_speed = 3
 
 /datum/ammo/bullet/micro_rail/do_at_max_range(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	var/datum/effect_system/smoke_spread/smoke = new
-	smoke.set_up(0, get_turf(proj), 1)
+	smoke.set_up(0, det_turf, 1)
 	smoke.start()
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, get_turf(proj)) )
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 
 //piercing scatter shot
 /datum/ammo/bullet/micro_rail/airburst

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -27,7 +27,7 @@
 	penetration = 10
 	sundering = 1.5
 
-/datum/ammo/bullet/atgun_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/atgun_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	return
 
 /datum/ammo/bullet/atgun_spread/incendiary/drop_flame(turf/T)
@@ -35,7 +35,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/atgun_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/atgun_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	drop_flame(T)
 
 /*
@@ -60,7 +60,7 @@
 	///Flat plasma to drain, unaffected by caste plasma amount.
 	var/plasma_drain = 25
 
-/datum/ammo/bullet/pepperball/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pepperball/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(mob))
 		var/mob/living/carbon/xenomorph/X = mob
 		if(!(X.xeno_caste.caste_flags & CASTE_PLASMADRAIN_IMMUNE))
@@ -109,16 +109,16 @@
 		return
 	T.ignite(burntime, burnlevel, fire_color)
 
-/datum/ammo/flamethrower/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/flamethrower/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_flame(get_turf(M))
 
-/datum/ammo/flamethrower/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/flamethrower/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_flame(get_turf(O))
 
-/datum/ammo/flamethrower/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/flamethrower/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
-/datum/ammo/flamethrower/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/flamethrower/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
 /datum/ammo/flamethrower/tank_flamer/drop_flame(turf/T)
@@ -161,32 +161,32 @@
 			caught_mob.ExtinguishMob()
 	new /obj/effect/temp_visual/dir_setting/water_splash(extinguished_turf, splash_direction)
 
-/datum/ammo/water/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/water/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	splash(get_turf(M), P.dir)
 
-/datum/ammo/water/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/water/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	splash(get_turf(O), P.dir)
 
-/datum/ammo/water/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/water/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	splash(get_turf(T), P.dir)
 
-/datum/ammo/water/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/water/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	splash(get_turf(T), P.dir)
 
 /datum/ammo/rocket/toy
 	name = "\improper toy rocket"
 	damage = 1
 
-/datum/ammo/rocket/toy/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/rocket/toy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	to_chat(M, "<font size=6 color=red>NO BUGS</font>")
 
-/datum/ammo/rocket/toy/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/toy/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	return
 
-/datum/ammo/rocket/toy/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/toy/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return
 
-/datum/ammo/rocket/toy/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/toy/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return
 
 /datum/ammo/grenade_container
@@ -200,16 +200,16 @@
 	accuracy = 15
 	max_range = 10
 
-/datum/ammo/grenade_container/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/grenade_container/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/grenade_container/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/grenade_container/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/grenade_container/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/grenade_container/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/grenade_container/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/grenade_container/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/grenade_container/drop_nade(turf/T)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -36,7 +36,7 @@
 	T.ignite(5, 10)
 
 /datum/ammo/bullet/atgun_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
-	drop_flame(T)
+	drop_flame(target_turf)
 
 /*
 //================================================
@@ -61,8 +61,8 @@
 	var/plasma_drain = 25
 
 /datum/ammo/bullet/pepperball/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(isxeno(mob))
-		var/mob/living/carbon/xenomorph/X = mob
+	if(isxeno(target_mob))
+		var/mob/living/carbon/xenomorph/X = target_mob
 		if(!(X.xeno_caste.caste_flags & CASTE_PLASMADRAIN_IMMUNE))
 			X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
 			X.use_plasma(plasma_drain)
@@ -110,16 +110,16 @@
 	T.ignite(burntime, burnlevel, fire_color)
 
 /datum/ammo/flamethrower/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_flame(get_turf(M))
+	drop_flame(get_turf(target_mob))
 
 /datum/ammo/flamethrower/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_flame(get_turf(O))
+	drop_flame(get_turf(target_obj))
 
 /datum/ammo/flamethrower/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_flame(get_turf(T))
+	drop_flame(get_turf(target_turf))
 
 /datum/ammo/flamethrower/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_flame(get_turf(T))
+	drop_flame(get_turf(target_turf))
 
 /datum/ammo/flamethrower/tank_flamer/drop_flame(turf/T)
 	if(!istype(T))
@@ -162,23 +162,23 @@
 	new /obj/effect/temp_visual/dir_setting/water_splash(extinguished_turf, splash_direction)
 
 /datum/ammo/water/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	splash(get_turf(M), P.dir)
+	splash(get_turf(target_mob), proj.dir)
 
 /datum/ammo/water/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	splash(get_turf(O), P.dir)
+	splash(get_turf(target_obj), proj.dir)
 
 /datum/ammo/water/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	splash(get_turf(T), P.dir)
+	splash(get_turf(target_turf), proj.dir)
 
 /datum/ammo/water/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	splash(get_turf(T), P.dir)
+	splash(get_turf(target_turf), proj.dir)
 
 /datum/ammo/rocket/toy
 	name = "\improper toy rocket"
 	damage = 1
 
 /datum/ammo/rocket/toy/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	to_chat(M, "<font size=6 color=red>NO BUGS</font>")
+	to_chat(target_mob, "<font size=6 color=red>NO BUGS</font>")
 
 /datum/ammo/rocket/toy/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	return
@@ -201,16 +201,16 @@
 	max_range = 10
 
 /datum/ammo/grenade_container/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(P))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/grenade_container/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : O.loc)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/grenade_container/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/grenade_container/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/grenade_container/drop_nade(turf/T)
 	var/obj/item/explosive/grenade/G = new nade_type(T)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -27,7 +27,7 @@
 	penetration = 10
 	sundering = 1.5
 
-/datum/ammo/bullet/atgun_spread/incendiary/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/atgun_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
 	return
 
 /datum/ammo/bullet/atgun_spread/incendiary/drop_flame(turf/T)
@@ -35,7 +35,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/atgun_spread/incendiary/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/atgun_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
 	drop_flame(T)
 
 /*
@@ -60,9 +60,9 @@
 	///Flat plasma to drain, unaffected by caste plasma amount.
 	var/plasma_drain = 25
 
-/datum/ammo/bullet/pepperball/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	if(isxeno(victim))
-		var/mob/living/carbon/xenomorph/X = victim
+/datum/ammo/bullet/pepperball/on_hit_mob(mob/mob, obj/projectile/proj)
+	if(isxeno(mob))
+		var/mob/living/carbon/xenomorph/X = mob
 		if(!(X.xeno_caste.caste_flags & CASTE_PLASMADRAIN_IMMUNE))
 			X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
 			X.use_plasma(plasma_drain)
@@ -109,16 +109,16 @@
 		return
 	T.ignite(burntime, burnlevel, fire_color)
 
-/datum/ammo/flamethrower/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/flamethrower/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_flame(get_turf(M))
 
-/datum/ammo/flamethrower/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/flamethrower/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_flame(get_turf(O))
 
-/datum/ammo/flamethrower/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/flamethrower/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
-/datum/ammo/flamethrower/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/flamethrower/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_flame(get_turf(T))
 
 /datum/ammo/flamethrower/tank_flamer/drop_flame(turf/T)
@@ -161,32 +161,32 @@
 			caught_mob.ExtinguishMob()
 	new /obj/effect/temp_visual/dir_setting/water_splash(extinguished_turf, splash_direction)
 
-/datum/ammo/water/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/water/on_hit_mob(mob/mob, obj/projectile/proj)
 	splash(get_turf(M), P.dir)
 
-/datum/ammo/water/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/water/on_hit_obj(obj/obj, obj/projectile/proj)
 	splash(get_turf(O), P.dir)
 
-/datum/ammo/water/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/water/on_hit_turf(turf/turf, obj/projectile/proj)
 	splash(get_turf(T), P.dir)
 
-/datum/ammo/water/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/water/do_at_max_range(turf/turf, obj/projectile/proj)
 	splash(get_turf(T), P.dir)
 
 /datum/ammo/rocket/toy
 	name = "\improper toy rocket"
 	damage = 1
 
-/datum/ammo/rocket/toy/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/rocket/toy/on_hit_mob(mob/mob, obj/projectile/proj)
 	to_chat(M, "<font size=6 color=red>NO BUGS</font>")
 
-/datum/ammo/rocket/toy/on_hit_obj(obj/O,obj/projectile/P)
+/datum/ammo/rocket/toy/on_hit_obj(obj/obj, obj/projectile/proj)
 	return
 
-/datum/ammo/rocket/toy/on_hit_turf(turf/T,obj/projectile/P)
+/datum/ammo/rocket/toy/on_hit_turf(turf/turf, obj/projectile/proj)
 	return
 
-/datum/ammo/rocket/toy/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/rocket/toy/do_at_max_range(turf/turf, obj/projectile/proj)
 	return
 
 /datum/ammo/grenade_container
@@ -200,16 +200,16 @@
 	accuracy = 15
 	max_range = 10
 
-/datum/ammo/grenade_container/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/grenade_container/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(P))
 
-/datum/ammo/grenade_container/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/grenade_container/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/grenade_container/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/grenade_container/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/grenade_container/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/grenade_container/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/grenade_container/drop_nade(turf/T)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -204,13 +204,13 @@
 	drop_nade(get_turf(P))
 
 /datum/ammo/grenade_container/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : O.loc)
+	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
 /datum/ammo/grenade_container/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/grenade_container/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/grenade_container/drop_nade(turf/T)
 	var/obj/item/explosive/grenade/G = new nade_type(T)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -204,13 +204,13 @@
 	drop_nade(get_turf(target_mob))
 
 /datum/ammo/grenade_container/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/grenade_container/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/grenade_container/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/grenade_container/drop_nade(turf/T)
 	var/obj/item/explosive/grenade/G = new nade_type(T)

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -20,7 +20,7 @@
 /datum/ammo/mortar/drop_nade(turf/T)
 	explosion(T, 1, 2, 5, 0, 3)
 
-/datum/ammo/mortar/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/mortar/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T)
 
 /datum/ammo/mortar/incend/drop_nade(turf/T)

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -20,7 +20,7 @@
 /datum/ammo/mortar/drop_nade(turf/T)
 	explosion(T, 1, 2, 5, 0, 3)
 
-/datum/ammo/mortar/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/mortar/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T)
 
 /datum/ammo/mortar/incend/drop_nade(turf/T)

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -21,7 +21,7 @@
 	explosion(T, 1, 2, 5, 0, 3)
 
 /datum/ammo/mortar/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T)
+	drop_nade(target_turf)
 
 /datum/ammo/mortar/incend/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 0, 7, throw_range = 0)

--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -37,8 +37,8 @@
 	damage_type = STAMINA
 
 /datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(iscarbon(mob))
-		var/mob/living/carbon/carbon_victim = mob
+	if(iscarbon(target_mob))
+		var/mob/living/carbon/carbon_victim = target_mob
 		carbon_victim.reagents.add_reagent(/datum/reagent/toxin/potassium_chlorophoride, 1)
 
 /datum/ammo/bullet/pistol/hollow
@@ -49,7 +49,7 @@
 	sundering = 2
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
+	staggerstun(target_mob, proj, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/ap
 	name = "armor-piercing pistol bullet"
@@ -76,14 +76,14 @@
 	damage_falloff = 0.75
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 0.5 SECONDS, slowdown = 0.5, knockback = 1)
+	staggerstun(target_mob, proj, stagger = 0.5 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
 	handful_icon_state = "derringer"
 
 /datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, slowdown = 0.5)
+	staggerstun(target_mob, proj, slowdown = 0.5)
 
 /datum/ammo/bullet/pistol/incendiary
 	name = "incendiary pistol bullet"
@@ -115,6 +115,6 @@
 
 
 /datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!M.stat && !ismonkey(M))
-		P.visible_message(span_danger("The [src] chimpers furiously!"))
-		new /mob/living/carbon/human/species/monkey(P.loc)
+	if(!target_mob.stat && !ismonkey(target_mob))
+		proj.visible_message(span_danger("The [src] chimpers furiously!"))
+		new /mob/living/carbon/human/species/monkey(proj.loc)

--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -36,7 +36,7 @@
 	damage = 25
 	damage_type = STAMINA
 
-/datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(iscarbon(mob))
 		var/mob/living/carbon/carbon_victim = mob
 		carbon_victim.reagents.add_reagent(/datum/reagent/toxin/potassium_chlorophoride, 1)
@@ -48,7 +48,7 @@
 	shrapnel_chance = 45
 	sundering = 2
 
-/datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/ap
@@ -75,14 +75,14 @@
 	sundering = 3
 	damage_falloff = 0.75
 
-/datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 0.5 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
 	handful_icon_state = "derringer"
 
-/datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/pistol/incendiary
@@ -114,7 +114,7 @@
 	damage = 15
 
 
-/datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!M.stat && !ismonkey(M))
 		P.visible_message(span_danger("The [src] chimpers furiously!"))
 		new /mob/living/carbon/human/species/monkey(P.loc)

--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -36,9 +36,9 @@
 	damage = 25
 	damage_type = STAMINA
 
-/datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/victim, obj/projectile/proj)
-	if(iscarbon(victim))
-		var/mob/living/carbon/carbon_victim = victim
+/datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/mob, obj/projectile/proj)
+	if(iscarbon(mob))
+		var/mob/living/carbon/carbon_victim = mob
 		carbon_victim.reagents.add_reagent(/datum/reagent/toxin/potassium_chlorophoride, 1)
 
 /datum/ammo/bullet/pistol/hollow
@@ -48,7 +48,7 @@
 	shrapnel_chance = 45
 	sundering = 2
 
-/datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/ap
@@ -75,14 +75,14 @@
 	sundering = 3
 	damage_falloff = 0.75
 
-/datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 0.5 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
 	handful_icon_state = "derringer"
 
-/datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/pistol/incendiary
@@ -114,7 +114,7 @@
 	damage = 15
 
 
-/datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!M.stat && !ismonkey(M))
 		P.visible_message(span_danger("The [src] chimpers furiously!"))
 		new /mob/living/carbon/human/species/monkey(P.loc)

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -15,7 +15,7 @@
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
+	staggerstun(target_mob, proj, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/revolver/tp44
 	name = "standard revolver bullet"
@@ -24,7 +24,7 @@
 	sundering = 1
 
 /datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, knockback = 1)
+	staggerstun(target_mob, proj, knockback = 1)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
@@ -32,7 +32,7 @@
 	damage = 30
 
 /datum/ammo/bullet/revolver/small/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, slowdown = 0.5)
+	staggerstun(target_mob, proj, slowdown = 0.5)
 
 /datum/ammo/bullet/revolver/marksman
 	name = "slimline revolver bullet"
@@ -74,7 +74,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, knockback = 1)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, knockback = 1)
 
 /datum/ammo/bullet/revolver/highimpact
 	name = "high-impact revolver bullet"
@@ -85,7 +85,7 @@
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/revolver/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/small
@@ -104,7 +104,7 @@
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/ricochet/three
 
 /datum/ammo/bullet/revolver/ricochet/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, slowdown = 0.5)
+	staggerstun(target_mob, proj, slowdown = 0.5)
 
 /datum/ammo/bullet/revolver/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	reflect(T, proj, 10)
+	reflect(target_turf, proj, 10)

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -14,7 +14,7 @@
 	penetration = 10
 	sundering = 3
 
-/datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/revolver/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/revolver/tp44
@@ -23,7 +23,7 @@
 	penetration = 15
 	sundering = 1
 
-/datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 1)
 
 /datum/ammo/bullet/revolver/small
@@ -31,7 +31,7 @@
 	hud_state = "revolver_small"
 	damage = 30
 
-/datum/ammo/bullet/revolver/small/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/revolver/small/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/revolver/marksman
@@ -73,7 +73,7 @@
 	penetration = 40
 	sundering = 0.5
 
-/datum/ammo/bullet/revolver/t76/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/revolver/t76/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, knockback = 1)
 
 /datum/ammo/bullet/revolver/highimpact
@@ -84,7 +84,7 @@
 	penetration = 20
 	sundering = 3
 
-/datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/revolver/ricochet
@@ -103,8 +103,8 @@
 /datum/ammo/bullet/revolver/ricochet/four
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/ricochet/three
 
-/datum/ammo/bullet/revolver/ricochet/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/revolver/ricochet/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
-/datum/ammo/bullet/revolver/ricochet/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/revolver/ricochet/on_hit_turf(turf/turf, obj/projectile/proj)
 	reflect(T, proj, 10)

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -14,7 +14,7 @@
 	penetration = 10
 	sundering = 3
 
-/datum/ammo/bullet/revolver/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 2 SECONDS, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/revolver/tp44
@@ -23,7 +23,7 @@
 	penetration = 15
 	sundering = 1
 
-/datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 1)
 
 /datum/ammo/bullet/revolver/small
@@ -31,7 +31,7 @@
 	hud_state = "revolver_small"
 	damage = 30
 
-/datum/ammo/bullet/revolver/small/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/small/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/revolver/marksman
@@ -73,7 +73,7 @@
 	penetration = 40
 	sundering = 0.5
 
-/datum/ammo/bullet/revolver/t76/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, knockback = 1)
 
 /datum/ammo/bullet/revolver/highimpact
@@ -84,7 +84,7 @@
 	penetration = 20
 	sundering = 3
 
-/datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/revolver/ricochet
@@ -103,8 +103,8 @@
 /datum/ammo/bullet/revolver/ricochet/four
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/ricochet/three
 
-/datum/ammo/bullet/revolver/ricochet/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/revolver/ricochet/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 0.5)
 
-/datum/ammo/bullet/revolver/ricochet/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/revolver/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	reflect(T, proj, 10)

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -42,7 +42,7 @@
 	penetration = 20
 	sundering = 1.25
 
-/datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1 SECONDS)
 
 /datum/ammo/bullet/rifle/incendiary
@@ -67,7 +67,7 @@
 	penetration = 12.5
 	sundering = 1
 
-/datum/ammo/bullet/rifle/som_machinegun/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/rifle/som_machinegun/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 20, slowdown = 0.5)
 
 /datum/ammo/bullet/rifle/tx8
@@ -98,7 +98,7 @@
 	penetration = 20
 	sundering = 6.5
 
-/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/rifle/mpi_km

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -43,7 +43,7 @@
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1 SECONDS)
+	staggerstun(target_mob, proj, max_range = 3, slowdown = 2, stagger = 1 SECONDS)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"
@@ -68,7 +68,7 @@
 	sundering = 1
 
 /datum/ammo/bullet/rifle/som_machinegun/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, max_range = 20, slowdown = 0.5)
+	staggerstun(target_mob, proj, max_range = 20, slowdown = 0.5)
 
 /datum/ammo/bullet/rifle/tx8
 	name = "A19 high velocity bullet"
@@ -99,7 +99,7 @@
 	sundering = 6.5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)
+	staggerstun(target_mob, proj, max_range = 14, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/rifle/mpi_km
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -42,7 +42,7 @@
 	penetration = 20
 	sundering = 1.25
 
-/datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1 SECONDS)
 
 /datum/ammo/bullet/rifle/incendiary
@@ -67,7 +67,7 @@
 	penetration = 12.5
 	sundering = 1
 
-/datum/ammo/bullet/rifle/som_machinegun/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/rifle/som_machinegun/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 20, slowdown = 0.5)
 
 /datum/ammo/bullet/rifle/tx8
@@ -98,7 +98,7 @@
 	penetration = 20
 	sundering = 6.5
 
-/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, max_range = 14, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/rifle/mpi_km

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -27,16 +27,16 @@
 /datum/ammo/rocket/drop_nade(turf/T)
 	explosion(T, 0, 4, 6, 0, 2)
 
-/datum/ammo/rocket/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/rocket/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/rocket/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/rocket/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/rocket/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/rocket/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/rocket/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/rocket/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/he
@@ -82,7 +82,7 @@
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, 0, 2, 5, 0, 3)
 
-/datum/ammo/rocket/ltb/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/rocket/ltb/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(victim))
 	if(!isxeno(victim))
 		victim.gib()
@@ -118,14 +118,14 @@
 	accurate_range = 24
 	max_range = 35
 
-/datum/ammo/bullet/isg_apfds/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/isg_apfds/on_hit_turf(turf/turf, obj/projectile/proj)
 	P.proj_max_range -= 5
 
-/datum/ammo/bullet/isg_apfds/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/isg_apfds/on_hit_mob(mob/mob, obj/projectile/proj)
 	P.proj_max_range -= 2
 	staggerstun(M, P, max_range = 20, slowdown = 0.5)
 
-/datum/ammo/bullet/isg_apfds/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/bullet/isg_apfds/on_hit_obj(obj/obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/rocket/wp
@@ -230,7 +230,7 @@
 	accuracy = -10 //Not designed for anti human use
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
-/datum/ammo/rocket/recoilless/heat/mech/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/rocket/recoilless/heat/mech/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 	if(ismecha(O))
 		P.damage *= 3 //this is specifically designed to hurt mechs
@@ -358,7 +358,7 @@
 	accuracy = -10 //Not designed for anti human use
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
-/datum/ammo/rocket/som/heat/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/rocket/som/heat/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 	if(ismecha(O))
 		P.damage *= 3 //this is specifically designed to hurt mechs
@@ -417,7 +417,7 @@
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 0, 2)
 
-/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/T, obj/projectile/P) //no explosion every time it hits a turf
+/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/turf, obj/projectile/proj) //no explosion every time it hits a turf
 	P.proj_max_range -= 10
 
 /datum/ammo/rocket/atgun_shell/apcr
@@ -432,15 +432,15 @@
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
 	explosion(T, flash_range = 1)
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 	P.proj_max_range -= 5
 	staggerstun(M, P, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/turf, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/he
@@ -454,7 +454,7 @@
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
 	explosion(T, 0, 3, 5)
 
-/datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/atgun_shell/beehive
@@ -472,24 +472,24 @@
 /datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/T)
 	explosion(T, flash_range = 1)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.2, knockback = 1)
 	drop_nade(det_turf)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, M), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -31,13 +31,13 @@
 	drop_nade(get_turf(M))
 
 /datum/ammo/rocket/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : O.loc)
+	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
 /datum/ammo/rocket/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/he
 	name = "high explosive rocket"
@@ -455,7 +455,7 @@
 	explosion(T, 0, 3, 5)
 
 /datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/atgun_shell/beehive
 	name = "beehive shell"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -28,16 +28,16 @@
 	explosion(T, 0, 4, 6, 0, 2)
 
 /datum/ammo/rocket/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/rocket/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : O.loc)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/rocket/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/rocket/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/rocket/he
 	name = "high explosive rocket"
@@ -83,9 +83,9 @@
 	explosion(T, 0, 2, 5, 0, 3)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(victim))
-	if(!isxeno(victim))
-		victim.gib()
+	drop_nade(get_turf(target_mob))
+	if(!isxeno(target_mob))
+		target_mob.gib()
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"
@@ -119,14 +119,14 @@
 	max_range = 35
 
 /datum/ammo/bullet/isg_apfds/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	P.proj_max_range -= 5
+	proj.proj_max_range -= 5
 
 /datum/ammo/bullet/isg_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	P.proj_max_range -= 2
-	staggerstun(M, P, max_range = 20, slowdown = 0.5)
+	proj.proj_max_range -= 2
+	staggerstun(target_mob, proj, max_range = 20, slowdown = 0.5)
 
 /datum/ammo/bullet/isg_apfds/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	P.proj_max_range -= 5
+	proj.proj_max_range -= 5
 
 /datum/ammo/rocket/wp
 	name = "white phosphorous rocket"
@@ -231,9 +231,9 @@
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
 /datum/ammo/rocket/recoilless/heat/mech/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(get_turf(O))
-	if(ismecha(O))
-		P.damage *= 3 //this is specifically designed to hurt mechs
+	drop_nade(get_turf(target_obj))
+	if(ismecha(target_obj))
+		proj.damage *= 3 //this is specifically designed to hurt mechs
 
 /datum/ammo/rocket/recoilless/heat/mech/drop_nade(turf/T)
 	explosion(T, 0, 1, 0, 0, 1)
@@ -359,9 +359,9 @@
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
 /datum/ammo/rocket/som/heat/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(get_turf(O))
-	if(ismecha(O))
-		P.damage *= 3 //this is specifically designed to hurt mechs
+	drop_nade(get_turf(target_obj))
+	if(ismecha(target_obj))
+		proj.damage *= 3 //this is specifically designed to hurt mechs
 
 /datum/ammo/rocket/som/heat/drop_nade(turf/T)
 	explosion(T, 0, 1, 0, 0, 1)
@@ -418,7 +418,7 @@
 	explosion(T, 0, 2, 3, 0, 2)
 
 /datum/ammo/rocket/atgun_shell/on_hit_turf(turf/target_turf, obj/projectile/proj) //no explosion every time it hits a turf
-	P.proj_max_range -= 10
+	proj.proj_max_range -= 10
 
 /datum/ammo/rocket/atgun_shell/apcr
 	name = "tungsten penetrator"
@@ -433,15 +433,15 @@
 	explosion(T, flash_range = 1)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
-	P.proj_max_range -= 5
-	staggerstun(M, P, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
+	drop_nade(get_turf(target_mob))
+	proj.proj_max_range -= 5
+	staggerstun(target_mob, proj, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	P.proj_max_range -= 5
+	proj.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	P.proj_max_range -= 5
+	proj.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/he
 	name = "low velocity high explosive shell"
@@ -455,7 +455,7 @@
 	explosion(T, 0, 3, 5)
 
 /datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive
 	name = "beehive shell"
@@ -473,24 +473,24 @@
 	explosion(T, flash_range = 1)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/det_turf = get_turf(M)
-	staggerstun(M, proj, slowdown = 0.2, knockback = 1)
+	var/turf/det_turf = get_turf(target_mob)
+	staggerstun(target_mob, proj, slowdown = 0.2, knockback = 1)
 	drop_nade(det_turf)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, M), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_mob), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, O), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, T), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -480,17 +480,17 @@
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_mob), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -31,13 +31,13 @@
 	drop_nade(get_turf(target_mob))
 
 /datum/ammo/rocket/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/rocket/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/rocket/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/rocket/he
 	name = "high explosive rocket"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -27,16 +27,16 @@
 /datum/ammo/rocket/drop_nade(turf/T)
 	explosion(T, 0, 4, 6, 0, 2)
 
-/datum/ammo/rocket/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/rocket/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/rocket/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/rocket/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/rocket/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/he
@@ -82,7 +82,7 @@
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, 0, 2, 5, 0, 3)
 
-/datum/ammo/rocket/ltb/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(victim))
 	if(!isxeno(victim))
 		victim.gib()
@@ -118,14 +118,14 @@
 	accurate_range = 24
 	max_range = 35
 
-/datum/ammo/bullet/isg_apfds/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/isg_apfds/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	P.proj_max_range -= 5
 
-/datum/ammo/bullet/isg_apfds/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/isg_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	P.proj_max_range -= 2
 	staggerstun(M, P, max_range = 20, slowdown = 0.5)
 
-/datum/ammo/bullet/isg_apfds/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/bullet/isg_apfds/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/rocket/wp
@@ -230,7 +230,7 @@
 	accuracy = -10 //Not designed for anti human use
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
-/datum/ammo/rocket/recoilless/heat/mech/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/recoilless/heat/mech/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 	if(ismecha(O))
 		P.damage *= 3 //this is specifically designed to hurt mechs
@@ -358,7 +358,7 @@
 	accuracy = -10 //Not designed for anti human use
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_UNWIELDY
 
-/datum/ammo/rocket/som/heat/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/som/heat/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 	if(ismecha(O))
 		P.damage *= 3 //this is specifically designed to hurt mechs
@@ -417,7 +417,7 @@
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 0, 2)
 
-/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/turf, obj/projectile/proj) //no explosion every time it hits a turf
+/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/target_turf, obj/projectile/proj) //no explosion every time it hits a turf
 	P.proj_max_range -= 10
 
 /datum/ammo/rocket/atgun_shell/apcr
@@ -432,15 +432,15 @@
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
 	explosion(T, flash_range = 1)
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 	P.proj_max_range -= 5
 	staggerstun(M, P, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	P.proj_max_range -= 5
 
-/datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	P.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/he
@@ -454,7 +454,7 @@
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
 	explosion(T, 0, 3, 5)
 
-/datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/rocket/atgun_shell/beehive
@@ -472,24 +472,24 @@
 /datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/T)
 	explosion(T, flash_range = 1)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.2, knockback = 1)
 	drop_nade(det_turf)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, M), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = T.density ? get_step(T, proj) : T
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -473,22 +473,26 @@
 	explosion(T, flash_range = 1)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/M, obj/projectile/proj)
+	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.2, knockback = 1)
-	drop_nade(get_turf(M))
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, M) )
+	drop_nade(det_turf)
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, M), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_obj(obj/O, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, O) )
+	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, O), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_turf(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, T) )
+	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, T), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/do_at_max_range(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)) )
+	var/turf/det_turf = T.density ? get_step(T, proj) : T
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 5, 3, Get_Angle(proj.firer, get_turf(proj)), det_turf)
 
 /datum/ammo/rocket/atgun_shell/beehive/incend
 	name = "napalm shell"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -21,7 +21,7 @@
 	penetration = 20
 	sundering = 7.5
 
-/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
 
@@ -36,7 +36,7 @@
 	shrapnel_chance = 0
 	accuracy = 5
 
-/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, knockback = 1, slowdown = 2, hard_size_threshold = 1)
 
 /datum/ammo/bullet/shotgun/incendiary
@@ -51,7 +51,7 @@
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 2, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/flechette
@@ -91,7 +91,7 @@
 	damage = 40
 	damage_falloff = 4
 
-/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
@@ -107,8 +107,8 @@
 	damage = 30
 	damage_falloff = 3
 
-/datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/mob_hit, obj/projectile/projectile)
-	staggerstun(mob_hit, projectile, knockback = 2, max_range = 4)
+/datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
+	staggerstun(mob, proj, knockback = 2, max_range = 4)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -139,16 +139,16 @@
 /datum/ammo/bullet/shotgun/frag/drop_nade(turf/T)
 	explosion(T, weak_impact_range = 2)
 
-/datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
@@ -199,7 +199,7 @@
 	damage = 40
 	penetration = 20
 
-/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/shotgun/tx15_flechette
@@ -231,7 +231,7 @@
 	penetration = 30
 	sundering = 3.5
 
-/datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 2, knockback = 1)
 
 /datum/ammo/bullet/shotgun/mbx900_buckshot
@@ -274,8 +274,8 @@
 	damage = 5
 	penetration = 100
 
-/datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	victim.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+/datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/mob, obj/projectile/proj)
+	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 /datum/ammo/bullet/shotgun/tracker
 	name = "shotgun tracker shell"
@@ -287,8 +287,8 @@
 	damage = 5
 	penetration = 100
 
-/datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	victim.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+/datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/mob, obj/projectile/proj)
+	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 //I INSERT THE SHELLS IN AN UNKNOWN ORDER
 /datum/ammo/bullet/shotgun/blank

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -143,13 +143,13 @@
 	drop_nade(get_turf(target_mob))
 
 /datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
 	name = "additional frag shell"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -143,13 +143,13 @@
 	drop_nade(get_turf(M))
 
 /datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : O.loc)
+	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
 	name = "additional frag shell"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -22,7 +22,7 @@
 	sundering = 7.5
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -37,7 +37,7 @@
 	accuracy = 5
 
 /datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, knockback = 1, slowdown = 2, hard_size_threshold = 1)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 4 SECONDS, knockback = 1, slowdown = 2, hard_size_threshold = 1)
 
 /datum/ammo/bullet/shotgun/incendiary
 	name = "incendiary slug"
@@ -52,7 +52,7 @@
 	bullet_color = COLOR_TAN_ORANGE
 
 /datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, knockback = 2, slowdown = 1)
+	staggerstun(target_mob, proj, knockback = 2, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/flechette
 	name = "shotgun flechette shell"
@@ -92,7 +92,7 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
 	name = "hefa fragment"
@@ -108,7 +108,7 @@
 	damage_falloff = 3
 
 /datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(mob, proj, knockback = 2, max_range = 4)
+	staggerstun(target_mob, proj, knockback = 2, max_range = 4)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -140,16 +140,16 @@
 	explosion(T, weak_impact_range = 2)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : O.loc)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
 	name = "additional frag shell"
@@ -200,7 +200,7 @@
 	penetration = 20
 
 /datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, slowdown = 1, knockback = 1)
+	staggerstun(target_mob, proj, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/shotgun/tx15_flechette
 	name = "shotgun flechette shell"
@@ -232,7 +232,7 @@
 	sundering = 3.5
 
 /datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, slowdown = 2, knockback = 1)
+	staggerstun(target_mob, proj, slowdown = 2, knockback = 1)
 
 /datum/ammo/bullet/shotgun/mbx900_buckshot
 	name = "light shotgun buckshot shell" // If .410 is the smallest shotgun shell, then...
@@ -275,7 +275,7 @@
 	penetration = 100
 
 /datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 /datum/ammo/bullet/shotgun/tracker
 	name = "shotgun tracker shell"
@@ -288,7 +288,7 @@
 	penetration = 100
 
 /datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 //I INSERT THE SHELLS IN AN UNKNOWN ORDER
 /datum/ammo/bullet/shotgun/blank

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -21,7 +21,7 @@
 	penetration = 20
 	sundering = 7.5
 
-/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
 
@@ -36,7 +36,7 @@
 	shrapnel_chance = 0
 	accuracy = 5
 
-/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 4 SECONDS, knockback = 1, slowdown = 2, hard_size_threshold = 1)
 
 /datum/ammo/bullet/shotgun/incendiary
@@ -51,7 +51,7 @@
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 2, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/flechette
@@ -91,7 +91,7 @@
 	damage = 40
 	damage_falloff = 4
 
-/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
@@ -107,7 +107,7 @@
 	damage = 30
 	damage_falloff = 3
 
-/datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(mob, proj, knockback = 2, max_range = 4)
 
 /datum/ammo/bullet/shotgun/spread
@@ -139,16 +139,16 @@
 /datum/ammo/bullet/shotgun/frag/drop_nade(turf/T)
 	explosion(T, weak_impact_range = 2)
 
-/datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/frag/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/frag/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/frag/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
@@ -199,7 +199,7 @@
 	damage = 40
 	penetration = 20
 
-/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/shotgun/tx15_flechette
@@ -231,7 +231,7 @@
 	penetration = 30
 	sundering = 3.5
 
-/datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, slowdown = 2, knockback = 1)
 
 /datum/ammo/bullet/shotgun/mbx900_buckshot
@@ -274,7 +274,7 @@
 	damage = 5
 	penetration = 100
 
-/datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 /datum/ammo/bullet/shotgun/tracker
@@ -287,7 +287,7 @@
 	damage = 5
 	penetration = 100
 
-/datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
 
 //I INSERT THE SHELLS IN AN UNKNOWN ORDER

--- a/code/modules/projectiles/ammo_types/smartgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smartgun_ammo.dm
@@ -72,7 +72,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 1, max_range = 12)
+	staggerstun(target_mob, proj, stagger = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/heavyrubber
 	name = "smart heavy-rubber spotting bullet"
@@ -81,7 +81,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, weaken = 1 SECONDS, slowdown = 1, max_range = 12)
+	staggerstun(target_mob, proj, weaken = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/plasmaloss
 	name = "smart tanglefoot spotting bullet"
@@ -90,9 +90,9 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(isxeno(victim))
-		var/mob/living/carbon/xenomorph/X = victim
-		X.use_plasma(20 + 0.2 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) // This is draining 20%+20 flat per hit.
+	if(isxeno(target_mob))
+		var/mob/living/carbon/xenomorph/target_xeno = target_mob
+		target_xeno.use_plasma(20 + 0.2 * target_xeno.xeno_caste.plasma_max * target_xeno.xeno_caste.plasma_regen_limit) // This is draining 20%+20 flat per hit.
 
 /datum/ammo/bullet/spottingrifle/tungsten
 	name = "smart tungsten spotting bullet"
@@ -101,7 +101,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, knockback = 3, max_range = 12)
+	staggerstun(target_mob, proj, knockback = 3, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/flak
 	name = "smart flak spotting bullet"
@@ -111,7 +111,7 @@
 	airburst_multiplier = 0.5
 
 /datum/ammo/bullet/spottingrifle/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	airburst(victim, proj)
+	airburst(target_mob, proj)
 
 /datum/ammo/bullet/spottingrifle/incendiary
 	name = "smart incendiary spotting  bullet"

--- a/code/modules/projectiles/ammo_types/smartgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smartgun_ammo.dm
@@ -71,7 +71,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/heavyrubber
@@ -80,7 +80,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/plasmaloss
@@ -89,7 +89,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/X = victim
 		X.use_plasma(20 + 0.2 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) // This is draining 20%+20 flat per hit.
@@ -100,7 +100,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 3, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/flak
@@ -110,7 +110,7 @@
 	sundering = 0.5
 	airburst_multiplier = 0.5
 
-/datum/ammo/bullet/spottingrifle/flak/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/bullet/spottingrifle/incendiary

--- a/code/modules/projectiles/ammo_types/smartgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smartgun_ammo.dm
@@ -71,7 +71,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, stagger = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/heavyrubber
@@ -80,7 +80,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, weaken = 1 SECONDS, slowdown = 1, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/plasmaloss
@@ -89,7 +89,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/living/victim, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/X = victim
 		X.use_plasma(20 + 0.2 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) // This is draining 20%+20 flat per hit.
@@ -100,7 +100,7 @@
 	damage = 10
 	sundering = 0.5
 
-/datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 3, max_range = 12)
 
 /datum/ammo/bullet/spottingrifle/flak
@@ -110,7 +110,7 @@
 	sundering = 0.5
 	airburst_multiplier = 0.5
 
-/datum/ammo/bullet/spottingrifle/flak/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/bullet/spottingrifle/flak/on_hit_mob(mob/mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/bullet/spottingrifle/incendiary

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -50,7 +50,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 3 SECONDS
 
-/datum/ammo/bullet/smg/squash/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/smg/squash/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -73,7 +73,7 @@
 	penetration = 15
 	sundering = 1
 
-/datum/ammo/bullet/smg/rad/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/smg/rad/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 	var/mob/living/living_victim = M

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -50,7 +50,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 3 SECONDS
 
-/datum/ammo/bullet/smg/squash/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/smg/squash/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -73,7 +73,7 @@
 	penetration = 15
 	sundering = 1
 
-/datum/ammo/bullet/smg/rad/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/smg/rad/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 	var/mob/living/living_victim = M

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -51,10 +51,10 @@
 	var/shatter_duration = 3 SECONDS
 
 /datum/ammo/bullet/smg/squash/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
 
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)
 
 
@@ -74,9 +74,9 @@
 	sundering = 1
 
 /datum/ammo/bullet/smg/rad/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	if(!prob(living_victim.modify_by_armor(proj.damage, BIO, penetration, proj.def_zone)))
 		return
 	living_victim.apply_radiation(2, 2)

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -38,7 +38,7 @@
 	sundering = 30
 	airburst_multiplier = 0.5
 
-/datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/bullet/sniper/flak/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(victim, proj,  max_range = 30)
 	airburst(victim, proj)
 
@@ -63,7 +63,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 10 SECONDS
 
-/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -97,7 +97,7 @@
 	sundering = 10
 	damage_falloff = 0.25
 
-/datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 4, slowdown = 1.5, stagger = 2 SECONDS, max_range = 17)
 
 

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -38,7 +38,7 @@
 	sundering = 30
 	airburst_multiplier = 0.5
 
-/datum/ammo/bullet/sniper/flak/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/sniper/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(victim, proj,  max_range = 30)
 	airburst(victim, proj)
 
@@ -63,7 +63,7 @@
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 10 SECONDS
 
-/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/sniper/martini/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(!isliving(M))
 		return
 
@@ -97,7 +97,7 @@
 	sundering = 10
 	damage_falloff = 0.25
 
-/datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 4, slowdown = 1.5, stagger = 2 SECONDS, max_range = 17)
 
 

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -39,8 +39,7 @@
 	airburst_multiplier = 0.5
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(victim, proj,  max_range = 30)
-	airburst(victim, proj)
+	airburst(target_mob, proj)
 
 /datum/ammo/bullet/sniper/svd
 	name = "crude sniper bullet"
@@ -64,10 +63,10 @@
 	var/shatter_duration = 10 SECONDS
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(!isliving(M))
+	if(!isliving(target_mob))
 		return
 
-	var/mob/living/living_victim = M
+	var/mob/living/living_victim = target_mob
 	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)
 
 /datum/ammo/bullet/sniper/elite
@@ -98,7 +97,7 @@
 	damage_falloff = 0.25
 
 /datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, knockback = 4, slowdown = 1.5, stagger = 2 SECONDS, max_range = 17)
+	staggerstun(target_mob, proj, knockback = 4, slowdown = 1.5, stagger = 2 SECONDS, max_range = 17)
 
 
 /datum/ammo/bullet/sniper/auto

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -81,10 +81,10 @@
 	drop_nade(get_turf(target_mob))
 
 /datum/ammo/flamer/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/flamer/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/flamer/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -51,7 +51,7 @@
 	damage_falloff = 1
 
 /datum/ammo/bullet/turret/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, P, knockback = 1, max_range = 4)
+	staggerstun(target_mob, proj, knockback = 1, max_range = 4)
 
 /datum/ammo/bullet/turret/spread
 	name = "additional buckshot"
@@ -78,13 +78,13 @@
 
 
 /datum/ammo/flamer/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/flamer/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : O.loc)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_obj.loc)
 
 /datum/ammo/flamer/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/flamer/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -81,10 +81,10 @@
 	drop_nade(get_turf(M))
 
 /datum/ammo/flamer/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : O.loc)
+	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
 /datum/ammo/flamer/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/flamer/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -50,7 +50,7 @@
 	penetration = 40
 	damage_falloff = 1
 
-/datum/ammo/bullet/turret/buckshot/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/turret/buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 1, max_range = 4)
 
 /datum/ammo/bullet/turret/spread
@@ -77,14 +77,14 @@
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
 
 
-/datum/ammo/flamer/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/flamer/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/flamer/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/flamer/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/flamer/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/flamer/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/flamer/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/flamer/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -50,7 +50,7 @@
 	penetration = 40
 	damage_falloff = 1
 
-/datum/ammo/bullet/turret/buckshot/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/turret/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, P, knockback = 1, max_range = 4)
 
 /datum/ammo/bullet/turret/spread
@@ -77,14 +77,14 @@
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
 
 
-/datum/ammo/flamer/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/flamer/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/flamer/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/flamer/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : O.loc)
 
-/datum/ammo/flamer/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/flamer/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/flamer/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/flamer/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -35,21 +35,23 @@
 	projectile_greyscale_colors = COLOR_AMMO_AIRBURST
 
 /datum/ammo/tx54/on_hit_mob(mob/M, obj/projectile/proj)
+	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.5, knockback = 1)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M) )
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M), loc_override = get_turf(M), det_turf)
 
 /datum/ammo/tx54/on_hit_obj(obj/O, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O) )
+	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O), det_turf)
 
 /datum/ammo/tx54/on_hit_turf(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, T) )
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, T), det_turf)
 
 /datum/ammo/tx54/do_at_max_range(turf/T, obj/projectile/proj)
-	playsound(proj, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, get_turf(proj)) )
+	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.starting_turf, get_turf(proj)), det_turf)
 
 /datum/ammo/tx54/incendiary
 	name = "20mm incendiary grenade"

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -34,22 +34,22 @@
 	projectile_greyscale_config = /datum/greyscale_config/projectile
 	projectile_greyscale_colors = COLOR_AMMO_AIRBURST
 
-/datum/ammo/tx54/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.5, knockback = 1)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M), loc_override = get_turf(M), det_turf)
 
-/datum/ammo/tx54/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/tx54/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_turf(turf/turf, obj/projectile/proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/tx54/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/tx54/do_at_max_range(turf/turf, obj/projectile/proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.starting_turf, get_turf(proj)), det_turf)
 
@@ -111,16 +111,16 @@
 /datum/ammo/tx54/he/drop_nade(turf/T)
 	explosion(T, 0, 0, 1, 3, 1)
 
-/datum/ammo/tx54/he/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/tx54/he/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/tx54/he/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/tx54/he/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 
-/datum/ammo/tx54/he/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/tx54/he/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/tx54/he/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/tx54/he/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 //The secondary projectiles
@@ -136,7 +136,7 @@
 	sundering = 3
 	damage_falloff = 0
 
-/datum/ammo/bullet/tx54_spread/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/on_hit_mob(mob/mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 3, stagger = 0.6 SECONDS, slowdown = 0.3)
 
 /datum/ammo/bullet/tx54_spread/incendiary
@@ -146,7 +146,7 @@
 	penetration = 10
 	sundering = 1.5
 
-/datum/ammo/bullet/tx54_spread/incendiary/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
 	return
 
 /datum/ammo/bullet/tx54_spread/incendiary/drop_flame(turf/T)
@@ -154,7 +154,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/tx54_spread/incendiary/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
 	drop_flame(T)
 
 /datum/ammo/bullet/tx54_spread/smoke
@@ -177,10 +177,10 @@
 		QDEL_NULL(trail_spread_system)
 	return ..()
 
-/datum/ammo/bullet/tx54_spread/smoke/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/smoke/on_hit_mob(mob/mob, obj/projectile/proj)
 	return
 
-/datum/ammo/bullet/tx54_spread/smoke/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/smoke/on_leave_turf(turf/turf, obj/projectile/proj)
 	trail_spread_system.set_up(0, T)
 	trail_spread_system.start()
 
@@ -218,9 +218,9 @@
 		QDEL_NULL(chemical_payload)
 	return ..()
 
-/datum/ammo/bullet/tx54_spread/razor/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/razor/on_hit_mob(mob/mob, obj/projectile/proj)
 	return
 
-/datum/ammo/bullet/tx54_spread/razor/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/razor/on_leave_turf(turf/turf, obj/projectile/proj)
 	chemical_payload.set_up(0, T, reagent_list, RAZOR_FOAM)
 	chemical_payload.start()

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -35,21 +35,23 @@
 	projectile_greyscale_colors = COLOR_AMMO_AIRBURST
 
 /datum/ammo/tx54/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/det_turf = get_turf(M)
-	staggerstun(M, proj, slowdown = 0.5, knockback = 1)
+	var/turf/det_turf = get_turf(target_mob)
+	staggerstun(target_mob, proj, slowdown = 0.5, knockback = 1)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M), loc_override = get_turf(M), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_mob), loc_override = det_turf)
 
 /datum/ammo/tx54/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/tx54/on_hit_turf(turf/target_turf, obj/projectile/proj)
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
-	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, T), det_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/tx54/do_at_max_range(turf/target_turf, obj/projectile/proj)
+	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.starting_turf, get_turf(proj)), det_turf)
 
@@ -112,16 +114,16 @@
 	explosion(T, 0, 0, 1, 3, 1)
 
 /datum/ammo/tx54/he/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M))
+	drop_nade(get_turf(target_mob))
 
 /datum/ammo/tx54/he/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(get_turf(O))
+	drop_nade(get_turf(target_obj))
 
 /datum/ammo/tx54/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/tx54/he/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 //The secondary projectiles
 /datum/ammo/bullet/tx54_spread
@@ -137,7 +139,7 @@
 	damage_falloff = 0
 
 /datum/ammo/bullet/tx54_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(M, proj, max_range = 3, stagger = 0.6 SECONDS, slowdown = 0.3)
+	staggerstun(target_mob, proj, max_range = 3, stagger = 0.6 SECONDS, slowdown = 0.3)
 
 /datum/ammo/bullet/tx54_spread/incendiary
 	name = "incendiary flechette"
@@ -155,7 +157,7 @@
 	T.ignite(5, 10)
 
 /datum/ammo/bullet/tx54_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
-	drop_flame(T)
+	drop_flame(target_turf)
 
 /datum/ammo/bullet/tx54_spread/smoke
 	name = "chemical bomblet"
@@ -181,7 +183,7 @@
 	return
 
 /datum/ammo/bullet/tx54_spread/smoke/on_leave_turf(turf/target_turf, obj/projectile/proj)
-	trail_spread_system.set_up(0, T)
+	trail_spread_system.set_up(0, target_turf)
 	trail_spread_system.start()
 
 /datum/ammo/bullet/tx54_spread/smoke/dense
@@ -222,5 +224,5 @@
 	return
 
 /datum/ammo/bullet/tx54_spread/razor/on_leave_turf(turf/target_turf, obj/projectile/proj)
-	chemical_payload.set_up(0, T, reagent_list, RAZOR_FOAM)
+	chemical_payload.set_up(0, target_turf, reagent_list, RAZOR_FOAM)
 	chemical_payload.start()

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -41,17 +41,17 @@
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_mob), loc_override = det_turf)
 
 /datum/ammo/tx54/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
+	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_obj), det_turf)
 
 /datum/ammo/tx54/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, target_turf), det_turf)
 
 /datum/ammo/tx54/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/det_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.starting_turf, get_turf(proj)), det_turf)
 
@@ -120,10 +120,10 @@
 	drop_nade(get_turf(target_obj))
 
 /datum/ammo/tx54/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/tx54/he/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 //The secondary projectiles
 /datum/ammo/bullet/tx54_spread

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -34,22 +34,22 @@
 	projectile_greyscale_config = /datum/greyscale_config/projectile
 	projectile_greyscale_colors = COLOR_AMMO_AIRBURST
 
-/datum/ammo/tx54/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(M)
 	staggerstun(M, proj, slowdown = 0.5, knockback = 1)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, M), loc_override = get_turf(M), det_turf)
 
-/datum/ammo/tx54/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/det_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, proj) : O
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, O), det_turf)
 
-/datum/ammo/tx54/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/tx54/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.firer, T), det_turf)
 
-/datum/ammo/tx54/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/tx54/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, 4, 3, Get_Angle(proj.starting_turf, get_turf(proj)), det_turf)
 
@@ -111,16 +111,16 @@
 /datum/ammo/tx54/he/drop_nade(turf/T)
 	explosion(T, 0, 0, 1, 3, 1)
 
-/datum/ammo/tx54/he/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/tx54/he/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M))
 
-/datum/ammo/tx54/he/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/tx54/he/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(get_turf(O))
 
-/datum/ammo/tx54/he/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/tx54/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/tx54/he/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/tx54/he/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 //The secondary projectiles
@@ -136,7 +136,7 @@
 	sundering = 3
 	damage_falloff = 0
 
-/datum/ammo/bullet/tx54_spread/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(M, proj, max_range = 3, stagger = 0.6 SECONDS, slowdown = 0.3)
 
 /datum/ammo/bullet/tx54_spread/incendiary
@@ -146,7 +146,7 @@
 	penetration = 10
 	sundering = 1.5
 
-/datum/ammo/bullet/tx54_spread/incendiary/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/incendiary/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	return
 
 /datum/ammo/bullet/tx54_spread/incendiary/drop_flame(turf/T)
@@ -154,7 +154,7 @@
 		return
 	T.ignite(5, 10)
 
-/datum/ammo/bullet/tx54_spread/incendiary/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/incendiary/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	drop_flame(T)
 
 /datum/ammo/bullet/tx54_spread/smoke
@@ -177,10 +177,10 @@
 		QDEL_NULL(trail_spread_system)
 	return ..()
 
-/datum/ammo/bullet/tx54_spread/smoke/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/smoke/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	return
 
-/datum/ammo/bullet/tx54_spread/smoke/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/smoke/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	trail_spread_system.set_up(0, T)
 	trail_spread_system.start()
 
@@ -218,9 +218,9 @@
 		QDEL_NULL(chemical_payload)
 	return ..()
 
-/datum/ammo/bullet/tx54_spread/razor/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/razor/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	return
 
-/datum/ammo/bullet/tx54_spread/razor/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/bullet/tx54_spread/razor/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	chemical_payload.set_up(0, T, reagent_list, RAZOR_FOAM)
 	chemical_payload.start()

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -118,10 +118,10 @@
 	drop_nade(get_turf(O))
 
 /datum/ammo/tx54/he/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/tx54/he/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 //The secondary projectiles
 /datum/ammo/bullet/tx54_spread

--- a/code/modules/projectiles/ammo_types/volkite_ammo.dm
+++ b/code/modules/projectiles/ammo_types/volkite_ammo.dm
@@ -33,7 +33,7 @@
 	sound_bounce = SFX_BALLISTIC_BOUNCE
 
 /datum/ammo/energy/volkite/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	deflagrate(M, P)
+	deflagrate(target_mob, proj)
 
 /datum/ammo/energy/volkite/medium
 	max_range = 25

--- a/code/modules/projectiles/ammo_types/volkite_ammo.dm
+++ b/code/modules/projectiles/ammo_types/volkite_ammo.dm
@@ -32,7 +32,7 @@
 	sound_miss = SFX_BALLISTIC_MISS
 	sound_bounce = SFX_BALLISTIC_BOUNCE
 
-/datum/ammo/energy/volkite/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/volkite/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	deflagrate(M, P)
 
 /datum/ammo/energy/volkite/medium

--- a/code/modules/projectiles/ammo_types/volkite_ammo.dm
+++ b/code/modules/projectiles/ammo_types/volkite_ammo.dm
@@ -32,7 +32,7 @@
 	sound_miss = SFX_BALLISTIC_MISS
 	sound_bounce = SFX_BALLISTIC_BOUNCE
 
-/datum/ammo/energy/volkite/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/energy/volkite/on_hit_mob(mob/mob, obj/projectile/proj)
 	deflagrate(M, P)
 
 /datum/ammo/energy/volkite/medium

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -60,16 +60,16 @@
 
 	new /obj/effect/temp_visual/shockwave(T, aoe_range + 2)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M), P)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step_towards(O, P) : O, P)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T, P)
 
-/datum/ammo/energy/xeno/psy_blast/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T, P)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance
@@ -86,18 +86,18 @@
 	channel_particle = /particles/warlock_charge/psy_blast/psy_lance
 	glow_color = "#CB0166"
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/obj, obj/projectile/proj)
 	if(isvehicle(O))
 		var/obj/vehicle/veh_victim = O
 		veh_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/mob, obj/projectile/proj)
 	if(isxeno(M))
 		return
 	staggerstun(M, P, 9, stagger = 1 SECONDS, slowdown = 2, knockback = 1)
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/turf, obj/projectile/proj)
 	return
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/do_at_max_range(turf/turf, obj/projectile/proj)
 	return

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -60,16 +60,16 @@
 
 	new /obj/effect/temp_visual/shockwave(T, aoe_range + 2)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M), P)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step_towards(O, P) : O, P)
 
-/datum/ammo/energy/xeno/psy_blast/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T, P)
 
-/datum/ammo/energy/xeno/psy_blast/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step_towards(T, P) : T, P)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance
@@ -86,18 +86,18 @@
 	channel_particle = /particles/warlock_charge/psy_blast/psy_lance
 	glow_color = "#CB0166"
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(isvehicle(O))
 		var/obj/vehicle/veh_victim = O
 		veh_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(M))
 		return
 	staggerstun(M, P, 9, stagger = 1 SECONDS, slowdown = 2, knockback = 1)
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return
 
-/datum/ammo/energy/xeno/psy_blast/psy_lance/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/energy/xeno/psy_blast/psy_lance/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -61,16 +61,16 @@
 	new /obj/effect/temp_visual/shockwave(T, aoe_range + 2)
 
 /datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M), P)
+	drop_nade(get_turf(target_mob), proj)
 
 /datum/ammo/energy/xeno/psy_blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step_towards(O, P) : O, P)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj, proj)
 
 /datum/ammo/energy/xeno/psy_blast/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step_towards(T, P) : T, P)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj)
 
 /datum/ammo/energy/xeno/psy_blast/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step_towards(T, P) : T, P)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance
 	name = "psychic lance"
@@ -87,14 +87,14 @@
 	glow_color = "#CB0166"
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	if(isvehicle(O))
-		var/obj/vehicle/veh_victim = O
+	if(isvehicle(target_obj))
+		var/obj/vehicle/veh_victim = target_obj
 		veh_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(isxeno(M))
+	if(isxeno(target_mob))
 		return
-	staggerstun(M, P, 9, stagger = 1 SECONDS, slowdown = 2, knockback = 1)
+	staggerstun(target_mob, proj, 9, stagger = 1 SECONDS, slowdown = 2, knockback = 1)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	return

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -96,13 +96,13 @@
 	if(ismecha(target_obj))
 		proj.damage *= 7 //Globs deal much higher damage to mechs.
 	var/turf/target_turf = get_turf(target_obj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_turf, proj.firer)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_turf, proj.firer)
 
 /datum/ammo/xeno/boiler_gas/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf, proj.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
 /datum/ammo/xeno/boiler_gas/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf, proj.firer)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro()

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -36,7 +36,7 @@
 	///We're going to reuse one smoke spread system repeatedly to cut down on processing.
 	var/datum/effect_system/smoke_spread/xeno/trail_spread_system
 
-/datum/ammo/xeno/boiler_gas/on_leave_turf(turf/T, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_leave_turf(turf/turf, obj/projectile/proj)
 	if(isxeno(proj.firer))
 		var/mob/living/carbon/xenomorph/X = proj.firer
 		trail_spread_system.strength = X.xeno_caste.bomb_strength
@@ -73,7 +73,7 @@
 /datum/ammo/xeno/boiler_gas/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
-/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M), proj)
 
 	if(!istype(victim) || victim.stat == DEAD || victim.issamexenohive(proj.firer))
@@ -93,16 +93,16 @@
 
 	carbon_victim.reagents.add_reagent_list(spit_reagents)
 
-/datum/ammo/xeno/boiler_gas/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/boiler_gas/on_hit_obj(obj/obj, obj/projectile/proj)
 	if(ismecha(O))
 		P.damage *= 7 //Globs deal much higher damage to mechs.
 	var/turf/target_turf = get_turf(O)
 	drop_nade(O.density ? get_step(O, proj) : target_turf, P.firer)
 
-/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T, P.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
-/datum/ammo/xeno/boiler_gas/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/boiler_gas/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T, P.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
@@ -146,7 +146,7 @@
 	trap.smoke.set_up(1, get_turf(trap))
 	return TRUE
 
-/datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/victim, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/boiler_gas/corrosive/set_smoke()

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -40,7 +40,7 @@
 	if(isxeno(proj.firer))
 		var/mob/living/carbon/xenomorph/X = proj.firer
 		trail_spread_system.strength = X.xeno_caste.bomb_strength
-	trail_spread_system.set_up(0, T)
+	trail_spread_system.set_up(0, target_turf)
 	trail_spread_system.start()
 
 /**
@@ -74,36 +74,35 @@
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M), proj)
+	drop_nade(get_turf(target_mob), proj)
+	if(target_mob.stat == DEAD || !ishuman(target_mob))
+		return
+	var/mob/living/carbon/human/human_victim = target_mob
 
-	if(!istype(victim) || victim.stat == DEAD || victim.issamexenohive(proj.firer))
+	human_victim.Paralyze(hit_paralyze_time)
+	human_victim.blur_eyes(hit_eye_blur)
+	human_victim.adjustDrowsyness(hit_drowsyness)
+
+	if(!reagent_transfer_amount)
 		return
 
-	victim.Paralyze(hit_paralyze_time)
-	victim.blur_eyes(hit_eye_blur)
-	victim.adjustDrowsyness(hit_drowsyness)
-
-	if(!reagent_transfer_amount || !iscarbon(victim))
-		return
-
-	var/mob/living/carbon/carbon_victim = victim
 	set_reagents()
 	for(var/reagent_id in spit_reagents)
-		spit_reagents[reagent_id] = carbon_victim.modify_by_armor(spit_reagents[reagent_id], armor_type, penetration, proj.def_zone)
+		spit_reagents[reagent_id] = human_victim.modify_by_armor(spit_reagents[reagent_id], armor_type, penetration, proj.def_zone)
 
-	carbon_victim.reagents.add_reagent_list(spit_reagents)
+	human_victim.reagents.add_reagent_list(spit_reagents)
 
 /datum/ammo/xeno/boiler_gas/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	if(ismecha(O))
-		P.damage *= 7 //Globs deal much higher damage to mechs.
-	var/turf/target_turf = get_turf(O)
-	drop_nade(O.density ? get_step(O, proj) : target_turf, P.firer)
+	if(ismecha(target_obj))
+		proj.damage *= 7 //Globs deal much higher damage to mechs.
+	var/turf/target_turf = get_turf(target_obj)
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : target_turf, proj.firer)
 
 /datum/ammo/xeno/boiler_gas/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T, P.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf, proj.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
 /datum/ammo/xeno/boiler_gas/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T, P.firer)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf, proj.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro()
@@ -147,7 +146,7 @@
 	return TRUE
 
 /datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/target_mob, obj/projectile/proj)
-	airburst(victim, proj)
+	airburst(target_mob, proj)
 
 /datum/ammo/xeno/boiler_gas/corrosive/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid()

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -36,7 +36,7 @@
 	///We're going to reuse one smoke spread system repeatedly to cut down on processing.
 	var/datum/effect_system/smoke_spread/xeno/trail_spread_system
 
-/datum/ammo/xeno/boiler_gas/on_leave_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_leave_turf(turf/target_turf, obj/projectile/proj)
 	if(isxeno(proj.firer))
 		var/mob/living/carbon/xenomorph/X = proj.firer
 		trail_spread_system.strength = X.xeno_caste.bomb_strength
@@ -73,7 +73,7 @@
 /datum/ammo/xeno/boiler_gas/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
-/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M), proj)
 
 	if(!istype(victim) || victim.stat == DEAD || victim.issamexenohive(proj.firer))
@@ -93,16 +93,16 @@
 
 	carbon_victim.reagents.add_reagent_list(spit_reagents)
 
-/datum/ammo/xeno/boiler_gas/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(ismecha(O))
 		P.damage *= 7 //Globs deal much higher damage to mechs.
 	var/turf/target_turf = get_turf(O)
 	drop_nade(O.density ? get_step(O, proj) : target_turf, P.firer)
 
-/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T, P.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
-/datum/ammo/xeno/boiler_gas/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T, P.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
@@ -146,7 +146,7 @@
 	trap.smoke.set_up(1, get_turf(trap))
 	return TRUE
 
-/datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/target_mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/boiler_gas/corrosive/set_smoke()

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -73,9 +73,8 @@
 /datum/ammo/xeno/boiler_gas/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
-/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	var/turf/target_turf = get_turf(victim)
-	drop_nade(target_turf.density ? proj.loc : target_turf, proj.firer)
+/datum/ammo/xeno/boiler_gas/on_hit_mob(mob/M, obj/projectile/proj)
+	drop_nade(get_turf(M), proj)
 
 	if(!istype(victim) || victim.stat == DEAD || victim.issamexenohive(proj.firer))
 		return
@@ -98,13 +97,13 @@
 	if(ismecha(O))
 		P.damage *= 7 //Globs deal much higher damage to mechs.
 	var/turf/target_turf = get_turf(O)
-	drop_nade(O.density ? P.loc : target_turf, P.firer)
+	drop_nade(O.density ? get_step(O, proj) : target_turf, P.firer)
 
 /datum/ammo/xeno/boiler_gas/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T, P.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
+	drop_nade(T.density ? get_step(T, proj) : T, P.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
 /datum/ammo/xeno/boiler_gas/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T, P.firer)
+	drop_nade(T.density ? get_step(T, proj) : T, P.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro()

--- a/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
@@ -18,19 +18,19 @@
 	var/obj/item/clothing/mask/facehugger/hugger_type = /obj/item/clothing/mask/facehugger
 
 /datum/ammo/xeno/hugger/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(M), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_mob), hivenumber)
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(O), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_obj), hivenumber)
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/slash

--- a/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
@@ -17,19 +17,19 @@
 	///The type of hugger thrown
 	var/obj/item/clothing/mask/facehugger/hugger_type = /obj/item/clothing/mask/facehugger
 
-/datum/ammo/xeno/hugger/on_hit_mob(mob/M, obj/projectile/proj)
+/datum/ammo/xeno/hugger/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(M), hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/xeno/hugger/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(O), hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/hugger/on_hit_turf(turf/turf, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/hugger/do_at_max_range(turf/turf, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
 	hugger.go_idle()
 

--- a/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
@@ -17,19 +17,19 @@
 	///The type of hugger thrown
 	var/obj/item/clothing/mask/facehugger/hugger_type = /obj/item/clothing/mask/facehugger
 
-/datum/ammo/xeno/hugger/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/hugger/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(M), hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/hugger/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(O), hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/hugger/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
 	hugger.go_idle()
 
-/datum/ammo/xeno/hugger/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/hugger/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(T.density ? P.loc : T, hivenumber)
 	hugger.go_idle()
 

--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -6,18 +6,18 @@
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_TARGET_TURF
 	bullet_color = null
 
-/datum/ammo/xeno/fireball/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/fireball/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_flame(mob)
 
-/datum/ammo/xeno/fireball/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/fireball/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	. = ..()
 	drop_flame(obj)
 
-/datum/ammo/xeno/fireball/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/fireball/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	. = ..()
 	drop_flame(turf.density ? proj : turf)
 
-/datum/ammo/xeno/fireball/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/fireball/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	. = ..()
 	drop_flame(turf.density ? proj : turf)
 

--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -7,19 +7,19 @@
 	bullet_color = null
 
 /datum/ammo/xeno/fireball/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_flame(mob)
+	drop_flame(target_mob)
 
 /datum/ammo/xeno/fireball/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	. = ..()
-	drop_flame(obj)
+	drop_flame(target_obj)
 
 /datum/ammo/xeno/fireball/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	. = ..()
-	drop_flame(turf.density ? proj : turf)
+	drop_flame(target_turf.density ? proj : target_turf)
 
 /datum/ammo/xeno/fireball/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	. = ..()
-	drop_flame(turf.density ? proj : turf)
+	drop_flame(target_turf.density ? proj : target_turf)
 
 /datum/ammo/xeno/fireball/drop_flame(atom/target_atom)
 	new /obj/effect/temp_visual/xeno_fireball_explosion(get_turf(target_atom))

--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -6,20 +6,20 @@
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_TARGET_TURF
 	bullet_color = null
 
-/datum/ammo/xeno/fireball/on_hit_mob(mob/target, obj/projectile/projectile)
-	drop_flame(target)
+/datum/ammo/xeno/fireball/on_hit_mob(mob/mob, obj/projectile/proj)
+	drop_flame(mob)
 
-/datum/ammo/xeno/fireball/on_hit_obj(obj/target, obj/projectile/proj)
+/datum/ammo/xeno/fireball/on_hit_obj(obj/obj, obj/projectile/proj)
 	. = ..()
-	drop_flame(target)
+	drop_flame(obj)
 
-/datum/ammo/xeno/fireball/on_hit_turf(turf/target, obj/projectile/proj)
+/datum/ammo/xeno/fireball/on_hit_turf(turf/turf, obj/projectile/proj)
 	. = ..()
-	drop_flame(target.density ? proj : target)
+	drop_flame(turf.density ? proj : turf)
 
-/datum/ammo/xeno/fireball/do_at_max_range(turf/target, obj/projectile/proj)
+/datum/ammo/xeno/fireball/do_at_max_range(turf/turf, obj/projectile/proj)
 	. = ..()
-	drop_flame(target.density ? proj : target)
+	drop_flame(turf.density ? proj : turf)
 
 /datum/ammo/xeno/fireball/drop_flame(atom/target_atom)
 	new /obj/effect/temp_visual/xeno_fireball_explosion(get_turf(target_atom))

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -56,14 +56,14 @@
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_neuro_smoke(get_turf(mob))
+	drop_neuro_smoke(get_turf(target_mob))
 
 	if(isxeno(proj.firer))
 		var/mob/living/carbon/xenomorph/xeno = proj.firer
 		if(xeno.IsStaggered())
 			reagent_transfer_amount *= STAGGER_DAMAGE_MULTIPLIER
 
-	var/mob/living/carbon/carbon_victim = mob
+	var/mob/living/carbon/carbon_victim = target_mob
 	if(!istype(carbon_victim) || carbon_victim.stat == DEAD || carbon_victim.issamexenohive(proj.firer) )
 		return
 
@@ -82,14 +82,14 @@
 	return ..()
 
 /datum/ammo/xeno/toxin/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/T = get_turf(O)
-	drop_neuro_smoke(T.density ? P.loc : T)
+	var/turf/target_turf = get_turf(target_obj)
+	drop_neuro_smoke(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/toxin/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_neuro_smoke(T.density ? P.loc : T)
+	drop_neuro_smoke(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/toxin/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_neuro_smoke(T.density ? P.loc : T)
+	drop_neuro_smoke(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/toxin/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro/light()
@@ -144,27 +144,27 @@
 
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_resin(get_turf(M))
-	if(istype(M,/mob/living/carbon))
-		var/mob/living/carbon/C = M
-		if(C.issamexenohive(P.firer))
+	drop_resin(get_turf(target_mob))
+	if(iscarbon(target_mob))
+		var/mob/living/carbon/target_carbon = target_mob
+		if(target_carbon.issamexenohive(proj.firer))
 			return
-		C.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
-		C.add_slowdown(slowdown_stacks) //slow em down
+		target_carbon.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
+		target_carbon.add_slowdown(slowdown_stacks) //slow em down
 
 
 /datum/ammo/xeno/sticky/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	if(isarmoredvehicle(O))
-		var/obj/vehicle/sealed/armored/tank = O
+	if(isarmoredvehicle(target_obj))
+		var/obj/vehicle/sealed/armored/tank = target_obj
 		COOLDOWN_START(tank, cooldown_vehicle_move, tank.move_delay)
-	var/turf/T = get_turf(O)
-	drop_resin(T.density ? P.loc : T)
+	var/turf/target_turf = get_turf(target_obj)
+	drop_resin(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/sticky/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_resin(T.density ? P.loc : T)
+	drop_resin(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/sticky/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_resin(T.density ? P.loc : T)
+	drop_resin(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
 	if(T.density || istype(T, /turf/open/space)) // No structures in space
@@ -197,24 +197,24 @@
 	max_range = 3
 
 /datum/ammo/xeno/sticky/globe/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/initial_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, P) : O
+	var/turf/initial_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/initial_turf = T.density ? get_step(T, P) : T
+	var/turf/initial_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), T)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), target_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/initial_turf = get_turf(M)
+	var/turf/initial_turf = get_turf(target_mob)
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/initial_turf = T.density ? get_step(T, P) : T
+	var/turf/initial_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
+	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/acid
 	name = "acid spit"
@@ -235,7 +235,7 @@
 	var/puddle_acid_damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE
 
 /datum/ammo/xeno/acid/on_shield_block(mob/target_mob, obj/projectile/proj)
-	airburst(victim, proj)
+	airburst(target_mob, proj)
 
 /datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
 	if(T.density)
@@ -255,16 +255,16 @@
 	added_spit_delay = 0
 
 /datum/ammo/xeno/acid/auto/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(M), P)
+	drop_nade(get_turf(target_mob), proj)
 
 /datum/ammo/xeno/acid/auto/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : get_turf(target_obj))
 
 /datum/ammo/xeno/acid/auto/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/auto/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/passthrough
 	name = "acid spittle"
@@ -284,17 +284,17 @@
 	max_range = 9
 
 /datum/ammo/xeno/acid/heavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/T = get_turf(M)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	var/turf/target_turf = get_turf(target_mob)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/heavy/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
+	drop_nade(target_obj.density ? get_step(target_obj, proj) : get_turf(target_obj))
 
 /datum/ammo/xeno/acid/heavy/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(T.density ? get_step(T, proj) : T)
+	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
 
 
 ///For the Spitter's Scatterspit ability

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -197,12 +197,12 @@
 	max_range = 3
 
 /datum/ammo/xeno/sticky/globe/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/initial_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step(target_obj, proj) : target_obj
+	var/turf/initial_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj
 	drop_resin(initial_turf)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/turf/initial_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/initial_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	drop_resin(initial_turf)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), target_turf)
 
@@ -212,7 +212,7 @@
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/turf/initial_turf = target_turf.density ? get_step(target_turf, proj) : target_turf
+	var/turf/initial_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
 	drop_resin(initial_turf)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(proj.firer, initial_turf), initial_turf)
 

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -258,13 +258,13 @@
 	drop_nade(get_turf(target_mob), proj)
 
 /datum/ammo/xeno/acid/auto/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : get_turf(target_obj))
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : get_turf(target_obj))
 
 /datum/ammo/xeno/acid/auto/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/auto/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/passthrough
 	name = "acid spittle"
@@ -285,16 +285,16 @@
 
 /datum/ammo/xeno/acid/heavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/target_turf = get_turf(target_mob)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/heavy/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	drop_nade(target_obj.density ? get_step(target_obj, proj) : get_turf(target_obj))
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : get_turf(target_obj))
 
 /datum/ammo/xeno/acid/heavy/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 
 ///For the Spitter's Scatterspit ability

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -254,17 +254,16 @@
 	added_spit_delay = 0
 
 /datum/ammo/xeno/acid/auto/on_hit_mob(mob/M, obj/projectile/P)
-	var/turf/T = get_turf(M)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(get_turf(M), P)
 
 /datum/ammo/xeno/acid/auto/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : get_turf(O))
+	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
 /datum/ammo/xeno/acid/auto/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/auto/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/passthrough
 	name = "acid spittle"
@@ -285,16 +284,17 @@
 
 /datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M, obj/projectile/P)
 	var/turf/T = get_turf(M)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/heavy/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(O.density ? P.loc : get_turf(O))
+	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
 /datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(turf/T, obj/projectile/P)
-	drop_nade(T.density ? P.loc : T)
+	drop_nade(T.density ? get_step(T, proj) : T)
+
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -196,24 +196,24 @@
 	max_range = 3
 
 /datum/ammo/xeno/sticky/globe/on_hit_obj(obj/O, obj/projectile/P)
-	var/turf/initial_turf = O.density ? P.loc : get_turf(O)
+	var/turf/initial_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, P) : O
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_turf(turf/T, obj/projectile/P)
-	var/turf/initial_turf = T.density ? P.loc : T
+	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), T)
 
 /datum/ammo/xeno/sticky/globe/on_hit_mob(mob/M, obj/projectile/P)
 	var/turf/initial_turf = get_turf(M)
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/sticky/globe/do_at_max_range(turf/T, obj/projectile/P)
-	var/turf/initial_turf = T.density ? P.loc : T
+	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
-	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf))
+	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
 /datum/ammo/xeno/acid
 	name = "acid spit"

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -55,14 +55,15 @@
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
-/datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/carbon_victim, obj/projectile/proj)
-	drop_neuro_smoke(get_turf(carbon_victim))
+/datum/ammo/xeno/toxin/on_hit_mob(mob/mob, obj/projectile/proj)
+	drop_neuro_smoke(get_turf(mob))
 
 	if(isxeno(proj.firer))
 		var/mob/living/carbon/xenomorph/xeno = proj.firer
 		if(xeno.IsStaggered())
 			reagent_transfer_amount *= STAGGER_DAMAGE_MULTIPLIER
 
+	var/mob/living/carbon/carbon_victim = mob
 	if(!istype(carbon_victim) || carbon_victim.stat == DEAD || carbon_victim.issamexenohive(proj.firer) )
 		return
 
@@ -80,14 +81,14 @@
 
 	return ..()
 
-/datum/ammo/xeno/toxin/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/toxin/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/T = get_turf(O)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
-/datum/ammo/xeno/toxin/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/toxin/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
-/datum/ammo/xeno/toxin/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/toxin/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
 /datum/ammo/xeno/toxin/set_smoke()
@@ -142,7 +143,7 @@
 	slowdown_stacks = 3
 
 
-/datum/ammo/xeno/sticky/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/sticky/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_resin(get_turf(M))
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
@@ -152,17 +153,17 @@
 		C.add_slowdown(slowdown_stacks) //slow em down
 
 
-/datum/ammo/xeno/sticky/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/sticky/on_hit_obj(obj/obj, obj/projectile/proj)
 	if(isarmoredvehicle(O))
 		var/obj/vehicle/sealed/armored/tank = O
 		COOLDOWN_START(tank, cooldown_vehicle_move, tank.move_delay)
 	var/turf/T = get_turf(O)
 	drop_resin(T.density ? P.loc : T)
 
-/datum/ammo/xeno/sticky/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/sticky/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_resin(T.density ? P.loc : T)
 
-/datum/ammo/xeno/sticky/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/sticky/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_resin(T.density ? P.loc : T)
 
 /datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
@@ -195,22 +196,22 @@
 	damage = 5
 	max_range = 3
 
-/datum/ammo/xeno/sticky/globe/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/sticky/globe/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/initial_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, P) : O
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
-/datum/ammo/xeno/sticky/globe/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/sticky/globe/on_hit_turf(turf/turf, obj/projectile/proj)
 	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), T)
 
-/datum/ammo/xeno/sticky/globe/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/sticky/globe/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/initial_turf = get_turf(M)
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
-/datum/ammo/xeno/sticky/globe/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/sticky/globe/do_at_max_range(turf/turf, obj/projectile/proj)
 	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
@@ -233,7 +234,7 @@
 	///Damage dealt by acid puddles
 	var/puddle_acid_damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE
 
-/datum/ammo/xeno/acid/on_shield_block(mob/victim, obj/projectile/proj)
+/datum/ammo/xeno/acid/on_shield_block(mob/mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
@@ -253,16 +254,16 @@
 	spit_cost = 25
 	added_spit_delay = 0
 
-/datum/ammo/xeno/acid/auto/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/acid/auto/on_hit_mob(mob/mob, obj/projectile/proj)
 	drop_nade(get_turf(M), P)
 
-/datum/ammo/xeno/acid/auto/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/acid/auto/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
-/datum/ammo/xeno/acid/auto/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/acid/auto/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/auto/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/acid/auto/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/passthrough
@@ -282,17 +283,17 @@
 	shell_speed = 2
 	max_range = 9
 
-/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/T = get_turf(M)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
-/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/heavy/do_at_max_range(turf/T, obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -55,7 +55,7 @@
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
-/datum/ammo/xeno/toxin/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/toxin/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_neuro_smoke(get_turf(mob))
 
 	if(isxeno(proj.firer))
@@ -81,14 +81,14 @@
 
 	return ..()
 
-/datum/ammo/xeno/toxin/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/toxin/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/T = get_turf(O)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
-/datum/ammo/xeno/toxin/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/toxin/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
-/datum/ammo/xeno/toxin/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/toxin/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_neuro_smoke(T.density ? P.loc : T)
 
 /datum/ammo/xeno/toxin/set_smoke()
@@ -143,7 +143,7 @@
 	slowdown_stacks = 3
 
 
-/datum/ammo/xeno/sticky/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/sticky/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_resin(get_turf(M))
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
@@ -153,17 +153,17 @@
 		C.add_slowdown(slowdown_stacks) //slow em down
 
 
-/datum/ammo/xeno/sticky/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/sticky/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(isarmoredvehicle(O))
 		var/obj/vehicle/sealed/armored/tank = O
 		COOLDOWN_START(tank, cooldown_vehicle_move, tank.move_delay)
 	var/turf/T = get_turf(O)
 	drop_resin(T.density ? P.loc : T)
 
-/datum/ammo/xeno/sticky/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/sticky/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_resin(T.density ? P.loc : T)
 
-/datum/ammo/xeno/sticky/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/sticky/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_resin(T.density ? P.loc : T)
 
 /datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
@@ -196,22 +196,22 @@
 	damage = 5
 	max_range = 3
 
-/datum/ammo/xeno/sticky/globe/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/sticky/globe/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/initial_turf = O.allow_pass_flags & PASS_PROJECTILE ? get_step(O, P) : O
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
-/datum/ammo/xeno/sticky/globe/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/sticky/globe/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), T)
 
-/datum/ammo/xeno/sticky/globe/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/sticky/globe/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/initial_turf = get_turf(M)
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
 
-/datum/ammo/xeno/sticky/globe/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/sticky/globe/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/turf/initial_turf = T.density ? get_step(T, P) : T
 	drop_resin(initial_turf)
 	fire_directionalburst(P, P.firer, P.shot_from, bonus_projectile_quantity, bonus_projectile_range, bonus_projectile_speed, Get_Angle(P.firer, initial_turf), initial_turf)
@@ -234,7 +234,7 @@
 	///Damage dealt by acid puddles
 	var/puddle_acid_damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE
 
-/datum/ammo/xeno/acid/on_shield_block(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/acid/on_shield_block(mob/target_mob, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
@@ -254,16 +254,16 @@
 	spit_cost = 25
 	added_spit_delay = 0
 
-/datum/ammo/xeno/acid/auto/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/acid/auto/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(M), P)
 
-/datum/ammo/xeno/acid/auto/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/acid/auto/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
-/datum/ammo/xeno/acid/auto/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/acid/auto/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/auto/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/acid/auto/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 /datum/ammo/xeno/acid/passthrough
@@ -283,17 +283,17 @@
 	shell_speed = 2
 	max_range = 9
 
-/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/T = get_turf(M)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(O.density ? get_step(O, proj) : get_turf(O))
 
-/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
-/datum/ammo/xeno/acid/heavy/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/acid/heavy/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(T.density ? get_step(T, proj) : T)
 
 

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -28,10 +28,10 @@
 
 /datum/ammo/xeno/web/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	. = ..()
-	if(!ishuman(victim))
+	if(!ishuman(target_mob))
 		return
-	playsound(get_turf(victim), sound(get_sfx("snap")), 30, falloff = 5)
-	var/mob/living/carbon/human/human_victim = victim
+	playsound(get_turf(target_mob), sound(get_sfx("snap")), 30, falloff = 5)
+	var/mob/living/carbon/human/human_victim = target_mob
 	if(proj.def_zone == BODY_ZONE_HEAD)
 		human_victim.blind_eyes(hit_eye_blind)
 		human_victim.balloon_alert(human_victim, "The web blinds you!")
@@ -56,21 +56,21 @@
 	max_range = 8
 
 /datum/ammo/xeno/leash_ball/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_leashball(T.density ? proj.loc : T)
+	drop_leashball(target_turf.density ? proj.loc : target_turf)
 
 /datum/ammo/xeno/leash_ball/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/T = get_turf(victim)
-	drop_leashball(T.density ? proj.loc : T, proj.firer)
+	var/turf/target_turf = get_turf(target_mob)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
 
 /datum/ammo/xeno/leash_ball/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/turf/T = get_turf(O)
-	if(T.density || (O.density && !(O.allow_pass_flags & PASS_PROJECTILE)))
-		T = get_turf(proj)
-	drop_leashball(T.density ? proj.loc : T, proj.firer)
+	var/turf/target_turf = get_turf(target_obj)
+	if(target_turf.density || (target_obj.density && !(target_obj.allow_pass_flags & PASS_PROJECTILE)))
+		target_turf = get_turf(proj)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
 
 /datum/ammo/xeno/leash_ball/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_leashball(T.density ? proj.loc : T)
+	drop_leashball(target_turf.density ? proj.loc : target_turf)
 
 /// This spawns a leash ball and checks if the turf is dense before doing so
-/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/T)
-	new /obj/structure/xeno/aoe_leash(get_turf(T), hivenumber)
+/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/target_turf)
+	new /obj/structure/xeno/aoe_leash(get_turf(target_turf), hivenumber)

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -26,7 +26,7 @@
 	///List for bodyparts that upon being hit cause the target to become ensnared
 	var/list/snare_list = list(BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT)
 
-/datum/ammo/xeno/web/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/xeno/web/on_hit_mob(mob/mob, obj/projectile/proj)
 	. = ..()
 	if(!ishuman(victim))
 		return
@@ -55,20 +55,20 @@
 	accurate_range = 8
 	max_range = 8
 
-/datum/ammo/xeno/leash_ball/on_hit_turf(turf/T, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_turf(turf/turf, obj/projectile/proj)
 	drop_leashball(T.density ? proj.loc : T)
 
-/datum/ammo/xeno/leash_ball/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_mob(mob/mob, obj/projectile/proj)
 	var/turf/T = get_turf(victim)
 	drop_leashball(T.density ? proj.loc : T, proj.firer)
 
-/datum/ammo/xeno/leash_ball/on_hit_obj(obj/O, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_obj(obj/obj, obj/projectile/proj)
 	var/turf/T = get_turf(O)
 	if(T.density || (O.density && !(O.allow_pass_flags & PASS_PROJECTILE)))
 		T = get_turf(proj)
 	drop_leashball(T.density ? proj.loc : T, proj.firer)
 
-/datum/ammo/xeno/leash_ball/do_at_max_range(turf/T, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/do_at_max_range(turf/turf, obj/projectile/proj)
 	drop_leashball(T.density ? proj.loc : T)
 
 /// This spawns a leash ball and checks if the turf is dense before doing so

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -26,7 +26,7 @@
 	///List for bodyparts that upon being hit cause the target to become ensnared
 	var/list/snare_list = list(BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT)
 
-/datum/ammo/xeno/web/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/web/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	. = ..()
 	if(!ishuman(victim))
 		return
@@ -55,20 +55,20 @@
 	accurate_range = 8
 	max_range = 8
 
-/datum/ammo/xeno/leash_ball/on_hit_turf(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_leashball(T.density ? proj.loc : T)
 
-/datum/ammo/xeno/leash_ball/on_hit_mob(mob/mob, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/T = get_turf(victim)
 	drop_leashball(T.density ? proj.loc : T, proj.firer)
 
-/datum/ammo/xeno/leash_ball/on_hit_obj(obj/obj, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/T = get_turf(O)
 	if(T.density || (O.density && !(O.allow_pass_flags & PASS_PROJECTILE)))
 		T = get_turf(proj)
 	drop_leashball(T.density ? proj.loc : T, proj.firer)
 
-/datum/ammo/xeno/leash_ball/do_at_max_range(turf/turf, obj/projectile/proj)
+/datum/ammo/xeno/leash_ball/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_leashball(T.density ? proj.loc : T)
 
 /// This spawns a leash ball and checks if the turf is dense before doing so


### PR DESCRIPTION

## About The Pull Request
Fixex various projectile "on_hit" effects triggering on the incorrect turf in certain cases. This relates to how a projectile's loc does not change during a batch move, meaning the faster a projectile, the higher the inconsistancy could be.

Also made all the args for these on hit procs consistant.
## Why It's Good For The Game
Bug fix.
Consistant args good. Holy fuck there was so many variations.
## Changelog
:cl:
fix: fixed some projectile on hit effects triggering on the wrong turfs in some cases
/:cl:
