### PR TITLE
Tank throw fix

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -38,6 +38,7 @@
 	var/static/list/connections = list(
 		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_cross_hitbox),
 		COMSIG_TURF_JUMP_ENDED_HERE = PROC_REF(on_jump_landed),
+		COMSIG_TURF_THROW_ENDED_HERE = PROC_REF(on_stop_throw),
 		COMSIG_ATOM_EXITED = PROC_REF(on_exited),
 		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override),
 	)
@@ -85,17 +86,26 @@
 
 	return FALSE
 
+///Adds a new desant
+/obj/hitbox/proc/add_desant(atom/movable/new_desant)
+	if(HAS_TRAIT(new_desant, TRAIT_TANK_DESANT))
+		return
+	ADD_TRAIT(new_desant, TRAIT_TANK_DESANT, VEHICLE_TRAIT)
+	new_desant.add_nosubmerge_trait(VEHICLE_TRAIT)
+	LAZYSET(tank_desants, new_desant, new_desant.layer)
+	RegisterSignal(new_desant, COMSIG_QDELETING, PROC_REF(on_desant_del))
+	new_desant.layer = ABOVE_MOB_PLATFORM_LAYER
+	root.add_desant(new_desant)
+
 ///signal handler when someone jumping lands on us
 /obj/hitbox/proc/on_jump_landed(datum/source, atom/movable/lander)
 	SIGNAL_HANDLER
-	if(HAS_TRAIT(lander, TRAIT_TANK_DESANT))
-		return
-	ADD_TRAIT(lander, TRAIT_TANK_DESANT, VEHICLE_TRAIT)
-	lander.add_nosubmerge_trait(VEHICLE_TRAIT)
-	LAZYSET(tank_desants, lander, lander.layer)
-	RegisterSignal(lander, COMSIG_QDELETING, PROC_REF(on_desant_del))
-	lander.layer = ABOVE_MOB_PLATFORM_LAYER
-	root.add_desant(lander)
+	add_desant(lander)
+
+///signal handler when something thrown lands on us
+/obj/hitbox/proc/on_stop_throw(datum/source, atom/movable/thrown_movable)
+	SIGNAL_HANDLER
+	add_desant(thrown_movable)
 
 ///signal handler when we leave a turf under the hitbox
 /obj/hitbox/proc/on_exited(atom/source, atom/movable/AM, direction)
@@ -400,18 +410,3 @@
 //Some hover specific stuff for the SOM tank
 /obj/hitbox/rectangle/som_tank/get_projectile_loc(obj/item/armored_weapon/weapon)
 	return get_step(get_step(src, root.dir), root.dir)
-
-/obj/hitbox/rectangle/som_tank/on_jump_landed(datum/source, atom/lander)
-	if(HAS_TRAIT(lander, TRAIT_TANK_DESANT))
-		return
-	. = ..()
-	var/obj/vehicle/sealed/armored/multitile/som_tank/tank = root
-	tank.add_desant(lander)
-
-/obj/hitbox/rectangle/som_tank/on_exited(atom/source, atom/movable/AM, direction)
-	var/is_desant = HAS_TRAIT(AM, TRAIT_TANK_DESANT)
-	. = ..()
-	if(!is_desant || HAS_TRAIT(AM, TRAIT_TANK_DESANT))
-		return
-	var/obj/vehicle/sealed/armored/multitile/som_tank/tank = root
-	tank.remove_desant(AM)

--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -105,6 +105,8 @@
 ///signal handler when something thrown lands on us
 /obj/hitbox/proc/on_stop_throw(datum/source, atom/movable/thrown_movable)
 	SIGNAL_HANDLER
+	if(!isliving(thrown_movable)) //TODO: Make desants properly work for all AM's instead of mobs
+		return
 	add_desant(thrown_movable)
 
 ///signal handler when we leave a turf under the hitbox


### PR DESCRIPTION

## About The Pull Request
Multitile vehicles now add things to desants if they land on a tank via throw (of any sort).

Also removed some unneeded code I think I forgot to remove during the hover tank PR.
## Why It's Good For The Game
People being able to phase under tanks via leaps/knockbacks/throws etc is bad.
## Changelog
:cl:
fix: Mobs that land on tanks via any kind of throw now are correctly added to desants
/:cl:
