### PR TITLE
Larval Hugger rework

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -465,6 +465,10 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.larva_from_cocoon] larvas came from cocoons."
 	if(GLOB.round_statistics.larva_from_marine_spawning)
 		parts += "[GLOB.round_statistics.larva_from_marine_spawning] larvas came from marine spawning."
+	if(GLOB.round_statistics.larva_from_larvapsy)
+		parts += "[GLOB.round_statistics.larva_from_larvapsy] larvas came from larvas sapping psy energy."
+	if(GLOB.round_statistics.psypoints_from_larvapsy)
+		parts += "[GLOB.round_statistics.psypoints_from_larvapsy] psypoints came from larvas sapping psy energy"
 	if(GLOB.round_statistics.larva_from_siloing_body)
 		parts += "[GLOB.round_statistics.larva_from_siloing_body] larvas came from siloing bodies."
 	if(GLOB.round_statistics.psy_crushes)

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -94,6 +94,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/recycle_points_denied = 0
 	var/huggers_created = 0
 	var/impregnations = 0
+	var/psylarva_larva = 0
+	var/psylarva_psy = 0
 
 	//Close air support
 	var/cas_cannon_shots = 0
@@ -250,7 +252,10 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 		support_stats += "Gave birth to [huggers_created] hugger\s."
 	if(impregnations)
 		support_stats += "Impregnated [impregnations] host\s."
-
+	if(psylarva_larva)
+		support_stats += "Generated [psylarva_larva] larvas using larval huggers"
+	if(psylarva_psy)
+		support_stats += "Generated [psylarva_psy] psypoints using larval huggers"
 	if(LAZYLEN(support_stats))
 		stats += "<hr>"
 		stats += support_stats

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -92,6 +92,8 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/larva_from_silo = 0
 	var/larva_from_cocoon = 0
 	var/larva_from_psydrain = 0
+	var/larva_from_larvapsy = 0
+	var/psypoints_from_larvapsy = 0
 	var/larva_from_siloing_body = 0
 	var/req_items_produced = list()
 	var/psy_crushes = 0

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -16,7 +16,7 @@
 	var/boost_timer = 0
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/admin = FALSE
-
+	var/mob/living/carbon/xenomorph/source
 
 /obj/item/alien_embryo/Initialize(mapload)
 	. = ..()
@@ -145,6 +145,12 @@
 		xeno_job.add_job_points(points)
 		SSpoints.add_strategic_psy_points(hivenumber, psy_points)
 		SSpoints.add_tactical_psy_points(hivenumber, psy_points * 0.25) // tactical points are always reduced by a quarter.
+		if(source?.client)
+			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[source.ckey]
+			personal_statistics.psylarva_larva+= points / xeno_job.job_points_needed
+			personal_statistics.psylarva_psy += psy_points
+		GLOB.round_statistics.larva_from_larvapsy += points / xeno_job.job_points_needed
+		GLOB.round_statistics.psypoints_from_larvapsy += psy_points
 
 
 //We look for a candidate. If found, we spawn the candidate as a larva.

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -141,7 +141,8 @@
 			points = 0.0192
 			psy_points = 0.8
 	if(points > 0 && hivenumber == XENO_HIVE_NORMAL) // We check if points are greater than 0 and if your hive is normal in order to prevent valhalla embryos from generating points.
-		SSjob.GetJobType(/datum/job/xenomorph).add_job_points(points)
+		var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+		xeno_job.add_job_points(points)
 		SSpoints.add_strategic_psy_points(hivenumber, psy_points)
 		SSpoints.add_tactical_psy_points(hivenumber, psy_points * 0.25) // tactical points are always reduced by a quarter.
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -71,7 +71,7 @@
 
 /obj/item/alien_embryo/proc/process_growth()
 
-	if(stage <= 4)
+	if(stage <= 5)
 		counter += 2.5 //Free burst time in ~7/8 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/consumable/larvajelly))

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -16,7 +16,6 @@
 	var/boost_timer = 0
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/admin = FALSE
-	var/datum/job/xeno_job
 
 
 /obj/item/alien_embryo/Initialize(mapload)
@@ -30,7 +29,6 @@
 	if(iscarbon(affected_mob))
 		var/mob/living/carbon/C = affected_mob
 		C.med_hud_set_status()
-	xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 
 
 /obj/item/alien_embryo/Destroy()
@@ -143,7 +141,7 @@
 			points = 0.0192
 			psy_points = 0.8
 	if(points > 0 && hivenumber == XENO_HIVE_NORMAL) // We check if points are greater than 0 and if your hive is normal in order to prevent valhalla embryos from generating points.
-		xeno_job.add_job_points(points)
+		SSjob.GetJobType(/datum/job/xenomorph).add_job_points(points)
 		SSpoints.add_strategic_psy_points(hivenumber, psy_points)
 		SSpoints.add_tactical_psy_points(hivenumber, psy_points * 0.25) // tactical points are always reduced by a quarter.
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -103,14 +103,14 @@
 
 	switch(stage)
 		if(1)
-			points = 0.0003
-			psy_points = 0.0125
+			points = 0.0006
+			psy_points = 0.025
 
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts a little bit", "Your stomach hurts")]."))
-			points = 0.0006
-			psy_points = 0.025
+			points = 0.0012
+			psy_points = 0.05
 		if(3)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your throat feels sore", "Mucous runs down the back of your throat")]."))
@@ -120,28 +120,28 @@
 					affected_mob.take_limb_damage(1)
 			else if(prob(2))
 				affected_mob.emote("[pick("sneeze", "cough")]")
-			points = 0.0012
-			psy_points = 0.05
+			points = 0.0024
+			psy_points = 0.01
 		if(4)
 			if(prob(1))
 				affected_mob.visible_message(span_danger("\The [affected_mob] starts shaking uncontrollably!"), \
 				span_danger("You start shaking uncontrollably!"))
 				affected_mob.jitter(50)
-			points = 0.0024
-			psy_points = 0.1
+			points = 0.0048
+			psy_points = 0.2
 		if(5)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
 				affected_mob.jitter(105)
 				affected_mob.take_limb_damage(1)
-			points = 0.0048
-			psy_points = 0.2
+			points = 0.0096
+			psy_points = 0.4
 		if(6)
 			if(prob(0.5))
 				affected_mob.Unconscious(4 SECONDS)
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
-			points = 0.0096
-			psy_points = 0.4
+			points = 0.0192
+			psy_points = 0.8
 	if(points > 0 && hivenumber == XENO_HIVE_NORMAL) // We check if points are greater than 0 and if your hive is normal in order to prevent valhalla embryos from generating points.
 		xeno_job.add_job_points(points)
 		SSpoints.add_strategic_psy_points(hivenumber, psy_points)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -126,16 +126,20 @@
 			if(prob(1))
 				affected_mob.visible_message(span_danger("\The [affected_mob] starts shaking uncontrollably!"), \
 				span_danger("You start shaking uncontrollably!"))
-				affected_mob.jitter(105)
-				affected_mob.take_limb_damage(1)
-			if(prob(2))
-				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
+				affected_mob.jitter(50)
 			points = 0.0024
 			psy_points = 0.1
 		if(5)
+			if(prob(2))
+				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
+				affected_mob.jitter(105)
+				affected_mob.take_limb_damage(1)
 			points = 0.0048
 			psy_points = 0.2
 		if(6)
+			if(prob(0.5))
+				affected_mob.Unconscious(4 SECONDS)
+				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
 			points = 0.0096
 			psy_points = 0.4
 	if(points > 0 && hivenumber == XENO_HIVE_NORMAL) // We check if points are greater than 0 and if your hive is normal in order to prevent valhalla embryos from generating points.

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -16,6 +16,7 @@
 	var/boost_timer = 0
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/admin = FALSE
+	///The source of the facehugger's xeno that spawned/threw/dropped the hugger.
 	var/mob/living/carbon/xenomorph/source
 
 /obj/item/alien_embryo/Initialize(mapload)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -124,12 +124,10 @@
 			psy_points = 0.05
 		if(4)
 			if(prob(1))
-				if(!affected_mob.IsUnconscious())
-					affected_mob.visible_message(span_danger("\The [affected_mob] starts shaking uncontrollably!"), \
-												span_danger("You start shaking uncontrollably!"))
-					affected_mob.Unconscious(20 SECONDS)
-					affected_mob.jitter(105)
-					affected_mob.take_limb_damage(1)
+				affected_mob.visible_message(span_danger("\The [affected_mob] starts shaking uncontrollably!"), \
+				span_danger("You start shaking uncontrollably!"))
+				affected_mob.jitter(105)
+				affected_mob.take_limb_damage(1)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
 			points = 0.0024

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -103,13 +103,13 @@
 
 	switch(stage)
 		if(1)
-			points = 0.0001
+			points = 0.0003
 			psy_points = 0.0125
 
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts a little bit", "Your stomach hurts")]."))
-			points = 0.0002
+			points = 0.0006
 			psy_points = 0.025
 		if(3)
 			if(prob(2))
@@ -120,7 +120,7 @@
 					affected_mob.take_limb_damage(1)
 			else if(prob(2))
 				affected_mob.emote("[pick("sneeze", "cough")]")
-			points = 0.0004
+			points = 0.0012
 			psy_points = 0.05
 		if(4)
 			if(prob(1))
@@ -132,13 +132,13 @@
 					affected_mob.take_limb_damage(1)
 			if(prob(2))
 				to_chat(affected_mob, span_warning("[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")]."))
-			points = 0.0008
+			points = 0.0024
 			psy_points = 0.1
 		if(5)
-			points = 0.0016
+			points = 0.0048
 			psy_points = 0.2
 		if(6)
-			points = 0.0032
+			points = 0.0096
 			psy_points = 0.4
 	if(points > 0 && hivenumber == XENO_HIVE_NORMAL) // We check if points are greater than 0 and if your hive is normal in order to prevent valhalla embryos from generating points.
 		xeno_job.add_job_points(points)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -576,6 +576,7 @@
 		if(!(locate(/obj/item/alien_embryo) in target))
 			var/obj/item/alien_embryo/embryo = new(target)
 			embryo.hivenumber = hivenumber
+			embryo.source = source
 			GLOB.round_statistics.now_pregnant++
 			SSblackbox.record_feedback("tally", "round_statistics", 1, "now_pregnant")
 			if(source?.client)


### PR DESCRIPTION
## About The Pull Request
Completely reworks how larval huggers work, removing chestbursting entirely and replacing it with passive larva and psy point generation. At later embryo levels marines will start to ocasionally take damage and fall unconscious.

## Why It's Good For The Game

I spoke to a lot of people about my earlier PR for huggers and was told that Larval huggers were "basically leftover from capture times". I spoke to people and people seemed to agree that replacing chest bursters with a new passive system would be for the better for both marines and xenomorphs.

Benefits for marines:
You no longer need to instantly medevac if you get facehugged as chestbursters are not a thing.

Benefits for Xenomorphs:
Reliable and consistent larva generation if you are able to get marines with a larva in them to later stages.
Carriers should have more targets for their call of the younger as marines are more likely to stay on the field for longer.
## Changelog
:cl:
add: New passive psy/embryo point generation
del: No more chestbursters
/:cl:
