### PR TITLE
Xeno Acid Smoke Deals Damage to APC/Tank Based on HItbox

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -194,6 +194,11 @@
 /obj/hitbox/lava_act()
 	root.lava_act()
 
+/obj/hitbox/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
+		take_damage(10 * S.strength, BURN, ACID)
+
 ///2x2 hitbox version
 /obj/hitbox/medium
 	bound_width = 64


### PR DESCRIPTION
## About The Pull Request
Title, makes it so xeno acid smoke deals damage based on how many tiles is in the smoke, between 400-500 if it just sits in a boiler cloud completely enveloped the entire duration.
## Why It's Good For The Game
Consistancey and intuitiveness. Also makes acid smoke more of a threat for apc/tanks
## Changelog
:cl:
balance: Xeno acid smoke will deal damage per tile of apc/tanks hit, between 400-500 if completely enveloped the entire duration of a boiler cloud.
/:cl:
