### PR TITLE
Adjust price of Flare and Smoke shells for Mortar factory

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2420,12 +2420,12 @@ FACTORY
 /datum/supply_packs/factory/mortar_shell_flare_refill
 	name = "Mortar Flare shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_flare_refill)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/factory/mortar_shell_smoke_refill
 	name = "Mortar Smoke shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_smoke_refill)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/factory/mlrs_rocket_refill
 	name = "MLRS High Explosive rocket assembly refill"


### PR DESCRIPTION
## About The Pull Request

This pull adjusts the cost of the Smoke and Flare refill packs for the Mortar Factory refills; as at their current price it is more expensive to factory these rounds than it is to just buy outright as you get 2 shells for 5 points outright, but at 100 points for 30 factory parts works out to a higher cost than just buy straight
## Why It's Good For The Game

Give a reason to even use the factory for Flare and Smoke shells for mortar, as currently it is more economically to just buy these shells. The proposed price will create a 33% savings for Factory'ing these shells; the same as what T-Foot shells enjoy.
## Changelog
:cl:
balance: Changed price of Mortar Flare and Smoke shells for the Factory to 50 points each, to actually make a savings instead of a deficit.
fix: fixed a few things
/:cl:
