### PR TITLE
Updates the TGMC Campaign tank's description

### DIFF
--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -74,6 +74,7 @@
 
 //THe HvX tank is not balanced at all for HvH
 /obj/vehicle/sealed/armored/multitile/campaign
+	desc = "A gigantic wall of metal designed for maximum SOM destruction. Drag yourself onto it at an entrance to get inside."
 	required_entry_skill = SKILL_LARGE_VEHICLE_DEFAULT
 	max_integrity = 1400
 	soft_armor = list(MELEE = 90, BULLET = 95 , LASER = 95, ENERGY = 95, BOMB = 85, BIO = 100, FIRE = 100, ACID = 75)


### PR DESCRIPTION

## About The Pull Request
Updated the TGMC campaign tank's description
## Why It's Good For The Game
There's currently not any xenos in HvH, so having the tank's description talk about how it's meant for destroying SOM is a nice bit of flavor.
## Changelog
:cl:
spellcheck: Changed the TGMC campaign tank's description to reflect it fighting the SOM
/:cl:
