### PR TITLE
fix crash instaevo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -59,7 +59,11 @@
 /datum/evolution_panel/ui_data(mob/living/carbon/xenomorph/xeno)
 	var/list/data = list()
 
-	data["bypass_evolution_checks"] = SSresinshaping.active
+	if(iscrashgamemode(SSticker.mode))
+		var/datum/game_mode/infestation/crash/crash_mode = SSticker.mode
+		data["bypass_evolution_checks"] = !crash_mode.shuttle_landed
+	else
+		data["bypass_evolution_checks"] = (SSticker.mode?.round_type_flags & MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active
 
 	data["can_evolve"] = \
 		!xeno.is_ventcrawling && \


### PR DESCRIPTION

## About The Pull Request
fix crash instaevo
## Why It's Good For The Game
Xenos should not be able to evo into a ravager from larva when the marines are on the planet.
## Changelog
:cl:
fix: Xenos can no longer instaevo when the shuttle is crashed on crash gamemode
/:cl:
