### PR TITLE
Removes podlocks on outward facing tadpole windows

### DIFF
--- a/_maps/shuttles/minidropship_outrider.dmm
+++ b/_maps/shuttles/minidropship_outrider.dmm
@@ -69,9 +69,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "q" = (
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock"
-	},
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/structure/dropship_piece/tadpole/engine{
 	dir = 1;
@@ -80,9 +77,6 @@
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
 "r" = (
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock"
-	},
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
@@ -122,10 +116,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "z" = (
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock";
-	dir = 2
-	},
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/structure/dropship_piece/tadpole/tadpole_nose{
 	dir = 1;

--- a/_maps/shuttles/minidropship_umbilical.dmm
+++ b/_maps/shuttles/minidropship_umbilical.dmm
@@ -2,9 +2,6 @@
 "a" = (
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock"
-	},
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
 "b" = (


### PR DESCRIPTION

## About The Pull Request
See title. The only tadpole variants this effects are the vehicle carrier (outrider) and umbilical tadpoles.
## Why It's Good For The Game
Windows usually represent a weak point on a tadpole (can't be moved through, can't be fired through except by laser, can be destroyed by claws). However, covering them up with podlocks renders them completely slash-proof, requiring a xeno with acid to come and open up the tad. While this isn't inherently a problem, the outrider and umbilical tadpoles stand out by being the only tadpoles with this feature, and I see no reason why they especially need it.
## Changelog
:cl:
balance: removes podlocks from the outer windows of the "Outrider" and "Umbilical" tadpole variants
/:cl:
