### PR TITLE
xenos can now fully evo pre-shutters

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -57,14 +57,22 @@
 
 /// Some data to update the UI with the current evolution status
 /datum/evolution_panel/ui_data(mob/living/carbon/xenomorph/xeno)
-	. = list()
+	var/list/data = list()
 
-	.["can_evolve"] = !xeno.is_ventcrawling && !xeno.incapacitated(TRUE) && xeno.health >= xeno.maxHealth && xeno.plasma_stored >= (xeno.xeno_caste.plasma_max * xeno.xeno_caste.plasma_regen_limit)
+	data["bypass_evolution_checks"] = SSresinshaping.active
 
-	.["evolution"] = list(
+	data["can_evolve"] = \
+		!xeno.is_ventcrawling && \
+		!xeno.incapacitated(TRUE) && \
+		xeno.health >= xeno.maxHealth && \
+		xeno.plasma_stored >= (xeno.xeno_caste.plasma_max * xeno.xeno_caste.plasma_regen_limit)
+
+	data["evolution"] = list(
 		"current" = xeno.evolution_stored,
 		"max" = xeno.xeno_caste.evolution_threshold
 	)
+
+	return data
 
 /// Handles actuually evolving
 /datum/evolution_panel/ui_act(action, list/params)

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -332,7 +332,7 @@
 			else if(isxenodrone(src) && new_caste_type != /datum/xeno_caste/shrike)
 				to_chat(src, span_xenonotice("The hive currently has no sister able to become a ruler! The survival of the hive requires from us to be a Shrike!"))
 				return FALSE
-		if(!CHECK_BITFIELD(new_caste_flags, CASTE_INSTANT_EVOLUTION) && xeno_caste.evolution_threshold && evolution_stored < xeno_caste.evolution_threshold)
+		if(!CHECK_BITFIELD(new_caste_flags, CASTE_INSTANT_EVOLUTION) && xeno_caste.evolution_threshold && evolution_stored < xeno_caste.evolution_threshold && !SSresinshaping.active)
 			to_chat(src, span_warning("We must wait before evolving. Currently at: [evolution_stored] / [xeno_caste.evolution_threshold]."))
 			return FALSE
 	return TRUE

--- a/tgui/packages/tgui/interfaces/HiveEvolveScreen.tsx
+++ b/tgui/packages/tgui/interfaces/HiveEvolveScreen.tsx
@@ -45,10 +45,17 @@ const CasteView = (props) => {
 export const HiveEvolveScreen = (props) => {
   const { act, data } = useBackend();
 
-  const { name, evolution, abilities, evolves_to, can_evolve } =
-    data as ByondData;
+  const {
+    name,
+    evolution,
+    abilities,
+    evolves_to,
+    can_evolve,
+    bypass_evolution_checks,
+  } = data as ByondData;
 
   const canEvolve = can_evolve && evolution.current >= evolution.max;
+  const bypassEvolution = can_evolve && bypass_evolution_checks;
   // Most checks are skipped for shrike and queen so we except them below.
   const evolvesInto = Object.values(evolves_to);
 
@@ -66,7 +73,9 @@ export const HiveEvolveScreen = (props) => {
               title={`${evolve.name} (click for details)`}
               buttons={
                 <Button
-                  disabled={!canEvolve && !evolve.instant_evolve}
+                  disabled={
+                    !canEvolve && !evolve.instant_evolve && !bypassEvolution
+                  }
                   onClick={() => act('evolve', { path: evolve.type_path })}
                 >
                   Evolve
@@ -95,6 +104,7 @@ type ByondData = {
   abilities: XenoAbility[];
   evolves_to: EvolveCaste[];
   can_evolve: boolean;
+  bypass_evolution_checks: boolean;
 };
 
 type EvolveCaste = {


### PR DESCRIPTION

## About The Pull Request
Ties evolution to quick build.
If you have access to quick build, you can evo as much as you want.
## Why It's Good For The Game
Evo restrictions exist as a CM/Survivor era relic where there was an expectation of fighting during the prep phase.
Now with this gone, it no longer makes sense for xeno evolution to be restricted in prep phase.
## Changelog
:cl:
balance: Xenos no longer need evo points to evolve in prep phase
/:cl:
