### PR TITLE
Xeno seethrough button reset verb

### DIFF
--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -42,6 +42,7 @@
 	render_source_atom.render_source = "*transparent_bigmob[personal_uid]"
 
 	action = new(src)
+	action.give_action(parent)
 
 /datum/component/seethrough_mob/Destroy(force)
 	QDEL_NULL(render_source_atom)

--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -16,6 +16,8 @@
 	var/initial_render_target_value
 	///This component's personal uid
 	var/personal_uid
+	///Action for toggling see through
+	var/datum/action/ability/xeno_action/toggle_seethrough/action
 
 /datum/component/seethrough_mob/Initialize(target_alpha = 170, animation_time = 0.5 SECONDS, clickthrough = TRUE)
 	. = ..()
@@ -39,8 +41,7 @@
 
 	render_source_atom.render_source = "*transparent_bigmob[personal_uid]"
 
-	var/datum/action/ability/xeno_action/toggle_seethrough/action = new(src)
-	action.give_action(parent)
+	action = new(src)
 
 /datum/component/seethrough_mob/Destroy(force)
 	QDEL_NULL(render_source_atom)
@@ -102,6 +103,10 @@
 	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
 	clear_image(trickery_image, fool.client)
 
+///Resets the seethrough action button
+/datum/component/seethrough_mob/proc/ResetAction()
+	action.remove_action(parent)
+	action.give_action(parent)
 /datum/component/seethrough_mob/proc/toggle_active(datum/action/ability)
 	is_active = !is_active
 	if(is_active)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -573,3 +573,11 @@
 
 /mob/living/carbon/xenomorph/on_eord(turf/destination)
 	revive(TRUE)
+
+///Fixes the lack of see through by turning the action button off and on again
+/mob/living/carbon/xenomorph/verb/fix_seethrough()
+	set name = "Fix Seethrough"
+	set desc = "Reinitializes your seethrough component."
+	set category = "Alien"
+	var/datum/component/seethrough_mob/stm = GetComponent(/datum/component/seethrough_mob)
+	stm.ResetAction()


### PR DESCRIPTION

## About The Pull Request

Adds a verb in the alien tab that resets your seethrough button.

## Why It's Good For The Game

Currently there is a bug where on reconnect (the one that happens due to lag for an example, not a full relaunch of the game) you have a chance to lose your alien seethrough. This PR attempts to remedy this by adding a verb under the alien tab to fix it on demand if it should be missing for any reason.

## Changelog
:cl:
fix: Adds xeno seethrough button reset verb incase it goes missing
/:cl:
