### PR TITLE
Fix bino exploit

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -20,6 +20,9 @@
 	if(user.interactee && istype(user.interactee, /obj/machinery/deployable))
 		to_chat(user, span_warning("You can't use this right now!"))
 		return
+	if(user.client.eye != user || user.client.eye != user.loc)
+		to_chat(user, span_warning("you're looking through something else right now"))
+		return
 	zoom(user)
 
 #define MODE_CAS 0

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -21,7 +21,7 @@
 		to_chat(user, span_warning("You can't use this right now!"))
 		return
 	if(user.client.eye != user || user.client.eye != user.loc)
-		to_chat(user, span_warning("you're looking through something else right now"))
+		to_chat(user, span_warning("You're looking through something else right now."))
 		return
 	zoom(user)
 

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -568,7 +568,7 @@
 
 /obj/item/armor_module/module/binoculars/activate(mob/living/user)
 	if(user.client.eye != user || user.client.eye != user.loc)
-		to_chat(user, span_warning("you're looking through something else right now"))
+		to_chat(user, span_warning("You're looking through something else right now."))
 		return
 	zoom(user)
 	if(active == zoom) //Zooming failed for some reason and didn't change

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -567,6 +567,9 @@
 	toggle_signal = COMSIG_KB_HELMETMODULE
 
 /obj/item/armor_module/module/binoculars/activate(mob/living/user)
+	if(user.client.eye != user || user.client.eye != user.loc)
+		to_chat(user, span_warning("you're looking through something else right now"))
+		return
 	zoom(user)
 	if(active == zoom) //Zooming failed for some reason and didn't change
 		return


### PR DESCRIPTION
## About The Pull Request
You can no longer use binos (hand held or hat mod) while looking through things such as being in a tank seat.

Fixes #16053

:cl:
fix: fixed an exploit with binos
/:cl:
