### PR TITLE
Fixes being unable to draw from storages within a duffelbag.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -147,7 +147,7 @@
 		return TRUE
 
 	if(isitem(loc)) //Special case handling.
-		if(istype(loc, /obj/item/storage/internal) || istype(loc, /obj/item/armor_module)) //Special holders, could be contained really deep, like webbings, so let's go one step further.
+		if(item_flags & IN_STORAGE)
 			return loc.Adjacent(neighbor)
 		else //Backpacks and other containers.
 			if(!isturf(loc.loc)) //Item is inside an item neither held by neighbor nor in a turf. Can't access.

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -388,6 +388,11 @@
 	. = ..()
 	UnregisterSignal(unequipper, COMSIG_CLICK_RIGHT)
 
+/obj/item/storage/backpack/marine/duffelbag/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
+	if(item_flags & IN_INVENTORY && loc.Adjacent(neighbor)) //Special check to ensure that worn duffels are adjacent
+		return TRUE
+	return ..()
+
 ///Allows non-wearers to access this inventory
 /obj/item/storage/backpack/marine/duffelbag/proc/on_rclick_duffel_wearer(datum/source, mob/clicker)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Adds an adjacency check when trying to access a storage within a storage worn by someone else.
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: fixed being unable to take pills out of a pill bottle in someones duffel
code: items in storage now check a flag IN_STORAGE instead of type checking
/:cl:
