### PR TITLE
Campaign DNR fix

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -375,8 +375,17 @@
 				ready_candidate?.client?.screen?.Cut()
 				qdel(ready_candidate)
 				return
+
+			var/mob/living/carbon/human/human_current
 			if(isobserver(candidate))
+				var/mob/dead/observer/observer_candidate = candidate
+				if(!isnull(observer_candidate.can_reenter_corpse))
+					human_current = observer_candidate.can_reenter_corpse.resolve()
 				qdel(candidate)
+			else if(ishuman(candidate))
+				human_current = candidate
+
+			human_current?.set_undefibbable(TRUE)
 
 
 ///Actually respawns the player, if still able


### PR DESCRIPTION

## About The Pull Request
Respawning in campaign now DNR's your body like it used to.
## Why It's Good For The Game
The recent change to defibbing/DNR etc had the knock on effect in Campaign where people respawning would leave their bodies in a revivable state.

I was happy to leave this for a bit but its really not ideal.

Firstly because it makes it impossible to tell where GENUINELY revivable people are on the map.
Secondly because no one ever gets back into ssd corpses
Thirdly If someone did, there are no faction checks
And lastly it could mean dirt eating goobers could farm damage and revives on an SSd body.
## Changelog
:cl:
fix: Campaign: Respawning in campaign now DNR's your body like it used to
/:cl:
