### PR TITLE
Gibbed xenos drop remains for 1/4 value

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -131,3 +131,10 @@
 	icon_state = "rosary"
 	worn_icon_state = "rosary"
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/xeno_remains
+	name = "remains"
+	desc = "Scattered remains of a xenomorph. Might be worth something..."
+	gender = PLURAL
+	w_class = WEIGHT_CLASS_HUGE
+	var/tier

--- a/code/game/objects/machinery/sellingpad.dm
+++ b/code/game/objects/machinery/sellingpad.dm
@@ -47,12 +47,14 @@
 			can_sell = TRUE
 		if(is_research_product(onpad))
 			can_sell = TRUE
+		if(istype(onpad, /obj/item/xeno_remains))
+			can_sell = TRUE
 		if(!can_sell)
 			continue
 		var/datum/export_report/export_report = onpad.supply_export(user.faction)
 		if(export_report)
 			SSpoints.export_history += export_report
-		visible_message(span_notice("[src] buzzes: The [onpad] has been sold for [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."))
+		visible_message(span_notice("[src] buzzes: \The [onpad] has been sold for [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."))
 		qdel(onpad)
 
 	do_sparks(5, TRUE, src)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -82,9 +82,11 @@
 
 /mob/living/carbon/xenomorph/gib()
 
-	var/obj/effect/decal/remains/xeno/remains = new(get_turf(src))
+	var/obj/item/xeno_remains/remains = new(get_turf(src))
 	remains.icon = icon
-	remains.pixel_x = pixel_x //For 2x2.
+
+	remains.name = "remains - tier [tier]"
+	remains.tier = tier
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_GIBBING)
 

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -50,6 +50,22 @@
 			. = list(1100, 100)
 	return
 
+/obj/item/xeno_remains/get_export_value()
+	switch(tier) //about 1/4
+		if(XENO_TIER_MINION)
+			. = list(10, 1)
+		if(XENO_TIER_ZERO)
+			. = list(20, 2)
+		if(XENO_TIER_ONE)
+			. = list(40, 3)
+		if(XENO_TIER_TWO)
+			. = list(90, 7)
+		if(XENO_TIER_THREE)
+			. = list(150, 12)
+		if(XENO_TIER_FOUR)
+			. = list(275, 25)
+	return
+
 //I hate it but it's how it was so I'm not touching it further than this
 /mob/living/carbon/xenomorph/shrike/get_export_value()
 	return list(600, 50)


### PR DESCRIPTION

## About The Pull Request
After being `gib`bed, xenomorphs drop a stack of remains that sells for approximately `1/4` of the original xeno (rounded to 10.s for pretty number).

(Also fixes grammar in the "sold" message)
## Why It's Good For The Game
Slightly less sadness when either artillery or your super shotgun explodes king.
## Changelog
:cl:
add: The remains of gibbed xenos can now be sold.
balance: Xeno remains are worth 1/4 of the original xeno.
/:cl:
