### PR TITLE
Fixes tank aiming at darkness trying to shoot across zlevels

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -215,11 +215,11 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 ///Helper proc that processes a clicked target, if the target is not black tiles, it will not change it. If they are it will return the turf of the black tiles. It will return null if the object is a screen object other than black tiles.
 /proc/get_turf_on_clickcatcher(atom/target, mob/user, params)
 	var/list/modifiers = params2list(params)
-	var/loctoget = user.client?.eye ? user.client.eye : user
 	if(!istype(target, /atom/movable/screen))
 		return target
 	if(!istype(target, /atom/movable/screen/click_catcher))
 		return null
+	var/loctoget = user.client?.eye ? user.client.eye : user
 	return params2turf(modifiers["screen-loc"], get_turf(loctoget), user.client)
 
 //----------------------------------------------------------

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -215,11 +215,12 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 ///Helper proc that processes a clicked target, if the target is not black tiles, it will not change it. If they are it will return the turf of the black tiles. It will return null if the object is a screen object other than black tiles.
 /proc/get_turf_on_clickcatcher(atom/target, mob/user, params)
 	var/list/modifiers = params2list(params)
+	var/loctoget = user.client?.eye ? user.client.eye : user
 	if(!istype(target, /atom/movable/screen))
 		return target
 	if(!istype(target, /atom/movable/screen/click_catcher))
 		return null
-	return params2turf(modifiers["screen-loc"], get_turf(user), user.client)
+	return params2turf(modifiers["screen-loc"], get_turf(loctoget), user.client)
 
 //----------------------------------------------------------
 					//				   \\

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -614,7 +614,7 @@
 	SIGNAL_HANDLER
 	modifiers = params2list(modifiers)
 	if(isnull(location) && target.plane == CLICKCATCHER_PLANE) //Checks if the intended target is in deep darkness and adjusts target based on params.
-		target = params2turf(modifiers["screen-loc"], get_turf(user), user.client)
+		target = params2turf(modifiers["screen-loc"], get_turf(src), user.client)
 		modifiers["icon-x"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-x"])))
 		modifiers["icon-y"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-y"])))
 	if(modifiers[SHIFT_CLICK]) //Allows things to be examined.


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
fix: Fixed tank aiming at darkness trying to shoot across zlevels: aiming at darkness now shoots at your actual target
/:cl:
