### PR TITLE
Fixes doubled-up windows on Outrider

### DIFF
--- a/_maps/shuttles/minidropship_outrider.dmm
+++ b/_maps/shuttles/minidropship_outrider.dmm
@@ -69,7 +69,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "q" = (
-/obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
@@ -81,7 +80,6 @@
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
 "r" = (
-/obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
@@ -124,7 +122,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "z" = (
-/obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock";
 	dir = 2


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/59326706/392bff67-3e02-4bbf-a3c3-ae74ce15b606)
Oops
## Why It's Good For The Game

Fix good

## Changelog
:cl:
fix: doubled-up windows on Outrider Tadpole
/:cl: