### PR TITLE
Truck fix

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -571,7 +571,9 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/lambda_lab)
 "ahA" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "ahB" = (
@@ -13042,7 +13044,9 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast/garbledradio)
 "nVY" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "nWz" = (

--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -9294,7 +9294,9 @@
 	},
 /area/campaign/jungle_outpost/outpost/science/south)
 "UI" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
 "UJ" = (

--- a/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
+++ b/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
@@ -2318,7 +2318,9 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "bLJ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "bMh" = (
@@ -5549,7 +5551,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "ebK" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -8568,7 +8572,9 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/c_block/mining)
 "gpA" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "gpF" = (
@@ -9836,10 +9842,6 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
-"hmd" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "hmm" = (
 /turf/open/floor/prison{
 	dir = 10
@@ -11252,7 +11254,9 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "ind" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "inq" = (
@@ -12095,7 +12099,9 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/kitchen)
 "iVJ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "iVU" = (
@@ -13973,7 +13979,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "krB" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/gelida/powergen)
 "krK" = (
@@ -14356,7 +14364,9 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "kGX" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "kHD" = (
@@ -18149,7 +18159,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "nrX" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "nsn" = (
@@ -18884,7 +18896,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "nRW" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/landing_zone_1)
 "nSf" = (
@@ -22343,10 +22357,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
-"qol" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/w_rockies)
 "qoN" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/darkred/full,
@@ -24261,7 +24271,9 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "rFx" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "rFJ" = (
@@ -28803,10 +28815,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"uZC" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "uZK" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/prison/plate,
@@ -30328,7 +30336,9 @@
 /turf/open/floor/prison/plate,
 /area/gelida/landing_zone_1)
 "wfe" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "wfm" = (
@@ -36931,7 +36941,7 @@ pKS
 fBJ
 fBJ
 fBJ
-qol
+usn
 azN
 fBJ
 fBJ
@@ -69101,7 +69111,7 @@ dVf
 oQi
 mrh
 mrh
-uZC
+dtu
 mrh
 eDl
 ejE
@@ -70408,7 +70418,7 @@ vby
 vby
 vby
 vby
-hmd
+cei
 uGI
 uGI
 vby

--- a/_maps/map_files/Campaign maps/orion_2/orionoutpost_2.dmm
+++ b/_maps/map_files/Campaign maps/orion_2/orionoutpost_2.dmm
@@ -571,7 +571,9 @@
 	},
 /area/orion_outpost/surface/building/engineering)
 "cQ" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
 "cR" = (
@@ -1217,7 +1219,9 @@
 	},
 /area/orion_outpost/ground/outpostw)
 "fQ" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outposts)
 "fR" = (
@@ -2266,7 +2270,9 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/ground/outposts)
 "kU" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
 	},
@@ -2277,7 +2283,9 @@
 	},
 /area/orion_outpost/surface/building/ammodepot)
 "kX" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostw)
 "kY" = (
@@ -2304,7 +2312,9 @@
 	},
 /area/orion_outpost/ground/outpostw)
 "le" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outposte)
 "lf" = (
@@ -2647,7 +2657,9 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/command)
 "mN" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
 "mP" = (
@@ -2780,7 +2792,9 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
 "np" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostsw)
 "nq" = (
@@ -5168,7 +5182,9 @@
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostnw)
 "yy" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostsw)
 "yz" = (
@@ -5819,7 +5835,9 @@
 /turf/open/floor/podhatch/floor,
 /area/orion_outpost/surface/building/crashedufo)
 "BO" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/train_yard)
 "BP" = (
@@ -9370,7 +9388,9 @@
 	},
 /area/orion_outpost/surface/building/engineering)
 "ST" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostw)
 "SU" = (
@@ -9656,7 +9676,9 @@
 	},
 /area/orion_outpost/surface/building/prep)
 "Uh" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/train_yard)

--- a/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
+++ b/_maps/map_files/Campaign maps/patricks_rest/patricks_rest.dmm
@@ -2225,7 +2225,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/patricks_rest/surface/building/science)
 "jT" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/colonycent)
 "jU" = (
@@ -4421,7 +4423,9 @@
 /turf/open/floor/mainship/sterile/purple,
 /area/patricks_rest/surface/building/science)
 "tS" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
 	},
@@ -7760,7 +7764,9 @@
 /turf/open/floor/prison/darkpurple/full,
 /area/patricks_rest/surface/building/residential_e)
 "Kv" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/surface/building/ore_storage)
 "Kw" = (
@@ -7986,7 +7992,9 @@
 /area/patricks_rest/surface/building/command)
 "Lz" = (
 /obj/structure/desertdam/decals/road/line,
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/colonycent)
 "LB" = (
@@ -10426,7 +10434,9 @@
 	},
 /area/patricks_rest/surface/building/security_post_cargo)
 "WW" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/patricks_rest/ground/colonycent)
 "WX" = (

--- a/_maps/map_files/Campaign maps/som_base/sombase.dmm
+++ b/_maps/map_files/Campaign maps/som_base/sombase.dmm
@@ -7902,7 +7902,9 @@
 /turf/open/floor/mainship/sterile/corner,
 /area/rocinante_base/surface/building/medical)
 "lfy" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/ground/underground/caveN)
 "lgo" = (
@@ -9164,7 +9166,9 @@
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/security/brig)
 "mYm" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/surface/landing/landing_pad_one_external)
 "mYO" = (
@@ -10986,7 +10990,9 @@
 	},
 /area/rocinante_base/surface/building/security/command_sec)
 "ptA" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/ground/base_cent)
 "puB" = (
@@ -13481,7 +13487,9 @@
 	},
 /area/rocinante_base/surface/building/cargo/vehicle_garage)
 "sUK" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
 	},
@@ -14105,7 +14113,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/rocinante_base/surface/building/science/bio_lab)
 "tNW" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/ground/base_w)
 "tOl" = (
@@ -15424,7 +15434,9 @@
 	},
 /area/rocinante_base/surface/building/living/prep)
 "vvE" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/surface/building/cargo/southern_aux)
 "vwm" = (
@@ -15846,7 +15858,9 @@
 /turf/open/floor/mainship/som/sw,
 /area/rocinante_base/surface/building/administration)
 "vYI" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/surface/landing/landing_pad_two_external)
 "vYY" = (

--- a/_maps/map_files/Campaign maps/som_raid_base/som_raiding_base.dmm
+++ b/_maps/map_files/Campaign maps/som_raid_base/som_raiding_base.dmm
@@ -1444,7 +1444,9 @@
 /turf/closed/mineral/smooth,
 /area/campaign/som_raiding/outpost/req)
 "hU" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/campaign/som_raiding/outpost/tunnel)
 "hW" = (
@@ -2728,7 +2730,9 @@
 /turf/open/ground/grass/weedable,
 /area/campaign/som_raiding/ground/jungle/south)
 "oz" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/som_raiding/outpost/req/north)
@@ -3896,7 +3900,9 @@
 	},
 /area/campaign/som_raiding/outpost/command)
 "va" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/som_raiding/outpost/req/north)
 "vb" = (

--- a/_maps/map_files/Campaign maps/tgmc_raid_base/tgmc_raiding_base.dmm
+++ b/_maps/map_files/Campaign maps/tgmc_raid_base/tgmc_raiding_base.dmm
@@ -4084,7 +4084,9 @@
 /turf/open/floor/carpet/blue,
 /area/campaign/tgmc_raiding/underground/command/captain)
 "qC" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /obj/structure/desertdam/decals/road/edge/long,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/campaign/tgmc_raiding/colony/outdoor/south)
@@ -4641,7 +4643,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/campaign/tgmc_raiding/colony/outdoor/south)
 "sL" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/campaign/tgmc_raiding/colony/indoor/garage)
 "sM" = (
@@ -10071,7 +10075,9 @@
 /turf/open/floor/plating,
 /area/campaign/tgmc_raiding/underground/maintenance/sewer)
 "Or" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/campaign/tgmc_raiding/colony/indoor/garage)

--- a/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
+++ b/_maps/map_files/DaedalusPrison/DaedalusPrison.dmm
@@ -2054,7 +2054,9 @@
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/daedalusprison/inside/engineering)
 "bLB" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/daedalusprison/inside/garage)
 "bLJ" = (
@@ -4987,7 +4989,9 @@
 /turf/open/floor/prison/darkred,
 /area/daedalusprison/inside/centralhalls)
 "eeH" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/daedalusprison/inside/garage)
 "eeZ" = (
@@ -16835,7 +16839,9 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/daedalusprison/outside/south)
 "nNx" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/daedalusprison/outside/east)
 "nNB" = (

--- a/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
+++ b/_maps/map_files/Fort_Phobos/Fort_Phobos.dmm
@@ -1987,7 +1987,9 @@
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "zd" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som)
 "zk" = (
@@ -3827,7 +3829,9 @@
 /turf/open/floor/plating/ground/concrete,
 /area/mainship/patrol_base/som/hanger)
 "WB" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
 	},

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -9941,7 +9941,9 @@
 	},
 /area/magmoor/command/office/main)
 "gLM" = (
-/obj/structure/prop/vehicle/van,
+/obj/structure/prop/vehicle/van{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/southeast)
 "gLV" = (
@@ -16676,7 +16678,9 @@
 	},
 /area/magmoor/landing)
 "lEa" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
@@ -22908,7 +22912,9 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/arrivals/east)
 "qfw" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/civilian/jani)
 "qfD" = (

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -516,7 +516,9 @@
 	},
 /area/orion_outpost/surface/building/engineering)
 "cQ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
 "cR" = (
@@ -1194,7 +1196,9 @@
 	},
 /area/orion_outpost/ground/outpostw)
 "fQ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outposts)
 "fR" = (
@@ -2199,7 +2203,9 @@
 	},
 /area/orion_outpost/surface/building/ammodepot)
 "kX" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostw)
 "kY" = (
@@ -2226,7 +2232,9 @@
 	},
 /area/orion_outpost/ground/outpostw)
 "le" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outposte)
 "lf" = (
@@ -2571,7 +2579,9 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/command)
 "mN" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
 "mP" = (
@@ -5088,7 +5098,9 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/command)
 "yy" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostsw)
 "yz" = (
@@ -9236,7 +9248,9 @@
 	},
 /area/orion_outpost/surface/building/engineering)
 "ST" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostw)
 "SU" = (

--- a/_maps/map_files/deltastation/deltastation.dmm
+++ b/_maps/map_files/deltastation/deltastation.dmm
@@ -91364,7 +91364,9 @@
 /turf/open/floor/iron/grimy,
 /area/deltastation/security/detectives_office/private_investigators_office)
 "sDd" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/asteroidfloor,
 /area/deltastation/external/landingzone)
 "sDf" = (

--- a/_maps/map_files/desparity/desparity.dmm
+++ b/_maps/map_files/desparity/desparity.dmm
@@ -3855,7 +3855,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "uk" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "um" = (

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -2656,7 +2656,9 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "bLJ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "bMh" = (
@@ -6144,7 +6146,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "ebK" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -9544,7 +9548,9 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/c_block/mining)
 "gpA" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "gpF" = (
@@ -11014,10 +11020,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/central_streets)
-"hmd" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "hmm" = (
 /turf/open/floor/prison{
 	dir = 10
@@ -12631,7 +12633,9 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "ind" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "inq" = (
@@ -13575,7 +13579,9 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/kitchen)
 "iVJ" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "iVU" = (
@@ -15715,7 +15721,9 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "krB" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/gelida/powergen)
 "krK" = (
@@ -16133,7 +16141,9 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "kGX" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "kHy" = (
@@ -20253,7 +20263,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "nrX" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "nsn" = (
@@ -21055,7 +21067,9 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "nRW" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/landing_zone_1)
 "nSf" = (
@@ -24913,10 +24927,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
-"qol" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/w_rockies)
 "qoN" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/darkred/full,
@@ -27060,7 +27070,9 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "rFx" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "rFJ" = (
@@ -31940,10 +31952,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"uZC" = (
-/obj/structure/prop/vehicle/truck/destructible,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "uZK" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
 /turf/open/floor/prison/plate,
@@ -33578,7 +33586,9 @@
 /turf/open/floor/prison/plate,
 /area/gelida/landing_zone_1)
 "wfe" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "wfm" = (
@@ -40352,7 +40362,7 @@ pKS
 fBJ
 fBJ
 fBJ
-qol
+usn
 azN
 fBJ
 fBJ
@@ -72522,7 +72532,7 @@ dVf
 oQi
 mrh
 mrh
-uZC
+dtu
 mrh
 nUd
 ejE
@@ -73829,7 +73839,7 @@ ilb
 vby
 ilb
 ilb
-hmd
+cei
 uGI
 uGI
 ilb

--- a/_maps/map_files/oscar_outpost/oscar_outpost.dmm
+++ b/_maps/map_files/oscar_outpost/oscar_outpost.dmm
@@ -8349,7 +8349,9 @@
 	pixel_x = 39;
 	pixel_y = 26
 	},
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /obj/structure/reagent_dispensers/beerkeg{
 	pixel_x = 29;
 	pixel_y = 21

--- a/_maps/map_files/riptide/riptide.dmm
+++ b/_maps/map_files/riptide/riptide.dmm
@@ -16091,7 +16091,9 @@
 /area/riptide/outside/southjungle)
 "lox" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/riptide/inside/landingzoneone)
 "loN" = (
@@ -17616,7 +17618,9 @@
 /turf/open/floor/plating,
 /area/riptide/outside/beachlzone)
 "msE" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/riptide/outside/volcano)
 "msJ" = (

--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -20709,7 +20709,9 @@
 /turf/open/floor,
 /area/slumbridge/inside/hydrotreatment)
 "poq" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/platebot,
 /area/slumbridge/inside/houses/car)
 "ppi" = (
@@ -27961,7 +27963,9 @@
 /turf/open/floor,
 /area/slumbridge/inside/engi/central)
 "uCt" = (
-/obj/structure/prop/vehicle/truck/destructible,
+/obj/structure/prop/vehicle/truck/destructible{
+	dir = 8
+	},
 /turf/open/floor/plating/mainship,
 /area/slumbridge/inside/houses/car)
 "uCw" = (
@@ -28823,7 +28827,9 @@
 /turf/open/floor/asteroidfloor,
 /area/slumbridge/outside/northwest/nearlz)
 "vjm" = (
-/obj/structure/prop/vehicle/truck/truckcargo/destructible,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/platebot,
 /area/slumbridge/inside/houses/car)

--- a/_maps/modularmaps/jungle_outpost/joutpostscrates3.dmm
+++ b/_maps/modularmaps/jungle_outpost/joutpostscrates3.dmm
@@ -88,7 +88,9 @@
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
 "v" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/containers)
 "x" = (

--- a/_maps/modularmaps/jungle_outpost/joutpostscrates4.dmm
+++ b/_maps/modularmaps/jungle_outpost/joutpostscrates4.dmm
@@ -104,12 +104,16 @@
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
 "I" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
 "M" = (
 /obj/structure/cable,
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/jungle_outpost/outpost/req/depot)
 "N" = (

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -1215,7 +1215,7 @@
 
 /obj/structure/prop/vehicle/truck/setDir(newdir)
 	. = ..()
-	if(newdir & (WEST|EAST))
+	if(dir & (WEST|EAST))
 		bound_height = 32
 		bound_width = 64
 		pixel_x = 0

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -1209,6 +1209,21 @@
 	bound_width = 64
 	resistance_flags = RESIST_ALL
 
+/obj/structure/prop/vehicle/truck/Initialize(mapload)
+	. = ..()
+	setDir(dir)
+
+/obj/structure/prop/vehicle/truck/setDir(newdir)
+	. = ..()
+	if(newdir & (WEST|EAST))
+		bound_height = 32
+		bound_width = 64
+		pixel_x = 0
+	else
+		bound_height = 64
+		bound_width = 32
+		pixel_x = -16
+
 /obj/structure/prop/vehicle/truck/destructible
 	max_integrity = 150
 	resistance_flags = XENO_DAMAGEABLE


### PR DESCRIPTION

## About The Pull Request
Fixes trucks and a few other vehicle props.

I previously added north/south sprite variants for some vehicles which previously didn't have them, however in many cases maps used north/south dir which resulted them in being wonky and not what was originally intended.

All existing instances are now west/east facing, and ones placed north/south going forwards will have the correct hitbox.

:cl:
fix: fixed some issues with truck prop positioning and hitboxes
/:cl:
