### PR TITLE
Space extinguishes fire

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -435,13 +435,13 @@
 
 /datum/status_effect/spacefreeze/tick()
 	owner.adjustFireLoss(40)
-	owner.ExtinguishMob()
+	owner.fire_stacks = max(owner.fire_stacks - 10,0)
 
 /datum/status_effect/spacefreeze/light
 	id = "spacefreeze_light"
 
 /datum/status_effect/spacefreeze/light/tick()
-	owner.ExtinguishMob()
+	owner.fire_stacks = max(owner.fire_stacks - 6 ,0)
 	if(owner.stat == DEAD)
 		return
 	owner.adjustFireLoss(10)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -432,6 +432,7 @@
 /datum/status_effect/spacefreeze/on_creation(mob/living/new_owner)
 	. = ..()
 	to_chat(new_owner, span_danger("The cold vacuum instantly freezes you, maybe this was a bad idea?"))
+	new_owner.ExtinguishMob()
 
 /datum/status_effect/spacefreeze/tick()
 	owner.adjustFireLoss(40)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -440,7 +440,7 @@
 	id = "spacefreeze_light"
 
 /datum/status_effect/spacefreeze/light/tick()
-	owner.fire_stacks = max(owner.fire_stacks - 6 ,0)
+	owner.fire_stacks = max(owner.fire_stacks - 6, 0)
 	if(owner.stat == DEAD)
 		return
 	owner.adjustFireLoss(10)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -435,7 +435,6 @@
 
 /datum/status_effect/spacefreeze/tick()
 	owner.adjustFireLoss(40)
-	owner.fire_stacks = max(owner.fire_stacks - 10,0)
 
 /datum/status_effect/spacefreeze/light
 	id = "spacefreeze_light"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -432,10 +432,10 @@
 /datum/status_effect/spacefreeze/on_creation(mob/living/new_owner)
 	. = ..()
 	to_chat(new_owner, span_danger("The cold vacuum instantly freezes you, maybe this was a bad idea?"))
-	new_owner.ExtinguishMob()
 
 /datum/status_effect/spacefreeze/tick()
 	owner.adjustFireLoss(40)
+	owner.ExtinguishMob()
 
 /datum/status_effect/spacefreeze/light
 	id = "spacefreeze_light"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -441,6 +441,7 @@
 	id = "spacefreeze_light"
 
 /datum/status_effect/spacefreeze/light/tick()
+	owner.ExtinguishMob()
 	if(owner.stat == DEAD)
 		return
 	owner.adjustFireLoss(10)

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -92,7 +92,7 @@
 		var/mob/living/spaceman = arrived
 		if(!spaceman.has_status_effect(debuff_type))
 			spaceman.apply_status_effect(debuff_type)
-		spaceman.ExtinguishMob()
+
 
 /turf/open/space/Exited(atom/movable/leaver, direction)
 	if(isliving(leaver))

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -93,7 +93,6 @@
 		if(!spaceman.has_status_effect(debuff_type))
 			spaceman.apply_status_effect(debuff_type)
 
-
 /turf/open/space/Exited(atom/movable/leaver, direction)
 	if(isliving(leaver))
 		var/step = get_step(src, direction)

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -92,6 +92,7 @@
 		var/mob/living/spaceman = arrived
 		if(!spaceman.has_status_effect(debuff_type))
 			spaceman.apply_status_effect(debuff_type)
+		spaceman.ExtinguishMob()
 
 /turf/open/space/Exited(atom/movable/leaver, direction)
 	if(isliving(leaver))


### PR DESCRIPTION
## About The Pull Request

"Cold vacuum" that "instantly freezes you" will now extinguishes fire

## Why It's Good For The Game

Feels like an oversight that we apply spacefreeze onto mobs when they enter space but the fire keeps burning just fine in the infinite emptiness of space.
## Changelog
:cl:
balance: Space extinguishes fire
/:cl:
