### PR TITLE
Engi storage holds miner upgrades

### DIFF
--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -310,6 +310,7 @@
 		/obj/item/detpack,
 		/obj/item/circuitboard,
 		/obj/item/lightreplacer,
+		/obj/item/minerupgrade,
 	))
 
 /datum/storage/internal/medical


### PR DESCRIPTION

## About The Pull Request
Engineering storage armor modules now can hold miner upgrades.
## Why It's Good For The Game
Engineering storage should be able to hold equipment useful to engineers, and it always seemed like an oversight that miner upgrades were not included in this.
## Changelog
:cl:
add: Engineering storage modules can now hold miner upgrades.
/:cl:
