### PR TITLE
Commission: Title changes every 1 Minute

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -283,14 +283,11 @@
 	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/splashscreen/proc/randomtitle()
+	title_num += 1
+	if(title_num > icon_states(icon))
+		title_num = 0
 	icon_state = "title_painting[title_num]" //sets the title to the title_num here
-	//preps the next title below.
-	if(icon_state == "title_painting[total_titles]")
-		title_num == 0 //put to 0 if we saw the last image instead of going to the shadow realm.
-	else
-		title_num += 1 //sets the number for the next image cycle to have
-	update_icon()
-	addtimer(CALLBACK(src, PROC_REF(randomtitle)), 1 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -273,11 +273,24 @@
 //	icon_state = "title_holiday"
 	layer = FLY_LAYER
 	pixel_x = -64
+	var/total_titles = 35 //<--- just change this if adding images etc
+	var/title_num = 0 //do not change this
 
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
-	if(icon_state == "title_painting1")
-		icon_state = "title_painting[rand(0,35)]"
+	//random title as starting point so it isnt choking every time you see it.
+	icon_state = "title_painting[rand(0,total_titles)]"
+	addtimer(CALLBACK(src, PROC_REF(randomtitle)), 1 MINUTES)
+
+/turf/closed/wall/indestructible/splashscreen/proc/randomtitle()
+	icon_state = "title_painting[title_num]" //sets the title to the title_num here
+	//preps the next title below.
+	if(icon_state == "title_painting[total_titles]")
+		title_num == 0 //put to 0 if we saw the last image instead of going to the shadow realm.
+	else
+		title_num += 1 //sets the number for the next image cycle to have
+	update_icon()
+	addtimer(CALLBACK(src, PROC_REF(randomtitle)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -278,19 +278,19 @@
 	///Gets the current title number. It sets itself with the proc below, no need to touch.
 	var/icon/current_title
 	///The delay between title changes.
-	var/switchtime = 1 MINUTES
+	var/switch_time = 1 MINUTES
 
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
 	total_titles = icon_states(icon)
 	current_title = pick(icon_states(icon)) //randomly picks a starting screen.
 	icon_state = current_title
-	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switchtime)
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switch_time)
 
 /turf/closed/wall/indestructible/splashscreen/proc/next_splashscreen()
 	current_title = next_in_list(current_title, total_titles)
 	icon_state = current_title //sets the title to the current_title here
-	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switchtime)
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switch_time)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -273,21 +273,23 @@
 //	icon_state = "title_holiday"
 	layer = FLY_LAYER
 	pixel_x = -64
-	var/total_titles = 35 //<--- just change this if adding images etc
-	var/title_num = 0 //do not change this
+	//random title as starting point so it isnt choking every time you see it.
+	var/list/total_titles
+	///Gets the current title number. It sets itself with the proc below, no need to touch.
+	var/icon/current_title
+	///The delay between title changes.
+	var/switchtime = 1 MINUTES
 
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
-	//random title as starting point so it isnt choking every time you see it.
-	icon_state = "pick(icon_states(icon)"
-	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
+	total_titles = icon_states(icon)
+	icon_state = pick(icon_states(icon)) //randomly picks a starting screen.
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switchtime)
 
-/turf/closed/wall/indestructible/splashscreen/proc/random_title()
-	title_num += 1
-	if(title_num > icon_states(icon))
-		title_num = 0
-	icon_state = "title_painting[title_num]" //sets the title to the title_num here
-	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
+/turf/closed/wall/indestructible/splashscreen/proc/next_splashscreen()
+	current_title = next_in_list(current_title, total_titles)
+	icon_state = current_title //sets the title to the current_title here
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switchtime)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -283,7 +283,8 @@
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
 	total_titles = icon_states(icon)
-	icon_state = pick(icon_states(icon)) //randomly picks a starting screen.
+	current_title = pick(icon_states(icon)) //randomly picks a starting screen.
+	icon_state = current_title
 	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switchtime)
 
 /turf/closed/wall/indestructible/splashscreen/proc/next_splashscreen()

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -276,22 +276,20 @@
 	//random title as starting point so it isnt choking every time you see it.
 	var/list/total_titles
 	///Gets the current title number. It sets itself with the proc below, no need to touch.
-	var/icon/current_title
-	///The delay between title changes.
-	var/switch_time = 1 MINUTES
+	var/current_title
 
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
 	total_titles = icon_states(icon)
 	current_title = pick(icon_states(icon)) //randomly picks a starting screen.
 	icon_state = current_title
-	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switch_time)
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), 1 MINUTES)
 
 //timer above triggers this to change the image.
 /turf/closed/wall/indestructible/splashscreen/proc/next_splashscreen()
 	current_title = next_in_list(current_title, total_titles)
 	icon_state = current_title //sets the title to the current_title here
-	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switch_time)
+	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -279,8 +279,8 @@
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
 	//random title as starting point so it isnt choking every time you see it.
-	icon_state = "title_painting[rand(0,total_titles)]"
-	addtimer(CALLBACK(src, PROC_REF(randomtitle)), 1 MINUTES)
+	icon_state = "pick(icon_states(icon)"
+	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/splashscreen/proc/randomtitle()
 	icon_state = "title_painting[title_num]" //sets the title to the title_num here

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -287,6 +287,7 @@
 	icon_state = current_title
 	addtimer(CALLBACK(src, PROC_REF(next_splashscreen)), switch_time)
 
+//timer above triggers this to change the image.
 /turf/closed/wall/indestructible/splashscreen/proc/next_splashscreen()
 	current_title = next_in_list(current_title, total_titles)
 	icon_state = current_title //sets the title to the current_title here

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -282,7 +282,7 @@
 	icon_state = "pick(icon_states(icon)"
 	addtimer(CALLBACK(src, PROC_REF(random_title)), 1 MINUTES)
 
-/turf/closed/wall/indestructible/splashscreen/proc/randomtitle()
+/turf/closed/wall/indestructible/splashscreen/proc/random_title()
 	title_num += 1
 	if(title_num > icon_states(icon))
 		title_num = 0


### PR DESCRIPTION

## About The Pull Request
Not sure how the previous god-tier pr that does this got closed but here is as wanted, a basic PR that lets you even more easily change the max amount of titles you have, and cycles between them each minute, starting with a random title and going forward, then to the start when it reaches the end.
## Why It's Good For The Game
No more boring sitting at title, and doesnt take any resources if that's a worry. No fade outs and stuff either since i guess that was one of the deal breakers for some reason.
## Changelog
:cl:
add: Adds cycling title images.
/:cl:
