### PR TITLE
Ravage now hits more of the APC and Tank

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -122,7 +122,7 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
-		if(ishitbox(ravaged))
+		if(ishitbox(ravaged) || isarmoredvehicle(ravaged))
 			ravaged.attack_alien(X, X.xeno_caste.melee_damage) //Handles APC/Tank stuff
 			continue
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !X.Adjacent(ravaged))

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -122,7 +122,7 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
-		if(ishitbox(ravaged) || isarmoredvehicle(ravaged))
+		if(ishitbox(ravaged))
 			ravaged.attack_alien(X, X.xeno_caste.melee_damage) //Handles APC/Tank stuff
 			continue
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !X.Adjacent(ravaged))

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -122,8 +122,8 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
-		if(ishitbox(ravaged) || isarmoredvehicle(ravaged))
-			ravaged.attack_alien(X, X.xeno_caste.melee_damage) //Handles APC/Tank stuff
+		if(ishitbox(ravaged) || isvehicle(ravaged))
+			ravaged.attack_alien(X, X.xeno_caste.melee_damage) //Handles APC/Tank stuff. Has to be before the !ishuman check or else ravage does work properly on vehicles.
 			continue
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !X.Adjacent(ravaged))
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -122,8 +122,9 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
-		if(ishitbox(ravaged) || isarmoredvehicle(ravaged)) //Handles APC/Tank stuff in a different for loop
-			break
+		if(ishitbox(ravaged) || isarmoredvehicle(ravaged))
+			ravaged.attack_alien(X, X.xeno_caste.melee_damage) //Handles APC/Tank stuff
+			continue
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !X.Adjacent(ravaged))
 			continue
 		if(!ishuman(ravaged))
@@ -137,9 +138,6 @@
 		human_victim.knockback(X, RAV_RAVAGE_THROW_RANGE, RAV_CHARGESPEED)
 		shake_camera(human_victim, 2, 1)
 		human_victim.Paralyze(1 SECONDS)
-
-	for(var/obj/hitbox/ravaged AS in atoms_to_ravage)
-		ravaged.attack_alien(X, X.xeno_caste.melee_damage)
 
 	succeed_activate()
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -122,6 +122,8 @@
 	atoms_to_ravage += get_step(owner, turn(owner.dir, -45)).contents
 	atoms_to_ravage += get_step(owner, turn(owner.dir, 45)).contents
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
+		if(ishitbox(ravaged) || isarmoredvehicle(ravaged)) //Handles APC/Tank stuff in a different for loop
+			break
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !X.Adjacent(ravaged))
 			continue
 		if(!ishuman(ravaged))
@@ -135,6 +137,9 @@
 		human_victim.knockback(X, RAV_RAVAGE_THROW_RANGE, RAV_CHARGESPEED)
 		shake_camera(human_victim, 2, 1)
 		human_victim.Paralyze(1 SECONDS)
+
+	for(var/obj/hitbox/ravaged AS in atoms_to_ravage)
+		ravaged.attack_alien(X, X.xeno_caste.melee_damage)
 
 	succeed_activate()
 	add_cooldown()


### PR DESCRIPTION

## About The Pull Request
Title, ravage will now hit the tank/apc hitbox from anywhere, rather than only if it hits the center too.
## Why It's Good For The Game
More consistant and intuitive. Does about 50 damage if ravage hits 3 parts of the tank.
## Changelog
:cl:
balance: Ravage will now hit any part of the tank and APC.
/:cl:
