### PR TITLE
mapper icon fix

### DIFF
--- a/code/game/objects/effects/landmarks/gamemode/hvh_deploy_points.dm
+++ b/code/game/objects/effects/landmarks/gamemode/hvh_deploy_points.dm
@@ -98,6 +98,7 @@
 /obj/effect/landmark/patrol_point/tgmc_11
 	name = "TGMC exit point 1"
 	id = "TGMC_1"
+	icon_state = "blue_1"
 
 /obj/effect/landmark/patrol_point/tgmc_21
 	name = "TGMC exit point 2"


### PR DESCRIPTION

## About The Pull Request
One deploy point was missing its mapper icon. No ingame difference.

:cl:
code: Fixed a missing mapper icon for deploy points
/:cl:
