### PR TITLE
Fixes Arachne body scanner & sleeper consoles

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -10614,9 +10614,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "iQJ" = (
-/obj/machinery/computer/sleep_console{
-	dir = 1
-	},
+/obj/machinery/computer/sleep_console,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -29158,9 +29156,7 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "ygb" = (
-/obj/machinery/computer/body_scanconsole{
-	dir = 2
-	},
+/obj/machinery/computer/body_scanconsole,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request
Changes Arachne body scanner & sleeper consoles from THIS
![StrongDMM_2024-08-12_14-16-15](https://github.com/user-attachments/assets/2966cffc-a4d9-4d32-89c0-c1bbf5ca66c6)
To THIS
![StrongDMM_2024-08-12_14-23-29](https://github.com/user-attachments/assets/213dd605-3f20-481f-b13d-016601d2833c)

Making them now functional as tested in-game.

**Fixes #15897**
## Why It's Good For The Game
non-functional scanner & sleeper consoles are bad

## Changelog

:cl: Vondiech/Citruses
fix: Fixes the consoles of a body scanner & sleeper on the Arachne shipmap.
/:cl:
