### PR TITLE
Adds instructions for how to use hyposprays

### DIFF
--- a/code/modules/reagents/reagent_containers/autoinjectors.dm
+++ b/code/modules/reagents/reagent_containers/autoinjectors.dm
@@ -28,6 +28,8 @@
 	else
 		. += span_notice("It is spent.")
 
+	. += span_notice("Use to inject into yourself. Unique Action to configure injection settings.")
+
 /obj/item/reagent_containers/hypospray/autoinjector/fillable
 	desc = "An autoinjector loaded with... something, consult the doctor who gave this to you."
 	amount_per_transfer_from_this = 30

--- a/code/modules/reagents/reagent_containers/autoinjectors.dm
+++ b/code/modules/reagents/reagent_containers/autoinjectors.dm
@@ -28,7 +28,7 @@
 	else
 		. += span_notice("It is spent.")
 
-	. += span_notice("Use to inject into yourself. Unique Action to configure injection settings.")
+	. += span_notice("Use to inject into yourself. Unique Action to configure injection amount.")
 
 /obj/item/reagent_containers/hypospray/autoinjector/fillable
 	desc = "An autoinjector loaded with... something, consult the doctor who gave this to you."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -349,6 +349,7 @@
 	if(get_dist(user,src) > 2)
 		. += span_warning("You're too far away to see [src]'s reagent display!")
 		return
+	. += span_notice("Use to inject into yourself. Unique Action to open the hypospray menu.")
 
 	. += display_reagents(user)
 


### PR DESCRIPTION

## About The Pull Request

Injectors/hyposprays now display keybinds to use them when examined.
## Why It's Good For The Game

I changed how injectors work so Xander suggested this should probably be reflected in the description. Clarity good.
## Changelog
:cl:
add: Injectors/hyposprays now display instructions for using them in their description
/:cl:
