### PR TITLE
Hypospray can inject 60/120u at once

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -9,7 +9,7 @@
 	worn_icon_state = "hypo"
 	icon_state = "hypo"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30)
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 60)
 	volume = 60
 	reagent_flags = OPENCONTAINER
 	equip_slot_flags = ITEM_SLOT_BELT
@@ -506,6 +506,7 @@
 	icon_state = "hypomed"
 	core_name = "hypospray"
 	volume = 120
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 60, 120)
 
 /obj/item/reagent_containers/hypospray/advanced/big/bicaridine
 	name = "big bicaridine hypospray"


### PR DESCRIPTION

## About The Pull Request
Allows hyposprays to inject their full amount in 1 go
## Why It's Good For The Game
It is now possible to fully inject a chem mix entirely in 1 go.
## Changelog
:cl:
qol: Hyposprays can inject their entire storage at once.
/:cl:
