### PR TITLE
Campaign vehicle scaling

### DIFF
--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -526,6 +526,8 @@
 	if(!mech_faction)
 		return
 	var/total_count = (heavy_mech + medium_mech + light_mech)
+	if(!total_count)
+		return
 	for(var/obj/effect/landmark/campaign/vehicle_spawner/mech/mech_spawner AS in GLOB.campaign_mech_spawners[mech_faction])
 		if(!heavy_mech && !medium_mech && !light_mech)
 			break
@@ -547,6 +549,8 @@
 ///spawns mechs for a faction
 /datum/campaign_mission/proc/spawn_tank(tank_faction, quantity, override_message)
 	if(!tank_faction)
+		return
+	if(!quantity)
 		return
 	var/remaining_count = quantity
 	for(var/obj/effect/landmark/campaign/vehicle_spawner/tank/tank_spawner AS in GLOB.campaign_tank_spawners[tank_faction])

--- a/code/datums/gamemodes/campaign/missions/asat_capture.dm
+++ b/code/datums/gamemodes/campaign/missions/asat_capture.dm
@@ -64,11 +64,36 @@
 
 /datum/campaign_mission/capture_mission/asat/load_pre_mission_bonuses()
 	. = ..()
-	spawn_mech(hostile_faction, 0, 0, 5)
-	spawn_mech(starting_faction, 0, 1, 1)
-
 	var/datum/faction_stats/attacking_team = mode.stat_list[starting_faction]
 	attacking_team.add_asset(/datum/campaign_asset/asset_disabler/som_cas/instant)
+
+	var/tanks_to_spawn = 0
+	var/mechs_to_spawn = 0
+	var/current_pop = length(GLOB.clients)
+	switch(current_pop)
+		if(0 to 59)
+			tanks_to_spawn = 0
+		if(60 to 75)
+			tanks_to_spawn = 1
+		if(76 to 90)
+			tanks_to_spawn = 2
+		else
+			tanks_to_spawn = 3
+
+	switch(current_pop)
+		if(0 to 39)
+			mechs_to_spawn = 0
+		if(40 to 49)
+			mechs_to_spawn = 2
+		if(50 to 79)
+			mechs_to_spawn = 3
+		else
+			mechs_to_spawn = 4
+
+	spawn_tank(starting_faction, tanks_to_spawn)
+	spawn_tank(hostile_faction, tanks_to_spawn)
+	spawn_mech(hostile_faction, 0, 0, mechs_to_spawn)
+	spawn_mech(starting_faction, 0, 0, max(0, mechs_to_spawn - 1))
 
 /datum/campaign_mission/capture_mission/asat/load_objective_description()
 	starting_faction_objective_description = "Major Victory:Capture all [objectives_total] ASAT systems.[min_capture_amount ? " Minor Victory: Capture at least [min_capture_amount] ASAT systems." : ""]"

--- a/code/datums/gamemodes/campaign/missions/base_rescue.dm
+++ b/code/datums/gamemodes/campaign/missions/base_rescue.dm
@@ -73,12 +73,37 @@
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_pre_mission_bonuses()
 	. = ..()
-	spawn_mech(attacking_faction, 0, 0, 4)
-	spawn_mech(defending_faction, 0, 0, 2)
-
 	var/datum/faction_stats/defending_team = mode.stat_list[defending_faction]
 	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_cas/instant)
 	defending_team.add_asset(/datum/campaign_asset/asset_disabler/tgmc_mortar/instant)
+
+	var/tanks_to_spawn = 0
+	var/mechs_to_spawn = 0
+	var/current_pop = length(GLOB.clients)
+	switch(current_pop)
+		if(0 to 59)
+			tanks_to_spawn = 0
+		if(60 to 75)
+			tanks_to_spawn = 1
+		if(76 to 90)
+			tanks_to_spawn = 2
+		else
+			tanks_to_spawn = 3
+
+	switch(current_pop)
+		if(0 to 39)
+			mechs_to_spawn = 1
+		if(40 to 49)
+			mechs_to_spawn = 2
+		if(50 to 79)
+			mechs_to_spawn = 3
+		else
+			mechs_to_spawn = 4
+
+	spawn_tank(attacking_faction, tanks_to_spawn)
+	spawn_tank(defending_faction, tanks_to_spawn)
+	spawn_mech(attacking_faction, 0, 0, mechs_to_spawn)
+	spawn_mech(defending_faction, 0, 0, max(0, mechs_to_spawn - 1))
 
 /datum/campaign_mission/destroy_mission/base_rescue/load_mission_brief()
 	starting_faction_mission_brief = "NanoTrasen has issues an emergency request for assistance at an isolated medical facility located in the Western Ayolan Ranges. \

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -64,13 +64,42 @@
 	items += "Beacons remaining: [beacons_remaining]"
 
 /datum/campaign_mission/raiding_base/load_pre_mission_bonuses()
-	spawn_mech(starting_faction, 0, 0, 3)
-	spawn_mech(hostile_faction, 0, 2)
 	new /obj/item/storage/box/crate/loot/materials_pack(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
 	for(var/i = 1 to beacons_remaining)
 		new /obj/item/explosive/plastique(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
 		new /obj/item/explosive/plastique(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
 		new beacon_type(get_turf(pick(GLOB.campaign_reward_spawners[starting_faction])))
+
+	spawn_mech(starting_faction, 0, 0, 3)
+	spawn_mech(hostile_faction, 0, 2)
+
+	var/tanks_to_spawn = 0
+	var/mechs_to_spawn = 0
+	var/current_pop = length(GLOB.clients)
+	switch(current_pop)
+		if(0 to 59)
+			tanks_to_spawn = 0
+		if(60 to 75)
+			tanks_to_spawn = 1
+		if(76 to 90)
+			tanks_to_spawn = 2
+		else
+			tanks_to_spawn = 3
+
+	switch(current_pop)
+		if(0 to 39)
+			mechs_to_spawn = 1
+		if(40 to 49)
+			mechs_to_spawn = 2
+		if(50 to 79)
+			mechs_to_spawn = 3
+		else
+			mechs_to_spawn = 4
+
+	spawn_tank(starting_faction, tanks_to_spawn)
+	spawn_tank(hostile_faction, tanks_to_spawn)
+	spawn_mech(hostile_faction, 0, 0, mechs_to_spawn)
+	spawn_mech(starting_faction, 0, 0, max(0, mechs_to_spawn - 1))
 
 /datum/campaign_mission/raiding_base/start_mission()
 	. = ..()

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -70,9 +70,6 @@
 		new /obj/item/explosive/plastique(get_turf(pick(GLOB.campaign_reward_spawners[hostile_faction])))
 		new beacon_type(get_turf(pick(GLOB.campaign_reward_spawners[starting_faction])))
 
-	spawn_mech(starting_faction, 0, 0, 3)
-	spawn_mech(hostile_faction, 0, 2)
-
 	var/tanks_to_spawn = 0
 	var/mechs_to_spawn = 0
 	var/current_pop = length(GLOB.clients)


### PR DESCRIPTION

## About The Pull Request
Made some missions with mechs having scaling numbers of mechs and/or tanks.

1. Raiding Base
2. ASAT capture
3. NT base rescue
## Why It's Good For The Game

Less mechs at lower pop.
More tanks at higher pop.
## Changelog
:cl:
balance: Campaign: Some missions with mechs now scale number of mechs and tanks with player pop
/:cl:
