### PR TITLE
Adds Weight Check to Codex Item List Generation

### DIFF
--- a/code/modules/codex/entries/misc_codex.dm
+++ b/code/modules/codex/entries/misc_codex.dm
@@ -42,8 +42,8 @@
 		storage_strings += "<br><U>You can only carry the following in this</U>:"
 		for(var/X in storage_datum.can_hold)
 			var/obj/item/A = X
-			//check if the weight classes of the items are smaller or equal to the maximum weight class.
-			if(A.w_class <= src.storage_datum.max_w_class)
+			//check if the weight classes of the items are smaller or equal to the maximum weight class. Ignored if this pouch explicitly whitelists an item
+			if(is_type_in_typecache(A, typecacheof(storage_type_limits)) || A.w_class <= src.storage_datum.max_w_class)
 				storage_strings += "[initial(A.name)]"
 
 	if(length(storage_datum.storage_type_limits))

--- a/code/modules/codex/entries/misc_codex.dm
+++ b/code/modules/codex/entries/misc_codex.dm
@@ -42,10 +42,10 @@
 		storage_strings += "<br><U>You can only carry the following in this</U>:"
 		for(var/X in storage_datum.can_hold)
 			var/obj/item/A = X
-			//check if the weight classes of the items are smaller or equal to the maximum weight class. Ignored if this pouch explicitly whitelists an item
-			if(is_type_in_typecache(A, typecacheof(storage_type_limits)) || A.w_class <= src.storage_datum.max_w_class)
+			//check if the weight classes of the items are smaller or equal to the maximum weight class.
+			if(A.w_class <= src.storage_datum.max_w_class)
 				storage_strings += "[initial(A.name)]"
-
+				
 	if(length(storage_datum.storage_type_limits))
 		storage_strings += "<br><U>You can also carry the following special items in this</U>:"
 		for(var/X in storage_datum.storage_type_limits)

--- a/code/modules/codex/entries/misc_codex.dm
+++ b/code/modules/codex/entries/misc_codex.dm
@@ -42,7 +42,9 @@
 		storage_strings += "<br><U>You can only carry the following in this</U>:"
 		for(var/X in storage_datum.can_hold)
 			var/obj/item/A = X
-			storage_strings += "[initial(A.name)]"
+			//check if the weight classes of the items are smaller or equal to the maximum weight class.
+			if(A.w_class <= src.storage_datum.max_w_class)
+				storage_strings += "[initial(A.name)]"
 
 	if(length(storage_datum.storage_type_limits))
 		storage_strings += "<br><U>You can also carry the following special items in this</U>:"


### PR DESCRIPTION
## About The Pull Request

This adds a weight check to the codex's text generation for all items that act as storage
Thus, this fixes #14633 

## Why It's Good For The Game
Removes some misleading codex entries

## Changelog

:cl:
add: Adds a weight check to the codex's text generation for all items that act as storage
/:cl:
