### PR TITLE
area flag fix

### DIFF
--- a/code/game/area/patricks_rest.dm
+++ b/code/game/area/patricks_rest.dm
@@ -2,6 +2,7 @@
 /area/patricks_rest
 	name = "Patricks Rest"
 	icon_state = "dark"
+	area_flags = ALWAYS_RADIO
 
 /area/patricks_rest/ground
 	name = "Ground"


### PR DESCRIPTION

## About The Pull Request
Added a missing area flag for Patrick's Rest, in campaign.

:cl:
fix: Campaign: Radio works in caves on Patrick's Rest
/:cl:
