### PR TITLE
Removes nutriment from zoom pills

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -189,7 +189,7 @@
 
 /obj/item/reagent_containers/pill/zoom
 	pill_desc = "A Zoom pill! Gotta go fast!"
-	list_reagents = list(/datum/reagent/medicine/synaptizine = 3, /datum/reagent/medicine/hyronalin = 5, /datum/reagent/consumable/nutriment = 3)
+	list_reagents = list(/datum/reagent/medicine/synaptizine = 3, /datum/reagent/medicine/hyronalin = 5)
 	pill_id = 14
 
 /obj/item/reagent_containers/pill/russian_red


### PR DESCRIPTION

## About The Pull Request

CLF zoomies are no longer freemium weight gain pills

## Why It's Good For The Game

Eating zoom pills made you fat, therefore no zoom. You were often better off just not eating these if you wanted to go fast.

## Changelog

:cl: Joe13413
balance: removed nutriment from zoom pills
/:cl:
