### PR TITLE
DMR no longer has minimum range accuracy, has mildly higher penetration.

### DIFF
--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -116,10 +116,9 @@
 	damage_falloff = 0.5
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 25
-	accurate_range_min = 6
 	max_range = 40
 	damage = 65
-	penetration = 15
+	penetration = 17.5
 	sundering = 2
 
 /datum/ammo/bullet/rifle/garand


### PR DESCRIPTION

## About The Pull Request
DMR minimum accuracy malus removed. It no longer misses at mid ranges.
It has mildly higher penetration at 17.5 rather than 15.
## Why It's Good For The Game
DMR having a min range doesn't really make much sense, it isn't a dedicated sniper rifle and missing at medium ranges where its supposed to shine makes it an awkward weapon to use. The mild AP buff should also help it be a more popular option compared to other marksman-class weapons. 
## Changelog
:cl:
balance: DMR no longer has minimum range penalties and has mildly higher penetration.
/:cl:
