### PR TITLE
Nerfs harvester claymore ammo

### DIFF
--- a/code/game/objects/items/weapons/harvester.dm
+++ b/code/game/objects/items/weapons/harvester.dm
@@ -94,7 +94,7 @@
 
 /obj/item/weapon/twohanded/glaive/harvester/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/harvester, 60, TRUE)
+	AddComponent(/datum/component/harvester, 30, TRUE)
 
 /obj/item/weapon/twohanded/glaive/harvester/wield(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Nerfs harvester claymore chem storage from 60u each (240u total) to 30u each (120u total), making it equal to the other two harvester weapons instead of double.

Claymore is already the highest DPS of any of the weapons thanks to having both higher burst damage (making it outpace the other two if xenos arent standing completely still) and having higher true damage (making it outpace the other two even if xenos _are_ standing still). While the others have niches that separate them, the claymore is also the best in an extended fight due to having _double_ the chem capacity, requiring you to leave combat to reload far less often.
## Why It's Good For The Game
Claymore beats the other two vali weapons in nearly every scenario. This should hopefully make extended fights more even across the three rather than claymore being leagues better.
## Changelog
:cl:
balance: Vali claymore now has the same chem capacity as the other two vali weapons.
/:cl:
