### PR TITLE
CLF gets faster suicide vest detonate time

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/campaign_asset_jobs.dm
+++ b/code/datums/gamemodes/campaign/rewards/campaign_asset_jobs.dm
@@ -136,7 +136,7 @@ What you lack in equipment and military training you make up in bravery and conv
 
 /datum/outfit/job/som/militia/standard/fanatic
 	head = /obj/item/clothing/head/headband/rambo
-	wear_suit = /obj/item/clothing/suit/storage/marine/boomvest
+	wear_suit = /obj/item/clothing/suit/storage/marine/boomvest/fast
 	belt = /obj/item/weapon/gun/shotgun/double/sawn
 	suit_store = /obj/item/weapon/gun/smg/skorpion/mag_harness
 

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -128,7 +128,7 @@
 
 /datum/outfit/job/clf/standard/fanatic
 	head = /obj/item/clothing/head/headband/rambo
-	wear_suit = /obj/item/clothing/suit/storage/marine/boomvest
+	wear_suit = /obj/item/clothing/suit/storage/marine/boomvest/fast
 	belt = /obj/item/weapon/gun/shotgun/double/sawn
 	suit_store = /obj/item/weapon/gun/smg/skorpion/mag_harness
 

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -117,4 +117,4 @@
 	qdel(src)
 
 /obj/item/clothing/suit/storage/marine/boomvest/fast
-	detonate_time = 5
+	detonate_time = 0.5 SECONDS

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -10,6 +10,8 @@
 	var/bomb_message
 	///List of warcries that are not allowed.
 	var/bad_warcries_regex = "allahu ackbar|allah|ackbar"
+	///Time it takes to detonate
+	var/detonate_time = 2 SECONDS
 
 /obj/item/clothing/suit/storage/marine/boomvest/equipped(mob/user, slot)
 	. = ..()
@@ -46,7 +48,7 @@
 		return
 	if(bomb_message)
 		activator.say("[bomb_message]!!")
-	if(!do_after(user, 2 SECONDS, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_DANGER))
+	if(!do_after(user, detonate_time, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_DANGER))
 		return FALSE
 	var/turf/target = get_turf(loc)
 	if(bomb_message) //Checks for a non null bomb message.
@@ -91,6 +93,7 @@
 /obj/item/clothing/suit/storage/marine/boomvest/ob_vest
 	name = "orbital bombardment vest"
 	desc = "This is your lieutenant speaking, I know exactly what those coordinates are for."
+	detonate_time = 1 SECONDS
 
 /obj/item/clothing/suit/storage/marine/boomvest/ob_vest/attack_self(mob/user)
 	var/mob/living/carbon/human/activator = user
@@ -99,7 +102,7 @@
 		return FALSE
 	if(LAZYACCESS(user.do_actions, src))
 		return
-	if(!do_after(user, 1 SECONDS, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_DANGER))
+	if(!do_after(user, detonate_time, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_DANGER))
 		return FALSE
 	var/turf/target = get_turf(loc)
 	activator.say("I'M FIRING IT AS AN OB!!")
@@ -112,3 +115,6 @@
 		appendage.droplimb()
 	explosion(target, 15, 0, 0, 0, 15, 15)
 	qdel(src)
+
+/obj/item/clothing/suit/storage/marine/boomvest/fast
+	detonate_time = 5


### PR DESCRIPTION

## About The Pull Request
cut down from 2 seconds to 0.5
## Why It's Good For The Game
current vest detonate time takes too long for hvh gameplay and how weak clf are
## Changelog
:cl:
balance: clf suicide vest detonates faster
/:cl:
