### PR TITLE
Further declutters the export history

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -374,6 +374,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	for(var/datum/export_report/report AS in SSpoints.export_history)
 		if(report.faction != user.faction)
 			continue
+		if(report.points == 0)
+			continue
 		if(report.export_name == lastexport)
 			.["export_history"][id]["amount"] += 1
 			.["export_history"][id]["total"] += report.points


### PR DESCRIPTION

## About The Pull Request

If an export value of an item is 0 it won't be **DISPLAYED**

## Why It's Good For The Game

Further declutters the export history by removing items that are worthless in terms of export value. Important to note, that these items will still be logged for administrative purposes, just merely won't be sent to the ASRS interface to clutter it.

## Changelog
:cl:
qol: Req export history no longer displays worthless items
/:cl:
