### PR TITLE
Campaign - Shuffle team button

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -228,7 +228,7 @@
 		return list(factions[2], factions[1])
 
 ///Actually swaps the player to the other team, unless balance has been restored
-/datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction, forced = FALSE)
+/datum/game_mode/hvh/campaign/proc/swap_player_team(mob/living/carbon/human/user, new_faction, forced = FALSE, fund_bonus = TRUE)
 	if(!user.client)
 		return
 	if(forced)
@@ -245,7 +245,8 @@
 	user.job.add_job_positions(1)
 	qdel(user)
 	var/datum/individual_stats/new_stats = stat_list[new_faction].get_player_stats(ghost)
-	new_stats.give_funds(max(stat_list[new_faction].accumulated_mission_reward * 0.5, 200)) //Added credits for swapping team
+	if(fund_bonus)
+		new_stats.give_funds(max(stat_list[new_faction].accumulated_mission_reward * 0.5, 200)) //Added credits for swapping team
 	player_respawn(ghost) //auto open the respawn screen
 
 ///buffs the weaker team if players don't voluntarily switch
@@ -256,6 +257,21 @@
 
 	var/autobal_num = ROUND_UP((length(GLOB.alive_human_list_faction[autobalance_faction_list[1]]) - length(GLOB.alive_human_list_faction[autobalance_faction_list[2]])) * 0.2)
 	current_mission.spawn_mech(autobalance_faction_list[2], 0, 0, autobal_num, "[autobal_num] additional mechs granted for autobalance")
+
+///Shuffles the teams
+/datum/game_mode/hvh/campaign/proc/shuffle_teams()
+	var/list/player_list = GLOB.player_list.Copy()
+	player_list = shuffle(player_list)
+	for(var/i = 1 to length(player_list))
+		var/mob/player = player_list[i]
+		var/new_faction_index = (i % 2) + 1
+		var/new_faction = factions[new_faction_index]
+		if(player.faction == new_faction)
+			continue
+		if(ishuman(player))
+			swap_player_team(player, TRUE, FALSE)
+		else
+			player.faction = new_faction
 
 //respawn stuff
 

--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -258,7 +258,7 @@
 	var/autobal_num = ROUND_UP((length(GLOB.alive_human_list_faction[autobalance_faction_list[1]]) - length(GLOB.alive_human_list_faction[autobalance_faction_list[2]])) * 0.2)
 	current_mission.spawn_mech(autobalance_faction_list[2], 0, 0, autobal_num, "[autobal_num] additional mechs granted for autobalance")
 
-///Shuffles the teams
+///Shuffles the teams forcefully
 /datum/game_mode/hvh/campaign/proc/shuffle_teams()
 	var/list/player_list = GLOB.player_list.Copy()
 	player_list = shuffle(player_list)
@@ -269,7 +269,7 @@
 		if(player.faction == new_faction)
 			continue
 		if(ishuman(player))
-			swap_player_team(player, TRUE, FALSE)
+			swap_player_team(player, new_faction, TRUE, FALSE)
 		else
 			player.faction = new_faction
 

--- a/code/modules/admin/panels/Campaign_panel.dm
+++ b/code/modules/admin/panels/Campaign_panel.dm
@@ -116,6 +116,14 @@ GLOBAL_DATUM(campaign_admin_panel, /datum/campaign_admin_panel)
 			message_admins("[usr.client] [forced ? "forced" : "triggered"] autobalance")
 			log_admin("[usr.client] [forced ? "forced" : "triggered"] autobalance")
 			return TRUE
+		if("shuffle_teams")
+			var/choice = tgui_input_list(user, "Would you like to shuffle the teams?", "Shuffle teams", list("No", "Yes"))
+			if(choice != "Yes")
+				return FALSE
+			current_mode.shuffle_teams()
+			message_admins("[usr.client] shuffled the teams")
+			log_admin("[usr.client] shuffled the teams")
+			return TRUE
 		if("mission_start_timer")
 			if(current_mode.current_mission.mission_state != MISSION_STATE_LOADED)
 				to_chat(user, "Mission is not in pregame.")

--- a/tgui/packages/tgui/interfaces/CampaignAdminPanel.tsx
+++ b/tgui/packages/tgui/interfaces/CampaignAdminPanel.tsx
@@ -170,6 +170,20 @@ export const CampaignAdminPanel = (props) => {
               <Stack.Item mt={2}>
                 <Button
                   tooltip={multiline`
+                    Forcefully shuffles the teams.
+                    Shuffles all living and dead players to the available factions.
+                  `}
+                  mt={1}
+                  onClick={() => {
+                    act('shuffle_teams');
+                  }}
+                >
+                  Shuffle teams
+                </Button>
+              </Stack.Item>
+              <Stack.Item mt={2}>
+                <Button
+                  tooltip={multiline`
                     This pauses or resumes the PRE-GAME mission start timer.
                     Time can be edited when resuming.
                   `}


### PR DESCRIPTION

## About The Pull Request
Adds a new button to the admin campaign panel, to forcefully shuffle the two teams.
## Why It's Good For The Game
Force autobalance button is good if one team simply has more players than the other, but doesn't really help if one team is just stacked with better players.

This button should (hopefully) be good in cases like that, to avoid one sided stomps.
## Changelog
:cl:
admin: Campaign: Added a team shuffle button to the campaign panel
/:cl:
