### PR TITLE
Crash minor balance adjustments.

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -4399,10 +4399,6 @@
 	dir = 1
 	},
 /area/outpost/caves/north_west)
-"ux" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south_west)
 "uB" = (
 /turf/open/floor/tile/dark/blue2{
 	dir = 8
@@ -4760,10 +4756,6 @@
 	dir = 1
 	},
 /area/outpost/yard/south)
-"wk" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
 "wl" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -4857,10 +4849,6 @@
 	dir = 5
 	},
 /area/outpost/medbay/security)
-"wE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south_west)
 "wG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5701,10 +5689,6 @@
 	dir = 10
 	},
 /area/outpost/lz1)
-"Az" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/north)
 "AD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -6811,11 +6795,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz1)
-"FQ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
 "FR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/purple2{
@@ -8267,12 +8246,6 @@
 	dir = 8
 	},
 /area/outpost/science/research)
-"MT" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 8
-	},
-/area/outpost/caves/north)
 "MU" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -9107,10 +9080,6 @@
 	dir = 6
 	},
 /area/outpost/arrivals)
-"QP" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
 "QW" = (
 /obj/machinery/landinglight/lz2{
 	dir = 4
@@ -15565,13 +15534,13 @@ RN
 Hc
 yW
 vp
-ja
-ja
-ja
-wE
-wE
-wE
-ja
+yW
+yW
+yW
+ho
+ho
+ho
+yW
 yW
 gw
 gw
@@ -15697,13 +15666,13 @@ RN
 Hc
 VS
 AW
-wE
 ho
 ho
 ho
 ho
 ho
-ja
+ho
+yW
 yW
 gw
 gw
@@ -15829,13 +15798,13 @@ RN
 Hc
 VS
 AW
-wE
 ho
 ho
 ho
 ho
 ho
-ja
+ho
+yW
 yW
 gw
 gw
@@ -15961,13 +15930,13 @@ Yp
 Hc
 VS
 AW
-wE
+ho
 ho
 ho
 Uu
 cz
 ho
-ja
+yW
 yW
 gw
 gw
@@ -16093,13 +16062,13 @@ RN
 Hc
 VS
 AW
-wE
+ho
 ho
 Uu
 ho
-ux
 ho
-ja
+ho
+yW
 yW
 gw
 gw
@@ -16225,13 +16194,13 @@ RN
 Hc
 yW
 vp
-ja
+yW
 FU
 ho
 ho
 Uu
 ho
-ja
+yW
 yW
 gw
 gw
@@ -16357,13 +16326,13 @@ RN
 Hc
 yW
 vp
-ja
+yW
 yW
 ho
 ho
 ho
 ho
-ja
+yW
 yW
 gw
 gw
@@ -16489,13 +16458,13 @@ RN
 Hc
 yW
 vp
-ja
-ja
-ja
-wE
-wE
-wE
-ja
+yW
+yW
+yW
+ho
+ho
+ho
+yW
 yW
 gw
 gw
@@ -19309,13 +19278,13 @@ yW
 yW
 yW
 yW
-ja
-ja
-ja
-ja
-ja
-ja
-ja
+yW
+yW
+yW
+yW
+yW
+yW
+yW
 OR
 PK
 uU
@@ -19441,13 +19410,13 @@ yW
 yW
 yW
 yW
-ja
 yW
 yW
 yW
 yW
 yW
-Az
+yW
+OR
 iH
 uU
 Su
@@ -19573,13 +19542,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 yW
 yW
 yW
 uU
-MT
+XD
 uU
 uU
 uU
@@ -19705,13 +19674,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 yW
 yW
 Iq
 uU
-wk
+uU
 Su
 uU
 fV
@@ -19837,13 +19806,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 yW
 yW
 uU
 uU
-wk
+uU
 yW
 uU
 uU
@@ -19969,13 +19938,13 @@ yW
 yW
 yW
 yW
-ja
 yW
 yW
+yW
 uU
 uU
 uU
-ja
+yW
 yW
 yW
 uU
@@ -20101,13 +20070,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 uU
 pZ
 Su
 yW
-ja
+yW
 yW
 yW
 uU
@@ -20233,13 +20202,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 uU
-QP
+uU
 fV
 yW
-ja
+yW
 yW
 yW
 uU
@@ -20365,13 +20334,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 uU
 uU
 uU
 yW
-ja
+yW
 yW
 yW
 fV
@@ -20497,13 +20466,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 uU
 uU
 Su
 uU
-ja
+yW
 yW
 yW
 uU
@@ -20629,13 +20598,13 @@ yW
 yW
 yW
 yW
-ja
 yW
 yW
+yW
 uU
 uU
 uU
-wk
+uU
 yW
 uU
 Su
@@ -20761,13 +20730,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 yW
 yW
 fV
 uU
-FQ
+Su
 uU
 uU
 fV
@@ -20893,13 +20862,13 @@ yW
 yW
 yW
 yW
-ja
+yW
 yW
 yW
 yW
 yW
 uU
-wk
+uU
 uU
 uU
 uU
@@ -21025,13 +20994,13 @@ yW
 yW
 yW
 yW
-ja
-ja
-ja
-ja
-ja
-ja
-ja
+yW
+yW
+yW
+yW
+yW
+yW
+yW
 uU
 uU
 uU

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -516,10 +516,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northwestmonorail)
-"cw" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/breakroom)
 "cx" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -580,10 +576,6 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
-"cJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northwestmonorail/breakroom)
 "cK" = (
 /turf/closed/mineral/smooth/darkfrostwall/indestructible,
 /area/icy_caves/caves/northwestmonorail)
@@ -1192,11 +1184,6 @@
 	},
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
-"gr" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
 "gx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -1298,6 +1285,11 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
+"hg" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/bluefrostwall,
+/area/icy_caves/caves/rock)
 "hh" = (
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
@@ -1510,7 +1502,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "iq" = (
@@ -1843,14 +1834,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/research,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"kd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
 "kf" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/purple/whitepurplefull,
@@ -1882,11 +1865,6 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northwestmonorail)
-"kp" = (
-/obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northwestmonorail)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -1946,11 +1924,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/LZ2)
-"kE" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
 "kF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2204,6 +2177,11 @@
 	dir = 6
 	},
 /area/icy_caves/caves/northwestmonorail)
+"mc" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "md" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/tile/dark,
@@ -3338,11 +3316,6 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
-"ry" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail)
 "rz" = (
 /obj/structure/table,
 /obj/effect/spawner/random/medical/beaker/largeweighted,
@@ -4333,10 +4306,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vJ" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -5587,10 +5556,6 @@
 /obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"BM" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/caves/northern)
 "BO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2
@@ -6792,7 +6757,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "Hx" = (
@@ -7823,7 +7787,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "Mh" = (
@@ -9137,6 +9100,10 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"SL" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
@@ -14612,20 +14579,20 @@ ZP
 XV
 aY
 hd
-cv
-cz
-cz
-gr
-cz
-cz
-kd
-cz
-cz
-cz
-cz
-cz
-cz
-cz
+XV
+qI
+qI
+dL
+qI
+qI
+yS
+qI
+qI
+qI
+qI
+qI
+qI
+qI
 AT
 qI
 qI
@@ -14768,7 +14735,7 @@ ZP
 XV
 cs
 aY
-cv
+XV
 qI
 qI
 qI
@@ -14781,7 +14748,7 @@ qI
 qI
 dL
 qI
-ry
+DA
 qI
 qI
 qI
@@ -14924,7 +14891,7 @@ ZP
 XV
 cH
 in
-cv
+XV
 qI
 DA
 cO
@@ -14937,7 +14904,7 @@ cO
 cO
 cO
 cO
-kp
+cO
 HK
 xp
 cO
@@ -15080,7 +15047,7 @@ ZP
 XV
 df
 jA
-cv
+XV
 vY
 qI
 cO
@@ -15392,7 +15359,7 @@ ZP
 XV
 XV
 XV
-cv
+XV
 XV
 XV
 qI
@@ -15405,7 +15372,7 @@ XV
 xW
 qI
 DA
-cz
+qI
 yA
 Ia
 DA
@@ -15548,7 +15515,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 XV
 qI
@@ -15561,7 +15528,7 @@ XV
 hB
 qI
 qI
-cz
+qI
 qI
 qI
 qI
@@ -15704,7 +15671,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 XV
 qI
@@ -15717,7 +15684,7 @@ XV
 UR
 dL
 qI
-cz
+qI
 qI
 qI
 qI
@@ -15860,7 +15827,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 XV
 qI
@@ -15873,7 +15840,7 @@ XV
 XV
 DA
 XV
-cv
+XV
 qI
 qI
 zc
@@ -16016,7 +15983,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 sP
 sP
 jq
@@ -16029,7 +15996,7 @@ cK
 XV
 qI
 XV
-cv
+XV
 qI
 qI
 qI
@@ -16172,7 +16139,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 IU
 it
 IU
@@ -16185,7 +16152,7 @@ sP
 XV
 vY
 qI
-cz
+qI
 qI
 qI
 DA
@@ -16328,7 +16295,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 IU
 sW
 IU
@@ -16341,7 +16308,7 @@ sP
 qI
 fr
 Px
-kE
+Px
 Px
 Px
 Px
@@ -16484,12 +16451,12 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 Xh
 Xh
 IU
 IU
-cw
+IU
 HQ
 Xh
 IU
@@ -16497,7 +16464,7 @@ jq
 qI
 qI
 qI
-cz
+qI
 qI
 qI
 qI
@@ -16640,7 +16607,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 MT
 eD
 IU
@@ -16653,7 +16620,7 @@ eC
 qI
 nB
 qI
-cz
+qI
 qI
 qI
 Qr
@@ -16796,7 +16763,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 cp
 oM
 PZ
@@ -16809,7 +16776,7 @@ PZ
 cO
 cO
 cO
-kp
+cO
 cO
 cO
 cO
@@ -16952,7 +16919,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 BW
 BW
 sW
@@ -16965,7 +16932,7 @@ jq
 qI
 oL
 qI
-cz
+qI
 qI
 qI
 DA
@@ -17108,7 +17075,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 Un
 IU
 Fj
@@ -17121,7 +17088,7 @@ sP
 XV
 XV
 XV
-cv
+XV
 qI
 qI
 qI
@@ -17264,7 +17231,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 IU
 IU
 WB
@@ -17277,7 +17244,7 @@ sP
 ZP
 ZP
 ZP
-cv
+XV
 vY
 qI
 qI
@@ -17420,7 +17387,7 @@ ZP
 ZP
 ZP
 ZP
-cJ
+sP
 sP
 sP
 sP
@@ -17433,7 +17400,7 @@ sP
 ZP
 ZP
 ZP
-cv
+XV
 yS
 qI
 qI
@@ -17576,19 +17543,19 @@ ZP
 ZP
 ZP
 ZP
+ZP
 Mr
 Mr
 Mr
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+Mr
+Mr
+Mr
+Mr
+Mr
+Mr
+Mr
+Mr
+Mr
 cv
 NU
 Px
@@ -25195,10 +25162,10 @@ ow
 ZP
 ZP
 ZI
-Sb
-wD
-wD
-wD
+ZI
+Yl
+Yl
+Yl
 ZI
 ZP
 ZP
@@ -25351,10 +25318,10 @@ ZP
 ZP
 ZI
 ZI
-Sb
+ZI
 Yl
 SC
-wD
+Yl
 ZI
 ZP
 ZP
@@ -25496,21 +25463,21 @@ DD
 DD
 DD
 DD
-wD
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Sb
-Sb
-Sb
-Sb
+Yl
+hi
+hi
+hi
+hi
+hi
+ZP
+ZP
+ZI
+ZI
+ZI
+ZI
 Yl
 Yl
-Sb
+ZI
 ZI
 ZP
 ZP
@@ -25652,12 +25619,12 @@ IE
 DD
 DD
 IE
-wD
+Yl
 Yl
 Yl
 SC
-ZP
-ZP
+hi
+hi
 ZP
 ZI
 ZI
@@ -25666,7 +25633,7 @@ ZI
 Yl
 Yl
 Yl
-Sb
+ZI
 ZI
 ZP
 ZP
@@ -25808,7 +25775,7 @@ DD
 DD
 ow
 ZP
-Mr
+ZP
 SC
 Yl
 Yl
@@ -25822,7 +25789,7 @@ Yl
 SC
 SC
 Yl
-Sb
+ZI
 ZI
 ZP
 ZP
@@ -25964,7 +25931,7 @@ tH
 ZP
 ZP
 ZP
-Mr
+ZP
 Yl
 Yl
 Yl
@@ -25978,7 +25945,7 @@ Yl
 Yl
 Yl
 ZI
-Sb
+ZI
 ZP
 ZP
 ZP
@@ -26120,7 +26087,7 @@ tH
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZI
@@ -26134,7 +26101,7 @@ SC
 Yl
 Yl
 ZI
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -26276,7 +26243,7 @@ tH
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZI
 ZI
@@ -26290,7 +26257,7 @@ Yl
 Yl
 Yl
 ZI
-Sb
+ZI
 ZP
 ZP
 ZP
@@ -26432,7 +26399,7 @@ tH
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -26446,7 +26413,7 @@ SC
 Yl
 Yl
 ZI
-Sb
+ZI
 ZP
 ZP
 ZP
@@ -26588,7 +26555,7 @@ tH
 ZP
 ZP
 ZP
-Mr
+ZP
 ZI
 ZI
 ZI
@@ -26596,13 +26563,13 @@ ZP
 Yl
 Yl
 Yl
-vJ
+Yl
 Yl
 Yl
 Yl
 ZI
 ZI
-Sb
+ZI
 ZP
 ZP
 ZP
@@ -26741,23 +26708,23 @@ uC
 Nv
 zx
 tH
-ZI
-ZI
-ZI
+hg
+Sb
+Sb
 Mr
-ZP
-ZI
-Yl
-Yl
-Yl
-Yl
-Yl
-Yl
-Yl
-Yl
-Yl
-ZI
-ZI
+Mr
+Sb
+wD
+wD
+wD
+wD
+wD
+wD
+wD
+wD
+wD
+Sb
+Sb
 Mr
 ZP
 ZP
@@ -26897,10 +26864,10 @@ qm
 qJ
 xf
 tH
-ZI
-ZI
-ZI
 Sb
+ZI
+ZI
+ZI
 ZI
 Yl
 Yl
@@ -27053,10 +27020,10 @@ re
 qm
 Ee
 tH
-pR
-pR
-pR
 SU
+pR
+pR
+pR
 Yl
 Yl
 Yl
@@ -27209,10 +27176,10 @@ hh
 vM
 fu
 tH
-pR
+SU
 pR
 Za
-SU
+pR
 Yl
 Yl
 Yl
@@ -27365,10 +27332,10 @@ UH
 po
 rn
 tH
-pR
+SU
 Za
 Es
-Hx
+XO
 QP
 Yl
 Yl
@@ -27521,10 +27488,10 @@ rh
 Mh
 tH
 tH
-pR
+SU
 pR
 XO
-Ii
+Za
 Za
 Yl
 Yl
@@ -27677,12 +27644,12 @@ SI
 XO
 XO
 XO
-pR
+SU
 pR
 XO
-Ii
 Za
-QP
+Za
+SL
 Yl
 Yl
 Yl
@@ -27833,10 +27800,10 @@ Ln
 Es
 Za
 Za
+Hx
 XO
 XO
-XO
-Ii
+Za
 Es
 QP
 Yl
@@ -27989,10 +27956,10 @@ XO
 XO
 XO
 Za
-XO
+Hx
 XO
 Za
-Ii
+Za
 Za
 Yl
 Yl
@@ -28145,10 +28112,10 @@ XO
 XO
 ZI
 XO
-Es
+mc
 XO
 pR
-SU
+pR
 ZI
 ZI
 ZI
@@ -28300,11 +28267,11 @@ iK
 XO
 pR
 Lv
-XO
 Za
+Ii
 XO
 XO
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -28457,7 +28424,7 @@ OW
 XO
 Lv
 XO
-XO
+Hx
 XO
 ZI
 Sb
@@ -28613,10 +28580,10 @@ Za
 XO
 XO
 XO
-Za
-XO
-pR
-ZI
+Ii
+Hx
+SU
+Sb
 ZI
 ZP
 ZP
@@ -28677,13 +28644,13 @@ bl
 ZP
 ZI
 ZI
-Sb
-Sb
-yh
-jo
-yh
-yh
-Sb
+ZI
+ZI
+SR
+bl
+SR
+SR
+ZI
 ZI
 ZI
 ZI
@@ -28833,13 +28800,13 @@ SR
 ji
 SR
 ZI
-Sb
+ZI
 ZI
 ZI
 SR
 ji
 SR
-yh
+SR
 ZP
 ZP
 ZP
@@ -28989,13 +28956,13 @@ SR
 SR
 bl
 Zb
-yh
+SR
 ZI
 ZI
 ZI
 PI
 PI
-Mr
+ZP
 ZP
 ZP
 ZP
@@ -29145,13 +29112,13 @@ ZP
 SR
 SR
 bl
-yh
+SR
 SR
 im
 SR
 SR
 SR
-yh
+SR
 ZP
 ZP
 ZP
@@ -29301,17 +29268,17 @@ ZP
 ZP
 SR
 ZP
-jo
+bl
 SR
 SR
 we
 bl
 SR
-dM
-cb
-BM
-BM
-BM
+im
+im
+ne
+ne
+ne
 ZI
 ZI
 ZI
@@ -29457,7 +29424,7 @@ ZP
 ZP
 ZP
 ZP
-Sb
+ZI
 ZI
 SR
 ZI
@@ -29467,7 +29434,7 @@ SR
 SR
 SR
 bl
-BM
+ne
 ZI
 ZI
 ZI
@@ -29613,7 +29580,7 @@ ZP
 ZP
 ZP
 ZP
-Sb
+ZI
 ZI
 ZI
 ZI
@@ -29623,7 +29590,7 @@ SR
 im
 SR
 SR
-yh
+SR
 ZI
 ZI
 ZI
@@ -29769,7 +29736,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZI
 ZI
 ZI
@@ -29777,9 +29744,9 @@ ZI
 ZI
 ZI
 SR
-bC
 SR
-yh
+SR
+SR
 SR
 ZI
 SR
@@ -29925,7 +29892,7 @@ ZP
 ZP
 ZP
 ZP
-Mr
+ZP
 ZP
 ZP
 ZI
@@ -29935,7 +29902,7 @@ SR
 SR
 SR
 bl
-cb
+im
 SR
 im
 SR
@@ -30081,17 +30048,17 @@ ZP
 ZP
 ZP
 ZP
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-yh
-Mr
-Mr
-yh
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+SR
+ZP
+ZP
+SR
 SR
 SR
 SR

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -350,21 +350,8 @@
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "br" = (
-/obj/structure/table/mainship,
-/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
-/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
-/obj/item/t_scanner,
-/obj/item/storage/backpack/marine/engineerpack,
-/obj/item/storage/belt/utility/full,
-/obj/item/flashlight,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/facepaint/black,
-/obj/item/stack/sheet/glass/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/vehicle/ridden/powerloader,
+/obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bs" = (
@@ -562,12 +549,23 @@
 "cR" = (
 /turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
+"di" = (
+/obj/machinery/door_control{
+	dir = 8;
+	id = "aft_engine_podlock"
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "fL" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
+"gf" = (
+/obj/structure/window/framed/mainship/hull/canterbury,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "gv" = (
 /obj/structure/barricade/plasteel,
 /turf/open/floor/mainship/stripesquare,
@@ -634,6 +632,10 @@
 /area/shuttle/canterbury)
 "mM" = (
 /turf/open/floor/mainship/orange/full,
+/area/shuttle/canterbury)
+"mN" = (
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "mQ" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -741,6 +743,11 @@
 /obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"sx" = (
+/obj/structure/cable,
+/obj/effect/attach_point,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/canterbury)
 "sR" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/cargo,
@@ -832,6 +839,7 @@
 	name = "Emergency door-control";
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "yp" = (
@@ -1118,20 +1126,6 @@
 /obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"Xb" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	id = "aft_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
-/obj/machinery/door_control{
-	dir = 8;
-	id = "aft_engine_podlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/canterbury)
 "Xf" = (
 /obj/machinery/iv_drip,
 /obj/machinery/shower{
@@ -1175,8 +1169,8 @@ Uo
 Uo
 Uo
 ab
-ab
-ab
+gf
+gf
 ab
 Uo
 Uo
@@ -1211,10 +1205,10 @@ al
 Mj
 rb
 ab
+ab
 bU
 bU
-bU
-bU
+ab
 ab
 aS
 bj
@@ -1278,7 +1272,7 @@ UE
 ac
 ab
 CA
-an
+as
 ac
 su
 ab
@@ -1311,7 +1305,7 @@ Rd
 jq
 ab
 iy
-an
+as
 ac
 tP
 ab
@@ -1344,7 +1338,7 @@ AS
 ac
 ab
 YN
-an
+as
 ac
 su
 ab
@@ -1377,7 +1371,7 @@ FZ
 ac
 ab
 uZ
-an
+as
 ac
 uT
 sR
@@ -1410,7 +1404,7 @@ qh
 ac
 ab
 Wk
-an
+as
 ac
 ac
 ac
@@ -1427,8 +1421,8 @@ Yn
 qE
 XO
 ac
-ar
-bW
+ac
+ab
 Uo
 "}
 (9,1,1) = {"
@@ -1439,11 +1433,11 @@ af
 bK
 Ul
 ad
-ac
+mN
 ac
 ki
 ac
-an
+as
 ac
 ac
 ac
@@ -1477,7 +1471,7 @@ as
 nM
 as
 as
-as
+sx
 as
 as
 aa
@@ -1487,12 +1481,12 @@ as
 as
 as
 as
-an
-an
-an
-an
-an
-an
+as
+as
+as
+as
+as
+as
 gv
 bW
 Uo
@@ -1509,7 +1503,7 @@ ac
 ac
 zy
 ac
-an
+as
 ac
 ac
 ac
@@ -1559,8 +1553,8 @@ ac
 SA
 RT
 ac
-ar
-Xb
+di
+ab
 Uo
 "}
 (13,1,1) = {"
@@ -1575,7 +1569,7 @@ JX
 ac
 ab
 ms
-an
+as
 ac
 su
 ab
@@ -1608,7 +1602,7 @@ BZ
 bh
 ab
 uZ
-an
+as
 ac
 ww
 ab
@@ -1641,7 +1635,7 @@ aF
 jq
 ab
 qM
-an
+as
 ac
 OL
 ab
@@ -1674,7 +1668,7 @@ UP
 ac
 ab
 CA
-an
+as
 ac
 su
 ab
@@ -1739,10 +1733,10 @@ al
 te
 te
 ab
+ab
 bV
 bV
-bV
-bV
+ab
 ab
 JM
 bz
@@ -1769,8 +1763,8 @@ Uo
 Uo
 Uo
 ab
-ab
-ab
+gf
+gf
 ab
 Uo
 Uo


### PR DESCRIPTION


## About The Pull Request

Removes some extra useless silo areas and some silos that were making balance iffy. moves some silos away from disks that are to close, makes big bury a little better protected.

## Why It's Good For The Game

Crashed is messed up. currently the way silos are is balanced at a time where xenos weren't doing great, there were useless silo locations and some even to close, for instance the one east of icy caves disk. This isn't a catch all fix, but its the start of something being done. the big bury also gets a emplacement for extra defense and makes the entrances a little smaller.

## Changelog

:cl:
balance: moved some silos away away from being to close to disk.
balance: removed silos from icy caves 1 at northwest disk and 1 east of nuke path.
balance: each big bury entrance is now 2 wide east and west, and 3 wide south.
/:cl:

