### PR TITLE
CIC messages/ship announcements have the same cooldown as HUD orders (and more character limits)

### DIFF
--- a/code/game/objects/machinery/computer/communications.dm
+++ b/code/game/objects/machinery/computer/communications.dm
@@ -98,11 +98,14 @@
 
 		if("announce")
 			if(authenticated == 2)
+				if(TIMER_COOLDOWN_CHECK(usr, COOLDOWN_HUD_ORDER))
+					to_chat(usr, span_warning("You've sent an announcement or message too recently!"))
+					return
 				if(world.time < cooldown_message + COOLDOWN_COMM_MESSAGE)
 					to_chat(usr, span_warning("Please allow at least [COOLDOWN_COMM_MESSAGE*0.1] second\s to pass between announcements."))
 					return FALSE
 
-				var/input = tgui_input_text(usr, "Please write a message to announce to the station crew.", "Priority Announcement", "",multiline = TRUE, encode = FALSE)
+				var/input = tgui_input_text(usr, "Please write a message to announce to the station crew.", "Priority Announcement", "",multiline = TRUE, encode = FALSE, max_length = 100)
 				if(!input || !(usr in view(1,src)) || authenticated != 2 || world.time < cooldown_message + COOLDOWN_COMM_MESSAGE)
 					return FALSE
 
@@ -122,6 +125,7 @@
 				priority_announce(input, subtitle = "Sent by [sender.get_paygrade(0) ? sender.get_paygrade(0) : sender.job.title] [sender.real_name]", type = ANNOUNCEMENT_COMMAND)
 				message_admins("[ADMIN_TPMONTY(usr)] has just sent a command announcement")
 				log_game("[key_name(usr)] has just sent a command announcement.")
+				TIMER_COOLDOWN_START(usr, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 				cooldown_message = world.time
 
 		if("award")

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -23,6 +23,9 @@
 #define MESSAGE_SQUAD "Message all marines in a squad"
 #define SWITCH_SQUAD_NEAR "Move all nearby marines to a squad"
 
+/// The maximum length we should use for sending messages with stuff like `message_member`,
+/// `message_squad` etc.
+#define MAX_COMMAND_MESSAGE_LENGTH 100
 
 GLOBAL_LIST_EMPTY(active_orbital_beacons)
 GLOBAL_LIST_EMPTY(active_laser_targets)
@@ -376,7 +379,10 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 			attack_hand(operator)
 		if("message")
 			if(current_squad && operator == usr)
-				var/input = tgui_input_text(operator, "Please write a message to announce to the squad:", "Squad Message")
+				if(TIMER_COOLDOWN_CHECK(operator, COOLDOWN_HUD_ORDER))
+					to_chat(operator, span_warning("You've sent an announcement or message too recently!"))
+					return
+				var/input = tgui_input_text(operator, "Please write a message to announce to the squad:", "Squad Message", max_length = MAX_COMMAND_MESSAGE_LENGTH)
 				if(input)
 					current_squad.message_squad(input, operator) //message, adds username
 					if(issilicon(operator))
@@ -384,14 +390,18 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 					visible_message(span_boldnotice("Message sent to all Marines of squad '[current_squad]'."))
 		if("sl_message")
 			if(current_squad && operator == usr)
-				var/input = tgui_input_text(operator, "Please write a message to announce to the squad leader:", "SL Message")
+				if(TIMER_COOLDOWN_CHECK(operator, COOLDOWN_HUD_ORDER))
+					to_chat(operator, span_warning("You've sent an announcement or message too recently!"))
+					return
+				var/input = tgui_input_text(operator, "Please write a message to announce to the squad leader:", "SL Message", max_length = MAX_COMMAND_MESSAGE_LENGTH)
 				if(input)
+					TIMER_COOLDOWN_START(operator, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 					message_member(current_squad.squad_leader, input, operator)
 					if(issilicon(operator))
 						to_chat(operator, span_boldnotice("Message sent to Squad Leader [current_squad.squad_leader] of squad '[current_squad]'."))
 					visible_message(span_boldnotice("Message sent to Squad Leader [current_squad.squad_leader] of squad '[current_squad]'."))
 		if("set_primary")
-			var/input = tgui_input_text(operator, "What will be the squad's primary objective?", "Primary Objective")
+			var/input = tgui_input_text(operator, "What will be the squad's primary objective?", "Primary Objective", max_length = MAX_COMMAND_MESSAGE_LENGTH * 0.75)
 			if( is_ic_filtered(input) || NON_ASCII_CHECK(input))
 				to_chat(operator, span_boldnotice("Message invalid. Check your message does not contain filtered words or characters."))
 				return
@@ -401,7 +411,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 				to_chat(operator, span_boldnotice("Primary objective of squad '[current_squad]' set."))
 			visible_message(span_boldnotice("Primary objective of squad '[current_squad]' set."))
 		if("set_secondary")
-			var/input = tgui_input_text(operator, "What will be the squad's secondary objective?", "Secondary Objective")
+			var/input = tgui_input_text(operator, "What will be the squad's secondary objective?", "Secondary Objective", max_length = MAX_COMMAND_MESSAGE_LENGTH * 0.75)
 			if( is_ic_filtered(input) || NON_ASCII_CHECK(input))
 				to_chat(operator, span_boldnotice("Message invalid. Check your message does not contain filtered words or characters."))
 				return
@@ -785,6 +795,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	if(!target.client)
 		return
 	target.playsound_local(target, "sound/machines/dotprinter.ogg", 35)
+	to_chat(target, span_notice("<b><i>New message from [sender.real_name]:</b> [message]</i>"))
 	target.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>CIC MESSAGE FROM [sender.real_name]:</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, "#32cd32")
 	return TRUE
 
@@ -812,8 +823,12 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 
 	switch(choice)
 		if(MESSAGE_SINGLE)
-			var/input = tgui_input_text(source, "Please write a message to announce to this marine:", "CIC Message")
+			if(TIMER_COOLDOWN_CHECK(operator, COOLDOWN_HUD_ORDER))
+				to_chat(operator, span_warning("You've sent an announcement or message too recently!"))
+				return
+			var/input = tgui_input_text(source, "Please write a message to announce to this marine:", "CIC Message", max_length = MAX_COMMAND_MESSAGE_LENGTH)
 			message_member(human_target, input, source)
+			TIMER_COOLDOWN_START(operator, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 		if(ASL)
 			if(human_target == human_target.assigned_squad.squad_leader)
 				human_target.assigned_squad.demote_leader()
@@ -834,7 +849,10 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 		if(ORBITAL_SPOTLIGHT)
 			attempt_spotlight(source, turf_target, params)
 		if(MESSAGE_NEAR)
-			var/input = tgui_input_text(source, "Please write a message to announce to all marines nearby:", "CIC Proximity Message")
+			if(TIMER_COOLDOWN_CHECK(operator, COOLDOWN_HUD_ORDER))
+				to_chat(operator, span_warning("You've sent an announcement or message too recently!"))
+				return
+			var/input = tgui_input_text(source, "Please write a message to announce to all marines nearby:", "CIC Proximity Message", max_length = MAX_COMMAND_MESSAGE_LENGTH)
 			for(var/mob/living/carbon/human/target in GLOB.alive_human_list_faction[faction])
 				if(!target)
 					return
@@ -842,14 +860,19 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 					continue
 				message_member(target, input, source)
 			message_member(source, input, source)
+			TIMER_COOLDOWN_START(operator, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 		if(SQUAD_ACTIONS)
 			choice = show_radial_menu(source, turf_target, squad_radial_options, null, 48, null, FALSE, TRUE)
 			var/datum/squad/chosen_squad = squad_select(source, turf_target)
 			switch(choice)
 				if(MESSAGE_SQUAD)
-					var/input = tgui_input_text(source, "Please write a message to announce to the squad:", "Squad Message")
+					if(TIMER_COOLDOWN_CHECK(operator, COOLDOWN_HUD_ORDER))
+						to_chat(operator, span_warning("You've sent an announcement or message too recently!"))
+						return
+					var/input = tgui_input_text(source, "Please write a message to announce to the squad:", "Squad Message", max_length = MAX_COMMAND_MESSAGE_LENGTH)
 					if(input)
 						chosen_squad.message_squad(input, source)
+						TIMER_COOLDOWN_START(operator, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)
 				if(SWITCH_SQUAD_NEAR)
 					for(var/mob/living/carbon/human/target in GLOB.human_mob_list)
 						if(!target.faction == faction || get_dist(target, turf_target) > 9)
@@ -1228,3 +1251,4 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 
 #undef OW_MAIN
 #undef OW_MONITOR
+#undef MAX_COMMAND_MESSAGE_LENGTH

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -83,12 +83,10 @@
 				message = text,
 				color_override = override_color
 			))
-		TIMER_COOLDOWN_START(human_owner, COOLDOWN_HUD_ORDER, 35 SECONDS)
 		return
 	for(var/mob/faction_receiver in alert_receivers)
 		S = sound('sound/misc/notice2.ogg')
 		S.channel = CHANNEL_ANNOUNCEMENTS
-		TIMER_COOLDOWN_START(human_owner, COOLDOWN_HUD_ORDER, 35 SECONDS)
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(human_owner.job.title)]'S ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -83,10 +83,12 @@
 				message = text,
 				color_override = override_color
 			))
+		TIMER_COOLDOWN_START(human_owner, COOLDOWN_HUD_ORDER, 35 SECONDS)
 		return
 	for(var/mob/faction_receiver in alert_receivers)
 		S = sound('sound/misc/notice2.ogg')
 		S.channel = CHANNEL_ANNOUNCEMENTS
+		TIMER_COOLDOWN_START(human_owner, COOLDOWN_HUD_ORDER, 35 SECONDS)
 		if(faction_receiver.faction == human_owner.faction || isdead(faction_receiver))
 			faction_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(human_owner.job.title)]'S ANNOUNCEMENT:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order)
 			to_chat(faction_receiver, assemble_alert(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
CIC messages, and ship announcements (comms console) use the same cooldown as HUD orders from *Send Orders* and AI announcements. Also, they have a maximum length and CIC messages use `to_chat` now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These are *way* too easy to spam due to lacking cooldowns or maximum lengths, giving them a character limit and making them share the cooldown of Send Orders and AI announcements will significantly reduce that.

Chances are, CIC messages that are really long are either really terrible and impossible to understand in the short time they're visible or being (ab)used to fill your screen with random letters for 30 seconds. A character limit should help with both of these issues.

*Little side note, CIC messages in general suck (because either using big volume on the radio or using Send Orders does its job much, much better for many cases), but giving them chat feedback __alongside__ an easily missable screen alert will make them ever so slightly better.*

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: CIC messages and comms console announcements use the same cooldown as HUD orders from Send Orders/AI alerts.
balance: CIC messages have a maximum length of 100.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
