### PR TITLE
Adds Rangefinder Binos to Req

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1072,7 +1072,7 @@ EXPLOSIVES
 /datum/supply_packs/explosives/tactical_binos
 	name = "Rangefinding Binoculars"
 	contains = list(/obj/item/binoculars/tactical/range)
-	cost = 100
+	cost = 200
 	available_against_xeno_only = TRUE
 
 /*******************************************************************************

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1069,6 +1069,12 @@ EXPLOSIVES
 	cost = 100
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/explosives/tactical_binos
+	name = "Rangefinding Binoculars"
+	contains = list(/obj/item/binoculars/tactical/range)
+	cost = 100
+	available_against_xeno_only = TRUE
+
 /*******************************************************************************
 ARMOR
 *******************************************************************************/

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1071,7 +1071,10 @@ EXPLOSIVES
 
 /datum/supply_packs/explosives/tactical_binos
 	name = "Rangefinding Binoculars"
-	contains = list(/obj/item/binoculars/tactical/range)
+	contains = list(
+		/obj/item/binoculars/tactical/range,
+		/obj/item/encryptionkey/cas,
+	)
 	cost = 200
 	available_against_xeno_only = TRUE
 


### PR DESCRIPTION
## About The Pull Request
This pull adds the Rangefinding Binoculars to Requisitions for 200 Points, cheaper than the Tac Binos by 33% but more expensive than AI Targeting by double its cost, found under Explosive section just bellow the AI Module. This also includes a Fire Support Encryption key much like the Tac Binos crate does incase you want to co-ordinate with your Mortar/Artillery buddies.
## Why It's Good For The Game
Right now the only sources of Rangefinders is the Round start Mortar/artillery crate or from Engineers who purchase it from the NEXUS vendors, if you lose all of them that means you must buy Tac Binos instead; However someone mentioned in the Discord that Tac Binos do not work with Linking to mortars currently.
## Changelog
:cl:
add: Added Rangefinders to Requisitions for 200 Points, comes with free Fire Support Encryption Key!
/:cl:
