### PR TITLE
Tank fixes for mines and sentry

### DIFF
--- a/code/__HELPERS/ai.dm
+++ b/code/__HELPERS/ai.dm
@@ -54,6 +54,24 @@
 			continue
 		. += nearby_mech
 
+///Returns a list of vehicles via get_dist and same z level method, very cheap compared to range()
+/proc/cheap_get_tanks_near(atom/movable/source, distance)
+	. = list()
+	var/turf/source_turf = get_turf(source)
+	if(!source_turf)
+		return
+	for(var/obj/vehicle/sealed/armored/nearby_tank AS in GLOB.tank_list)
+		if(isnull(nearby_tank))
+			continue
+		if(source_turf.z != nearby_tank.z)
+			continue
+		var/bound_max = 1
+		if(nearby_tank.hitbox)
+			bound_max = max(nearby_tank.hitbox.bound_height, nearby_tank.hitbox.bound_width) / 32
+		if(get_dist(source_turf, nearby_tank) > distance + bound_max - 1)
+			continue
+		. += nearby_tank
+
 ///Returns the nearest target that has the right target flag
 /proc/get_nearest_target(atom/source, distance, target_flags, attacker_faction, attacker_hive)
 	if(!source)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -140,11 +140,16 @@ Stepping directly on the mine will also blow it up
 	var/mob/living/living_victim
 	if((target_mode & MINE_LIVING_ONLY) && isliving(victim))
 		living_victim = victim
-	else if((target_mode & MINE_VEHICLE_ONLY) && isvehicle(victim))
-		var/obj/vehicle/vehicle_victim = victim
-		if(!length(vehicle_victim.occupants))
-			return FALSE
-		living_victim = vehicle_victim.occupants[1]
+	else if(target_mode & MINE_VEHICLE_ONLY)
+		if(ishitbox(victim))
+			var/obj/hitbox/hitbox = victim
+			victim = hitbox.root
+		if(isvehicle(victim))
+			var/obj/vehicle/vehicle_victim = victim
+			var/list/driver_list = vehicle_victim.return_drivers()
+			if(!length(driver_list))
+				return FALSE
+			living_victim = driver_list[1]
 
 	if(!living_victim)
 		return FALSE

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -20,6 +20,8 @@
 	ignored_terrains = list(
 		/obj/machinery/deployable/mounted,
 		/obj/machinery/miner,
+		/obj/hitbox,
+		/obj/vehicle/sealed/armored/multitile,
 	)
 
 	turret_flags = TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
@@ -109,6 +111,8 @@
 	ignored_terrains = list(
 		/obj/machinery/deployable/mounted,
 		/obj/machinery/miner,
+		/obj/hitbox,
+		/obj/vehicle/sealed/armored/multitile,
 	)
 
 	gun_features_flags = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_ENERGY|GUN_SMOKE_PARTICLES

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -429,13 +429,13 @@
 /obj/machinery/deployable/mounted/sentry/proc/sentry_start_fire()
 	var/obj/item/weapon/gun/gun = get_internal_item()
 	var/atom/target = get_target()
-	sentry_alert(SENTRY_ALERT_HOSTILE, target)
-	update_icon()
 	if(!target)
 		gun.stop_fire()
 		firing = FALSE
 		update_minimap_icon()
 		return
+	sentry_alert(SENTRY_ALERT_HOSTILE, target)
+	update_icon()
 	if(target != gun.target)
 		gun.stop_fire()
 		firing = FALSE
@@ -482,14 +482,19 @@
 			return FALSE
 
 		for(var/atom/movable/AM AS in T)
+			if(AM == target)
+				continue
 			if(AM.opacity)
 				return FALSE
 			if(!AM.density)
 				continue
 			if(ismob(AM))
 				continue
-			if(!(AM.allow_pass_flags & (gun.ammo_datum_type::ammo_behavior_flags & AMMO_ENERGY ? (PASS_GLASS|PASS_PROJECTILE) : PASS_PROJECTILE) && !(AM.type in ignored_terrains))) //todo:accurately populate ignored_terrains
-				return FALSE
+			if(AM.type in ignored_terrains) //todo:accurately populate ignored_terrains
+				continue
+			if(AM.allow_pass_flags & (gun.ammo_datum_type::ammo_behavior_flags & AMMO_ENERGY ? (PASS_GLASS|PASS_PROJECTILE) : PASS_PROJECTILE))
+				continue
+			return FALSE
 
 	return TRUE
 

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -391,12 +391,21 @@
 			continue
 		potential_targets += nearby_xeno
 	for(var/obj/vehicle/sealed/mecha/nearby_mech AS in cheap_get_mechs_near(src, range))
-		if(!length(nearby_mech.occupants))
+		var/list/driver_list = nearby_mech.return_drivers()
+		if(!length(driver_list))
 			continue
-		var/mob/living/carbon/human/human_occupant = nearby_mech.occupants[1]
-		if(!istype(human_occupant) || (human_occupant.wear_id?.iff_signal & iff_signal))
+		var/mob/living/carbon/human/human_occupant = driver_list[1]
+		if(human_occupant.wear_id?.iff_signal & iff_signal)
 			continue
 		potential_targets += nearby_mech
+	for(var/obj/vehicle/sealed/armored/nearby_tank AS in cheap_get_tanks_near(src, range))
+		var/list/driver_list = nearby_tank.return_drivers()
+		if(!length(driver_list))
+			continue
+		var/mob/living/carbon/human/human_occupant = driver_list[1]
+		if(human_occupant.wear_id?.iff_signal & iff_signal)
+			continue
+		potential_targets += nearby_tank
 	return length(potential_targets)
 
 ///Checks the range and the path of the target currently being shot at to see if it is eligable for being shot at again. If not it will stop the firing.


### PR DESCRIPTION

## About The Pull Request
Mines and sentries will now target tanks as applicable.
## Why It's Good For The Game
Needed for HvH.
## Changelog
:cl:
fix: Mines and sentries will target hostile tanks
/:cl:
