### PR TITLE
Solid turf C4

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -21,6 +21,11 @@
 	AM.turf_collision(src, speed)
 	return TRUE
 
+/turf/closed/plastique_act(mob/living/plastique_user)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
+	ScrapeAway()
+
 /turf/closed/mineral
 	name = "rock"
 	icon = 'icons/turf/walls.dmi'


### PR DESCRIPTION

## About The Pull Request
C4 now works on solid turfs like mineral walls.
## Why It's Good For The Game
Currently these turfs can be instantly deleted with the plasma cutter, but is otherwise functionally indestructable.

C4 means more people can actually interact with these turfs meaningfully, but without the unlimited spam that the PC entails.

In particular, tank crews will probably appreciate people being able to clear the occasional wall without hoping there is some PC nerd running around.

I was originally going to make dev explosions do this instead of specifically C4, but that would notably be pretty wack with HE OB.
## Changelog
:cl:
balance: C4 works on dense turfs like mineral walls
/:cl:
