### PR TITLE
Reduce the amount of flame particles spawned from fire

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -488,7 +488,7 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	width = 100
 	height = 100
 	count = 1000
-	spawning = 8
+	spawning = 2
 	lifespan = 0.7 SECONDS
 	fade = 1 SECONDS
 	grow = -0.01


### PR DESCRIPTION
## About The Pull Request
Title, reduces the particles spawned from 8 to 2

https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/58afd7b3-b17a-4e61-b935-daef2828f64e
## Why It's Good For The Game
8 is an incredibly high number of particles considering how abundant fire is in the game. For reference, a standard flame grenade will create fire particles equivalent to 26 stacks of the melting debuff, which has particles similar to fire stats wise. This should hopefully fix issues like #14167, where users are lagging due to a massive amount of particles being generated.
## Changelog
:cl:
fix: Reduced the amount of particles generated from fire from 8 to 2. This should hopefully fix large amounts of fire tiles causing lag
/:cl:
