### PR TITLE
Fix pyrogen's fireball AoE checking the wrong armor type

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -26,4 +26,4 @@
 	for(var/turf/affecting AS in RANGE_TURFS(1, target_atom))
 		new /obj/fire/melting_fire(affecting)
 		for(var/mob/living/carbon/fired in affecting)
-			fired.take_overall_damage(PYROGEN_FIREBALL_AOE_DAMAGE, BURN, ACID, FALSE, FALSE, TRUE, 0, , max_limbs = 2)
+			fired.take_overall_damage(PYROGEN_FIREBALL_AOE_DAMAGE, BURN, FIRE, FALSE, FALSE, TRUE, 0, , max_limbs = 2)


### PR DESCRIPTION

## About The Pull Request
Title, changes it from acid to fire
## Why It's Good For The Game
Pyro does fire damage now, not acid damage. Will slightly increase the AoE damage of fireball due to armor having lower fire damage resistance compared to acid.
## Changelog
:cl:
fix: Fixed pyrogen's fireball AoE checking for armor's fire resistance instead of acid
/:cl:
