### PR TITLE
Disables LV759

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -89,7 +89,3 @@ endmap
 map kutjevo
 	minplayers 35
 endmap
-
-map lv759
-	minplayers 65
-endmap


### PR DESCRIPTION
## About The Pull Request
Disables LZ759 while leaving its files in the game
## Why It's Good For The Game
The map just kinda sucks and is universally hated; There's numerous issues from not being able to tunnel in caves, the 1000s of random  junk objects blocking marines / xenos / lagging people on lower end PCs, the ungodly prep work of slashing all the windows which have the health of reinforced ones, breaking all the lights that ignore power, or any of the lights that are double stacked and powered by default, etc, etc. I could go on and on and on but its fairly clear that people don't like this map and it shouldn't be in the pool until its fixed to a reasonable standard. It certainly is a interesting map and it could be a great map, but in its current state it isn't. If the map needs further testing, Testmerges exist for this exact reason. 
## Changelog

:cl: Cheese
config: Disabled LZ759 from the map pool
/:cl: