### PR TITLE
Brings the medic medkit pouch in line with the advanced autoinjector pouch

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -656,7 +656,7 @@ GLOBAL_LIST_INIT(synthetic_clothes_listed_products, list(
 		/obj/item/clothing/shoes/black = list(CAT_SHO, "Black Shoes", 0, "synth-armor"),
 		/obj/item/storage/pouch/tools/full = list(CAT_POU, "Tool pouch", 0, "black"),
 		/obj/item/storage/pouch/construction/full = list(CAT_POU, "Construction pouch", 0, "black"),
-		/obj/item/storage/pouch/medkit/medic = list(CAT_POU, "Medkit pouch", 0, "black"),
+		/obj/item/storage/pouch/medkit/doctor = list(CAT_POU, "Medkit pouch", 0, "black"),
 		/obj/item/storage/pouch/surgery = list(CAT_POU, "White surgical pouch", 0, "black"),
 		/obj/item/storage/pouch/field_pouch/full = list(CAT_POU, "Field pouch", 0, "black"),
 		/obj/item/clothing/head/modular/style/cap = list(CAT_SHN, "TGMC cap", 0, "synth-rcmarmstorage"),

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -994,7 +994,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	mask = /obj/item/clothing/mask/surgical
 	head = /obj/item/clothing/head/cmo
 	r_store = /obj/item/storage/pouch/surgery
-	l_store = /obj/item/storage/pouch/medkit/medic
+	l_store = /obj/item/storage/pouch/medkit/doctor
 
 
 /datum/outfit/job/medical/professor/robot
@@ -1084,7 +1084,7 @@ You are also an expert when it comes to medication and treatment. If you do not 
 	mask = /obj/item/clothing/mask/surgical
 	head = /obj/item/clothing/head/surgery/purple
 	r_store = /obj/item/storage/pouch/surgery
-	l_store = /obj/item/storage/pouch/medkit/medic
+	l_store = /obj/item/storage/pouch/medkit/doctor
 
 
 /datum/outfit/job/medical/medicalofficer/robot
@@ -1178,7 +1178,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 	glasses = /obj/item/clothing/glasses/hud/health
 	mask = /obj/item/clothing/mask/surgical
 	r_store = /obj/item/storage/pouch/surgery
-	l_store = /obj/item/storage/pouch/medkit/medic
+	l_store = /obj/item/storage/pouch/medkit/doctor
 
 
 /datum/outfit/job/medical/researcher/robot

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -599,7 +599,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the SOM h
 	glasses = /obj/item/clothing/glasses/hud/health
 	mask = /obj/item/clothing/mask/surgical
 	head = /obj/item/clothing/head/cmo
-	r_store = /obj/item/storage/pouch/medkit/medic
+	r_store = /obj/item/storage/pouch/medkit/doctor
 	l_store = /obj/item/storage/pouch/surgery
 
 /datum/outfit/job/som/medical/professor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -578,6 +578,15 @@
 	new /obj/item/stack/medical/splint(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline(src)
 
+/obj/item/storage/pouch/medkit/doctor/PopulateContents()
+	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
+	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
+	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
+	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
+	new /obj/item/reagent_containers/hypospray/advanced/meraderm(src)
+
 /obj/item/storage/pouch/medkit/medic/PopulateContents()
 	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
 	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -581,10 +581,10 @@
 /obj/item/storage/pouch/medkit/medic/PopulateContents()
 	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
 	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
-	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
 	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
-	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
+	new /obj/item/reagent_containers/hypospray/advanced/quickclotplus_medkit(src)
+	new /obj/item/reagent_containers/hypospray/advanced/peridaxonplus_medkit(src)
 	new /obj/item/reagent_containers/hypospray/advanced/meraderm(src)
 
 /obj/item/storage/pouch/medkit/som

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -490,12 +490,31 @@
 	)
 	description_overlay = "Pe+"
 
+/obj/item/reagent_containers/hypospray/advanced/peridaxonplus_medkit
+	name = "Peridaxon+ hypospray"
+	desc = "A hypospray loaded with Peridaxon Plus, a chemical that heals organs while causing a buildup of toxins. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
+	amount_per_transfer_from_this = 3
+	list_reagents = list(
+		/datum/reagent/medicine/peridaxon_plus = 6,
+		/datum/reagent/medicine/hyronalin = 12,
+	)
+	description_overlay = "Pe+"
+
 /obj/item/reagent_containers/hypospray/advanced/quickclotplus
 	name = "Quickclot+ hypospray"
 	desc = "A hypospray loaded with quick-clot plus, a chemical designed to remove internal bleeding. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
 	amount_per_transfer_from_this = 5
 	list_reagents = list(
 		/datum/reagent/medicine/quickclotplus = 60,
+	)
+	description_overlay = "Qk+"
+
+/obj/item/reagent_containers/hypospray/advanced/quickclotplus_medkit
+	name = "Quickclot+ hypospray"
+	desc = "A hypospray loaded with quick-clot plus, a chemical designed to remove internal bleeding. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
+	amount_per_transfer_from_this = 5
+	list_reagents = list(
+		/datum/reagent/medicine/quickclotplus = 30,
 	)
 	description_overlay = "Qk+"
 


### PR DESCRIPTION

## About The Pull Request

The medkit pouch now contains an advanced quick clot+ injector (30u qc+) and an advanced peridaxon plus injector (6u peri+ 12u hyronalin). Removed an advanced brute and burn kit to make space.

## Why It's Good For The Game

Currently the medkit pouch for corspman is inherently inferior to the advanced autoinjector pouch, as it lacks these two chemicals. People who choose to go with a medical pouch/prefer advanced injectors over autoinjectors for any reason has to go through the tedious process of emptying the autoinjectors into the advanced injectors every time, bogging down prep. This PR brings the medkit pouch in line with the exact same amount of reagents as you would get using the autoinjector pouch (except the dexalin and the oxycodone, dexalin is... questionably useful in rare, edge case scenarios, and oxycodone can be aquired for free in infinite amount). We get enough advanced kits anyways from the free advanced medkit everyone gets as part of the corspman essentials, not to mention them being free in generous amount in the marinemed vendor. Doctors' (Synth, MD, RSR, and CMO) medkit pouches remain untouched to avoid powercreep, as these roles have no inherent access to the advanced autoinjector pouch. 

## Changelog
:cl:
balance: Medic medkit pouches now contain QC+ and Pe+ exactly like the medic autoinjector pouch
/:cl:
