### PR TITLE
Allows toggling of xeno ranks + xeno rank fixes

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -532,7 +532,7 @@
 /mob/living/carbon/xenomorph/proc/hud_update_rank()
 	var/image/holder = hud_list[XENO_RANK_HUD]
 	holder.icon_state = ""
-	if(stat != DEAD && playtime_as_number() > 0)
+	if(stat != DEAD && playtime_as_number() > 0 && client.prefs.show_xeno_rank)
 		holder.icon = 'icons/mob/hud/xeno.dmi'
 		holder.icon_state = "upgrade_[playtime_as_number()]"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -135,6 +135,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/mute_others_combat_messages = FALSE
 	///Whether to mute xeno health alerts from when other xenos are badly hurt.
 	var/mute_xeno_health_alert_messages = TRUE
+	///Whether we generate a xeno name to show in the chatbox and on the mob.
+	var/show_xeno_rank = TRUE
 
 	///whether the user wants to hear tts
 	var/sound_tts = TTS_SOUND_ENABLED

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -174,6 +174,7 @@
 	READ_FILE(S["mute_self_combat_messages"], mute_self_combat_messages)
 	READ_FILE(S["mute_others_combat_messages"], mute_others_combat_messages)
 	READ_FILE(S["mute_xeno_health_alert_messages"], mute_xeno_health_alert_messages)
+	READ_FILE(S["show_xeno_rank"], show_xeno_rank)
 
 	// Runechat options
 	READ_FILE(S["chat_on_map"], chat_on_map)
@@ -234,6 +235,7 @@
 	mute_self_combat_messages = sanitize_integer(mute_self_combat_messages, FALSE, TRUE, initial(mute_self_combat_messages))
 	mute_others_combat_messages = sanitize_integer(mute_others_combat_messages, FALSE, TRUE, initial(mute_others_combat_messages))
 	mute_xeno_health_alert_messages = sanitize_integer(mute_xeno_health_alert_messages, FALSE, TRUE, initial(mute_xeno_health_alert_messages))
+	show_xeno_rank = sanitize_integer(show_xeno_rank, FALSE, TRUE, initial(show_xeno_rank))
 
 	chat_on_map = sanitize_integer(chat_on_map, FALSE, TRUE, initial(chat_on_map))
 	max_chat_length = sanitize_integer(max_chat_length, 1, CHAT_MESSAGE_MAX_LENGTH, initial(max_chat_length))
@@ -300,6 +302,7 @@
 	mute_self_combat_messages = sanitize_integer(mute_self_combat_messages, FALSE, TRUE, initial(mute_self_combat_messages))
 	mute_others_combat_messages = sanitize_integer(mute_others_combat_messages, FALSE, TRUE, initial(mute_others_combat_messages))
 	mute_xeno_health_alert_messages = sanitize_integer(mute_xeno_health_alert_messages, FALSE, TRUE, initial(mute_xeno_health_alert_messages))
+	show_xeno_rank = sanitize_integer(show_xeno_rank, FALSE, TRUE, initial(show_xeno_rank))
 
 	// Runechat
 	chat_on_map = sanitize_integer(chat_on_map, FALSE, TRUE, initial(chat_on_map))
@@ -351,6 +354,7 @@
 	WRITE_FILE(S["mute_self_combat_messages"], mute_self_combat_messages)
 	WRITE_FILE(S["mute_others_combat_messages"], mute_others_combat_messages)
 	WRITE_FILE(S["mute_xeno_health_alert_messages"], mute_xeno_health_alert_messages)
+	WRITE_FILE(S["show_xeno_rank"], show_xeno_rank)
 
 	// Runechat options
 	WRITE_FILE(S["chat_on_map"], chat_on_map)

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -118,6 +118,7 @@
 			data["see_rc_emotes"] = see_rc_emotes
 			data["mute_others_combat_messages"] = mute_others_combat_messages
 			data["mute_self_combat_messages"] = mute_self_combat_messages
+			data["show_xeno_rank"] = show_xeno_rank
 			data["show_typing"] = show_typing
 			data["tooltips"] = tooltips
 			data["widescreenpref"] = widescreenpref
@@ -670,6 +671,9 @@
 
 		if("mute_others_combat_messages")
 			mute_others_combat_messages = !mute_others_combat_messages
+
+		if("show_xeno_rank")
+			show_xeno_rank = !show_xeno_rank
 
 		if("change_quick_equip")
 			var/editing_slot = params["selection"]

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -28,6 +28,12 @@
 /mob/living/carbon/xenomorph/king/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	if(!client?.prefs.show_xeno_rank || !client)
+		name = prefix + "King ([nicknumber])"
+		real_name = name
+		if(mind)
+			mind.name = name
+		return
 	switch(playtime_mins)
 		if(0 to 600)
 			name = prefix + "Young King ([nicknumber])"

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -74,6 +74,12 @@
 /mob/living/carbon/xenomorph/queen/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	if(!client?.prefs.show_xeno_rank || !client)
+		name = prefix + "Queen ([nicknumber])"
+		real_name = name
+		if(mind)
+			mind.name = name
+		return
 	switch(playtime_mins)
 		if(0 to 600)
 			name = prefix + "Young Queen ([nicknumber])"

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -37,6 +37,7 @@
 			hud_used.alien_plasma_display.icon_state = "power_display_empty"
 	update_icons()
 	hud_set_plasma()
+	hud_update_rank()
 
 	death_cry()
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -150,6 +150,10 @@
 /mob/living/carbon/xenomorph/proc/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
 	var/rank_name
+	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	if(!client?.prefs.show_xeno_rank || !client)
+		name = prefix + "[xeno_caste.display_name] ([nicknumber])"
+		return
 	switch(playtime_mins)
 		if(0 to 600)
 			rank_name = "Young"
@@ -163,7 +167,6 @@
 			rank_name = "Prime"
 		else
 			rank_name = "Young"
-	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	name = prefix + "[rank_name ? "[rank_name] " : ""][xeno_caste.display_name] ([nicknumber])"
 
 	//Update linked data so they show up properly
@@ -183,6 +186,8 @@
 ///Returns the playtime as a number, used for rank icons
 /mob/living/carbon/xenomorph/proc/playtime_as_number()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
+	if(!client?.prefs.show_xeno_rank)
+		return 0
 	switch(playtime_mins)
 		if(0 to 600)
 			return 0

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -186,7 +186,7 @@
 ///Returns the playtime as a number, used for rank icons
 /mob/living/carbon/xenomorph/proc/playtime_as_number()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
-	if(!client?.prefs.show_xeno_rank)
+	if(!client?.prefs.show_xeno_rank || !client)
 		return 0
 	switch(playtime_mins)
 		if(0 to 600)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -186,8 +186,6 @@
 ///Returns the playtime as a number, used for rank icons
 /mob/living/carbon/xenomorph/proc/playtime_as_number()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
-	if(!client?.prefs.show_xeno_rank || !client)
-		return 0
 	switch(playtime_mins)
 		if(0 to 600)
 			return 0

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
@@ -214,6 +214,15 @@ export const GameSettings = (props) => {
                 rightValue={1}
                 rightLabel={'Disabled'}
               />
+              <ToggleFieldPreference
+                label="Show xeno rank"
+                value="show_xeno_rank"
+                action="show_xeno_rank"
+                leftValue={1}
+                leftLabel={'Enabled'}
+                rightValue={0}
+                rightLabel={'Disabled'}
+              />
             </LabeledList>
           </Section>
         </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Can toggle rank on and off
Clientless xenos have no rank
Rank HUD deletes on death
## Why It's Good For The Game
Requested feature if you wanted to play anonymously, additionally this was possible before maturity removal and then I removed it. Sometimes people just want to play as Drone (123) and I don't think we should deny that to them. Additionally fixes good.
## Changelog
:cl:
add: Xeno Ranks: Preference to toggle them on and off
fix: Clientless xenos no longer have ranks
fix: Xeno rank HUD no longer persists after death
/:cl:
