### PR TITLE
SSD takeover fixes

### DIFF
--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -63,9 +63,8 @@
 	if(new_mob.stat == DEAD)
 		to_chat(owner, span_warning("You cannot join if the mob is dead."))
 		return FALSE
-	switch(tgui_alert(owner, "Are you sure you want to take " + new_mob.real_name +" ("+new_mob.job.title+")?", "Take SSD mob", list("Yes", "No",)))
-		if("No")
-			return
+	if(tgui_alert(owner, "Are you sure you want to take " + new_mob.real_name +" ("+new_mob.job.title+")?", "Take SSD mob", list("Yes", "No",)) != "Yes")
+		return
 	if(isxeno(new_mob))
 		var/mob/living/carbon/xenomorph/ssd_xeno = new_mob
 		if(ssd_xeno.tier != XENO_TIER_MINION && XENODEATHTIME_CHECK(owner))
@@ -100,7 +99,10 @@
 	log_admin("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd.")
 	new_mob.transfer_mob(owner)
 	var/mob/living/carbon/human/H = new_mob
+	var/datum/job/j = H.job
+	var/datum/outfit/job/o = j.outfit
 	H.on_transformation()
+	o.handle_id(H)
 
 //respawn button for campaign gamemode
 /datum/action/observer_action/campaign_respawn

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -54,8 +54,12 @@
 	if(subspecies)
 		set_species(subspecies)
 	if(client)
-		name = client.prefs.real_name
-		real_name = client.prefs.real_name
+		if(issynth(src))
+			name = client.prefs.synthetic_name
+			real_name = client.prefs.synthetic_name
+		else
+			name = client.prefs.real_name
+			real_name = client.prefs.real_name
 		gender = client.prefs.gender
 		h_style = client.prefs.h_style
 		f_style = client.prefs.f_style

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -79,6 +79,8 @@
 		age = client.prefs.age
 		ethnicity = client.prefs.ethnicity
 		flavor_text = client.prefs.flavor_text
+		voice = client.prefs.tts_voice
+		pitch = client.prefs.tts_pitch
 		update_body()
 		update_hair()
 		regenerate_icons()


### PR DESCRIPTION
## About The Pull Request

Fixes Four issues related to the ssd takeover PR (https://github.com/tgstation/TerraGov-Marine-Corps/pull/16253) 
1) If the confirmation panel times out, it automatically takes it as a yes
2) The ID card doesn't update with you, locking you out of the vendors besides the ones that do not require ID.
3) If you are overtaking a synth, it will pull your normal name instead of your synth one
4) TTS voice doesn't get changed
## Why It's Good For The Game

Fixes oversight by my previous PR. Sorry!

## Changelog
:cl:
fix: SSD takeover confirmation doesn't automatically assume yes
fix: SSD takeover now updates your ID as well
fix: SSD takeover now uses your synth name on synths
fix: SSD takeover now changes your voice too
/:cl:
