### PR TITLE
Fixes requesting console screen width

### DIFF
--- a/tgui/packages/tgui/interfaces/Cargo.jsx
+++ b/tgui/packages/tgui/interfaces/Cargo.jsx
@@ -571,7 +571,7 @@ export const CargoRequest = (props) => {
     : null;
 
   return (
-    <Window width={900} height={700}>
+    <Window width={1100} height={700}>
       <Flex height="650px" align="stretch">
         <Flex.Item width="280px">
           <Menu readOnly={1} />


### PR DESCRIPTION

## About The Pull Request

Makes the ordering console's width equal to the ASRS console screen width (1100px)

## Why It's Good For The Game

With my recent addition (https://github.com/tgstation/TerraGov-Marine-Corps/pull/16245) the rows are now too wide to display on the previous width, so I changed the screen to make it wider. I accidently only did this for the full, req's screen, and forgot about the outsider, ordering screen. Oopsie.

## Changelog


:cl:
fix: Ordering req console now the proper width
/:cl:
