### PR TITLE
Fixes melting fire on the ground dealing the wrong damage type

### DIFF
--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -204,7 +204,7 @@
 		debuff.add_stacks(PYROGEN_MELTING_FIRE_EFFECT_STACK)
 	else
 		target.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK)
-	target.take_overall_damage(damage, BURN, BURN, max_limbs = 2)
+	target.take_overall_damage(damage, BURN, FIRE, max_limbs = 2)
 
 /obj/fire/melting_fire/on_cross(datum/source, mob/living/carbon/human/crosser, oldloc, oldlocs)
 	if(istype(crosser))

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -204,7 +204,7 @@
 		debuff.add_stacks(PYROGEN_MELTING_FIRE_EFFECT_STACK)
 	else
 		target.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK)
-	target.take_overall_damage(damage, BURN, ACID, max_limbs = 2)
+	target.take_overall_damage(damage, BURN, BURN, max_limbs = 2)
 
 /obj/fire/melting_fire/on_cross(datum/source, mob/living/carbon/human/crosser, oldloc, oldlocs)
 	if(istype(crosser))


### PR DESCRIPTION

## About The Pull Request
Title, changes the damage from acid to fire
## Why It's Good For The Game
This is something I missed when converting pyro from acid damage to fire damage in #16014. Makes it consistant with the rest of pyro's abilities
## Changelog
:cl:
fix: Fixed pyrogen's melting ground fire using ACID armor instead of FIRE
/:cl:
