### PR TITLE
Resin silos give minions the correct hive number

### DIFF
--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -29,7 +29,7 @@
 			RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(resin_silo_proxy_alert))
 
 	if(SSticker.mode?.round_type_flags & MODE_SILOS_SPAWN_MINIONS)
-		SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, null)
+		SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(spawner_post_spawn)))
 		SSspawning.spawnerdata[src].required_increment = 2 * max(45 SECONDS, 3 MINUTES - SSmonitor.maximum_connected_players_count * SPAWN_RATE_PER_PLAYER)/SSspawning.wait
 		SSspawning.spawnerdata[src].max_allowed_mobs = max(1, MAX_SPAWNABLE_MOB_PER_PLAYER * SSmonitor.maximum_connected_players_count * 0.5)
 	update_minimap_icon()
@@ -153,3 +153,7 @@
 /obj/structure/xeno/silo/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "silo[warning ? "_warn" : "_passive"]", HIGH_FLOAT_LAYER))
+
+/obj/structure/xeno/silo/proc/spawner_post_spawn(list/newly_spawned_mobs)
+	for(var/mob/living/carbon/xenomorph/minion in newly_spawned_mobs)
+		minion.transfer_to_hive(hivenumber)

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -156,8 +156,5 @@
 
 /// Transfers the spawned minion to the silo's hivenumber.
 /obj/structure/xeno/silo/proc/on_spawn(list/newly_spawned_things)
-	for(var/spawned_thing AS in newly_spawned_things)
-		if(!isxeno(spawned_thing))
-			CRASH("Xeno silo somehow tried to spawn a non xeno (tried to spawn [spawned_thing])")
-		var/mob/living/carbon/xenomorph/spawned_minion = spawned_thing
+	for(var/mob/living/carbon/xenomorph/spawned_minion AS in newly_spawned_things)
 		spawned_minion.transfer_to_hive(hivenumber)

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -29,7 +29,7 @@
 			RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(resin_silo_proxy_alert))
 
 	if(SSticker.mode?.round_type_flags & MODE_SILOS_SPAWN_MINIONS)
-		SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(spawner_post_spawn)))
+		SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(on_spawn)))
 		SSspawning.spawnerdata[src].required_increment = 2 * max(45 SECONDS, 3 MINUTES - SSmonitor.maximum_connected_players_count * SPAWN_RATE_PER_PLAYER)/SSspawning.wait
 		SSspawning.spawnerdata[src].max_allowed_mobs = max(1, MAX_SPAWNABLE_MOB_PER_PLAYER * SSmonitor.maximum_connected_players_count * 0.5)
 	update_minimap_icon()
@@ -154,6 +154,10 @@
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "silo[warning ? "_warn" : "_passive"]", HIGH_FLOAT_LAYER))
 
-/obj/structure/xeno/silo/proc/spawner_post_spawn(list/newly_spawned_mobs)
-	for(var/mob/living/carbon/xenomorph/minion AS in newly_spawned_mobs)
-		minion.transfer_to_hive(hivenumber)
+/// Transfers the spawned minion to the silo's hivenumber.
+/obj/structure/xeno/silo/proc/on_spawn(list/newly_spawned_things)
+	for(var/spawned_thing AS in newly_spawned_things)
+		if(!isxeno(spawned_thing))
+			CRASH("Xeno silo somehow tried to spawn a non xeno (tried to spawn [spawned_thing])")
+		var/mob/living/carbon/xenomorph/spawned_minion = spawned_thing
+		spawned_minion.transfer_to_hive(hivenumber)

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -155,5 +155,5 @@
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "silo[warning ? "_warn" : "_passive"]", HIGH_FLOAT_LAYER))
 
 /obj/structure/xeno/silo/proc/spawner_post_spawn(list/newly_spawned_mobs)
-	for(var/mob/living/carbon/xenomorph/minion in newly_spawned_mobs)
+	for(var/mob/living/carbon/xenomorph/minion AS in newly_spawned_mobs)
 		minion.transfer_to_hive(hivenumber)

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -96,14 +96,16 @@
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "spawner[warning ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))
 
-/obj/structure/xeno/spawner/proc/on_spawn(list/squad)
-	if(!isxeno(squad[length(squad)]))
-		CRASH("Xeno spawner somehow tried to spawn a non xeno (tried to spawn [squad[length(squad)]])")
-	var/mob/living/carbon/xenomorph/X = squad[length(squad)]
-	X.transfer_to_hive(hivenumber)
-	linked_minions = squad
-	if(hivenumber == XENO_HIVE_FALLEN) //snowflake so valhalla isnt filled with minions after you're done
-		RegisterSignal(src, COMSIG_QDELETING, PROC_REF(kill_linked_minions))
+/// Transfers the spawned minion to the silo's hivenumber.
+/obj/structure/xeno/spawner/proc/on_spawn(list/newly_spawned_things)
+	for(var/spawned_thing AS in newly_spawned_things) // While we can expect it to be an xenomorph, it could be any typepath.
+		if(!isxeno(spawned_thing))
+			CRASH("Xeno spawner somehow tried to spawn a non xeno (tried to spawn [spawned_thing])")
+		var/mob/living/carbon/xenomorph/spawned_minion = spawned_thing
+		spawned_minion.transfer_to_hive(hivenumber)
+		linked_minions += spawned_minion
+		if(hivenumber == XENO_HIVE_FALLEN) //snowflake so valhalla isnt filled with minions after you're done
+			RegisterSignal(src, COMSIG_QDELETING, PROC_REF(kill_linked_minions))
 
 /obj/structure/xeno/spawner/proc/kill_linked_minions()
 	for(var/mob/living/carbon/xenomorph/linked in linked_minions)

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -98,10 +98,7 @@
 
 /// Transfers the spawned minion to the silo's hivenumber.
 /obj/structure/xeno/spawner/proc/on_spawn(list/newly_spawned_things)
-	for(var/spawned_thing AS in newly_spawned_things) // While we can expect it to be an xenomorph, it could be any typepath.
-		if(!isxeno(spawned_thing))
-			CRASH("Xeno spawner somehow tried to spawn a non xeno (tried to spawn [spawned_thing])")
-		var/mob/living/carbon/xenomorph/spawned_minion = spawned_thing
+	for(var/mob/living/carbon/xenomorph/spawned_minion AS in newly_spawned_things)
 		spawned_minion.transfer_to_hive(hivenumber)
 		linked_minions += spawned_minion
 		if(hivenumber == XENO_HIVE_FALLEN) //snowflake so valhalla isnt filled with minions after you're done


### PR DESCRIPTION
## About The Pull Request
Resin silos now give spawned minions the correct hive number. This means corrupted resin silos now creates corrupted minions (and thus doesn't attack their owner hive).
![image](https://github.com/user-attachments/assets/dfda2353-9dd2-4567-b9aa-8261c1ee9f12)

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Resin silos now grant their spawned minions the correct hive number.
/:cl: