### PR TITLE
SSD takeover now loads your active character slot

### DIFF
--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -94,7 +94,7 @@
 		new_mob.transfer_mob(owner)
 		return
 	if(CONFIG_GET(flag/prevent_dupe_names) && GLOB.real_names_joined.Find(owner.client.prefs.real_name))
-		to_chat(usr, "<span class='warning'>Someone has already joined the round with this character name. Please pick another.<spawn>")
+		to_chat(usr, span_warning("Someone has already joined the round with this character name. Please pick another."))
 		return
 	message_admins(span_adminnotice("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd."))
 	log_admin("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd.")

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -85,13 +85,21 @@
 	if(is_banned_from(owner.ckey, new_mob?.job?.title))
 		to_chat(owner, span_warning("You are jobbaned from the [new_mob?.job.title] role."))
 		return
+
+	if(!ishuman(new_mob))
+		message_admins(span_adminnotice("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd."))
+		log_admin("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd.")
+		new_mob.transfer_mob(owner)
+		return
+	if(CONFIG_GET(flag/prevent_dupe_names) && GLOB.real_names_joined.Find(owner.client.prefs.real_name))
+		to_chat(usr, "<span class='warning'>Someone has already joined the round with this character name. Please pick another.<spawn>")
+		return
 	message_admins(span_adminnotice("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd."))
 	log_admin("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd.")
 	new_mob.transfer_mob(owner)
-	if(!ishuman(new_mob))
-		return
 	var/mob/living/carbon/human/H = new_mob
-	H.fully_replace_character_name(H.real_name, H.species.random_name(H.gender))
+	H.on_transformation()
+	//H.fully_replace_character_name(H.real_name, H.species.random_name(H.gender))
 
 //respawn button for campaign gamemode
 /datum/action/observer_action/campaign_respawn

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -99,7 +99,6 @@
 	new_mob.transfer_mob(owner)
 	var/mob/living/carbon/human/H = new_mob
 	H.on_transformation()
-	//H.fully_replace_character_name(H.real_name, H.species.random_name(H.gender))
 
 //respawn button for campaign gamemode
 /datum/action/observer_action/campaign_respawn

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -63,7 +63,9 @@
 	if(new_mob.stat == DEAD)
 		to_chat(owner, span_warning("You cannot join if the mob is dead."))
 		return FALSE
-
+	switch(tgui_alert(owner, "Are you sure you want to take " + new_mob.real_name +" ("+new_mob.job.title+")?", "Take SSD mob", list("Yes", "No",)))
+		if("No")
+			return
 	if(isxeno(new_mob))
 		var/mob/living/carbon/xenomorph/ssd_xeno = new_mob
 		if(ssd_xeno.tier != XENO_TIER_MINION && XENODEATHTIME_CHECK(owner))

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -590,7 +590,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		if(job.job_flags & JOB_FLAG_SPECIALNAME)
 			name_to_check = job.get_special_name(NP.client)
 		if(CONFIG_GET(flag/prevent_dupe_names) && GLOB.real_names_joined.Find(name_to_check))
-			to_chat(usr, "<span class='warning'>Someone has already joined the round with this character name. Please pick another.<spawn>")
+			to_chat(usr, span_warning("Someone has already joined the round with this character name. Please pick another."))
 			return FALSE
 	if(!SSjob.AssignRole(NP, job, TRUE))
 		to_chat(usr, "<span class='warning'>Failed to assign selected role.<spawn>")


### PR DESCRIPTION
## About The Pull Request

SSD takeover will now load your active character slot (meaning name, gender, hair, eyes, age, ethnicity, flavour text, basically everything except subrace (human/robot/vatgrown)) with a check to see if the character is already in the round (optional, and based on config value)
Also adds a currently missing confirmation window, with the job also listed during confirmation.

## Why It's Good For The Game

Round removal is bad and we and other branches of ss13 have been trying to remedy it for years, and TGMC offers a variety of colourful options, including respawning after 30 minutes (With a fancy valhalla to test out things while waiting, great idea by the way!), taking over a newly born vatgrown soldier, the larva queue, taking over minion xenos, or least commonly used, taking over an SSD marine. 
This PR aims to address this, by trying to remedy the inherent problems that come with playing an already estabilished character, that will feel alien and such. Already, the names are randomized (meaning that thankfully, you don't have to play as candice balls), but the visual appearance, gender, and the randomized name just feels alien and uncomfortable, so this PR aims to address this by (attempting to) load in your current character slot.
## Changelog
:cl:
qol: Taken over SSD mobs will now load your active character slot if possible
/:cl:
