### PR TITLE
Fixes being able to get 2 shots out of 1 shell in Tank

### DIFF
--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -64,7 +64,7 @@
 
 ///called by the chassis: begins firing, yes this is stolen from mech but I made both so bite me
 /obj/item/armored_weapon/proc/begin_fire(mob/source, atom/target, list/modifiers)
-	if(!ammo || ammo.current_rounds < 0)
+	if(!ammo || ammo.current_rounds <= 0)
 		playsound(source, 'sound/weapons/guns/fire/empty.ogg', 15, 1)
 		return
 	if(TIMER_COOLDOWN_CHECK(chassis, COOLDOWN_MECHA_EQUIPMENT(type)))


### PR DESCRIPTION
## About The Pull Request
There was a missing equal sign that made it possible to fire the same shell twice. 
Step 1; Fire ltb
Step 2; Put shell back in
Step 3; Fire again

## Why It's Good For The Game

Is bug, bad.

## Changelog

:cl:

fix: Tanks can no longer fire the same shell twice

/:cl:

