### PR TITLE
Adjust price of Mortar Smoke/Flare refills

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2420,12 +2420,12 @@ FACTORY
 /datum/supply_packs/factory/mortar_shell_flare_refill
 	name = "Mortar Flare shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_flare_refill)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/factory/mortar_shell_smoke_refill
 	name = "Mortar Smoke shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_smoke_refill)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/factory/mlrs_rocket_refill
 	name = "MLRS High Explosive rocket assembly refill"


### PR DESCRIPTION

## About The Pull Request

Currently; Smoke and Flare Mortar Shells are more economically to buy outright rather than factory; which costs about 33% **more** to factory than to just buy. This Pull inverses this and makes it so you **save** 33% when you factory these shells over just buying them
## Why It's Good For The Game

It would actually make it economically viable to use the factory refills for Smoke and Flare Mortar shells, as currently you end up spending more for using the factory than if you just outright buy them
## Changelog
:cl:
balance: Changed price of Mortar Flare and Smoke Refills for Factory, they now cost 50 points per refill item
/:cl:
