### PR TITLE
Queen timelock to 25hrs from 10 (part 3)

### DIFF
--- a/code/datums/jobs/job/xenomorph.dm
+++ b/code/datums/jobs/job/xenomorph.dm
@@ -60,7 +60,7 @@
 	supervisors = "Queen mother"
 	selection_color = "#8972AA"
 	display_order = JOB_DISPLAY_ORDER_XENO_QUEEN
-	exp_requirements = XP_REQ_EXPERIENCED
+	exp_requirements = XP_REQ_EXPERT
 	job_flags = JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_NOHEADSET|JOB_FLAG_OVERRIDELATEJOINSPAWN|JOB_FLAG_BOLD_NAME_ON_SELECTION|JOB_FLAG_HIDE_CURRENT_POSITIONS|JOB_FLAG_LOUDER_TTS
 	jobworth = list(/datum/job/survivor/rambo = SURVIVOR_POINTS_REGULAR)
 	html_description = {"


### PR DESCRIPTION
## About The Pull Request
Increases the timelock on queen from 10hrs to 25
## Why It's Good For The Game
Queen tends to be a vital role for xenos & a bad queen can severely muddle things, almost always resulting in a marine win. Increasing the timelock by 15 hours should at the very least ensure that anyone playing queen knows how to use the blessings menu, what leaders and pheros are, where silo goes, and how to fight and survive. If a queen dies, marines get tons of req points, xenos leaders loose pheros, along with orphan & hivemind collapse if there aren't any other leaders, all of which are severely bad for xenos.

## Changelog
:cl: Cheese
balance: Queen timelock increased to 25 hours, from 10
/:cl: