### PR TITLE
Nanites only heal brute/burn if they can fix at least 3 damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -1286,13 +1286,13 @@
 				L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 				L.adjustToxLoss(-0.15 * effect_str)
 
-			if(volume > 5 && L.getBruteLoss(organic_only = TRUE))
+			if(volume > 5 && (L.getBruteLoss(organic_only = TRUE) >= (3 * effect_str))) // only heal if we can derive the full value from it. slows down IB causing super blood loss from limb damage ticks we can't ignore (because we purge bicaridine)
 				L.heal_overall_damage(3 * effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))
 					to_chat(L, span_notice("Your cuts and bruises begin to scab over rapidly!"))
 
-			if(volume > 5 && L.getFireLoss(organic_only = TRUE))
+			if(volume > 5 && (L.getFireLoss(organic_only = TRUE) >= (3 * effect_str))) // as above, only heal if we get full value healing. slows down chip mitigated fire damage from super-killing fire-resistant users with nanite regen blood loss
 				L.heal_overall_damage(0, 3 * effect_str)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))


### PR DESCRIPTION
## About The Pull Request

If you take an IB as a nanite user, the tiny chip damage it deals to its parent limb (0.1 brute) will trigger a full tick of nanite healing, consuming 0.5u nanites. 

0.5u nanites costs roughly **7u** of blood to regenerate. This means that any source of trivially small chip damage is an existential threat to nanite users.

This PR fixes that and makes it so that nanites only fire if they can heal at least 3 brute or burn, independently checked. IB or  other sources of small trickle damage will have to amass to at least 3 damage total before your nanites will repair it, dramatically slowing the 3 minute death spiral you currently experience without this change.

If this is too power-creep or whatever then the other alternative is making inaprovaline + nanites do what bicaridine + inaprovaline does to stop IB trickle damage. Happy to do that instead if it's needed.

## Why It's Good For The Game
Spending 6 minutes shipside having your blood replaced because a ravager tapped you once is not very entertaining, and previous changes made to lock the IB damage ticks behind bicaridine+inaprovaline means that nanite users can't realistically med against this interaction.

IB is still the same ticking time-bomb it was before and the bloodloss it naturally causes has extra implications for nanite users, as intended. This doesn't change that, it just stops you from ending up at 50% blood in 3 minutes from a single IB.

Nanites have enough downsides and this chip/trickle damage interaction doesn't feel intentional to me, but I guess you're the judge of that in the end.

## Changelog
:cl:
balance: Nanites now only spend themselves to heal brute or burn damage if they can cover at least 3 damage of either type, making instances of trickle/chip damage from things like IB much less immediately dangerous to your blood level.
/:cl:
