### PR TITLE
Clarifies armor stat panel entry

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -131,7 +131,7 @@
 	if(xeno_caste.plasma_max > 0)
 		. += "Plasma: [plasma_stored]/[xeno_caste.plasma_max]"
 
-	. += "Sunder: [100-sunder]% armor left"
+	. += "Armor: [100-sunder]%"
 
 	. += "Regeneration power: [max(regen_power * 100, 0)]%"
 


### PR DESCRIPTION

## About The Pull Request

Changes the text from `Sunder: <% armor> armor left` to `Armor: <% armor>`
## Why It's Good For The Game

This entry is very deceiving, sunder is the opposite of armor, so the % of armor left should not be labeled as sunder
## Changelog
:cl:
qol: The percentage of armor left is no longer labeled as sunder in the xeno stat panel
/:cl:
