### PR TITLE
Buffs the tank Chaingun

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -33,12 +33,12 @@
 
 /datum/ammo/bullet/minigun/ltaap
 	name = "chaingun bullet"
-	damage = 30
+	damage = 40
 	penetration = 15
-	sundering = 0
+	sundering = 1
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_IFF
-	damage_falloff = 2
-	accuracy = 80
+	damage_falloff = 1.5
+	accuracy = 90
 
 /datum/ammo/bullet/auto_cannon
 	name = "autocannon high-velocity bullet"

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -38,7 +38,7 @@
 	sundering = 1
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_IFF
 	damage_falloff = 1
-	accuracy = 90
+	accuracy = 80
 
 /datum/ammo/bullet/auto_cannon
 	name = "autocannon high-velocity bullet"

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -33,11 +33,11 @@
 
 /datum/ammo/bullet/minigun/ltaap
 	name = "chaingun bullet"
-	damage = 40
-	penetration = 15
+	damage = 30
+	penetration = 35
 	sundering = 1
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_IFF
-	damage_falloff = 1.5
+	damage_falloff = 1
 	accuracy = 90
 
 /datum/ammo/bullet/auto_cannon


### PR DESCRIPTION
## About The Pull Request

Buffs the tank's ap, sunder and falloff, also slightly buffs accuracy

## Why It's Good For The Game

Tank chaingun was never that good compared to LTB, even with IFF the gibcannon was way above it in performance, especially after the xeno buffs.
This should bring them close together in terms of performance.

## Changelog

:cl:
balance: Buffs the tank chaingun
/:cl:
