### PR TITLE
Desant z fix

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -127,11 +127,6 @@
 	SIGNAL_HANDLER
 	qdel(src, TRUE)
 
-/obj/hitbox/onTransitZ(old_z, new_z)
-	. = ..()
-	for(var/mob/living/tank_desant AS in tank_desants)
-		continue //fug
-
 ///when the owner moves, let's move with them!
 /obj/hitbox/proc/root_move(atom/movable/mover, atom/oldloc, direction, forced, list/turf/old_locs)
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -127,6 +127,11 @@
 	SIGNAL_HANDLER
 	qdel(src, TRUE)
 
+/obj/hitbox/onTransitZ(old_z, new_z)
+	. = ..()
+	for(var/mob/living/tank_desant AS in tank_desants)
+		continue //fug
+
 ///when the owner moves, let's move with them!
 /obj/hitbox/proc/root_move(atom/movable/mover, atom/oldloc, direction, forced, list/turf/old_locs)
 	SIGNAL_HANDLER
@@ -134,9 +139,10 @@
 	direction = get_dir(oldloc, mover)
 	var/move_dist = get_dist(oldloc, mover)
 	forceMove(mover.loc)
+	var/new_z = (z != oldloc.z)
 	for(var/mob/living/tank_desant AS in tank_desants)
 		tank_desant.set_glide_size(root.glide_size)
-		tank_desant.forceMove(get_step(tank_desant, direction))
+		tank_desant.forceMove(new_z ? loc : get_step(tank_desant, direction)) //For simplicity we just move desants to the middle of the tank on z change to avoid various issues
 		if(isxeno(tank_desant))
 			continue
 		if(move_dist > 1)


### PR DESCRIPTION

## About The Pull Request
Little fix to stop tank riders getting thrown into space and other funny thing when the vehicle they're riding on changes z-level.

There is probably a better, more accurate fix we can put in place, but this is a long standing bug that required admin intervention so good to just squash it for now.
## Why It's Good For The Game
ahelp: Help admins, I was standing on tank and now I am dead in space ?!?!?!
## Changelog
:cl:
fix: Riding a tank across z-levels will no longer curse you to death
/:cl:
