### PR TITLE
Death fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,25 +1,14 @@
 /mob/living/carbon/human/gib()
-
-	var/is_a_synth = issynth(src)
 	for(var/datum/limb/E in limbs)
 		if(istype(E, /datum/limb/chest))
 			continue
-		if(istype(E, /datum/limb/groin) && is_a_synth)
+		if(istype(E, /datum/limb/groin))
 			continue
 		// Only make the limb drop if it's not too damaged
 		if(prob(100 - E.get_damage()))
 			// Override the current limb status
 			E.droplimb()
-
-
-	if(is_a_synth)
-		spawn_gibs()
-		return
-	..()
-
-
-
-
+	return ..()
 
 /mob/living/carbon/human/gib_animation()
 	new /obj/effect/overlay/temp/gib_animation(loc, 0, src, species ? species.gibbed_anim : "gibbed-h")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -56,12 +56,6 @@
 	SEND_SIGNAL(src, COMSIG_HUMAN_SET_UNDEFIBBABLE)
 	SSmobs.stop_processing(src) //Last round of processing.
 
-	if(CHECK_BITFIELD(status_flags, XENO_HOST))
-		var/obj/item/alien_embryo/parasite = locate(/obj/item/alien_embryo) in src
-		if(parasite) //The larva cannot survive without a host.
-			qdel(parasite)
-		DISABLE_BITFIELD(status_flags, XENO_HOST)
-
 	if((SSticker.mode?.round_type_flags & MODE_TWO_HUMAN_FACTIONS) && job?.job_cost)
 		job.free_job_positions(1)
 	if(hud_list)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -29,7 +29,7 @@
 	if(iscarbon(affected_mob))
 		var/mob/living/carbon/C = affected_mob
 		C.med_hud_set_status()
-
+	RegisterSignal(affected_mob, COMSIG_HUMAN_SET_UNDEFIBBABLE, PROC_REF(on_host_dnr))
 
 /obj/item/alien_embryo/Destroy()
 	if(affected_mob)
@@ -66,6 +66,10 @@
 
 	process_growth()
 
+///Kills larva when host goes DNR
+/obj/item/alien_embryo/proc/on_host_dnr(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
 
 /obj/item/alien_embryo/proc/process_growth()
 


### PR DESCRIPTION

## About The Pull Request
Cleaned up some code weirdness I noticed when looking at death procs.

Larva now just qdel's on DNR via sig instead of funny snowflake check.

Synth is no longer completely immune to being gibbed due to funny CM legacy reasons.
## Why It's Good For The Game
Kill snowflake.
## Changelog
:cl:
balance: Synth is no longer immune to gibbing
/:cl:
