### PR TITLE
Gives the heavy_isg/FK-88 a scope.

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -312,9 +312,9 @@
 	gun_features_flags = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_SMOKE_PARTICLES
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
 
-	attachable_allowed = list(/obj/item/attachable/scope/unremovable/hsg_102/nest)
+	attachable_allowed = list(/obj/item/attachable/scope/unremovable/standard_atgun)
 
-	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/hsg_102/nest)
+	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/standard_atgun)
 
 	allowed_ammo_types = list(
 		/obj/item/ammo_magazine/heavy_isg/he,


### PR DESCRIPTION
## About The Pull Request
This mounted weapon's only good quality is the giant explosion yet the scope is small, and has no IFF
## Why It's Good For The Game
This doesn't really improve it's issues but atleast you dont hit your teammates with a heavy explosion the size of an entire screen if you leave it on guided mode.

https://github.com/user-attachments/assets/9fc304c4-7c45-4308-ad0d-60132781c9b7


## Changelog
:cl:
balance: The FK-88 now has a fullscope instead of the old HSG sight it had.
/:cl:
