### PR TITLE
Adds some sanity checks to xeno evolution/upgrading

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -151,6 +151,10 @@
 		return
 	new_xeno.upgrade_stored = upgrade_stored
 	while(new_xeno.upgrade_stored >= new_xeno.xeno_caste?.upgrade_threshold && new_xeno.upgrade_possible())
+		if(!new_xeno.upgrade_next()) //Upgrade tier wasn't set properly, let's avoid looping forever
+			qdel(new_xeno)
+			stack_trace("[src] tried to evolve and upgrade, but the castes upgrade tier wasn't valid.")
+			return
 		new_xeno.upgrade_xeno(new_xeno.upgrade_next(), TRUE)
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_EVOLVED, new_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -204,22 +204,32 @@
 			return 0
 
 /mob/living/carbon/xenomorph/proc/upgrade_next()
+	if(!(upgrade in GLOB.xenoupgradetiers))
+		CRASH("Invalid upgrade tier set for caste!")
 	switch(upgrade)
 		if(XENO_UPGRADE_INVALID)
 			return XENO_UPGRADE_INVALID
 		if(XENO_UPGRADE_NORMAL)
 			return XENO_UPGRADE_PRIMO
+		if(XENO_UPGRADE_BASETYPE)
+			return XENO_UPGRADE_PRIMO
 		if(XENO_UPGRADE_PRIMO)
 			return XENO_UPGRADE_PRIMO
+	stack_trace("Logic for handling this Upgrade tier wasn't written")
 
 /mob/living/carbon/xenomorph/proc/upgrade_prev()
+	if(!(upgrade in GLOB.xenoupgradetiers))
+		CRASH("Invalid upgrade tier set for caste!")
 	switch(upgrade)
 		if(XENO_UPGRADE_INVALID)
 			return XENO_UPGRADE_INVALID
 		if(XENO_UPGRADE_NORMAL)
 			return XENO_UPGRADE_NORMAL
+		if(XENO_UPGRADE_BASETYPE)
+			return XENO_UPGRADE_BASETYPE
 		if(XENO_UPGRADE_PRIMO)
 			return XENO_UPGRADE_NORMAL
+	stack_trace("Logic for handling this Upgrade tier wasn't written")
 
 /mob/living/carbon/xenomorph/proc/setup_job()
 	var/datum/job/xenomorph/xeno_job = SSjob.type_occupations[xeno_caste.job_type]

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -97,6 +97,9 @@
 
 ///returns TRUE if we are permitted to evo to the next caste FALSE otherwise
 /mob/living/carbon/xenomorph/proc/upgrade_possible()
+	if(!(upgrade in GLOB.xenoupgradetiers))
+		stack_trace("Upgrade isn't in upgrade list, incorrect define provided")
+		return FALSE
 	if(HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		return FALSE
 	if(upgrade == XENO_UPGRADE_NORMAL)


### PR DESCRIPTION

## About The Pull Request

I'm still not exactly sure how XENO_UPGRADE_BASETYPE should be handled, but this is meant to prevent an infinite loop should someone set an incorrect upgrade define

## Why It's Good For The Game

Less coders (i.e. me) typing in upgrade = "banana" and unintentionally creating a crash exploit that can't be tracked down via logs.
## Changelog
:cl:
code: Added some sanity checks on evolving and upgrading
/:cl:
