### PR TITLE
Daedalus Changes (#3)

### DIFF
--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -340,7 +340,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/daedalusprison/inside/medical)
 "apf" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/southclass)
 "apB" = (
 /obj/structure/cable,
@@ -348,6 +348,12 @@
 /obj/effect/mapping_helpers/broken_apc/lowchance,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/staffbreakroom)
+"apN" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred{
+	dir = 8
+	},
+/area/daedalusprison/inside/easternhalls)
 "apS" = (
 /obj/machinery/floodlight/colony,
 /obj/effect/landmark/weed_node,
@@ -1141,6 +1147,13 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/medical)
+"aWD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/daedalusprison/inside/security/office)
 "aWE" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/burger/chicken,
@@ -1296,6 +1309,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/colonydorms)
+"bfj" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/daedalusprison/outside/northeast)
 "bfk" = (
 /obj/structure/table/reinforced/weak,
 /obj/item/tool/hand_labeler,
@@ -2054,6 +2071,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/northeast)
+"bLY" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/daedalusprison/inside/habitationsouth)
 "bMk" = (
 /obj/machinery/hydroponics/slashable,
 /turf/open/floor/prison/green{
@@ -3377,7 +3400,7 @@
 	},
 /area/daedalusprison/inside/medical/treatment)
 "cTb" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/secbreakroom)
 "cTh" = (
 /obj/machinery/light{
@@ -3455,7 +3478,7 @@
 /area/daedalusprison/inside/pmcdropship)
 "cXm" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/easternhalls)
 "cXs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3547,7 +3570,7 @@
 	},
 /area/daedalusprison/inside/security/easternbooth)
 "daj" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/sportstorage)
 "das" = (
 /obj/structure/rack,
@@ -3971,7 +3994,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/south)
 "dqk" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/northclass)
 "dqo" = (
 /obj/structure/table/reinforced/weak,
@@ -4173,7 +4196,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/inside/landingzoneone)
 "dxK" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/janitorial)
 "dxO" = (
 /obj/effect/decal/cleanable/blood,
@@ -4216,7 +4239,7 @@
 /area/daedalusprison/inside/barracks)
 "dAP" = (
 /obj/machinery/mineral/stacking_unit_console,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/mining)
 "dAR" = (
 /obj/machinery/space_heater,
@@ -4870,13 +4893,7 @@
 	},
 /area/daedalusprison/inside/pmcdropship)
 "ebl" = (
-/obj/structure/stairs/seamless,
-/obj/machinery/door/poddoor/shutters/mainship/open{
-	dir = 1;
-	id = "UD6";
-	name = "\improper Shutters"
-	},
-/turf/open/floor/plating,
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/daedalusprison/inside/pmcdropship)
 "ebp" = (
 /obj/machinery/light{
@@ -4888,7 +4905,7 @@
 /area/daedalusprison/inside/mining)
 "ebw" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/southclass)
 "ebD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4987,7 +5004,7 @@
 /area/daedalusprison/inside/habitationnorth)
 "efq" = (
 /obj/effect/acid_hole,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/freezer)
 "efF" = (
 /obj/effect/spawner/random/misc/trash,
@@ -5588,7 +5605,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/northclass)
 "eFJ" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationnorth)
 "eFP" = (
 /turf/open/floor/prison/green{
@@ -5702,7 +5719,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/cafeteria)
 "eJo" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/gym)
 "eJp" = (
 /obj/effect/spawner/random/engineering/tool,
@@ -5718,7 +5735,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/staffbreakroom)
 "eJE" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/northmeetingroom)
 "eJQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6085,7 +6102,7 @@
 	},
 /area/daedalusprison/inside/southclass)
 "eZX" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/westernbooth)
 "fae" = (
 /obj/structure/bed/chair{
@@ -6213,7 +6230,7 @@
 /area/daedalusprison/inside/colonydorms)
 "feW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical)
 "feX" = (
 /turf/open/floor/plating/ground/snow/layer0,
@@ -6313,7 +6330,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/daedalusprison/inside/cargo)
 "fjx" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/easternbooth)
 "fjK" = (
 /obj/structure/table/mainship/nometal,
@@ -6545,6 +6562,10 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/studyroom)
+"frE" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/tile/dark2,
+/area/daedalusprison/inside/colonydorms)
 "frY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -6858,6 +6879,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/daedalusprison/inside/recreation)
+"fGV" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/daedalusprison/inside/security/office)
 "fHT" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/purple2/corner,
@@ -7132,6 +7159,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/secbreakroom)
+"fSw" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor,
+/area/daedalusprison/inside/hydroponics)
 "fSL" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/structure/cable,
@@ -7243,7 +7274,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/easternhalls)
 "fWP" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/centralhalls)
 "fXg" = (
 /obj/structure/table/mainship,
@@ -7976,6 +8007,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
+"gFu" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/execution)
 "gFR" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -8094,7 +8129,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/daedalusprison/caves/east)
 "gLx" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/chapel)
 "gLX" = (
 /obj/effect/landmark/xeno_tunnel_spawn,
@@ -8232,6 +8267,7 @@
 /area/daedalusprison/inside/bar)
 "gRx" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -8636,7 +8672,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/habitationsouth)
 "hmB" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/recreation)
 "hmI" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -8823,7 +8859,7 @@
 /area/daedalusprison/inside/engineering)
 "huF" = (
 /obj/effect/acid_hole,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/westcomputerlab)
 "huH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -9010,7 +9046,7 @@
 /turf/open/floor/plating,
 /area/daedalusprison/inside/easternhalls)
 "hCI" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/easternhalls)
 "hCT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9223,7 +9259,7 @@
 /area/daedalusprison/inside/gym)
 "hMy" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/mining)
 "hMS" = (
 /turf/open/floor/tile/dark/yellow2{
@@ -9292,6 +9328,10 @@
 	dir = 8
 	},
 /area/daedalusprison/inside/lobby)
+"hPU" = (
+/obj/item/ammo_casing/bullet,
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/daedalusprison/inside/pmcdropship)
 "hQl" = (
 /turf/open/floor/freezer,
 /area/daedalusprison/inside/staffrestroom)
@@ -9366,7 +9406,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "hUa" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/warden)
 "hUb" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
@@ -9382,6 +9422,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/tile/white,
 /area/daedalusprison/inside/corporateoffice)
+"hUo" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/plate,
+/area/daedalusprison/inside/centralhalls)
 "hUv" = (
 /obj/effect/landmark/patrol_point/tgmc_12,
 /turf/open/floor/plating/ground/ice,
@@ -9512,7 +9556,7 @@
 	},
 /area/daedalusprison/inside/easternhalls)
 "ibH" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical/treatment)
 "ibP" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -9672,7 +9716,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/cafeteria)
 "ijq" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/prisongarden)
 "ijy" = (
 /obj/structure/platform/nondense{
@@ -9858,6 +9902,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
+"ioB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred{
+	dir = 8
+	},
+/area/daedalusprison/inside/centralhalls)
 "ioE" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -10324,8 +10375,7 @@
 	},
 /area/daedalusprison/inside/northmeetingroom)
 "iHM" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/shuttle/dropship/floor,
+/turf/closed/mineral/smooth/darkfrostwall,
 /area/daedalusprison/inside/pmcdropship)
 "iIQ" = (
 /obj/machinery/computer/body_scanconsole,
@@ -10696,7 +10746,7 @@
 /area/daedalusprison/inside/bar)
 "iWf" = (
 /obj/effect/acid_hole,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationsouth)
 "iWh" = (
 /turf/open/floor/prison/red{
@@ -10805,7 +10855,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/lobby)
 "jbA" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/kitchen)
 "jca" = (
 /obj/structure/sink{
@@ -11734,6 +11784,11 @@
 	dir = 1
 	},
 /area/daedalusprison/inside/medical/treatment)
+"jLu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/southclass)
 "jLz" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/prison/whitegreen{
@@ -11937,6 +11992,12 @@
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/daedalusprison/inside/habitationnorth)
+"jVp" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred{
+	dir = 6
+	},
+/area/daedalusprison/inside/centralhalls)
 "jVr" = (
 /obj/item/shard,
 /obj/effect/landmark/weed_node,
@@ -12013,7 +12074,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
 "jXr" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical)
 "jXI" = (
 /obj/machinery/shower{
@@ -12196,7 +12257,7 @@
 /turf/closed/shuttle/dropship2/wallthree/alt,
 /area/daedalusprison/inside/pmcdropship)
 "keX" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/cameras)
 "keZ" = (
 /obj/effect/ai_node,
@@ -12407,6 +12468,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/sportstorage)
+"kom" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/habitationsouth)
 "kon" = (
 /obj/machinery/light{
 	dir = 8
@@ -12797,7 +12862,7 @@
 /area/daedalusprison/inside/bar)
 "kFE" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/kitchen)
 "kGo" = (
 /obj/effect/turf_decal/warning_stripes/box,
@@ -12886,7 +12951,7 @@
 /area/daedalusprison/inside/habitationnorth)
 "kJz" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/library)
 "kJE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -12895,7 +12960,7 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/staffbreakroom)
 "kJF" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/westcomputerlab)
 "kJW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
@@ -13550,7 +13615,7 @@
 /area/daedalusprison/inside/westernbooth)
 "ljp" = (
 /obj/effect/acid_hole,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical)
 "ljq" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -14511,7 +14576,7 @@
 /area/daedalusprison/inside/janitorial)
 "lYl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/laundromat)
 "lYv" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -14543,7 +14608,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/daedalusprison/inside/security/interrogation)
 "maf" = (
-/obj/structure/window/framed/colony,
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/tile/green/whitegreencorner{
 	dir = 8
 	},
@@ -14829,7 +14894,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/centralbooth)
 "mnB" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/laundromat)
 "mnR" = (
 /obj/machinery/light,
@@ -15024,11 +15089,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/security/secbreakroom)
 "mvx" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/daedalusprison/outside/northeast)
 "mvI" = (
 /obj/effect/spawner/random/misc/trash,
@@ -15893,7 +15954,7 @@
 	},
 /area/daedalusprison/inside/hydroponics)
 "ncm" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical/chemistry)
 "ncK" = (
 /obj/structure/closet/secure_closet/personal,
@@ -16579,6 +16640,9 @@
 	dir = 8
 	},
 /area/daedalusprison/inside/hydroponics)
+"nEe" = (
+/turf/closed/wall/r_wall,
+/area/daedalusprison/inside/hydroponics)
 "nFc" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Dormitories"
@@ -16680,7 +16744,7 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/cargo)
 "nIV" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/substation)
 "nIZ" = (
 /obj/structure/toilet{
@@ -16994,6 +17058,10 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/colonydorms)
+"nYw" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/plate,
+/area/daedalusprison/inside/habitationsouth)
 "nYA" = (
 /turf/open/floor/prison/red{
 	dir = 4
@@ -17093,7 +17161,7 @@
 /turf/open/floor/prison,
 /area/daedalusprison/inside/westernbooth)
 "odi" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/execution)
 "odu" = (
 /obj/machinery/disposal,
@@ -17256,7 +17324,7 @@
 	},
 /area/daedalusprison/inside/pmcdropship)
 "oky" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/basketball)
 "okK" = (
 /obj/item/ammo_casing/bullet,
@@ -17268,7 +17336,7 @@
 /turf/open/floor/prison/red/corner,
 /area/daedalusprison/inside/mining)
 "ola" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/medsec)
 "olj" = (
 /obj/structure/table/mainship,
@@ -17293,6 +17361,9 @@
 	dir = 1
 	},
 /area/daedalusprison/inside/habitationnorth)
+"omr" = (
+/turf/closed/mineral/smooth/darkfrostwall/indestructible,
+/area/daedalusprison/outside/east)
 "omB" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -18015,7 +18086,7 @@
 	},
 /area/daedalusprison/inside/security/secbreakroom)
 "oOP" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/garage)
 "oOY" = (
 /obj/effect/spawner/random/misc/trash,
@@ -18498,7 +18569,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationnorth)
 "pfG" = (
 /obj/machinery/space_heater,
@@ -18714,6 +18785,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/green/greentaupecorner,
 /area/daedalusprison/inside/garden)
+"pnv" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/daedalusprison/inside/easternhalls)
 "pnF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
@@ -18798,7 +18875,7 @@
 /turf/open/floor/prison/whitegreen,
 /area/daedalusprison/inside/medical/treatment)
 "prk" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/auxstorage)
 "prx" = (
 /turf/open/floor/plating/ground/snow/layer0,
@@ -20005,6 +20082,11 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/hydroponics)
+"qpO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/habitationnorth)
 "qqa" = (
 /obj/structure/table/mainship,
 /obj/item/tool/stamp/ce,
@@ -20929,7 +21011,7 @@
 /area/daedalusprison/outside/northeast)
 "rit" = (
 /obj/effect/acid_hole,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationnorth)
 "riG" = (
 /obj/machinery/light/small{
@@ -21015,6 +21097,10 @@
 "rkX" = (
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/recreation)
+"rlr" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/plate,
+/area/daedalusprison/inside/easternhalls)
 "rlt" = (
 /obj/structure/table/mainship,
 /obj/item/tool/soap,
@@ -21954,7 +22040,7 @@
 /turf/open/floor/tile/purple/taupepurple,
 /area/daedalusprison/inside/hydroponicstesting)
 "rUP" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/prisonshower)
 "rVn" = (
 /obj/structure/bed/chair/wood/wings{
@@ -22226,6 +22312,12 @@
 "shm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/daedalusprison/outside/southeast)
+"shn" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/daedalusprison/inside/habitationnorth)
 "shx" = (
 /obj/machinery/vending/security,
 /obj/machinery/light,
@@ -23027,6 +23119,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/daedalusprison/inside/engineering)
+"sKf" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/cafeteria)
 "sKo" = (
 /obj/item/detective_scanner,
 /turf/open/floor/prison/red{
@@ -23867,7 +23963,7 @@
 /area/daedalusprison/inside/mining)
 "tvG" = (
 /obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/mining)
 "twa" = (
 /obj/effect/turf_decal/tracks/wheels/bloody,
@@ -24036,6 +24132,11 @@
 "tDr" = (
 /turf/open/floor/prison/kitchen,
 /area/daedalusprison/inside/prisonshower)
+"tDw" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/concrete,
+/area/daedalusprison/inside/garage)
 "tDP" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -24096,7 +24197,7 @@
 /area/daedalusprison/inside/medical)
 "tGi" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/northclass)
 "tGA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24354,7 +24455,7 @@
 	},
 /area/daedalusprison/inside/sportstorage)
 "tPF" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/interrogation)
 "tPY" = (
 /obj/structure/cable,
@@ -25041,6 +25142,12 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/daedalusprison/inside/medical)
+"utI" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/daedalusprison/inside/laundromat)
 "utK" = (
 /obj/effect/spawner/random/misc/trash,
 /turf/open/floor/prison/green{
@@ -25328,8 +25435,12 @@
 "uEv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/mining)
+"uEG" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/daedalusprison/inside/cafeteria)
 "uEH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -25627,10 +25738,10 @@
 /turf/open/floor/tile/dark2,
 /area/daedalusprison/inside/colonydorms)
 "uRA" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/office)
 "uRM" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/freezer)
 "uSd" = (
 /obj/effect/decal/cleanable/blood,
@@ -25775,7 +25886,7 @@
 /area/daedalusprison/inside/habitationsouth)
 "uYt" = (
 /obj/effect/spawner/random/misc/trash,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/laundromat)
 "uYz" = (
 /obj/structure/table/reinforced/weak,
@@ -26131,8 +26242,12 @@
 /turf/open/floor/prison/plate,
 /area/daedalusprison/inside/easternhalls)
 "vmj" = (
-/turf/open/shuttle/dropship/floor,
-/area/daedalusprison/inside/pmcdropship)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 4
+	},
+/area/daedalusprison/inside/hydroponics)
 "vmq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -26452,6 +26567,15 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/prison,
 /area/daedalusprison/inside/studyroom)
+"vDJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/daedalusprison/inside/centralhalls)
 "vDX" = (
 /obj/effect/spawner/random/misc/trash,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -26525,7 +26649,7 @@
 /area/daedalusprison/inside/cargo)
 "vGR" = (
 /obj/machinery/light,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/northmeetingroom)
 "vHn" = (
 /obj/effect/turf_decal/warning_stripes/box,
@@ -27095,6 +27219,9 @@
 	dir = 4
 	},
 /area/daedalusprison/inside/hydroponics)
+"wfE" = (
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/daedalusprison/outside/east)
 "wfG" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison/sterilewhite,
@@ -27126,7 +27253,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/security/office)
 "wgM" = (
 /obj/effect/turf_decal/warning_stripes/box,
@@ -27150,7 +27277,7 @@
 /area/daedalusprison/inside/gym)
 "whc" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/medical/treatment)
 "whz" = (
 /obj/structure/bed/chair/comfy,
@@ -27518,7 +27645,7 @@
 /turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/daedalusprison/inside/landingzoneone)
 "wqR" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/lobby)
 "wrB" = (
 /obj/structure/bed/chair/office/dark,
@@ -27622,6 +27749,13 @@
 	dir = 1
 	},
 /area/daedalusprison/inside/pmcdropship)
+"wuM" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison,
+/area/daedalusprison/inside/prisongarden)
 "wuP" = (
 /turf/open/floor/prison/darkred{
 	dir = 4
@@ -27888,6 +28022,9 @@
 	},
 /turf/open/floor/tile/green/greentaupe,
 /area/daedalusprison/inside/hydroponics)
+"wHd" = (
+/turf/closed/mineral/smooth/darkfrostwall,
+/area/daedalusprison/outside/northeast)
 "wHq" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -28210,7 +28347,7 @@
 /area/daedalusprison/inside/staffbreakroom)
 "wVk" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationnorth)
 "wVo" = (
 /obj/structure/table/mainship,
@@ -28924,7 +29061,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "xxz" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/mining)
 "xxA" = (
 /obj/structure/table/mainship,
@@ -29044,6 +29181,13 @@
 	dir = 1
 	},
 /area/daedalusprison/inside/centralhalls)
+"xBZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/greentaupecorner{
+	dir = 4
+	},
+/area/daedalusprison/inside/hydroponics)
 "xCi" = (
 /turf/open/floor/prison/darkred{
 	dir = 5
@@ -29331,7 +29475,7 @@
 	},
 /area/daedalusprison/inside/habitationnorth)
 "xNg" = (
-/turf/closed/wall/prison,
+/turf/closed/wall/r_wall/prison,
 /area/daedalusprison/inside/habitationsouth)
 "xNm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29390,11 +29534,8 @@
 /turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/daedalusprison/caves/rock)
 "xPJ" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/daedalusprison/outside/northeast)
+/turf/closed/wall/r_wall,
+/area/daedalusprison/inside/colonydorms)
 "xPU" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
@@ -29566,6 +29707,10 @@
 /obj/structure/table/mainship,
 /turf/open/floor/prison/darkyellow,
 /area/daedalusprison/inside/mechanicshop)
+"xXQ" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/prison/darkred/full,
+/area/daedalusprison/inside/centralhalls)
 "xYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -42049,7 +42194,7 @@ xNg
 xNg
 xNg
 iLU
-lAz
+kom
 efe
 xNg
 xNg
@@ -43525,7 +43670,7 @@ rwg
 hNa
 qFR
 gIY
-oOZ
+nYw
 iTM
 xNg
 iTM
@@ -44409,27 +44554,27 @@ dmP
 dmP
 dmP
 dmP
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-cdG
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+frE
 nFc
-cdG
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
+frE
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
 nmg
 fir
 dmP
@@ -44621,7 +44766,7 @@ dmP
 dmP
 dmP
 dmP
-aok
+xPJ
 sDb
 aok
 pNT
@@ -44641,7 +44786,7 @@ aok
 sDb
 aok
 sDb
-aok
+xPJ
 dmP
 dmP
 vXI
@@ -44833,7 +44978,7 @@ dmP
 dmP
 nmg
 fir
-aok
+xPJ
 xXi
 aok
 xXi
@@ -44853,7 +44998,7 @@ aok
 xXi
 aok
 xXi
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -45045,7 +45190,7 @@ dmP
 dmP
 dmP
 dmP
-aok
+xPJ
 pIm
 qzU
 fYV
@@ -45065,7 +45210,7 @@ gPP
 dEj
 qzU
 fCy
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -45257,7 +45402,7 @@ dmP
 dmP
 dmP
 dmP
-aok
+xPJ
 mod
 dEj
 dEj
@@ -45277,7 +45422,7 @@ dEj
 dEj
 dEj
 mod
-aok
+xPJ
 dmP
 fir
 dmP
@@ -45469,7 +45614,7 @@ dmP
 dmP
 dmP
 dmP
-aok
+xPJ
 mod
 imG
 dEj
@@ -45489,7 +45634,7 @@ hIX
 dEj
 gvJ
 mod
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -45638,7 +45783,7 @@ dQm
 xyf
 xyf
 cYw
-xyf
+shn
 xyf
 csX
 xQp
@@ -45681,7 +45826,7 @@ dmP
 dmP
 nmg
 fir
-aok
+xPJ
 pIm
 kVp
 dEj
@@ -45701,7 +45846,7 @@ dEj
 dEj
 pZh
 fCy
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -45893,7 +46038,7 @@ dmP
 nmg
 dmP
 dmP
-aok
+xPJ
 xXi
 aok
 xXi
@@ -45913,7 +46058,7 @@ aok
 lLi
 aok
 xXi
-aok
+xPJ
 nmg
 dmP
 dmP
@@ -46105,7 +46250,7 @@ dmP
 dmP
 dmP
 dmP
-aok
+xPJ
 oUD
 aok
 oUD
@@ -46125,7 +46270,7 @@ aok
 oUD
 aok
 ucx
-aok
+xPJ
 dmP
 fir
 dmP
@@ -46315,9 +46460,9 @@ nmO
 dmP
 dmP
 dmP
-aok
-aok
-aok
+xPJ
+xPJ
+xPJ
 aok
 aok
 aok
@@ -46337,8 +46482,8 @@ aok
 aok
 aok
 aok
-aok
-aok
+xPJ
+xPJ
 dmP
 dmP
 dmP
@@ -46504,7 +46649,7 @@ saQ
 mjU
 yjO
 ckP
-ckP
+bLY
 huW
 mbN
 nqg
@@ -46527,7 +46672,7 @@ nmO
 fir
 dmP
 dmP
-aok
+xPJ
 nXN
 rSk
 cDB
@@ -46550,7 +46695,7 @@ aok
 mCo
 vKA
 ePD
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -46739,7 +46884,7 @@ nmO
 dmP
 dmP
 dmP
-aok
+xPJ
 dom
 vQm
 szO
@@ -46762,7 +46907,7 @@ aok
 vKA
 kTS
 plI
-aok
+xPJ
 dmP
 dmP
 dmP
@@ -46951,7 +47096,7 @@ nmO
 vXI
 vXI
 vXI
-cdG
+frE
 cDB
 pxe
 vQm
@@ -46974,7 +47119,7 @@ dsQ
 mQj
 mQj
 vtC
-aok
+xPJ
 fir
 dmP
 dmP
@@ -47186,7 +47331,7 @@ aok
 vKA
 vKA
 vKA
-aok
+xPJ
 dmP
 dmP
 nmg
@@ -47398,7 +47543,7 @@ aok
 aok
 aok
 aok
-aok
+xPJ
 qqi
 qqi
 qqi
@@ -47533,7 +47678,7 @@ nLt
 wtO
 fIP
 fIP
-jnL
+qpO
 fIP
 fIP
 xQp
@@ -47587,7 +47732,7 @@ ihW
 tCL
 tCL
 tCL
-cdG
+frE
 rSk
 dwR
 wNH
@@ -47610,13 +47755,13 @@ eLO
 ngk
 xZR
 fjM
-aok
-aok
+xPJ
+xPJ
 maf
 maf
 maf
 aok
-aok
+xPJ
 qqi
 qqi
 qqi
@@ -47799,7 +47944,7 @@ ihW
 tCL
 qqi
 qqi
-aok
+xPJ
 vQm
 usJ
 ngk
@@ -47828,7 +47973,7 @@ lJM
 lJM
 lJM
 fPf
-aok
+xPJ
 qqi
 qqi
 kaT
@@ -48011,7 +48156,7 @@ ihW
 qqi
 qqi
 qqi
-aok
+xPJ
 nCe
 pBz
 rSk
@@ -48188,7 +48333,7 @@ stE
 ctI
 tJP
 xeq
-tJP
+hUo
 cEc
 njP
 uHE
@@ -48223,7 +48368,7 @@ iyr
 kaT
 qqi
 bUI
-aok
+xPJ
 aok
 eXT
 aok
@@ -48435,7 +48580,7 @@ cqH
 qqi
 qqi
 qqi
-aok
+xPJ
 vKJ
 xeM
 xKF
@@ -48647,7 +48792,7 @@ ihW
 qqi
 qqi
 qqi
-cdG
+frE
 wnV
 gnq
 kjI
@@ -48859,7 +49004,7 @@ ihW
 qqi
 qqi
 qqi
-cdG
+frE
 sHV
 qcV
 xds
@@ -48888,7 +49033,7 @@ lJM
 lJM
 lJM
 sNf
-aok
+xPJ
 bUI
 gmu
 gmu
@@ -49071,7 +49216,7 @@ ihW
 kaT
 qqi
 qqi
-cdG
+frE
 sHV
 xeM
 aXz
@@ -49094,13 +49239,13 @@ aok
 bRq
 ahX
 cbi
-aok
-aok
+xPJ
+xPJ
 maf
 maf
 maf
-aok
-aok
+xPJ
+xPJ
 qqi
 gmu
 gmu
@@ -49269,7 +49414,7 @@ bSq
 fWP
 fir
 dmP
-fir
+dmP
 dmP
 dmP
 fir
@@ -49283,7 +49428,7 @@ wJE
 qqi
 qqi
 qqi
-aok
+xPJ
 xbi
 gnq
 uIK
@@ -49306,7 +49451,7 @@ aok
 sXI
 dvo
 jpF
-aok
+xPJ
 kaT
 qqi
 bUI
@@ -49495,7 +49640,7 @@ wJE
 qqi
 qqi
 qqi
-aok
+xPJ
 hQW
 job
 oGi
@@ -49518,7 +49663,7 @@ aok
 wnV
 gnq
 aXz
-cdG
+frE
 qqi
 qqi
 qqi
@@ -49707,7 +49852,7 @@ wJE
 qqi
 qqi
 bUI
-cdG
+frE
 sXI
 qcV
 uIK
@@ -49730,7 +49875,7 @@ aok
 qJi
 sLV
 aXz
-cdG
+frE
 qqi
 qqi
 qqi
@@ -49905,7 +50050,7 @@ fDX
 fWP
 fir
 dmP
-fir
+dmP
 dmP
 dmP
 fir
@@ -49919,7 +50064,7 @@ wJE
 kaT
 qqi
 qqi
-cdG
+frE
 sHV
 gnq
 aXz
@@ -49942,7 +50087,7 @@ aok
 sHV
 ahX
 aXz
-cdG
+frE
 qqi
 qqi
 qqi
@@ -50107,7 +50252,7 @@ sCy
 nzP
 rxS
 rxS
-dSE
+utI
 dSE
 dSE
 vjc
@@ -50131,7 +50276,7 @@ wJE
 qqi
 qqi
 qqi
-cdG
+frE
 tin
 jtX
 kjI
@@ -50154,7 +50299,7 @@ aok
 sHV
 jtX
 vRs
-aok
+xPJ
 kaT
 qqi
 qqi
@@ -50343,7 +50488,7 @@ bui
 bqd
 bqd
 bqd
-aok
+xPJ
 sHV
 gnq
 kcY
@@ -50366,7 +50511,7 @@ qeC
 sAI
 xeM
 aXz
-cdG
+frE
 qqi
 qqi
 qqi
@@ -50541,7 +50686,7 @@ fDX
 fWP
 fir
 dmP
-fir
+dmP
 dmP
 dmP
 fir
@@ -50555,7 +50700,7 @@ prx
 prx
 prx
 prx
-aok
+xPJ
 sHV
 wDW
 bWA
@@ -50578,7 +50723,7 @@ bWA
 ngk
 vkB
 eum
-cdG
+frE
 qqi
 qqi
 qqi
@@ -50735,7 +50880,7 @@ njP
 uHE
 uHE
 vLn
-wnu
+ioB
 tJP
 aCY
 bou
@@ -50767,7 +50912,7 @@ prx
 dqa
 prx
 prx
-aok
+xPJ
 lrI
 gmt
 tdg
@@ -50790,7 +50935,7 @@ tdg
 gmt
 vQm
 eIo
-cdG
+frE
 qqi
 qqi
 qqi
@@ -50979,9 +51124,9 @@ prx
 prx
 prx
 prx
-aok
-aok
-aok
+xPJ
+xPJ
+xPJ
 aok
 fUE
 aok
@@ -51001,8 +51146,8 @@ fUE
 aok
 aok
 fUE
-aok
-aok
+xPJ
+xPJ
 kaT
 qqi
 qqi
@@ -51136,7 +51281,7 @@ hLi
 hGA
 hWe
 bMk
-ksz
+wuM
 pmh
 ijq
 lqX
@@ -51177,7 +51322,7 @@ fDX
 fWP
 fir
 dmP
-fir
+dmP
 dmP
 dmP
 fir
@@ -51193,7 +51338,7 @@ prx
 prx
 wJE
 qqi
-aok
+xPJ
 rJU
 cYz
 aok
@@ -51213,7 +51358,7 @@ rBO
 aok
 rJU
 qmP
-aok
+xPJ
 qqi
 qqi
 qqi
@@ -51351,7 +51496,7 @@ cGy
 xuq
 pmh
 ijq
-nzr
+vDJ
 eZJ
 fDX
 oOc
@@ -51405,7 +51550,7 @@ prx
 prx
 wJE
 qqi
-aok
+xPJ
 qmP
 lHR
 aok
@@ -51425,7 +51570,7 @@ tkd
 aok
 cYz
 lHR
-aok
+xPJ
 qqi
 qqi
 qqi
@@ -51617,7 +51762,7 @@ prx
 tmQ
 wJE
 kaT
-aok
+xPJ
 fvS
 fmc
 aok
@@ -51637,7 +51782,7 @@ dOT
 aok
 fvS
 fmc
-aok
+xPJ
 qqi
 qqi
 qqi
@@ -51813,7 +51958,7 @@ kdZ
 fWP
 fir
 dmP
-fir
+dmP
 dmP
 dmP
 fir
@@ -51829,27 +51974,27 @@ prx
 prx
 wJE
 qqi
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
 vQm
 mHn
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
+xPJ
 qqi
 kaT
 qqi
@@ -53496,7 +53641,7 @@ hLb
 dPS
 hkv
 qyq
-sse
+xXQ
 uuA
 efS
 ibl
@@ -53508,7 +53653,7 @@ qzj
 hTd
 lhk
 nSd
-kQS
+jLu
 gYN
 ntN
 muX
@@ -55198,7 +55343,7 @@ eas
 aaI
 tJP
 pHe
-tJP
+hUo
 uNi
 wjW
 wjW
@@ -55595,7 +55740,7 @@ qWc
 ktk
 rpx
 cGA
-pkd
+jVp
 fWP
 vPI
 wjW
@@ -57071,7 +57216,7 @@ tJP
 tJP
 tJP
 nlX
-tJP
+hUo
 tJP
 tJP
 dsY
@@ -57954,7 +58099,7 @@ pel
 mBe
 tec
 pel
-pel
+uEG
 pel
 oEj
 daj
@@ -59216,7 +59361,7 @@ usB
 yip
 mVW
 mVW
-yip
+sKf
 pel
 cNW
 gEi
@@ -61527,7 +61672,7 @@ eGz
 ryH
 ups
 wXk
-wXk
+gFu
 wXk
 dgM
 mNV
@@ -61957,7 +62102,7 @@ bQs
 bpU
 wXk
 odi
-sUN
+pnv
 rCV
 ryH
 mwD
@@ -62582,7 +62727,7 @@ hCs
 nMU
 amz
 eJo
-sUN
+pnv
 rCV
 ryH
 odi
@@ -63028,7 +63173,7 @@ ibG
 ibG
 ibG
 ibG
-ibG
+apN
 bNI
 ibG
 ibG
@@ -63462,7 +63607,7 @@ lze
 oOP
 htF
 oSI
-pGk
+tDw
 oSI
 oSI
 htF
@@ -64901,7 +65046,7 @@ vEA
 cWT
 kcM
 pSv
-loZ
+wHd
 luQ
 maY
 kAD
@@ -64924,7 +65069,7 @@ iJj
 hKz
 hCI
 wVU
-kcK
+rlr
 kcK
 kcK
 vlM
@@ -65112,8 +65257,8 @@ rHx
 rtA
 iHM
 ebl
-xPJ
-loZ
+mvx
+wHd
 vJy
 maY
 maY
@@ -65322,10 +65467,10 @@ kgs
 rQT
 okK
 xgk
-okK
+hPU
 ebl
-loZ
-gyW
+mvx
+bfj
 maY
 maY
 maY
@@ -65534,11 +65679,11 @@ hwA
 rHh
 mqC
 jcg
-vmj
+iHM
 ebl
 mvx
-loZ
-tsN
+wHd
+wHd
 maY
 maY
 maY
@@ -65749,8 +65894,8 @@ wuB
 bqa
 keu
 cMo
-loZ
-luQ
+wHd
+wHd
 maY
 maY
 kAD
@@ -65962,7 +66107,7 @@ wfT
 bcU
 uSi
 loZ
-maY
+luQ
 maY
 kAD
 kAD
@@ -66984,28 +67129,28 @@ sLx
 sLx
 sLx
 sLx
-eeZ
-eeZ
+nEe
+nEe
 vaQ
 vaQ
 vaQ
-eeZ
-eeZ
+nEe
+nEe
 vaQ
 vaQ
 vaQ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
+nEe
 vaQ
 vaQ
 vaQ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
 maY
 maY
 maY
@@ -67196,7 +67341,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 xAR
 gAL
 sns
@@ -67217,7 +67362,7 @@ kPw
 nnh
 aaW
 reF
-eeZ
+nEe
 maY
 maY
 maY
@@ -67408,7 +67553,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 sns
 elH
 lmN
@@ -67429,11 +67574,11 @@ uaa
 oSF
 jFS
 kPy
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
+nEe
 luQ
 maY
 maY
@@ -67620,7 +67765,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 gAL
 mLl
 hpT
@@ -67645,12 +67790,12 @@ ijB
 kPw
 nnh
 kbK
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
 maY
 maY
 lHH
@@ -67832,8 +67977,8 @@ sLx
 sLx
 sLx
 sLx
-eeZ
-mQw
+nEe
+fSw
 gcb
 rjQ
 mQw
@@ -67862,7 +68007,7 @@ gxa
 oWy
 oxi
 rsg
-eeZ
+nEe
 vJy
 maY
 lHH
@@ -68044,7 +68189,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 jVv
 gcb
 xGH
@@ -68074,7 +68219,7 @@ fyR
 dBD
 pLH
 aqj
-eeZ
+nEe
 maY
 sTP
 lvf
@@ -68107,7 +68252,7 @@ kkg
 vtv
 rrg
 mJy
-mJy
+lvy
 nKR
 nKR
 nKR
@@ -68256,7 +68401,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 mQw
 epm
 rjQ
@@ -68267,7 +68412,7 @@ gWd
 idg
 inS
 oSB
-xTL
+xBZ
 hOV
 aLv
 aUx
@@ -68286,7 +68431,7 @@ fyR
 dBD
 aqj
 sGi
-eeZ
+nEe
 luQ
 asY
 kAD
@@ -68468,7 +68613,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 wTj
 opN
 jBD
@@ -68498,7 +68643,7 @@ eeZ
 waT
 eeZ
 eeZ
-eeZ
+nEe
 maY
 asY
 kAD
@@ -68534,12 +68679,12 @@ oFS
 oFS
 oFS
 oFS
+jET
 oFS
 oFS
 oFS
 oFS
-oFS
-oFS
+jET
 iCy
 xTK
 iYg
@@ -68680,7 +68825,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 hOV
 wTj
 iZr
@@ -68710,7 +68855,7 @@ oRm
 mQI
 hnN
 qJQ
-eeZ
+nEe
 maY
 lMW
 kAD
@@ -68742,16 +68887,16 @@ nTn
 ham
 mDd
 uRA
-oFS
-oFS
 jET
+tQh
 oFS
 oFS
 oFS
-jET
+tQh
 oFS
 oFS
-jET
+tQh
+oFS
 iCy
 dAO
 rOS
@@ -68891,8 +69036,8 @@ sLx
 sLx
 liI
 sLx
-eeZ
-eeZ
+nEe
+nEe
 eeZ
 eeZ
 eeZ
@@ -68915,14 +69060,14 @@ waP
 iXV
 uBn
 poO
-mQw
+fSw
 wIV
 nDT
 xhJ
 qjj
 cuO
 xxe
-eeZ
+nEe
 maY
 lMW
 loZ
@@ -68960,7 +69105,7 @@ oFS
 oFS
 oFS
 oFS
-oFS
+jET
 oFS
 oFS
 oFS
@@ -69103,7 +69248,7 @@ liI
 liI
 liI
 liI
-eeZ
+nEe
 fLa
 oSB
 cZU
@@ -69134,7 +69279,7 @@ dbb
 wjK
 czd
 iqk
-eeZ
+nEe
 sWa
 lMW
 loZ
@@ -69167,15 +69312,15 @@ ham
 qgO
 atT
 oFS
-oFS
 tQh
 oFS
 oFS
 oFS
 oFS
 oFS
-tQh
 oFS
+oFS
+jET
 vly
 dAO
 btm
@@ -69315,7 +69460,7 @@ ohx
 ohx
 vZC
 ohx
-eeZ
+nEe
 xGB
 jVv
 mTY
@@ -69361,7 +69506,7 @@ qkt
 ueD
 jBt
 aEB
-bNN
+aWD
 jBt
 jBt
 aEB
@@ -69379,12 +69524,12 @@ sat
 ogY
 vfC
 oFS
+jET
 oFS
 oFS
-oFS
-oFS
-oFS
-oFS
+wfE
+wfE
+wfE
 oFS
 oFS
 oFS
@@ -69591,15 +69736,15 @@ nNB
 sls
 uRA
 oFS
+tQh
 oFS
-jET
+wfE
+omr
+omr
+wfE
+wfE
 oFS
 oFS
-oFS
-jET
-oFS
-oFS
-jET
 vly
 dAO
 rCj
@@ -69770,7 +69915,7 @@ eeZ
 eeZ
 eeZ
 eeZ
-eeZ
+nEe
 nBd
 kAD
 rin
@@ -69805,12 +69950,12 @@ uRA
 oFS
 oFS
 oFS
-oFS
-oFS
-oFS
-oFS
-oFS
-oFS
+wfE
+omr
+omr
+omr
+wfE
+jET
 oFS
 iCy
 yiy
@@ -69982,7 +70127,7 @@ ryW
 xlJ
 kEx
 frY
-eeZ
+nEe
 luQ
 maY
 maY
@@ -70016,12 +70161,12 @@ xlU
 atT
 oFS
 oFS
-oFS
-oFS
-oFS
-oFS
-oFS
-oFS
+wfE
+wfE
+omr
+omr
+omr
+wfE
 oFS
 oFS
 vly
@@ -70228,13 +70373,13 @@ xlU
 vNA
 oFS
 oFS
-tQh
+wfE
+omr
+omr
+omr
+omr
+wfE
 oFS
-oFS
-oFS
-oFS
-oFS
-tQh
 oFS
 vly
 nwk
@@ -70375,7 +70520,7 @@ ohx
 vZC
 liI
 liI
-eeZ
+nEe
 kPu
 jkX
 sdk
@@ -70431,7 +70576,7 @@ cuP
 arX
 mzt
 jBt
-jBt
+fGV
 aEB
 sGF
 wbG
@@ -70440,14 +70585,14 @@ prY
 vNA
 oFS
 oFS
-jET
+wfE
+wfE
+omr
+wfE
+wfE
 oFS
 oFS
 oFS
-jET
-oFS
-oFS
-jET
 vly
 dAO
 bVg
@@ -70587,7 +70732,7 @@ ohx
 liI
 liI
 sLx
-eeZ
+nEe
 eeZ
 eUp
 eeZ
@@ -70651,11 +70796,11 @@ rJN
 eHA
 uRA
 oFS
+tQh
 oFS
-oFS
-oFS
-oFS
-oFS
+wfE
+wfE
+wfE
 oFS
 oFS
 oFS
@@ -70799,7 +70944,7 @@ liI
 liI
 sLx
 sLx
-eeZ
+nEe
 nbV
 dor
 kbK
@@ -70830,7 +70975,7 @@ rSs
 xlJ
 uDs
 gCs
-eeZ
+nEe
 luQ
 maY
 maY
@@ -70870,7 +71015,7 @@ oFS
 oFS
 oFS
 oFS
-oFS
+jET
 oFS
 iCy
 dCl
@@ -71011,7 +71156,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 xfA
 sfS
 nbH
@@ -71042,7 +71187,7 @@ ues
 wke
 wke
 pvH
-eeZ
+nEe
 maY
 maY
 maY
@@ -71076,7 +71221,7 @@ aAe
 vNA
 yaP
 oFS
-oFS
+jET
 oFS
 oFS
 oFS
@@ -71223,7 +71368,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 qDY
 jkX
 joJ
@@ -71239,22 +71384,22 @@ sfS
 bTz
 uKB
 mqE
-sdk
+vmj
 uyE
 qFa
 sKu
 lkc
 xle
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
 vJy
 lHH
 lHH
@@ -71287,15 +71432,15 @@ ham
 dWd
 vfC
 oFS
+tQh
+oFS
+oFS
 oFS
 jET
 oFS
 oFS
 oFS
-jET
 oFS
-oFS
-jET
 iCy
 iCy
 iCy
@@ -71435,7 +71580,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 xGB
 uYH
 pQN
@@ -71457,7 +71602,7 @@ pcM
 eeZ
 eeZ
 eeZ
-eeZ
+nEe
 maY
 maY
 maY
@@ -71647,7 +71792,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 qQG
 sfS
 pQN
@@ -71669,7 +71814,7 @@ ivP
 ivP
 ivP
 gNR
-eeZ
+nEe
 maY
 luQ
 maY
@@ -71859,7 +72004,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 rmZ
 sfS
 joJ
@@ -71881,7 +72026,7 @@ chS
 pxq
 dci
 ivP
-eeZ
+nEe
 maY
 maY
 maY
@@ -72071,7 +72216,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 owe
 jcQ
 uPX
@@ -72093,7 +72238,7 @@ gNR
 ivP
 ekb
 ivP
-eeZ
+nEe
 vJy
 maY
 maY
@@ -72283,7 +72428,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 dKe
 rcH
 lpj
@@ -72305,7 +72450,7 @@ rPG
 hBX
 xTL
 ivP
-eeZ
+nEe
 maY
 maY
 maY
@@ -72495,7 +72640,7 @@ sLx
 sLx
 sLx
 sLx
-eeZ
+nEe
 bkt
 sdk
 oyr
@@ -72517,7 +72662,7 @@ ivP
 xTL
 ivP
 qpK
-eeZ
+nEe
 maY
 luQ
 maY
@@ -72707,29 +72852,29 @@ sLx
 sLx
 sLx
 sLx
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
+nEe
 vaQ
 vaQ
 vaQ
 vaQ
-eeZ
-eeZ
-eeZ
+nEe
+nEe
+nEe
 maY
 maY
 maY

--- a/code/game/area/daedalusprison.dm
+++ b/code/game/area/daedalusprison.dm
@@ -104,39 +104,45 @@
 /area/daedalusprison/inside
 	name = "Inside"
 	icon_state = "red"
-	ceiling = CEILING_METAL
+	ceiling = CEILING_GLASS
 	outside = FALSE
 
 /area/daedalusprison/inside/engineering
 	name = "Engineering"
 	icon_state = "engine"
 	minimap_color = MINIMAP_AREA_ENGI
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/colonydorms
 	name = "Colony Dorms"
 	icon_state = "Sleep"
 	minimap_color = MINIMAP_AREA_LIVING
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/bar
 	name = "Colony Bar"
 	icon_state = "bar"
 	minimap_color = MINIMAP_AREA_LIVING
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/cargo
 	name = "Colony Cargo"
 	icon_state = "primarystorage"
 	minimap_color = MINIMAP_AREA_REQ
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/colonyauxstorage
 	name = "Colony Auxillary Storage"
 	icon_state = "storage"
 	always_unpowered = TRUE
 	minimap_color = MINIMAP_AREA_REQ
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/bunker
 	name = "Landing Zone Bunker"
 	icon_state = "shuttlered"
 	minimap_color = MINIMAP_AREA_SEC
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/bunker/west
 	name = "Western Bunker"
@@ -352,13 +358,13 @@
 
 /area/daedalusprison/inside/security/medsec
 	name = "Prison Medbay Security"
-	ceiling = CEILING_OBSTRUCTED
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/medical
 	name = "Prison Infirmary"
 	icon_state = "medbay"
 	minimap_color = MINIMAP_AREA_MEDBAY
-	ceiling = CEILING_OBSTRUCTED
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/medical/chemistry
 	name = "Prison Chemistry"
@@ -375,16 +381,19 @@
 	name = "Hydroponics Garden"
 	icon_state = "garden"
 	minimap_color = MINIMAP_AREA_LIVING
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/hydroponics
 	name = "Hydroponics"
 	icon_state = "hydro"
 	minimap_color = MINIMAP_AREA_LIVING
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/hydroponicstesting
 	name = "Hydroponics Testing"
 	icon_state = "hydro_north"
 	minimap_color = MINIMAP_AREA_LIVING
+	ceiling = CEILING_METAL
 
 /area/daedalusprison/inside/seccheckpoint
 	name = "Security Checkpoint"


### PR DESCRIPTION

## About The Pull Request
Most of the walls are rwalls now instead of normal walls
Added a few rocks for xenos to heal
The prison area is mostly glass ceilings (tad can enter)
More excavation sites in the main prison for RSR
## Why It's Good For The Game
Daedalus Prison has been pretty marine favored since vehicles came out as normal walls are nothing to them (and marine bullets by that measure, but it is rarer for marines to shoot them down) so the map was just torn down. Additionally, Tadpole couldn't exactly play in half the map outside of caves, as well as RSR. This remedies that.
## Changelog
:cl:
balance: Daedalus Prison: Way more r walls, more rocks for xenos to heal, glass ceilings in many prison areas (tad can land) and more RSR excavation sites in the prison.
/:cl:
