### PR TITLE
Reduces boiler damage against APCs/Tanks

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -221,7 +221,7 @@
 /obj/hitbox/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
-		take_damage((10 * S.strength) / 5, BURN, ACID)
+		take_damage((10 * S.strength) * 0.2 , BURN, ACID)
 
 ///Returns the turf where primary weapon projectiles should source from
 /obj/hitbox/proc/get_projectile_loc(obj/item/armored_weapon/weapon)

--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -221,7 +221,7 @@
 /obj/hitbox/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
-		take_damage(10 * S.strength, BURN, ACID)
+		take_damage((10 * S.strength) / 5, BURN, ACID)
 
 ///Returns the turf where primary weapon projectiles should source from
 /obj/hitbox/proc/get_projectile_loc(obj/item/armored_weapon/weapon)


### PR DESCRIPTION

## About The Pull Request
Title, divides the damage that vehicles take by 5
## Why It's Good For The Game
Currently tanks/apcs are taking an absurd amount of damage trying to move out of boiler smoke. This should make boiler smoke less oppressive while still keeping it as a threat to stay away from. Standing still in the boiler smoke will do about 175 damage now.
## Changelog
:cl:
balance: Divided the damage dealt from boiler gas to tanks/apcs by 5
/:cl:
