### PR TITLE
Emp changes

### DIFF
--- a/code/game/objects/items/blink_drive.dm
+++ b/code/game/objects/items/blink_drive.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	blink_action = new(src)
 
-/obj/item/blink_drive/update_icon()
+/obj/item/blink_drive/update_appearance(UPDATE_ICON)
 	. = ..()
 	equipped_user?.update_inv_back()
 	if(charges)
@@ -71,6 +71,14 @@
 
 /obj/item/blink_drive/ui_action_click(mob/user, datum/action/item_action/action, target)
 	return teleport(target, user)
+
+/obj/item/blink_drive/emp_act(severity)
+	. = ..()
+	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
+	charges = 0
+	deltimer(charge_timer)
+	charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME * (4 - severity), TIMER_STOPPABLE)
+	update_appearance(UPDATE_ICON)
 
 ///Handles the actual teleportation
 /obj/item/blink_drive/proc/teleport(atom/A, mob/user)
@@ -128,7 +136,7 @@
 	charges --
 	deltimer(charge_timer)
 	charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME * 2, TIMER_STOPPABLE)
-	update_icon()
+	update_appearance(UPDATE_ICON)
 	return TRUE
 
 ///Recharges the drive, and sets another timer if not maxed out
@@ -139,7 +147,7 @@
 		charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME, TIMER_STOPPABLE)
 	else
 		charge_timer = null
-	update_icon()
+	update_appearance(UPDATE_ICON)
 
 ///The effects applied on teleporting from or to a location
 /obj/item/blink_drive/proc/teleport_debuff_aoe(atom/movable/teleporter)

--- a/code/game/objects/items/blink_drive.dm
+++ b/code/game/objects/items/blink_drive.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	blink_action = new(src)
 
-/obj/item/blink_drive/update_appearance(UPDATE_ICON)
+/obj/item/blink_drive/update_icon(updates=ALL)
 	. = ..()
 	equipped_user?.update_inv_back()
 	if(charges)

--- a/code/game/objects/items/blink_drive.dm
+++ b/code/game/objects/items/blink_drive.dm
@@ -77,7 +77,7 @@
 	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
 	charges = 0
 	deltimer(charge_timer)
-	charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME * (4 - severity), TIMER_STOPPABLE)
+	charge_timer = addtimer(CALLBACK(src, PROC_REF(recharge)), BLINK_DRIVE_CHARGE_TIME * (6 - severity), TIMER_STOPPABLE)
 	update_appearance(UPDATE_ICON)
 
 ///Handles the actual teleportation

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -256,6 +256,9 @@ Stepping directly on the mine will also blow it up
 	QDEL_NULL(tripwire)
 	qdel(src)
 
+/obj/item/explosive/mine/anti_tank/emp_act()
+	return
+
 /obj/item/explosive/mine/anti_tank/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)

--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -86,6 +86,13 @@
 		if(24 to 30)
 			machine_stat ^= PANEL_OPEN
 
+/obj/machinery/door/airlock/emp_act(severity)
+	. = ..()
+	if(prob(75 / severity))
+		set_electrified(MACHINE_DEFAULT_ELECTRIFY_TIME)
+	if(prob(30 / severity))
+		open()
+
 ///connect potential airlocks to each other for cycling
 /obj/machinery/door/airlock/proc/cyclelinkairlock()
 	if (cycle_linked_airlock)

--- a/code/game/objects/machinery/doors/door.dm
+++ b/code/game/objects/machinery/doors/door.dm
@@ -144,17 +144,6 @@
 	else if(density)
 		flick("door_deny", src)
 
-
-/obj/machinery/door/emp_act(severity)
-	. = ..()
-	if(prob(30/severity) && (istype(src,/obj/machinery/door/airlock) || istype(src,/obj/machinery/door/window)) )
-		open()
-	if(prob(60/severity))
-		if(secondsElectrified == 0)
-			secondsElectrified = -1
-			spawn(300)
-				secondsElectrified = 0
-
 /obj/machinery/door/ex_act(severity)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
 		return

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -52,8 +52,6 @@
 
 /obj/machinery/door/window/emp_act(severity)
 	. = ..()
-	if(prob(75 / severity))
-		set_electrified(MACHINE_DEFAULT_ELECTRIFY_TIME)
 	if(prob(30 / severity))
 		open()
 

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -50,6 +50,12 @@
 		return
 	icon_state = density ? base_state : "[base_state]open"
 
+/obj/machinery/door/window/emp_act(severity)
+	. = ..()
+	if(prob(75 / severity))
+		set_electrified(MACHINE_DEFAULT_ELECTRIFY_TIME)
+	if(prob(30 / severity))
+		open()
 
 /obj/machinery/door/window/proc/open_and_close()
 	open()

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -339,6 +339,21 @@
 	UnregisterSignal(parent, list(COMSIG_ITEM_UNEQUIPPED, COMSIG_ITEM_EQUIPPED, COMSIG_ATOM_EXAMINE))
 	return ..()
 
+/obj/item/armor_module/module/eshield/emp_act(severity)
+	. = ..()
+	if(!isliving(parent.loc))
+		return
+	var/mob/living/affected = parent.loc
+	affected.remove_filter("eshield")
+
+	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
+	spark_system.start()
+	shield_health = 0
+
+	STOP_PROCESSING(SSobj, src)
+	deltimer(recharge_timer)
+	recharge_timer = addtimer(CALLBACK(src, PROC_REF(begin_recharge)), damaged_shield_cooldown * 3 / severity, TIMER_STOPPABLE)
+
 ///Called to give extra info on parent examine.
 /obj/item/armor_module/module/eshield/proc/parent_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -278,6 +278,7 @@
 	for(var/mob/living/living_occupant AS in occupants)
 		living_occupant.Stagger((6 - severity) SECONDS)
 
+///Plays the engine sound for this vehicle if its not on cooldown
 /obj/vehicle/sealed/armored/proc/play_engine_sound(freq_vary = TRUE, sound_freq)
 	if(!COOLDOWN_CHECK(src, enginesound_cooldown))
 		return

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -271,6 +271,13 @@
 /obj/vehicle/sealed/armored/exit_location(mob/M)
 	return get_step(src, REVERSE_DIR(dir))
 
+/obj/vehicle/sealed/armored/emp_act(severity)
+	. = ..()
+	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
+	take_damage(400 / severity, BURN, ENERGY)
+	for(var/mob/living/living_occupant AS in occupants)
+		living_occupant.Stagger((6 - severity) SECONDS)
+
 /obj/vehicle/sealed/armored/proc/play_engine_sound(freq_vary = TRUE, sound_freq)
 	if(!COOLDOWN_CHECK(src, enginesound_cooldown))
 		return


### PR DESCRIPTION
## About The Pull Request
Various EMP additions.

Tanks: Negligible damage, but will stagger the occupants
Blink Drive: Drains charges and delays recharge time
Eshield: Drains shield and delays recharge time
AT mines: No longer effected by EMP

Cleaned up EMP code for doors, slightly higher chance for them to get shocked.

## Why It's Good For The Game
More uses for EMP nades, and lets it counter some extra stuff.
AT mine EMP interaction is too exploitable (but funny)


## Changelog
:cl:
balance: Added EMP effects against tanks, blink drives and eshield modules. AT mines are now EMP immune
/:cl:
