### PR TITLE
Fixes LR-73 ammo box overlay

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -968,7 +968,7 @@
 /obj/item/storage/box/visual/magazine/compact/lasrifle
 	name = "LR-73 cell box"
 	desc = "A box specifically designed to hold a large amount of TX-73 cells."
-	closed_overlay = "mag_box_small_overlay_tx73"
+	closed_overlay = "mag_box_small_overlay_lr73"
 
 /obj/item/storage/box/visual/magazine/compact/lasrifle/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Title

## Changelog

:cl:
fix: fixed LR-73 ammo box overlay sprite
/:cl: