### PR TITLE
Campaign medical asset change

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/equipment.dm
+++ b/code/datums/gamemodes/campaign/rewards/equipment.dm
@@ -42,9 +42,11 @@
 	desc = "An assortment of medical supplies"
 	detailed_desc = "Activatable by squad leaders. An assortment of basic medical supplies and some stimulants."
 	ui_icon = "medkit"
-	uses = 3
-	cost = 1
+	uses = 1
+	cost = 3
 	equipment_to_spawn = list(
+		/obj/item/storage/pouch/firstaid/basic,
+		/obj/item/storage/pouch/firstaid/basic,
 		/obj/item/storage/pouch/firstaid/basic,
 		/obj/item/storage/pouch/firstaid/basic,
 		/obj/item/storage/pouch/firstaid/basic,
@@ -60,6 +62,8 @@
 /datum/campaign_asset/equipment/medkit_basic/som
 	asset_portrait = /atom/movable/screen/text/screen_text/picture/potrait/som_req
 	equipment_to_spawn = list(
+		/obj/item/storage/pouch/firstaid/som/full,
+		/obj/item/storage/pouch/firstaid/som/full,
 		/obj/item/storage/pouch/firstaid/som/full,
 		/obj/item/storage/pouch/firstaid/som/full,
 		/obj/item/storage/pouch/firstaid/som/full,


### PR DESCRIPTION

## About The Pull Request
Asset is now 1 use and cost 3 attrition.
Has 6 kits instead of 4.
## Why It's Good For The Game
The med asset has become the real gamer goblin choice, as everyone huffs up piles of giga cheap synap and advanced combat injectors.

That was never really intended, so now if you want to be a memester, it will actually cost quite a lot.
## Changelog
:cl:
balance: Campaign: Medical asset is now single use and costs 3 attrition
/:cl:
