### PR TITLE
Tracks and rewards healing, repairing, and tanks killed in campaign

### DIFF
--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/melee_damage = 0
 
 	var/mechs_destroyed = 0
-
+	var/tanks_destroyed = 0
 	//We are watching
 	var/friendly_fire_damage = 0
 
@@ -120,6 +120,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/mission_objective_captured = 0
 	var/mission_objective_decaptured = 0
 	var/mission_mechs_destroyed = 0
+	var/mission_tanks_destroyed = 0
 	var/mission_shrapnel_removed = 0
 	var/mission_traps_created = 0
 	var/mission_grenades_primed = 0
@@ -311,6 +312,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_objective_captured = 0
 	mission_objective_decaptured = 0
 	mission_mechs_destroyed = 0
+	mission_tanks_destroyed = 0
 	mission_shrapnel_removed = 0
 	mission_traps_created = 0
 	mission_grenades_primed = 0
@@ -331,6 +333,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	credit_bonus += mission_objective_captured * 20
 	credit_bonus += mission_objective_decaptured * 20
 	credit_bonus += mission_mechs_destroyed * 20
+	credit_bonus += mission_tanks_destroyed * 50
 	credit_bonus += mission_shrapnel_removed * 3
 	credit_bonus += mission_traps_created * 4
 	credit_bonus += mission_grenades_primed * 2

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -123,6 +123,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/mission_shrapnel_removed = 0
 	var/mission_traps_created = 0
 	var/mission_grenades_primed = 0
+	var/mission_heals = 0
+	var/mission_integrity_repaired = 0
 
 /datum/personal_statistics/New()
 	. = ..()
@@ -312,6 +314,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	mission_shrapnel_removed = 0
 	mission_traps_created = 0
 	mission_grenades_primed = 0
+	mission_heals = 0
+	mission_integrity_repaired = 0
 
 ///Returns the credit bonus based on stats from the current mission
 /datum/personal_statistics/proc/get_mission_reward()
@@ -330,6 +334,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	credit_bonus += mission_shrapnel_removed * 3
 	credit_bonus += mission_traps_created * 4
 	credit_bonus += mission_grenades_primed * 2
+	credit_bonus += mission_heals * 1
+	credit_bonus += integrity_repaired * 0.1
 
 	return max(floor(credit_bonus), 0)
 
@@ -428,6 +434,7 @@ The alternative is scattering them everywhere under their respective objects whi
 				//If a receiving mob exists, we tally up to the user mob's stats that it performed a heal
 				if(receiver)
 					personal_statistics_user.heals++
+					personal_statistics_user.mission_heals++
 				else
 					personal_statistics_user.self_heals++
 			is_healing = TRUE
@@ -445,6 +452,7 @@ The alternative is scattering them everywhere under their respective objects whi
 	//If a receiving mob exists, we tally up to the user mob's stats that it performed a heal
 	if(receiver)
 		personal_statistics_user.heals++
+		personal_statistics_user.mission_heals++
 	else
 		personal_statistics_user.self_heals++
 	return TRUE

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -30,6 +30,7 @@
 	if(user?.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
 		personal_statistics.integrity_repaired += repair_amount
+		personal_statistics.mission_integrity_repaired += repair_amount
 		personal_statistics.times_repaired++
 	obj_integrity += repair_amount
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -224,6 +224,7 @@
 	if(user?.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
 		personal_statistics.integrity_repaired += repair_amount
+		personal_statistics.mission_integrity_repaired += repair_amount
 		personal_statistics.times_repaired++
 	wall_integrity += repair_amount
 	update_icon()

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -154,11 +154,20 @@
 	if(Adjacent(entering_thing, src))
 		return list(get_turf(entering_thing))
 
-/obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag)
+/obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
 	playsound(get_turf(src), SFX_EXPLOSION_LARGE, 100, TRUE) //destroy sound is normally very quiet
 	new /obj/effect/temp_visual/explosion(get_turf(src), 7, LIGHT_COLOR_LAVA, FALSE, TRUE)
 	for(var/mob/living/nearby_mob AS in occupants + cheap_get_living_near(src, 7))
 		shake_camera(nearby_mob, 4, 2)
+	if(istype(blame_mob) && blame_mob.ckey)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[blame_mob.ckey]
+		if(faction == blame_mob.faction)
+			personal_statistics.tanks_destroyed --
+			personal_statistics.mission_tanks_destroyed --
+		else
+			personal_statistics.tanks_destroyed ++
+			personal_statistics.mission_tanks_destroyed ++
+
 	return ..()
 
 /obj/vehicle/sealed/armored/update_icon_state()


### PR DESCRIPTION
## About The Pull Request

Tracks healing (which is rewarded one point per kitting (with my other PR, https://github.com/tgstation/TerraGov-Marine-Corps/pull/16295) /pill, and repairing (which is rewarded one point per 10 fixed)

## Why It's Good For The Game

Promotes teamwork and picking support classes. Both engineers and medics are in a peculiar spot at the moment with only barricading and reviving giving points, so in order to be most efficent you just spam barricades until you run out of mats then pretend you are a normal marine, and wait for people to die so you can revive them, which isn't how anybody really plays but it's what the system currently encourages. This PR aims to reward taking care of teammates, cades, and mechs/tanks, so that more people will play support roles, and those that do play support roles will be herded towards positive behaviour. Also, especially the healing bit, this helps ungas take care of eachother in general, as even the everyday soldier is equipped with some pills and gauze/ointment, which are also tracked all the same, promoting even more teamwork.

Also tracks tanks killed as per Lumi's request.

## Changelog
:cl:
add: Reward for healing in campaign
add: Reward for repairing in campaign
add: Reward for blowing up tanks
/:cl:
