### PR TITLE
Harvester weapon usability improvements (no friendly fire on help intent, kelotane support buff)

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -271,7 +271,7 @@
 
 ///Handles behavior when attacking a mob with bicaridine
 /datum/component/harvester/proc/attack_bicaridine(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
-	if(user.a_intent != INTENT_HELP) //Self-heal on attacking
+	if(user.a_intent != INTENT_HELP || isxeno(target)) //Self-heal on attacking
 		new /obj/effect/temp_visual/telekinesis(get_turf(user))
 		target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
 		user.adjustStaminaLoss(-30)


### PR DESCRIPTION
## About The Pull Request

- Harvester weapons no longer attack humans on **help intent**. They continue to attack xenos on help intent like normal. HvH harvester users should ensure they're in any intent other than help before heading out to fight.
- There is over-head and in-chat messaging if you hold back from striking someone on help intent, just so you don't sit there wondering why you're not slashing the SOM guy's legs off if you forgot to set help intent.
- If you strike a person with a harvester weapon with help intent on and kelotane loaded, you will apply the kelotane fire effect (for removing larva or anything like that) but will not actually hit them with the weapon in question.
- Kelotane, tramadol and tricord harvester effects now have their own messaging for both the user and the target. Useful for seeing who you clipped with your hits after a fight.

No other melee behavior is changed - everything is keyed to the harvester component.

As part of this PR, I've also gone ahead and updated the [guide to the Vali module on the wiki](https://tgstation13.org/wiki/TGMC:Guide_to_Vali) with up-to-date information about how Harvester weapons currently work, since it was super outdated and I think that a fair few people's impression of the weapons is based on old info.

## Why It's Good For The Game

Vali/harvester gameplay can get stupid hectic during heavy time dilation or in massive ungaballs, and accidentally hitting your ally while you're being bumped by two runners and a pyrogen can be absolutely devastating with something like a claymore. I think a lot of 'valitard' presentation is due to some of the issues I've fixed in this PR.

This also makes dedicated use of the harvester-bicaridine interaction actually possible. I tried to do a harvester-bicaridine medic once and ended up stabbing people due to space lag more than I was actually helping them. It's a pretty good effect, so maybe now that it's actually usable, some Vali players can moonlight as kitters if the medics are desperately trying to deal with the aftermath of a near-wipe.

Being able to swipe a freshly facehugged ally while loaded with kelotane to set them ablaze also felt pretty thematic and not all that many people seem to use kelotane loading much, so why not?

## Changelog
:cl: 
qol: Harvester weapons no longer perform damaging attacks on human targets when help intent is active.
balance: Loading kelotane into a Harvester weapon can be used on help intent to set friendlies ablaze without actually damaging them with the weapon. They still take damage from being on fire, obviously.
qol: Improved messaging for hitting something with a reagent-loaded Harvester weapon.
/:cl:
