### PR TITLE
mecha cannon change

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -154,6 +154,11 @@
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.85
 
+/datum/ammo/bullet/apfsds/on_hit_obj(obj/target_obj, obj/projectile/proj)
+	if(ishitbox(target_obj) || ismecha(target_obj) || isarmoredvehicle(target_obj))
+		proj.damage *= 1.5
+		proj.max_range = 0
+
 /datum/ammo/bullet/coilgun // ICC coilgun
 	name = "high-velocity tungsten slug"
 	hud_state = "railgun_ap"

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -157,7 +157,7 @@
 /datum/ammo/bullet/apfsds/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(ishitbox(target_obj) || ismecha(target_obj) || isarmoredvehicle(target_obj))
 		proj.damage *= 1.5
-		proj.max_range = 0
+		proj.proj_max_range = 0
 
 /datum/ammo/bullet/coilgun // ICC coilgun
 	name = "high-velocity tungsten slug"


### PR DESCRIPTION

## About The Pull Request
Mecha heavy cannon no longer pierces tanks or mechs, but does get a 50% damage bonus against them.
## Why It's Good For The Game
Funny x5 hit due to piercing was bad.
## Changelog
:cl:
balance: Mecha heavy cannon no longer pierces mechs or tanks
/:cl:
