### PR TITLE
Submerge fix

### DIFF
--- a/code/datums/elements/submerge.dm
+++ b/code/datums/elements/submerge.dm
@@ -25,7 +25,7 @@
 	SIGNAL_HANDLER
 	if(HAS_TRAIT(mover, TRAIT_NOSUBMERGE))
 		return
-	if(!source.get_submerge_height() || !source.get_submerge_depth())
+	if(!source.get_submerge_height() && !source.get_submerge_depth())
 		return
 	mover.set_submerge_level(mover.loc, old_loc)
 


### PR DESCRIPTION

## About The Pull Request
logic typo meant grass and such wasn't submerging in cases where it should.
:cl:
fix: fixed an issue with grass or flames not submerging correctly in some cases
/:cl:
