### PR TITLE
Reinforced table parts give two metal

### DIFF
--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -20,6 +20,7 @@
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
+	var/deconstruct_amount = 1
 
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -28,7 +29,7 @@
 
 	var/turf/table_turf = get_turf(src)
 	if(iswrench(I) && deconstruct_type)
-		new deconstruct_type(table_turf)
+		new deconstruct_type(table_turf, deconstruct_amount)
 		qdel(src)
 
 	else if(istype(I, /obj/item/stack/rods))
@@ -91,6 +92,7 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "reinf_tableparts"
 	table_type = /obj/structure/table/reinforced
+	deconstruct_amount = 2
 
 /*
 * Wooden Table Parts

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -20,6 +20,7 @@
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
+	/// How much of `deconstruct_type` will be spawned on wrench?
 	var/deconstruct_amount = 1
 
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## About The Pull Request
Deconstructing reinforced table parts gives two metal instead of one.


## Why It's Good For The Game
It cost 2 metal to make reinforced table parts.
![image](https://github.com/user-attachments/assets/0f13cee7-7417-42ba-bcd3-7a2056e013c6)
It is likely not intended for the second metal you use to make it to just disappear.

## Changelog
:cl:
fix: Deconstructing reinforced table parts correctly give two metal instead of one.
/:cl: