### PR TITLE
Random event cleanup

### DIFF
--- a/code/modules/events/hive_threat.dm
+++ b/code/modules/events/hive_threat.dm
@@ -5,7 +5,7 @@
 	weight = 10
 	earliest_start = 30 MINUTES
 
-	gamemode_blacklist = list("Combat Patrol","Sensor Capture", "Crash")
+	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture", "Campaign")
 
 /datum/round_event/hive_threat
 	///The human target for this event

--- a/code/modules/events/intel_computer.dm
+++ b/code/modules/events/intel_computer.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/intel_computer
 	weight = 25
 
-	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture")
+	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture", "Campaign")
 
 /datum/round_event_control/intel_computer/can_spawn_event(players_amt, gamemode)
 	if(length(GLOB.intel_computers) <= 0)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -5,7 +5,7 @@
 	earliest_start = 60 MINUTES
 	max_occurrences = 1
 
-	gamemode_blacklist = list("Crash")
+	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture", "Campaign")
 
 /datum/round_event_control/ion_storm/can_spawn_event(players_amt, gamemode)
 	return ..()

--- a/code/modules/events/stock_uptick.dm
+++ b/code/modules/events/stock_uptick.dm
@@ -5,7 +5,7 @@
 	earliest_start = 30 MINUTES
 	max_occurrences = 10
 
-	gamemode_blacklist = list("Crash","Combat Patrol","Sensor Capture")
+	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture", "Campaign")
 
 /datum/round_event_control/stock_uptick/can_spawn_event(players_amt, gamemode)
 	if(SSpoints.supply_points[FACTION_TERRAGOV] >= 300)

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -5,7 +5,7 @@
 	weight = 10
 	earliest_start = 5 MINUTES
 
-	gamemode_whitelist = list("Combat Patrol","Sensor Capture")
+	gamemode_whitelist = list("Combat Patrol", "Sensor Capture")
 
 /datum/round_event/supply_drop
 	///How long between the event firing and the supply drop actually landing


### PR DESCRIPTION

## About The Pull Request
Cleaned up the blacklists for some random events.
## Why It's Good For The Game
Funny comms blackout or intel computers in campaign is wew.
## Changelog
:cl:
fix: Certain random events will no longer happen in the campaign gamemode
/:cl:
