### PR TITLE
Light interior fix

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -301,7 +301,7 @@
 		else
 			W.static_lighting_object = null
 			if(old_lighting_object)
-				qdel(old_lighting_object)
+				qdel(old_lighting_object, TRUE)
 
 		if(static_lighting_object && !static_lighting_object.needs_update)
 			static_lighting_object.update()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -291,11 +291,17 @@
 	lighting_corner_SW = old_lighting_corner_SW
 	lighting_corner_NW = old_lighting_corner_NW
 
+	var/area/thisarea = get_area(W)
 	//static Update
 	if(SSlighting.initialized)
 		recalculate_directional_opacity()
 
-		W.static_lighting_object = old_lighting_object
+		if(thisarea.static_lighting)
+			W.static_lighting_object = old_lighting_object || new /datum/static_lighting_object(src)
+		else
+			W.static_lighting_object = null
+			if(old_lighting_object)
+				qdel(old_lighting_object)
 
 		if(static_lighting_object && !static_lighting_object.needs_update)
 			static_lighting_object.update()
@@ -308,7 +314,6 @@
 	if(W.directional_opacity != old_directional_opacity)
 		W.reconsider_lights()
 
-	var/area/thisarea = get_area(W)
 	if(thisarea.lighting_effect)
 		W.add_overlay(thisarea.lighting_effect)
 

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -44,8 +44,9 @@
 				continue
 			if(istype(A, /obj/machinery/atmospherics))
 				atmos_machines += A
-
-	SSmapping.reg_in_areas_in_z(areas)
+	for(var/area/area AS in areas) //areas are init'd when the first turf is generated, some somethings in init are not done correctly
+		area.update_base_lighting()
+		area.reg_in_areas_in_z()
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 


### PR DESCRIPTION

## About The Pull Request
Fixes static lighting for vehicle interiors.

While this does not fix lighting for shuttle interiors, they WERE impacted by this bug... they are just also impacted by a second bug that I can't figure out. (If anyone is smarter than me, its an issue specifically with shuttle code, and ChangeTurf() fixes shuttle turfs but I cannot for the life of me track down how).
## Why It's Good For The Game
Cool lighting effects.
## Changelog
:cl:
fix: Static lighting works in vehicle interiors, or other generated areas
/:cl:
