### PR TITLE
Xeno viscontent fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -144,7 +144,7 @@
 
 ///Used to display the xeno wounds without rapidly switching overlays
 /atom/movable/vis_obj/xeno_wounds
-	vis_flags = VIS_INHERIT_DIR
+	vis_flags = VIS_INHERIT_DIR|VIS_INHERIT_ID
 
 /atom/movable/vis_obj/xeno_wounds/fire_overlay
 	light_system = MOVABLE_LIGHT


### PR DESCRIPTION

## About The Pull Request
Stops these vis contents from being visible in the right click menu.
![image](https://github.com/user-attachments/assets/72c15d60-db06-48df-b12e-89f105b63a0f)
## Why It's Good For The Game
No real gameplay changes, but this was always annoying.
## Changelog
:cl:
qol: Xeno fire and wound overlays no longer appear in the right click menu
/:cl:
