### PR TITLE
Campaign loadout fixes and improvements

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/engineer.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/engineer.dm
@@ -55,11 +55,11 @@
 
 /datum/loadout_item/suit_store/main_gun/som_engineer/mpi
 	name = "MPi-KM"
-	desc = "Equipped with a mag harness and laser sight. The MPi-KM is a modern reproduction based off several variants of kalashnikov type rifles used during the original Martian rebellion. \
+	desc = "Equipped with a red dot sight and underslung grenade launcher. The MPi-KM is a modern reproduction based off several variants of kalashnikov type rifles used during the original Martian rebellion. \
 	These weapons were already ancient at that time, and their continued use by the SOM speaks more to their cultural legacy than any tactical benefits. \
 	Despite having relatively poor mobility and handling, it never the less has fearsome firepower and good capacity, ensuring it stays a relevant weapon choice for the SOM. Uses 7.62x39mm ammunition."
 	ui_icon = "ak47"
-	item_typepath = /obj/item/weapon/gun/rifle/mpi_km/black/magharness
+	item_typepath = /obj/item/weapon/gun/rifle/mpi_km/black/grenadier
 
 /datum/loadout_item/suit_store/main_gun/som_engineer/mpi/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/medic.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/medic.dm
@@ -40,11 +40,11 @@
 
 /datum/loadout_item/suit_store/main_gun/som_medic/mpi
 	name = "MPi-KM"
-	desc = "Equipped with a mag harness and laser sight. The MPi-KM is a modern reproduction based off several variants of kalashnikov type rifles used during the original Martian rebellion. \
+	desc = "Equipped with a red dot sight and underslung grenade launcher. The MPi-KM is a modern reproduction based off several variants of kalashnikov type rifles used during the original Martian rebellion. \
 	These weapons were already ancient at that time, and their continued use by the SOM speaks more to their cultural legacy than any tactical benefits. \
 	Despite having relatively poor mobility and handling, it never the less has fearsome firepower and good capacity, ensuring it stays a relevant weapon choice for the SOM. Uses 7.62x39mm ammunition."
 	ui_icon = "ak47"
-	item_typepath = /obj/item/weapon/gun/rifle/mpi_km/black/magharness
+	item_typepath = /obj/item/weapon/gun/rifle/mpi_km/black/grenadier
 
 /datum/loadout_item/suit_store/main_gun/som_medic/mpi/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	. = ..()

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/belt.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/belt.dm
@@ -68,6 +68,7 @@
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. \
 	This version is designed for the SMG-25, and features a larger frame to support the gun. Due to its unorthodox design, it isn't a very common sight, and is only specially issued."
 	ui_icon = "m25"
+	req_desc = "Requires an SMG-25, MG-27 or FL-84."
 	item_typepath = /obj/item/storage/holster/m25
 	jobs_supported = list(SQUAD_MARINE)
 	item_whitelist = list(
@@ -78,6 +79,17 @@
 
 /datum/loadout_item/belt/smg_holster/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout)
 	wearer.equip_to_slot_or_del(new /obj/item/weapon/gun/smg/m25/holstered(wearer), SLOT_IN_HOLSTER)
+	var/ammo_type = /obj/item/ammo_magazine/smg/m25
+	if(istype(wearer.r_store, /obj/item/storage/pouch/magazine))
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_R_POUCH)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_R_POUCH)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_R_POUCH)
+	if(wearer.skills.getRating(SKILL_SMGS) >= SKILL_SMGS_TRAINED)
+		ammo_type = /obj/item/ammo_magazine/smg/m25/ap
+	if(istype(wearer.l_store, /obj/item/storage/pouch/magazine))
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_L_POUCH)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_L_POUCH)
+		wearer.equip_to_slot_or_del(new ammo_type, SLOT_IN_L_POUCH)
 
 /datum/loadout_item/belt/machete
 	name = "Machete"

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -370,7 +370,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 	else if(owner_stats.faction == FACTION_SOM)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_store/main_gun/som_marine/smg/enhanced, /datum/loadout_item/suit_store/main_gun/som_marine/smg, SOM_SQUAD_MARINE)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_store/main_gun/som_marine/smg_and_shield/enhanced, /datum/loadout_item/suit_store/main_gun/som_marine/smg_and_shield, SOM_SQUAD_MARINE)
-		owner_stats.replace_loadout_option(/datum/loadout_item/suit_store/main_gun/som_marine/smg/enhanced, /datum/loadout_item/suit_store/main_gun/som_marine/smg, SOM_SQUAD_CORPSMAN)
+		owner_stats.replace_loadout_option(/datum/loadout_item/suit_store/main_gun/som_medic/smg/enhanced, /datum/loadout_item/suit_store/main_gun/som_medic/smg, SOM_SQUAD_CORPSMAN)
 		owner_stats.replace_loadout_option(/datum/loadout_item/suit_store/main_gun/som_engineer/smg/enhanced, /datum/loadout_item/suit_store/main_gun/som_engineer/smg, SOM_SQUAD_ENGINEER)
 
 /datum/perk/skill_mod/heavy_weapons


### PR DESCRIPTION
## About The Pull Request
Gives the SOM medic and engie the MPI with UGL (instead of laser sight). I did the same with corpsman but forgot to look at the SOM side.

Fixed the SMG-25 belt holster not populating mag pouches.

Fixed SOM medics not getting the upgraded SMG loadout when they have the SMG perk.
## Why It's Good For The Game
Fixes and improvements to loadouts.
## Changelog
:cl:
balance: Campaign: SOM medic and engineer MPI loadouts now come with a UGL
fix: Campaign: SOM medics correctly receive the AP V-21 if they have the SMG perk
fix: Campaign: TGMC standards get SMG mags in their pouches if they chose the SMG belt holster
/:cl:
