### PR TITLE
Vehicle interior door allows non-mobs to exit

### DIFF
--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -107,7 +107,8 @@
 		owner.interior.mob_leave(dropping)
 		return
 	if(is_type_in_typecache(dropping.type, owner.easy_load_list))
-		user.temporarilyRemoveItemFromInventory(dropping)
+		if(isitem(dropping))
+			user.temporarilyRemoveItemFromInventory(dropping)
 		dropping.forceMove(owner.exit_location(dropping))
 		user.balloon_alert(user, "item thrown outside")
 		return
@@ -119,7 +120,8 @@
 		owner.interior.mob_leave(grabbed_thing)
 		return
 	if(is_type_in_typecache(grabbed_thing.type, owner.easy_load_list))
-		user.temporarilyRemoveItemFromInventory(grabbed_thing)
+		if(isitem(grabbed_thing.type))
+			user.temporarilyRemoveItemFromInventory(grabbed_thing)
 		grabbed_thing.forceMove(owner.exit_location(grabbed_thing))
 		user.balloon_alert(user, "item thrown outside")
 		return

--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -102,13 +102,13 @@
 	. = ..()
 	owner.interior.mob_leave(user)
 
-/turf/closed/interior/tank/door/MouseDrop_T(atom/movable/dropping, mob/M)
+/turf/closed/interior/tank/door/MouseDrop_T(atom/movable/dropping, mob/user)
 	if(ismob(dropping))
 		owner.interior.mob_leave(dropping)
 		return
 	if(is_type_in_typecache(dropping.type, owner.easy_load_list))
-		user.temporarilyRemoveItemFromInventory(grabbed_thing)
-		grabbed_thing.forceMove(owner.exit_location(grabbed_thing))
+		user.temporarilyRemoveItemFromInventory(dropping)
+		dropping.forceMove(owner.exit_location(dropping))
 		user.balloon_alert(user, "item thrown outside")
 		return
 	return ..()

--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -103,14 +103,28 @@
 	owner.interior.mob_leave(user)
 
 /turf/closed/interior/tank/door/MouseDrop_T(atom/movable/dropping, mob/M)
-	if(!ismob(dropping))
-		return ..()
-	owner.interior.mob_leave(dropping)
+	if(ismob(dropping))
+		owner.interior.mob_leave(dropping)
+		return
+	if(is_type_in_typecache(dropping.type, owner.easy_load_list))
+		user.temporarilyRemoveItemFromInventory(grabbed_thing)
+		grabbed_thing.forceMove(owner.exit_location(grabbed_thing))
+		user.balloon_alert(user, "item thrown outside")
+		return
+	return ..()
 
 /turf/closed/interior/tank/door/grab_interact(obj/item/grab/grab, mob/user, base_damage, is_sharp)
-	if(!ismob(grab.grabbed_thing))
-		return ..()
-	owner.interior.mob_leave(grab.grabbed_thing)
+	var/atom/movable/grabbed_thing = grab.grabbed_thing
+	if(ismob(grabbed_thing))
+		owner.interior.mob_leave(grabbed_thing)
+		return
+	if(is_type_in_typecache(grabbed_thing.type, owner.easy_load_list))
+		user.temporarilyRemoveItemFromInventory(grabbed_thing)
+		grabbed_thing.forceMove(owner.exit_location(grabbed_thing))
+		user.balloon_alert(user, "item thrown outside")
+		return
+	return ..()
+
 
 ///returns where we want to spit out new enterers
 /turf/closed/interior/tank/door/proc/get_enter_location()

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -312,7 +312,8 @@
 	if(isliving(thing_to_load))
 		user.visible_message(span_notice("[user] starts to stuff [thing_to_load] into \the [src]!"))
 		return mob_try_enter(thing_to_load, user, TRUE)
-	user.temporarilyRemoveItemFromInventory(thing_to_load)
+	if(isitem(thing_to_load))
+		user.temporarilyRemoveItemFromInventory(thing_to_load)
 	thing_to_load.forceMove(interior.door.get_enter_location())
 	user.balloon_alert(user, "item thrown inside")
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Things that you can put inside vehicles can be taken out by grabbing and using grab intent or drag n' drop on the interior door.

Fixes runtime caused by inserting a non-item into vehicles.

## Why It's Good For The Game
Prevents objects that cannot be picked up in hand from being permanently stuck inside vehicles when they should be allowed to be taken out if they're allowed to be placed inside.

## Changelog
:cl:
add: Vehicle interior door is on-par with its exterior door as it now allows you to take out non-mobs (like crates).
/:cl:
