### PR TITLE
Removes unnecessary space from shock's forced emote

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -26,7 +26,7 @@
 			add_slowdown(1)
 		if(60 to 79)
 			if(!lying_angle && prob(20))
-				emote("me", 1, " is having trouble standing.")
+				emote("me", 1, "is having trouble standing.")
 			blur_eyes(2)
 			set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
 			Stagger(3 SECONDS)


### PR DESCRIPTION
## About The Pull Request
Removes unnecessary space from shock's "is having trouble standing".

## Why It's Good For The Game
Additional space bad.
![image](https://github.com/user-attachments/assets/dddffca0-46ab-4b09-b1b0-e95f26d39ced)

## Changelog
:cl:
spellcheck: Removes unnecessary space from shock's "is having trouble standing".
/:cl:
