### PR TITLE
Changes B18 to heavy armour slowdown

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -154,7 +154,7 @@
 	desc = "A heavy, rugged set of armor plates for when you really, really need to not die horribly. Slows you down though.\nHas an automated diagnostics and medical system for keeping its wearer alive."
 	icon_state = "xarmor"
 	soft_armor = list(MELEE = 75, BULLET = 80, LASER = 80, ENERGY = 85, BOMB = 85, BIO = 70, FIRE = 85, ACID = 70)
-	slowdown = SLOWDOWN_ARMOR_MEDIUM
+	slowdown = SLOWDOWN_ARMOR_HEAVY
 	supporting_limbs = CHEST | GROIN | ARM_LEFT | ARM_RIGHT | HAND_LEFT | HAND_RIGHT | LEG_LEFT | LEG_RIGHT | FOOT_LEFT | FOOT_RIGHT | HEAD //B18 effectively stabilizes these.
 	resistance_flags = UNACIDABLE
 	item_flags = AUTOBALANCE_CHECK


### PR DESCRIPTION
## About The Pull Request

B18:
SLOWDOWN_ARMOR_MEDIUM  ==>  slowdown = SLOWDOWN_ARMOR_HEAVY

B17 Unaffected

## Why It's Good For The Game

B18 Has become a rather "meta" item and is purchased from requisitions seemingly on an average of multiple per round.

Unlike other "heavy" armour's, B18 only has medium armour slowdown giving it a large chase potential relative to other heavy armour's while also providing massive durability. B18 Being extremely effective in chasing xenomorphs contributes significantly to marines snowballing with requisitions.

This should leave B18's ability to prevent a wipe by defending an area relatively unaffected while decreasing its ability to chase xenos for kills with its extreme durability.

## Changelog
:cl:
balance: B18 Medium Armour Slowdown (0.5) => Heavy Armour Slowdown (0.7)
/:cl:
