### PR TITLE
Fixes inability to create custom squads on sulaco

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -21274,6 +21274,10 @@
 	dir = 1
 	},
 /area/sulaco/hallway/central_hall)
+"qoU" = (
+/obj/machinery/telecomms/server/presets/alpha,
+/turf/open/floor/mainship/tcomms,
+/area/sulaco/telecomms)
 "qpo" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -68856,7 +68860,7 @@ aaV
 aYM
 bdx
 baz
-baz
+qoU
 baz
 bbs
 baz


### PR DESCRIPTION
## About The Pull Request

Adds alpha tcoms to sulaco, thereby fixing the null list error on squads.dm:461 while playing sulaco, and allows the successful creation of squads

## Why It's Good For The Game

Especially if we are moving towards a single initial squad system, I think this bug should be fixed, as this drawback of sulaco has been a non minor factor for people not chosing this antiquated map, almost entirely avoiding it on high pop when popular custom squads like pink or rabbits are in rotation.

## Changelog
:cl:
fix: Fixed inability to create squads on Sulaco
/:cl:
