### PR TITLE
V-31 scatter adjustment

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2111,10 +2111,11 @@
 
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.55
-	scatter = 1
+	scatter = -2
 	scatter_unwielded = 15
 
 	burst_amount = 3
+	burst_scatter_mult = 4
 	burst_delay = 0.1 SECONDS
 	extra_delay = 0.1 SECONDS
 


### PR DESCRIPTION

## About The Pull Request
Makes burstmode actually have noticable scatter compared to full auto.

Its still pretty low, but screen edge+ its less accurate.

Kinda want to do this to the tgmc rifles, but will leave for another pr since thats hvx balance.
## Why It's Good For The Game
Downside of autoburst increased DPS
## Changelog
:cl:
balance: V-31 has slightly higher burst scatter
/:cl:
