### PR TITLE
Allows Marines to shoot through mech using IFF

### DIFF
--- a/code/modules/vehicles/mecha/combat/combat.dm
+++ b/code/modules/vehicles/mecha/combat/combat.dm
@@ -13,3 +13,10 @@
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = I
 			gun.projectiles_cache = gun.projectiles_cache_max
+
+/obj/vehicle/sealed/mecha/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	for(var/mob/living/carbon/human/crew AS in occupants)
+		if(crew.wear_id?.iff_signal & proj.iff_signal)
+			return FALSE
+	return ..()
+


### PR DESCRIPTION

## About The Pull Request
Allows marines to shoot through the mech if they have IFF, such as aim mode or smart gunners
## Why It's Good For The Game
Suggestion by Kuro, one of the complaints about mech was the inability to shoot through it at all as a marine. This helps to fix that by allowing IFF to shoot through the mech.
## Changelog
:cl:
balance: The mech can now be shot through using IFF (aim mode, smart guns, etc)
/:cl:
