### PR TITLE
Makes large req export histories more readable and less laggy

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -370,11 +370,17 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		.["awaiting_delivery"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["export_history"] = list()
 	var/id = 0
+	var/lastexport = ""
 	for(var/datum/export_report/report AS in SSpoints.export_history)
 		if(report.faction != user.faction)
 			continue
-		.["export_history"] += list(list("id" = id, "name" = report.export_name, "points" = report.points))
-		id++
+		if(report.export_name == lastexport)
+			.["export_history"][id]["amount"] += 1
+			.["export_history"][id]["total"] += report.points
+		else
+			.["export_history"] += list(list("id" = id, "name" = report.export_name, "points" = report.points, "amount" = 1, total = report.points))
+			id++
+			lastexport = report.export_name
 	.["shopping_history"] = list()
 	for(var/datum/supply_order/SO AS in SSpoints.shopping_history)
 		if(SO.faction != user.faction)

--- a/tgui/packages/tgui/interfaces/Cargo.jsx
+++ b/tgui/packages/tgui/interfaces/Cargo.jsx
@@ -94,7 +94,9 @@ const Exports = (props) => {
         {export_history.map((exp) => (
           <Table.Row key={exp.id}>
             <Table.Cell>{exp.name}</Table.Cell>
-            <Table.Cell>{exp.points} points</Table.Cell>
+            <Table.Cell>
+              {exp.amount} x {exp.points} points ({exp.total})
+            </Table.Cell>
           </Table.Row>
         ))}
       </Table>


### PR DESCRIPTION
## About The Pull Request

Makes it so that if the same item was sold as the last one, then it doesn't begin a new row, and instead adds up to the previous row. (With the following format: stack number x single item points (total stack points) )

## Why It's Good For The Game

Especially when for an example, selling credits or pizza, instead of a morbillion quachillion rows, you get this
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/60290575/92ad6396-a3f3-478c-b2a5-e365f3690576)


## Changelog
:cl:
qol: Same as last rows in req export history now stack
/:cl:
