### PR TITLE
Window fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -417,9 +417,8 @@
 /obj/structure/window/framed/update_nearby_icons()
 	QUEUE_SMOOTH_NEIGHBORS(src)
 
-/obj/structure/window/framed/update_icon()
-	QUEUE_SMOOTH(src)
-	return ..()
+/obj/structure/window/framed/update_icon_state()
+	QUEUE_SMOOTH(src) //we update icon state through the smoothing system exclusively
 
 /obj/structure/window/framed/deconstruct(disassembled = TRUE, leave_frame = TRUE)
 	if(window_frame && leave_frame)


### PR DESCRIPTION

## About The Pull Request
Fixes windows flickering in and out of existance when being shot.

Objects update icon every time they take damage, but because windows use smoothing, every hit they queue themselves for smoothing again, but then base window code sets the icon to an invalid state, leading to no sprite for a split second before smoothing procs.

:cl:
fix: fixed a flicker issue with windows when taking damage
/:cl:
