### PR TITLE
Ram fixes

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -245,7 +245,7 @@
 	var/list/drivers = return_drivers()
 	if(length(drivers))
 		pilot = drivers[1]
-	A.vehicle_collision(src, get_dir(src, A), get_turf(loc), get_turf(loc), pilot)
+	A.vehicle_collision(src, get_dir(src, A), pilot)
 
 /obj/vehicle/sealed/armored/auto_assign_occupant_flags(mob/new_occupant)
 	if(interior) //handled by interior seats

--- a/code/modules/vehicles/armored/vehicle_collision.dm
+++ b/code/modules/vehicles/armored/vehicle_collision.dm
@@ -7,58 +7,50 @@
  * * T is the turf where the vehicle is used with-
  * * temp to check whether a mob is squished
  */
-/atom/proc/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
-	var/damage = veh.ram_damage // Each vehicle gets its own damage, you can modify it with snowplows and such ideally
+/atom/proc/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
+	if(TIMER_COOLDOWN_CHECK(veh, COOLDOWN_VEHICLE_CRUSHSOUND))
+		return
+	visible_message(span_danger("[veh] rams [src]!"))
+	playsound(src, 'sound/effects/metal_crash.ogg', 45)
+	TIMER_COOLDOWN_START(veh, COOLDOWN_VEHICLE_CRUSHSOUND, 1 SECONDS)
 
-	if(!TIMER_COOLDOWN_CHECK(veh, COOLDOWN_VEHICLE_CRUSHSOUND))
-		visible_message(span_danger("[veh] rams [src]!"))
-		playsound(src, 'sound/effects/metal_crash.ogg', 45)
-		TIMER_COOLDOWN_START(veh, COOLDOWN_VEHICLE_CRUSHSOUND, 1 SECONDS)
-	return damage
-
-/obj/structure/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/obj/structure/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
-	take_damage(., BRUTE, MELEE, TRUE, facing, 0)
+	take_damage(ram_damage, BRUTE, MELEE, TRUE, REVERSE_DIR(facing), 0, pilot)
 
-/obj/structure/barricade/plasteel/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/obj/structure/barricade/plasteel/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
 	toggle_open(FALSE)
 
-/obj/vehicle/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)	//MONSTER TRUCKS
+/obj/vehicle/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)	//MONSTER TRUCKS
 	. = ..()
-	take_damage(., BRUTE, MELEE, TRUE, facing, 0)
+	take_damage(ram_damage, BRUTE, MELEE, TRUE, REVERSE_DIR(facing), 0, pilot)
 
-/obj/machinery/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/obj/machinery/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
-	take_damage(., BRUTE, MELEE, TRUE, facing, 0)
+	take_damage(ram_damage, BRUTE, MELEE, TRUE, REVERSE_DIR(facing), 0, pilot)
 
-/turf/closed/wall/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/turf/closed/wall/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
-	take_damage(., BRUTE, MELEE, TRUE, facing, 0)
+	take_damage(ram_damage, BRUTE, MELEE, TRUE, REVERSE_DIR(facing), 0)
 
-/mob/living/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp, mob/pilot)
+/mob/living/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
 	if(stat == DEAD)
 		return 0
 	if(lying_angle)
 		return 0
 	log_attack("[key_name(pilot)] drove into [key_name(src)] with [veh]")
-	temp = get_step(veh.loc, facing)
-	T = temp
-	T = get_step(T, facing)
-	T = get_step(T, facing)
-	T = get_step(T, facing)
-	face_atom(T)
-	throw_at(T, 3, 2, veh, 1)
-	return take_overall_damage(., BRUTE, MELEE, FALSE, FALSE, TRUE, 0, 4)
+	throw_at(get_step(get_step(loc, facing), facing), 3, 2, veh, 1)
+	return take_overall_damage(ram_damage, BRUTE, MELEE, FALSE, FALSE, TRUE, 0, 4)
 
 
-/mob/living/carbon/xenomorph/larva/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/mob/living/carbon/xenomorph/larva/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	gib() //fuck you
 
-/obj/effect/alien/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/obj/effect/alien/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	. = ..()
-	take_damage(., BRUTE, MELEE, TRUE, facing, 0)
+	take_damage(ram_damage, BRUTE, MELEE, TRUE, REVERSE_DIR(facing), 0, pilot)
 
-/obj/effect/alien/weeds/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, turf/T, turf/temp)
+/obj/effect/alien/weeds/vehicle_collision(obj/vehicle/sealed/armored/veh, facing, mob/pilot, ram_damage = veh.ram_damage)
 	return


### PR DESCRIPTION

## About The Pull Request
Fixes rams using the wrong direction (leading to triple the intended damage on mechs).
Cleaned up mob ramming (it now always throws you 2 turfs, instead of 4 from the middle of the tank, which is wack with varying hitbox sizes).

Cleaned up the args.
## Why It's Good For The Game
Fixes and cleanup.
## Changelog
:cl:
fix: fixed tanks ramming mechs for triple damage
fix: fixed some inconsistancies with vehicle ramming
/:cl:
