### PR TITLE
Miner repair rework draft 3

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,12 +10,6 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define repair_time_Upgrade 15 SECONDS
-#define repair_time_Remove 20 SECONDS
-#define repair_time_Welding 15 SECONDS
-#define repair_time_Wirecut 14 SECONDS
-#define repair_time_Wrench 10 SECONDS
-
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -103,10 +103,10 @@
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Upgrade = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Upgrade = 3 SECONDS
-	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 3 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
 		if(MINER_RESISTANT)
@@ -151,10 +151,10 @@
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Remove = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Remove = 4 SECONDS
-		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 4 SECONDS
+		if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -191,10 +191,10 @@
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Welding = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Welding = 4 SECONDS
-	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
+		var/repair_time = 4 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
 	if(miner_status != MINER_DESTROYED )
@@ -222,10 +222,10 @@
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wirecut = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wirecut = 3 SECONDS
-	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 3 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
 		return FALSE
@@ -250,10 +250,10 @@
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wrench = 2 SECONDS
-	if(!do_after(user, repair_time_Wrench, NONE, src, BUSY_ICON_BUILD))
+		var/repair_time = 2 SECONDS
+	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)
 		return FALSE

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,11 +10,11 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define repair_time_Upgrade
-#define repair_time_Remove
-#define repair_time_Welding
-#define repair_time_Wirecut
-#define repair_time_Wrench
+#define repair_time_Upgrade 15 SECONDS
+#define repair_time_Remove 20 SECONDS
+#define repair_time_Welding 15 SECONDS
+#define repair_time_Wirecut 14 SECONDS
+#define repair_time_Wrench 10 SECONDS
 
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,7 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Upgrade = 2 SECONDS
@@ -150,7 +150,7 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Remove = 2 SECONDS
@@ -190,7 +190,7 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Welding = 2 SECONDS
@@ -221,7 +221,7 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wirecut = 2 SECONDS
@@ -249,7 +249,7 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
 		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
 		var/repair_time_Wrench = 2 SECONDS

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,10 +102,7 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
-	else
-		var/repair_time = 3 SECONDS
+	var/repair_time = clamp(15 SECONDS - 1 SECONDS * user.skills.getRating(SKILL_ENGINEER), 10 SECONDS, 15 SECONDS)
 	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
@@ -150,10 +147,7 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
-	else
-		var/repair_time = 4 SECONDS
+		var/repair_time = clamp(30 SECONDS - 1 SECONDS * user.skills.getRating(SKILL_ENGINEER), 25 SECONDS, 30 SECONDS)
 		if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
@@ -190,10 +184,7 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
-	else
-		var/repair_time = 4 SECONDS
+	var/repair_time = clamp(20 SECONDS - 1 SECONDS * user.skills.getRating(SKILL_ENGINEER), 15 SECONDS, 20 SECONDS)
 	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
@@ -221,10 +212,7 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
-	else
-		var/repair_time = 3 SECONDS
+	var/repair_time = clamp(12 SECONDS - 1 SECONDS * user.skills.getRating(SKILL_ENGINEER), 8 SECONDS, 12 SECONDS)
 	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
@@ -249,10 +237,7 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
-	else
-		var/repair_time = 2 SECONDS
+	var/repair_time = clamp(15 SECONDS - 1 SECONDS * user.skills.getRating(SKILL_ENGINEER), 10 SECONDS, 15 SECONDS)
 	if(!do_after(user, repair_time, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,6 +10,12 @@
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
+#define repair_time_Upgrade
+#define repair_time_Remove
+#define repair_time_Welding
+#define repair_time_Wirecut
+#define repair_time_Wrench
+
 #define PHORON_CRATE_SELL_AMOUNT 150
 #define PLATINUM_CRATE_SELL_AMOUNT 300
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -102,7 +102,11 @@
 			return FALSE
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
-	if(!do_after(user, 15 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Upgrade = 2 SECONDS
+	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
 		if(MINER_RESISTANT)
@@ -146,7 +150,11 @@
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-		if(!do_after(user, 30 SECONDS, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Remove = 2 SECONDS
+		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -182,7 +190,11 @@
 	user.visible_message(span_notice("[user] starts welding [src]'s internal damage."),
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
-	if(!do_after(user, 200, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Welding = 2 SECONDS
+	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
 	if(miner_status != MINER_DESTROYED )
@@ -209,7 +221,11 @@
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
-	if(!do_after(user, 120, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wirecut = 2 SECONDS
+	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)
 		return FALSE
@@ -233,7 +249,11 @@
 	playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
 	user.visible_message(span_notice("[user] starts repairing [src]'s tubing and plating."),
 	span_notice("You start repairing [src]'s tubing and plating."))
-	if(!do_after(user, 150, NONE, src, BUSY_ICON_BUILD))
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_MASTER)
+		var/repair_time_Wrench = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+	else
+		var/repair_time_Wrench = 2 SECONDS
+	if(!do_after(user, repair_time_Wrench, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_SMALL_DAMAGE)
 		return FALSE

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -103,9 +103,9 @@
 	user.visible_message(span_notice("[user] begins attaching a module to [src]'s sockets."))
 	to_chat(user, span_info("You begin installing the [upgrade] on the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Upgrade = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Upgrade = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Upgrade = 2 SECONDS
+		var/repair_time_Upgrade = 3 SECONDS
 	if(!do_after(user, repair_time_Upgrade, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	switch(upgrade.uptype)
@@ -151,9 +151,9 @@
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Remove = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Remove = 20 SECONDS - 4 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Remove = 2 SECONDS
+		var/repair_time_Remove = 4 SECONDS
 		if(!do_after(user, repair_time_Remove, NONE, src, BUSY_ICON_BUILD))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
@@ -191,9 +191,9 @@
 	span_notice("You start welding [src]'s internal damage."))
 	add_overlay(GLOB.welding_sparks)
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Welding = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Welding = 15 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Welding = 2 SECONDS
+		var/repair_time_Welding = 4 SECONDS
 	if(!do_after(user, repair_time_Welding, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, TYPE_PROC_REF(/obj/item/tool/weldingtool, isOn))))
 		cut_overlay(GLOB.welding_sparks)
 		return FALSE
@@ -222,9 +222,9 @@
 	user.visible_message(span_notice("[user] starts securing [src]'s wiring."),
 	span_notice("You start securing [src]'s wiring."))
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_EXPERT)
-		var/repair_time_Wirecut = 10 SECONDS - 2 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		var/repair_time_Wirecut = 14 SECONDS - 3 SECONDS * user.skills.getRating(SKILL_ENGINEER)
 	else
-		var/repair_time_Wirecut = 2 SECONDS
+		var/repair_time_Wirecut = 3 SECONDS
 	if(!do_after(user, repair_time_Wirecut, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(miner_status != MINER_MEDIUM_DAMAGE)


### PR DESCRIPTION

## About The Pull Request
This change looks to make the repair time and the upgrade time for mining wells to scale based on your character's Engineer skill; reducing it by 1 second per level of skill. This does not remove the fumble check and just makes Engineers do the tasks 3 seconds faster and synths do it 4 seconds faster, the maximum possible reduction in time is 5 seconds per step with the exception of the wirecutting step which has its fastest time capped at 8 seconds to preform. This is to help reduce the amount of time staring at a mining well waiting for a progress bar to complete to help reduce the headache of having to start a step over when your interrupted by either a marine bumping you or a xeno coming to ask why you don't have cades.

This pull has not been tested yet and is listed as a draft pending proper testing completion
## Why It's Good For The Game
Right now the repair time for mining wells is hard coded to be a fixed time regardless of skill, while a fumble check does exist if you do not meet the minimum requirements; it didn't make any difference if an engineer made the repair or a synth did, despite the synth being classed as a higher engineer level than squad engineers by skill value. 

This change makes it so you get a 1 second reduction on your progress timer for all interactions with mining wells but it is also capped so the maximum reduction does not go anymore than 5 seconds faster than the current values. Exception being the wirecut step as it only give a maximum reduction of 4 seconds as its default time was 12 seconds prior. 

Its overall more a buff in favor of marines yes but right now you have to stare at a mining well for a total of **47 seconds** not counting messing around with tools just to repair it, or being shuffled by another marine or interrupted by a xeno. For squad engineers (Skill 3) this cuts the total time down to just 38 seconds (Reduction of 9 seconds or about 20% over current value) and for Synths (Skill 4) this cuts it down to just 35 seconds (12 seconds less or about 25% less) in total between all three steps. Technically the level 5 master skill jobs like Early synth are able to do this now in 33 seconds (14 seconds less or about 30%) as you do not gain any more over a Skill 4 engineer for the wirecut step. 

Technically jobs like SL, Mech Pilot, and TO also benefit as they have some engineer skill but they still must preform the required fumble check as they are bellow a skill 3 engineer so they still take considerably longer to preform these tasks over Squad Engis, ST, CSE, and Synths of both types. [specifically not counting the fumbles; Level 2 skill does it in 41 seconds (6 seconds, -13%), Level 1 in 44 seconds (3 seconds, -6%) and level 0 is still the same as before.]

You also do install/remove modules that little bit faster now with higher skills but its 1 second per skill level. Module installs probably didn't need the change but since I was here it made sense to just add it in for now and see how folks felt about the difference. It is just a draft still pending balancing and testing to ensure stability.
## Changelog
:cl:
add: Makes the repair and module install/uninstall process for mining wells be variable based on your engineer skill rather than a fixed timer per step
balance: You take 1 second less time to preform mining well repairs and upgrades per level of engineer skill, capped at a max of 5 seconds for any step in the process; except the wire cut step which is capped at a max of 4 seconds reduction
/:cl:
