### PR TITLE
Xeno name fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -153,6 +153,9 @@
 	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
 	if(!client?.prefs.show_xeno_rank || !client)
 		name = prefix + "[xeno_caste.display_name] ([nicknumber])"
+		real_name = name
+		if(mind)
+			mind.name = name
 		return
 	switch(playtime_mins)
 		if(0 to 600)


### PR DESCRIPTION

## About The Pull Request
Fixed improper names when using the rankless pref
No more Mature Larva (123) when you are Hivelord (123) in reality (hopefully)
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: Fixed improper names showing when you played as a xeno without your rank turned on
/:cl:
