### PR TITLE
Hunters can now disguise as humans & can psychic mark without line of sight

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -235,9 +235,9 @@
 	if(!mark.marked_target)
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
-	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner,)
+	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner)
 	disguised_icon.override = TRUE
-	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS))
+	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS)
 	ADD_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -222,12 +222,14 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_DISGUISE,
 	)
+	var/old_appearance
 
 /datum/action/ability/xeno_action/stealth/disguise/action_activate()
 	if(stealth)
 		cancel_stealth()
 		return TRUE
 	var/mob/living/carbon/xenomorph/xenoowner = owner
+	old_appearance = xenoowner.appearance
 	var/datum/action/ability/activable/xeno/hunter_mark/mark = xenoowner.actions_by_path[/datum/action/ability/activable/xeno/hunter_mark]
 	if(HAS_TRAIT_FROM(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT))   // stops stealth and disguise from stacking
 		owner.balloon_alert(owner, "already in a form of stealth!")
@@ -235,9 +237,8 @@
 	if(!mark.marked_target)
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
-	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner)
-	disguised_icon.override = TRUE
-	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS)
+	xenoowner.appearance = mark.marked_target.appearance
+	xenoowner.underlays.Cut()
 	ADD_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
 	return ..()
@@ -245,8 +246,8 @@
 /datum/action/ability/xeno_action/stealth/disguise/cancel_stealth()
 	. = ..()
 	var/mob/living/carbon/xenomorph/xenoowner = owner
+	owner.appearance = old_appearance
 	REMOVE_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
-	xenoowner.remove_alt_appearance("hunter_disguise")
 	xenoowner.update_wounds()
 
 /datum/action/ability/xeno_action/stealth/disguise/handle_stealth()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -235,9 +235,6 @@
 	if(!mark.marked_target)
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
-	if(ishuman(mark.marked_target))
-		to_chat(owner, "You cannot turn into a human!")
-		return
 	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner)
 	disguised_icon.override = TRUE
 	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon)
@@ -411,11 +408,6 @@
 	if(A == X)
 		if(!silent)
 			to_chat(X, span_xenowarning("Why would we target ourselves?"))
-		return FALSE
-
-	if(!line_of_sight(X, A)) //Need line of sight.
-		if(!silent)
-			to_chat(X, span_xenowarning("We require line of sight to mark them!"))
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -234,7 +234,7 @@
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	old_appearance = xenoowner.appearance
 	old_caste_desc = xenoowner.xeno_caste.caste_desc
-	old_name = xenoowner.name
+	old_name = owner.name
 	old_desc = owner.desc
 	var/datum/action/ability/activable/xeno/hunter_mark/mark = xenoowner.actions_by_path[/datum/action/ability/activable/xeno/hunter_mark]
 	if(HAS_TRAIT_FROM(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT))   // stops stealth and disguise from stacking
@@ -244,7 +244,7 @@
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
 	xenoowner.appearance = mark.marked_target.appearance
-	xenoowner.name = mark.marked_target.name
+	owner.name = mark.marked_target.name
 	xenoowner.xeno_caste.caste_desc = null
 	owner.desc = null
 	xenoowner.underlays.Cut()
@@ -256,7 +256,7 @@
 	. = ..()
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	xenoowner.appearance = old_appearance
-	xenowner.name = old_name
+	owner.name = old_name
 	xenoowner.xeno_caste.caste_desc = old_caste_desc
 	owner.desc = old_desc
 	REMOVE_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -237,7 +237,7 @@
 		return
 	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner,)
 	disguised_icon.override = TRUE
-	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS)
+	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS))
 	ADD_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
 	return ..()
@@ -424,10 +424,6 @@
 	var/mob/living/carbon/xenomorph/X = owner
 
 	X.face_atom(A) //Face towards the target so we don't look silly
-
-	if(!line_of_sight(X, A)) //Need line of sight.
-		to_chat(X, span_xenowarning("We lost line of sight to the target!"))
-		return fail_activate()
 
 	if(marked_target)
 		UnregisterSignal(marked_target, COMSIG_QDELETING)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -235,9 +235,9 @@
 	if(!mark.marked_target)
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
-	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner)
+	var/image/disguised_icon = image(icon = mark.marked_target.icon, icon_state = mark.marked_target.icon_state, loc = owner,)
 	disguised_icon.override = TRUE
-	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon)
+	xenoowner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "hunter_disguise", disguised_icon, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS)
 	ADD_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -225,6 +225,7 @@
 	var/old_appearance
 	var/old_caste_desc
 	var/old_name
+	var/old_desc
 
 /datum/action/ability/xeno_action/stealth/disguise/action_activate()
 	if(stealth)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -223,6 +223,8 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_DISGUISE,
 	)
 	var/old_appearance
+	var/old_caste_desc
+	var/old_name
 
 /datum/action/ability/xeno_action/stealth/disguise/action_activate()
 	if(stealth)
@@ -230,6 +232,9 @@
 		return TRUE
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	old_appearance = xenoowner.appearance
+	old_caste_desc = xenoowner.xeno_caste.caste_desc
+	old_name = xenoowner.name
+	old_desc = owner.desc
 	var/datum/action/ability/activable/xeno/hunter_mark/mark = xenoowner.actions_by_path[/datum/action/ability/activable/xeno/hunter_mark]
 	if(HAS_TRAIT_FROM(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT))   // stops stealth and disguise from stacking
 		owner.balloon_alert(owner, "already in a form of stealth!")
@@ -238,6 +243,9 @@
 		to_chat(owner, span_warning("We have no target to disguise into!"))
 		return
 	xenoowner.appearance = mark.marked_target.appearance
+	xenoowner.name = mark.marked_target.name
+	xenoowner.xeno_caste.caste_desc = null
+	owner.desc = null
 	xenoowner.underlays.Cut()
 	ADD_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
@@ -246,7 +254,10 @@
 /datum/action/ability/xeno_action/stealth/disguise/cancel_stealth()
 	. = ..()
 	var/mob/living/carbon/xenomorph/xenoowner = owner
-	owner.appearance = old_appearance
+	xenoowner.appearance = old_appearance
+	xenowner.name = old_name
+	xenoowner.xeno_caste.caste_desc = old_caste_desc
+	owner.desc = old_desc
 	REMOVE_TRAIT(xenoowner, TRAIT_XENOMORPH_INVISIBLE_BLOOD, STEALTH_TRAIT)
 	xenoowner.update_wounds()
 


### PR DESCRIPTION
## About The Pull Request
Allows hunters to psychic mark targets through walls & allows them to use disguise (primo ability)  to disguise as humans

## Why It's Good For The Game
https://youtu.be/OR4N5OhcY9s
Hunters mark change is mainly just QQL; as it stands, a hunter has to go run in to the line of fire, switch to the mark, mark the target, and then just run away, which really isn't all that fun and defeats the point of hunter being a stealthy xeno, and if you miss you have to wait 60 seconds to do it again. As for the disguise change, hunter primo kinda sucks right now in general because moving as a object is fairly obvious & not all that useful, and if you use it to stay still for however long you can just use stealth and 99% of marines  won't see you

A human disguised hunter can be detected by all of the following
grabbing them (automatically stuns you)
damaging them enough
IFF shooting (will hit them)
Not being able to open cades, nor rest
Medhuds wont show a icon over them
movespeed
not being able to speak common

## Changelog
:cl: Cheese
qol: Hunter's mark no longer requires line of sight
balance: Hunters can now disguise as humans with their primordial ability.  Shoot a red spy near you today!
/:cl:
