### PR TITLE
Corspman can now suture without fumbling

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -289,6 +289,7 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/shard = 20,
 	)
+	surgery_skill_required = SKILL_SURGERY_TRAINED
 	open_step = 0
 	min_duration = SUTURE_MIN_DURATION
 	max_duration = SUTURE_MAX_DURATION

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 	var/list/allowed_tools = null //Array of type path referencing tools that can be used for this step, and how well are they suited for it
 	var/list/allowed_species = null //List of names referencing species that this step applies to.
 	var/list/disallowed_species = null
-
+	///Surgery skill required for this surgery step to start without the innitial fumble delay. By default it's SKILL_SURGERY_PROFESSIONAL (3). For reference, squaddies are 0, command is 1, corpsman is 2, researcher is 3, synths and doctors are 4, and CMO is 5
 	var/surgery_skill_required = SKILL_SURGERY_PROFESSIONAL
 
 	var/min_duration = 0 //Minimum duration of the step

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 	var/list/allowed_tools = null //Array of type path referencing tools that can be used for this step, and how well are they suited for it
 	var/list/allowed_species = null //List of names referencing species that this step applies to.
 	var/list/disallowed_species = null
-	///Surgery skill required for this surgery step to start without the innitial fumble delay. By default it's SKILL_SURGERY_PROFESSIONAL (3). For reference, squaddies are 0, command is 1, corpsman is 2, researcher is 3, synths and doctors are 4, and CMO is 5
+	///Surgery skill required for this surgery step to start without the innitial fumble delay
 	var/surgery_skill_required = SKILL_SURGERY_PROFESSIONAL
 
 	var/min_duration = 0 //Minimum duration of the step

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 	var/list/allowed_species = null //List of names referencing species that this step applies to.
 	var/list/disallowed_species = null
 
-
+	var/surgery_skill_required = SKILL_SURGERY_PROFESSIONAL
 
 	var/min_duration = 0 //Minimum duration of the step
 	var/max_duration = 0 //Maximum duration of the step
@@ -147,7 +147,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 			if(SURGERY_INVALID)
 				return TRUE
 
-		if(user.skills.getRating(SKILL_SURGERY) < SKILL_SURGERY_PROFESSIONAL)
+		if(user.skills.getRating(SKILL_SURGERY) < surgery_step.surgery_skill_required)
 			user.visible_message(span_notice("[user] fumbles around figuring out how to operate [M]."),
 			span_notice("You fumble around figuring out how to operate [M]."))
 			var/fumbling_time = max(0, SKILL_TASK_FORMIDABLE - ( 8 SECONDS * user.skills.getRating(SKILL_SURGERY) )) // 20 secs non-trained, 12 amateur, 4 trained, 0 prof


### PR DESCRIPTION
## About The Pull Request

Corpsman can now suture without fumbling

## Why It's Good For The Game

Field surgery is already weak as is without a medical APC or medical tad (which is infrequently chosen as the tad usually is better off with protection instead), this change makes it so that corspman can suture without fumbling. If I remember correctly, their fumble time is 4 seconds as is, which is impractical because to extend a lifetime of a corpse you have to do CPR every 7 seconds and every precious second counts. 
While I don't believe most corpsman will begin carrying sutures in most cases as only having a corpse once or twice have over -100% health post kitting is rare on most OPs, and would instead probably be medevaced like usual, this is a buff to corpsman on maps where corpses regularly gain over 200 combined damage post kitting and the medevac is on cooldown for longer than the interval of corpses piling up (Think magmore engineering for an example, with marines being braziled into lava.) or crash/lowpop in general where we might not have shipside medical.
Note, that this is already how CM works, with corpsman being able to perform basic surgeries, such as suturing or internal bleeding, so for the balance side of things, I feel like they have already paved the path and playtested it for us, if that's any consideration towards approving and testmerging these changes.

## Changelog
:cl:
balance: Corpsman can now suture without fumbling
code: Dynamic surgery skill requirements
/:cl:
