### PR TITLE
Warlock Crush Hits more of the Tank now

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -403,9 +403,9 @@
 				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE * 1.5, STAMINA, blocked = BOMB)
 				carbon_victim.adjust_stagger(5 SECONDS)
 				carbon_victim.add_slowdown(6)
-			else if(isvehicle(victim))
+			else if(isvehicle(victim) || ishitbox(victim))
 				var/obj/vehicle/veh_victim = victim
-				var/dam_mult = 1.5
+				var/dam_mult = 0.5
 				if(ismecha(veh_victim))
 					dam_mult = 5
 				veh_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -403,12 +403,12 @@
 				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE * 1.5, STAMINA, blocked = BOMB)
 				carbon_victim.adjust_stagger(5 SECONDS)
 				carbon_victim.add_slowdown(6)
-			else if(ismecha(victim) || ishitbox(victim))
-				var/obj/vehicle/veh_victim = victim
+			else if(isvehicle(victim) || ishitbox(victim))
+				var/obj/obj_victim = victim
 				var/dam_mult = 0.5
-				if(ismecha(veh_victim))
+				if(ismecha(obj_victim))
 					dam_mult = 5
-				veh_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)
+				obj_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)
 	stop_crush()
 
 /// stops channeling and unregisters all listeners, resetting the ability

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -403,7 +403,7 @@
 				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE * 1.5, STAMINA, blocked = BOMB)
 				carbon_victim.adjust_stagger(5 SECONDS)
 				carbon_victim.add_slowdown(6)
-			else if(isvehicle(victim) || ishitbox(victim))
+			else if(ismecha(victim) || ishitbox(victim))
 				var/obj/vehicle/veh_victim = victim
 				var/dam_mult = 0.5
 				if(ismecha(veh_victim))


### PR DESCRIPTION

## About The Pull Request
Title, crush will now hit the hitbox of tanks and apcs for 10 damage each.
## Why It's Good For The Game
Consistency and intuitiveness. Will slightly lower the damage of insta-crushes on the tank/apc.
## Changelog
:cl:
balance: Warlock's crush now hits more parts of tanks/APCs, dealing 10 damage per part hit.
/:cl:
