### PR TITLE
Squad chat fix whitelist

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -417,7 +417,7 @@
 GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 ///initializes a new custom squad. all args mandatory
 /proc/create_squad(squad_name, squad_color, mob/living/carbon/human/creator)
-	var/radio_whitelist = list(MODE_KEY_BINARY = MODE_KEY_BINARY)
+	var/radio_whitelist = list(MODE_KEY_BINARY = MODE_KEY_BINARY, MODE_KEY_R_HAND = MODE_KEY_R_HAND, MODE_KEY_L_HAND = MODE_KEY_L_HAND, MODE_KEY_INTERCOM = MODE_KEY_INTERCOM, MODE_KEY_DEPARTMENT , MODE_KEY_DEPARTMENT)
 	//Create the squad
 	if(!squad_name)
 		return

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -448,12 +448,13 @@ GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 			if(!GLOB.department_radio_keys[letter])
 				key_prefix = letter
 				break
+	if(GLOB.department_radio_keys[key_prefix])
 		//okay... mustve been a very short name, randomly pick things from the alphabet now
 		for(var/letter in shuffle(GLOB.alphabet))
 			if(!GLOB.department_radio_keys[letter])
 				key_prefix = letter
 				break
-		key_prefix = "ERROR"
+
 	GLOB.department_radio_keys[key_prefix] = radio_channel_name
 	GLOB.channel_tokens[radio_channel_name] = ":[key_prefix]"
 

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -417,6 +417,7 @@
 GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 ///initializes a new custom squad. all args mandatory
 /proc/create_squad(squad_name, squad_color, mob/living/carbon/human/creator)
+	var/radio_whitelist = list(MODE_KEY_BINARY = MODE_KEY_BINARY)
 	//Create the squad
 	if(!squad_name)
 		return
@@ -443,15 +444,15 @@ GLOBAL_LIST_EMPTY_TYPED(custom_squad_radio_freqs, /datum/squad)
 	LAZYADDASSOCSIMPLE(GLOB.reverseradiochannels, "[freq]", radio_channel_name)
 	new_squad.faction = squad_faction
 	var/key_prefix = lowertext_name[1]
-	if(GLOB.department_radio_keys[key_prefix])
+	if(GLOB.department_radio_keys[key_prefix] || radio_whitelist[key_prefix])
 		for(var/letter in splittext(lowertext_name, ""))
-			if(!GLOB.department_radio_keys[letter])
+			if(! (GLOB.department_radio_keys[letter] || radio_whitelist[letter]))
 				key_prefix = letter
 				break
-	if(GLOB.department_radio_keys[key_prefix])
+	if(GLOB.department_radio_keys[key_prefix] || radio_whitelist[key_prefix])
 		//okay... mustve been a very short name, randomly pick things from the alphabet now
 		for(var/letter in shuffle(GLOB.alphabet))
-			if(!GLOB.department_radio_keys[letter])
+			if(! (GLOB.department_radio_keys[letter] || radio_whitelist[letter]))
 				key_prefix = letter
 				break
 


### PR DESCRIPTION

## About The Pull Request

Adds a whitelist of tokens that are already in use elsewhere other than the radio list

## Why It's Good For The Game

Today I noticed that "Naptelek" has been assigned the :n token, which is already in use by binary, making command staff unable to use it.. This adds various tokens to the whitelist that are already in use by other things
## Changelog
:cl:
fix: Fixes custom squads being assigned tokens that were already in use by non radio prefixes
/:cl:
