### PR TITLE
Valhalla Vehicle Area Update

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -3088,7 +3088,9 @@
 /turf/open/floor/tile/red/yellowfull,
 /area/tdome/tdomeadmin)
 "dRR" = (
-/obj/vehicle/sealed/armored/multitile,
+/obj/effect/landmark/valhalla/vehicle_spawner_landmark{
+	where = "marinecenter"
+	},
 /turf/open/floor/mainship/hexagon,
 /area/centcom/valhalla)
 "dSO" = (
@@ -3253,10 +3255,11 @@
 /turf/open/floor/wood,
 /area/centcom/valhalla)
 "efF" = (
-/obj/structure/table/mainship,
-/obj/item/armored_weapon,
-/obj/item/armored_weapon/ltaap,
-/turf/open/floor/plating,
+/obj/machinery/button/valhalla/vehicle_button{
+	link = "vehiclemarineupper";
+	name = "North Vehicle Spawner"
+	},
+/turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
 "efJ" = (
 /obj/item/radio/intercom{
@@ -4322,7 +4325,9 @@
 	},
 /area/centcom/valhalla)
 "fRn" = (
-/obj/vehicle/sealed/armored/multitile,
+/obj/effect/landmark/valhalla/vehicle_spawner_landmark{
+	where = "marineupper"
+	},
 /turf/open/floor/plating,
 /area/centcom/valhalla)
 "fRC" = (
@@ -4898,6 +4903,13 @@
 	},
 /obj/effect/turf_decal/warning_stripes/box/empty,
 /turf/open/floor/freezer,
+/area/centcom/valhalla)
+"gFO" = (
+/obj/machinery/button/valhalla/vehicle_button{
+	link = "vehiclemarinecenter";
+	name = "Center Vehicle Spawner"
+	},
+/turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
 "gGv" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -15324,9 +15336,7 @@
 /area/centcom/valhalla)
 "wlz" = (
 /obj/structure/table/mainship,
-/obj/item/armored_weapon/secondary_weapon,
-/obj/item/armored_weapon/secondary_weapon,
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
 "wnL" = (
 /obj/effect/ai_node,
@@ -18762,10 +18772,10 @@ bbR
 boq
 boq
 boq
+wJM
 efF
-ivs
-ivs
-ivs
+wlz
+gFO
 xOn
 boq
 boq
@@ -18900,7 +18910,7 @@ bbR
 boq
 boq
 boq
-wlz
+wJM
 ivs
 ivs
 ivs

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -328,4 +328,18 @@
 		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
 	linked = new selected_vehicle(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
 
+/obj/machinery/button/valhalla/vehicle_button/attack_hand(mob/living/user)
+	var/list/spawnable_vehicles = list(/obj/vehicle/sealed/armored/multitile,
+	/obj/vehicle/sealed/armored/multitile/apc)
+
+	var/selected_vehicle = tgui_input_list(usr, "Which vehicle do you want to spawn?", "Vehicle spawn", spawnable_vehicles)
+	if(!selected_vehicle)
+		return
+
+	QDEL_NULL(linked)
+	if(!get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+		to_chat(user, span_warning("An error occured, yell at the coders."))
+		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
+	linked = new selected_vehicle(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+
 #undef DOOR_FLAG_OPEN_ONLY

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1551,6 +1551,9 @@
 			/obj/item/implanter/blade = -1,
 		),
 		"Assault Vehicle" = list(
+			/obj/item/armored_weapon = -1,
+			/obj/item/armored_weapon/ltaap = -1,
+			/obj/item/armored_weapon/secondary_weapon = -1,
 			/obj/item/ammo_magazine/tank/ltb_cannon = -1,
 			/obj/item/ammo_magazine/tank/ltaap_chaingun = -1,
 			/obj/item/ammo_magazine/tank/secondary_cupola = -1,


### PR DESCRIPTION
## About The Pull Request
Updates the vehicle spawner area in marine valhalla to use buttons to spawn vehicles, and removes two spawned vehicles that are there currently. Also adds the current vehicle guns to the valhalla req vendor.
## Why It's Good For The Game
Makes it easier to test vehicle stuff in valhalla without risking permanent loss of said vehicles.
## Changelog
:cl:
add: Added the APC/tank weapons to the valhalla req vendor
qol: Replaced the spawned vehicles in marine Valhalla with vehicle spawner buttons
/:cl:
