### PR TITLE
Buffs teleporter

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -1,4 +1,4 @@
-#define TELEPORTING_COST 250
+#define TELEPORTING_COST 100
 /obj/machinery/deployable/teleporter
 	density = FALSE
 	max_integrity = 200

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1531,7 +1531,7 @@ ENGINEERING
 /datum/supply_packs/engineering/teleporter
 	name = "Teleporter pads"
 	contains = list(/obj/effect/teleporter_linker)
-	cost = 500
+	cost = 300
 
 /*******************************************************************************
 SUPPLIES


### PR DESCRIPTION

## About The Pull Request
Reduces teleporter price from 500 to 300, reduces teleport cost from 250 charge to 100 (40 teleports to 100).
## Why It's Good For The Game
Teleporter is an underutilized item due to its high cost and the inconvenience with having to power both of them or carry replacement cells for both ends. 

This PR aims to make it more affordable so that it can be used more often like it used to be before being sent to req hell, and to make it less of a headache to power when marines are actually using it.
## Changelog
:cl:
balance: Teleporter is now only 300 req points.
balance: Teleporter now uses 2.5x less charge.
/:cl:
