### PR TITLE
Sombase map fixes

### DIFF
--- a/_maps/map_files/Campaign maps/som_base/sombase.dmm
+++ b/_maps/map_files/Campaign maps/som_base/sombase.dmm
@@ -278,7 +278,7 @@
 /turf/open/floor/mainship/white/full,
 /area/rocinante_base/surface/building/lz_control)
 "atk" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /obj/machinery/light,
 /turf/open/floor/mainship/black,
 /area/rocinante_base/surface/building/cargo/vehicle_garage)
@@ -2571,7 +2571,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/rocinante_base/ground/base_w)
 "dBX" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/blue{
 	dir = 10
 	},
@@ -2610,7 +2610,7 @@
 /turf/open/ground/grass/weedable/patch,
 /area/rocinante_base/surface/building/administration/south_com)
 "dGQ" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/living/barracks)
@@ -7269,7 +7269,7 @@
 	},
 /area/rocinante_base/surface/building/administration)
 "kjN" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/administration/command)
 "kjO" = (
@@ -10231,7 +10231,7 @@
 /turf/open/floor/plating/ground/concrete,
 /area/rocinante_base/ground/southern_containers)
 "orZ" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
@@ -10664,7 +10664,7 @@
 /turf/open/floor/mainship/sterile/white,
 /area/rocinante_base/surface/building/living/barracks)
 "oUS" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/ground/base_cent)
 "oVs" = (
@@ -12487,7 +12487,7 @@
 /turf/open/floor/mainship/red,
 /area/rocinante_base/surface/building/science/complex_hall_e)
 "rBc" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/administration/north_com)
 "rBO" = (
@@ -12938,7 +12938,7 @@
 	},
 /area/rocinante_base/surface/building/cargo/vehicle_garage)
 "slV" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
@@ -13419,7 +13419,7 @@
 	},
 /area/rocinante_base/surface/building/command_hall)
 "sRP" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/administration/air_com)
 "sRU" = (
@@ -14679,7 +14679,7 @@
 /turf/open/ground/grass/weedable/patch,
 /area/rocinante_base/ground/base_se)
 "uyr" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/cic_maptable/no_flags,
 /turf/open/floor/mainship/blue{
 	dir = 5
 	},
@@ -17230,7 +17230,7 @@
 /turf/open/floor/mainship/mono,
 /area/rocinante_base/surface/building/living/chapel_ne)
 "xJE" = (
-/obj/machinery/computer/nuke_disk_generator/green,
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/sterile/side,
 /area/rocinante_base/surface/building/medical)
 "xKs" = (


### PR DESCRIPTION

## About The Pull Request
Fixes some maptables being the marine version.
Removed a stray nuke disk computer.

:cl:
fix: Campaign: fixed a couple of mapping issues on the Rocinante base map
/:cl:
