### PR TITLE
Probably fixes secondary tank weapon overlays duplicating

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -158,7 +158,7 @@
 	. = ..()
 	playsound(get_turf(src), 'sound/weapons/guns/fire/tank_cannon1.ogg', 100, TRUE)
 
-/obj/vehicle/sealed/armored/update_icon()
+/obj/vehicle/sealed/armored/update_icon_state()
 	. = ..()
 	if(!damage_overlay)
 		return

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -188,9 +188,8 @@
 			chassis.swivel_turret(current_target)
 			return AUTOFIRE_CONTINUE
 	else if(chassis.turret_overlay)
-		chassis.turret_overlay.cut_overlay(chassis.turret_overlay.secondary_overlay)
 		chassis.turret_overlay.secondary_overlay.dir = get_cardinal_dir(chassis, current_target)
-		chassis.turret_overlay.add_overlay(chassis.turret_overlay.secondary_overlay)
+		chassis.turret_overlay.update_appearance(UPDATE_OVERLAYS)
 	else
 		chassis.cut_overlay(chassis.secondary_weapon_overlay)
 		chassis.secondary_weapon_overlay.dir = get_cardinal_dir(chassis, current_target)


### PR DESCRIPTION

## About The Pull Request

looks like duplicate overlay handling was the issue from a previous ver, i just removed that and it still works fine so let's see how this fares

## Why It's Good For The Game
## Changelog
:cl:
fix: Probably fixed secondary tank weapon overlays duplicating
/:cl:
