### PR TITLE
Adds a Valhalla surgery area, modifies the marine spawner xeno button.

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1042,11 +1042,9 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla)
 "bgz" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
 	},
-/turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
 "bgM" = (
 /obj/structure/table,
@@ -3564,6 +3562,12 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
+"eJc" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/centcom/valhalla)
 "eKo" = (
 /obj/structure/table,
 /obj/item/clothing/tie/medal/gold,
@@ -4128,6 +4132,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/vault{
 	dir = 5
+	},
+/area/centcom/valhalla)
+"fDs" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
 /area/centcom/valhalla)
 "fEt" = (
@@ -10601,6 +10610,13 @@
 	dir = 8
 	},
 /area/centcom/valhalla)
+"pni" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/dark/gray,
+/area/centcom/valhalla)
 "pon" = (
 /obj/machinery/light_switch{
 	pixel_x = 38;
@@ -10632,6 +10648,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/centcom/valhalla)
+"pqs" = (
+/obj/machinery/vending/medical/valhalla,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/centcom/valhalla)
 "pqM" = (
 /obj/machinery/marine_selector/clothes/valhalla,
@@ -10731,6 +10753,13 @@
 /obj/item/book/manual/engineering_particle_accelerator,
 /obj/item/book/manual/engineering_singularity_safety,
 /turf/open/floor/tile/dark,
+/area/centcom/valhalla)
+"pzM" = (
+/obj/machinery/door/airlock/mainship/medical/or/free_access{
+	dir = 2;
+	name = "\improper Medical Airlock"
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla)
 "pzZ" = (
 /obj/effect/turf_decal/tile/pink{
@@ -13154,6 +13183,10 @@
 	},
 /turf/open/floor/gcircuit,
 /area/centcom/valhalla)
+"tjs" = (
+/obj/machinery/optable,
+/turf/open/floor/mainship/sterile/dark,
+/area/centcom/valhalla)
 "tkB" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -13845,6 +13878,9 @@
 /turf/open/floor/tile/vault{
 	dir = 5
 	},
+/area/centcom/valhalla)
+"ukF" = (
+/turf/open/floor/mainship/sterile/side,
 /area/centcom/valhalla)
 "ukJ" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -15379,6 +15415,12 @@
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
+	},
+/area/centcom/valhalla)
+"wqs" = (
+/obj/machinery/vending/MarineMed/valhalla,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
 /area/centcom/valhalla)
 "wqU" = (
@@ -19734,8 +19776,8 @@ xrI
 xrI
 xrI
 xrI
-vQc
-jYG
+xrI
+xrI
 jYG
 jYG
 jYG
@@ -19868,12 +19910,12 @@ xrI
 xrI
 xrI
 xrI
-wQi
 xrI
-xrI
-xrI
-jYG
-jYG
+box
+box
+box
+box
+box
 box
 box
 box
@@ -20007,11 +20049,11 @@ xrI
 xrI
 xrI
 xrI
-xrI
-xrI
-jYG
-jYG
-jYG
+box
+bgz
+fDs
+fDs
+jKv
 box
 nKg
 jWH
@@ -20145,11 +20187,11 @@ xrI
 xrI
 xrI
 xrI
-xrI
-xrI
-xrI
-jYG
-jYG
+box
+eJc
+rfF
+tjs
+ukF
 box
 foh
 jWH
@@ -20283,11 +20325,11 @@ xrI
 vQc
 vQc
 xXc
-xXc
-vQc
-vQc
-jYG
-jYG
+box
+pqs
+rfF
+rfF
+ukF
 box
 lPX
 oNZ
@@ -20421,11 +20463,11 @@ fmR
 fmR
 vQc
 fmR
-vQc
-fmR
-fmR
-fmR
-jYG
+box
+eJc
+rfF
+tjs
+ukF
 box
 nKg
 jWH
@@ -20559,11 +20601,11 @@ fmR
 fmR
 fmR
 fmR
-fmR
-fmR
-fmR
-vQc
-fmR
+box
+wqs
+rfF
+rfF
+ukF
 box
 foh
 jWH
@@ -20697,19 +20739,19 @@ fWu
 fWu
 fWu
 fWu
-fWu
-fWu
-fWu
-fWu
-fWu
 box
-bgz
+ojf
+fgO
+fgO
+bEo
+pzM
+mCI
 rBJ
 mCI
 lMV
 xgU
 lMV
-mCI
+pni
 gMl
 gJS
 myT
@@ -20836,9 +20878,9 @@ fmR
 fmR
 fmR
 aEn
-bcm
-fmR
-fmR
+box
+bRv
+bRv
 bjQ
 box
 bog

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1042,6 +1042,7 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla)
 "bgz" = (
+/obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -1415,6 +1416,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/tile/dark/gray,
+/area/centcom/valhalla)
+"bMr" = (
+/obj/machinery/vending/MarineMed/valhalla,
+/turf/open/floor/mainship/sterile/corner,
 /area/centcom/valhalla)
 "bMv" = (
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -4892,7 +4897,7 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
 "gEX" = (
-/obj/machinery/button/valhalla/xeno_button{
+/obj/machinery/button/valhalla/marine_spawner{
 	link = "marineright"
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -5171,7 +5176,7 @@
 /turf/open/floor/tile/cafe,
 /area/centcom/valhalla)
 "hda" = (
-/obj/machinery/button/valhalla/xeno_button{
+/obj/machinery/button/valhalla/marine_spawner{
 	link = "marinetop"
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -5185,7 +5190,7 @@
 /turf/open/floor/plating/scorched,
 /area/centcom/valhalla)
 "heB" = (
-/obj/machinery/button/valhalla/xeno_button{
+/obj/machinery/button/valhalla/marine_spawner{
 	link = "marineleft"
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -6732,6 +6737,12 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/centcom/valhalla)
+"jvT" = (
+/obj/machinery/button/valhalla/marine_spawner{
+	link = "marinesurgeryright"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/centcom/valhalla)
 "jxN" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -7531,6 +7542,12 @@
 	},
 /turf/open/floor,
 /area/tdome)
+"kvr" = (
+/obj/machinery/button/valhalla/marine_spawner{
+	link = "marinesurgeryleft"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/centcom/valhalla)
 "kxq" = (
 /obj/structure/closet/crate,
 /obj/machinery/firealarm{
@@ -8244,6 +8261,10 @@
 /area/centcom/valhalla)
 "lIu" = (
 /obj/machinery/optable,
+/obj/effect/landmark/valhalla/marine_spawner_landmark{
+	where = "surgeryleft"
+	},
+/obj/item/tank/anesthetic,
 /turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla)
 "lIC" = (
@@ -10733,7 +10754,7 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla)
 "pwE" = (
-/obj/machinery/vending/MarineMed/valhalla,
+/obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -13956,6 +13977,14 @@
 	},
 /obj/effect/turf_decal/tile/pink,
 /turf/open/floor/tile/dark/gray,
+/area/centcom/valhalla)
+"utb" = (
+/obj/machinery/optable,
+/obj/effect/landmark/valhalla/marine_spawner_landmark{
+	where = "surgeryright"
+	},
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla)
 "utM" = (
 /obj/effect/turf_decal/warning_stripes/thick,
@@ -20189,7 +20218,7 @@ xrI
 xrI
 box
 uCL
-rfF
+kvr
 lIu
 sgT
 box
@@ -20465,8 +20494,8 @@ vQc
 fmR
 box
 uCL
-rfF
-lIu
+jvT
+utb
 sgT
 box
 nKg
@@ -20740,7 +20769,7 @@ fWu
 fWu
 fWu
 box
-ojf
+bMr
 fgO
 fgO
 bEo

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -2441,6 +2441,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/centcom/valhalla)
+"dgG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/dark/gray,
+/area/centcom/valhalla)
 "dgR" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall,
@@ -3562,12 +3569,6 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
-"eJc" = (
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/centcom/valhalla)
 "eKo" = (
 /obj/structure/table,
 /obj/item/clothing/tie/medal/gold,
@@ -4132,11 +4133,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/vault{
 	dir = 5
-	},
-/area/centcom/valhalla)
-"fDs" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
 	},
 /area/centcom/valhalla)
 "fEt" = (
@@ -5329,6 +5325,13 @@
 	dir = 1
 	},
 /area/centcom/valhalla)
+"hnH" = (
+/obj/machinery/door/airlock/mainship/medical/or/free_access{
+	dir = 2;
+	name = "\improper Medical Airlock"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/centcom/valhalla)
 "hnQ" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -5367,6 +5370,12 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /obj/structure/closet/crate,
 /turf/open/floor/tile/dark/gray,
+/area/centcom/valhalla)
+"hqA" = (
+/obj/machinery/vending/medical/valhalla,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/centcom/valhalla)
 "hrg" = (
 /obj/item/storage/box/bodybags{
@@ -8233,6 +8242,10 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/grimy,
 /area/centcom/valhalla)
+"lIu" = (
+/obj/machinery/optable,
+/turf/open/floor/mainship/sterile/dark,
+/area/centcom/valhalla)
 "lIC" = (
 /turf/closed/wall/mainship,
 /area/tdome)
@@ -10610,13 +10623,6 @@
 	dir = 8
 	},
 /area/centcom/valhalla)
-"pni" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/tile/dark/gray,
-/area/centcom/valhalla)
 "pon" = (
 /obj/machinery/light_switch{
 	pixel_x = 38;
@@ -10648,12 +10654,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/centcom/valhalla)
-"pqs" = (
-/obj/machinery/vending/medical/valhalla,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
 /area/centcom/valhalla)
 "pqM" = (
 /obj/machinery/marine_selector/clothes/valhalla,
@@ -10732,6 +10732,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/centcom/valhalla)
+"pwE" = (
+/obj/machinery/vending/MarineMed/valhalla,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/centcom/valhalla)
 "pwR" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -10753,13 +10759,6 @@
 /obj/item/book/manual/engineering_particle_accelerator,
 /obj/item/book/manual/engineering_singularity_safety,
 /turf/open/floor/tile/dark,
-/area/centcom/valhalla)
-"pzM" = (
-/obj/machinery/door/airlock/mainship/medical/or/free_access{
-	dir = 2;
-	name = "\improper Medical Airlock"
-	},
-/turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla)
 "pzZ" = (
 /obj/effect/turf_decal/tile/pink{
@@ -12414,6 +12413,9 @@
 	},
 /turf/open/floor/tile/lightred/full,
 /area/centcom/valhalla)
+"sgT" = (
+/turf/open/floor/mainship/sterile/side,
+/area/centcom/valhalla)
 "sis" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/air_alarm{
@@ -12815,6 +12817,11 @@
 	dir = 5
 	},
 /area/centcom/valhalla)
+"sGi" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/centcom/valhalla)
 "sGw" = (
 /obj/effect/ai_node,
 /turf/open/floor/carpet/side{
@@ -13182,10 +13189,6 @@
 	dir = 5
 	},
 /turf/open/floor/gcircuit,
-/area/centcom/valhalla)
-"tjs" = (
-/obj/machinery/optable,
-/turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla)
 "tkB" = (
 /obj/effect/turf_decal/warning_stripes/thick,
@@ -13879,9 +13882,6 @@
 	dir = 5
 	},
 /area/centcom/valhalla)
-"ukF" = (
-/turf/open/floor/mainship/sterile/side,
-/area/centcom/valhalla)
 "ukJ" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -14064,6 +14064,12 @@
 	pixel_y = 2
 	},
 /turf/open/floor/tile/cafe,
+/area/centcom/valhalla)
+"uCL" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/centcom/valhalla)
 "uEe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -15415,12 +15421,6 @@
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
-	},
-/area/centcom/valhalla)
-"wqs" = (
-/obj/machinery/vending/MarineMed/valhalla,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
 	},
 /area/centcom/valhalla)
 "wqU" = (
@@ -20051,8 +20051,8 @@ xrI
 xrI
 box
 bgz
-fDs
-fDs
+sGi
+sGi
 jKv
 box
 nKg
@@ -20188,10 +20188,10 @@ xrI
 xrI
 xrI
 box
-eJc
+uCL
 rfF
-tjs
-ukF
+lIu
+sgT
 box
 foh
 jWH
@@ -20326,10 +20326,10 @@ vQc
 vQc
 xXc
 box
-pqs
+hqA
 rfF
 rfF
-ukF
+sgT
 box
 lPX
 oNZ
@@ -20464,10 +20464,10 @@ fmR
 vQc
 fmR
 box
-eJc
+uCL
 rfF
-tjs
-ukF
+lIu
+sgT
 box
 nKg
 jWH
@@ -20602,10 +20602,10 @@ fmR
 fmR
 fmR
 box
-wqs
+pwE
 rfF
 rfF
-ukF
+sgT
 box
 foh
 jWH
@@ -20744,14 +20744,14 @@ ojf
 fgO
 fgO
 bEo
-pzM
+hnH
 mCI
 rBJ
 mCI
 lMV
 xgU
 lMV
-pni
+dgG
 gMl
 gJS
 myT

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -336,7 +336,6 @@
 		return
 	linked.equipOutfit(job_outfits[selected_outfit], FALSE)
 
-
 /obj/machinery/button/valhalla/vehicle_button
 	name = "Vehicle Spawner"
 

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -281,12 +281,12 @@
 		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
 	linked = new xeno_wanted(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
 
-/obj/machinery/button/valhalla/xeno_button
+/obj/machinery/button/valhalla/marine_spawner
 	name = "Marine spawner"
 	///The list of outfits we can equip on the humans we're spawning
 	var/outfit_list = list()
 
-/obj/machinery/button/valhalla/xeno_button/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+/obj/machinery/button/valhalla/marine_spawner/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	var/list/job_outfits = list()
 	for(var/type in subtypesof(/datum/outfit/job))
 		if(istype(type, /datum/outfit))
@@ -310,6 +310,32 @@
 	if(selected_outfit == "Naked" || !selected_outfit)
 		return
 	linked.equipOutfit(job_outfits[selected_outfit], FALSE)
+
+/obj/machinery/button/valhalla/marine_spawner/attack_hand(mob/living/user)
+	var/list/job_outfits = list()
+	for(var/type in subtypesof(/datum/outfit/job))
+		if(istype(type, /datum/outfit))
+			continue
+		var/datum/outfit/out = type
+		if(initial(out.can_be_admin_equipped))
+			job_outfits[initial(out.name)] = out
+
+	job_outfits = sortList(job_outfits)
+	job_outfits.Insert(1, "Naked")
+
+	var/datum/outfit/selected_outfit = tgui_input_list(usr, "Which outfit do you want the human to wear?", "Human spawn", job_outfits)
+	if(!selected_outfit)
+		return
+
+	QDEL_NULL(linked)
+	if(!get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+		to_chat(user, span_warning("An error occured, yell at the coders."))
+		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
+	linked = new /mob/living/carbon/human(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+	if(selected_outfit == "Naked" || !selected_outfit)
+		return
+	linked.equipOutfit(job_outfits[selected_outfit], FALSE)
+
 
 /obj/machinery/button/valhalla/vehicle_button
 	name = "Vehicle Spawner"


### PR DESCRIPTION

## About The Pull Request
Title, adds a surgery area in valhalla, and modifies the xeno caves buttons to be usable by marines.
![Change Me - Pillar of Spring 6_30_2024 4_33_30 AM](https://github.com/tgstation/TerraGov-Marine-Corps/assets/87689371/a0de94f1-dec7-4724-b7df-9406040a2160)
## Why It's Good For The Game
The first part is so that it let's new players practice surgery without putting some helpless soul in perma-sleep. The second part is so I didn't make another button solely with the ability that marines can use it to spawn humans.
## Changelog
:cl:
add: Added a surgery practice area to marine Valhalla.
code: Modified the marine spawner buttons in xeno Valhalla to be usable by marines.
/:cl:
