### PR TITLE
Prevents Fallen jobs from talking over radios, adds a fallen job helper

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -91,6 +91,7 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 #define issurvivorjob(J) (istype(J, /datum/job/survivor))
 #define ischaplainjob(J) (istype(J, /datum/job/survivor/chaplain))
 #define isxenosjob(J) (istype(J, /datum/job/xenomorph))
+#define isfallenjob(J) (istype(J, /datum/job/fallen))
 
 //Monkey sub-species
 

--- a/code/game/objects/items/radio/radio.dm
+++ b/code/game/objects/items/radio/radio.dm
@@ -253,6 +253,10 @@
 	if(!talking_movable.IsVocal())
 		return
 
+	var/mob/living/carbon/human/talker = talking_movable
+	if(isfallenjob(talker.job)) // prevents any of the valhalla jobs from talking to the living
+		return
+
 	if(use_command)
 		spans |= SPAN_COMMAND
 


### PR DESCRIPTION

## About The Pull Request
Prevents fallen jobs from talking on radios at all, and adds an isfallenjob helper.
## Why It's Good For The Game
Issues with fallen getting access to coms keeps popping up, so this should solve any current and future issues with this once and for all.
## Changelog
:cl:
fix: Fallen can no longer use the radio
code: Added a isfallenjob helper
/:cl:
