### PR TITLE
Halves alkysines brain damage healing

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -596,7 +596,7 @@
 
 /datum/reagent/medicine/alkysine/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_LIGHT
-	L.adjustBrainLoss(-1.5*effect_str)
+	L.adjustBrainLoss(-0.75*effect_str)
 	L.adjust_ear_damage(-2 * effect_str, -2 * effect_str)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Reduces alkysines brain damage healing from 1.5/tick to 0.75/tick

## Why It's Good For The Game

Head is almost never targeted because of how easy it is to fix brain/eye damage, as well as helmets always having heavy armor stats. Reducing the healrate of alkysine still allows marines to recover quickly and easily from brain damage, but increases the window where marines are screwed over by brain damage

## Changelog

:cl: Joe13413
balance: Halved alkysine brain damage healing
/:cl:
