### PR TITLE
Delete blue weeds

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -59,21 +59,18 @@
 //List of weed types
 GLOBAL_LIST_INIT(weed_type_list, typecacheof(list(
 		/obj/alien/weeds/node,
-		/obj/alien/weeds/node/sticky,
 		/obj/alien/weeds/node/resting,
 		)))
 
 //List of weeds with probability of spawning
 GLOBAL_LIST_INIT(weed_prob_list, list(
-		/obj/alien/weeds/node = 80,
-		/obj/alien/weeds/node/sticky = 5,
+		/obj/alien/weeds/node = 85,
 		/obj/alien/weeds/node/resting = 10,
 		))
 
 //List of weed images
 GLOBAL_LIST_INIT(weed_images_list, list(
 		WEED = image('icons/Xeno/actions.dmi', icon_state = WEED),
-		STICKY_WEED = image('icons/Xeno/actions.dmi', icon_state = STICKY_WEED),
 		RESTING_WEED = image('icons/Xeno/actions.dmi', icon_state = RESTING_WEED),
 		AUTOMATIC_WEEDING = image('icons/Xeno/actions.dmi', icon_state = AUTOMATIC_WEEDING)
 		))

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -40,6 +40,11 @@
 	)
 	AddElement(/datum/element/connect_loc, connections)
 
+	var/static/list/slow_down_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
+	)
+	AddElement(/datum/element/connect_loc, slow_down_connections)
+
 	if(!isnull(node))
 		if(!istype(node))
 			CRASH("Weed created with non-weed node. Type: [node.type]")
@@ -129,19 +134,8 @@
 	SIGNAL_HANDLER
 	footstep_overrides[FOOTSTEP_RESIN] = layer
 
-/obj/alien/weeds/sticky
-	name = "sticky weeds"
-	desc = "A layer of disgusting sticky slime, it feels like it's going to slow your movement down."
-	color_variant = STICKY_COLOR
-
-/obj/alien/weeds/sticky/Initialize(mapload, obj/alien/weeds/node/node)
-	. = ..()
-	var/static/list/connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
-	)
-	AddElement(/datum/element/connect_loc, connections)
-
-/obj/alien/weeds/sticky/proc/slow_down_crosser(datum/source, atom/movable/crosser)
+///Slows down crosser when they enter a tile with weeds on it
+/obj/alien/weeds/proc/slow_down_crosser(datum/source, atom/movable/crosser)
 	SIGNAL_HANDLER
 	if(crosser.throwing || crosser.buckled)
 		return
@@ -168,7 +162,6 @@
 		return
 
 	victim.next_move_slowdown += WEED_SLOWDOWN
-
 
 /obj/alien/weeds/resting
 	name = "resting weeds"
@@ -299,45 +292,6 @@
 	. = ..()
 	overlays.Cut()
 	overlays += node_icon + "[rand(0,5)]"
-
-//Sticky weed node
-/obj/alien/weeds/node/sticky
-	name = STICKY_WEED
-	desc = "A weird, pulsating blue node."
-	weed_type = /obj/alien/weeds/sticky
-	color_variant = STICKY_COLOR
-	node_icon = "weednodegreen"
-	ability_cost_mult = 3
-
-/obj/alien/weeds/node/sticky/Initialize(mapload, obj/alien/weeds/node/node)
-	. = ..()
-	var/static/list/connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
-	)
-	AddElement(/datum/element/connect_loc, connections)
-
-/obj/alien/weeds/node/sticky/proc/slow_down_crosser(datum/source, atom/movable/crosser)
-	SIGNAL_HANDLER
-	if(crosser.throwing || crosser.buckled)
-		return
-
-	if(isvehicle(crosser))
-		var/obj/vehicle/vehicle = crosser
-		vehicle.last_move_time += WEED_SLOWDOWN
-		return
-
-	if(!ishuman(crosser))
-		return
-
-	if(CHECK_MULTIPLE_BITFIELDS(crosser.pass_flags, HOVERING))
-		return
-
-	var/mob/living/carbon/human/victim = crosser
-
-	if(victim.lying_angle)
-		return
-
-	victim.next_move_slowdown += WEED_SLOWDOWN
 
 //Resting weed node
 /obj/alien/weeds/node/resting

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -40,11 +40,6 @@
 	)
 	AddElement(/datum/element/connect_loc, connections)
 
-	var/static/list/slow_down_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
-	)
-	AddElement(/datum/element/connect_loc, slow_down_connections)
-
 	if(!isnull(node))
 		if(!istype(node))
 			CRASH("Weed created with non-weed node. Type: [node.type]")
@@ -56,6 +51,11 @@
 		update_neighbours()
 	for(var/mob/living/living_mob in loc.contents)
 		SEND_SIGNAL(living_mob, COMSIG_LIVING_WEEDS_AT_LOC_CREATED, src)
+
+	var/static/list/slow_down_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
+	)
+	AddElement(/datum/element/connect_loc, slow_down_connections)
 
 /obj/alien/weeds/Destroy()
 	parent_node = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes sticky weeds.
All weeds now have the slowing effect
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66163761/6780a128-bdf3-43ca-a8cf-a6edba536469)
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/66163761/b9aaa775-eb9f-44de-b618-6f631dc29c9c)

TLDR Blue weeds are unecessary
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: All xeno weeds slow down marines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
