### PR TITLE
Fixes mashing confirm on the dropship selector bugging the Tad out

### DIFF
--- a/code/game/objects/machinery/computer/dropship_picker.dm
+++ b/code/game/objects/machinery/computer/dropship_picker.dm
@@ -81,11 +81,11 @@
 		if("confirm")
 			if(!current_template_ref)
 				return FALSE
+			dropship_selected = TRUE
 			var/datum/map_template/shuttle/template = locate(current_template_ref) in SSmapping.minidropship_templates
 			var/obj/docking_port/mobile/shuttle = SSshuttle.action_load(template)
 			SSshuttle.moveShuttleQuickToDock(template.shuttle_id, dock_id)
 			shuttle.setTimer(0)
-			dropship_selected = TRUE
 			balloon_alert(usr, "shuttle selected, locking")
 			ui.close()
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
No it doesn't fix the lag issue, but at least mashing during the lag period won't cause the Tad to bug out. Fix shamelessly stolen from discord.

## Why It's Good For The Game
Slightly less Tad borking

## Changelog
:cl:
fix: Mashing the confirm button on the dropship selector won't bug the Tad out
/:cl:
