### PR TITLE
Fixes AI double spawning

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -96,7 +96,6 @@
 		var/datum/job/terragov/silicon/ai/ai_job = SSjob.GetJobType(/datum/job/terragov/silicon/ai)
 		if(!ai_job)
 			stack_trace("Unemployment has reached to an AI, who has failed to find a job.")
-		//apply_assigned_role_to_spawn(ai_job)
 
 	GLOB.ai_list += src
 	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_SQUAD_TERRAGOV]

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -96,7 +96,7 @@
 		var/datum/job/terragov/silicon/ai/ai_job = SSjob.GetJobType(/datum/job/terragov/silicon/ai)
 		if(!ai_job)
 			stack_trace("Unemployment has reached to an AI, who has failed to find a job.")
-		apply_assigned_role_to_spawn(ai_job)
+		//apply_assigned_role_to_spawn(ai_job)
 
 	GLOB.ai_list += src
 	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_SQUAD_TERRAGOV]


### PR DESCRIPTION

## About The Pull Request

Fixes AI being spawned twice

## Why It's Good For The Game

Makes it so that AI only gets spawned once, so that it doesn't send two announcements, the first one with incorrect name, instead only the second one with correct information.

## Changelog
:cl:
fix: Fixed AI double spawning
/:cl:
