### PR TITLE
Fixes strain swapping not being instant

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -81,7 +81,7 @@
 			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[newpath][XENO_UPGRADE_BASETYPE]
 			if(!caste)
 				return
-			xeno.do_evolve(caste.type, (HAS_TRAIT(xeno, TRAIT_CASTE_SWAP) || HAS_TRAIT(xeno, TRAIT_REGRESSING))) // All the checks for can or can't are handled inside do_evolve
+			xeno.do_evolve(caste.type, (HAS_TRAIT(xeno, TRAIT_CASTE_SWAP) || HAS_TRAIT(xeno, TRAIT_REGRESSING)|| HAS_TRAIT(xeno, TRAIT_STRAIN_SWAP))) // All the checks for can or can't are handled inside do_evolve
 			return TRUE
 
 /datum/evolution_panel/ui_close(mob/user)


### PR DESCRIPTION
## About The Pull Request
This was intended in code, but this check was missing here

## Why It's Good For The Game

You're meant to be able to strain swap instantly without waiting for the evo timer

## Changelog
:cl:
fix: Fixed Strain Swapping not being instant and relying on evo timer
/:cl:
