### PR TITLE
C4 ex_act tweak

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -144,6 +144,12 @@
 		update_icon()
 	return ..()
 
+/obj/item/explosive/plastique/ex_act()
+	if(QDELETED(src))
+		return
+	if(severity = EXPLODE_DEVASTATE)
+		take_damage(INFINITY, BRUTE, BOMB, 0)
+
 ///Handles the actual explosion effects
 /obj/item/explosive/plastique/proc/detonate()
 	if(QDELETED(plant_target))

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -147,7 +147,7 @@
 /obj/item/explosive/plastique/ex_act(severity)
 	if(QDELETED(src))
 		return
-	if(severity = EXPLODE_DEVASTATE)
+	if(severity == EXPLODE_DEVASTATE)
 		take_damage(INFINITY, BRUTE, BOMB, 0)
 
 ///Handles the actual explosion effects

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -144,7 +144,7 @@
 		update_icon()
 	return ..()
 
-/obj/item/explosive/plastique/ex_act()
+/obj/item/explosive/plastique/ex_act(severity)
 	if(QDELETED(src))
 		return
 	if(severity = EXPLODE_DEVASTATE)


### PR DESCRIPTION

## About The Pull Request
C4 is no longer damaged by explosions other than dev.
## Why It's Good For The Game
Stops them being qdel'd by chucking a load of nades at it.
## Changelog
:cl:
balance: C4 is immune to all explosions below devastate.
/:cl:
