### PR TITLE
Makes the 1000 Hour time role for FC "Brigadier General"

### DIFF
--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -311,6 +311,12 @@
 			. = size ? "LtCol" : "Lieutenant Colonel"
 		if("MO6")
 			. = size ? "Col" : "Colonel"
+		if("MO7")
+			. = size ? "BGen" : "Brigadier General"
+		if("MO8")
+			. = size ? "MajGen" : "Major General"
+		if("MO9")
+			. = size ? "LtGen" : "Lieutenant General"
 		if("M10")
 			. = size ? "Gen" : "General"
 		if("UPP1")

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -168,7 +168,7 @@ Make the TGMC proud!"})
 		if(18001 to 60000) // 300 hrs
 			new_human.wear_id.paygrade = "MO6"
 		if(60001 to INFINITY) // 1000 hrs
-			new_human.wear_id.paygrade = "M10" //If you play way too much TGMC. 1000 hours.
+			new_human.wear_id.paygrade = "M07" //If you play way too much TGMC. 1000 hours.
 
 
 /datum/outfit/job/command/fieldcommander


### PR DESCRIPTION
# BEFORE YOU SCREAM AT ME, THIS DOES NOT TOUCH THE TIME REQS, JUST PAYGRADE

## About The Pull Request

Simply moves the 1000 hour time role for FC down to BGen, and adds the proper paygrades inbetween Col and Gen.

## Why It's Good For The Game

Having a full 4 Star General out on the battlefield slinging guns in my honest opinion does not really fit. This combined with the fact that the FC can, even with both roles maxed out, be at the same paygrade and rank as the Captain. (even though they are technically not in the same branch of military for some reason)

This will also free up slots and paygrades for Admins to spawn in as, should they wish to arepee or do event rounds, while still letting those sweaty FC mains to be a proper Flag Officer

## Changelog
:cl:
add: 1000 hour FC is now a Brigadier General
/:cl:
