### PR TITLE
Lighting error fix

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -102,16 +102,3 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized
 	return ..()
-
-///sets up light objects for a particular z level. Used for late loading
-/datum/controller/subsystem/lighting/proc/create_lighting_objects_for_z(z_level)
-	for(var/area/new_area in world)
-		if(new_area.z != z_level)
-			continue
-		if(!new_area.static_lighting)
-			continue
-
-		for(var/turf/T in new_area)
-			new/datum/static_lighting_object(T)
-			CHECK_TICK
-		CHECK_TICK

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -68,7 +68,6 @@
 	SSweather.load_late_z(level.z_value)
 	SSair.setup_atmos_machinery()
 	SSair.setup_pipenets()
-	SSlighting.create_lighting_objects_for_z(level.z_value)
 	smooth_zlevel(level.z_value)
 	if(minimap)
 		SSminimaps.load_new_z(null, level)


### PR DESCRIPTION

## About The Pull Request
Fixed a runtime error that would come up when late loading z-levels, so basically only effected campaign.

Light objects are now created when the turfs are populated, so it doesn't need to be called manually later.

:cl:
code: Fixed a lighting runtime when late loading z-levels
/:cl:
