### PR TITLE
Optimizes and declutters the requests panel

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -348,7 +348,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/cost = 0
 		for(var/P in SO.pack)
 			var/datum/supply_packs/SP = P
-			packs += SP.type
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["deniedrequests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["approvedrequests"] = list()
@@ -358,8 +361,12 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			continue
 		var/list/packs = list()
 		var/cost = 0
-		for(var/datum/supply_packs/SP AS in SO.pack)
-			packs += SP.type
+		for(var/P in SO.pack)
+			var/datum/supply_packs/SP = P
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["approvedrequests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["awaiting_delivery"] = list()
@@ -553,7 +560,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/cost = 0
 		for(var/P in SO.pack)
 			var/datum/supply_packs/SP = P
-			packs += SP.type
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["deniedrequests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["approvedrequests"] = list()
@@ -565,7 +575,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/cost = 0
 		for(var/P in SO.pack)
 			var/datum/supply_packs/SP = P
-			packs += SP.type
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["approvedrequests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	if(!SSpoints.request_shopping_cart[user.ckey])

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -333,7 +333,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/cost = 0
 		for(var/P in SO.pack)
 			var/datum/supply_packs/SP = P
-			packs += SP.type
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["requests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["deniedrequests"] = list()
@@ -535,7 +538,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/cost = 0
 		for(var/P in SO.pack)
 			var/datum/supply_packs/SP = P
-			packs += SP.type
+			if(packs[SP.type])
+				packs[SP.type] += 1
+			else
+				packs[SP.type] = 1
 			cost += SP.cost
 		.["requests"] += list(list("id" = SO.id, "orderer" = SO.orderer, "orderer_rank" = SO.orderer_rank, "reason" = SO.reason, "cost" = cost, "packs" = packs, "authed_by" = SO.authorised_by))
 	.["deniedrequests"] = list()

--- a/tgui/packages/tgui/interfaces/Cargo.jsx
+++ b/tgui/packages/tgui/interfaces/Cargo.jsx
@@ -51,7 +51,7 @@ export const Cargo = (props) => {
     : null;
 
   return (
-    <Window width={900} height={700}>
+    <Window width={1100} height={700}>
       <Flex height="650px" align="stretch">
         <Flex.Item width="280px">
           <Menu />
@@ -309,18 +309,21 @@ const Packs = (props) => {
   const { act, data } = useBackend();
   const { packs } = props;
 
-  return packs.map((pack) => <Pack pack={pack} key={pack} />);
+  return Object.keys(packs).map((pack) => (
+    <Pack pack={pack} key={pack} amount={packs[pack]} />
+  ));
 };
 
 const Pack = (props) => {
   const { act, data } = useBackend();
-  const { pack } = props;
+  const { pack, amount } = props;
   const { supplypackscontents } = data;
   const { name, cost, contains } = supplypackscontents[pack];
+
   return !!contains && contains.constructor === Object ? (
     <Collapsible
       color="gray"
-      title={<PackName cost={cost} name={name} pl={0} />}
+      title={<PackName cost={cost} name={name} pl={0} amount={amount} />}
     >
       <Table>
         <PackContents contains={contains} />
@@ -332,12 +335,12 @@ const Pack = (props) => {
 };
 
 const PackName = (props) => {
-  const { cost, name, pl } = props;
-
+  const { cost, name, pl, amount } = props;
   return (
     <Box inline pl={pl}>
-      <Box textAlign="right" inline width="65px">
-        {cost} points
+      <Box textAlign="right" inline width="140px">
+        {amount ? amount + 'x' : ''}
+        {cost} points {amount ? '(' + amount * cost + ')' : ''}
       </Box>
       <Box width="15px" inline />
       <Box inline>{name}</Box>


### PR DESCRIPTION

## About The Pull Request

Same orders now stack.

## Why It's Good For The Game

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/16237 by making the pending/denied/approved orders menu miles more optimized both on the network and rendering end. 
Also makes large orders easier to read.

Looks like this:
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/60290575/e35d96fb-ea72-4040-ab72-ae8e41819b0d)


## Changelog
:cl:
qol: Makes large orders easier to read
fix: Fixes bug that can crash game on particularly large orders
code: Vastly optimized req request packets
/:cl:
