### PR TITLE
Fixes synthetic isntruments being offkey

### DIFF
--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -64,7 +64,7 @@
 		var/mob/M = i
 		if(M?.client?.prefs?.toggles_sound & SOUND_INSTRUMENTS_OFF)
 			continue
-		M.playsound_local(get_turf(parent), copy, volume, FALSE, K.frequency, null, FALSE, channel)
+		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, FALSE, channel,copy)
 		// Could do environment and echo later but not for now
 
 /**

--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -64,7 +64,7 @@
 		var/mob/M = i
 		if(M?.client?.prefs?.toggles_sound & SOUND_INSTRUMENTS_OFF)
 			continue
-		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, FALSE, channel,copy)
+		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, FALSE, channel, copy)
 		// Could do environment and echo later but not for now
 
 /**


### PR DESCRIPTION
## About The Pull Request
Fixes #15907
This is normally the part where I bullshit you about how and why this was borked. I have no idea why this works, and I don't think it's because get_sfx() call that used to get triggered somehow messed with the frequency var.

## Why It's Good For The Game
Someone promised me their soul or something. In practicality it isn't really good for the game to have more marines playing awful songs and causing ear damage/brainrot, but at least what you put in is what you'll get.

## Changelog
:cl:
fix: Syntheised instruments should no longer be off key
/:cl:
