### PR TITLE
Lying offset fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -918,3 +918,6 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define CARBON_NO_CHEST_BURST 0
 #define CARBON_IS_CHEST_BURSTING 1
 #define CARBON_CHEST_BURSTED 2
+
+///Pixel_y offset when lying down
+#define CARBON_LYING_Y_OFFSET -6

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -24,9 +24,10 @@
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 1
 	var/foldabletype //To fold into an item (e.g. roller bed item)
-	/// pixel x shift to give to the buckled mob
+	///pixel x shift to give to the buckled mob
 	var/buckling_x = 0
-	var/buckling_y = 0 //pixel y shift to give to the buckled mob.
+	///pixel y shift to give to the buckled mob. This stacks with the lying down pixel shift when relevant
+	var/buckling_y = 3
 	var/obj/structure/closet/bodybag/buckled_bodybag
 	var/accepts_bodybag = FALSE //Whether you can buckle bodybags to this bed
 	var/base_bed_icon //Used by beds that change sprite when something is buckled to them
@@ -235,7 +236,7 @@
 	anchored = FALSE
 	buckle_flags = CAN_BUCKLE
 	drag_delay = 0 //Pulling something on wheels is easy
-	buckling_y = 6
+	buckling_y = 9
 	foldabletype = /obj/item/roller
 	accepts_bodybag = TRUE
 	base_bed_icon = "roller"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -17,6 +17,7 @@
 	desc = "A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably."
 	icon_state = "chair"
 	buckle_lying = 0
+	buckling_y = 0
 	max_integrity = 20
 	var/propelled = 0 //Check for fire-extinguisher-driven chairs
 

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -26,11 +26,10 @@
 		ntransform.TurnTo(lying_prev, lying_angle)
 		if(!lying_angle) //Lying to standing
 			final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
-		empulse
-			if(lying_prev == 0) //Standing to lying down
-				final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
-				if(dir & (EAST|WEST))
-					final_dir = pick(NORTH, SOUTH)
+		else if(lying_prev == 0) //Standing to lying down
+			final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
+			if(dir & (EAST|WEST))
+				final_dir = pick(NORTH, SOUTH)
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -17,7 +17,7 @@
 
 ///IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
 /mob/living/carbon/update_transform()
-	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
+	var/matrix/ntransform = matrix(transform)
 	var/final_pixel_y = pixel_y
 	var/final_dir = dir
 	var/changed = 0
@@ -25,13 +25,12 @@
 		changed++
 		ntransform.TurnTo(lying_prev, lying_angle)
 		if(!lying_angle) //Lying to standing
-			final_pixel_y = lying_angle ? -6 : initial(pixel_y)
-		else //if(lying_angle != 0)
+			final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
+		empulse
 			if(lying_prev == 0) //Standing to lying down
-				pixel_y = lying_angle ? -6 : initial(pixel_y)
-				final_pixel_y = lying_angle ? -6 : initial(pixel_y)
-				if(dir & (EAST|WEST)) //Facing east or west
-					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
+				final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
+				if(dir & (EAST|WEST))
+					final_dir = pick(NORTH, SOUTH)
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
@@ -39,4 +38,4 @@
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)
-		animate(src, transform = ntransform, time = (lying_prev == 0 || lying_angle == 0) ? 0.2 SECONDS : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))
+		animate(src, transform = ntransform, time = (lying_prev == 0 || lying_angle == 0) ? 0.2 SECONDS : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT), flags = ANIMATION_PARALLEL)


### PR DESCRIPTION

## About The Pull Request
Fixes the way lying offsets are calcuated for carbon mobs.
Cleaned up bed offsets to work/look correct.
## Why It's Good For The Game
Bug fix.
## Changelog
:cl:
fix: fixed some minor offset issues with lying on beds
/:cl:
