### PR TITLE
Allow soap to be stored in surgery pouches/webbing

### DIFF
--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -137,7 +137,7 @@
 	))
 
 /datum/storage/internal/surgery_webbing
-	storage_slots = 12
+	storage_slots = 13
 	max_storage_space = 24
 
 /datum/storage/internal/surgery_webbing/New(atom/parent)
@@ -147,6 +147,7 @@
 		/obj/item/stack/nanopaste,
 		/obj/item/tweezers,
 		/obj/item/tweezers_advanced,
+		/obj/item/tool/soap,
 	))
 
 /datum/storage/internal/holster

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -723,13 +723,14 @@
 /obj/item/storage/pouch/surgery/Initialize(mapload, ...)
 	. = ..()
 	storage_datum.sprite_slots = 1
-	storage_datum.storage_slots = 12
+	storage_datum.storage_slots = 13
 	storage_datum.max_storage_space = 24
 	storage_datum.set_holdable(can_hold_list = list(
 		/obj/item/tool/surgery,
 		/obj/item/stack/nanopaste,
 		/obj/item/tweezers,
 		/obj/item/tweezers_advanced,
+		/obj/item/tool/soap,
 	))
 
 /obj/item/storage/pouch/surgery/PopulateContents()


### PR DESCRIPTION

## About The Pull Request

Really simple: adds 1 more storage slot to surgery webbing/pouches and adds soap to the allowed storage list, permitting a full contingent of surgery tools + tweezers + soap to be carried in the same object.

Otherwise, you have to stuff the soap into your helmet slot storage at the moment which is irritating when everything else for surgery is in the same container.

## Why It's Good For The Game

Soap is pretty integral to groundside surgery practices, and groundside surgery is *fun*. Minor but meaningful QoL adjustment for the few groundside surgeons we do actually have. Shipside might benefit from a little less storage juggling as well if they're the type that bothers to use soap.

## Changelog
:cl:
balance: Surgery pouches and surgery webbing can now hold bars of soap plus tweezers and a full contingent of surgery tools.
/:cl:
