### PR TITLE
Lets you empty sandbags

### DIFF
--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -85,7 +85,7 @@
 
 /obj/item/stack/sandbags/examine(mob/user)
 	. = ..()
-	. += span_notice("Right click to empty [src].")
+	. += span_notice("Right click while selected to empty [src].")
 
 /obj/item/stack/sandbags/large_stack
 	amount = 25
@@ -105,20 +105,17 @@
 
 	to_chat(user, span_notice("You start emptying [src]."))	
 	while(get_amount() > 0)
-		if(!do_after(user, 0.5 SECONDS, IGNORE_USER_LOC_CHANGE, user))
+		if(!do_after(user, 0.5 SECONDS, IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE, user))
 			to_chat(user, span_notice("You stop emptying [src]."))
 			break
 		if(zero_amount())
 			to_chat(user, span_notice("You finish emptying [src]."))
 		// check if we can stuff it into the user's hands
+		use(1)
 		var/obj/item/stack/sandbag = user.get_inactive_held_item()
-		if(istype(sandbag, /obj/item/stack/sandbags_empty))
-			sandbag.add(1)
+		if(istype(sandbag, /obj/item/stack/sandbags_empty) && sandbag.add(1))
 			continue
 		var/obj/item/stack/sandbags_empty/E = new(get_turf(user))
-		if(!sandbag)
-			user.put_in_hands(E)
+		if(!sandbag && user.put_in_hands(E))
 			continue
-		E.add(1)
 		E.add_to_stacks(user)
-		use(1)

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -100,18 +100,20 @@
 	if(get_amount() < 1)
 		return
 	if(LAZYLEN(user.do_actions))
-		to_chat(user, span_warning("You are too busy to empty [src]!"))
+		user.balloon_alert(user, "You are already busy.")
 		return
 
-	to_chat(user, span_notice("You start emptying [src]."))	
+	user.balloon_alert(user, "You start emptying [src].")
 	while(get_amount() > 0)
 		if(!do_after(user, 0.5 SECONDS, IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE, user))
-			to_chat(user, span_notice("You stop emptying [src]."))
+			user.balloon_alert(user, "You stop emptying [src].")
 			break
-		if(zero_amount())
-			to_chat(user, span_notice("You finish emptying [src]."))
 		// check if we can stuff it into the user's hands
-		use(1)
+		if(!use(1))
+			break
+		if(amount < 1)
+			user.balloon_alert(user, "You finish emptying [src].")
+			break
 		var/obj/item/stack/sandbag = user.get_inactive_held_item()
 		if(istype(sandbag, /obj/item/stack/sandbags_empty) && sandbag.add(1))
 			continue
@@ -119,3 +121,4 @@
 		if(!sandbag && user.put_in_hands(E))
 			continue
 		E.add_to_stacks(user)
+

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -85,7 +85,7 @@
 
 /obj/item/stack/sandbags/examine(mob/user)
 	. = ..()
-	. += span_notice("Right click to empty the [src].")
+	. += span_notice("Right click to empty [src].")
 
 /obj/item/stack/sandbags/large_stack
 	amount = 25
@@ -103,13 +103,13 @@
 		to_chat(user, span_warning("You are too busy to empty [src]!"))
 		return
 
-	to_chat(user, span_notice("You start emptying the [src]."))	
+	to_chat(user, span_notice("You start emptying [src]."))	
 	while(get_amount() > 0)
 		if(!do_after(user, 0.5 SECONDS, IGNORE_USER_LOC_CHANGE, user))
-			to_chat(user, span_notice("You stop emptying the [src]."))
+			to_chat(user, span_notice("You stop emptying [src]."))
 			break
 		if(zero_amount())
-			to_chat(user, span_notice("You finish emptying the [src]."))
+			to_chat(user, span_notice("You finish emptying [src]."))
 		// check if we can stuff it into the user's hands
 		var/obj/item/stack/sandbag = user.get_inactive_held_item()
 		if(istype(sandbag, /obj/item/stack/sandbags_empty))

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -83,6 +83,10 @@
 	merge_type = /obj/item/stack/sandbags
 
 
+/obj/item/stack/sandbags/examine(mob/user)
+	. = ..()
+	. += span_notice("Right click to empty the [src].")
+
 /obj/item/stack/sandbags/large_stack
 	amount = 25
 
@@ -90,3 +94,31 @@
 	. = ..()
 	var/building_time = LERP(2 SECONDS, 1 SECONDS, user.skills.getPercent(SKILL_CONSTRUCTION, SKILL_ENGINEER_EXPERT))
 	create_object(user, new/datum/stack_recipe("sandbag barricade", /obj/structure/barricade/sandbags, 5, time = building_time, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_CHECK_DIRECTION | CRAFT_ON_SOLID_GROUND), 1)
+
+/obj/item/stack/sandbags/attack_self_alternate(mob/user)
+	. = ..()
+	if(get_amount() < 1)
+		return
+	if(LAZYLEN(user.do_actions))
+		to_chat(user, span_warning("You are too busy to empty [src]!"))
+		return
+
+	to_chat(user, span_notice("You start emptying the [src]."))	
+	while(get_amount() > 0)
+		if(!do_after(user, 0.5 SECONDS, IGNORE_USER_LOC_CHANGE, user))
+			to_chat(user, span_notice("You stop emptying the [src]."))
+			break
+		if(zero_amount())
+			to_chat(user, span_notice("You finish emptying the [src]."))
+		// check if we can stuff it into the user's hands
+		var/obj/item/stack/sandbag = user.get_inactive_held_item()
+		if(istype(sandbag, /obj/item/stack/sandbags_empty))
+			sandbag.add(1)
+			continue
+		var/obj/item/stack/sandbags_empty/E = new(get_turf(user))
+		if(!sandbag)
+			user.put_in_hands(E)
+			continue
+		E.add(1)
+		E.add_to_stacks(user)
+		use(1)


### PR DESCRIPTION

## About The Pull Request
Lets you empty full sandbags back into empty sandbags by right clicking

## Why It's Good For The Game
It's wierd that this is not possible, now it's possible to do

## Changelog

:cl:
add: You can now right click full sandbags to empty them,
/:cl:

