### PR TITLE
Fixes evil goat (and hostile/retaliate animals proccing Retaliate() when hit while dead)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate.dm
@@ -38,4 +38,5 @@
 
 /mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(damage, updating_health = FALSE)
 	. = ..()
-	Retaliate()
+	if(stat < DEAD)
+		Retaliate()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate.dm
@@ -38,5 +38,5 @@
 
 /mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(damage, updating_health = FALSE)
 	. = ..()
-	if(stat < DEAD)
+	if(stat < UNCONSCIOUS)
 		Retaliate()


### PR DESCRIPTION
## About The Pull Request
Changes this line
![Code_2024-08-11_14-43-42](https://github.com/user-attachments/assets/a6e1cbb4-9bdd-40f4-bd76-bda9f3517c87)

Into this line
![Code_2024-08-11_14-47-27](https://github.com/user-attachments/assets/e6601cf3-7386-4fab-9857-f207cd2a3fc8)

Thereby making the game check if hostile/retaliate creature is conscious or not before activating the Retaliate() proc

**Fixes #16420** 

## Why It's Good For The Game
Dead/Unconscious horses (and goats) should not considering retaliating when being hit.

## Changelog

:cl: Vondiech/Citruses
fix: GOATS no longer get an EVIL-looking GLEAM in their EYE when getting HIT while UNCONSCIOUS/DEAD.
/:cl:
