### PR TITLE
Piercing defib for campaign

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit.dm
@@ -22,7 +22,7 @@
 
 /datum/loadout_item/suit_slot/som_light_shield/overclocked/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/som_light_shield/overclocked/engineer
 	item_typepath = /obj/item/clothing/suit/modular/som/light/shield_overclocked/engineer
@@ -60,7 +60,7 @@
 
 /datum/loadout_item/suit_slot/som_medium_shield/overclocked/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/som_medium_shield/overclocked/engineer
 	item_typepath = /obj/item/clothing/suit/modular/som/shield_overclocked/engineer
@@ -133,7 +133,7 @@
 
 /datum/loadout_item/suit_slot/som_heavy_tyr/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/som_heavy_tyr/engineer
 	item_typepath = /obj/item/clothing/suit/modular/som/heavy/lorica/engineer
@@ -214,7 +214,7 @@
 
 /datum/loadout_item/suit_slot/som_medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/som_medic/light
 	name = "L armor"

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/suit.dm
@@ -52,7 +52,7 @@
 
 /datum/loadout_item/suit_slot/light_shield/overclocked/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/light_shield/overclocked/engineer
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/light/shield_overclocked/engineer
@@ -84,7 +84,7 @@
 
 /datum/loadout_item/suit_slot/medium_shield/overclocked/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/medium_shield/overclocked/engineer
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/shield_overclocked/engineer
@@ -146,7 +146,7 @@
 
 /datum/loadout_item/suit_slot/heavy_tyr/medic/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 /datum/loadout_item/suit_slot/heavy_tyr/engineer
 	item_typepath = /obj/item/clothing/suit/modular/xenonauten/heavy/tyr_two/engineer
@@ -198,7 +198,7 @@
 
 /datum/loadout_item/suit_slot/medium_mimir/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/tool/extinguisher, SLOT_IN_SUIT)
-	wearer.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_SUIT)
+	wearer.equip_to_slot_or_del(new /obj/item/defibrillator/piercing, SLOT_IN_SUIT)
 
 //engineer
 /datum/loadout_item/suit_slot/medium_engineer

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -24,6 +24,8 @@
 	var/datum/effect_system/spark_spread/sparks
 	///The cooldown for using the defib, applied to shocking *and* toggling
 	COOLDOWN_DECLARE(defib_cooldown)
+	///Whenever the defib will work through armor
+	var/piercing = FALSE
 
 
 /obj/item/defibrillator/suicide_act(mob/user)
@@ -149,7 +151,7 @@
 	if(patient.stat != DEAD)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient is not in a valid state. Operation aborted."))
 		return FALSE
-	if(patient.wear_suit && (patient.wear_suit.atom_flags & CONDUCT)) // something conductive on their chest
+	if(patient.wear_suit && (patient.wear_suit.atom_flags & CONDUCT) && !piercing) // something conductive on their chest
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Paddles registering >100,000 ohms. Remove interfering suit or armor and try again."))
 		return FALSE
 	return TRUE
@@ -348,3 +350,9 @@
 /obj/item/defibrillator/internal/update_icon()
 	. = ..()
 	parent_obj.update_icon()
+
+
+/obj/item/defibrillator/piercing
+	name = "Advanced piercing defibrillator"
+	desc = "A device that delivers powerful shocks to resuscitate incapacitated patients. This one is an advanced, very expensive model, reserved only for crucial frontline engagements, able to resuscitate patients without stripping them of their armor, as the paddles create nano conduits that pierce the material until they detect skin, delivering the shock to the patient underneath."
+	piercing = TRUE


### PR DESCRIPTION

## About The Pull Request

Introduces a new type of defib that ignores armor. Campaign exclusive, for only the standard medical loadout of both TGMC and SOM.

## Why It's Good For The Game

Makes revives faster and more viable, also increases patient survivability, as the medics no longer have to strip the soldier, and the soldier no longer has to reequip armor and weapons, and the medics/teammates babysit the critted marine/the marine fumbling with putting on their gear, making the gamemode's medical side snappier and more fast paced, in line with the rest of the gamemode. Idea credit goes to Teagarden.

## Changelog
:cl:
add: Piercing defib for campaign
/:cl:
