### PR TITLE
Xenos can now see research digsites.

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -647,7 +647,7 @@ SUBSYSTEM_DEF(minimaps)
 
 
 /datum/action/minimap/xeno
-	minimap_flags = MINIMAP_FLAG_XENO
+	minimap_flags = MINIMAP_FLAG_XENO|MINIMAP_FLAG_EXCAVATION_ZONE
 
 /datum/action/minimap/researcher
 	minimap_flags = MINIMAP_FLAG_MARINE|MINIMAP_FLAG_EXCAVATION_ZONE


### PR DESCRIPTION

## About The Pull Request
Xenos can now see research digsites on the minimap just like researchers can.
## Why It's Good For The Game
There is no point to a side objective if only one team even knows it is there. Xenos should be able to prepare defences on these and researchers should need to prepare a team to take these objectives. 
## Changelog
:cl:
balance: Xenos can now see research digsites on the map.
/:cl:
