### PR TITLE
Miner repair speed rework Draft 2

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,12 +10,6 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define repair_time_Upgrade 15 SECONDS
-#define repair_time_Remove 20 SECONDS
-#define repair_time_Welding 15 SECONDS
-#define repair_time_Wirecut 14 SECONDS
-#define repair_time_Wrench 10 SECONDS
-
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -103,10 +103,10 @@
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Upgrade = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Upgrade = 3 SECONDS
-	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 3 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
 		if(MINER_RESISTANT)
@@ -151,10 +151,10 @@
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Remove = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Remove = 4 SECONDS
-		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 4 SECONDS
+		if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -191,10 +191,10 @@
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Welding = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Welding = 4 SECONDS
-	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
+		var/repair_time = 4 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
 	if(miner_status != MINER_DESTROYED )
@@ -222,10 +222,10 @@
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wirecut = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wirecut = 3 SECONDS
-	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 3 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
 		return FALSE
@@ -250,10 +250,10 @@
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wrench = 2 SECONDS
-	if(!do_after(user, repair_time_Wrench, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 2 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)
 		return FALSE

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,11 +10,11 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define repair_time_Upgrade
-#define repair_time_Remove
-#define repair_time_Welding
-#define repair_time_Wirecut
-#define repair_time_Wrench
+#define repair_time_Upgrade 15 SECONDS
+#define repair_time_Remove 20 SECONDS
+#define repair_time_Welding 15 SECONDS
+#define repair_time_Wirecut 14 SECONDS
+#define repair_time_Wrench 10 SECONDS
 
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,7 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Upgrade = 2 SECONDS
@@ -150,7 +150,7 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Remove = 2 SECONDS
@@ -190,7 +190,7 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Welding = 2 SECONDS
@@ -221,7 +221,7 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wirecut = 2 SECONDS
@@ -249,7 +249,7 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wrench = 2 SECONDS

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,6 +10,12 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
+#define repair_time_Upgrade
+#define repair_time_Remove
+#define repair_time_Welding
+#define repair_time_Wirecut
+#define repair_time_Wrench
+
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,11 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(!do_after(user, 15 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Upgrade = 2 SECONDS
+	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
 		if(MINER_RESISTANT)
@@ -146,7 +150,11 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-		if(!do_after(user, 30 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Remove = 2 SECONDS
+		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -182,7 +190,11 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(!do_after(user, 200, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Welding = 2 SECONDS
+	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
 	if(miner_status != MINER_DESTROYED )
@@ -209,7 +221,11 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(!do_after(user, 120, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wirecut = 2 SECONDS
+	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
 		return FALSE
@@ -233,7 +249,11 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(!do_after(user, 150, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wrench = 2 SECONDS
+	if(!do_after(user, repair_time_Wrench, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)
 		return FALSE

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -103,9 +103,9 @@
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Upgrade = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Upgrade = 2 SECONDS
+		var/repair_time_Upgrade = 3 SECONDS
 	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
@@ -151,9 +151,9 @@
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Remove = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Remove = 2 SECONDS
+		var/repair_time_Remove = 4 SECONDS
 		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
@@ -191,9 +191,9 @@
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Welding = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Welding = 2 SECONDS
+		var/repair_time_Welding = 4 SECONDS
 	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
@@ -222,9 +222,9 @@
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Wirecut = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wirecut = 2 SECONDS
+		var/repair_time_Wirecut = 3 SECONDS
 	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)


### PR DESCRIPTION

## About The Pull Request
Reworks the miner repair speed to be based on the skill of the Marine preforming the task, as well as reducing the general time it takes to preform the task in general. Also changes how long it takes to install/remove upgrades in a similar manner.

Warning; Draft Pull; Needs to be tested to see if stable.
## Why It's Good For The Game
Right now engineers are not encouraged to go secure miners as it takes an excessive amount of time (Currently; with no fumble checks its 20/12/15 seconds per step in the chain regardless of skill; this change reduces it down to be so a squad engineer would do the same task in 6/5/4 seconds respectively; and Synths/CSE/ST can do it even faster at 4/3/2 seconds per step. Any level lower than engi skill 3 still triggers the 10 second fumble check and has still relatively high repair times to preform the tasks. This change also impacts Upgrading the well and removing upgrades from wells in a similar manner.
## Changelog
:cl:
balance: Mining Well repairs and upgrades are reduced and now scale based on your engineering skill. In general most of the steps of repair or upgrades are reduced by 1/4th their original time for squad engineers.
/:cl:
