### PR TITLE
Mining well repair time now scales based on your engineer skill and is significantly reduced

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,11 +10,11 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define repair_time_Upgrade
-#define repair_time_Remove
-#define repair_time_Welding
-#define repair_time_Wirecut
-#define repair_time_Wrench
+#define repair_time_Upgrade 15 SECONDS
+#define repair_time_Remove 20 SECONDS
+#define repair_time_Welding 15 SECONDS
+#define repair_time_Wirecut 14 SECONDS
+#define repair_time_Wrench 10 SECONDS
 
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,7 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Upgrade = 2 SECONDS
@@ -150,7 +150,7 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Remove = 2 SECONDS
@@ -190,7 +190,7 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Welding = 2 SECONDS
@@ -221,7 +221,7 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wirecut = 2 SECONDS
@@ -249,7 +249,7 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wrench = 2 SECONDS

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,6 +10,12 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
+#define repair_time_Upgrade
+#define repair_time_Remove
+#define repair_time_Welding
+#define repair_time_Wirecut
+#define repair_time_Wrench
+
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,11 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(!do_after(user, 15 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Upgrade = 2 SECONDS
+	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
 		if(MINER_RESISTANT)
@@ -146,7 +150,11 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-		if(!do_after(user, 30 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Remove = 2 SECONDS
+		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -182,7 +190,11 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(!do_after(user, 200, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Welding = 2 SECONDS
+	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
 	if(miner_status != MINER_DESTROYED )
@@ -209,7 +221,11 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(!do_after(user, 120, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wirecut = 2 SECONDS
+	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
 		return FALSE
@@ -233,7 +249,11 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(!do_after(user, 150, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wrench = 2 SECONDS
+	if(!do_after(user, repair_time_Wrench, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)
 		return FALSE

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -103,9 +103,9 @@
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Upgrade = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Upgrade = 2 SECONDS
+		var/repair_time_Upgrade = 3 SECONDS
 	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
@@ -151,9 +151,9 @@
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Remove = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Remove = 2 SECONDS
+		var/repair_time_Remove = 4 SECONDS
 		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
@@ -191,9 +191,9 @@
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Welding = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Welding = 2 SECONDS
+		var/repair_time_Welding = 4 SECONDS
 	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
@@ -222,9 +222,9 @@
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Wirecut = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wirecut = 2 SECONDS
+		var/repair_time_Wirecut = 3 SECONDS
 	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)


### PR DESCRIPTION

## About The Pull Request
This pull is designed to change the repair time of Mining wells to be scaled based on your engineering skill; thus letting higher skilled (in terms of job role skills) players preform the task much quicker than those without the proper skill. It also drastically reduces the time it takes to repair in general to reduce the amount of downtime an engineer spends staring at a mining well hoping to not be shuffled by a fellow marine. As of now its all hardcoded in code ticks and this changes it to seconds with a variable set based on your SKILL_ENGINEER, and a failsafe (read; hardcoded minimum time) is added to prevent negative values from occurring by abnormally high (read; admemes) skill values. Abnormally low values will still produce the desired comically long repair time.

WARNING: I have not been able to test this code change yet in a local environment as I'm at work still. I cannot guarantee this PR won't completely break everything and crash the server should it be merged in its current state. Fair warning has been issued.
## Why It's Good For The Game
Engineers are discouraged to go repair miners as it takes a very long time to repair and your likely to be interrupted by either a Marine shuffling your tile or a Xeno coming over to say hi. This change makes it so engineers and other high engineering skilled jobs like Synth are encouraged to go repair the miners as they can do so at a much greater pace than prior. 

Currently this PR makes it so Squad engineers can do each step in 6/5/4 seconds respectively and CSE/Synths to do it in 4/3/2 seconds respectively. All other levels still have the fumble time check and on top of that have variable times based on their skill level; SLs can do it in 9/8/6 seconds after fumble checks, Mech Pilots, APC and Tank crews can do it in 12/11/8 seconds, and anyone no listed does it in 15/14/10 seconds per step of the process chain (Weld, Wire Cut, and Wrench). Having timed it right now it takes about 21 seconds for a Squad Engineer to complete the welding time currently; this makes the time down to just 6 seconds makes it almost 1/4th the time spent staring at a well. This PR change will also impact the install time of upgrades as well as the removal of upgrades; so your not staring at a mining well trying to plug in an autominer or speed miner upgrade for 15 seconds (Unless you are a regular Marine!)

Official Time per process (Not counting fumble check For skills 2 and lower):
Engineer Skill   Upgrading Miner     Removing Upgrade    Welding       Wire Cut        Wrenching
0                       15 Seconds               20 Seconds               15 Seconds   14 Seconds   10 Seconds
1                       12 Seconds               16 Seconds               12 Seconds   11 Seconds    8 Seconds
2                        9 Seconds                12 Seconds                9 Seconds     8 Seconds     6 Seconds
3 (Squad Engi)   6 Seconds                 8 Seconds                 6 Seconds     5 Seconds     4 Seconds
4 and up            3 Seconds                 4 Seconds                 4 Seconds     3 Seconds     2 Seconds
## Changelog
:cl:
balance: Repairing and upgrading mining wells now scales based on your Engineer skill level, high skill jobs will be able to complete repairs and upgrade mining wells faster than before.
balance: Mining well repair speed and upgrade times are drastically reduced to lower the amount of staring at a progress bar while preforming Mining Well duties.
/:cl:
