### PR TITLE
Xeno selling rework

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -469,7 +469,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SLOWDOWN_REGEN 0.4
 
 #define XENO_DEADHUMAN_DRAG_SLOWDOWN 2
-#define XENO_EXPLOSION_GIB_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will gib xenos
+#define XENO_EXPLOSION_INSTACRIT_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will insta-crit xenos
 
 #define SPIT_UPGRADE_BONUS(Xenomorph) (Xenomorph.upgrade_as_number() ?  0.6 : 0.45 ) //Primo damage increase
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -469,7 +469,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SLOWDOWN_REGEN 0.4
 
 #define XENO_DEADHUMAN_DRAG_SLOWDOWN 2
-#define XENO_EXPLOSION_INSTACRIT_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will insta-crit xenos
+#define XENO_EXPLOSION_GIB_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will gib xenos
 
 #define SPIT_UPGRADE_BONUS(Xenomorph) (Xenomorph.upgrade_as_number() ?  0.6 : 0.45 ) //Primo damage increase
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -180,3 +180,22 @@
 /mob/living/carbon/proc/handle_disabilities()
 	handle_impaired_vision()
 	handle_impaired_hearing()
+
+/// instantly sends a mob into crit
+/mob/living/carbon/proc/insta_crit(damage_type = BRUTE, zone)
+	var/amt = max(health - get_crit_threshold() + 1, 0)
+	apply_damage(amt, damage_type, zone, updating_health = TRUE) //wound the target...
+	if(health > get_crit_threshold())
+		amt = max(health - get_crit_threshold() + 1, 0) //then deal the rest of the damage directly
+		switch(damage_type)
+			if(BRUTE)
+				adjustBruteLoss(amt)
+			if(BURN)
+				adjustFireLoss(amt)
+			if(TOX)
+				adjustToxLoss(amt)
+			if(OXY)
+				adjustOxyLoss(amt)
+			if(CLONE)
+				adjustCloneLoss(amt)
+	Paralyze(1 SECONDS, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -28,7 +28,7 @@
 	if(bomb_armor_ratio <= 0) //we have 100 effective bomb armor
 		return
 
-	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_INSTACRIT_THRESHOLD))
+	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_GIB_THRESHOLD))
 		return gib() //gibs unprotected benos
 
 	switch(severity)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -29,8 +29,7 @@
 		return
 
 	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_INSTACRIT_THRESHOLD))
-		if(health > 190)
-			return insta_crit() //Insta-crits unprotected benos
+		return gib() //gibs unprotected benos
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -28,8 +28,9 @@
 	if(bomb_armor_ratio <= 0) //we have 100 effective bomb armor
 		return
 
-	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_GIB_THRESHOLD))
-		return gib() //Gibs unprotected benos
+	if((severity == EXPLODE_DEVASTATE) && (bomb_armor_ratio > XENO_EXPLOSION_INSTACRIT_THRESHOLD))
+		if(health > 190)
+			return insta_crit() //Insta-crits unprotected benos
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -82,7 +82,8 @@
 
 /mob/living/carbon/xenomorph/gib()
 
-	var/obj/effect/decal/remains/xeno/remains = new(get_turf(src))
+	var/turf/T = get_turf(src)
+	var/obj/effect/decal/remains/xeno/remains = new(T)
 	remains.icon = icon
 	remains.pixel_x = pixel_x //For 2x2.
 
@@ -91,6 +92,9 @@
 	remains.icon_state = xeno_caste.gib_anim
 
 	check_blood_splash(35, BURN, 65, 2)
+
+	if(prob(1))
+		var/obj/item/reagent_containers/food/snacks/meat/xeno/I = new(T)
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -224,7 +224,7 @@
 		return
 
 	if(health <= get_death_threshold())
-		if(crit_damage_penalty > 20 && prob(crit_damage_penalty * 0.75)) //if above 20, chance to gib based on crit_damage_penalty
+		if(crit_damage_penalty > 20 && prob(crit_damage_penalty * 0.75 - 12)) //if above 20, chance to gib based on crit_damage_penalty
 			gib() //womp womp
 			return TRUE
 		crit_damage_penalty = 0

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -217,3 +217,14 @@
 		add_movespeed_modifier(MOVESPEED_ID_FRENZY_AURA, TRUE, 0, NONE, TRUE, -frenzy_aura * 0.06)
 		return
 	remove_movespeed_modifier(MOVESPEED_ID_FRENZY_AURA)
+
+/mob/living/carbon/xenomorph/update_stat()
+	. = ..()
+	if(.)
+		return
+
+	if(health <= get_death_threshold())
+		if(crit_damage_penalty > 20 && prob(crit_damage_penalty * 0.75)) //if above 20, chance to gib based on crit_damage_penalty
+			gib() //womp womp
+			return TRUE
+		crit_damage_penalty = 0

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -1,7 +1,7 @@
 #define DEBUG_XENO_LIFE 0
 #define XENO_RESTING_HEAL 1.1
 #define XENO_STANDING_HEAL 0.2
-#define XENO_CRIT_DAMAGE 5
+#define XENO_CRIT_DAMAGE 7
 
 /mob/living/carbon/xenomorph/Life()
 
@@ -224,7 +224,7 @@
 		return
 
 	if(health <= get_death_threshold())
-		if(crit_damage_penalty > 20 && prob(crit_damage_penalty * 0.75 - 12)) //if above 20, chance to gib based on crit_damage_penalty
+		if(crit_damage_penalty > 70 && prob(crit_damage_penalty - 65)) //if above 20, chance to gib based on crit_damage_penalty
 			gib() //womp womp
 			return TRUE
 		crit_damage_penalty = 0

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -55,7 +55,7 @@
 	///Maximum health a caste has.
 	var/max_health = 100
 	///What negative health amount they die at.
-	var/crit_health = -100
+	var/crit_health = -140
 
 	// *** Evolution *** //
 	///Threshold amount of evo points to next evolution

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	faction = FACTION_XENO
 	initial_language_holder = /datum/language_holder/xeno
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.8,aresample=%SAMPLE_RATE%,atempo=1/0.8,aformat=channel_layouts=mono [p0]; [out2] asetrate=%SAMPLE_RATE%*1.2,aresample=%SAMPLE_RATE%,atempo=1/1.2,aformat=channel_layouts=mono[p2]; [p0][0][p2] amix=inputs=3"}
-	gib_chance = 5
+	gib_chance = 0
 	light_system = MOVABLE_LIGHT
 
 	///Hive name define
@@ -419,6 +419,9 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 
 	/// The type of footstep this xeno has.
 	var/footstep_type = FOOTSTEP_XENO_MEDIUM
+
+	/// The amount of damage the xeno has taken while in crit, resets on exiting crit
+	var/crit_damage_penalty = 0
 
 	COOLDOWN_DECLARE(xeno_health_alert_cooldown)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -428,9 +428,14 @@
 	switch(stat)
 		if(UNCONSCIOUS)
 			see_in_dark = xeno_caste.unconscious_see_in_dark
+			RegisterSignal(src, COMSIG_XENOMORPH_TAKING_DAMAGE, TYPE_PROC_REF(/mob/living/carbon/xenomorph, oncrittakedamage))
 		if(DEAD, CONSCIOUS)
 			if(. == UNCONSCIOUS)
 				see_in_dark = xeno_caste.conscious_see_in_dark
+				UnregisterSignal(src, COMSIG_XENOMORPH_TAKING_DAMAGE)
+	if(new_stat == CONSCIOUS)
+		crit_damage_penalty = 0
+
 
 ///Kick the player from this mob, replace it by a more competent ai
 /mob/living/carbon/xenomorph/proc/replace_by_ai()

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -573,3 +573,7 @@
 
 /mob/living/carbon/xenomorph/on_eord(turf/destination)
 	revive(TRUE)
+
+/mob/living/carbon/xenomorph/proc/oncrittakedamage(mob/living/carbon/xenomorph/X, damage_taken)
+	SIGNAL_HANDLER
+	X.crit_damage_penalty += damage_taken

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -37,17 +37,17 @@
 /mob/living/carbon/xenomorph/get_export_value()
 	switch(tier)
 		if(XENO_TIER_MINION)
-			. = list(50, 5)
+			. = list(40, 5)
 		if(XENO_TIER_ZERO)
-			. = list(70, 7)
+			. = list(60, 7)
 		if(XENO_TIER_ONE)
-			. = list(150, 15)
+			. = list(120, 15)
 		if(XENO_TIER_TWO)
-			. = list(350, 30)
+			. = list(300, 30)
 		if(XENO_TIER_THREE)
-			. = list(600, 50)
+			. = list(510, 50)
 		if(XENO_TIER_FOUR)
-			. = list(1100, 100)
+			. = list(940, 100)
 	return
 
 //I hate it but it's how it was so I'm not touching it further than this


### PR DESCRIPTION
## About The Pull Request
Xenomorphs are ~no longer~ gibbed by devastating explosions, and are instead instantly ~put into crit~ gibbed if their bomb armor is low enough. Instead of having an ever-present 5% chance to be gibbed, the chance to gib on death is now affected by how much damage they took while in crit. If a xenomorph sustains more than ~20~ `70` damage while in crit (bleeding-out damage not counted, of course), they will have a ~x * 0.75 - 12~ `{total damage taken} - 65`% chance to be gibbed. This resets when they leave crit. 

Xenos now have -140 crit health (die at -140) and bleed out 7 per life tick instead of 5.

(also they have a 1% chance to drop a slab of meat on death hehe)

All xenos now sell for ~15% less req points.
## Why It's Good For The Game
Kings shall not unceremoniously blow up after marines make a effort to carefully recover the corpse, ~nor~ the shrike shall blow up instantly after hitting their head on a flying artillery shell. Now rewarded for making an effort to preserve the corpse.
## Changelog
:cl:
balance: Xenos have a chance to be gibbed on death based on how much damage they took while in crit. Try to keep them in one piece.
balance: Xenos sell for ~15% less req points.
qol: Xenos are no longer randomly gibbed on death.
/:cl:
