### PR TITLE
Fixes squad radio for non squad members

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -448,12 +448,13 @@ GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 			if(!GLOB.department_radio_keys[letter])
 				key_prefix = letter
 				break
+	if(GLOB.department_radio_keys[key_prefix])
 		//okay... mustve been a very short name, randomly pick things from the alphabet now
 		for(var/letter in shuffle(GLOB.alphabet))
 			if(!GLOB.department_radio_keys[letter])
 				key_prefix = letter
 				break
-		key_prefix = "ERROR"
+
 	GLOB.department_radio_keys[key_prefix] = radio_channel_name
 	GLOB.channel_tokens[radio_channel_name] = ":[key_prefix]"
 


### PR DESCRIPTION

## About The Pull Request

Fixes squad radio so command members can not only listen but also talk on custom squad radio channels

## Why It's Good For The Game

It annoyed rabbit lead. I fix bug for rabbit lead.

## Changelog
:cl:
fix: Command now can talk on custom squad radios
/:cl:
