### PR TITLE
Removes the ability to attack with weapons while prone

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -5,7 +5,7 @@
 		return melee_attack_chain_alternate(user, target, params)
 	if(tool_behaviour && tool_attack_chain(user, target))
 		return
-	if(user.lying_angle == 90 || user.lying_angle == 270)
+	if(user.lying_angle)
 		user.balloon_alert(user, "Can't while prone!")
 		return
 	// Return TRUE in attackby() to prevent afterattack() effects (when safely moving items for example)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -5,6 +5,9 @@
 		return melee_attack_chain_alternate(user, target, params)
 	if(tool_behaviour && tool_attack_chain(user, target))
 		return
+	if(user.lying_angle == 90 || user.lying_angle == 270)
+		user.balloon_alert(user, "Can't while prone!")
+		return
 	// Return TRUE in attackby() to prevent afterattack() effects (when safely moving items for example)
 	var/resolved = target.attackby(src, user, params)
 	if(resolved || QDELETED(target) || QDELETED(src))

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -17,4 +17,8 @@
 /obj/item/weapon/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)
 		return
+	var/mob/living/attacker = user
+	if(isliving(attacker) && attacker.resting)
+		user.balloon_alert(user, "Can't while prone!")
+		return
 	return ..()

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -17,7 +17,7 @@
 /obj/item/weapon/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)
 		return
-	if(user.lying_angle)
+	if(user.lying_angle == 90 || user.lying_angle == 270)
 		user.balloon_alert(user, "Can't while prone!")
 		return
 	return ..()

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -17,7 +17,4 @@
 /obj/item/weapon/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)
 		return
-	if(user.lying_angle == 90 || user.lying_angle == 270)
-		user.balloon_alert(user, "Can't while prone!")
-		return
 	return ..()

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -17,8 +17,7 @@
 /obj/item/weapon/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)
 		return
-	var/mob/living/attacker = user
-	if(isliving(attacker) && attacker.resting)
+	if(user.lying_angle)
 		user.balloon_alert(user, "Can't while prone!")
 		return
 	return ..()


### PR DESCRIPTION

## About The Pull Request
Title, removes the ability to attack with weapons if you are prone. This should include things like getting stunned from a pounce, or simply lying down.
## Why It's Good For The Game
Melee weapons being able to attack while prone has been a long standing bug, and I'm gonna finally fix it.
## Changelog
:cl:
fix: Can no longer attack with melee weapons while lying down.
/:cl:
