### PR TITLE
Martini Penetration Buff

### DIFF
--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -58,7 +58,7 @@
 	handful_amount = 5
 	ammo_behavior_flags = AMMO_BALLISTIC
 	damage = 120
-	penetration = 20
+	penetration = 50
 	accurate_range_min = 0
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 10 SECONDS


### PR DESCRIPTION
## About The Pull Request

Gives Martini Henry rounds the penetration equal to the sr-127, without any sunder.

## Why It's Good For The Game

Gun is clunky, easy to fumble, and needs more oomph given it's single shot of a giant bullet meant to take down elephants. It also does no sunder damage. Gun currently has 15 pen; which is significantly less than most tier ones have.

![martinihenry](https://github.com/tgstation/TerraGov-Marine-Corps/assets/36761380/79891bf1-191a-439c-8f18-de35c58aba13)

this is how big the bullets the martini henry uses are. Come on now.

## Changelog

:cl:
balance: Increased Penetration value of Martini Henry rounds from 15 to 50.
/:cl:
