### PR TITLE
Medical items now apply to yourself if you use them in-hand

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -63,6 +63,9 @@
 	///Set of wound flags applied by use, including BANDAGE, SALVE, and DISINFECT
 	var/heal_flags = NONE
 
+/obj/item/stack/medical/heal_pack/attack_self(mob/user)
+	. = ..()
+	/obj/item/stack/medical/heal_pack/attack(user, user)
 
 /obj/item/stack/medical/heal_pack/attack(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -226,6 +226,9 @@
 	///How much splint health per medical skill is applied
 	var/applied_splint_health = 15
 
+/obj/item/stack/medical/splint/attack_self(mob/user)
+	. = ..()
+	attack(user, user)
 
 /obj/item/stack/medical/splint/attack(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -19,7 +19,7 @@
 	///Fumble delay applied without sufficient skill
 	var/unskilled_delay = SKILL_TASK_TRIVIAL
 
-/obj/item/stack/medical/splint/attack_self(mob/user)
+/obj/item/stack/medical/attack_self(mob/user)
 	. = ..()
 	attack(user, user)
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -19,6 +19,10 @@
 	///Fumble delay applied without sufficient skill
 	var/unskilled_delay = SKILL_TASK_TRIVIAL
 
+/obj/item/stack/medical/splint/attack_self(mob/user)
+	. = ..()
+	attack(user, user)
+
 /obj/item/stack/medical/attack(mob/living/M, mob/living/user)
 	. = ..()
 	if(.)
@@ -62,10 +66,6 @@
 	var/heal_burn = 0
 	///Set of wound flags applied by use, including BANDAGE, SALVE, and DISINFECT
 	var/heal_flags = NONE
-
-/obj/item/stack/medical/heal_pack/attack_self(mob/user)
-	. = ..()
-	/obj/item/stack/medical/heal_pack/attack(user, user)
 
 /obj/item/stack/medical/heal_pack/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -225,10 +225,6 @@
 	unskilled_delay = SKILL_TASK_TOUGH
 	///How much splint health per medical skill is applied
 	var/applied_splint_health = 15
-
-/obj/item/stack/medical/splint/attack_self(mob/user)
-	. = ..()
-	attack(user, user)
 
 /obj/item/stack/medical/splint/attack(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -52,7 +52,16 @@
 	. = ..()
 	change_transfer_amount(user)
 
+/obj/item/reagent_containers/attack_self(mob/living/user)
+	. = ..()
+	afterattack(user, user) //If player uses the hypospray, try to inject themselves
+
+
 /obj/item/reagent_containers/attack_self_alternate(mob/living/user)
+	. = ..()
+	change_transfer_amount(user)
+
+/obj/item/reagent_containers/unique_action(mob/user, special_treatment)
 	. = ..()
 	change_transfer_amount(user)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -54,8 +54,7 @@
 
 /obj/item/reagent_containers/attack_self(mob/living/user)
 	. = ..()
-	afterattack(user, user) //If player uses the hypospray, try to inject themselves
-
+	afterattack(user, user) //If player uses the container, use it on themselves
 
 /obj/item/reagent_containers/attack_self_alternate(mob/living/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -15,7 +15,6 @@
 	equip_slot_flags = ITEM_SLOT_BELT
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_SMALL
-	interaction_flags = INTERACT_OBJ_UI
 	var/skilllock = 1
 	var/inject_mode = HYPOSPRAY_INJECT_MODE_INJECT
 	var/core_name = "hypospray"
@@ -205,6 +204,9 @@
 	desc.maptext = MAPTEXT(description_overlay)
 	desc.maptext_width = 16
 	. += desc
+
+/obj/item/reagent_containers/hypospray/unique_action(mob/user, special_treatment)
+	ui_interact(user)
 
 /obj/item/reagent_containers/hypospray/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
## About The Pull Request

Using an injector, splint, gauze, etc. in-hand (same button as wielding a weapon) will apply/inject them to yourself.
Pressing unique action with an injector in-hand will now open its menu.
## Why It's Good For The Game

Small QoL requested by Elsa. Less mouse movement good. Also more in line with how CM's autoinjectors function, making them more intuitive.
## Changelog
:cl:
qol: Using medical items in-hand will now apply them to yourself
qol: Unique action now opens the injector menu
/:cl:
