### PR TITLE
Pass flag changes

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -8,11 +8,19 @@
 	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	interaction_flags = INTERACT_OBJ_DEFAULT|INTERACT_POWERLOADER_PICKUP_ALLOWED
+	allow_pass_flags = PASSABLE|PASS_WALKOVER|PASS_LOW_STRUCTURE
 	max_integrity = 40
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hit_sound = 'sound/effects/woodhit.ogg'
 	var/spawn_type
 	var/spawn_amount
+
+/obj/structure/largecrate/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+	)
+	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/largecrate/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_WOOD, -10, 5)

--- a/code/game/objects/structures/rocks.dm
+++ b/code/game/objects/structures/rocks.dm
@@ -10,6 +10,7 @@
 	density = TRUE
 	anchored = TRUE
 	layer = ABOVE_TURF_LAYER
+	allow_pass_flags = PASSABLE|PASS_DEFENSIVE_STRUCTURE
 
 /obj/structure/rock/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION

## About The Pull Request
Rocks have the defensive structure pass flag, allowing xeno leaps and such over them (but not jump).
Large crates (the big ones, and subtypes such as barrels and green storage boxes) are jumpable.
## Why It's Good For The Game
Some QOL for passability to be a bit more consistant with other stuff.
## Changelog
:cl:
balance: Largecrates are jumpable
balance: Large rocks can pouched over etc, similar to unwired cades
/:cl:
