### PR TITLE
Forced campaign autobalance option

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -192,15 +192,19 @@
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, bioscan_interval)
 
 ///Checks team balance and tries to correct if possible
-/datum/game_mode/hvh/campaign/proc/autobalance_cycle()
+/datum/game_mode/hvh/campaign/proc/autobalance_cycle(forced = FALSE)
 	var/list/autobalance_faction_list = autobalance_check()
 	if(!autobalance_faction_list)
 		return
 
+	message_admins("Campaign autobalance run: [autobalance_faction_list ? "[autobalance_faction_list[1]] has [length(GLOB.alive_human_list_faction[autobalance_faction_list[1]])] players, \
+	autobalance_faction_list[2] has [length(GLOB.alive_human_list_faction[autobalance_faction_list[2]])] players." : "teams balanced."] \
+	Forced autobalance is [forced ? "ON." : "OFF."]")
+
 	for(var/mob/living/carbon/human/faction_member AS in GLOB.alive_human_list_faction[autobalance_faction_list[1]])
 		if(stat_list[faction_member.faction].faction_leader == faction_member)
 			continue
-		swap_player_team(faction_member, autobalance_faction_list[2])
+		swap_player_team(faction_member, autobalance_faction_list[2], forced)
 
 	addtimer(CALLBACK(src, PROC_REF(autobalance_bonus)), CAMPAIGN_AUTOBALANCE_DECISION_TIME + 1 SECONDS)
 
@@ -218,11 +222,13 @@
 		return list(factions[2], factions[1])
 
 ///Actually swaps the player to the other team, unless balance has been restored
-/datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction)
+/datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction, forced = FALSE)
 	if(!user.client)
 		return
-	if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), CAMPAIGN_AUTOBALANCE_DECISION_TIME, FALSE) != "Change team")
-		return
+	if(forced)
+		to_chat(user, "The teams are currently imbalanced, in favour of your team. Forced autobalance is on, so you may be swapped to the other team.")
+	else if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), CAMPAIGN_AUTOBALANCE_DECISION_TIME, FALSE) != "Change team")
+			return
 	var/list/current_ratio = autobalance_check(1)
 	if(!current_ratio || current_ratio[2] == user.faction)
 		to_chat(user, span_warning("Team balance already corrected."))

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -228,7 +228,7 @@
 	if(forced)
 		to_chat(user, "The teams are currently imbalanced, in favour of your team. Forced autobalance is on, so you may be swapped to the other team.")
 	else if(tgui_alert(user, "The teams are currently imbalanced, in favour of your team.", "Join the other team?", list("Stay on team", "Change team"), CAMPAIGN_AUTOBALANCE_DECISION_TIME, FALSE) != "Change team")
-			return
+		return
 	var/list/current_ratio = autobalance_check(1)
 	if(!current_ratio || current_ratio[2] == user.faction)
 		to_chat(user, span_warning("Team balance already corrected."))


### PR DESCRIPTION

## About The Pull Request
Adds an arg to let admins force autobalance through on campaign.
## Why It's Good For The Game
If the teams are really unbalanced, the game is unfun. If one team refused to autobalance to that point, admins can just force them so its not a one sided stomp.
## Changelog
:cl:
admin: You can force autobalance during Campaign
/:cl:
