### PR TITLE
Fixes surgery privacy shutters on pos

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4654,7 +4654,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
+	id = "or1privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/window/framed/mainship/white,
@@ -13623,7 +13623,7 @@
 "qMJ" = (
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
+	id = "or1privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/window/framed/mainship/white,


### PR DESCRIPTION

## About The Pull Request

Changes the signal ID for the left side privacy shutters to 1

## Why It's Good For The Game

Currently it's bugged so that the OR2 shutters open both of them.
Thanks CrystalNole for reminding me of this

## Changelog
:cl:
fix: Pillar of Spring medbay shutters 1 are now linked to it's proper button
/:cl:
