### PR TITLE
Advanced autoinjectors now have tramadol instead of oxy

### DIFF
--- a/code/modules/reagents/reagent_containers/autoinjectors.dm
+++ b/code/modules/reagents/reagent_containers/autoinjectors.dm
@@ -57,13 +57,13 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced
 	name = "advanced combat autoinjector"
-	desc = "An autoinjector loaded with 2 doses of advanced healing and painkilling chemicals. Intended for use in active combat."
+	desc = "An autoinjector loaded with 3 doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	icon_state = "Lilac"
 	amount_per_transfer_from_this = 15
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 10,
 		/datum/reagent/medicine/dermaline = 10,
-		/datum/reagent/medicine/oxycodone = 10,
+		/datum/reagent/medicine/tramadol = 10
 	)
 	description_overlay = "Ca"
 


### PR DESCRIPTION

## About The Pull Request

Replaces oxycodone with tramadol in the advanced autoinjectors

## Why It's Good For The Game

Oxycodone is the same as tramadol in every sense except the initial kick in stamina and the fact that it is purged by the only two chemicals that are in the advanced autoinjectors, mera and derma. I find it silly that the painkiller barely lasts any time because those two chems just purges it, so while tramadol doesn't have the stamina on inject effect, it will stay longer in the system. If experienced medics won't like this change, they can always make their own custom autoinjectors or even advanced autoinjectors, however it being the default feels a bit like a noob trap for people who don't know any better and just trust whatever they have been given to be good.

## Changelog
:cl:
balance: Advanced autoinjectors will now have tramadol instead of oxycodone
/:cl:
