### PR TITLE
Changes some bad/inaccurate var names in xeno abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1456,7 +1456,7 @@
 					addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(behemoth_area_attack), xeno_owner, spread_turfs, enhanced), wind_up_duration)
 					continue
 				if(isvehicle(affected_atom) || ishitbox(affected_atom))
-					var/obj/vehicle/obj_victim = affected_atom
+					var/obj/obj_victim = affected_atom
 					var/damage_add = 0
 					if(ismecha(obj_victim))
 						damage_add = 9.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1456,11 +1456,11 @@
 					addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(behemoth_area_attack), xeno_owner, spread_turfs, enhanced), wind_up_duration)
 					continue
 				if(isvehicle(affected_atom) || ishitbox(affected_atom))
-					var/obj/vehicle/veh_victim = affected_atom
+					var/obj/vehicle/obj_victim = affected_atom
 					var/damage_add = 0
-					if(ismecha(veh_victim))
+					if(ismecha(obj_victim))
 						damage_add = 9.5
-					veh_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER + damage_add), MELEE)
+					obj_victim.take_damage(attack_damage * (AREA_ATTACK_DAMAGE_VEHICLE_MODIFIER + damage_add), MELEE)
 					continue
 				if(istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
 					var/obj/structure/reagent_dispensers/fueltank/affected_tank = affected_atom

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -269,11 +269,11 @@
 			carbon_victim.apply_effect(1 SECONDS, WEAKEN)
 			to_chat(carbon_victim, "You are smashed to the ground!")
 		else if(isvehicle(victim) || ishitbox(victim))
-			var/obj/vehicle/veh_victim = victim
-			var/armored_vehicle_penalty = 0
+			var/obj/obj_victim = victim
+			var/hitbox_penalty = 0
 			if(ishitbox(victim))
-				armored_vehicle_penalty = 20
-			veh_victim.take_damage((SHATTERING_ROAR_DAMAGE - armored_vehicle_penalty) * 5 * severity, BRUTE, MELEE)
+				hitbox_penalty = 20
+			obj_victim.take_damage((SHATTERING_ROAR_DAMAGE - armored_vehicle_penalty) * 5 * severity, BRUTE, MELEE)
 		else if(istype(victim, /obj/structure/window))
 			var/obj/structure/window/window_victim = victim
 			if(window_victim.damageable)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -273,7 +273,7 @@
 			var/hitbox_penalty = 0
 			if(ishitbox(victim))
 				hitbox_penalty = 20
-			obj_victim.take_damage((SHATTERING_ROAR_DAMAGE - armored_vehicle_penalty) * 5 * severity, BRUTE, MELEE)
+			obj_victim.take_damage((SHATTERING_ROAR_DAMAGE - hitbox_penalty) * 5 * severity, BRUTE, MELEE)
 		else if(istype(victim, /obj/structure/window))
 			var/obj/structure/window/window_victim = victim
 			if(window_victim.damageable)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -309,10 +309,10 @@
 			return precrush2signal(crushed_obj.post_crush_act(charger, src))
 		playsound(crushed_obj.loc, SFX_PUNCH, 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
-		var/vehicle_damage_mult = 1
+		var/obj_damage_mult = 1
 		if(isarmoredvehicle(crushed) || ishitbox(crushed))
-			vehicle_damage_mult = 5
-		crushed_obj.take_damage(precrush * vehicle_damage_mult, BRUTE, MELEE)
+			obj_damage_mult = 5
+		crushed_obj.take_damage(precrush * obj_damage_mult, BRUTE, MELEE)
 		if(QDELETED(crushed_obj))
 			charger.visible_message(span_danger("[charger] crushes [preserved_name]!"),
 			span_xenodanger("We crush [preserved_name]!"))


### PR DESCRIPTION

## About The Pull Request
Title, changes a var name from vehicle_damage_mult to obj_damage_mult
## Why It's Good For The Game
Less confusing
## Changelog
:cl:
code: Changed vehicle_damage_mult in crusher charge ability to obj_damage_mult
/:cl:
