### PR TITLE
Fixes looped power on Pillar of Spring

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -5157,7 +5157,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm,
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
@@ -6158,7 +6157,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -8298,7 +8296,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/lower_engineering)
 "kCk" = (
@@ -13345,7 +13342,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
 "qtz" = (


### PR DESCRIPTION
## About The Pull Request

The SMES units inputs and outputs are looped on the Pillar of Spring. This fixes that issue.

## Why It's Good For The Game

Looping SMES units causes a variety of behaviors that are usually thought to be undesirable, causing the power consoles to misrepresent loads and APCs to not charge even when there should be excess power available, for example.

## Changelog

:cl:
fix: Fixed looping power issue with the SMES units on the Pillar of Spring.
/:cl:

