### PR TITLE
Adds campaign TGMC tank to Valhalla

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -332,7 +332,7 @@
 		/obj/vehicle/sealed/armored/multitile,
 		/obj/vehicle/sealed/armored/multitile/apc,
 		/obj/vehicle/sealed/armored/multitile/som_tank,
-		/obj/vehicle/sealed/armored/multitile/campaign
+		/obj/vehicle/sealed/armored/multitile/campaign,
 	)
 
 	var/selected_vehicle = tgui_input_list(user, "Which vehicle do you want to spawn?", "Vehicle spawn", spawnable_vehicles)

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -330,8 +330,9 @@
 /obj/machinery/button/valhalla/vehicle_button/proc/spawn_vehicles(mob/living/user)
 	var/list/spawnable_vehicles = list(
 		/obj/vehicle/sealed/armored/multitile,
+		/obj/vehicle/sealed/armored/multitile/apc,
 		/obj/vehicle/sealed/armored/multitile/som_tank,
-		/obj/vehicle/sealed/armored/multitile/apc
+		/obj/vehicle/sealed/armored/multitile/campaign
 	)
 
 	var/selected_vehicle = tgui_input_list(user, "Which vehicle do you want to spawn?", "Vehicle spawn", spawnable_vehicles)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Apparently there was a separate tank for TGMC HvH that I didn't add to Valhalla. This makes testing vehicle vs. vehicle more accurate and possible.
## Changelog
:cl:
add: Added the TGMC campaign tank to Valhalla
/:cl:
