### PR TITLE
Gives Kelotane Vali 5 fire stack (also use better proc)

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -224,7 +224,8 @@
 
 		if(/datum/reagent/medicine/kelotane)
 			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)
-			target.fire_act(10)
+			target.adjust_fire_stacks(5)
+			target.IgniteMob()
 
 		if(/datum/reagent/medicine/tramadol)
 			target.apply_damage(weapon.force*0.6, BRUTE, user.zone_selected)


### PR DESCRIPTION
## About The Pull Request

Harvester weapons now apply 5 stacks of fire when loaded with kelotane

## Why It's Good For The Game

Kelotane Harvester isn't being used because its effects can be dealt with only one rest. Now it'll take a full retreat or the active use of acid wells to get rid of the stacks. 
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/32490372/c464bfdf-701b-43d7-a461-e95f8208452e)

## Changelog
:cl:
balance: Harvester weapons now apply 5 stacks of fire when loaded with kelotane
/:cl:
