### PR TITLE
Xeno attack fixes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -687,9 +687,6 @@
 ///from /mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location, random_location, no_head, no_crit, force_intent)
 #define COMSIG_XENOMORPH_ATTACK_LIVING "xenomorph_attack_living"
 	#define COMSIG_XENOMORPH_BONUS_APPLIED (1<<0)
-///from /mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
-///only on INTENT_HARM, INTENT_DISARM, IF it does damaage
-#define COMSIG_XENOMORPH_ATTACK_HOSTILE_XENOMORPH "xenomorph_attack_xenomorph"
 
 ///after attacking, accounts for armor
 #define COMSIG_XENOMORPH_POSTATTACK_LIVING "xenomorph_postattack_living"

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -316,7 +316,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, PROC_REF(vehicle_turned))
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(vehicle_mob_unbuckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(vehicle_moved))
-	RegisterSignals(parent, list(COMSIG_XENOMORPH_ATTACK_LIVING, COMSIG_XENOMORPH_ATTACK_OBJ, COMSIG_XENOMORPH_ATTACK_HOSTILE_XENOMORPH), PROC_REF(check_widow_attack))
+	RegisterSignals(parent, list(COMSIG_XENOMORPH_ATTACK_LIVING, COMSIG_XENOMORPH_ATTACK_OBJ), PROC_REF(check_widow_attack))
 
 /datum/component/riding/creature/widow/vehicle_mob_unbuckle(datum/source, mob/living/former_rider, force = FALSE)
 	unequip_buckle_inhands(parent)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -9,11 +9,11 @@
 /mob/living/proc/attack_alien_grab(mob/living/carbon/xenomorph/X)
 	if(X == src || anchored || buckled || X.buckled)
 		return FALSE
-
 	if(!Adjacent(X))
 		return FALSE
-
-	X.start_pulling(src)
+	if(!X.start_pulling(src))
+		return FALSE
+	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 	return TRUE
 
 /mob/living/carbon/human/attack_alien_grab(mob/living/carbon/xenomorph/X)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -196,8 +196,6 @@
 	if (xeno_attacker.fortify || xeno_attacker.behemoth_charging)
 		return FALSE
 
-	SEND_SIGNAL(xeno_attacker, COMSIG_XENOMORPH_ATTACK_LIVING, src, damage_amount, xeno_attacker.xeno_caste.melee_damage * xeno_attacker.xeno_melee_damage_modifier)
-
 	switch(xeno_attacker.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -67,7 +67,7 @@
 /datum/ai_behavior/spiderling/New(loc, parent_to_assign, escorted_atom, can_heal = FALSE)
 	. = ..()
 	default_escorted_atom = WEAKREF(escorted_atom)
-	RegisterSignals(escorted_atom, list(COMSIG_XENOMORPH_ATTACK_LIVING, COMSIG_XENOMORPH_ATTACK_HOSTILE_XENOMORPH), PROC_REF(go_to_target))
+	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(go_to_target))
 	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_ATTACK_OBJ, PROC_REF(go_to_obj_target))
 	RegisterSignal(escorted_atom, COMSIG_SPIDERLING_GUARD, PROC_REF(attempt_guard))
 	RegisterSignal(escorted_atom, COMSIG_SPIDERLING_UNGUARD, PROC_REF(attempt_unguard))

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -76,11 +76,6 @@
 	if(src == xeno_attacker)
 		return TRUE
 
-	if(isxenolarva(xeno_attacker)) //Larvas can't eat people
-		xeno_attacker.visible_message(span_danger("[xeno_attacker] nudges its head against \the [src]."), \
-		span_danger("We nudge our head against \the [src]."))
-		return FALSE
-
 	switch(xeno_attacker.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)
@@ -93,43 +88,10 @@
 						span_notice("We extinguished the fire on [src]."), null, 5)
 					ExtinguishMob()
 				return TRUE
-
 			xeno_attacker.visible_message(span_notice("\The [xeno_attacker] caresses \the [src] with its scythe-like arm."), \
 			span_notice("We caress \the [src] with our scythe-like arm."), null, 5)
-
+			return TRUE
 		if(INTENT_GRAB)
-			if(anchored)
-				return FALSE
-			if(!xeno_attacker.start_pulling(src))
-				return FALSE
-			xeno_attacker.visible_message(span_warning("[xeno_attacker] grabs \the [src]!"), \
-			span_warning("We grab \the [src]!"), null, 5)
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
-
-		if(INTENT_HARM, INTENT_DISARM)//Can't slash other xenos for now. SORRY  // You can now! --spookydonut
-			if(issamexenohive(xeno_attacker))
-				xeno_attacker.do_attack_animation(src)
-				xeno_attacker.visible_message(span_warning("\The [xeno_attacker] nibbles \the [src]."), \
-				span_warning("We nibble \the [src]."), null, 5)
-				return TRUE
-			// Not at the base of the proc otherwise we can just nibble for free slashing effects
-			SEND_SIGNAL(xeno_attacker, COMSIG_XENOMORPH_ATTACK_HOSTILE_XENOMORPH, src, damage_amount, xeno_attacker.xeno_caste.melee_damage * xeno_attacker.xeno_melee_damage_modifier)
-			// copypasted from attack_alien.dm
-			//From this point, we are certain a full attack will go out. Calculate damage and modifiers
-			var/damage = xeno_attacker.xeno_caste.melee_damage
-
-			//Somehow we will deal no damage on this attack
-			if(!damage)
-				xeno_attacker.do_attack_animation(src)
-				playsound(xeno_attacker.loc, 'sound/weapons/alien_claw_swipe.ogg', 25, 1)
-				xeno_attacker.visible_message(span_danger("\The [xeno_attacker] lunges at [src]!"), \
-				span_danger("We lunge at [src]!"), null, 5)
-				return FALSE
-
-			xeno_attacker.visible_message(span_danger("\The [xeno_attacker] slashes [src]!"), \
-			span_danger("We slash [src]!"), null, 5)
-			log_combat(xeno_attacker, src, "slashed")
-
-			xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_REDSLASH)
-			playsound(loc, SFX_ALIEN_CLAW_FLESH, 25, 1)
-			apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
+			return attack_alien_grab(xeno_attacker)
+		if(INTENT_HARM, INTENT_DISARM)
+			return attack_alien_harm(xeno_attacker)


### PR DESCRIPTION

## About The Pull Request
#13924 broke all xeno actions that used damage or ap mod on attack.

Unbreaks these, and also purges a bunch of other shitcode like more bad copy paste, pointless checks and signals etc, and they now just use the correct procs.

Specifically, /mob/living/carbon/xenomorph/attack_alien was pretty much entirely horrible.
## Why It's Good For The Game
Working abilities, less spaghetti.
## Changelog
:cl:
fix: fixed all xeno abilities that use damage or ap mods on attack
/:cl:
