### PR TITLE
Marines start the round with only 1 squad now

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -9,7 +9,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/votable = TRUE
 	var/required_players = 0
 	var/maximum_players = INFINITY
-	var/squads_max_number = 4
+	//Max number of starting squads on a shipmap
+	var/squads_max_number = 1
 
 	var/round_finished
 	var/list/round_end_states = list()
@@ -671,8 +672,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		if(squad.faction == FACTION_TERRAGOV)
 			preferred_squads[squad.name] = 0
 	if(!length(preferred_squads))
-		to_chat(world, span_boldnotice("Error, no squads found."))
-		return FALSE
+		preferred_squads["Alpha"] = 1 //Default to Alpha if there is no special preference
 	for(var/mob/new_player/player AS in GLOB.new_player_list)
 		if(!player.ready || !player.client?.prefs?.preferred_squad)
 			continue

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -703,10 +703,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		scaled_job.job_points_needed = job_points_needed_by_job_type[job_type]
 	return TRUE
 
-/datum/game_mode/proc/scale_squad_jobs()
-	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/leader)
-	scaled_job.total_positions = length(SSjob.active_squads[FACTION_TERRAGOV])
-
 ///Return the list of joinable factions, with regards with the current round balance
 /datum/game_mode/proc/get_joinable_factions(should_look_balance)
 	return

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -695,8 +695,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 /datum/game_mode/proc/scale_roles()
 	if(SSjob.ssjob_flags & SSJOB_OVERRIDE_JOBS_START)
 		return FALSE
-	if(length(SSjob.active_squads[FACTION_TERRAGOV]))
-		scale_squad_jobs()
 	for(var/job_type in job_points_needed_by_job_type)
 		if(!(job_type in subtypesof(/datum/job)))
 			stack_trace("Invalid job type in job_points_needed_by_job_type. Current mode : [name], Invalid type: [job_type]")

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -8,7 +8,7 @@
 		/datum/job/terragov/squad/engineer = 1,
 		/datum/job/terragov/squad/corpsman = 1,
 		/datum/job/terragov/squad/smartgunner = 1,
-		/datum/job/terragov/squad/leader = 1,
+		/datum/job/terragov/squad/leader = 4,
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/fieldcommander = 1,

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -25,7 +25,7 @@
 		/datum/job/terragov/squad/engineer = 1,
 		/datum/job/terragov/squad/corpsman = 1,
 		/datum/job/terragov/squad/smartgunner = 1,
-		/datum/job/terragov/squad/leader = 1,
+		/datum/job/terragov/squad/leader = 4,
 		/datum/job/terragov/squad/standard = -1,
 		/datum/job/xenomorph = FREE_XENO_AT_START,
 		/datum/job/xenomorph/queen = 1

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -17,7 +17,7 @@
 	)
 	var/max_positions = list(
 		SQUAD_MARINE = -1,
-		SQUAD_LEADER = 1)
+		SQUAD_LEADER = 4)
 
 	var/list/marines_list = list() // list of humans in that squad.
 

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -32,6 +32,8 @@
 	///Faction of that squad
 	var/faction = FACTION_TERRAGOV
 
+	//Should this squad be initialised at roundstart?
+	var/starting_squad = TRUE
 
 /datum/squad/alpha
 	name = "Alpha"
@@ -47,6 +49,7 @@
 	color = "#ffc32d" // rgb(255,195,45)
 	access = list(ACCESS_MARINE_BRAVO)
 	radio_freq = FREQ_BRAVO
+	starting_squad = FALSE
 
 
 /datum/squad/charlie
@@ -55,6 +58,7 @@
 	color = "#c864c8" // rgb(200,100,200)
 	access = list(ACCESS_MARINE_CHARLIE)
 	radio_freq = FREQ_CHARLIE
+	starting_squad = FALSE
 
 /datum/squad/delta
 	name = "Delta"
@@ -62,6 +66,7 @@
 	color = "#4148c8" // rgb(65,72,200)
 	access = list(ACCESS_MARINE_DELTA)
 	radio_freq = FREQ_DELTA
+	starting_squad = FALSE
 
 //SOM squads
 /datum/squad/zulu

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -380,8 +380,6 @@
 		if(current_positions[job.title] >= max_positions[job.title])
 			return FALSE
 		return TRUE
-	if(current_positions[job.title] >= SQUAD_MAX_POSITIONS(job.total_positions))
-		return FALSE
 	return TRUE
 
 

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -747,10 +747,6 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	if(!new_squad)
 		return
 
-	if((ismarineleaderjob(transfer_marine.job) || issommarineleaderjob(transfer_marine.job)) && new_squad.current_positions[transfer_marine.job.type] >= SQUAD_MAX_POSITIONS(transfer_marine.job.total_positions))
-		to_chat(source, "[icon2html(src, source)] [span_warning("Transfer aborted. [new_squad] can't have another [transfer_marine.job.title].")]")
-		return
-
 	var/datum/squad/old_squad = transfer_marine.assigned_squad
 	if(new_squad == old_squad)
 		to_chat(source, "[icon2html(src, source)] [span_warning("[transfer_marine] is already in [new_squad]!")]")


### PR DESCRIPTION

## About The Pull Request

Changes squads from having 4 default squads at roundstart --> 1. The amount of squad leaders is unchanged. Effectively this will mean the round starts with Alpha, Bravo, Charlie or Delta as the default squad and squad leaders can then create custom squads on top of that.

Intention is to have a single squad for the frontline ungaball and custom squads can then be added/opted into as needed. 

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/80229419/04d1edcc-044e-4148-b06c-d6fbd95a1eae)
_Further squads can be added through the SL's Squad Manager console._

This was the original plan like months ago when custom squads were originally being added. If people are very against we can TM and see how it goes but I don't think it'll be an issue, alpha/bravo/charlie/delta is soul but this change does need to be made really & there's no reason people can't just make custom squads for them anyway
## Why It's Good For The Game

 **We are not CM, people are not forced to do [x] duty and so randomly assigning duties doesn't make sense as a result.** Having a single squad is way more intuitive for how TGMC round flow usually goes - most rounds have a singular marine ungaball (i.e one squad) with people opting into extra squad stuff if/when they want to. Having this carry over into squad structure makes more sense in general.

This also provides a couple smaller benefits for command:
- Custom squads are more malleable than roundstart squads. 
- SLs helping with the frontline can send squad orders/announcements across the default squad, rather than pissing in the wind on general radio.
- Currently there can be between 4-8 squads. We do not have the population to support this, so half of them end up as bloat with nowhere near enough SLs to fill in.
- Hopefully greater clarity for plans as specific squads can be mentioned
## Changelog
:cl:
add: Maximum number of starting squads 4 --> 1
/:cl:
