### PR TITLE
Detpack QOL

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -86,7 +86,7 @@
 		var/obj/item/assembly/signaler/signaler = I
 		code = signaler.code
 		set_frequency(signaler.frequency)
-		to_chat(user, "You transfer the frequency and code of \the [signaler.name] to \the [name].")
+		to_chat(user, "You transfer the frequency and code of [signaler] to [src].")
 
 /obj/item/detpack/attack_hand(mob/living/user)
 	if(armed)
@@ -254,7 +254,7 @@
 		var/obj/item/assembly/signaler/signaler = target
 		code = signaler.code
 		set_frequency(signaler.frequency)
-		to_chat(user, "You transfer the frequency and code of \the [signaler.name] to \the [name].")
+		to_chat(user, "You transfer the frequency and code of [signaler] to [src].")
 		return
 	if(istype(target, /obj/item) || istype(target, /mob))
 		return FALSE

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -82,30 +82,11 @@
 	. = ..()
 	if(.)
 		return
-
-	if(ismultitool(I) && armed)
-		if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_METAL)
-			user.visible_message(span_notice("[user] fumbles around figuring out how to use the [src]."),
-			span_notice("You fumble around figuring out how to use [src]."))
-			var/fumbling_time = 30
-			if(!do_after(user, fumbling_time, NONE, src, BUSY_ICON_UNSKILLED))
-				return
-
-			if(prob((SKILL_ENGINEER_METAL - user.skills.getRating(SKILL_ENGINEER)) * 20))
-				to_chat(user, "<font color='danger'>After several seconds of your clumsy meddling the [src] buzzes angrily as if offended. You have a <b>very</b> bad feeling about this.</font>")
-				timer = 0 //Oops. Now you fucked up. Immediate detonation.
-
-		user.visible_message(span_notice("[user] begins disarming [src] with [I]."),
-		span_notice("You begin disarming [src] with [I]."))
-
-		if(!do_after(user, 30, NONE, src, BUSY_ICON_FRIENDLY))
-			return
-
-		user.visible_message(span_notice("[user] disarms [src]."),
-		span_notice("You disarm [src]."))
-		armed = FALSE
-		update_icon()
-
+	if(issignaler(I))
+		var/obj/item/assembly/signaler/signaler = I
+		code = signaler.code
+		set_frequency(signaler.frequency)
+		to_chat(user, "You transfer the frequency and code of \the [signaler.name] to \the [name].")
 
 /obj/item/detpack/attack_hand(mob/living/user)
 	if(armed)
@@ -120,6 +101,31 @@
 		span_notice("You unsecure [src] from [plant_target]."))
 		nullvars()
 	return ..()
+
+/obj/item/detpack/multitool_act(mob/living/user, obj/item/I)
+	if(!armed && !on)
+		balloon_alert(user, "Inactive")
+		return
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_METAL)
+		user.visible_message(span_notice("[user] fumbles around figuring out how to use the [src]."),
+		span_notice("You fumble around figuring out how to use [src]."))
+		var/fumbling_time = 3 SECONDS
+		if(!do_after(user, fumbling_time, NONE, src, BUSY_ICON_UNSKILLED))
+			return
+
+		if(prob((SKILL_ENGINEER_METAL - user.skills.getRating(SKILL_ENGINEER)) * 20))
+			to_chat(user, "<font color='danger'>After several seconds of your clumsy meddling the [src] buzzes angrily as if offended. You have a <b>very</b> bad feeling about this.</font>")
+			timer = 0 //Oops. Now you fucked up. Immediate detonation.
+
+	user.visible_message(span_notice("[user] begins disarming [src] with [I]."),
+	span_notice("You begin disarming [src] with [I]."))
+
+	if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_FRIENDLY))
+		return
+
+	user.visible_message(span_notice("[user] disarms [src]."),
+	span_notice("You disarm [src]."))
+	disarm()
 
 /obj/item/detpack/proc/nullvars()
 	if(ismovableatom(plant_target) && plant_target.loc)
@@ -163,7 +169,6 @@
 	else
 		armed = FALSE
 		disarm()
-		update_icon()
 
 
 /obj/item/detpack/Topic(href, href_list)
@@ -245,6 +250,12 @@
 /obj/item/detpack/afterattack(atom/target, mob/user, flag)
 	if(!flag)
 		return FALSE
+	if(issignaler(target))
+		var/obj/item/assembly/signaler/signaler = target
+		code = signaler.code
+		set_frequency(signaler.frequency)
+		to_chat(user, "You transfer the frequency and code of \the [signaler.name] to \the [name].")
+		return
 	if(istype(target, /obj/item) || istype(target, /mob))
 		return FALSE
 	if(target.resistance_flags & INDESTRUCTIBLE)
@@ -319,6 +330,8 @@
 	if(detonation_pending)
 		deltimer(detonation_pending)
 		detonation_pending = null
+	armed = FALSE
+	on = FALSE
 	update_icon()
 
 /obj/item/detpack/proc/do_detonate()

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -114,7 +114,7 @@
 			return
 
 		if(prob((SKILL_ENGINEER_METAL - user.skills.getRating(SKILL_ENGINEER)) * 20))
-			to_chat(user, "<font color='danger'>After several seconds of your clumsy meddling the [src] buzzes angrily as if offended. You have a <b>very</b> bad feeling about this.</font>")
+			to_chat(user, span_highdanger("After several seconds of your clumsy meddling the [src] buzzes angrily as if offended. You have a <b>very</b> bad feeling about this."))
 			timer = 0 //Oops. Now you fucked up. Immediate detonation.
 
 	user.visible_message(span_notice("[user] begins disarming [src] with [I]."),
@@ -123,8 +123,7 @@
 	if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_FRIENDLY))
 		return
 
-	user.visible_message(span_notice("[user] disarms [src]."),
-	span_notice("You disarm [src]."))
+	balloon_alert_to_viewers("Disarmed")
 	disarm()
 
 /obj/item/detpack/proc/nullvars()


### PR DESCRIPTION

## About The Pull Request
You can now set the code and freq of a detpack by hitting it with a signaler (or hitting the signaler with the detpack).

Disarming a detpack now properly disarms it.

Moved the multitool code to the right place.
## Why It's Good For The Game
Easier to use detpacks - having to mess about with every single one is fiddly and time consuming.
## Changelog
:cl:
qol: You can update detpack freq and code by hitting it with a signaler, or hitting the signaler with the detpack
/:cl:
