### PR TITLE
Introduce a reqtorio valhalla vendor

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -8984,7 +8984,7 @@
 /turf/open/floor/engine,
 /area/centcom/valhalla)
 "mNo" = (
-/obj/machinery/vending/valhalla_factorio,
+/obj/machinery/vending/valhalla_reqtorio,
 /turf/open/floor/plating,
 /area/centcom/valhalla)
 "mOd" = (

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -8983,6 +8983,10 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/valhalla)
+"mNo" = (
+/obj/machinery/vending/valhalla_factorio,
+/turf/open/floor/plating,
+/area/centcom/valhalla)
 "mOd" = (
 /obj/structure/sign/nosmoking_1,
 /obj/machinery/newscaster{
@@ -20540,7 +20544,7 @@ wlz
 gFO
 xOn
 boq
-boq
+mNo
 boq
 nUd
 aMq

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1747,8 +1747,8 @@
 		)
 	)
 
-/obj/machinery/vending/valhalla_factorio
-	name = "\improper TerraGovTech factorio vendor"
+/obj/machinery/vending/valhalla_reqtorio
+	name = "\improper TerraGovTech reqtorio vendor"
 	desc = "An automated rack hooked up to a colossal storage of items."
 	icon_state = "requisitionop"
 	resistance_flags = INDESTRUCTIBLE

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1747,6 +1747,120 @@
 		)
 	)
 
+/obj/machinery/vending/valhalla_factorio
+	name = "\improper TerraGovTech factorio vendor"
+	desc = "An automated rack hooked up to a colossal storage of items."
+	icon_state = "requisitionop"
+	resistance_flags = INDESTRUCTIBLE
+	use_power = NO_POWER_USE
+	products = list(
+		"Machinery" = list(
+			/obj/item/conveyor_switch_construct = -1,
+			/obj/item/stack/conveyor/thirty = -1,
+			/obj/machinery/factory/compressor = -1,
+			/obj/machinery/factory/cutter = -1,
+			/obj/machinery/factory/driller = -1,
+			/obj/machinery/factory/flatter = -1,
+			/obj/machinery/factory/former = -1,
+			/obj/machinery/factory/galvanizer = -1,
+			/obj/machinery/factory/heater = -1,
+			/obj/machinery/factory/reconstructor = -1,
+			/obj/item/paper/factoryhowto = -1,
+		),
+		"Ammunition" = list(
+			/obj/item/factory_refill/amr_magazine_flak_refill = -1,
+			/obj/item/factory_refill/amr_magazine_incend_refill = -1,
+			/obj/item/factory_refill/amr_magazine_refill = -1,
+			/obj/item/factory_refill/auto_sniper_magazine_refill = -1,
+			/obj/item/factory_refill/mateba_speedloader_refill = -1,
+			/obj/item/factory_refill/minigun_powerpack_refill = -1,
+			/obj/item/factory_refill/railgun_hvap_magazine_refill = -1,
+			/obj/item/factory_refill/railgun_magazine_refill = -1,
+			/obj/item/factory_refill/railgun_smart_magazine_refill = -1,
+			/obj/item/factory_refill/scout_rifle_impact_magazine_refill = -1,
+			/obj/item/factory_refill/scout_rifle_incen_magazine_refill = -1,
+			/obj/item/factory_refill/scout_rifle_magazine_refill = -1,
+			/obj/item/factory_refill/smartgunner_machinegun_magazine_refill = -1,
+			/obj/item/factory_refill/smartgunner_minigun_box_refill = -1,
+			/obj/item/factory_refill/smartgunner_targetrifle_ammobin_refill = -1,
+			/obj/item/factory_refill/smartgunner_targetrifle_magazine_refill = -1,
+			/obj/item/factory_refill/sniper_flak_magazine_refill = -1,
+		),
+		"Ordnance" = list(
+			/obj/item/factory_refill/ac_flak_refill = -1,
+			/obj/item/factory_refill/ac_hv_refill = -1,
+			/obj/item/factory_refill/agls_cloak_refill = -1,
+			/obj/item/factory_refill/agls_frag_refill = -1,
+			/obj/item/factory_refill/agls_he_refill = -1,
+			/obj/item/factory_refill/agls_incendiary_refill = -1,
+			/obj/item/factory_refill/agls_tanglefoot_refill = -1,
+			/obj/item/factory_refill/atgun_apcr_refill = -1,
+			/obj/item/factory_refill/atgun_aphe_refill = -1,
+			/obj/item/factory_refill/atgun_beehive_refill = -1,
+			/obj/item/factory_refill/atgun_he_refill = -1,
+			/obj/item/factory_refill/atgun_incend_refill = -1,
+			/obj/item/factory_refill/mlrs_rocket_refill = -1,
+			/obj/item/factory_refill/mlrs_rocket_refill_cloak = -1,
+			/obj/item/factory_refill/mlrs_rocket_refill_gas = -1,
+			/obj/item/factory_refill/mlrs_rocket_refill_incendiary = -1,
+			/obj/item/factory_refill/agls_flare_refill = -1,
+			/obj/item/factory_refill/heavy_isg_he_refill = -1,
+			/obj/item/factory_refill/heavy_isg_sabot_refill = -1,
+			/obj/item/factory_refill/howitzer_shell_he_refill = -1,
+			/obj/item/factory_refill/howitzer_shell_incen_refill = -1,
+			/obj/item/factory_refill/howitzer_shell_tfoot_refill = -1,
+			/obj/item/factory_refill/howitzer_shell_wp_refill = -1,
+			/obj/item/factory_refill/mortar_shell_flare_refill = -1,
+			/obj/item/factory_refill/mortar_shell_he_refill = -1,
+			/obj/item/factory_refill/mortar_shell_incen_refill = -1,
+			/obj/item/factory_refill/mortar_shell_smoke_refill = -1,
+			/obj/item/factory_refill/mortar_shell_tfoot_refill = -1,
+		),
+		"Grenade/Explosive" = list(
+			/obj/item/factory_refill/antigas_refill = -1,
+			/obj/item/factory_refill/cloaknade_refill = -1,
+			/obj/item/factory_refill/hefanade_refill = -1,
+			/obj/item/factory_refill/incennade_refill = -1,
+			/obj/item/factory_refill/lasenade_refill = -1,
+			/obj/item/factory_refill/phosnade_refill = -1,
+			/obj/item/factory_refill/razornade_refill = -1,
+			/obj/item/factory_refill/stickynade_refill = -1,
+			/obj/item/factory_refill/tfootnade_refill = -1,
+			/obj/item/factory_refill/trailblazer_refill = -1,
+			/obj/item/factory_refill/sadar_ap_refill = -1,
+			/obj/item/factory_refill/sadar_he_refill = -1,
+			/obj/item/factory_refill/sadar_he_unguided_refill = -1,
+			/obj/item/factory_refill/sadar_wp_refill = -1,
+			/obj/item/factory_refill/detpack_refill = -1,
+			/obj/item/factory_refill/plastique_incendiary_refill = -1,
+			/obj/item/factory_refill/plastique_refill = -1,
+			/obj/item/factory_refill/claymore_refill = -1,
+			/obj/item/factory_refill/cloak_rr_missile_refill = -1,
+			/obj/item/factory_refill/heat_rr_missile_refill = -1,
+			/obj/item/factory_refill/light_rr_missile_refill = -1,
+			/obj/item/factory_refill/normal_rr_missile_refill = -1,
+			/obj/item/factory_refill/smoke_rr_missile_refill = -1,
+			/obj/item/factory_refill/tfoot_rr_missile_refill = -1,
+			/obj/item/factory_refill/thermobaric_wp_refill = -1,
+		),
+		"Utility" = list(
+			/obj/item/factory_refill/deployable_camera_refill = -1,
+			/obj/item/factory_refill/deployable_floodlight_refill = -1,
+			/obj/item/factory_refill/swat_mask_refill = -1,
+		),
+		"Modules" = list(
+			/obj/item/factory_refill/module_hlin_refill = -1,
+			/obj/item/factory_refill/module_mimir2_refill = -1,
+			/obj/item/factory_refill/module_surt_refill = -1,
+			/obj/item/factory_refill/module_tyr2_refill = -1,
+			/obj/item/factory_refill/module_valk_refill = -1,
+		),
+		"Misc" = list(
+			/obj/item/factory_refill/cigarette_refill = -1,
+			/obj/item/factory_refill/pizza_refill = -1,
+		)
+	)
+
 /obj/machinery/vending/tool
 	name = "YouTool"
 	desc = "Tools for tools."


### PR DESCRIPTION

## About The Pull Request
Brings all the factorio goodness in a compact, hopefully well organized package, in the form of a valhalla vendor. Currently has every factorio machines, the factorio paper guide, conveyor belts and the switch to go with it. Every refill available to req has is available with the only exception being drop pods as I suspect it could be used to deploy valhalla characters on the map. I am not sure. But if it's safe to do so I might add it.
## Why It's Good For The Game
It would allow req enthustiasts to experiment with factory designs in valhalla, check recipes, improve productivity, learn about the intricacies of production, so on and so forth.
## Changelog
:cl: Koenigsegg
add: Added a valhalla reqtorio vendor
add: Added the reqtorio valhalla vendor to the vehicle pit in valhalla
/:cl:
