### PR TITLE
Less misleading jump stamina message

### DIFF
--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -77,9 +77,8 @@
 		if(isrobot(jumper) || issynth(jumper))
 			to_chat(jumper, span_warning("Your leg servos do not allow you to jump!"))
 			return
-		else
-			to_chat(jumper, span_warning("Catch your breath!"))
-			return
+		to_chat(jumper, span_warning("Catch your breath!"))
+		return
 
 	var/effective_jump_duration = jump_duration
 	var/effective_jump_height = jump_height

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -74,8 +74,12 @@
 		return
 
 	if(stamina_cost && (jumper.getStaminaLoss() > -stamina_cost))
-		to_chat(jumper, span_warning("Catch your breath!"))
-		return
+		if(isrobot(jumper) || issynth(jumper))
+			to_chat(jumper, span_warning("Your leg servos do not allow you to jump!"))
+			return
+		else
+			to_chat(jumper, span_warning("Catch your breath!"))
+			return
 
 	var/effective_jump_duration = jump_duration
 	var/effective_jump_height = jump_height


### PR DESCRIPTION

## About The Pull Request
Closes #16032
Robots and synths do not have the ability to jump intentionally however get a "catch your breath message", this flavors it to them specifically
## Why It's Good For The Game
Robots and synths do not have a breath to catch
## Changelog
:cl:
fix: Synths and robots no longer get a "catch your breath" message when trying to jump, instead a silicon specific message
/:cl:
