### PR TITLE
Adds vehicle modules to valhalla

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1557,6 +1557,10 @@
 			/obj/item/ammo_magazine/tank/ltb_cannon = -1,
 			/obj/item/ammo_magazine/tank/ltaap_chaingun = -1,
 			/obj/item/ammo_magazine/tank/secondary_cupola = -1,
+			/obj/item/tank_module/overdrive = -1,
+			/obj/item/tank_module/ability/zoom = -1,
+			/obj/item/tank_module/ability/smoke_launcher = -1,
+			/obj/item/tank_module/interior/medical = -1,
 		),
 	)
 


### PR DESCRIPTION

## About The Pull Request
Adds vehicle modules to valhalla. Does not add the passenger module and clone module. Passenger due to not actually doing anything, and clone cause clone vats were not designed with being in Valhalla.
## Why It's Good For The Game
Let's people test vehicle modules in valhalla.
## Changelog
:cl:
add: Added the overdrive, zoom, smoke launcher, and medical vehicle modules to the req vendor.
/:cl:
