### PR TITLE
Xenos now recieve a 1000% health, damage, and health regen buff during prep phase

### DIFF
--- a/code/controllers/subsystem/processing/resinshaping.dm
+++ b/code/controllers/subsystem/processing/resinshaping.dm
@@ -12,10 +12,17 @@ SUBSYSTEM_DEF(resinshaping)
 /datum/controller/subsystem/resinshaping/proc/toggle_off()
 	SIGNAL_HANDLER
 	active = FALSE
+	GLOB.xeno_stat_multiplicator_buff = 1
+	SSmonitor.is_automatic_balance_on = TRUE
+	SSmonitor.apply_balance_changes()
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE,COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND,COMSIG_GLOB_TADPOLE_LAUNCHED,COMSIG_GLOB_DROPPOD_LANDED))
 
 /datum/controller/subsystem/resinshaping/Initialize()
 	for(var/hivenumber in GLOB.hive_datums)
 		quickbuild_points_by_hive[hivenumber] = SSmapping.configs[GROUND_MAP].quickbuilds
+	/// Also apply a 1000% buff to xenos, using the autobalance system
+	GLOB.xeno_stat_multiplicator_buff = 10
+	SSmonitor.is_automatic_balance_on = FALSE /// So it doesnt get overwritten by any shenanigans
+	SSmonitor.apply_balance_changes()
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE,COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND,COMSIG_GLOB_TADPOLE_LAUNCHED,COMSIG_GLOB_DROPPOD_LANDED), PROC_REF(toggle_off))
 	return SS_INIT_SUCCESS


### PR DESCRIPTION
## About The Pull Request
Xenos get a 1000% statbuff during prep phase, disabled alongside quickbuild, when a podder lands, when shutters open, or when tad lands
## Why It's Good For The Game
Less of a chore to maze / build / destroy things during prep, no more slashing a window 10 times, and then the frame 10 more times. If the goal is to move away from prep phase being very long this in some form will be necessary.
## Changelog
:cl: Cheese
balance: xenos now receive a 1000% damage, health, and health regen buff during prep phase.
/:cl:
