### PR TITLE
Removes X-Fuel

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -759,15 +759,9 @@ WEAPONS
 	cost = 200
 
 /datum/supply_packs/weapons/back_fuel_tank_x
-	name = "Type X back fuel tank"
+	name = "X-fuel back tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/backtank/X)
 	cost = 600
-
-/datum/supply_packs/weapons/fueltank
-	name = "X-fuel tank"
-	contains = list(/obj/structure/reagent_dispensers/fueltank/xfuel)
-	cost = 600
-	containertype = null
 
 /datum/supply_packs/weapons/rpgoneuse
 	name = "RL-72 Disposable RPG"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

# Title is a small lie

This removes X-Fuel tanks from req while keeping the X-Fuel backpack tanks.

## Why It's Good For The Game

X-Fuel tanks and the backpack contain the same amount of fuel, same price, and are the same. X-Fuel tanks require a X-Fuel backpack to refill, however it is better to order a new backpack.

X-Fuel backpacks have also been renamed. Their previous name was, "Type X back fuel tank."
X-Fuel tanks were named, "X-fuel tank."

X-Fuel tanks cannot be sent via req pad and require Alamo or tad to pickup.

X-Fuel tanks are never ordered outside of mistakes and are considered a noob trap.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/70779744/d22ddcf4-51fb-4d89-9b88-a47cd9b39e6d)

https://cdn.discordapp.com/attachments/877777075027714148/1260120736568447048/Untitled_video_-_Made_with_Clipchamp_1.mp4?ex=668e2a63&is=668cd8e3&hm=0b763f8a847d7e9ed73904a1b47641f17c2ee287d702e977513c64e006ba1181&

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: X-Fuel tanks are no longer orderable from req. X-Fuel backpacks remain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
