### PR TITLE
Tele asset fix

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/teleporter.dm
+++ b/code/datums/gamemodes/campaign/rewards/teleporter.dm
@@ -46,7 +46,7 @@
 	detailed_desc = "Central command have allocated the battalion with six additional uses of the Teleporter Array, with two added per use. Its extremely costly to run and demand is high across the conflict zone, so make them count."
 	asset_portrait = /atom/movable/screen/text/screen_text/picture/potrait/som_scientist
 	ui_icon = "tele_uses"
-	uses = 6
+	uses = 3
 	cost = 6
 
 /datum/campaign_asset/teleporter_charges/activated_effect()


### PR DESCRIPTION

## About The Pull Request
Fixed the teleporter uses asset having twice as many uses as its supposed to. Whoops.

:cl:
fix: Campaign: Fixed the Teleporter Array charges asset having twice as many uses as intended
/:cl:
