### PR TITLE
Campaign admin panel QOL - Nonforced autobalance

### DIFF
--- a/code/modules/admin/panels/Campaign_panel.dm
+++ b/code/modules/admin/panels/Campaign_panel.dm
@@ -107,10 +107,14 @@ GLOBAL_DATUM(campaign_admin_panel, /datum/campaign_admin_panel)
 			message_admins("[usr.client] added the asset [choice] to [faction_datum.faction]")
 			log_admin("[usr.client] added the asst [choice] to [faction_datum.faction]")
 			return TRUE
-		if("force_autobalance")
-			current_mode.autobalance_cycle(TRUE)
-			message_admins("[usr.client] forced autobalance")
-			log_admin("[usr.client] forced autobalance")
+		if("autobalance")
+			var/choice = tgui_input_list(user, "Would you like to force autobalance?", "Forced autobalance", list("No", "Yes"))
+			if(!choice)
+				return FALSE
+			var/forced = choice == "Yes"
+			current_mode.autobalance_cycle(forced)
+			message_admins("[usr.client] [forced ? "forced" : "triggered"] autobalance")
+			log_admin("[usr.client] [forced ? "forced" : "triggered"] autobalance")
 			return TRUE
 		if("mission_start_timer")
 			if(current_mode.current_mission.mission_state != MISSION_STATE_LOADED)

--- a/tgui/packages/tgui/interfaces/CampaignAdminPanel.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignAdminPanel.tsx
@@ -156,15 +156,15 @@ export const CampaignAdminPanel = (props) => {
               <Stack.Item mt={2}>
                 <Button
                   tooltip={multiline`
-                    Forces autobalance to run.
-                    Players on the high pop team will be FORCED to swap.
+                    Triggers autobalance to run.
+                    This can be forced, to not give players a choice.
                   `}
                   mt={1}
                   onClick={() => {
-                    act('force_autobalance');
+                    act('autobalance');
                   }}
                 >
-                  Force Autobalance
+                  Trigger Autobalance
                 </Button>
               </Stack.Item>
               <Stack.Item mt={2}>


### PR DESCRIPTION

## About The Pull Request
The autobalance button now prompts if you want to force autobalance or simply suggest it as it normally runs.
## Why It's Good For The Game
More admin control.
## Changelog
:cl:
admin: Campaign panel autobalance button prompts if you want to force it or not
/:cl:
