### PR TITLE
Removes desant trait when deleting hitbox of a vehicle.

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -46,6 +46,9 @@
 /obj/hitbox/Destroy(force)
 	if(!force) // only when the parent is deleted
 		return QDEL_HINT_LETMELIVE
+	for(var/mob/living/desant AS in tank_desants) // Lets clean up our riders before deleting.
+		if(HAS_TRAIT(desant, TRAIT_TANK_DESANT))
+			desant.remove_traits(list(TRAIT_TANK_DESANT, TRAIT_NOSUBMERGE), VEHICLE_TRAIT)
 	root?.hitbox = null
 	root = null
 	return ..()


### PR DESCRIPTION

## About The Pull Request

This PR removes the desant trait from any living that has it while riding on a vehicle. 
## Why It's Good For The Game

The trait will be stuck on players if a vehicle is destroyed while riding them, causing unintentional consequences for anything that relies or checks on if someone is on top of a vehicle. This fixes that.
Fixes issue #16297
## Changelog
:cl:GameMaster85
fix: fixed detection checks on riding a vehicle lingering if the vehicle is destroyed while riding it, such as the xeno hide action
/:cl:
