### PR TITLE
bumps puppet and spiderling accuracy

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/castedatum_puppet.dm
@@ -10,7 +10,7 @@
 	tier = XENO_TIER_MINION
 	upgrade = XENO_UPGRADE_BASETYPE
 	melee_damage = 12
-	accuracy_malus = 65
+	accuracy_malus = 45
 	speed = -0.8
 	plasma_max = 2
 	plasma_gain = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
@@ -12,7 +12,7 @@
 
 	// *** Melee Attacks *** //
 	melee_damage = 8
-	accuracy_malus = 65
+	accuracy_malus = 45
 
 	// *** Speed *** //
 	speed = -0.6


### PR DESCRIPTION

## About The Pull Request

A while back the accuracy of both puppets and spiderlings was severely nerfed to 5%.This is actually lower than the other limps meaning you had less of chance to hit the limb you actually intended to break. This pr hopes to alleviate that by upping their accuracy to 25% instead of 5%.IN THEORY AND SO LONG MY MATH ARE CORRECT this should bring the puppet break accuracy where other castes are .(NOTE  because of the higher number of spiderlings widow might have a better chance at fraccing (she is a t3 so at least to me it makes sense she is better in that regard)).
## Why It's Good For The Game

More strength to actually hurt marines in assassin benos instead of merely scratching them good.
## Changelog
:cl:
balance: spiderlings are 25% accurate on limb hits instead of 5%
balance: puppets are 25% accurate on limb hits instead of 5%
/:cl:
