### PR TITLE
Fixes Boiler Direct Hits

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -74,8 +74,7 @@
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/target_turf = get_turf(target_mob)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer)
+	drop_nade(get_turf(target_mob), proj.firer)
 	if(target_mob.stat == DEAD || !ishuman(target_mob))
 		return
 	var/mob/living/carbon/human/human_victim = target_mob

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -75,7 +75,7 @@
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/target_turf = get_turf(target_mob)
-	drop_nade(target_turf.density ? proj.loc : target_turf, proj.firer)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer)
 	if(target_mob.stat == DEAD || !ishuman(target_mob))
 		return
 	var/mob/living/carbon/human/human_victim = target_mob

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -74,7 +74,8 @@
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(target_mob), proj)
+	var/turf/target_turf = get_turf(target_mob)
+	drop_nade(target_turf.density ? proj.loc : target_turf, proj.firer)
 	if(target_mob.stat == DEAD || !ishuman(target_mob))
 		return
 	var/mob/living/carbon/human/human_victim = target_mob


### PR DESCRIPTION

## About The Pull Request
Fixes boiler direct hits on mobs reducing the smoke size.
## Why It's Good For The Game
#16056 unintentionally made direct hits with boiler globs reduce the size range down to one. This fixes a bug, and bugs are bad, therefor pr is good.
## Changelog
:cl:
fix: Boiler globs getting a direct hit should no longer reduce their smoke size
/:cl:
