### PR TITLE
Adds RESIST_ALL flag to tadpole/ert engines to prevent melting/crushing

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -530,30 +530,25 @@
 	icon = 'icons/turf/ert_shuttle.dmi'
 	icon_state = "stan4"
 	plane = GAME_PLANE
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/left
 	icon_state = "leftengine_1"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/left/two
 	icon_state = "leftengine_2"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/left/three
 	icon_state = "leftengine_3"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right
 	icon_state = "rightengine_1"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right/two
 	icon_state = "rightengine_2"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right/three
 	icon_state = "rightengine_3"
-	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/dropship1
 	name = "\improper Alamo"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -533,21 +533,27 @@
 
 /turf/closed/shuttle/ert/engines/left
 	icon_state = "leftengine_1"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/left/two
 	icon_state = "leftengine_2"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/left/three
 	icon_state = "leftengine_3"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right
 	icon_state = "rightengine_1"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right/two
 	icon_state = "rightengine_2"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/ert/engines/right/three
 	icon_state = "rightengine_3"
+	resistance_flags = RESIST_ALL
 
 /turf/closed/shuttle/dropship1
 	name = "\improper Alamo"


### PR DESCRIPTION
## About The Pull Request

title

in my defence this was never just an outrider issue it was true for all tads

## Why It's Good For The Game
xenos could hitch a ride outside the tadpole and this is probably kinda sorta maybe bad
![image](https://github.com/user-attachments/assets/9ebe5fc2-f9ed-401c-8b44-99055eb0e9d0)

## Changelog
:cl:
fix: Tadpole/Shuttle engines are now built from copium and are thus unable to be melted or crushed.
/:cl: