### PR TITLE
Attempts to give marines a trickling economy with stimulus on crash

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -79,10 +79,10 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "aw" = (
-/obj/machinery/computer/body_scanconsole,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/gibber/apc,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "ax" = (
@@ -811,7 +811,6 @@
 /turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "vY" = (
-/obj/machinery/computer/body_scanconsole,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
@@ -854,6 +853,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"zk" = (
+/obj/machinery/computer/body_scanconsole,
+/turf/open/floor/mainship/sterile,
+/area/shuttle/canterbury/medical)
 "zy" = (
 /obj/machinery/door/poddoor/mainship{
 	dir = 2;
@@ -916,6 +919,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
+"Gl" = (
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile,
+/area/shuttle/canterbury/medical)
 "JM" = (
 /obj/machinery/marine_selector/gear/smartgun,
 /turf/open/floor/mainship/mono,
@@ -996,6 +1003,15 @@
 	dir = 4
 	},
 /area/shuttle/canterbury/cic)
+"PJ" = (
+/obj/machinery/computer/cloning_console/vats{
+	dir = 2;
+	layer = 2.99;
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/turf/open/floor/mainship/sterile,
+/area/shuttle/canterbury/medical)
 "PW" = (
 /obj/machinery/marine_selector/clothes/medic,
 /turf/open/floor/mainship/mono,
@@ -1220,9 +1236,9 @@ aS
 bj
 bk
 ap
+Gl
+PJ
 av
-aq
-ay
 aq
 ay
 az
@@ -1255,7 +1271,7 @@ bl
 ap
 aw
 aq
-aB
+zk
 aq
 aB
 az
@@ -1286,7 +1302,7 @@ bq
 mM
 oj
 ap
-av
+aq
 aq
 aC
 aq

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -597,9 +597,7 @@
 /turf/open/floor/plating,
 /area/shuttle/canterbury)
 "cs" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 2
-	},
+/obj/machinery/computer/cloning_console/vats,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cv" = (
@@ -744,6 +742,14 @@
 	},
 /turf/open/floor/mainship/red,
 /area/shuttle/canterbury)
+"fG" = (
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/shuttle/canterbury/medical)
+"gd" = (
+/obj/machinery/gibber/apc,
+/turf/open/floor/mainship/sterile/dark,
+/area/shuttle/canterbury/medical)
 "nN" = (
 /obj/machinery/quick_vendor/beginner,
 /turf/open/floor/mainship/red/full,
@@ -853,7 +859,7 @@ bi
 bo
 bw
 bG
-bK
+fG
 bR
 bZ
 cf
@@ -876,7 +882,7 @@ bj
 bo
 aC
 bH
-bK
+cs
 bS
 ca
 ce
@@ -899,7 +905,7 @@ zE
 bo
 by
 bI
-cs
+cJ
 cJ
 YI
 cd
@@ -922,7 +928,7 @@ aT
 bo
 bz
 bI
-bK
+gd
 bU
 cb
 cg

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -200,6 +200,12 @@
 	var/larva_surplus = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
 	if(larva_surplus < 1)
 		return //Things are balanced, no burrowed needed
+	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+		if(!H.job)
+			continue
+		var/obj/item/card/id/user_id =  H.get_idcard()
+		for(var/i in user_id.marine_points)
+			user_id.marine_points[i] += 1
 	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
 

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -173,6 +173,13 @@
 	deltimer(current_timer)
 	current_timer = null
 	completed_segments = min(completed_segments + 1, total_segments)
+	if(completed_segments == 5 && GLOB.master_mode == "Crash")
+		for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+			if(!H.job)
+				continue
+			var/obj/item/card/id/user_id =  H.get_idcard()
+			for(var/i in user_id.marine_points)
+				user_id.marine_points[i] += 50
 	update_minimap_icon()
 	running = FALSE
 

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -173,7 +173,7 @@
 	deltimer(current_timer)
 	current_timer = null
 	completed_segments = min(completed_segments + 1, total_segments)
-	if(completed_segments == 5 && GLOB.master_mode == "Crash")
+	if(completed_segments == 5 && iscrashgamemode(SSticker.mode))
 		for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 			if(!H.job)
 				continue


### PR DESCRIPTION
## About The Pull Request

Gives marines a gibber that gives 20 biomass per xenomorph and a cloning vat that gives a vatgrown every 40 biomass. Makes it so that each passively respawning xenomorph gives 1 job points to all marines. Also gives 50 job points on completed disks

## Why It's Good For The Game

As outlines by my previous PR, crash is in a tragic state, single digit winrate for marines, and (I think much needed) nerfs xenos by adjusting numbers, while this one empowers marines. The one sided nature of the gamemode is partly because marines have a finite, and really limited economy, lacking a requsition. While in an ideal world, we would have req in crash, it doesn't have the pop or the space to really work out, so this is the second best thing. 

Currently corpses have no use case in crash, so the first part of the PR with the gibber and the vat tubes give xeno corpses and souless bodies an use case scenario (Currently 1 beno = 20u, cloners spit out a vatgrown for 40u), and allows marines to "respawn" as an underequipped squad marine, evening the playing field a tiny bit simmilar to how xenos get constant reinforcements. Note, that the marine respawn is not consistent or constant, and require actively killing xenos, securing bodies, and dragging them all the way back to the ship. In addition, currently soulless corpses count towards the marine count for the purposes of larva reinforcements, so it's also incentivizing to recycle corpses for denying the enemy resources.

The second part of this PR gives a job point for every "reinforcement" larva spawned. Note that it only counts reinforcement larva, that is spawned passively every 2 minutes in accordance with the marine forces as autobalance (excluding if the xenos are wiped out and the reinforcement larva would be the first xeno), not the larvas gained by marines joining. The reason why this is needed, is because marines are operating off a very limited and finite economy, with engineers and smartgunners in particular being boned pretty hard and rendered useless if they just... run out of supplies, which is inevitable and usually happens around the second disk if the marines get that far. This attempts to remedy this by giving a single point to all marines per reinforcement larva. That's about 5 metal or sandbag, or 2.5 plasteel or 1/50th of a point defense sentry per engineer, and a quarter of T-29 drum mag or a fifth of an SG-85 per smartgunner.

## Changelog
:cl:
add: Vat and gibber for crash
add: Trickling marine economy for crash
/:cl:
