### PR TITLE
LV 759 Cleaning and Caves Improvement

### DIFF
--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -669,6 +669,12 @@
 /obj/structure/rock/dark/stalagmite/one,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
+"ags" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/hospital/janitor)
 "agv" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison/whitegreen{
@@ -1760,6 +1766,7 @@
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "aql" = (
@@ -1928,7 +1935,6 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "ars" = (
-/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -2810,7 +2816,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/meridian/meridian_office)
 "aAw" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/excavation_site_spawner,
@@ -2818,6 +2823,7 @@
 	color = "#a6aeab";
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsfoyer)
 "aAB" = (
@@ -7131,6 +7137,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "bpu" = (
@@ -8352,6 +8359,7 @@
 	pixel_y = 21
 	},
 /obj/item/ammo_casing/bullet,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "bAj" = (
@@ -10487,6 +10495,7 @@
 "bUj" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "bUm" = (
@@ -14201,6 +14210,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "cCg" = (
 /obj/item/flashlight,
+/obj/effect/ai_node,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "cCj" = (
@@ -15542,6 +15552,12 @@
 /obj/structure/cable,
 /turf/open/urban/street/cement1,
 /area/lv759/indoors/meridian/meridian_factory)
+"cOP" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/hospital/virology)
 "cOU" = (
 /obj/machinery/conveyor,
 /obj/structure/largecrate/random/mini/small_case/c{
@@ -18476,6 +18492,7 @@
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "dnv" = (
@@ -20611,6 +20628,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "dIp" = (
 /obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "dIv" = (
@@ -21634,6 +21652,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "dSq" = (
@@ -24007,6 +24026,12 @@
 "eof" = (
 /turf/closed/wall/r_wall/bunker,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"eog" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "eoj" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/trash/five,
@@ -25556,6 +25581,7 @@
 "eCX" = (
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "eDb" = (
@@ -25672,6 +25698,14 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/north_street)
+"eDQ" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "eDR" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red,
 /turf/open/urban/street/cement3,
@@ -26673,6 +26707,11 @@
 	dir = 1
 	},
 /area/lv759/indoors/hospital/operation)
+"eMQ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "eMV" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/multi_tiles,
@@ -27574,6 +27613,12 @@
 	},
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
+"eVt" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/landing_zone_1/flight_control_room)
 "eVy" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/urbanshale/layer1,
@@ -32529,6 +32574,7 @@
 	pixel_y = 16
 	},
 /obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "fNe" = (
@@ -34252,6 +34298,14 @@
 	},
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/apartment/northapartments)
+"gct" = (
+/obj/item/ammo_casing/bullet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/prison,
+/area/lv759/outdoors/colony_streets/south_west_street)
 "gcE" = (
 /obj/structure/prop/urban/misc/phonebox/lightup{
 	pixel_x = 4;
@@ -34966,6 +35020,21 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/south_west_street)
+"gix" = (
+/obj/structure/stairs{
+	color = "#a6aeab";
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
+"giB" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/north_east_caves)
 "giC" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -35303,6 +35372,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetbluedeco,
 /area/lv759/indoors/apartment/westbedrooms)
+"glt" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "glu" = (
 /obj/machinery/landinglight/lz1{
 	dir = 8
@@ -37783,6 +37857,12 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
+"gHy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/mining_outpost/northeast)
 "gHA" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/tile/yellow_bigtile,
@@ -38710,6 +38790,13 @@
 	},
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/vip)
+"gRZ" = (
+/obj/effect/urban/decal/road/road_stop/five{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/colony_streets/north_west_street)
 "gSd" = (
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /obj/structure/cable,
@@ -40362,6 +40449,12 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
+"hgK" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/nt_security/checkpoint_northeast)
 "hgL" = (
 /obj/structure/prop/urban/vehicles/large/van/hyperdynevan,
 /turf/open/urban/street/asphalt,
@@ -42167,8 +42260,10 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/reception)
 "hvU" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/urbanshale/layer0_plate,
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "hwq" = (
 /obj/effect/urban/decal/dirt,
@@ -42825,6 +42920,7 @@
 "hBx" = (
 /obj/effect/urban/decal/grate,
 /obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "hBB" = (
@@ -43030,6 +43126,14 @@
 /obj/effect/ai_node,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
+"hDo" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	pixel_y = -1
+	},
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/indoors/nt_security/checkpoint_northwest)
 "hDs" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/wooden{
@@ -43808,6 +43912,11 @@
 /obj/structure/prop/mainship/gelida/planterboxsoilgrid,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
+"hKz" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "hKA" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -44492,6 +44601,11 @@
 	},
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/eastfoyer)
+"hQj" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "hQt" = (
 /obj/structure/barricade/handrail/urban/handrail{
 	dir = 1
@@ -45119,6 +45233,11 @@
 	dir = 10
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+"hWz" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "hWB" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/window_frame/urban/colony/engineering/reinforced,
@@ -47365,6 +47484,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "irR" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "irU" = (
@@ -55828,6 +55948,11 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
+"jRv" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "jRJ" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -56035,6 +56160,11 @@
 /obj/structure/catwalk,
 /turf/open/floor/plating/heatinggrate,
 /area/lv759/indoors/nt_research_complex/hangarbay)
+"jTE" = (
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "jTI" = (
 /obj/structure/prop/urban/vehicles/large/truck/garbage{
 	pixel_y = 18
@@ -58549,6 +58679,10 @@
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
+"krI" = (
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "krS" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60870,6 +61004,11 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/spaceport/engineering)
+"kOe" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "kOh" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison{
@@ -61249,6 +61388,14 @@
 	},
 /turf/open/floor/urban/tile/tilegrey,
 /area/lv759/indoors/nt_research_complex/hallwaysoutheast)
+"kRD" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/prison,
+/area/lv759/indoors/caves/north_west_caves)
 "kRL" = (
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
@@ -64724,6 +64871,12 @@
 	dir = 9
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
+"lxc" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "lxe" = (
 /obj/item/paper,
 /obj/structure/disposalpipe/segment{
@@ -65046,6 +65199,11 @@
 /obj/structure/rock/dark/stalagmite/three,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
+"lAI" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "lAP" = (
 /obj/item/stack/sheet/cardboard{
 	layer = 1
@@ -65271,6 +65429,7 @@
 /area/lv759/indoors/caves/west_caves)
 "lCS" = (
 /obj/effect/landmark/nuke_spawn,
+/obj/effect/ai_node,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "lCT" = (
@@ -65753,6 +65912,19 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/hospital/outgoing)
+"lHk" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1;
+	layer = 3.33;
+	pixel_y = 2
+	},
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/indoors/nt_security/checkpoint_northwest)
 "lHl" = (
 /obj/structure/rock/dark/large{
 	layer = 2.9
@@ -67706,6 +67878,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "lXl" = (
@@ -68443,6 +68616,15 @@
 "meO" = (
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_northeast)
+"meQ" = (
+/obj/structure/prop/mainship/gelida/smallwire,
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 8
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "meR" = (
 /obj/effect/urban/decal/road/lines5,
 /obj/effect/urban/decal/road/lines3,
@@ -72133,6 +72315,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	pixel_y = -1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -75219,6 +75402,7 @@
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "nkS" = (
 /obj/item/inflatable/wall,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "nkU" = (
@@ -76918,8 +77102,10 @@
 /area/lv759/indoors/meridian/meridian_factory)
 "nzN" = (
 /obj/effect/ai_node,
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/indoors/caves/south_west_caves)
 "nzO" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods{
@@ -77512,6 +77698,11 @@
 /obj/item/trash/cigbutt,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/central_streets)
+"nFO" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/east_caves)
 "nFQ" = (
 /obj/item/tool/surgery/retractor,
 /obj/item/tool/surgery/cautery,
@@ -82664,6 +82855,7 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
+/obj/effect/ai_node,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "oDj" = (
@@ -83837,6 +84029,11 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_office/pressroom)
+"oOb" = (
+/obj/structure/platform_decoration/urban/rockdark,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "oOc" = (
 /obj/machinery/light/blue{
 	dir = 1
@@ -86841,6 +87038,7 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pqj" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "pqm" = (
@@ -88374,6 +88572,7 @@
 	layer = 3.3
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -90105,6 +90304,12 @@
 "pSI" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/spaceport/security)
+"pSJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/hospital/east_hallway)
 "pSM" = (
 /obj/structure/rock/dark/large/two,
 /turf/open/urbanshale/layer2,
@@ -90914,6 +91119,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"pZF" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "pZH" = (
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalk{
@@ -91935,6 +92145,14 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"qiy" = (
+/obj/effect/urban/decal/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/prison,
+/area/lv759/outdoors/colony_streets/south_west_street)
 "qiA" = (
 /obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
@@ -94424,6 +94642,18 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysoutheast)
+"qHY" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "qIm" = (
 /obj/item/target,
 /turf/open/floor/prison/cellstripe{
@@ -95031,6 +95261,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/bullet,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -102105,6 +102336,11 @@
 	dir = 6
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
+"sch" = (
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "sci" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -103852,6 +104088,16 @@
 /obj/effect/urban/decal/road/road_edge/seven,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
+"srs" = (
+/obj/effect/urban/decal/dirt,
+/obj/structure/barricade/handrail/urban/road/plastic/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/urban/street/sidewalk,
+/area/lv759/outdoors/colony_streets/north_west_street)
 "srv" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/largecrate/random/barrel/green{
@@ -105433,6 +105679,11 @@
 	dir = 1
 	},
 /area/lv759/indoors/garage_reception)
+"sFp" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "sFz" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating,
@@ -110999,6 +111250,7 @@
 	},
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/engineership/engineer_floor3,
 /area/lv759/indoors/derelict_ship)
 "tCW" = (
@@ -113638,6 +113890,11 @@
 	},
 /turf/open/floor/kutjevo/fake_wood,
 /area/lv759/indoors/bar)
+"tZl" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "tZr" = (
 /obj/machinery/light{
 	dir = 8
@@ -115814,6 +116071,11 @@
 	},
 /turf/open/floor/spiralplate,
 /area/lv759/outdoors/colony_streets/central_streets)
+"urc" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "urd" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -118081,6 +118343,12 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
+"uLO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/hospital/icu)
 "uLP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -120814,8 +121082,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/south_maintenance)
 "vjk" = (
-/obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "vjl" = (
@@ -122000,6 +122268,7 @@
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "vtj" = (
 /obj/item/stack/rods,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "vtk" = (
@@ -122928,6 +123197,7 @@
 	dir = 8;
 	layer = 3.3
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -124712,6 +124982,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "vRX" = (
@@ -125171,6 +125442,7 @@
 /obj/effect/urban/decal/engineership_corners{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/engineership/engineer_floor8{
 	dir = 4
 	},
@@ -126438,6 +126710,7 @@
 /area/lv759/indoors/nt_office/vip)
 "wgm" = (
 /obj/item/tool/surgery/circular_saw,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -127112,6 +127385,13 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/roadlines4,
 /area/lv759/outdoors/colony_streets/north_west_street)
+"wlY" = (
+/obj/effect/urban/decal/grate{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "wmi" = (
 /obj/machinery/light{
 	dir = 8
@@ -129344,6 +129624,11 @@
 	dir = 6
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
+"wGm" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "wGx" = (
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/effect/ai_node,
@@ -129614,16 +129899,10 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "wIY" = (
-/obj/structure/barricade/handrail/urban/road/plastic/black{
-	dir = 1
-	},
+/obj/structure/cable,
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/urban/street/roadlines4,
-/area/lv759/outdoors/colony_streets/south_west_street)
+/turf/open/floor/prison,
+/area/lv759/indoors/caves/central_caves)
 "wJb" = (
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 8
@@ -130626,6 +130905,11 @@
 /obj/structure/prop/urban/misc/floorprops/grate,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/east_central_street)
+"wRz" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "wRB" = (
 /obj/structure/barricade/handrail/kutjevo{
 	dir = 4;
@@ -131386,6 +131670,7 @@
 	},
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "wYy" = (
@@ -132151,6 +132436,7 @@
 	layer = 3.33;
 	pixel_y = 2
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -132203,6 +132489,13 @@
 	},
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/colonial_marshals/head_office)
+"xfb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "xfh" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/road/wood/blue,
@@ -138360,6 +138653,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "yje" = (
@@ -140245,7 +140539,7 @@ eUg
 eUg
 plS
 plS
-plS
+exb
 plS
 plS
 eUg
@@ -140445,15 +140739,15 @@ sMd
 ydz
 lmj
 iLK
+exb
 plS
-plS
-plS
+exb
 ohD
-plS
+exb
 plS
 plS
 uFY
-nGY
+hNF
 hcp
 kzn
 qFA
@@ -140657,7 +140951,7 @@ gbV
 plS
 gbV
 nGY
-nGY
+hNF
 plS
 plS
 plS
@@ -140861,7 +141155,7 @@ plS
 gbV
 nqO
 nqO
-plS
+exb
 plS
 plS
 eUg
@@ -141065,7 +141359,7 @@ plS
 nGY
 nqO
 uFY
-plS
+exb
 uFY
 szk
 plS
@@ -141267,14 +141561,14 @@ ohD
 gbV
 hNF
 nGY
-plS
+exb
 ohD
-szk
+bgs
 szk
 szk
 bgs
 plS
-plS
+exb
 nGY
 eUg
 eUg
@@ -141282,7 +141576,7 @@ plS
 eUg
 plS
 uLW
-plS
+exb
 tbO
 hAE
 faN
@@ -141478,7 +141772,7 @@ mrx
 szk
 plS
 nqO
-nGY
+hNF
 eUg
 plS
 plS
@@ -141673,16 +141967,16 @@ plS
 nGY
 eUg
 eUg
-plS
+exb
 szk
-szk
+bgs
 szk
 szk
 szk
 gbV
 nqO
 nGY
-plS
+exb
 szk
 szk
 plS
@@ -141877,21 +142171,21 @@ uLW
 eUg
 eUg
 eUg
-plS
+exb
 ohD
-szk
+bgs
 plS
 exb
-plS
+exb
 nqO
-nGY
+hNF
 plS
 bgs
 szk
 szk
 plS
 plS
-szk
+bgs
 hGa
 jvO
 oSk
@@ -142086,7 +142380,7 @@ plS
 eUg
 eUg
 nGY
-nGY
+hNF
 nGY
 wfm
 ohD
@@ -142290,7 +142584,7 @@ eUg
 eUg
 eUg
 nGY
-plS
+exb
 gbV
 ohD
 plS
@@ -142485,16 +142779,16 @@ eUg
 eUg
 eUg
 nGY
-plS
+exb
 plS
 gbV
-plS
+exb
 plS
 eUg
 eUg
 eUg
 plS
-plS
+exb
 ohD
 ohD
 plS
@@ -142687,18 +142981,18 @@ eUg
 eUg
 eUg
 nGY
-nGY
+hNF
 nqO
-uFY
+wGm
 plS
 gbV
-nGY
+hNF
 nGY
 eUg
 eUg
 eUg
 plS
-plS
+exb
 eUx
 rRj
 wve
@@ -142711,7 +143005,7 @@ ejv
 tDm
 shA
 cTl
-iWB
+taJ
 fdM
 fdM
 iWB
@@ -142889,19 +143183,19 @@ jFE
 kNJ
 gbV
 gbV
-ljm
+urc
 nqO
 nGY
 wad
 nGY
 ljm
 nGY
-nGY
+hNF
 plS
-plS
+exb
 eUg
 eUg
-plS
+exb
 atY
 fhx
 hWD
@@ -143109,7 +143403,7 @@ wMG
 sCK
 cGf
 aLX
-wve
+lxc
 wve
 dpu
 bGh
@@ -143295,8 +143589,8 @@ dCJ
 cnc
 aAo
 eoQ
-myS
-myS
+qiy
+qiy
 myS
 myS
 aAo
@@ -143505,7 +143799,7 @@ emW
 bFF
 bFF
 bFF
-emW
+ngl
 ngl
 emW
 fOQ
@@ -143688,15 +143982,15 @@ vOe
 bcs
 plW
 rTc
-hrx
+gRZ
 wpM
 mgr
-xFR
+lHk
 vJv
 cGv
 uuM
 cGv
-gUt
+hDo
 qRi
 fcZ
 nyD
@@ -143917,7 +144211,7 @@ sZb
 sZb
 sZb
 qRP
-wIY
+fWj
 yjd
 gCh
 rHL
@@ -144136,7 +144430,7 @@ lLo
 qUo
 qUo
 iWB
-jjV
+khA
 aLY
 jjV
 mzJ
@@ -144319,7 +144613,7 @@ giw
 aAo
 myS
 xtw
-xtw
+gct
 rbC
 qxk
 jbW
@@ -144335,11 +144629,11 @@ lLo
 lLo
 qUo
 qUo
-iHr
+lAI
 qUo
 qUo
 iWB
-jjV
+khA
 mAs
 iWB
 sxv
@@ -144515,7 +144809,7 @@ plS
 plS
 szk
 szk
-szk
+bgs
 szk
 szk
 ohD
@@ -144719,7 +145013,7 @@ plS
 plS
 mrx
 szk
-szk
+bgs
 ohD
 aOS
 szk
@@ -145131,12 +145425,12 @@ szk
 fkr
 cer
 szT
-rRP
+qHY
 iRV
 kQg
 szk
 lWe
-qWK
+wgF
 xdL
 iPA
 plC
@@ -145147,11 +145441,11 @@ wVZ
 lLo
 lLo
 icp
-qUo
+pHF
 iHr
 qUo
 iWB
-jjV
+khA
 mAs
 eHm
 wwX
@@ -145328,7 +145622,7 @@ eUg
 eUg
 bXj
 plS
-plS
+exb
 ohD
 szk
 jcN
@@ -145339,7 +145633,7 @@ pZs
 kQg
 kQg
 lWe
-wgF
+qWK
 kWT
 tdD
 ggb
@@ -145530,7 +145824,7 @@ eUg
 eUg
 eUg
 plS
-plS
+exb
 plS
 uxT
 jdW
@@ -145732,15 +146026,15 @@ eUg
 eUg
 eUg
 eUg
-uFY
+wGm
 plS
 gbV
 ohD
 szk
-szk
+bgs
 ohD
 szk
-szk
+bgs
 txY
 hQP
 szk
@@ -145934,17 +146228,17 @@ eUg
 eUg
 eUg
 eUg
-plS
+exb
 plS
 plS
 ohD
 ohD
-enw
+jRv
 ohD
 gbV
 gbV
 plS
-szk
+bgs
 mrx
 szk
 xVG
@@ -146130,25 +146424,25 @@ tKv
 drp
 hMa
 szk
-plS
+exb
 sYp
 slH
 eUg
 plS
 plS
-plS
+exb
 plS
 gbV
 szk
 szk
+bgs
 szk
-szk
 plS
 plS
 plS
 plS
 plS
-szk
+bgs
 szk
 xVG
 ufc
@@ -146334,16 +146628,16 @@ nKy
 kmC
 ohD
 szk
+exb
 plS
+exb
 plS
-plS
-plS
-mrx
+tZl
 szk
 ohD
 ohD
 ohD
-szk
+bgs
 ohD
 mrx
 plS
@@ -146545,7 +146839,7 @@ ohD
 bgs
 szk
 ohD
-szk
+bgs
 szk
 bgs
 plS
@@ -146572,7 +146866,7 @@ nHQ
 nHQ
 aQV
 bVo
-bVo
+kRD
 ota
 fdM
 lLo
@@ -146740,14 +147034,14 @@ nKy
 hMa
 szk
 ohD
-mrx
+tZl
 szk
 szk
 ohD
 ohD
 plS
 plS
-szk
+bgs
 uFY
 plS
 plS
@@ -146774,7 +147068,7 @@ iYt
 wTC
 iWB
 vEo
-taJ
+iWB
 iWB
 bxm
 fdM
@@ -146937,13 +147231,13 @@ srY
 uwD
 uFC
 eNw
-jWq
+srs
 kdP
 sin
 kmC
 szk
-szk
-szk
+bgs
+bgs
 ohD
 szk
 szk
@@ -147061,12 +147355,12 @@ gzr
 ghY
 ghY
 ghY
-uCf
+dbQ
 gWH
 ffF
-pVe
+gix
 hup
-hQQ
+nzN
 hQQ
 hup
 uvA
@@ -147263,14 +147557,14 @@ iDp
 iDp
 ghY
 ghY
-uCf
 dbQ
+uCf
 rSh
 ffF
 pVe
 hup
 ars
-hQQ
+nzN
 hup
 uvA
 ffF
@@ -147673,7 +147967,7 @@ uCf
 ffF
 rSh
 ffF
-ffF
+roJ
 tSo
 snM
 snM
@@ -147872,10 +148166,10 @@ iDp
 ghY
 bcr
 vyc
-uCf
+dbQ
 gme
 hMK
-uCf
+dbQ
 mix
 ghY
 ghY
@@ -147991,8 +148285,8 @@ lLo
 lLo
 lLo
 qUo
-qUo
 pHF
+qUo
 qUo
 lLo
 lLo
@@ -148074,11 +148368,11 @@ dZP
 dZP
 qBR
 pVG
-pVG
+xfb
 rLo
 bIp
 ylp
-uCf
+dbQ
 ghY
 ghY
 ghY
@@ -148280,7 +148574,7 @@ qsQ
 ccf
 taw
 taw
-uCf
+dbQ
 ghY
 ghY
 ghY
@@ -148480,7 +148774,7 @@ iDp
 iDp
 ghY
 osL
-uCf
+dbQ
 ffF
 taw
 uCf
@@ -148490,7 +148784,7 @@ ghY
 ghY
 ghY
 ghY
-uCf
+dbQ
 uCf
 uCf
 dbQ
@@ -148684,7 +148978,7 @@ iDp
 ghY
 uCf
 vJw
-uCf
+dbQ
 ffF
 uCf
 ghY
@@ -148889,7 +149183,7 @@ ghY
 ghY
 uCf
 roJ
-uCf
+dbQ
 uCf
 ghY
 ghY
@@ -149209,11 +149503,11 @@ gVB
 atI
 atI
 aNS
-eXS
+aNS
 aNS
 aNS
 tHU
-pLX
+tHU
 tHU
 tHU
 hIq
@@ -149299,13 +149593,13 @@ lAB
 uCf
 ccf
 uCf
+dbQ
 uCf
 uCf
-uCf
-uCf
+dbQ
 adQ
 uCf
-uCf
+dbQ
 ghY
 lwn
 "}
@@ -149412,11 +149706,11 @@ jHt
 atI
 atI
 pwh
-aNS
+eXS
 aNS
 aNS
 pwh
-ltM
+hWz
 tHU
 pLX
 hIq
@@ -149692,25 +149986,25 @@ csj
 ghY
 ghY
 oty
-cat
+ihu
 uCf
 dbQ
 uCf
 uCf
 ffF
 ffF
+roJ
+roJ
+taw
+dbQ
+ffF
 ffF
 roJ
 taw
-uCf
-ffF
-ffF
-roJ
-taw
 taw
 uCf
 uCf
-uCf
+dbQ
 dbQ
 ghY
 lwn
@@ -149904,15 +150198,15 @@ gme
 lol
 taw
 ffF
-ffF
+roJ
 ffF
 taw
 ffF
 gme
 uCf
-uCf
-uCf
-uCf
+dbQ
+dbQ
+dbQ
 ghY
 ghY
 ghY
@@ -150098,7 +150392,7 @@ csj
 csj
 csj
 uCf
-uCf
+dbQ
 lAB
 uCf
 ffF
@@ -150112,7 +150406,7 @@ taw
 taw
 taw
 uCf
-uCf
+dbQ
 osL
 ghY
 ghY
@@ -150298,9 +150592,9 @@ csj
 csj
 csj
 csj
+pLX
 tHU
-tHU
-uCf
+dbQ
 lAB
 taw
 taw
@@ -150310,11 +150604,11 @@ ffF
 uCf
 lAB
 esT
-uCf
+dbQ
 ffF
 taw
 uCf
-uCf
+dbQ
 vyc
 uCf
 ghY
@@ -150512,11 +150806,11 @@ uCf
 uCf
 uCf
 uCf
-uCf
+dbQ
 ccf
 uCf
 ffF
-uCf
+dbQ
 ccf
 ghY
 ghY
@@ -150699,11 +150993,11 @@ csj
 csj
 slN
 csj
-tHU
+pLX
 tHU
 ltM
 tHU
-tHU
+pLX
 kZP
 oXR
 oXR
@@ -150716,11 +151010,11 @@ xzl
 jRp
 ghY
 uCf
-uCf
+dbQ
 uCf
 taw
 ffF
-uCf
+dbQ
 ghY
 ghY
 ghY
@@ -150901,7 +151195,7 @@ tHU
 tHU
 tHU
 ltM
-tHU
+pLX
 tHU
 tHU
 kZP
@@ -150910,9 +151204,9 @@ aNS
 aNS
 oXR
 aNS
+dbQ
 uCf
-uCf
-uCf
+dbQ
 cat
 cat
 cat
@@ -150924,7 +151218,7 @@ lAB
 taw
 taw
 uCf
-uCf
+dbQ
 ghY
 ghY
 ghY
@@ -151112,7 +151406,7 @@ oXR
 gmq
 aNS
 tHU
-tHU
+pLX
 van
 ghY
 ghY
@@ -151122,7 +151416,7 @@ cat
 cat
 ghY
 ghY
-uCf
+dbQ
 uCf
 lAB
 gme
@@ -151309,12 +151603,12 @@ aNS
 aNS
 eXS
 aNS
-tHU
+pLX
 kZP
-tHU
-tHU
+pLX
 pLX
 tHU
+pLX
 fKs
 dPQ
 ghY
@@ -151330,7 +151624,7 @@ cat
 uCf
 uCf
 uCf
-cat
+ihu
 cat
 cat
 ghY
@@ -151513,7 +151807,7 @@ oXR
 pwh
 tHU
 tHU
-tHU
+pLX
 tHU
 tHU
 csj
@@ -151529,7 +151823,7 @@ ghY
 ghY
 bBO
 ghY
-cat
+ihu
 cat
 ihu
 qeC
@@ -151539,7 +151833,7 @@ uCf
 uCf
 ccf
 uCf
-uCf
+dbQ
 lwn
 "}
 (64,1,1) = {"
@@ -151715,7 +152009,7 @@ oXR
 oXR
 kZP
 tHU
-tHU
+pLX
 ltM
 tHU
 csj
@@ -151917,7 +152211,7 @@ pLX
 tHU
 oXR
 tHU
-tHU
+pLX
 csj
 csj
 csj
@@ -152119,7 +152413,7 @@ lxG
 tHU
 tHU
 aNS
-tHU
+pLX
 lxG
 lxG
 lxG
@@ -152321,7 +152615,7 @@ lxG
 lxG
 pLX
 aNS
-aNS
+eXS
 ltM
 lxG
 kBD
@@ -152346,7 +152640,7 @@ ghY
 ghY
 uCf
 uCf
-gme
+hKz
 uCf
 ghY
 ghY
@@ -152525,7 +152819,7 @@ bLL
 aNS
 aNS
 oXR
-tHU
+pLX
 tHU
 qij
 lxG
@@ -152684,7 +152978,7 @@ hIq
 bVc
 hIq
 tHU
-ltM
+hWz
 oXR
 oXR
 oXR
@@ -152729,7 +153023,7 @@ kCo
 oXR
 oXR
 oXR
-tHU
+pLX
 tHU
 lxG
 lxG
@@ -152931,11 +153225,11 @@ aNS
 pwh
 aNS
 rtM
-fQM
+eog
 aNS
-aNS
+eXS
 tHU
-tHU
+pLX
 csj
 csj
 lxG
@@ -153088,12 +153382,12 @@ pwh
 aNS
 pLX
 kZP
-bYt
+eMQ
 hIq
 tHU
 tHU
-eXS
 aNS
+eXS
 aNS
 tHU
 bLL
@@ -153131,15 +153425,15 @@ csj
 csj
 tHU
 jiZ
-aNS
+eXS
 aSf
-lRa
+wxr
 lRa
 fQM
 aNS
 pwh
 aNS
-tHU
+pLX
 csj
 csj
 lxG
@@ -153290,23 +153584,23 @@ tHU
 tHU
 tHU
 tHU
-tHU
+pLX
 hIq
 csj
 csj
 tHU
 aNS
 oXR
-aNS
-pwh
-aNS
-aNS
+eXS
+kOe
 aNS
 aNS
-aNS
+eXS
 aNS
 aNS
 aNS
+aNS
+eXS
 tHU
 tHU
 csj
@@ -153545,7 +153839,7 @@ aNS
 qKE
 oXR
 oXR
-pwh
+kOe
 tHU
 csj
 lxG
@@ -153749,7 +154043,7 @@ slN
 nRd
 eXS
 aNS
-aNS
+eXS
 tHU
 lxG
 lxG
@@ -154313,7 +154607,7 @@ csj
 csj
 udt
 ptJ
-ltM
+hWz
 tHU
 aNS
 tHU
@@ -154517,9 +154811,9 @@ csj
 udt
 tHU
 csj
+pLX
 tHU
-tHU
-tHU
+pLX
 lAC
 kqj
 kqj
@@ -154560,7 +154854,7 @@ wji
 wji
 wji
 kRv
-kgG
+abx
 kgG
 siK
 kRv
@@ -155135,9 +155429,9 @@ kRv
 kRv
 umq
 kRv
+mDf
 kRv
-kRv
-kRv
+mDf
 fdb
 fLw
 fLw
@@ -155159,7 +155453,7 @@ xRf
 qLZ
 hlw
 tcF
-kRv
+mDf
 wWc
 dci
 abx
@@ -155328,20 +155622,20 @@ kqj
 kqj
 kqj
 kqj
-kRv
-kRv
 mDf
-kgG
+mDf
+kRv
+abx
 kgG
 kgG
 cCg
 kgG
-kgG
+abx
 abx
 siK
 kgG
 kRv
-kRv
+mDf
 fdb
 lIc
 dab
@@ -155365,19 +155659,19 @@ tcF
 kRv
 abx
 kgG
-kgG
+abx
 kRv
 kRv
 lIc
-lIc
+nQX
 kRv
 kgG
 kgG
-wWc
+wlY
 dXr
 epS
 jmz
-uNd
+sFp
 jHs
 vcE
 uZo
@@ -155530,7 +155824,7 @@ kqj
 kqj
 eSq
 kqj
-kRv
+mDf
 kRv
 siK
 siK
@@ -155545,8 +155839,8 @@ siK
 siK
 kRv
 kRv
-kRv
-lIc
+mDf
+nQX
 kqj
 kqj
 cYG
@@ -155567,7 +155861,7 @@ rni
 tcF
 fdb
 siK
-kgG
+abx
 kRv
 kRv
 sHN
@@ -155770,7 +156064,7 @@ hlw
 tcF
 fdb
 siK
-gpA
+fMO
 kRv
 wji
 wji
@@ -155972,7 +156266,7 @@ mJI
 rni
 tcF
 kRv
-kgG
+abx
 kgG
 kRv
 bLF
@@ -155982,11 +156276,11 @@ wji
 wji
 pbh
 kPD
-hVK
+meQ
 kgG
 kgG
 kRv
-uNd
+sFp
 sQn
 vcE
 vcE
@@ -156190,7 +156484,7 @@ gpA
 kgG
 fdb
 ocK
-umH
+eDQ
 jHs
 hNH
 vcE
@@ -156342,8 +156636,8 @@ lIc
 lIc
 nQX
 lIc
-lIc
-lIc
+nQX
+nQX
 kRv
 mDf
 kRv
@@ -156542,7 +156836,7 @@ wji
 kqj
 kqj
 kqj
-kRv
+mDf
 kRv
 fdb
 lIc
@@ -156795,11 +157089,11 @@ wji
 wji
 wji
 wji
-lIc
+nQX
 umq
 kRv
 kRv
-gKc
+oOb
 pmB
 jHs
 vcE
@@ -157138,12 +157432,12 @@ kqj
 lIc
 lIc
 kRv
-kRv
+mDf
 kgG
 kRv
 kRv
 eay
-lIc
+nQX
 kRv
 kqj
 kRv
@@ -157201,7 +157495,7 @@ kRv
 kgG
 kRv
 kRv
-lIc
+nQX
 lIc
 wji
 hgt
@@ -157221,7 +157515,7 @@ eDh
 iia
 jLt
 jLt
-gYy
+iia
 mKv
 mKv
 lwn
@@ -157347,7 +157641,7 @@ kRv
 wji
 eay
 lIc
-kRv
+mDf
 kRv
 kRv
 siK
@@ -157358,7 +157652,7 @@ kkF
 kgG
 kgG
 umq
-kRv
+mDf
 kRv
 kqj
 wji
@@ -157403,7 +157697,7 @@ kRv
 gpA
 siK
 siK
-umq
+mxw
 kRv
 lIc
 lIc
@@ -157422,7 +157716,7 @@ vcE
 wxD
 gnl
 gYy
-jll
+jvG
 jLt
 jll
 mKv
@@ -157605,7 +157899,7 @@ kgG
 kgG
 kgG
 siK
-kgG
+abx
 kgG
 kqj
 jYA
@@ -157755,12 +158049,12 @@ wji
 wji
 kRv
 kgG
-kgG
+abx
 kRv
 kRv
 kRv
 kRv
-kgG
+abx
 kgG
 siK
 kgG
@@ -157774,7 +158068,7 @@ kqj
 kqj
 oSZ
 dXr
-pbl
+wIY
 nFG
 avk
 kSq
@@ -157803,12 +158097,12 @@ wxD
 ddR
 mDf
 kRv
-abx
+kgG
 kgG
 heY
 ril
 lCS
-abx
+kgG
 kqj
 kqj
 lIc
@@ -157970,10 +158264,10 @@ siK
 kRv
 kRv
 kqj
-eay
+vjk
 lIc
 kRv
-kRv
+mDf
 kqj
 kqj
 buo
@@ -158005,18 +158299,18 @@ vcE
 cYG
 bKP
 jZc
-kgG
+abx
 kgG
 heY
 epS
 epS
 ril
-kgG
+abx
 kgG
 kRv
 nQX
 lIc
-hvU
+jvG
 sML
 jug
 jug
@@ -158171,13 +158465,13 @@ kgG
 siK
 kRv
 gKT
-kRv
-kRv
+mDf
+mDf
 eay
 kqj
 kqj
 umq
-kRv
+mDf
 kqj
 kqj
 ibI
@@ -158209,7 +158503,7 @@ vcE
 wxD
 kDn
 kRv
-gpA
+fMO
 wWc
 epS
 epS
@@ -158220,7 +158514,7 @@ kRv
 lIc
 lIc
 jll
-gYy
+iia
 tau
 tau
 tau
@@ -158381,14 +158675,14 @@ kqj
 kqj
 kqj
 kRv
-kRv
+mDf
 kRv
 irR
 qlq
 cPV
 kRv
 rfV
-vzy
+jTE
 eSq
 kqj
 wji
@@ -158413,10 +158707,10 @@ cYG
 vVr
 ckW
 dyr
-kgG
+abx
 wWc
 jmz
-kgG
+abx
 kgG
 kgG
 kRv
@@ -158424,7 +158718,7 @@ lIc
 lIc
 gYy
 gYy
-gYy
+iia
 tau
 mKv
 gYy
@@ -158439,7 +158733,7 @@ gYy
 gYy
 cmr
 sTZ
-gYy
+iia
 gYy
 mKv
 lwn
@@ -158771,10 +159065,10 @@ fdb
 siK
 kgG
 kRv
+mDf
 kRv
 kRv
-kRv
-kRv
+mDf
 kgG
 siK
 siK
@@ -158830,14 +159124,14 @@ nQX
 jll
 gYy
 gYy
-vbb
+hQj
 iia
 gYy
 gYy
 xnI
 wgV
 gYy
-gYy
+iia
 jLt
 jll
 wbg
@@ -158973,7 +159267,7 @@ kRv
 fdb
 siK
 kgG
-kgG
+abx
 siK
 gpA
 kgG
@@ -159002,7 +159296,7 @@ lIc
 ome
 kqj
 kRv
-kRv
+mDf
 heY
 epS
 epS
@@ -159193,7 +159487,7 @@ kRv
 umq
 abx
 kRv
-kRv
+mDf
 aEf
 xkr
 kqj
@@ -159240,18 +159534,18 @@ gYy
 gYy
 wyd
 uyJ
+iia
 gYy
-gYy
-gYy
+iia
 gYy
 jLt
-qjg
+glt
 wPt
 jll
 gYy
 gYy
 gYy
-gYy
+iia
 mKv
 mKv
 lwn
@@ -159446,9 +159740,9 @@ qvK
 sTZ
 gYy
 jLt
+iia
 gYy
-gYy
-gYy
+iia
 ert
 xor
 mKv
@@ -159598,7 +159892,7 @@ kRv
 siK
 siK
 siK
-kRv
+mDf
 mPX
 kRv
 kRv
@@ -159650,7 +159944,7 @@ gOg
 jLt
 sBJ
 jLt
-gYy
+iia
 nXO
 mKv
 jll
@@ -159849,11 +160143,11 @@ hBB
 iia
 tQe
 kog
-gYy
+iia
 gYy
 jLt
 gYy
-iia
+gYy
 mKv
 mKv
 mKv
@@ -160053,10 +160347,10 @@ gYy
 jLt
 jLt
 jLt
+iia
 gYy
 gYy
-gYy
-gYy
+iia
 gYy
 mKv
 mKv
@@ -160215,12 +160509,12 @@ wji
 kqj
 kqj
 fLE
+mDf
 kRv
 kRv
 kRv
 kRv
-kRv
-kRv
+mDf
 lIc
 lIc
 kqj
@@ -160256,7 +160550,7 @@ vbb
 gYy
 jLt
 gYy
-huh
+hvU
 jLt
 gYy
 vbb
@@ -160456,19 +160750,19 @@ pbr
 nkS
 gYy
 gYy
+iia
 gYy
-gYy
-vbb
+hQj
 jLt
 jLt
 jLt
 jvG
-jll
+jvG
 jll
 jll
 gYy
-huh
-iia
+hvU
+gYy
 gYy
 mKv
 mKv
@@ -160613,13 +160907,13 @@ kRv
 kgG
 siK
 kRv
-kRv
+mDf
 wji
 wji
 kqj
 kqj
 kqj
-kRv
+mDf
 kRv
 kgG
 kgG
@@ -160662,9 +160956,9 @@ jLt
 gYy
 tau
 gYy
-gYy
+iia
 wbg
-jll
+jvG
 jll
 aUf
 wPt
@@ -160821,7 +161115,7 @@ kqj
 kqj
 kqj
 kqj
-vzy
+jTE
 kRv
 umq
 kgG
@@ -160866,7 +161160,7 @@ huh
 tau
 tau
 jll
-jll
+jvG
 wPt
 jll
 gYy
@@ -161013,17 +161307,17 @@ wji
 kqj
 kqj
 kqj
-kRv
+mDf
 fdb
 siK
 siK
-kgG
+abx
 kRv
 kqj
 kqj
 kqj
 onO
-kRv
+mDf
 vzy
 fdb
 vzy
@@ -161062,10 +161356,10 @@ mKv
 mKv
 nXO
 mOU
-vbb
+hQj
 gYy
-iia
-vbb
+gYy
+hQj
 gYy
 tau
 tau
@@ -161215,7 +161509,7 @@ kqj
 kqj
 kqj
 kRv
-kRv
+mDf
 kRv
 kRv
 siK
@@ -161230,7 +161524,7 @@ lIc
 cSw
 kmd
 fdb
-vzy
+jTE
 kRv
 kRv
 kgG
@@ -161417,7 +161711,7 @@ wji
 kqj
 kqj
 umq
-kRv
+mDf
 fdb
 kRv
 kgG
@@ -161428,8 +161722,8 @@ kqj
 wji
 wji
 xlQ
-vZS
-ruu
+gNa
+sch
 lIc
 fLw
 tJy
@@ -161471,7 +161765,7 @@ gYy
 gYy
 jLt
 jLt
-gYy
+iia
 mKv
 tau
 tau
@@ -161619,7 +161913,7 @@ wji
 wji
 kqj
 kRv
-kRv
+mDf
 fdb
 fdb
 fdb
@@ -161671,9 +161965,9 @@ gYy
 gYy
 gYy
 jLt
+iia
 gYy
-gYy
-vbb
+hQj
 gYy
 tau
 tau
@@ -162032,7 +162326,7 @@ kgG
 gpA
 cwL
 gpA
-kRv
+mDf
 lIc
 wji
 wji
@@ -162077,9 +162371,9 @@ kwZ
 gYy
 huh
 gYy
-huh
+hvU
 gYy
-gYy
+iia
 tau
 mKv
 tau
@@ -162234,17 +162528,17 @@ siK
 kRv
 mDf
 kgG
+mDf
 kRv
-kRv
-nQX
 lIc
+nQX
 wji
 wXm
-gNa
-lIc
+vZS
+nQX
 lIc
 ruu
-ruu
+sch
 txy
 hXu
 wji
@@ -162434,19 +162728,19 @@ gpA
 kgG
 siK
 siK
-kgG
+abx
 wji
 kRv
 kRv
 fLw
 fLw
 kRv
-umq
-vzy
+mxw
+jTE
 kRv
 cSw
 umq
-umq
+mxw
 ruu
 wji
 wji
@@ -162634,9 +162928,9 @@ kqj
 kgG
 kgG
 kgG
-kgG
-kgG
-kgG
+abx
+abx
+abx
 kgG
 wji
 wji
@@ -162686,7 +162980,7 @@ mKv
 gYy
 gYy
 gYy
-gYy
+iia
 jUp
 vbb
 gYy
@@ -162846,15 +163140,15 @@ wji
 lIc
 umq
 kRv
+abx
+siK
+mDf
 kgG
 siK
-kRv
 kgG
-siK
-kgG
+mDf
 kRv
-kRv
-kRv
+mDf
 kqj
 kqj
 wji
@@ -162890,7 +163184,7 @@ mKv
 mKv
 mKv
 gYy
-gYy
+iia
 wyd
 sTZ
 gYy
@@ -163046,19 +163340,19 @@ rOE
 vYx
 bBk
 wji
-lIc
+nQX
 kRv
-kRv
+mDf
 siK
 siK
 siK
-kgG
+abx
 kgG
 gpA
 siK
 fdb
 kRv
-kRv
+mDf
 kqj
 wji
 wji
@@ -163250,8 +163544,8 @@ xFH
 bBk
 wji
 wji
-kRv
 mDf
+kRv
 kRv
 siK
 kgG
@@ -163261,7 +163555,7 @@ kgG
 kgG
 siK
 fdb
-mDf
+kRv
 xoe
 kqj
 wji
@@ -163454,10 +163748,10 @@ bBk
 wji
 wji
 wji
-kRv
+mDf
 kRv
 gpA
-kgG
+abx
 siK
 siK
 siK
@@ -163661,7 +163955,7 @@ lhB
 ucq
 kRv
 kgG
-kRv
+mDf
 fdb
 kRv
 gpA
@@ -163702,7 +163996,7 @@ mKv
 mKv
 mKv
 kxt
-gYy
+iia
 iia
 gYy
 jLt
@@ -164276,12 +164570,12 @@ kRv
 kRv
 kRv
 kRv
-gKT
+wRz
 ome
 eay
 lIc
 kRv
-umq
+mxw
 kRv
 kRv
 wji
@@ -164320,7 +164614,7 @@ jLt
 jLt
 jLt
 gYy
-gYy
+iia
 vbb
 gYy
 gYy
@@ -164479,7 +164773,7 @@ kRv
 wji
 wji
 wji
-nzN
+wji
 fLw
 eay
 kRv
@@ -164495,12 +164789,12 @@ wji
 wji
 wji
 eay
-kRv
+mDf
 umq
 vyq
-mDx
+nDX
 cqS
-dLn
+bVk
 vcE
 vcE
 vcE
@@ -164522,7 +164816,7 @@ gYy
 gYy
 jLt
 gYy
-gYy
+iia
 jLt
 gYy
 gYy
@@ -164689,7 +164983,7 @@ kRv
 kgG
 siK
 kgG
-kgG
+abx
 gpA
 kRv
 wji
@@ -164697,8 +164991,8 @@ wji
 wji
 wji
 lIc
-eay
-mDf
+vjk
+kRv
 kRv
 kRv
 vyq
@@ -164717,14 +165011,14 @@ kAL
 kKn
 jll
 pAQ
+iia
 gYy
 gYy
-gYy
-gYy
+iia
 gYy
 gYy
 huh
-gYy
+iia
 jLt
 jLt
 jLt
@@ -164893,13 +165187,13 @@ fdb
 fdb
 fdb
 kgG
-kgG
+abx
 kRv
 wji
 wji
 wji
-nQX
-ome
+lIc
+pZF
 vjk
 lIc
 kRv
@@ -164928,7 +165222,7 @@ gYy
 gYy
 jLt
 gYy
-gYy
+iia
 jLt
 gYy
 gYy
@@ -165097,11 +165391,11 @@ siK
 kgG
 kgG
 kgG
-kgG
-kRv
+abx
+mDf
 kRv
 lIc
-lIc
+nQX
 lIc
 eay
 wji
@@ -165302,9 +165596,9 @@ siK
 kgG
 kRv
 kRv
-mDf
+kRv
 umq
-nQX
+lIc
 wji
 wji
 qvx
@@ -166316,8 +166610,8 @@ kRv
 kRv
 kRv
 siK
-kgG
-kRv
+abx
+mDf
 kqj
 kqj
 kqj
@@ -166518,7 +166812,7 @@ wji
 kRv
 fdb
 umq
-kgG
+abx
 kgG
 kRv
 mPX
@@ -166718,9 +167012,9 @@ wji
 wji
 wji
 wji
+mDf
 kRv
-kRv
-kRv
+mDf
 siK
 kgG
 kgG
@@ -166922,11 +167216,11 @@ wji
 wji
 wji
 wji
-kRv
+mDf
 fdb
 siK
 siK
-gpA
+fMO
 kRv
 kqj
 wji
@@ -167531,7 +167825,7 @@ kRv
 kRv
 lsv
 lIc
-kRv
+mDf
 siK
 kgG
 kgG
@@ -167729,11 +168023,11 @@ iyW
 aAJ
 wkX
 azJ
-gpA
+fMO
 kgG
 kRv
 lIc
-ome
+pZF
 fdb
 siK
 siK
@@ -167937,12 +168231,12 @@ kgG
 kRv
 lIc
 lIc
-kRv
+mDf
 fdb
 kgG
 kgG
 kRv
-kRv
+mDf
 kRv
 kqj
 wji
@@ -168141,7 +168435,7 @@ kRv
 lIc
 wji
 kRv
-kRv
+mDf
 kgG
 fdb
 umq
@@ -168551,7 +168845,7 @@ kRv
 gpA
 siK
 kgG
-kRv
+mDf
 wji
 wji
 wji
@@ -168750,10 +169044,10 @@ wji
 wji
 wji
 wji
-kRv
+mDf
 kgG
 kgG
-kgG
+abx
 kgG
 wji
 wji
@@ -169148,9 +169442,9 @@ vqA
 daU
 wLK
 elv
-wRF
+jen
 wqQ
-kgG
+abx
 kRv
 wji
 wji
@@ -169361,9 +169655,9 @@ wji
 wji
 wji
 kRv
-gpA
+fMO
 kgG
-kgG
+abx
 wji
 wji
 kRv
@@ -169563,11 +169857,11 @@ wji
 wji
 wji
 wji
-kRv
+mDf
 fdb
 siK
 kgG
-gpA
+fMO
 kRv
 kRv
 kRv
@@ -169767,7 +170061,7 @@ wji
 wji
 wji
 kRv
-kRv
+mDf
 fdb
 siK
 kgG
@@ -170379,7 +170673,7 @@ ylT
 bOx
 fdb
 fdb
-kgG
+abx
 kRv
 mDf
 kqj
@@ -170581,11 +170875,11 @@ pAy
 hXu
 hqO
 kRv
-kgG
+abx
 kgG
 siK
 kgG
-kRv
+mDf
 kRv
 kqj
 kqj
@@ -170991,10 +171285,10 @@ fMT
 vjb
 iaZ
 vjb
-vjb
+fGY
 vjb
 fMT
-fMT
+qpy
 qdm
 aWQ
 aWQ
@@ -171190,10 +171484,10 @@ tLh
 tLh
 tLh
 tLh
-fMT
+qpy
 fMT
 usF
-vjb
+fGY
 iaZ
 gSJ
 fMT
@@ -171396,7 +171690,7 @@ tLh
 tLh
 wfP
 fMT
-iaZ
+vjb
 iaZ
 iaZ
 vjb
@@ -171603,7 +171897,7 @@ gSJ
 iaZ
 vjb
 vjb
-vjb
+fGY
 gSJ
 fMT
 aWQ
@@ -172011,7 +172305,7 @@ iaZ
 iaZ
 vjb
 vjb
-fMT
+qpy
 aWQ
 aWQ
 aWQ
@@ -172212,10 +172506,10 @@ fMT
 vjb
 iaZ
 vjb
-vjb
+fGY
 iaZ
 fMT
-fMT
+qpy
 fMT
 aWQ
 aWQ
@@ -172411,15 +172705,15 @@ dTb
 tLh
 tLh
 tLh
-fMT
+qpy
 fMT
 vjb
-vjb
+fGY
 iaZ
 iaZ
 iaZ
 gdc
-fMT
+qpy
 fMT
 aWQ
 fMT
@@ -172623,8 +172917,8 @@ iaZ
 vjb
 vjb
 iaZ
-fMT
-fMT
+qpy
+qpy
 fMT
 fMT
 hAw
@@ -172817,7 +173111,7 @@ dTb
 tLh
 tLh
 tLh
-fMT
+qpy
 fMT
 qXI
 qXI
@@ -173021,16 +173315,16 @@ tLh
 tLh
 fMT
 xGB
-fMT
+qpy
 fMT
 iaZ
 vjb
-fGY
+vjb
 gSJ
 vjb
 iaZ
 vjb
-vjb
+fGY
 qXI
 fMT
 fMT
@@ -173225,14 +173519,14 @@ tLh
 fMT
 fMT
 szi
-fMT
-fMT
-vjb
-fMT
-fMT
-fMT
+qpy
 fMT
 vjb
+qpy
+fMT
+fMT
+fMT
+fGY
 iaZ
 vpI
 qXI
@@ -173436,7 +173730,7 @@ tLh
 tLh
 fMT
 vjb
-vjb
+fGY
 iaZ
 vjb
 gdc
@@ -173640,7 +173934,7 @@ tLh
 dXT
 fMT
 vjb
-fGY
+vjb
 vjb
 vjb
 fMT
@@ -173842,13 +174136,13 @@ tLh
 tLh
 tLh
 yiD
+fGY
 vjb
 vjb
 vjb
-iaZ
 vjb
-fMT
-fMT
+qpy
+qpy
 kwO
 ldK
 ldK
@@ -174052,15 +174346,15 @@ iaZ
 iaZ
 vjb
 gdc
-nmI
+krI
 mfz
 eqz
 fWb
 iJK
 nIl
-nmI
+krI
 gdc
-fMT
+qpy
 aWQ
 nhE
 ogd
@@ -174256,14 +174550,14 @@ vjb
 vjb
 qXI
 fMT
-nmI
+krI
 eqz
 cWZ
 iJK
-nmI
+krI
 buV
 qXI
-fMT
+qpy
 fMT
 fMT
 dzq
@@ -174451,12 +174745,12 @@ tLh
 tLh
 fMT
 vjb
-vjb
 fGY
+vjb
 vjb
 fMT
 iaF
-fMT
+qpy
 qXI
 qXI
 nmI
@@ -174467,7 +174761,7 @@ nmI
 qXI
 klV
 iaZ
-vjb
+fGY
 fGY
 hNU
 vjb
@@ -174660,13 +174954,13 @@ fMT
 aWQ
 aWQ
 fMT
-fMT
-fMT
-nmI
+qpy
+qpy
+krI
 uoH
 cWZ
 iJK
-nmI
+krI
 gdc
 qXI
 gSJ
@@ -174858,7 +175152,7 @@ vjb
 gxw
 fGY
 vjb
-qpy
+fMT
 fMT
 aWQ
 aWQ
@@ -174871,9 +175165,9 @@ fWb
 iJK
 boy
 nmI
-fMT
+qpy
 vjb
-fMT
+qpy
 fMT
 dQJ
 fMT
@@ -176088,9 +176382,9 @@ aWQ
 aWQ
 aWQ
 kXA
-fMT
+qpy
 gSJ
-udn
+bYY
 ctS
 unW
 unW
@@ -176292,7 +176586,7 @@ aWQ
 dXT
 qdm
 fMT
-vjb
+fGY
 bYY
 bYY
 iaZ
@@ -176706,7 +177000,7 @@ fMT
 vjb
 iaZ
 usF
-fMT
+qpy
 fMT
 qpy
 gdc
@@ -176906,9 +177200,9 @@ xLT
 bYY
 fMT
 mTA
-fMT
+qpy
 vjb
-vjb
+fGY
 fMT
 aWQ
 aWQ
@@ -177510,7 +177804,7 @@ aWQ
 aWQ
 aWQ
 wfP
-gSJ
+nFO
 bYY
 rdR
 fMT
@@ -177712,16 +178006,16 @@ aWQ
 aWQ
 aWQ
 qdm
-fMT
+qpy
 vjb
 xLT
 bYY
 vjb
 vjb
-vjb
+fGY
 gSJ
 vjb
-fMT
+qpy
 aWQ
 aWQ
 aWQ
@@ -177915,12 +178209,12 @@ aWQ
 aWQ
 aWQ
 aWQ
-qpy
+fMT
 iaZ
 xLT
 xLT
 usF
-vjb
+fGY
 iaZ
 iaZ
 iaZ
@@ -178121,13 +178415,13 @@ aWQ
 fMT
 fMT
 xLT
-udn
-vjb
+bYY
+fGY
 fMT
 fMT
 vjb
 vjb
-vjb
+fGY
 qXI
 aWQ
 aWQ
@@ -178321,10 +178615,10 @@ aWQ
 aWQ
 aWQ
 vjb
-vjb
+fGY
 gSJ
 bYY
-bYY
+udn
 fMT
 aWQ
 aWQ
@@ -180766,7 +181060,7 @@ sIR
 vjb
 vjb
 vjb
-vjb
+fGY
 fMT
 aWQ
 aWQ
@@ -181386,7 +181680,7 @@ lwn
 (211,1,1) = {"
 lwn
 jcQ
-aVz
+eVt
 nhc
 nhc
 nhc
@@ -181589,7 +181883,7 @@ lwn
 (212,1,1) = {"
 lwn
 jcQ
-aVz
+gHy
 nhc
 nhc
 nhc
@@ -181792,7 +182086,7 @@ lwn
 (213,1,1) = {"
 lwn
 jcQ
-aVz
+pSJ
 nhc
 nhc
 nhc
@@ -181995,7 +182289,7 @@ lwn
 (214,1,1) = {"
 lwn
 jcQ
-aVz
+uLO
 nhc
 nhc
 cBk
@@ -182198,7 +182492,7 @@ lwn
 (215,1,1) = {"
 lwn
 jcQ
-aVz
+cOP
 nhc
 nhc
 cBk
@@ -182401,7 +182695,7 @@ lwn
 (216,1,1) = {"
 lwn
 jcQ
-aVz
+ags
 nhc
 hfL
 cBk
@@ -182604,7 +182898,7 @@ lwn
 (217,1,1) = {"
 lwn
 jcQ
-aVz
+hgK
 nhc
 cBk
 cBk
@@ -182807,7 +183101,7 @@ lwn
 (218,1,1) = {"
 lwn
 jcQ
-aVz
+giB
 nhc
 hfL
 hfL

--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -81,6 +81,13 @@
 	dir = 1
 	},
 /area/lv759/indoors/hospital/reception)
+"abh" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/urban/metal/stripe_red{
+	dir = 1
+	},
+/area/lv759/outdoors/colony_streets/north_west_street)
 "abm" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/urban,
@@ -573,10 +580,6 @@
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "afE" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
 /mob/living/simple_animal/mouse/gray,
 /mob/living/simple_animal/mouse/brown,
 /turf/open/urbanshale/layer1,
@@ -865,8 +868,10 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/casino)
 "aiG" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/mining_outpost/east)
+/obj/structure/platform_decoration/urban/engineer_corner,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "aiH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -1693,10 +1698,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/power_plant/telecomms)
-"apx" = (
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "apy" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -1756,8 +1757,11 @@
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "aqg" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/outdoors/landing_zone_1)
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 4
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "aql" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/metal/grated,
@@ -1983,9 +1987,6 @@
 /obj/structure/sign/poster,
 /turf/closed/wall/urban,
 /area/lv759/indoors/spaceport/cuppajoes)
-"arS" = (
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
 "arU" = (
 /obj/structure/bed/chair/sofa/corsat/left,
 /turf/open/floor/urban_wood,
@@ -2049,9 +2050,11 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "aso" = (
-/obj/machinery/floodlight,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/prop/urban/misc/machinery/screens/multimonitormedium_off{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/flight_control_room)
 "asv" = (
 /obj/structure/window/framed/urban/marshalls/cell,
 /turf/open/floor/plating,
@@ -2767,14 +2770,8 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/garage_workshop_storage)
 "azJ" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/obj/structure/closet/crate/miningcar{
-	layer = 3
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/colonial_marshals/restroom)
 "azU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -2796,6 +2793,10 @@
 	},
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
+"aAi" = (
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "aAo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -3105,8 +3106,9 @@
 /turf/open/floor/squares,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "aEf" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/hobosecret)
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "aEh" = (
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone{
@@ -3346,12 +3348,10 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/power_plant/south_hallway)
 "aFM" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/rock/dark/stalagmite/five,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "aFP" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/ai_node,
@@ -4141,6 +4141,9 @@
 /obj/item/toy/deck/kotahi,
 /turf/open/floor/grimy,
 /area/lv759/indoors/apartment/westhallway)
+"aMh" = (
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "aMq" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/item/clothing/mask/facehugger/dead,
@@ -4553,8 +4556,8 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/emergency_room)
 "aQh" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/north_west_caves)
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "aQn" = (
 /obj/effect/urban/decal/dirt{
 	pixel_y = 12
@@ -5005,6 +5008,11 @@
 "aUc" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/casino/casino_restroom)
+"aUf" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "aUi" = (
 /obj/structure/bed/chair{
 	dir = 4;
@@ -5034,11 +5042,10 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "aUq" = (
-/obj/structure/barricade/metal/deployable,
-/turf/open/floor/prison{
-	dir = 10
+/turf/open/floor/prison/ramptop{
+	dir = 8
 	},
-/area/lv759/indoors/caves/north_west_caves)
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "aUs" = (
 /obj/structure/closet/crate/trashcart{
 	layer = 6
@@ -5547,6 +5554,10 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_security/checkpoint_northeast)
+"aYy" = (
+/obj/item/stack/rods,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "aYz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5831,13 +5842,12 @@
 /turf/open/floor/plate,
 /area/lv759/indoors/meridian/meridian_factory)
 "bbj" = (
-/obj/structure/largecrate/random/mini{
-	layer = 4;
-	pixel_x = 1;
-	pixel_y = 14
+/obj/effect/spawner/random/engineering/metal,
+/obj/item/tool/shovel{
+	pixel_y = 12
 	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "bbm" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/medical{
@@ -5913,11 +5923,9 @@
 /turf/open/floor/mainship,
 /area/lv759/indoors/spaceport/horizon_runner)
 "bcr" = (
-/obj/structure/prop/urban/signs/high_voltage{
-	desc = null
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "bcs" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/asphalt,
@@ -6078,10 +6086,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "bef" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor2,
+/area/lv759/indoors/derelict_ship)
 "beo" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/paper,
@@ -6159,11 +6167,10 @@
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "bfa" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "bff" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 1;
@@ -6569,9 +6576,8 @@
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "biP" = (
 /obj/effect/urban/decal/dirt,
-/obj/effect/spawner/random/misc/structure/large/car,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_office)
 "bja" = (
 /obj/structure/closet,
 /obj/effect/urban/decal/dirt,
@@ -6712,9 +6718,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "bkn" = (
-/obj/effect/ai_node,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/changingroom)
 "bkt" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/orange_edge,
@@ -6900,7 +6905,7 @@
 "bmL" = (
 /obj/structure/sign/safety/blast_door,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/cargo)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "bmO" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7076,9 +7081,11 @@
 /turf/open/floor/urban/tile/beige_bigtile,
 /area/lv759/indoors/power_plant/workers_canteen)
 "boy" = (
-/obj/effect/landmark/xeno_resin_wall,
+/obj/machinery/light/small/blue{
+	dir = 4
+	},
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/caves/east_caves)
 "boB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/structure/lattice/autosmooth,
@@ -7830,7 +7837,7 @@
 /area/lv759/indoors/landing_zone_1/flight_control_room)
 "buV" = (
 /obj/item/stack/rods,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "buW" = (
 /obj/machinery/streetlight/traffic_alt{
@@ -7844,7 +7851,7 @@
 "buY" = (
 /obj/machinery/door/poddoor,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/cargo)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "buZ" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/reagent_containers/glass/bucket{
@@ -7917,11 +7924,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/meridian/meridian_factory)
-"bvE" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cable,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "bvJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -8301,10 +8303,6 @@
 	},
 /turf/open/floor/wood/variable,
 /area/lv759/indoors/jacks_surplus)
-"bzq" = (
-/obj/structure/rock/dark/large,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
 "bzA" = (
 /obj/machinery/floodlight{
 	layer = 4;
@@ -8463,18 +8461,11 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/colonial_marshals/hallway_north)
 "bBa" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8;
-	layer = 3.3
-	},
-/obj/effect/landmark/weed_node,
+/obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/indoors/caves/north_west_caves)
 "bBe" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -8514,6 +8505,9 @@
 /obj/structure/window/framed/urban,
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/kitchen)
+"bBO" = (
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/south_west_caves)
 "bBS" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 7
@@ -8890,6 +8884,13 @@
 	dir = 10
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
+"bFv" = (
+/obj/effect/urban/decal/grate{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "bFC" = (
 /obj/effect/urban/decal/tiretrack{
 	dir = 6;
@@ -9255,17 +9256,12 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "bIp" = (
-/obj/structure/rock/dark/small{
-	layer = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
 	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/south_east_street)
-"bIu" = (
-/obj/structure/prop/urban/misc/machinery/screens/multimonitormedium_off{
-	dir = 1
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/engineering)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "bIz" = (
 /obj/structure/platform/mineral{
 	dir = 1
@@ -9282,9 +9278,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
-"bIG" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/nt_security/checkpoint_northwest)
 "bIJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/interior_wall,
@@ -9432,11 +9425,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
-"bJQ" = (
-/obj/structure/rock/dark/stalagmite/five,
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
 "bJR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -10164,7 +10152,6 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/power_plant/geothermal_generators)
 "bRk" = (
-/obj/structure/platform_decoration/urban/rockdark,
 /obj/item/trash/trashbag{
 	pixel_x = 2;
 	pixel_y = 20
@@ -11711,15 +11698,6 @@
 	},
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"cdy" = (
-/obj/structure/window/framed/urban/colony{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
 "cdC" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/spawner/random/misc/structure/large/car{
@@ -11833,11 +11811,9 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/mining_outpost/processing)
 "cfi" = (
-/obj/structure/ore_box{
-	layer = 2
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/rock/dark/large,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "cfj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	pixel_y = -1
@@ -12812,9 +12788,6 @@
 	},
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
-"coE" = (
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/indoors/southwest_public_restroom)
 "coH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -12925,6 +12898,10 @@
 	},
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/jacks_surplus)
+"cpp" = (
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/nt_research_complex_entrance)
 "cpq" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -13273,9 +13250,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
 "crS" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -13708,9 +13682,10 @@
 	},
 /area/lv759/indoors/caves/north_west_caves)
 "cwm" = (
-/obj/structure/rock/dark/stalagmite/four,
+/obj/item/stack/rods,
+/obj/item/tool/shovel,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
+/area/lv759/indoors/caves/central_caves)
 "cwn" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic{
@@ -13915,6 +13890,7 @@
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/caveplateau)
 "czf" = (
@@ -14647,6 +14623,9 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/northeast)
+"cFA" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/east)
 "cFD" = (
 /obj/item/stack/sheet/wood,
 /obj/item/stack/sheet/cardboard{
@@ -15078,13 +15057,8 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/north_west_caves)
 "cJt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/north_caves)
-"cJw" = (
-/obj/structure/rock/dark/wide/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/southwest_public_restroom)
 "cJD" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/shard,
@@ -15312,18 +15286,9 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"cMe" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/caveplateau)
 "cMi" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/north_caves)
 "cMj" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15802,6 +15767,10 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"cQl" = (
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "cQr" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16064,7 +16033,7 @@
 /area/lv759/indoors/caves/north_west_caves)
 "cSw" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/rock/dark/small/three,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "cSI" = (
@@ -16240,6 +16209,10 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
+"cTN" = (
+/obj/structure/cargo_container/gorg,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "cTO" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16386,10 +16359,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
-"cUS" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
 "cUV" = (
 /obj/structure/bed/urban/chairs/black,
 /obj/effect/landmark/weed_node,
@@ -17240,10 +17209,12 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "dce" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor2,
-/area/lv759/indoors/derelict_ship)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab";
+	dir = 4
+	},
+/turf/open/floor/urban/metal/zbrownfloor_full,
+/area/lv759/indoors/meridian/meridian_factory)
 "dcg" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17260,6 +17231,13 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
+"dci" = (
+/obj/effect/urban/decal/grate{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "dck" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/urban/tile/tilegreen,
@@ -17459,9 +17437,11 @@
 	},
 /area/lv759/indoors/hospital/emergency_room)
 "ddR" = (
-/obj/item/inflatable/wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
+	},
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "ddZ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -18102,10 +18082,6 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"djY" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "dkb" = (
 /obj/item/reagent_containers/food/snacks/muffin,
 /obj/structure/table/reinforced/prison{
@@ -18490,12 +18466,12 @@
 	},
 /area/lv759/indoors/spaceport/heavyequip)
 "dnq" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/nt_research_complex_entrance)
 "dnu" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 1
@@ -18667,8 +18643,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/landing_zone_1)
 "dpm" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/landing_zone_2)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "dpq" = (
 /obj/structure/rock/dark/large{
 	layer = 4
@@ -19366,6 +19343,16 @@
 	},
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
+"dvq" = (
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
+"dvt" = (
+/obj/structure/largecrate/random/barrel/red{
+	layer = 4
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "dvu" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -19867,11 +19854,6 @@
 	},
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_1)
-"dBc" = (
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/indoors/nt_research_complex/xenobiology)
 "dBd" = (
 /obj/effect/urban/decal/trash,
 /turf/open/floor/urban/carpet/carpetbeigedeco,
@@ -20202,11 +20184,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "dDI" = (
-/obj/structure/largecrate/random/barrel/red{
-	layer = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/east_caves)
 "dDP" = (
 /obj/structure/bed/urban/bunkbed2,
 /turf/open/floor/urban/wood/redwood,
@@ -20321,7 +20301,7 @@
 	light_range = 2
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/engineering)
+/area/lv759/indoors/spaceport/security)
 "dFk" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light/blue{
@@ -20775,9 +20755,9 @@
 	},
 /area/lv759/indoors/caves/north_caves)
 "dKa" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/machinery/light/small/blue,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/area/lv759/indoors/caves/north_east_caves)
 "dKc" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -20993,6 +20973,13 @@
 	dir = 8
 	},
 /area/lv759/indoors/hospital/central_hallway)
+"dLQ" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/central_caves)
 "dLS" = (
 /obj/machinery/door/airlock/vault,
 /obj/structure/cable,
@@ -21049,9 +21036,9 @@
 /turf/open/floor/urban/carpet/carpetbluedeco,
 /area/lv759/indoors/colonial_marshals/north_office)
 "dMr" = (
-/obj/structure/rock/dark/large/three,
+/obj/machinery/floodlight,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/outdoors/caveplateau)
 "dMA" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 1
@@ -21198,10 +21185,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/janitor)
 "dNK" = (
-/obj/structure/platform_decoration/urban/engineer_corner,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/hallwayeast)
 "dNO" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -21361,10 +21346,8 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/hospital/icu)
 "dPb" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_caves)
 "dPk" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -21423,11 +21406,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "dPQ" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -9;
-	pixel_y = 20
-	},
-/turf/open/urbanshale/layer1,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "dQd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -21713,13 +21693,6 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/mining_outpost/northeast)
-"dSH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/west_caves)
 "dSL" = (
 /obj/structure/platform_decoration/shiva{
 	dir = 1
@@ -21782,6 +21755,9 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
+"dTb" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/hobosecret)
 "dTf" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison{
@@ -22056,15 +22032,11 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "dVA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = 1;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/meridian/meridian_office)
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "dVE" = (
 /obj/structure/stairs/seamless/edge{
 	color = "#a6aeab";
@@ -22497,9 +22469,6 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "eay" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
@@ -22887,11 +22856,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "eeq" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/effect/acid_hole,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_research_complex/changingroom)
 "eer" = (
 /obj/structure/largecrate/random/barrel/white{
 	layer = 2
@@ -22921,10 +22888,6 @@
 	dir = 10
 	},
 /area/lv759/indoors/spaceport/cargo)
-"eeA" = (
-/obj/machinery/door/poddoor,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/docking_bay_1)
 "eeE" = (
 /obj/structure/prop/mainship/sensor_computer2/black,
 /turf/open/floor/prison/cellstripe{
@@ -23340,6 +23303,9 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/garage)
+"eiw" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_showroom)
 "eiB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -23415,6 +23381,9 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
+"eja" = (
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "ejc" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -24426,9 +24395,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "ert" = (
-/obj/effect/landmark/weed_node,
+/obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/outdoors/caveplateau)
 "erF" = (
 /obj/item/stool{
 	pixel_x = -4;
@@ -24734,10 +24703,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/colonial_marshals/hallway_south)
-"eue" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
 "eug" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/trash/green,
@@ -24838,6 +24803,14 @@
 	},
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/press_room)
+"euT" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/multi_tiles{
+	dir = 8
+	},
+/area/lv759/indoors/spaceport/docking_bay_2)
 "euU" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/rack,
@@ -25515,7 +25488,7 @@
 /area/lv759/outdoors/landing_zone_2)
 "eCq" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "eCw" = (
 /obj/structure/barricade/handrail/medical{
@@ -25768,9 +25741,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/north)
 "eEq" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/west_caves)
 "eEw" = (
 /obj/structure/prop/urban/signs/high_voltage{
 	desc = null
@@ -26048,7 +26020,7 @@
 	},
 /area/lv759/indoors/hospital/reception)
 "eGB" = (
-/obj/structure/rock/dark/small,
+/obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "eGN" = (
@@ -26257,8 +26229,9 @@
 /turf/open/floor/redone,
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "eIP" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/mining_outpost/vehicledeployment)
+/obj/effect/urban/decal/dirt,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/east_caves)
 "eIU" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/logo_wall/four,
@@ -26302,10 +26275,6 @@
 "eJo" = (
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
-"eJp" = (
-/obj/structure/rock/dark/stalagmite/one,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
 "eJv" = (
 /obj/item/reagent_containers/food/drinks/bottle/tomatojuice{
 	pixel_x = 5;
@@ -26719,10 +26688,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/eastbedrooms)
-"eNf" = (
-/obj/structure/prop/urban/containersextended/blackwyleft,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
 "eNg" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/urban/street/sidewalk,
@@ -26826,6 +26791,10 @@
 	dir = 4
 	},
 /area/lv759/indoors/power_plant/fusion_generators)
+"eOw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/lv759/indoors/caves/central_caves)
 "eOy" = (
 /obj/structure/closet/bombclosetsecurity,
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
@@ -27322,9 +27291,11 @@
 	},
 /area/lv759/indoors/spaceport/starglider)
 "eSb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/south_west_caves)
 "eSo" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -27455,6 +27426,13 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
+"eTx" = (
+/obj/item/clothing/head/warning_cone{
+	pixel_x = -9;
+	pixel_y = 20
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "eTB" = (
 /obj/structure/largecrate/random/barrel/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -27465,11 +27443,9 @@
 	},
 /area/lv759/indoors/power_plant)
 "eTF" = (
-/obj/machinery/light/small/blue{
-	dir = 1
-	},
+/obj/structure/rock/dark/stalagmite/four,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/outdoors/landing_zone_2)
 "eTN" = (
 /obj/structure/prop/urban/signs/high_voltage/small,
 /obj/structure/prop/urban/signs/high_voltage/small,
@@ -28112,9 +28088,9 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "faB" = (
-/obj/structure/girder,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/acid_hole,
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/outdoors/colony_streets/central_streets)
 "faC" = (
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/structure/cable,
@@ -28243,12 +28219,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
-"fbG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/closed/wall/urban/colony,
-/area/lv759/indoors/south_public_restroom)
 "fbM" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/signs/high_voltage/small,
@@ -29283,8 +29253,15 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "fkr" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/nt_research_complex/hallwayeast)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	pixel_y = -1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "fkw" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -29421,9 +29398,8 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/electical_systems/substation2)
 "flR" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/outdoors/colony_streets/central_streets)
 "flS" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -29462,6 +29438,11 @@
 /obj/effect/urban/decal/dirt,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
+"fmk" = (
+/obj/effect/urban/decal/road/lines2,
+/obj/effect/urban/decal/road/road_edge/four,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "fmx" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/item/stack/rods{
@@ -30306,9 +30287,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/colonial_marshals/hallway_north_locker)
-"ftl" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/NTmart)
 "ftr" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -30398,13 +30376,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_security)
-"fuq" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "fur" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -31052,12 +31023,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetblue,
 /area/lv759/indoors/hospital/virology)
-"fAu" = (
-/obj/structure/prop/urban/signs/high_voltage{
-	desc = null
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/electical_systems/substation1)
 "fAv" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/tool/kitchen/tray{
@@ -31448,10 +31413,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"fDJ" = (
-/obj/structure/rock/dark/large/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
 "fDT" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
@@ -32123,7 +32084,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/caves/west_caves)
 "fJn" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/prison/cellstripe{
@@ -32261,6 +32222,10 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
+"fKs" = (
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "fKx" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -32382,6 +32347,10 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/south_public_restroom)
+"fLw" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "fLz" = (
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -32797,7 +32766,7 @@
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 1
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "fPh" = (
 /obj/effect/urban/decal/dirt,
@@ -32982,14 +32951,6 @@
 	},
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/spaceport/heavyequip)
-"fQy" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
 "fQB" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/prop/urban/containersextended/whitewyleft,
@@ -33053,6 +33014,11 @@
 	dir = 1
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
+"fQM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "fQP" = (
 /obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
@@ -33097,10 +33063,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
-"fRu" = (
-/obj/structure/xeno/tunnel,
-/turf/open/engineership/engineer_floor2,
-/area/lv759/indoors/derelict_ship)
 "fRv" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -33159,13 +33121,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
-"fRT" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+"fRU" = (
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "fRW" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/structure/cable,
@@ -33440,8 +33399,11 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
 "fUG" = (
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/obj/machinery/light/small/blue{
+	dir = 1
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "fUI" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/urban,
@@ -33913,9 +33875,12 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/landing_zone_2)
 "fYW" = (
-/obj/structure/rock/dark/large/two,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate{
+	dir = 1
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "fYX" = (
 /obj/machinery/vending/cola{
 	pixel_y = 16
@@ -34840,12 +34805,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/colonial_marshals/armory_foyer)
-"ggP" = (
-/obj/structure/prop/urban/signs/high_voltage{
-	desc = null
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/north_west_caves)
 "ggS" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -35574,9 +35533,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
-"gmP" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/central_caves)
 "gmT" = (
 /obj/structure/sign/poster,
 /obj/structure/sign/poster{
@@ -35784,10 +35740,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
-"goC" = (
-/obj/effect/spawner/random/misc/structure/girder,
-/turf/open/floor/plating,
-/area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "goD" = (
 /obj/structure/table/reinforced/prison,
 /obj/structure/window/reinforced/toughened,
@@ -36194,9 +36146,9 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/mining_outpost/east_command)
 "grJ" = (
-/obj/structure/largecrate/random/barrel/brown,
+/obj/structure/rock/dark/stalagmite/four,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/caves/west_caves)
 "grK" = (
 /obj/structure/stairs{
 	color = "#a6aeab"
@@ -36216,10 +36168,6 @@
 	},
 /turf/open/floor/floorthree,
 /area/lv759/indoors/nt_research_complex/mainlabs)
-"gse" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/south_west_caves)
 "gsj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -36781,7 +36729,7 @@
 /area/lv759/outdoors/colony_streets/north_west_street)
 "gxw" = (
 /obj/item/stack/rods,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "gxx" = (
 /obj/structure/prop/urban/misc/fake/pipes/pipe1,
@@ -37393,9 +37341,8 @@
 /turf/open/floor/prison/kitchen,
 /area/lv759/indoors/spaceport/kitchen)
 "gCY" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/mining_outpost/northeast)
 "gDf" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -38393,6 +38340,10 @@
 /obj/structure/platform/urban/metalplatform2,
 /turf/closed/wall/urban/colony,
 /area/lv759/outdoors/colony_streets/central_streets)
+"gOl" = (
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "gOo" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -38462,9 +38413,8 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "gOR" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/engineership/engineer_floor2,
-/area/lv759/indoors/derelict_ship)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/mining_outpost/northeast)
 "gPc" = (
 /turf/open/floor/urban/metal/stripe_red{
 	dir = 4
@@ -38487,8 +38437,9 @@
 /turf/open/floor/urban/carpet/carpetred,
 /area/lv759/indoors/casino)
 "gPk" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "gPp" = (
 /obj/item/reagent_containers/glass/rag{
 	desc = "A pile of clothing, these need washing...";
@@ -38799,12 +38750,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_research_complex/cafeteria)
-"gSz" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
 "gSE" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -38938,13 +38883,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"gUa" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "gUe" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
@@ -39540,9 +39478,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/landing_zone_2)
 "gZK" = (
-/obj/structure/cable,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/landing_zone_1)
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "gZQ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -39758,12 +39696,8 @@
 	},
 /area/lv759/indoors/hospital/icu)
 "hbu" = (
-/obj/effect/urban/decal/grate{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_security/checkpoint_west)
 "hbz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -39813,6 +39747,14 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
+"hbN" = (
+/obj/effect/urban/decal/dirt,
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/urban/metal/stripe_red{
+	dir = 1
+	},
+/area/lv759/outdoors/colony_streets/north_west_street)
 "hbR" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/excavation_site_spawner,
@@ -39945,6 +39887,10 @@
 	},
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
+"hcF" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "hcG" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -40709,11 +40655,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/power_plant/south_hallway)
-"hjq" = (
-/turf/open/floor/prison/ramptop{
-	dir = 8
-	},
-/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "hjr" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalkfull,
@@ -40977,6 +40918,9 @@
 "hlx" = (
 /turf/open/floor/urban/metal/bluemetal1,
 /area/lv759/indoors/spaceport/flight_control_room)
+"hly" = (
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/landing_zone_2)
 "hlA" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -41191,13 +41135,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "hnn" = (
-/obj/structure/platform_decoration/urban/engineer_corner,
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/derelict_ship)
+/obj/structure/prop/urban/containersextended/blackwyleft,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "hno" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/lines1,
@@ -41357,9 +41297,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "hoK" = (
-/obj/structure/grille,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/urban/decal/grate{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "hoM" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
@@ -41986,13 +41929,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"htG" = (
-/obj/effect/spawner/random/engineering/metal,
-/obj/item/tool/shovel{
-	pixel_y = 12
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
 "htH" = (
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/lines2,
@@ -42049,9 +41985,6 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "huh" = (
 /obj/effect/landmark/start/job/xenomorph,
-/obj/effect/urban/decal/grate{
-	dir = 1
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
@@ -42159,9 +42092,6 @@
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"hvd" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/jacks_surplus)
 "hvj" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/faxmachine,
@@ -42506,13 +42436,6 @@
 /turf/open/floor/prison/red,
 /area/lv759/indoors/colonial_marshals/press_room)
 "hyn" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
 /obj/effect/urban/decal/dirt,
 /obj/item/weapon/broken_bottle,
 /obj/item/shard,
@@ -43136,14 +43059,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/botany/botany_mainroom)
-"hDF" = (
-/obj/effect/urban/decal/grate{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
 "hDK" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -43208,6 +43123,10 @@
 	},
 /turf/open/floor/urban/wood/redwood,
 /area/lv759/indoors/nt_office/floor)
+"hEn" = (
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "hEq" = (
 /obj/item/storage/briefcase,
 /obj/structure/largecrate/random/case/small{
@@ -43617,8 +43536,7 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsfoyer)
 "hIq" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "hIt" = (
 /obj/structure/stairs/seamless{
@@ -43662,6 +43580,14 @@
 	dir = 1
 	},
 /area/lv759/outdoors/landing_zone_2)
+"hIJ" = (
+/obj/item/clothing/head/warning_cone{
+	pixel_x = -9;
+	pixel_y = 20
+	},
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "hIN" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 4
@@ -44113,11 +44039,12 @@
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/power_plant/south_hallway)
 "hMK" = (
-/obj/effect/urban/decal/grate{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab";
+	dir = 4
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "hMP" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/closet/crate/trashcart,
@@ -44205,9 +44132,9 @@
 /turf/open/floor/urban/tile/asteroidfloor_bigtile,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "hNC" = (
-/obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/effect/acid_hole,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/garage_workshop_storage)
 "hND" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -44216,8 +44143,9 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office/supervisor)
 "hNF" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/meridian/meridian_showroom)
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "hNG" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "autoname"
@@ -44681,6 +44609,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner,
 /area/lv759/indoors/colonial_marshals/armory)
+"hRC" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "hRD" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard2{
@@ -45239,9 +45174,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "hXu" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/central_caves)
 "hXz" = (
 /obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
@@ -45368,6 +45302,9 @@
 "hYt" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/eastfoyer)
+"hYz" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/central_streets)
 "hYD" = (
 /obj/structure/largecrate/random/mini/small_case,
 /obj/machinery/light/spot/blue{
@@ -45449,8 +45386,8 @@
 	dir = 8
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "hZe" = (
 /obj/item/device/flashlight/lamp/tripod/grey,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45752,15 +45689,6 @@
 	dir = 10
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
-"ice" = (
-/obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor13{
-	dir = 10
-	},
-/area/lv759/indoors/derelict_ship)
 "icf" = (
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/landmark/weed_node,
@@ -45784,9 +45712,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "icp" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "icq" = (
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/landing_zone_2)
@@ -45985,6 +45913,9 @@
 /obj/structure/cable,
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/mining_outpost/processing)
+"ieq" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart/maintenance)
 "ieu" = (
 /obj/machinery/conveyor_switch{
 	id = "cargo_storage"
@@ -46244,10 +46175,6 @@
 /obj/structure/prop/urban/misc/floorprops/grate,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"igF" = (
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
 "igG" = (
 /obj/machinery/light{
 	dir = 8
@@ -46465,8 +46392,10 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/colonial_marshals/armory_firingrange)
 "iiF" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/item/clothing/mask/facehugger/dead,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_west_caves)
 "iiI" = (
 /obj/machinery/door/poddoor/shutters/urban/biohazard/white{
 	dir = 2
@@ -46727,6 +46656,10 @@
 	},
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
+"ilr" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "ils" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/structure/barricade/handrail/urban/road/plastic/blue{
@@ -46835,12 +46768,8 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "imu" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/north_west_caves)
 "imz" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/xeno_resin_wall,
@@ -47502,9 +47431,6 @@
 "isw" = (
 /turf/open/floor/prison,
 /area/lv759/indoors/hospital/pharmacy)
-"isz" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "isB" = (
 /obj/structure/largecrate/random/mini/small_case,
 /obj/effect/ai_node,
@@ -47634,6 +47560,10 @@
 	},
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/supervisor)
+"itR" = (
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "itS" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/storage/box/lightstick/red{
@@ -47675,9 +47605,8 @@
 /turf/open/floor/urban/metal/zbrownfloor1,
 /area/lv759/indoors/meridian/meridian_office)
 "iub" = (
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/jacks_surplus)
 "iug" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
@@ -47911,9 +47840,10 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "iwx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/urban/decal/dirt,
+/obj/effect/spawner/random/misc/structure/large/car,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/colony_streets/north_street)
 "iwy" = (
 /obj/structure/window/framed/urban/reinforced,
 /obj/structure/curtain/temple{
@@ -47931,11 +47861,9 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "iwK" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/cable,
+/turf/open/urban/street/cement1,
+/area/lv759/outdoors/landing_zone_1)
 "iwO" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -47964,6 +47892,10 @@
 /obj/item/trash/cigbutt,
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
+"ixj" = (
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/nt_research_complex_entrance)
 "ixm" = (
 /obj/structure/disposalpipe/tagger{
 	dir = 4
@@ -48257,6 +48189,12 @@
 "izK" = (
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/landing_zone_1)
+"izL" = (
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "izN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1
@@ -48330,10 +48268,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
-"iAz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/landing_zone_2)
 "iAA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/ammo_casing/bullet,
@@ -48432,8 +48366,11 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/hallwaycentral)
 "iBn" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance)
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "iBq" = (
 /obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
@@ -48518,10 +48455,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/meridian/meridian_showroom)
 "iCB" = (
-/obj/structure/prop/urban/signs/high_voltage{
-	desc = null
-	},
-/turf/closed/wall/r_wall/urban,
+/obj/structure/rock/dark/stalagmite/four,
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "iCD" = (
 /obj/effect/urban/decal/dirt,
@@ -48723,9 +48659,10 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "iEH" = (
-/obj/structure/sign/poster,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/hobosecret)
+/obj/item/stack/rods,
+/obj/structure/grille,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "iEN" = (
 /obj/machinery/light/small/blue{
 	dir = 1
@@ -49007,12 +48944,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/landing_zone_2)
 "iHj" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor4,
+/area/lv759/indoors/derelict_ship)
 "iHr" = (
 /obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer1,
@@ -49172,9 +49106,10 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/hospital/medical_storage)
 "iJa" = (
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "iJb" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -49467,11 +49402,11 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "iLK" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
 	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "iLP" = (
 /obj/machinery/shower{
 	dir = 8
@@ -50073,12 +50008,10 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "iQQ" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/urban/decal/dirt,
+/obj/structure/cable,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "iQV" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -50177,7 +50110,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison{
 	dir = 10
 	},
@@ -51105,6 +51037,12 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/power_plant)
+"iZP" = (
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/electical_systems/substation1)
 "iZT" = (
 /obj/structure/prop/urban/xenobiology/small/hugger,
 /turf/open/floor/podhatch/floor,
@@ -51255,13 +51193,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/north_street)
-"jbk" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/nt_research_complex_entrance)
 "jbn" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -51404,10 +51335,6 @@
 	},
 /turf/open/urban/dropship/dropship4,
 /area/lv759/indoors/spaceport/horizon_runner)
-"jcw" = (
-/obj/structure/rock/dark/large/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
 "jcE" = (
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westentertainment)
@@ -51425,11 +51352,8 @@
 	},
 /area/lv759/outdoors/north_west_caves_outdoors)
 "jcQ" = (
-/obj/machinery/light/small/blue{
-	dir = 4
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/landing_zone_1)
 "jcS" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/urban/colony,
@@ -51763,6 +51687,10 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
+"jeZ" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "jfb" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic{
@@ -51778,7 +51706,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/east_caves)
 "jff" = (
 /obj/structure/sign/safety/medical_supplies,
 /turf/closed/wall/r_wall/white_research_wall,
@@ -52098,9 +52026,9 @@
 	},
 /area/lv759/indoors/hospital/medical_storage)
 "jib" = (
-/obj/structure/sign/safety/airlock,
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/indoors/colonial_marshals/south_maintenance)
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "jif" = (
 /obj/structure/prop/mainship/gelida/barrier,
 /obj/machinery/light{
@@ -52348,7 +52276,9 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/colonial_marshals/hallway_north)
 "jjV" = (
-/turf/open/urbanshale/layer0_plate,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "jjY" = (
 /obj/machinery/vending/coffee,
@@ -52502,6 +52432,12 @@
 	},
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
+"jkX" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "jlb" = (
 /turf/open/urban/street/sidewalk{
 	dir = 1
@@ -52857,6 +52793,12 @@
 	dir = 8
 	},
 /area/lv759/indoors/colonial_marshals/wardens_office)
+"jom" = (
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 8
+	},
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "joy" = (
 /obj/machinery/floodlight{
 	layer = 5
@@ -53363,6 +53305,10 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
+"jsY" = (
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "jsZ" = (
 /obj/structure/barricade/handrail/urban/handrail{
 	dir = 1
@@ -53392,8 +53338,12 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "jtv" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/mining_outpost/northeast)
+/area/lv759/outdoors/caveplateau)
 "jtw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -54197,10 +54147,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/colonial_marshals/reception)
-"jAm" = (
-/obj/structure/xeno/tunnel,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "jAq" = (
 /obj/machinery/landinglight/lz2{
 	dir = 1
@@ -54510,7 +54456,7 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "jDH" = (
-/obj/structure/rock/dark/stalagmite/two,
+/obj/structure/prop/urban/containersextended/blackwyright,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "jDI" = (
@@ -54553,9 +54499,11 @@
 /turf/open/floor/urban/tile/asteroidfloor_bigtile,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "jEj" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/central_caves)
 "jEm" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 8;
@@ -54675,13 +54623,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "jFE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor4,
-/area/lv759/indoors/derelict_ship)
-"jFU" = (
-/obj/structure/rock/dark/wide/two,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/wall/urban/colony/ribbed,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "jGb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -55337,9 +55280,12 @@
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "jMi" = (
-/obj/machinery/light/small/blue,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/central_caves)
 "jMk" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/effect/decal/cleanable/blood,
@@ -55958,10 +55904,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"jSn" = (
-/obj/structure/rock/dark/stalagmite,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
 "jSq" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red{
 	dir = 4
@@ -56211,12 +56153,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "jUH" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_research_complex/mainlabs)
 "jUJ" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -56274,11 +56212,6 @@
 	},
 /turf/open/floor/urban/wood/redwood,
 /area/lv759/indoors/nt_office/floor)
-"jVy" = (
-/obj/structure/rock/dark/small,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
 "jVG" = (
 /obj/structure/bed/stool,
 /obj/effect/ai_node,
@@ -56340,14 +56273,6 @@
 	},
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
-"jWi" = (
-/obj/structure/prop/mainship/gelida/smallwire,
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "jWk" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/medical_decals/triage/bottom,
@@ -56447,9 +56372,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/indoors/garage_workshop_storage)
-"jWQ" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "jWU" = (
 /obj/effect/ai_node,
 /turf/open/urban/street/cement3,
@@ -56652,6 +56574,10 @@
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/kutjevo/colors/orange,
 /area/lv759/indoors/spaceport/docking_bay_1)
+"jYA" = (
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "jYB" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -57140,8 +57066,9 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "kcZ" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "kda" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/urbanshale/layer1,
@@ -57264,6 +57191,11 @@
 	dir = 8
 	},
 /area/lv759/indoors/hospital/emergency_room)
+"keo" = (
+/obj/structure/rock/dark/large,
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "key" = (
 /obj/machinery/streetlight/street{
 	level = 7;
@@ -57911,12 +57843,6 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
-"kkG" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
 "kkI" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/landmark/weed_node,
@@ -58010,6 +57936,8 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "klV" = (
 /obj/effect/urban/decal/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "klX" = (
@@ -58220,6 +58148,12 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_research_complex/mainlabs)
+"kog" = (
+/obj/effect/urban/decal/grate{
+	dir = 1
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "koh" = (
 /obj/structure/sign/safety/vent{
 	desc = "Semiotic Standard denoting the nearby presence of a weapon research lab.";
@@ -58306,13 +58240,6 @@
 	},
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/central_streets)
-"koX" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
 "koZ" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -58924,12 +58851,6 @@
 /obj/machinery/light/small/blue,
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/fusion_generators)
-"kva" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/south_west_caves)
 "kvd" = (
 /obj/item/paper/crumpled,
 /obj/machinery/light{
@@ -59122,6 +59043,10 @@
 /obj/structure/prop/urban/containersextended/whitewyright,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
+"kwO" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "kwP" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/sheet/cardboard{
@@ -59146,8 +59071,13 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "kwZ" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/landing_zone_1)
+/obj/structure/prop/mainship/gelida/smallwire,
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "kxb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60014,11 +59944,9 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "kEQ" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/outdoors/caveplateau)
+/obj/effect/urban/decal/dirt,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_showroom)
 "kFb" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/iv_drip,
@@ -60135,13 +60063,9 @@
 	},
 /area/lv759/indoors/hospital/reception)
 "kGb" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -9;
-	pixel_y = 20
-	},
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/east_caves)
 "kGd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/tile/supermartfloor2,
@@ -60988,8 +60912,15 @@
 	},
 /area/lv759/indoors/caves/central_caves)
 "kOC" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/west_caves)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/lv759/indoors/meridian/meridian_office)
 "kOG" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 8;
@@ -61041,9 +60972,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/recycling_plant/garage)
-"kPk" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/NTmart/backrooms)
 "kPn" = (
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/urban/decal/road/lines1,
@@ -61241,9 +61169,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/electical_systems/substation1)
-"kQM" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/nt_research_complex/dormsbedroom)
 "kQU" = (
 /obj/machinery/space_heater/radiator/red{
 	dir = 8
@@ -61304,13 +61229,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "kRm" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/urban/metal/stripe_red{
-	dir = 1
-	},
-/area/lv759/outdoors/colony_streets/north_west_street)
+/obj/structure/sign/safety/airlock,
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/colonial_marshals/south_maintenance)
 "kRv" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
@@ -61884,6 +61805,9 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/logo_wall/two,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
+"kWj" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_security/checkpoint_northwest)
 "kWm" = (
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 4
@@ -62697,7 +62621,7 @@
 /area/lv759/indoors/apartment/northfoyer)
 "ldK" = (
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/electical_systems/substation2)
+/area/lv759/indoors/caves/east_caves)
 "ldQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62728,10 +62652,6 @@
 	},
 /turf/closed/wall/r_wall/engineership,
 /area/lv759/indoors/derelict_ship)
-"ldZ" = (
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "leb" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -63169,7 +63089,7 @@
 /area/lv759/indoors/power_plant/telecomms)
 "lhZ" = (
 /turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/electical_systems/substation2)
+/area/lv759/indoors/nt_research_complex_entrance)
 "lie" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/r_wall/urban,
@@ -63235,9 +63155,12 @@
 	},
 /area/lv759/indoors/nt_office/pressroom)
 "liu" = (
-/obj/structure/sign/safety/blast_door,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "liy" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/urban,
@@ -63334,9 +63257,6 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/mining_outpost/north_maint)
 "ljm" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
@@ -63711,12 +63631,8 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/apartment/eastrestroomsshower)
 "lmj" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/urban/metal/stripe_red{
-	dir = 1
-	},
-/area/lv759/outdoors/colony_streets/north_west_street)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "lmn" = (
 /obj/structure/ore_box,
 /turf/open/urban/street/cement3,
@@ -64284,12 +64200,9 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "lsv" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/urban/decal/grate{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "lsw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/platform_decoration/mineral{
@@ -64773,15 +64686,14 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "lwO" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 1
-	},
-/obj/structure/prop/mainship/gelida/smallwire{
+/obj/effect/urban/decal/dirt,
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/floor/multi_tiles{
+	dir = 8
+	},
+/area/lv759/indoors/spaceport/docking_bay_1)
 "lwQ" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -65126,10 +65038,13 @@
 /obj/structure/window/framed/urban/reinforced,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
+"lAB" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "lAC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/urban/decal/grate,
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "lAP" = (
 /obj/item/stack/sheet/cardboard{
@@ -65351,10 +65266,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "lCQ" = (
-/obj/structure/rock/dark/large,
-/obj/structure/rock/dark/small/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/large/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "lCS" = (
 /obj/effect/landmark/nuke_spawn,
 /turf/open/ground/sandrock,
@@ -65445,13 +65359,6 @@
 	},
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/central_streets)
-"lDN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/south_west_caves)
 "lDQ" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/doubleroad/lines3{
@@ -66309,13 +66216,6 @@
 "lLk" = (
 /turf/open/floor/urban/carpet/carpetreddeco,
 /area/lv759/indoors/casino)
-"lLm" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "lLo" = (
 /turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/north_west_caves)
@@ -67225,11 +67125,6 @@
 	},
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/hallway_north)
-"lSp" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
 "lSt" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison/darkyellow{
@@ -67855,10 +67750,9 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/power_plant)
 "lXN" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/prop/mainship/gelida/smallwire,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "lXU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -67950,10 +67844,8 @@
 	},
 /area/lv759/indoors/hospital/virology)
 "lYR" = (
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor8{
-	dir = 4
-	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/engineership/engineer_floor2,
 /area/lv759/indoors/derelict_ship)
 "lYU" = (
 /obj/structure/table/mainship,
@@ -68125,9 +68017,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/westhallway)
-"mai" = (
-/turf/closed/wall/urban/colony/ribbed,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "man" = (
 /obj/structure/prop/urban/containersextended/redright,
 /turf/open/urban/street/sidewalk{
@@ -68728,12 +68617,6 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"mgn" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "mgr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/cellstripe{
@@ -70008,11 +69891,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/spaceport/baggagehandling)
-"mqJ" = (
-/obj/item/stack/rods,
-/obj/item/tool/shovel,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "mqQ" = (
 /obj/effect/urban/decal/trash/two{
 	pixel_y = 12
@@ -70240,6 +70118,9 @@
 /obj/machinery/light,
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
+"msJ" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/electical_systems/substation1)
 "msK" = (
 /obj/structure/bed/chair{
 	pixel_x = 3;
@@ -70277,10 +70158,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
-"mta" = (
-/obj/structure/girder,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
 "mtd" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/fake/wire/red{
@@ -70361,9 +70238,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mtM" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
 /obj/structure/rock/dark/small{
 	layer = 4
 	},
@@ -71027,6 +70901,12 @@
 /obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
+"mzJ" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/indoors/nt_research_complex_entrance)
 "mzP" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -71527,12 +71407,14 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "mED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
 	},
-/obj/effect/landmark/xeno_resin_wall,
+/obj/structure/closet/crate/miningcar{
+	layer = 3
+	},
 /turf/open/ground/sandrock,
-/area/lv759/indoors/caves/south_west_caves)
+/area/lv759/indoors/caves/east_caves)
 "mEE" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalk{
@@ -71891,13 +71773,11 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mIe" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/prop/urban/vehicles/large/colonycrawlers/mining{
+	layer = 4
 	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_2)
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "mIg" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 4;
@@ -71942,8 +71822,8 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsbedroom)
 "mIs" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/nt_security/checkpoint_west)
+/turf/open/floor/plating,
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "mIH" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/lattice_prop/lattice_6{
@@ -72106,6 +71986,9 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
+"mKv" = (
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "mKx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -72208,6 +72091,10 @@
 /obj/structure/sign/safety/airlock,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
+"mLs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "mLt" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -72403,8 +72290,8 @@
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "mMV" = (
 /obj/structure/girder,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "mMW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -72647,11 +72534,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mOU" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/xeno/tunnel,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "mOV" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt,
@@ -73158,15 +73043,9 @@
 /turf/open/floor/floorthree,
 /area/lv759/indoors/NTmart)
 "mTA" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	pixel_y = -1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "mTE" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/lattice/autosmooth,
@@ -74858,9 +74737,8 @@
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/power_plant/equipment_west)
 "nhc" = (
-/obj/machinery/door/poddoor,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/landing_zone_1)
 "nhe" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office/supervisor)
@@ -75340,9 +75218,9 @@
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "nkS" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/item/inflatable/wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "nkU" = (
 /obj/machinery/space_heater/radiator/red{
 	dir = 4;
@@ -75364,9 +75242,9 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "nlp" = (
-/obj/structure/rock/dark/small/three,
+/obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/north_west_caves)
 "nlr" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/lines2,
@@ -76039,9 +75917,8 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "nqO" = (
-/obj/structure/rock/dark/stalagmite/four,
-/obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "nre" = (
 /obj/structure/barricade/handrail{
@@ -76109,10 +75986,6 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"nrL" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "nrT" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light{
@@ -76950,9 +76823,6 @@
 	dir = 10
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"nyW" = (
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
 "nzd" = (
 /obj/item/clothing/glasses/science{
 	layer = 4
@@ -77338,15 +77208,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/north_west_caves)
-"nCx" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "nCz" = (
 /obj/structure/window/framed/urban/colony/office{
 	dir = 4
@@ -77549,9 +77410,12 @@
 	},
 /area/lv759/indoors/colonial_marshals/changing_room)
 "nEL" = (
-/obj/structure/rock/dark/stalagmite/five,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/obj/effect/urban/decal/grate{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "nER" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red{
 	dir = 1
@@ -77829,6 +77693,18 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
+"nHx" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "nHz" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/engineership/engineer_floor9,
@@ -78456,6 +78332,12 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/caves/north_caves)
+"nNx" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv759/indoors/caves/west_caves)
 "nNz" = (
 /obj/structure/sign/safety/storage,
 /turf/closed/wall/r_wall/urban,
@@ -78473,9 +78355,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/cuppajoes)
-"nNO" = (
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/nt_research_complex_entrance)
 "nNR" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
 	dir = 8
@@ -78791,9 +78670,10 @@
 /turf/open/floor/officesquares,
 /area/lv759/outdoors/colony_streets/central_streets)
 "nQG" = (
-/obj/structure/girder,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "nQI" = (
 /obj/structure/stairs/seamless/edge{
 	color = "#a6aeab";
@@ -78851,13 +78731,17 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "nQX" = (
-/obj/structure/rock/dark/wide/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "nQY" = (
 /obj/machinery/miner/damaged,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
+"nRd" = (
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "nRh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -78984,11 +78868,12 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "nRX" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/urban/decal/grate{
+	dir = 4
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "nSf" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -79081,9 +78966,6 @@
 /obj/effect/urban/decal/road/road_stop/three,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"nSM" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/north_east_caves)
 "nSU" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -79273,6 +79155,11 @@
 /obj/item/trash/cigbutt,
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
+"nUX" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor4,
+/area/lv759/indoors/derelict_ship)
 "nUZ" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_stop/five{
@@ -80190,6 +80077,15 @@
 	dir = 8
 	},
 /area/lv759/outdoors/landing_zone_2)
+"odl" = (
+/obj/structure/closet/crate/miningcar{
+	layer = 3
+	},
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "odp" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -80823,7 +80719,7 @@
 "oiz" = (
 /obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
+/area/lv759/indoors/nt_research_complex_entrance)
 "oiA" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -80911,9 +80807,9 @@
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/bar)
 "ojk" = (
-/obj/structure/rock/dark/small,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/machinery/door/poddoor,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/docking_bay_1)
 "ojn" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -11;
@@ -81173,9 +81069,9 @@
 	},
 /area/lv759/indoors/NTmart)
 "ome" = (
-/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
+/area/lv759/indoors/caves/central_caves)
 "omh" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/window/reinforced/tinted{
@@ -81687,8 +81583,9 @@
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/spaceport/baggagehandling)
 "osL" = (
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/indoors/colonial_marshals/restroom)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "osM" = (
 /turf/open/floor/mainship/research/containment/floor1,
 /area/lv759/indoors/nt_research_complex/xenobiology)
@@ -81767,9 +81664,9 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/northhallway)
 "oty" = (
-/obj/structure/rock/dark/stalagmite/five,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "otA" = (
 /obj/structure/bed/roller,
 /obj/effect/urban/decal/dirt,
@@ -81834,11 +81731,19 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "oua" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
 	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "ouc" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -82249,8 +82154,9 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "oyv" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/southwest_public_restroom)
+/obj/structure/platform_decoration/urban/rockdark,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/south_west_caves)
 "oyx" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -82303,6 +82209,13 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/floor)
+"oyW" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/central_caves)
 "oyX" = (
 /obj/item/radio{
 	pixel_x = -5;
@@ -82711,9 +82624,14 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "oCW" = (
-/obj/effect/acid_hole,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/nt_research_complex/changingroom)
+/obj/structure/window/framed/urban/colony{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv759/indoors/caves/central_caves)
 "oCX" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/closet/firecloset,
@@ -83636,8 +83554,8 @@
 	},
 /area/lv759/indoors/hospital/virology)
 "oKL" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/mining_outpost/northeast)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_east_caves)
 "oKM" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -85324,7 +85242,6 @@
 	},
 /area/lv759/indoors/spaceport/hallway_east)
 "pcs" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
 /obj/item/stack/sheet/cardboard,
 /obj/structure/bed/bedroll{
 	dir = 9
@@ -85449,10 +85366,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "pdr" = (
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/xeno/tunnel,
+/turf/open/engineership/engineer_floor2,
+/area/lv759/indoors/derelict_ship)
 "pdv" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -86017,12 +85933,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "phE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
+/obj/structure/girder,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "phJ" = (
 /obj/item/storage/box/donkpockets,
 /obj/item/stack/sheet/cardboard{
@@ -86251,10 +86164,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "pkl" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/ai_node,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "pkq" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/road/plastic/blue{
@@ -86338,10 +86249,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/apartment/northfoyer)
-"pln" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "plp" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -87079,6 +86986,14 @@
 	dir = 5
 	},
 /area/lv759/indoors/meridian/meridian_foyer)
+"prF" = (
+/obj/structure/largecrate/random/mini{
+	layer = 4;
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/turf/open/floor/plating,
+/area/lv759/indoors/caves/west_caves)
 "prR" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalkcenter,
@@ -87160,9 +87075,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"psk" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/meridian/meridian_managersoffice)
 "psl" = (
 /obj/structure/prop/mainship/cannon_cables{
 	pixel_y = 12
@@ -87939,8 +87851,8 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pyy" = (
-/obj/structure/rock/dark/wide,
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/north_caves)
 "pyz" = (
 /obj/effect/urban/decal/dirt,
@@ -88250,7 +88162,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pAu" = (
-/obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "pAx" = (
@@ -88275,10 +88186,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/cafeteriakitchen)
-"pAE" = (
-/obj/structure/rock/dark/small/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
 "pAF" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -88459,9 +88366,18 @@
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "pCl" = (
-/obj/structure/sign/poster,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/garage_managersoffice)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8;
+	layer = 3.3
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "pCo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -88717,14 +88633,6 @@
 	},
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
-"pDY" = (
-/obj/structure/sign/poster,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/security_office)
-"pEe" = (
-/obj/structure/grille,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
 "pEn" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood/oil/streak,
@@ -88976,9 +88884,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwayeast)
 "pHh" = (
-/obj/effect/urban/decal/dirt,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/landing_zone_2)
 "pHk" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal_solid_white{
@@ -89564,8 +89472,9 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pMf" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/nt_research_complex/changingroom)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "pMh" = (
 /obj/effect/urban/decal/dirt,
 /obj/vehicle/ridden/wheelchair,
@@ -89620,10 +89529,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/north_west_caves)
-"pMN" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
 "pMX" = (
 /obj/structure/rock/dark/small/three,
 /obj/structure/rock/dark/small/three,
@@ -89752,12 +89657,6 @@
 "pND" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/colonial_marshals/changing_room)
-"pNG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
 "pNJ" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -89981,9 +89880,11 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/westshowers)
 "pQt" = (
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_west_caves)
 "pQz" = (
 /obj/item/tool/kitchen/utensil/spoon{
 	pixel_x = 10
@@ -90185,6 +90086,16 @@
 	},
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/mining_outpost/northeast)
+"pSt" = (
+/obj/structure/largecrate/random/barrel/black{
+	pixel_x = -6
+	},
+/obj/structure/largecrate/random/barrel/black{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "pSC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -90446,10 +90357,6 @@
 	},
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"pVw" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
 "pVG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -90588,12 +90495,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pWx" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
+/obj/effect/urban/decal/dirt,
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
 	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_east_caves)
 "pWA" = (
 /obj/structure/closet/crate/miningcar{
 	layer = 3
@@ -90951,10 +90858,14 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/nt_research_complex/cafeteriakitchen)
 "pZs" = (
-/obj/item/stack/rods,
-/obj/structure/grille,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "pZu" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/power_plant/geothermal_generators)
@@ -91289,6 +91200,10 @@
 /obj/effect/urban/decal/road/road_edge/four,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
+"qcD" = (
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/security_office)
 "qcF" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light/small{
@@ -91501,6 +91416,16 @@
 /obj/structure/prop/urban/misc/floorprops/grate,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
+"qdT" = (
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 1
+	},
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 8
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "qdW" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreeblies/greeble7{
@@ -91551,8 +91476,9 @@
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qek" = (
-/obj/structure/rock/dark/stalagmite/one,
-/turf/open/urbanshale/layer1,
+/obj/structure/rock/dark/small,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "qep" = (
 /obj/effect/landmark/weed_node,
@@ -91595,11 +91521,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qeC" = (
-/obj/structure/xeno/tunnel,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/electical_systems/substation1)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "qeF" = (
 /obj/item/stool,
 /obj/effect/urban/decal/road/lines1,
@@ -91672,11 +91596,12 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "qfd" = (
-/obj/structure/prop/urban/signs/high_voltage{
-	desc = null
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 8
 	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "qfk" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -91806,14 +91731,18 @@
 "qgD" = (
 /turf/open/floor/prison/darkyellow,
 /area/lv759/indoors/nt_research_complex/hallwaynorth)
+"qgH" = (
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/dormsbedroom)
 "qgP" = (
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
 /area/lv759/outdoors/landing_zone_2)
 "qgR" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/south_west_caves)
+/obj/structure/grille,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "qhd" = (
 /obj/structure/prop/mainship/gelida/barrier{
 	pixel_y = -12
@@ -92251,8 +92180,9 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/northeast)
 "qkB" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/electical_systems/substation1)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "qkJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -92342,9 +92272,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
-"qln" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qlo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/multi_tiles,
@@ -92799,8 +92726,9 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/mining_outpost/east_command)
 "qpO" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "qpP" = (
 /obj/structure/barricade/handrail,
 /turf/open/floor/prison/darkyellow,
@@ -93190,11 +93118,10 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "qtK" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "qtL" = (
 /obj/structure/table/mainship{
 	color = "#848484"
@@ -93430,6 +93357,14 @@
 "qwc" = (
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/electical_systems/substation1)
+"qwf" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab";
+	dir = 4
+	},
+/turf/open/floor/urban/metal/zbrownfloor_full,
+/area/lv759/indoors/meridian/meridian_factory)
 "qwl" = (
 /obj/structure/sink{
 	dir = 1;
@@ -93483,12 +93418,6 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
-"qwD" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "qwE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/safety/maintenance,
@@ -93973,8 +93902,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
 "qBM" = (
-/obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer0_plate,
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "qBR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -94309,11 +94239,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qGn" = (
-/obj/structure/prop/urban/vehicles/large/colonycrawlers/mining{
-	layer = 4
-	},
+/obj/effect/urban/decal/dirt,
+/obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/central_caves)
 "qGq" = (
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/meridian/meridian_foyer)
@@ -94330,6 +94259,12 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
+"qGE" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/north_west_street)
 "qGH" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt,
@@ -95132,6 +95067,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_security)
+"qOy" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/vehicledeployment)
 "qOz" = (
 /turf/open/engineership/engineer_floor13{
 	dir = 6
@@ -95606,11 +95544,6 @@
 /obj/machinery/science/analyser,
 /turf/open/floor/prison/blue,
 /area/lv759/indoors/hospital/pharmacy)
-"qSF" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
 "qSG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/urban/decal/bloodtrail,
@@ -95670,8 +95603,10 @@
 /turf/open/engineership/pillars/east/pillareast4,
 /area/lv759/indoors/derelict_ship)
 "qTg" = (
-/obj/structure/girder,
-/turf/open/ground/sandrock,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/central_caves)
 "qTj" = (
 /obj/structure/foamedmetal,
@@ -96392,11 +96327,9 @@
 	},
 /area/lv759/indoors/meridian/meridian_factory)
 "ram" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/outdoors/colony_streets/north_west_street)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "rar" = (
 /obj/structure/prop/urban/lattice_prop/lattice_4{
 	pixel_y = 16
@@ -96540,9 +96473,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/lv759/indoors/bar/entertainment)
-"rbR" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/north_east_caves)
 "rbX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -96839,11 +96769,10 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/recycling_plant)
 "reL" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/north_west_caves)
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "reS" = (
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_west_street)
@@ -97367,6 +97296,14 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/caveplateau)
+"rji" = (
+/obj/structure/prop/urban/misc/redmeter{
+	light_color = "#FF004A";
+	light_on = 1;
+	light_range = 2
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/engineering)
 "rjk" = (
 /obj/item/clothing/mask/gas,
 /obj/effect/decal/cleanable/blood{
@@ -97460,17 +97397,9 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "rjX" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/caves/west_caves)
 "rke" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -97490,6 +97419,9 @@
 	dir = 10
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
+"rkm" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart/backrooms)
 "rko" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -98192,6 +98124,11 @@
 /obj/effect/urban/decal/road/lines1,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_1)
+"rpT" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "rpX" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -98298,9 +98235,6 @@
 "rqX" = (
 /turf/open/floor/plating,
 /area/lv759/indoors/apartment/westhallway)
-"rrn" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/nt_research_complex/mainlabs)
 "rro" = (
 /obj/effect/urban/decal/doubleroad/lines2{
 	pixel_y = 4
@@ -98531,10 +98465,6 @@
 	},
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/virology)
-"rtg" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
 "rti" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
@@ -98562,6 +98492,9 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"rtv" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/electical_systems/substation2)
 "rtB" = (
 /obj/structure/bed/stool,
 /turf/open/floor/wood,
@@ -98610,8 +98543,7 @@
 /area/lv759/outdoors/landing_zone_2)
 "ruu" = (
 /obj/effect/urban/decal/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "ruw" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -98620,6 +98552,9 @@
 	dir = 1
 	},
 /area/lv759/indoors/power_plant)
+"rux" = (
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/colony_streets/east_central_street)
 "ruE" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/urban/tile/darkbrown_bigtile{
@@ -100215,8 +100150,14 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "rJP" = (
-/turf/open/ground/sandrock,
-/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
+/obj/structure/closet/crate/science,
+/obj/effect/spawner/random/medical/pillbottle,
+/obj/item/storage/box/lightstick/red{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "rJR" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -100384,6 +100325,12 @@
 /obj/item/shard,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/mainlabs)
+"rLo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "rLu" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable,
@@ -100652,9 +100599,10 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "rNL" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/indoors/nt_research_complex/xenobiology)
 "rNP" = (
 /obj/structure/rock/dark/small,
 /turf/open/urbanshale/layer1,
@@ -101376,6 +101324,9 @@
 /obj/effect/ai_node,
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
+"rTR" = (
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/southwest_public_restroom)
 "rTS" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -101427,6 +101378,12 @@
 "rUt" = (
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/apartment/northapartments)
+"rUB" = (
+/obj/structure/xeno/tunnel,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/indoors/electical_systems/substation1)
 "rUD" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/prison/cellstripe,
@@ -101569,11 +101526,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/urban/street/sidewalkfull,
 /area/lv624/lazarus/console)
-"rVT" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/landmark/weed_node,
-/turf/open/engineership/engineer_floor4,
-/area/lv759/indoors/derelict_ship)
 "rVW" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -101582,7 +101534,6 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "rVY" = (
-/obj/structure/platform_decoration/urban/rockdark,
 /obj/item/trash/trashbag{
 	pixel_x = 2;
 	pixel_y = 20
@@ -101944,15 +101895,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_research_complex/hangarbay)
-"rZC" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
 "rZH" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_y = 19
@@ -102958,12 +102900,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"sji" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "sjj" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/r_wall/urban,
@@ -103287,12 +103223,12 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "slH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "slM" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/north_east_caves)
 "slN" = (
 /obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer1,
@@ -103364,7 +103300,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/flight_control_room)
+/area/lv759/indoors/spaceport/engineering)
 "smD" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -104180,9 +104116,9 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/mining_outpost/east_command)
 "stz" = (
-/obj/item/stack/rods,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "stH" = (
 /obj/structure/prop/urban/fakeplatforms/platform1{
 	dir = 8
@@ -104191,10 +104127,9 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "stJ" = (
-/obj/item/stack/rods,
-/obj/structure/grille,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/rock/dark/large,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "stL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
@@ -104270,6 +104205,10 @@
 /obj/machinery/light,
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westbedrooms)
+"sum" = (
+/obj/effect/urban/decal/road/lines5,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "suo" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
@@ -104746,6 +104685,13 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
+"syS" = (
+/obj/effect/urban/decal/dirt,
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "syT" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 6;
@@ -104844,10 +104790,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/botany/botany_mainroom)
-"szw" = (
-/obj/effect/urban/decal/dirt,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/meridian/meridian_showroom)
 "szx" = (
 /obj/structure/bed/urban/bunkbed3{
 	dir = 8
@@ -104900,10 +104842,6 @@
 "szM" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_fuel)
-"szN" = (
-/obj/item/tool/shovel,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "szQ" = (
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt{
@@ -104933,6 +104871,12 @@
 /obj/structure/closet/walllocker/hydrant,
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
+"szT" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "szW" = (
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/urban/colony/engineering,
@@ -105126,7 +105070,12 @@
 "sBI" = (
 /obj/effect/urban/decal/dirt,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/meridian/meridian_office)
+/area/lv759/indoors/caves/north_caves)
+"sBJ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "sBL" = (
 /obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
@@ -105257,15 +105206,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
-"sDl" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/east_caves)
 "sDm" = (
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
@@ -105296,6 +105236,10 @@
 	dir = 6
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
+"sDt" = (
+/obj/structure/rock/dark/stalagmite,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "sDu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
@@ -106252,6 +106196,11 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
+"sMe" = (
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "sMg" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -106341,8 +106290,11 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "sML" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 1
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/caveplateau)
 "sMM" = (
 /turf/closed/shuttle/dropship4/window{
 	dir = 8
@@ -106378,9 +106330,6 @@
 /obj/machinery/bodyscanner,
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
-"sNe" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/outdoors/colony_streets/central_streets)
 "sNf" = (
 /obj/structure/table/reinforced/prison,
 /obj/machinery/faxmachine,
@@ -106501,12 +106450,9 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "sOn" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/urban/decal/grate{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "sOt" = (
 /obj/structure/barricade/handrail/urban/handrail,
 /obj/effect/ai_node,
@@ -106665,11 +106611,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_research_complex/reception)
-"sPK" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "sPL" = (
 /obj/structure/prop/urban/misc/firehydrant{
 	dir = 1
@@ -107098,11 +107039,6 @@
 /obj/structure/largecrate/random,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"sTB" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "sTC" = (
 /obj/structure/largecrate/random/barrel/red{
 	layer = 4
@@ -107884,9 +107820,8 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_2)
 "tau" = (
-/obj/structure/rock/dark/large/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/caveplateau)
 "tav" = (
 /obj/machinery/streetlight/traffic{
 	dir = 8;
@@ -107896,8 +107831,8 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/central_streets)
 "taw" = (
-/obj/structure/rock/dark/small/two,
-/turf/open/urbanshale/layer0_plate,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "tay" = (
 /turf/open/urban/street/asphalt,
@@ -107908,6 +107843,9 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
+"taD" = (
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/colony_streets/north_street)
 "taF" = (
 /turf/open/floor/urban/metal/bluemetal1{
 	dir = 5
@@ -109135,8 +109073,10 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/botany/botany_mainroom)
 "tlf" = (
-/obj/structure/rock/dark/wide,
-/turf/open/urbanshale/layer1,
+/obj/structure/barricade/metal/deployable,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "tlg" = (
 /obj/effect/mapping_helpers/airlock_autoname,
@@ -109345,19 +109285,12 @@
 /obj/structure/prop/urban/containersextended/greywyleft,
 /turf/open/floor/mainship,
 /area/lv759/indoors/spaceport/cargo)
-"tnq" = (
-/obj/structure/prop/mainship/gelida/smallwire,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "tnx" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/meridian/meridian_showroom)
 "tnB" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/processing)
 "tnG" = (
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_edge/two,
@@ -109860,9 +109793,9 @@
 	},
 /area/lv759/indoors/hospital/operation)
 "trR" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/south_west_caves)
+/obj/structure/sign/safety/blast_door,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/cargo)
 "trS" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/trash/green{
@@ -110647,9 +110580,9 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "tyX" = (
-/obj/structure/rock/dark/wide,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/obj/machinery/door/poddoor,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/cargo)
 "tza" = (
 /obj/item/trash/tgmc_tray,
 /obj/item/trash/cuppa_joes/lid,
@@ -110898,8 +110831,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "tAY" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/NTmart/maintenance)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/urban/decal/grate{
+	dir = 8
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "tBa" = (
 /turf/closed/shuttle/dropship4/damagedconsoleone,
 /area/lv759/indoors/spaceport/starglider)
@@ -111625,6 +111562,10 @@
 	dir = 4
 	},
 /area/lv759/indoors/hospital/east_hallway)
+"tHI" = (
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "tHJ" = (
 /obj/structure/flora/pottedplant{
 	pixel_y = 6
@@ -111659,7 +111600,7 @@
 "tHT" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/garage_reception)
+/area/lv759/indoors/hobosecret)
 "tHU" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
@@ -111976,9 +111917,8 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
 "tLh" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/east_caves)
 "tLj" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -112150,9 +112090,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/power_plant/gas_generators)
 "tMM" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/garage_managersoffice)
 "tMN" = (
 /obj/effect/urban/decal/trash/eleven,
 /obj/effect/urban/decal/trash/six{
@@ -112899,25 +112839,15 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "tSX" = (
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor8{
 	dir = 4
 	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/indoors/derelict_ship)
 "tTd" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "tTe" = (
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
@@ -112945,12 +112875,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "tTu" = (
-/obj/effect/urban/decal/grate{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "tTx" = (
 /obj/structure/fence/dark,
 /obj/structure/cable,
@@ -113898,6 +113824,11 @@
 	},
 /turf/open/floor/urban/carpet/carpetdarkerblue,
 /area/lv759/indoors/spaceport/docking_bay_1)
+"uaL" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "uaN" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -115198,10 +115129,6 @@
 "ulp" = (
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/north_street)
-"ult" = (
-/obj/structure/rock/dark/large,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "ulA" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -115316,10 +115243,11 @@
 /turf/open/floor/podhatch/floor,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "umk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/central_caves)
 "umn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -115355,6 +115283,13 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/garage_workshop)
+"umH" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "umJ" = (
 /obj/structure/sign/safety/cryogenic,
 /turf/closed/wall/urban,
@@ -115754,6 +115689,10 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/derelict_ship)
+"upU" = (
+/obj/structure/grille,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "upX" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/blood,
@@ -115912,8 +115851,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/north)
 "urj" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/north_caves)
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "urk" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/patient_ward)
@@ -116128,9 +116068,6 @@
 	},
 /turf/open/floor/plate,
 /area/lv759/indoors/colonial_marshals/garage)
-"usC" = (
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/outdoors/caveplateau)
 "usF" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/sandrock,
@@ -116340,9 +116277,9 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "uvk" = (
-/obj/structure/rock/dark/small/two,
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/indoors/caves/north_caves)
 "uvp" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalk{
@@ -116843,6 +116780,14 @@
 "uAh" = (
 /turf/open/floor/urban/tile/tilered,
 /area/lv759/indoors/pizzaria)
+"uAk" = (
+/obj/effect/urban/decal/road/lines1,
+/obj/effect/urban/decal/road/road_edge,
+/obj/effect/urban/decal/road/road_stop/five{
+	dir = 4
+	},
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "uAo" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/item/trash/cigbutt,
@@ -117761,9 +117706,8 @@
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
 "uIa" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/hobosecret)
 "uId" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -117997,10 +117941,6 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/landing_zone_1)
-"uKb" = (
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
 "uKc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -118567,9 +118507,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"uPs" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/colony_streets/north_street)
 "uPD" = (
 /obj/structure/prop/urban/containersextended/whitewyright,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -118988,10 +118925,8 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "uTE" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/item/clothing/mask/facehugger/dead,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/electical_systems/substation1)
 "uTG" = (
 /obj/effect/urban/decal/checkpoint_decal{
 	dir = 4;
@@ -120042,6 +119977,9 @@
 	dir = 4
 	},
 /area/lv759/indoors/colonial_marshals/armory_foyer)
+"vcG" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_managersoffice)
 "vcM" = (
 /obj/structure/cable,
 /turf/open/floor/redfour,
@@ -120078,8 +120016,9 @@
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
 "vcV" = (
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/outdoors/colony_streets/central_streets)
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "vde" = (
 /obj/item/tool/mop{
 	pixel_x = -6;
@@ -120680,10 +120619,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/south_east_street)
-"vhM" = (
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
 "vhP" = (
 /obj/structure/concrete_planter/seat{
 	dir = 8;
@@ -121933,10 +121868,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_office)
 "vrP" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/structure/rock/dark/wide/two,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/south_east_street)
 "vrT" = (
 /obj/structure/closet/crate/trashcart{
 	pixel_y = 8
@@ -122066,8 +121999,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "vtj" = (
-/turf/open/floor/plating,
-/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+/obj/item/stack/rods,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "vtk" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 4
@@ -122287,6 +122221,10 @@
 	dir = 4
 	},
 /area/lv759/indoors/derelict_ship)
+"vvv" = (
+/obj/item/tool/shovel,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "vvy" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/bar)
@@ -122412,9 +122350,8 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "vwE" = (
-/obj/structure/girder,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_west_caves)
 "vwH" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -122828,10 +122765,9 @@
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
 "vAJ" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "vAO" = (
 /obj/structure/barricade/handrail/urban/handrail{
 	dir = 1
@@ -123100,11 +123036,12 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_street)
+"vDh" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart)
 "vDk" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/north_west_caves)
 "vDm" = (
 /obj/item/stack/sheet/cardboard{
 	layer = 1
@@ -123582,12 +123519,9 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "vHx" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "vHz" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
 	pixel_y = 28
@@ -123659,9 +123593,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/colonial_marshals/holding_cells)
 "vHW" = (
-/obj/structure/rock/dark/wide/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/garage_reception)
 "vIc" = (
 /obj/effect/urban/decal/tiretrack{
 	dir = 1;
@@ -123788,9 +123722,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_west)
 "vJb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "vJc" = (
 /obj/item/trash/trashbag{
 	pixel_x = 2;
@@ -123933,9 +123867,8 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "vKq" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance)
 "vKt" = (
 /obj/machinery/light/spot/blue,
 /obj/machinery/light/spot/blue{
@@ -124278,9 +124211,9 @@
 /turf/open/urban/street/roadlines4,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "vNw" = (
-/obj/effect/acid_hole,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/garage_workshop_storage)
+/obj/effect/spawner/random/misc/structure/girder,
+/turf/open/floor/plating,
+/area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "vNB" = (
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 4
@@ -124601,9 +124534,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/xenobiology)
-"vQw" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/caves/east_caves)
 "vQA" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -4;
@@ -124620,8 +124550,13 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "vQB" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/mining_outpost/processing)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/urban/decal/grate{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "vQF" = (
 /turf/open/floor/urban/tile/beige_bigtile,
 /area/lv759/indoors/power_plant/workers_canteen)
@@ -124696,16 +124631,6 @@
 "vRe" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/bar/bathroom)
-"vRj" = (
-/obj/structure/largecrate/random/barrel/black{
-	pixel_x = -6
-	},
-/obj/structure/largecrate/random/barrel/black{
-	pixel_x = 12;
-	pixel_y = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "vRk" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -124943,6 +124868,14 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
+"vTi" = (
+/obj/effect/urban/decal/grate{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "vTo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -124989,8 +124922,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "vTI" = (
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer0_plate,
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "vTL" = (
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -125066,9 +124999,8 @@
 	},
 /area/lv759/indoors/caves/south_west_caves)
 "vUg" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/electical_systems/substation2)
 "vUo" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -125899,13 +125831,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
-"waF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/east_caves)
 "waL" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/prison/blue,
@@ -126849,6 +126774,9 @@
 /obj/structure/sign/safety/blast_door,
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+"wji" = (
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/central_caves)
 "wjo" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -127220,10 +127148,6 @@
 /obj/item/trash/cigbutt,
 /turf/open/floor/spiralplate,
 /area/lv759/outdoors/colony_streets/central_streets)
-"wmo" = (
-/obj/structure/rock/dark/wide,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "wmr" = (
 /obj/structure/barricade/handrail/kutjevo,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -127329,10 +127253,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
-"wne" = (
-/obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/north_caves)
 "wng" = (
 /obj/structure/bed/roller/hospital_empty/bigrollerempty2{
 	dir = 8
@@ -127350,6 +127270,10 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
+"wnt" = (
+/obj/item/stack/rods,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "wnD" = (
 /obj/effect/urban/decal/trash/five,
 /turf/open/urban/street/sidewalk,
@@ -127430,14 +127354,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"woq" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
 "wos" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines2,
@@ -127531,12 +127447,9 @@
 /turf/open/floor/squares,
 /area/lv759/indoors/nt_research_complex/cafeteria)
 "wpf" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/effect/ai_node,
+/obj/structure/rock/dark/small,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/outdoors/north_west_caves_outdoors)
 "wph" = (
 /obj/item/trash/trashbag{
 	pixel_x = 2;
@@ -128149,6 +128062,9 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
+"wvl" = (
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/north_east_caves)
 "wvm" = (
 /obj/structure/stairs{
 	color = "#a6aeab";
@@ -128387,6 +128303,11 @@
 /obj/effect/urban/decal/trash/two,
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_flight_control_room)
+"wxR" = (
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "wxS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -128418,9 +128339,9 @@
 /turf/open/floor/urban/tile/tilegrey,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "wyb" = (
-/obj/machinery/floodlight/colony,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+/obj/effect/urban/decal/road/road_stop/one,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "wyd" = (
 /obj/effect/urban/decal/grate{
 	dir = 4
@@ -129105,8 +129026,11 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "wDF" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/ore_box{
+	layer = 2
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_east_caves)
 "wDG" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -129337,12 +129261,6 @@
 /obj/effect/urban/decal/trash/eleven,
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
-"wFG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "wFH" = (
 /obj/structure/cable,
 /obj/item/tool/wrench{
@@ -129659,9 +129577,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_security)
 "wIM" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/ai_node,
-/turf/open/ground/sandrock,
+/obj/item/stack/rods,
+/obj/structure/grille,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "wIO" = (
 /obj/effect/urban/decal/dirt,
@@ -130167,11 +130085,6 @@
 	dir = 10
 	},
 /area/lv759/indoors/hospital/virology)
-"wMR" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "wMV" = (
 /turf/open/floor/urban/metal/zbrownfloor1{
 	dir = 5
@@ -130455,8 +130368,12 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
 "wPV" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate{
+	dir = 8
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "wPY" = (
 /obj/structure/table/reinforced/prison,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -130622,8 +130539,14 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
 "wQY" = (
-/turf/closed/wall/r_wall/kutjevo,
-/area/lv759/indoors/hobosecret)
+/obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor13{
+	dir = 10
+	},
+/area/lv759/indoors/derelict_ship)
 "wRa" = (
 /obj/structure/lattice/autosmooth,
 /obj/item/trash/cigbutt{
@@ -130985,10 +130908,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"wTG" = (
-/obj/effect/acid_hole,
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/outdoors/colony_streets/central_streets)
 "wTH" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison{
@@ -131340,6 +131259,12 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/lv759/indoors/spaceport/docking_bay_1)
+"wXm" = (
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/central_caves)
 "wXo" = (
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/full,
@@ -132043,14 +131968,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "xdu" = (
-/obj/structure/closet/crate/miningcar{
-	layer = 3
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
 	},
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/west_caves)
 "xdv" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/medical_decals/doc/stripe{
@@ -132684,14 +132607,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "xix" = (
-/obj/structure/closet/crate/science,
-/obj/effect/spawner/random/medical/pillbottle,
-/obj/item/storage/box/lightstick/red{
-	pixel_x = -4;
-	pixel_y = 10
-	},
+/obj/structure/rock/dark/wide/two,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/west_caves)
 "xiy" = (
 /obj/item/tool/wet_sign{
 	pixel_x = -11;
@@ -132859,6 +132777,9 @@
 	},
 /turf/open/floor/wood,
 /area/lv759/indoors/hospital/cmo_office)
+"xjI" = (
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/south_public_restroom)
 "xkb" = (
 /obj/machinery/computer/marine_card,
 /obj/structure/table/black,
@@ -132880,10 +132801,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/fusion_generators)
-"xki" = (
-/obj/structure/rock/dark/stalagmite/five,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/nt_research_complex_entrance)
 "xkj" = (
 /obj/machinery/light{
 	dir = 1
@@ -132909,11 +132826,8 @@
 	},
 /area/lv759/indoors/hospital/pharmacy)
 "xkr" = (
-/obj/effect/urban/decal/grate{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "xkz" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
@@ -133012,9 +132926,13 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "xlO" = (
-/obj/effect/urban/decal/road/lines5,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
+/obj/structure/platform_decoration/urban/engineer_corner,
+/obj/structure/platform_decoration/urban/engineer_corner{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor9,
+/area/lv759/indoors/derelict_ship)
 "xlQ" = (
 /obj/structure/prop/urban/signs/high_voltage/small{
 	pixel_x = 6
@@ -133046,10 +132964,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"xlZ" = (
-/obj/item/stack/rods,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
 "xmc" = (
 /obj/structure/prop/urban/misc/fake/wire/blue{
 	dir = 4;
@@ -133158,10 +133072,10 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "xnl" = (
-/obj/effect/urban/decal/road/lines2,
-/obj/effect/urban/decal/road/road_edge/four,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "xno" = (
 /obj/structure/filingcabinet/nondense{
 	layer = 3.1;
@@ -133282,11 +133196,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/east)
 "xor" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "xos" = (
 /obj/structure/closet,
 /turf/open/floor/mainship{
@@ -133691,21 +133603,21 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "xrP" = (
-/obj/item/stack/rods,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "xrT" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/spaceport/cargo)
 "xsf" = (
-/obj/structure/prop/urban/misc/redmeter{
-	light_color = "#FF004A";
-	light_on = 1;
-	light_range = 2
+/obj/structure/rock/dark/small{
+	layer = 4
 	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/security)
+/turf/open/urbanshale/layer2,
+/area/lv759/outdoors/colony_streets/south_east_street)
 "xsg" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/prison{
@@ -133962,9 +133874,6 @@
 /obj/machinery/light,
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/vip)
-"xun" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/electical_systems/substation1)
 "xup" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/structure/barricade/metal/deployable{
@@ -134130,14 +134039,6 @@
 	},
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"xvy" = (
-/obj/effect/urban/decal/road/lines1,
-/obj/effect/urban/decal/road/road_edge,
-/obj/effect/urban/decal/road/road_stop/five{
-	dir = 4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
 "xvA" = (
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /obj/structure/cable,
@@ -134331,7 +134232,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/indoors/caves/south_west_caves)
+/area/lv759/indoors/caves/central_caves)
 "xxJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -134443,7 +134344,6 @@
 /turf/open/floor/prison/red,
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "xyS" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt_2,
 /mob/living/simple_animal/mouse/gray,
@@ -134500,10 +134400,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "xzl" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "xzn" = (
 /obj/structure/stairs{
 	color = "#a6aeab"
@@ -134966,9 +134865,9 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "xEq" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "xEs" = (
 /turf/open/floor/tile/dark/brown3{
 	dir = 9
@@ -135253,12 +135152,6 @@
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"xFY" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration/urban/rockdark,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "xGm" = (
 /obj/structure/sign/safety/laser,
 /turf/closed/wall/r_wall/urban,
@@ -135585,8 +135478,9 @@
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/caveplateau)
 "xJg" = (
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/south_public_restroom)
+/obj/structure/girder,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "xJi" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 1
@@ -135768,9 +135662,11 @@
 /turf/open/urban/street/cement2,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "xKA" = (
-/obj/structure/rock/dark/small,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/east_caves)
 "xKG" = (
 /obj/structure/prop/urban/containersextended/redleft,
 /turf/open/floor/urban/metal/zbrownfloor1{
@@ -136197,10 +136093,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/marked,
 /area/lv759/outdoors/colony_streets/north_street)
-"xOI" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "xOJ" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
 	dir = 4
@@ -136307,9 +136199,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "xPp" = (
-/obj/effect/urban/decal/road/road_stop/one,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/landing_zone_1)
+/obj/structure/largecrate/random/barrel/brown,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "xPs" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt{
@@ -136462,9 +136354,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/spaceport/docking_bay_2)
-"xQu" = (
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "xQB" = (
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
@@ -137122,16 +137011,9 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/power_plant/telecomms)
 "xXm" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 1
-	},
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "xXs" = (
 /turf/closed/wall/urban/colony/ribbed,
 /area/lv759/indoors/nt_security/checkpoint_northeast)
@@ -137146,6 +137028,15 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
+"xXw" = (
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "xXC" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/clipboard,
@@ -137435,13 +137326,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"xZZ" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/outdoors/caveplateau)
 "yaa" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -137495,10 +137379,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"yaK" = (
-/obj/structure/prop/urban/containersextended/blackwyright,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
 "yaN" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/sheet/cardboard,
@@ -137510,6 +137390,10 @@
 /obj/effect/urban/decal/trash/eight,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
+"yaO" = (
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "yaP" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/girder,
@@ -137534,8 +137418,15 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "ybk" = (
-/obj/structure/rock/dark/wide,
-/turf/open/urbanshale/layer0_plate,
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 1
+	},
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "ybw" = (
 /obj/effect/urban/decal/road/road_stop/five{
@@ -138718,6 +138609,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
+"yle" = (
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "ylk" = (
 /obj/structure/bed/urban/chairs/brown{
 	dir = 8
@@ -139118,15 +139015,15 @@ ydz
 ydz
 ydz
 ydz
-ram
-ram
-ram
-ram
+qGE
+qGE
+qGE
+qGE
 ydz
 ydz
 ydz
-sML
-sML
+lmj
+lmj
 eUg
 eUg
 eUg
@@ -139153,17 +139050,17 @@ eUg
 eUg
 eUg
 eUg
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
 lLo
 lLo
 lLo
@@ -139198,30 +139095,30 @@ jJd
 jJd
 jJd
 jJd
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
-rrn
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
+jUH
 qhg
 qhg
 qhg
@@ -139328,7 +139225,7 @@ wTF
 dmT
 ydz
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -139356,17 +139253,17 @@ eUg
 eUg
 eUg
 eUg
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
 lLo
 lLo
 lLo
@@ -139375,7 +139272,7 @@ lLo
 lLo
 wwX
 wwX
-slM
+lhZ
 wwX
 fzZ
 eMt
@@ -139531,7 +139428,7 @@ vlX
 nOh
 mjF
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -139550,26 +139447,26 @@ eUg
 eUg
 eUg
 eUg
-isz
-isz
-isz
-isz
-isz
+pkl
+pkl
+pkl
+pkl
+pkl
 eUg
 eUg
 eUg
 eUg
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
-xun
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
+uTE
 lLo
 lLo
 lLo
@@ -139577,8 +139474,8 @@ lLo
 lLo
 wwX
 wwX
-slM
-slM
+lhZ
+lhZ
 wwX
 uzf
 tAK
@@ -139734,7 +139631,7 @@ eFp
 xXJ
 lHy
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -139753,35 +139650,35 @@ eUg
 eUg
 eUg
 eUg
-isz
+pkl
 auM
 auM
 auM
-isz
+pkl
 eUg
 eUg
 eUg
 eUg
-xun
-xun
-xun
-xun
-xun
-qkB
-qkB
-qkB
-qkB
-qkB
-qkB
+uTE
+uTE
+uTE
+uTE
+uTE
+msJ
+msJ
+msJ
+msJ
+msJ
+msJ
 lLo
 lLo
 lLo
 lLo
 wwX
 wwX
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
 wwX
 rto
 tAK
@@ -139937,7 +139834,7 @@ uzd
 sTR
 fal
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -139956,35 +139853,35 @@ eUg
 eUg
 eUg
 eUg
-isz
+pkl
 auM
 eHV
 auM
-isz
+pkl
 eUg
 eUg
 eUg
 eUg
-xun
-qkB
-qkB
-qkB
-qkB
+uTE
+msJ
+msJ
+msJ
+msJ
 iLa
 rKU
 uih
 nBw
-qeC
-qkB
+rUB
+msJ
 lLo
 lLo
 lLo
 wwX
 wwX
-slM
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
+lhZ
 wwX
 ngU
 tAK
@@ -140140,13 +140037,13 @@ eWy
 fxg
 etp
 ydz
-sML
+lmj
 eUg
 eUg
 uLW
-eEq
+slH
 rLE
-nqO
+iCB
 vAB
 eUg
 eUg
@@ -140159,17 +140056,17 @@ eUg
 eUg
 eUg
 eUg
-isz
+pkl
 auM
 auM
 auM
-isz
+pkl
 eUg
 eUg
 eUg
 eUg
-xun
-qkB
+uTE
+msJ
 wmD
 aeS
 tDh
@@ -140178,7 +140075,7 @@ lsO
 gbG
 xgB
 lQi
-qkB
+msJ
 lLo
 lLo
 lLo
@@ -140343,7 +140240,7 @@ kQr
 sOG
 kEp
 ydz
-sML
+lmj
 eUg
 eUg
 plS
@@ -140362,17 +140259,17 @@ eUg
 eUg
 eUg
 eUg
-isz
-isz
-isz
-isz
-isz
+pkl
+pkl
+pkl
+pkl
+pkl
 eUg
 eUg
 eUg
 eUg
-xun
-qkB
+uTE
+msJ
 qdF
 qwc
 xrm
@@ -140381,7 +140278,7 @@ cqd
 xgB
 xgB
 lQi
-qkB
+msJ
 lLo
 lLo
 lLo
@@ -140492,7 +140389,7 @@ bZF
 suR
 ixO
 oRG
-smy
+aso
 bCe
 rZY
 xAQ
@@ -140546,8 +140443,8 @@ vyk
 cAg
 sMd
 ydz
-sML
-iCB
+lmj
+iLK
 plS
 plS
 plS
@@ -140574,8 +140471,8 @@ eUg
 eUg
 eUg
 eUg
-qkB
-qkB
+msJ
+msJ
 vYz
 uWE
 rIr
@@ -140584,7 +140481,7 @@ lEQ
 rKU
 rKU
 nBw
-qkB
+msJ
 lLo
 lLo
 lLo
@@ -140748,7 +140645,7 @@ rhc
 tYY
 saD
 gJB
-kRm
+hbN
 fwo
 hMa
 plS
@@ -140777,8 +140674,8 @@ eUg
 eUg
 eUg
 eUg
-qkB
-qkB
+msJ
+msJ
 iyB
 qwc
 xrm
@@ -140787,7 +140684,7 @@ xFu
 fSO
 ogV
 oEq
-qkB
+msJ
 lLo
 lLo
 lLo
@@ -140962,8 +140859,8 @@ ohD
 szk
 plS
 gbV
-djY
-djY
+nqO
+nqO
 plS
 plS
 plS
@@ -140980,8 +140877,8 @@ eUg
 eUg
 eUg
 eUg
-qkB
-fAu
+msJ
+iZP
 vYz
 uWE
 xrm
@@ -140989,11 +140886,11 @@ ezn
 ezn
 rrM
 ezn
-qkB
-qkB
+msJ
+msJ
 lLo
 lLo
-tlf
+ram
 wwX
 wwX
 fVI
@@ -141154,7 +141051,7 @@ bKA
 ugc
 oqA
 mSe
-kRm
+hbN
 fwo
 hMa
 szk
@@ -141166,7 +141063,7 @@ szk
 plS
 plS
 nGY
-djY
+nqO
 uFY
 plS
 uFY
@@ -141183,7 +141080,7 @@ eUg
 gRU
 eUg
 eUg
-qkB
+msJ
 kut
 fQq
 tuY
@@ -141193,7 +141090,7 @@ cwh
 jxF
 sIA
 jrZ
-hNC
+icp
 hBK
 tgV
 qUo
@@ -141368,7 +141265,7 @@ mrx
 szk
 ohD
 gbV
-vKq
+hNF
 nGY
 plS
 ohD
@@ -141560,7 +141457,7 @@ uwD
 xns
 lAc
 gYG
-lmj
+abh
 sin
 kmC
 szk
@@ -141580,29 +141477,29 @@ ltZ
 mrx
 szk
 plS
-djY
+nqO
 nGY
 eUg
 plS
-mgn
+plS
 eUg
 plS
 szk
 plS
-qkB
+msJ
 sHl
 dwf
-qkB
-qkB
-qkB
+msJ
+msJ
+msJ
 alU
 pbG
 rjk
 tfx
-pdr
+jjV
 khA
-pdr
-pdr
+jjV
+jjV
 uOH
 dUp
 hDS
@@ -141763,7 +141660,7 @@ uwD
 xns
 ybx
 ydr
-kRm
+hbN
 nKy
 kmC
 szk
@@ -141783,7 +141680,7 @@ szk
 szk
 szk
 gbV
-djY
+nqO
 nGY
 plS
 szk
@@ -141795,15 +141692,15 @@ szk
 dgv
 qvL
 eKS
-qkB
-qkB
-qkB
+msJ
+msJ
+msJ
 gJq
 bdC
 pde
-aUq
-pdr
-pdr
+tlf
+jjV
+jjV
 rjL
 eOz
 tEM
@@ -141910,7 +141807,7 @@ wmt
 kCY
 ngr
 jOn
-pDY
+qcD
 wnN
 mVY
 ebY
@@ -141966,7 +141863,7 @@ bff
 whb
 jya
 mSe
-kRm
+hbN
 fwo
 kmC
 szk
@@ -141986,7 +141883,7 @@ szk
 plS
 exb
 plS
-djY
+nqO
 nGY
 plS
 bgs
@@ -141998,18 +141895,18 @@ szk
 hGa
 jvO
 oSk
-qkB
-qkB
-fAu
+msJ
+msJ
+iZP
 jnr
 guV
 kCh
 sRG
 iWB
-pdr
+jjV
 aLY
 hDb
-jbk
+dnq
 gzg
 pru
 nXT
@@ -142169,7 +142066,7 @@ uwD
 whb
 aUG
 mSe
-lmj
+abh
 jdC
 kmC
 plS
@@ -142209,7 +142106,7 @@ irf
 cGA
 hWX
 iWB
-pdr
+jjV
 gEj
 xxn
 wwX
@@ -142316,7 +142213,7 @@ gAd
 kCY
 tPs
 tro
-eeA
+ojk
 qaG
 xsZ
 xKW
@@ -142373,8 +142270,8 @@ whb
 aUG
 unY
 ydz
-sML
-sML
+lmj
+lmj
 eUg
 eUg
 eUg
@@ -142401,7 +142298,7 @@ plS
 eUg
 eUg
 eUg
-sML
+lmj
 eif
 dND
 ejv
@@ -142410,7 +142307,7 @@ ftO
 tgl
 iWB
 eHm
-tlf
+ram
 ivr
 flH
 aLY
@@ -142519,7 +142416,7 @@ jek
 jPU
 tPs
 tro
-eeA
+ojk
 sFf
 xsZ
 oaj
@@ -142576,7 +142473,7 @@ pwz
 wde
 iho
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -142604,7 +142501,7 @@ plS
 plS
 plS
 eUg
-sML
+lmj
 wdT
 tvA
 ejv
@@ -142615,9 +142512,9 @@ iWB
 fdM
 qUo
 iWB
-pdr
+jjV
 aLY
-reL
+bBa
 kLy
 wwX
 fVI
@@ -142625,7 +142522,7 @@ lEh
 lEh
 sCz
 ago
-pAu
+oiz
 sCz
 vtr
 vtr
@@ -142722,7 +142619,7 @@ jek
 uuZ
 tPs
 tro
-eeA
+ojk
 oIi
 tMH
 jsk
@@ -142779,7 +142676,7 @@ rtN
 kth
 laZ
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -142791,7 +142688,7 @@ eUg
 eUg
 nGY
 nGY
-djY
+nqO
 uFY
 plS
 gbV
@@ -142826,8 +142723,8 @@ wwX
 vtr
 vtr
 sCz
-xki
-nNO
+ixj
+pAu
 uUx
 sCz
 sCz
@@ -142982,22 +142879,22 @@ whb
 njo
 fhA
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
 eUg
 eUg
-mai
+jFE
 kNJ
 gbV
 gbV
 ljm
-djY
+nqO
 nGY
 wad
 nGY
-tLh
+ljm
 nGY
 nGY
 plS
@@ -143021,7 +142918,7 @@ iWB
 iyx
 fdM
 iWB
-pdr
+jjV
 aLY
 iWB
 kHo
@@ -143030,8 +142927,8 @@ vtr
 vtr
 sCz
 lwX
-nNO
-nNO
+pAu
+pAu
 sCz
 sCz
 lEh
@@ -143121,13 +143018,13 @@ eqU
 "}
 (22,1,1) = {"
 lwn
-bIu
+smy
 tTL
 mtd
 jek
 wVA
 ooS
-xsf
+dFb
 nEt
 iXb
 lnV
@@ -143196,7 +143093,7 @@ krV
 plS
 plS
 nGY
-ojk
+wpf
 nGY
 nGY
 nGY
@@ -143234,7 +143131,7 @@ lEh
 lEh
 sCz
 qZF
-nkS
+cpp
 sCz
 vtr
 vtr
@@ -143324,7 +143221,7 @@ eqU
 "}
 (23,1,1) = {"
 lwn
-dFb
+rji
 efu
 dBO
 tqw
@@ -143427,7 +143324,7 @@ iWB
 qUo
 glD
 iWB
-pdr
+jjV
 aLY
 iWB
 bxm
@@ -143622,15 +143519,15 @@ hTa
 cFf
 fki
 pLs
-aQh
-aQh
-ggP
+vwE
+vwE
+pQt
 hBQ
 iWB
 qUo
 qUo
 iWB
-pdr
+jjV
 aLY
 iWB
 wwX
@@ -143758,8 +143655,8 @@ yeb
 qpb
 cpX
 iJb
-rZC
-rZC
+lwO
+lwO
 nrU
 jXu
 xYX
@@ -143825,15 +143722,15 @@ kRl
 mij
 hCp
 biI
-aQh
-aQh
-aQh
-aQh
-aQh
+vwE
+vwE
+vwE
+vwE
+vwE
 lLo
 lLo
 iWB
-pdr
+jjV
 hLx
 iWB
 sxv
@@ -144034,9 +143931,9 @@ lLo
 lLo
 lLo
 lLo
-xKA
+kcZ
 iWB
-pdr
+jjV
 miR
 eOz
 xtm
@@ -144234,15 +144131,15 @@ lWe
 lLo
 lLo
 qUo
-ult
+stJ
 lLo
 qUo
 qUo
 iWB
-pdr
+jjV
 aLY
-pdr
-mOU
+jjV
+mzJ
 gkf
 pru
 tkI
@@ -144442,7 +144339,7 @@ iHr
 qUo
 qUo
 iWB
-pdr
+jjV
 mAs
 iWB
 sxv
@@ -144639,13 +144536,13 @@ ceO
 bNB
 lLo
 lLo
-tlf
+ram
 qUo
 qUo
 qUo
 lLo
 iWB
-pdr
+jjV
 mAs
 fdM
 wwX
@@ -144848,7 +144745,7 @@ qUo
 lLo
 lLo
 ubY
-pdr
+jjV
 mAs
 fdM
 wwX
@@ -145029,7 +144926,7 @@ szk
 szk
 mrx
 kot
-tSX
+oua
 rkJ
 ygs
 hQP
@@ -145051,7 +144948,7 @@ qUo
 qUo
 lLo
 iWB
-pdr
+jjV
 mAs
 fdM
 wwX
@@ -145096,7 +144993,7 @@ egn
 ycE
 egn
 uFA
-dBc
+rNL
 caA
 vDq
 bor
@@ -145221,7 +145118,7 @@ ptI
 gnp
 dgH
 tEc
-bIG
+kWj
 eUg
 eUg
 eUg
@@ -145231,11 +145128,11 @@ sYp
 plS
 ohD
 szk
-mTA
+fkr
 cer
-xor
+szT
 rRP
-woq
+iRV
 kQg
 szk
 lWe
@@ -145249,12 +145146,12 @@ xEY
 wVZ
 lLo
 lLo
-hNC
+icp
 qUo
 iHr
 qUo
 iWB
-pdr
+jjV
 mAs
 eHm
 wwX
@@ -145354,7 +145251,7 @@ lwn
 "}
 (33,1,1) = {"
 lwn
-liu
+bmL
 asS
 sKg
 gYs
@@ -145424,7 +145321,7 @@ eOI
 mOY
 gFT
 poJ
-bIG
+kWj
 eUg
 eUg
 eUg
@@ -145438,7 +145335,7 @@ jcN
 woR
 kMs
 rRP
-iRV
+pZs
 kQg
 kQg
 lWe
@@ -145457,7 +145354,7 @@ lLo
 qUo
 qUo
 iWB
-pdr
+jjV
 mAs
 fdM
 wwX
@@ -145557,7 +145454,7 @@ lwn
 "}
 (34,1,1) = {"
 lwn
-nhc
+buY
 aga
 oWh
 whk
@@ -145620,14 +145517,14 @@ ykb
 whb
 cXi
 pMB
-bIG
-bIG
-bIG
-bIG
-bIG
-bIG
-bIG
-bIG
+kWj
+kWj
+kWj
+kWj
+kWj
+kWj
+kWj
+kWj
 eUg
 eUg
 eUg
@@ -145638,10 +145535,10 @@ plS
 uxT
 jdW
 mku
-bBa
+pCl
 vCa
 arb
-sPK
+bfa
 txY
 szk
 lWe
@@ -145660,7 +145557,7 @@ lLo
 lLo
 qUo
 iWB
-pdr
+jjV
 mAs
 fdM
 wwX
@@ -145760,7 +145657,7 @@ lwn
 "}
 (35,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 whk
@@ -145844,7 +145741,7 @@ szk
 ohD
 szk
 szk
-xFY
+txY
 hQP
 szk
 wDe
@@ -145863,15 +145760,15 @@ lLo
 lLo
 lLo
 ubY
-pdr
+jjV
 mAs
 fdM
 wwX
 wwX
-slM
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
+lhZ
 wwX
 rto
 sCz
@@ -145963,7 +145860,7 @@ lwn
 "}
 (36,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 whk
@@ -146066,15 +145963,15 @@ lLo
 lLo
 lLo
 iWB
-pdr
+jjV
 sJg
 fdM
 lLo
 wwX
 wwX
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
 wwX
 rto
 sCz
@@ -146166,7 +146063,7 @@ lwn
 "}
 (37,1,1) = {"
 lwn
-nhc
+buY
 gWb
 gsV
 iQJ
@@ -146235,7 +146132,7 @@ hMa
 szk
 plS
 sYp
-eEq
+slH
 eUg
 plS
 plS
@@ -146269,15 +146166,15 @@ iWB
 iWB
 lLo
 iWB
-pdr
+jjV
 nCv
 fdM
 lLo
 lLo
 wwX
 wwX
-slM
-slM
+lhZ
+lhZ
 wwX
 rto
 sCz
@@ -146369,7 +146266,7 @@ lwn
 "}
 (38,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 tlG
@@ -146472,15 +146369,15 @@ mpE
 iWB
 iWB
 iWB
-pdr
+jjV
 mAs
-uTE
+iiF
 lLo
 lLo
-gPk
+imu
 wwX
 wwX
-slM
+lhZ
 wwX
 bXV
 imA
@@ -146572,7 +146469,7 @@ lwn
 "}
 (39,1,1) = {"
 lwn
-nhc
+buY
 gWb
 kqD
 vGU
@@ -146679,9 +146576,9 @@ bVo
 ota
 fdM
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 wwX
 wwX
 wwX
@@ -146775,7 +146672,7 @@ lwn
 "}
 (40,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 vGU
@@ -146882,9 +146779,9 @@ iWB
 bxm
 fdM
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 lxG
 wwX
 wwX
@@ -146893,12 +146790,12 @@ wwX
 wwX
 wwX
 wwX
-slM
-slM
-slM
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
 wwX
 orT
 eOY
@@ -146978,7 +146875,7 @@ lwn
 "}
 (41,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 xQt
@@ -147085,9 +146982,9 @@ vjL
 fdM
 fdM
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 lxG
 lxG
 lxG
@@ -147097,11 +146994,11 @@ lxG
 lxG
 wwX
 wwX
-slM
-slM
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
 wwX
 orT
 mOA
@@ -147181,7 +147078,7 @@ lwn
 "}
 (42,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 iQJ
@@ -147288,9 +147185,9 @@ fdM
 qUo
 qDW
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 lxG
 lxG
 lxG
@@ -147301,10 +147198,10 @@ lxG
 lxG
 wwX
 wwX
-slM
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
+lhZ
 wwX
 orT
 rfQ
@@ -147384,7 +147281,7 @@ lwn
 "}
 (43,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 whk
@@ -147491,9 +147388,9 @@ qUo
 huz
 lLo
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 lxG
 lxG
 lxG
@@ -147505,9 +147402,9 @@ lxG
 lxG
 wwX
 wwX
-slM
-slM
-slM
+lhZ
+lhZ
+lhZ
 wwX
 bSm
 nIH
@@ -147570,9 +147467,9 @@ iDp
 ghY
 ghY
 uCf
-rtg
+lAB
 nPH
-mED
+bIp
 uAB
 otm
 hQQ
@@ -147587,7 +147484,7 @@ lwn
 "}
 (44,1,1) = {"
 lwn
-nhc
+buY
 gWb
 oWh
 djc
@@ -147651,8 +147548,8 @@ rtN
 jgh
 bnQ
 ydz
-sML
-iCB
+lmj
+iLK
 plS
 plS
 plS
@@ -147687,16 +147584,16 @@ lLo
 lLo
 lLo
 lLo
-jjV
-jjV
-jjV
-slH
+vDk
+vDk
+vDk
+nlp
 lLo
 lLo
 lLo
-gPk
-gPk
-gPk
+imu
+imu
+imu
 lxG
 lxG
 lxG
@@ -147709,8 +147606,8 @@ lxG
 lxG
 wwX
 wwX
-slM
-slM
+lhZ
+lhZ
 wwX
 tnX
 kfD
@@ -147753,7 +147650,7 @@ uIr
 lgo
 aEd
 uIr
-hjq
+aUq
 wWe
 obT
 lIM
@@ -147790,7 +147687,7 @@ lwn
 "}
 (45,1,1) = {"
 lwn
-nhc
+buY
 gRx
 oWh
 cyL
@@ -147802,8 +147699,8 @@ ssQ
 lne
 lne
 ssQ
-mIe
-mIe
+euT
+euT
 ssQ
 qyl
 lne
@@ -147854,10 +147751,10 @@ whb
 oqA
 xoH
 ydz
-sML
+lmj
 eUg
 eUg
-eEq
+slH
 plS
 sYp
 eUg
@@ -147890,14 +147787,14 @@ lLo
 lLo
 lLo
 lLo
-jjV
-slH
-jjV
+vDk
+nlp
+vDk
 lLo
 lLo
 lLo
 lLo
-gPk
+imu
 lxG
 lxG
 lxG
@@ -147913,7 +147810,7 @@ lxG
 lxG
 wwX
 wwX
-slM
+lhZ
 wwX
 djH
 tYO
@@ -147973,11 +147870,11 @@ pFr
 iDp
 iDp
 ghY
-vHW
+bcr
 vyc
 uCf
 gme
-lDN
+hMK
 uCf
 mix
 ghY
@@ -147993,7 +147890,7 @@ lwn
 "}
 (46,1,1) = {"
 lwn
-liu
+bmL
 ufw
 paN
 ivB
@@ -148057,7 +147954,7 @@ whb
 tpZ
 sVH
 ydz
-sML
+lmj
 eUg
 eUg
 eUg
@@ -148178,8 +148075,8 @@ dZP
 qBR
 pVG
 pVG
-kva
-mED
+rLo
+bIp
 ylp
 uCf
 ghY
@@ -148260,8 +148157,8 @@ pwz
 ejL
 hsM
 ydz
-sML
-sML
+lmj
+lmj
 eUg
 eUg
 eUg
@@ -148381,8 +148278,8 @@ iDp
 ghY
 qsQ
 ccf
-gse
-gse
+taw
+taw
 uCf
 ghY
 ghY
@@ -148494,11 +148391,11 @@ vZT
 myS
 tgB
 aVA
-mIs
-mIs
-mIs
-mIs
-mIs
+hbu
+hbu
+hbu
+hbu
+hbu
 czr
 fdM
 qUo
@@ -148507,11 +148404,11 @@ lLo
 csj
 csj
 csj
-kOC
+eEq
 csj
-kOC
+eEq
 csj
-kOC
+eEq
 csj
 csj
 csj
@@ -148582,10 +148479,10 @@ aJV
 iDp
 iDp
 ghY
-tyX
+osL
 uCf
 ffF
-gse
+taw
 uCf
 ghY
 ghY
@@ -148701,7 +148598,7 @@ jLB
 jLB
 jLB
 jLB
-mIs
+hbu
 qUo
 eHm
 qUo
@@ -148710,16 +148607,16 @@ csj
 csj
 tHU
 wpK
-kOC
-kOC
-kOC
-kOC
+eEq
+eEq
+eEq
+eEq
 rAy
-fUG
+hIq
 tHU
 csj
 csj
-nEL
+itR
 tHU
 eyS
 csj
@@ -148797,15 +148694,15 @@ ghY
 ghY
 ghY
 uCf
-rtg
-gse
+lAB
+taw
 uCf
 uCf
 lwn
 "}
 (50,1,1) = {"
 lwn
-bmL
+trR
 dWF
 tjh
 aHv
@@ -148912,7 +148809,7 @@ tHU
 qKE
 tHU
 tHU
-fUG
+hIq
 peq
 iPP
 wPh
@@ -148925,7 +148822,7 @@ tHU
 tHU
 tHU
 tHU
-jDH
+vJb
 csj
 csj
 slN
@@ -149000,15 +148897,15 @@ ghY
 ghY
 ghY
 uCf
-rtg
-gse
+lAB
+taw
 uCf
 uCf
 lwn
 "}
 (51,1,1) = {"
 lwn
-buY
+tyX
 dSL
 eWM
 dTN
@@ -149116,11 +149013,11 @@ tHU
 tHU
 tHU
 nDm
-fUG
+hIq
 iPP
 noQ
 xlk
-fUG
+hIq
 tHU
 ltM
 tHU
@@ -149133,7 +149030,7 @@ tHU
 tHU
 tHU
 tHU
-oCW
+eeq
 kAy
 sVL
 unr
@@ -149178,10 +149075,10 @@ sYH
 xPa
 obT
 iDp
-kQM
-kQM
-kQM
-kQM
+qgH
+qgH
+qgH
+qgH
 iDp
 iDp
 uCf
@@ -149211,7 +149108,7 @@ lwn
 "}
 (52,1,1) = {"
 lwn
-buY
+tyX
 gff
 gDW
 dzp
@@ -149319,11 +149216,11 @@ tHU
 pLX
 tHU
 tHU
-fUG
+hIq
 iPP
 wPh
 xlk
-fUG
+hIq
 tHU
 tHU
 tHU
@@ -149334,7 +149231,7 @@ tHU
 tHU
 tHU
 tHU
-bJQ
+aFM
 uhf
 uhf
 fhJ
@@ -149377,13 +149274,13 @@ uIr
 mpx
 ePF
 uIr
-hjq
-hjq
+aUq
+aUq
 obT
 iDp
-kQM
-kQM
-kQM
+qgH
+qgH
+qgH
 iDp
 iDp
 ghY
@@ -149398,7 +149295,7 @@ vJw
 uCf
 uCf
 ffF
-rtg
+lAB
 uCf
 ccf
 uCf
@@ -149414,7 +149311,7 @@ lwn
 "}
 (53,1,1) = {"
 lwn
-buY
+tyX
 pys
 eWM
 dzp
@@ -149522,11 +149419,11 @@ pwh
 ltM
 tHU
 pLX
-fUG
+hIq
 iPP
 noQ
 xlk
-fUG
+hIq
 pLX
 euN
 tHU
@@ -149584,14 +149481,14 @@ vot
 vot
 obT
 iDp
-kQM
-kQM
+qgH
+qgH
 iDp
 iDp
 ghY
 ghY
 ghY
-taw
+xzl
 cat
 cat
 cat
@@ -149600,14 +149497,14 @@ uCf
 uCf
 uCf
 ffF
-gse
-rtg
-rtg
+taw
+lAB
+lAB
 uCf
 uCf
 uCf
-gse
-gse
+taw
+taw
 ffF
 ffF
 uCf
@@ -149617,7 +149514,7 @@ lwn
 "}
 (54,1,1) = {"
 lwn
-buY
+tyX
 gff
 xrT
 dzp
@@ -149787,14 +149684,14 @@ aep
 mZe
 obT
 iDp
-kQM
+qgH
 iDp
 iDp
 csj
 csj
 ghY
 ghY
-pln
+oty
 cat
 uCf
 dbQ
@@ -149804,13 +149701,13 @@ ffF
 ffF
 ffF
 roJ
-gse
+taw
 uCf
 ffF
 ffF
 roJ
-gse
-gse
+taw
+taw
 uCf
 uCf
 uCf
@@ -149820,7 +149717,7 @@ lwn
 "}
 (55,1,1) = {"
 lwn
-buY
+tyX
 pys
 spa
 dzp
@@ -149928,12 +149825,12 @@ aNS
 aNS
 tHU
 vic
-kOC
-kOC
-kOC
-kOC
+eEq
+eEq
+eEq
+eEq
 rAy
-fUG
+hIq
 tHU
 tHU
 tHU
@@ -149946,11 +149843,11 @@ tHU
 csj
 uhf
 uhf
-pMf
-pMf
-pMf
-pMf
-pMf
+bkn
+bkn
+bkn
+bkn
+bkn
 uhf
 rjr
 bst
@@ -149959,11 +149856,11 @@ vne
 alm
 rjr
 sfu
-fkr
-fkr
-fkr
-fkr
-fkr
+dNK
+dNK
+dNK
+dNK
+dNK
 sfu
 uBH
 oDp
@@ -150001,15 +149898,15 @@ ghY
 ccf
 uCf
 uCf
-rtg
-gse
+lAB
+taw
 gme
 lol
-gse
+taw
 ffF
 ffF
 ffF
-gse
+taw
 ffF
 gme
 uCf
@@ -150023,7 +149920,7 @@ lwn
 "}
 (56,1,1) = {"
 lwn
-buY
+tyX
 pys
 eWM
 oNB
@@ -150131,11 +150028,11 @@ aNS
 pwh
 tHU
 tHU
-kOC
+eEq
 csj
-kOC
+eEq
 csj
-kOC
+eEq
 csj
 tHU
 csj
@@ -150149,11 +150046,11 @@ tHU
 csj
 uhf
 uhf
-pMf
-pMf
-pMf
-pMf
-pMf
+bkn
+bkn
+bkn
+bkn
+bkn
 uhf
 rjr
 rHY
@@ -150162,11 +150059,11 @@ vne
 did
 rjr
 sfu
-fkr
-fkr
-fkr
-fkr
-fkr
+dNK
+dNK
+dNK
+dNK
+dNK
 sfu
 hvw
 rNS
@@ -150202,21 +150099,21 @@ csj
 csj
 uCf
 uCf
-rtg
+lAB
 uCf
 ffF
-gse
+taw
 ffF
-gse
-gse
-gse
+taw
+taw
+taw
 ffF
-gse
-gse
-gse
+taw
+taw
+taw
 uCf
 uCf
-tyX
+osL
 ghY
 ghY
 ghY
@@ -150226,7 +150123,7 @@ lwn
 "}
 (57,1,1) = {"
 lwn
-buY
+tyX
 gff
 eWM
 dzp
@@ -150326,8 +150223,8 @@ jLB
 jLB
 atI
 atI
-vcV
-vcV
+flR
+flR
 csj
 csj
 aNS
@@ -150353,10 +150250,10 @@ csj
 csj
 uhf
 uhf
-pMf
-pMf
-pMf
-pMf
+bkn
+bkn
+bkn
+bkn
 uhf
 rjr
 rHY
@@ -150365,10 +150262,10 @@ vne
 did
 rjr
 sfu
-fkr
-fkr
-fkr
-fkr
+dNK
+dNK
+dNK
+dNK
 sfu
 sfu
 hvw
@@ -150404,18 +150301,18 @@ csj
 tHU
 tHU
 uCf
-rtg
-gse
-gse
+lAB
+taw
+taw
 ffF
 ffF
 ffF
 uCf
-rtg
+lAB
 esT
 uCf
 ffF
-gse
+taw
 uCf
 uCf
 vyc
@@ -150429,7 +150326,7 @@ lwn
 "}
 (58,1,1) = {"
 lwn
-buY
+tyX
 pys
 eWM
 dzp
@@ -150530,7 +150427,7 @@ uZJ
 bYP
 yjf
 qxq
-vcV
+flR
 csj
 slN
 aNS
@@ -150545,7 +150442,7 @@ csj
 tHU
 wwN
 csj
-fUG
+hIq
 bLL
 aNS
 aNS
@@ -150557,9 +150454,9 @@ csj
 csj
 uhf
 uhf
-pMf
-pMf
-pMf
+bkn
+bkn
+bkn
 uhf
 rjr
 sHW
@@ -150568,9 +150465,9 @@ vne
 sJA
 rjr
 sfu
-fkr
-fkr
-fkr
+dNK
+dNK
+dNK
 sfu
 sfu
 csj
@@ -150608,7 +150505,7 @@ pLX
 kZP
 ffF
 gme
-gse
+taw
 roJ
 uCf
 uCf
@@ -150632,7 +150529,7 @@ lwn
 "}
 (59,1,1) = {"
 lwn
-buY
+tyX
 cbt
 xrT
 eez
@@ -150733,7 +150630,7 @@ jUb
 jRt
 hJK
 jIA
-vcV
+flR
 csj
 aNS
 aNS
@@ -150747,9 +150644,9 @@ csj
 csj
 tHU
 tHU
-fUG
-fUG
-fUG
+hIq
+hIq
+hIq
 pLX
 tHU
 aNS
@@ -150761,8 +150658,8 @@ csj
 csj
 uhf
 uhf
-pMf
-pMf
+bkn
+bkn
 uhf
 rjr
 dqc
@@ -150771,8 +150668,8 @@ vne
 aEk
 rjr
 sfu
-fkr
-fkr
+dNK
+dNK
 sfu
 sfu
 csj
@@ -150815,13 +150712,13 @@ uCf
 uCf
 uCf
 ccf
-taw
+xzl
 jRp
 ghY
 uCf
 uCf
 uCf
-gse
+taw
 ffF
 uCf
 ghY
@@ -150835,7 +150732,7 @@ lwn
 "}
 (60,1,1) = {"
 lwn
-bmL
+trR
 lFc
 xAC
 uXi
@@ -150936,7 +150833,7 @@ wjO
 cmc
 mTE
 aFy
-vcV
+flR
 aNS
 aNS
 aNS
@@ -150953,19 +150850,19 @@ tHU
 ltM
 csj
 csj
-fUG
+hIq
 tHU
 tHU
 aNS
 tHU
 tHU
-fUG
+hIq
 csj
 csj
 csj
 uhf
 uhf
-pMf
+bkn
 uhf
 rjr
 rjr
@@ -150974,7 +150871,7 @@ xLD
 rjr
 rjr
 sfu
-fkr
+dNK
 sfu
 sfu
 csj
@@ -151023,9 +150920,9 @@ brE
 ghY
 ghY
 uCf
-rtg
-gse
-gse
+lAB
+taw
+taw
 uCf
 uCf
 ghY
@@ -151139,7 +151036,7 @@ jPj
 sol
 eyn
 hgA
-wTG
+faB
 aNS
 aNS
 aNS
@@ -151150,19 +151047,19 @@ aNS
 tHU
 csj
 csj
-fUG
-fUG
+hIq
+hIq
 csj
 tHU
 tHU
 csj
-fUG
+hIq
 csj
 tHU
 tHU
 tHU
-fUG
-fUG
+hIq
+hIq
 bYt
 csj
 csj
@@ -151192,16 +151089,16 @@ tHU
 tHU
 nCl
 obT
-vtj
-vtj
-vtj
-vtj
+mIs
+mIs
+mIs
+mIs
 ana
 obT
-wyb
-fUG
+hcF
+hIq
 csj
-fUG
+hIq
 tHU
 ltM
 tHU
@@ -151219,7 +151116,7 @@ tHU
 van
 ghY
 ghY
-apx
+stz
 vmE
 cat
 cat
@@ -151227,7 +151124,7 @@ ghY
 ghY
 uCf
 uCf
-rtg
+lAB
 gme
 uCf
 uCf
@@ -151241,18 +151138,18 @@ lwn
 "}
 (62,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 kaE
-pEe
+qgR
 pjR
-pEe
-pEe
-pEe
-wPV
-wPV
+qgR
+qgR
+qgR
+cMi
+cMi
 laB
 laB
 laB
@@ -151342,7 +151239,7 @@ oTD
 jRt
 wWZ
 wmu
-vcV
+flR
 aNS
 aNS
 csj
@@ -151352,19 +151249,19 @@ aNS
 aNS
 tHU
 tHU
-hXu
-fUG
+ilr
+hIq
 csj
 csj
 tHU
 tHU
 ltM
-fUG
+hIq
 csj
 csj
 csj
-fUG
-fUG
+hIq
+hIq
 tHU
 tHU
 csj
@@ -151395,16 +151292,16 @@ pLX
 tHU
 tHU
 hOH
-vtj
-vtj
-vtj
-vtj
-vtj
+mIs
+mIs
+mIs
+mIs
+mIs
 hOH
 tHU
-fUG
-fUG
-xEq
+hIq
+hIq
+rjX
 tHU
 pLX
 aNS
@@ -151418,8 +151315,8 @@ tHU
 tHU
 pLX
 tHU
-uvk
-iJa
+fKs
+dPQ
 ghY
 ghY
 ghY
@@ -151444,9 +151341,9 @@ lwn
 "}
 (63,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 iSB
@@ -151455,7 +151352,7 @@ pjR
 iSB
 pjR
 aSK
-wPV
+cMi
 laB
 qkv
 fcu
@@ -151545,7 +151442,7 @@ hcD
 wUI
 jSm
 lgh
-vcV
+flR
 csj
 csj
 csj
@@ -151566,7 +151463,7 @@ slN
 csj
 csj
 csj
-xEq
+rjX
 tHU
 tHU
 eXS
@@ -151605,9 +151502,9 @@ aUH
 aNS
 tHU
 ltM
-fUG
-fUG
-fUG
+hIq
+hIq
+hIq
 tHU
 tHU
 ltM
@@ -151620,24 +151517,24 @@ tHU
 tHU
 tHU
 csj
-fUG
-dMr
+hIq
+lCQ
 csj
 ghY
-qgR
-qgR
+bBO
+bBO
 ghY
 ghY
 ghY
 ghY
-qgR
+bBO
 ghY
 cat
 cat
 ihu
-xOI
+qeC
 cat
-sTB
+qtK
 uCf
 uCf
 ccf
@@ -151647,8 +151544,8 @@ lwn
 "}
 (64,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -151657,8 +151554,8 @@ pjR
 pjR
 uTs
 aSK
-wPV
-wPV
+cMi
+cMi
 laB
 kUR
 gOG
@@ -151748,10 +151645,10 @@ aFy
 nLo
 gmg
 nxH
-sNe
-ftl
-ftl
-ftl
+hYz
+vDh
+vDh
+vDh
 csj
 tHU
 eXS
@@ -151808,7 +151705,7 @@ lRa
 aUH
 aNS
 tHU
-fUG
+hIq
 csj
 csj
 tHU
@@ -151823,24 +151720,24 @@ ltM
 tHU
 csj
 csj
-fUG
-fUG
+hIq
+hIq
 csj
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
 ghY
 ghY
 ghY
 ghY
-qgR
+bBO
 ghY
 cat
 bRq
-xOI
-xOI
-xOI
-ome
+qeC
+qeC
+qeC
+qkB
 ghY
 rsK
 vyc
@@ -151850,8 +151747,8 @@ lwn
 "}
 (65,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 hqC
 ixA
 aSK
@@ -151860,8 +151757,8 @@ rTg
 pjR
 ilO
 aSK
-wPV
-wPV
+cMi
+cMi
 laB
 tkU
 iNk
@@ -151954,8 +151851,8 @@ kvl
 kvl
 kvl
 kvl
-ftl
-ftl
+vDh
+vDh
 tHU
 aNS
 oXR
@@ -151967,15 +151864,15 @@ tHU
 tHU
 csj
 csj
-fUG
-fUG
+hIq
+hIq
 csj
 csj
 csj
 tHU
 eyS
 aNS
-lsv
+nRX
 vxK
 vxK
 aUH
@@ -152029,19 +151926,19 @@ lxG
 csj
 csj
 csj
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 ghY
 ghY
-rNL
-rNL
-rtg
+jeZ
+jeZ
+lAB
 uCf
 uCf
 ghY
@@ -152053,8 +151950,8 @@ lwn
 "}
 (66,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 aSK
 aSK
@@ -152063,8 +151960,8 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 laB
 khZ
 iZy
@@ -152171,14 +152068,14 @@ tHU
 tHU
 csj
 csj
-hXu
+ilr
 csj
 csj
 csj
 udt
 tHU
 aNS
-fRT
+wPV
 vxK
 vxK
 qES
@@ -152212,7 +152109,7 @@ lRa
 vxK
 vxK
 lRa
-sOn
+fYW
 tHU
 csj
 lxG
@@ -152232,15 +152129,15 @@ lxG
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 jQO
 uCf
@@ -152256,18 +152153,18 @@ lwn
 "}
 (67,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 laB
 wMN
 djn
@@ -152363,10 +152260,10 @@ eui
 fyR
 hnu
 kvl
-kPk
+rkm
 hwN
 hxe
-kPk
+rkm
 csj
 tHU
 aNS
@@ -152374,7 +152271,7 @@ aNS
 tHU
 tHU
 tHU
-fUG
+hIq
 csj
 csj
 csj
@@ -152387,7 +152284,7 @@ qES
 aNS
 tHU
 wHv
-eNf
+hnn
 lRx
 hpg
 qMq
@@ -152398,19 +152295,19 @@ sTC
 slN
 tHU
 oXR
-koX
+oXR
 aNS
 aNS
 tHU
 wHv
 pBH
 lRx
-bbj
+prF
 eGj
 qMq
 qMq
 pvB
-dDI
+dvt
 pmd
 wxr
 lRa
@@ -152435,15 +152332,15 @@ lxG
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 ghY
 ghY
@@ -152453,24 +152350,24 @@ gme
 uCf
 ghY
 ghY
-trR
-xxz
+oyv
+eSb
 lwn
 "}
 (68,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 pjR
 pjR
 pjR
 pjR
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 laB
 uru
 djn
@@ -152566,10 +152463,10 @@ xKy
 aEb
 oTF
 kvl
-kPk
+rkm
 xIg
 xIg
-kPk
+rkm
 csj
 csj
 pLX
@@ -152580,8 +152477,8 @@ tHU
 tHU
 csj
 csj
-fUG
-fUG
+hIq
+hIq
 tHU
 tHU
 aNS
@@ -152590,7 +152487,7 @@ oXR
 aNS
 tHU
 oMD
-yaK
+jDH
 upA
 qMq
 eGj
@@ -152638,42 +152535,42 @@ lxG
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 ghY
 uCf
 uCf
 uCf
-trR
-xxz
+oyv
+eSb
 nLp
 deK
 lwn
 "}
 (69,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 gsL
 aSK
 aSK
 pjR
 ilO
 pjR
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 laB
 fnl
 pJx
@@ -152772,8 +152669,8 @@ kvl
 qSZ
 ruV
 tNX
-kPk
-kPk
+rkm
+rkm
 csj
 tHU
 tHU
@@ -152783,9 +152680,9 @@ pwh
 tHU
 csj
 tHU
-fUG
+hIq
 bVc
-fUG
+hIq
 tHU
 ltM
 oXR
@@ -152810,7 +152707,7 @@ aNS
 eXS
 tHU
 tHU
-gSz
+nNx
 qMq
 qMq
 qMq
@@ -152841,21 +152738,21 @@ lxG
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 ghY
-rNL
-rNL
+jeZ
+jeZ
 ghY
 nLp
 deK
@@ -152865,18 +152762,18 @@ lwn
 "}
 (70,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 oth
 aSK
 pjR
 pjR
 pjR
-faB
-wPV
-wPV
-wPV
-wPV
+dvq
+cMi
+cMi
+cMi
+cMi
 laB
 dKA
 nnx
@@ -152976,7 +152873,7 @@ qSZ
 qve
 gNc
 mbm
-kPk
+rkm
 csj
 csj
 tHU
@@ -152989,7 +152886,7 @@ tHU
 kZP
 bVc
 bVc
-fUG
+hIq
 tHU
 eXS
 oXR
@@ -153021,7 +152918,7 @@ qMq
 xKk
 tHU
 oXR
-bef
+uaL
 kZP
 tHU
 udt
@@ -153034,7 +152931,7 @@ aNS
 pwh
 aNS
 rtM
-lAC
+fQM
 aNS
 aNS
 tHU
@@ -153044,19 +152941,19 @@ csj
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
 ghY
 ghY
-trR
-xxz
-xxz
+oyv
+eSb
+eSb
 bRq
 cat
 cat
@@ -153068,14 +152965,14 @@ lwn
 "}
 (71,1,1) = {"
 lwn
-wPV
+cMi
 sBL
 aSK
 iUW
 giV
 miQ
 pjR
-pEe
+qgR
 wPf
 wPf
 wPf
@@ -153179,7 +153076,7 @@ qSZ
 uGW
 qBh
 mbm
-kPk
+rkm
 csj
 csj
 csj
@@ -153192,7 +153089,7 @@ aNS
 pLX
 kZP
 bYt
-fUG
+hIq
 tHU
 tHU
 eXS
@@ -153238,7 +153135,7 @@ aNS
 aSf
 lRa
 lRa
-lAC
+fQM
 aNS
 pwh
 aNS
@@ -153248,15 +153145,15 @@ csj
 lxG
 lxG
 lxG
-qgR
-qgR
-qgR
-qgR
-qgR
+bBO
+bBO
+bBO
+bBO
+bBO
 ghY
-trR
-xxz
-xxz
+oyv
+eSb
+eSb
 nLp
 deK
 wxD
@@ -153271,15 +153168,15 @@ lwn
 "}
 (72,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 pjR
 pjR
-vNw
+hNC
 jWM
 lED
 xGH
@@ -153382,8 +153279,8 @@ fGm
 uUc
 qBh
 mbm
-kPk
-kPk
+rkm
+rkm
 jLF
 bKG
 oEd
@@ -153394,7 +153291,7 @@ tHU
 tHU
 tHU
 tHU
-fUG
+hIq
 csj
 csj
 tHU
@@ -153419,7 +153316,7 @@ tHU
 kZP
 lRa
 lau
-dPQ
+eTx
 tHU
 tHU
 tHU
@@ -153452,11 +153349,11 @@ lxG
 lxG
 lxG
 lxG
-qgR
-qgR
+bBO
+bBO
 ghY
-trR
-xxz
+oyv
+eSb
 nLp
 deK
 pnY
@@ -153474,8 +153371,8 @@ lwn
 "}
 (73,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 gsL
 aSK
 pjR
@@ -153586,7 +153483,7 @@ fOb
 gNc
 jjZ
 alw
-kPk
+rkm
 wOt
 lRa
 grK
@@ -153594,7 +153491,7 @@ aNS
 tHU
 tHU
 eyS
-nQX
+xix
 tHU
 tHU
 csj
@@ -153602,7 +153499,7 @@ csj
 csj
 tHU
 kZP
-bef
+uaL
 oXR
 aNS
 aSf
@@ -153657,7 +153554,7 @@ lxG
 lxG
 lxG
 ghY
-trR
+oyv
 nLp
 deK
 pnY
@@ -153677,14 +153574,14 @@ lwn
 "}
 (74,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 pjR
-pZs
+iEH
 wPf
 rlH
 azC
@@ -153789,7 +153686,7 @@ tXg
 muL
 pdI
 jKw
-kPk
+rkm
 eYy
 gCt
 grK
@@ -153847,9 +153744,9 @@ aNS
 eXS
 aNS
 aNS
-jDH
+vJb
 slN
-hIq
+nRd
 eXS
 aNS
 aNS
@@ -153870,8 +153767,8 @@ uZo
 vcE
 vcE
 vcE
-rNL
-rNL
+jeZ
+jeZ
 vcE
 vcE
 vcE
@@ -153880,14 +153777,14 @@ lwn
 "}
 (75,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 iSB
-pZs
+iEH
 wPf
 wPf
 wPf
@@ -153992,14 +153889,14 @@ ffH
 qBh
 gNc
 jKw
-kPk
+rkm
 bxF
 bKG
 aNS
 kfk
 aNS
 euN
-vwE
+xJg
 tHU
 tHU
 csj
@@ -154025,8 +153922,8 @@ lxG
 lxG
 csj
 csj
-fUG
-xEq
+hIq
+rjX
 vcE
 vcE
 vcE
@@ -154044,14 +153941,14 @@ vcE
 hMX
 hQY
 tHU
-dNK
+aiG
 kZP
 oXR
 aNS
 aNS
 tHU
 lxG
-nEL
+itR
 aNS
 aNS
 pwh
@@ -154062,7 +153959,7 @@ lxG
 lxG
 lxG
 dis
-dSH
+xdu
 deK
 hNH
 vcE
@@ -154083,18 +153980,18 @@ lwn
 "}
 (76,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 hOK
 pjR
 aGA
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 laB
 xms
 mDA
@@ -154195,7 +154092,7 @@ wtZ
 qBh
 bBZ
 kHZ
-kPk
+rkm
 xRu
 bKG
 phU
@@ -154222,14 +154119,14 @@ tHU
 csj
 csj
 lxG
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
-icp
-icp
+eay
+eay
 vcE
 uZo
 vcE
@@ -154254,7 +154151,7 @@ eXS
 tHU
 lxG
 lxG
-igF
+grJ
 tHU
 oXR
 oXR
@@ -154264,7 +154161,7 @@ lxG
 lxG
 lxG
 dis
-dSH
+xdu
 deK
 vcE
 vcE
@@ -154286,18 +154183,18 @@ lwn
 "}
 (77,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 iFQ
 pjR
 pjR
 pjR
 ixA
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 laB
 fFU
 gNH
@@ -154397,8 +154294,8 @@ tPk
 bif
 xXV
 ibW
-kPk
-kPk
+rkm
+rkm
 auG
 lRa
 jrY
@@ -154423,11 +154320,11 @@ tHU
 csj
 csj
 csj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -154454,18 +154351,18 @@ kRv
 kgG
 kgG
 kgG
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 abx
 siK
 abx
 kRv
 uFb
-gmP
-gmP
+wji
+wji
 vzo
 deK
 hNH
@@ -154489,18 +154386,18 @@ lwn
 "}
 (78,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 laB
 umB
 oBI
@@ -154600,15 +154497,15 @@ tPI
 pfp
 rqC
 ubm
-kPk
-kPk
+rkm
+rkm
 ewe
-cdy
-cdy
-cdy
-cdy
-cdy
-kOC
+fJl
+fJl
+fJl
+fJl
+fJl
+eEq
 ewe
 csj
 lxG
@@ -154623,13 +154520,13 @@ csj
 tHU
 tHU
 tHU
-uKb
+lAC
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -154658,10 +154555,10 @@ heY
 ril
 kgG
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
@@ -154669,7 +154566,7 @@ siK
 kRv
 sHN
 hgt
-imu
+dLQ
 jHs
 vcE
 uZo
@@ -154692,18 +154589,18 @@ lwn
 "}
 (79,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 hqC
 aSK
 pjR
 pjR
 pjR
 aGA
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 eBP
 hiU
 jmo
@@ -154714,7 +154611,7 @@ dSe
 bnJ
 tpT
 dpy
-pQt
+dpm
 qwL
 geF
 xiF
@@ -154803,8 +154700,8 @@ fWx
 wtZ
 lYY
 lYY
-kPk
-kPk
+rkm
+rkm
 mFl
 vSa
 vSa
@@ -154812,7 +154709,7 @@ vSa
 vSa
 vSa
 uMo
-kOC
+eEq
 csj
 lxG
 lxG
@@ -154822,22 +154719,22 @@ csj
 csj
 csj
 csj
-jFU
-hXu
+vHx
+ilr
 csj
-icp
-jVy
+eay
+qek
 kqj
 kqj
-gmP
+wji
 kRv
 oAc
-gmP
+wji
 kqj
 kqj
 lIc
 saQ
-szN
+vvv
 kRv
 kRv
 qOz
@@ -154862,9 +154759,9 @@ epS
 ril
 kRv
 pPh
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 kgG
 siK
@@ -154895,8 +154792,8 @@ lwn
 "}
 (80,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 aSK
 ilO
@@ -154917,7 +154814,7 @@ wFQ
 qwL
 pST
 tpT
-eJp
+fRU
 qwL
 geF
 xiF
@@ -155006,25 +154903,25 @@ eIE
 edW
 eIE
 eIE
-tAY
-tAY
-kcZ
-fJl
-fJl
-fJl
-fJl
-fJl
-kcZ
+ieq
+ieq
+hXu
+oCW
+oCW
+oCW
+oCW
+oCW
+hXu
 iTq
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 lIc
 lIc
 lIc
@@ -155035,11 +154932,11 @@ kRv
 sHN
 kRv
 kRv
-gmP
+wji
 kRv
 umq
 lIc
-boy
+fLw
 lIc
 mDf
 kRv
@@ -155061,17 +154958,17 @@ rni
 tcF
 hsv
 epS
-dnq
-xkr
+umk
+dci
 kRv
 kqj
-gmP
-gmP
+wji
+wji
 oFM
 kgG
 kgG
 gpA
-hbu
+nEL
 uii
 kgG
 uNd
@@ -155098,9 +154995,9 @@ lwn
 "}
 (81,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 fME
 pjR
 pjR
@@ -155220,13 +155117,13 @@ uFG
 uxf
 uFG
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 kRv
@@ -155242,8 +155139,8 @@ kRv
 kRv
 kRv
 fdb
-boy
-boy
+fLw
+fLw
 lIc
 kRv
 rni
@@ -155264,20 +155161,20 @@ hlw
 tcF
 kRv
 wWc
-xkr
+dci
 abx
 kRv
 oFM
-gmP
-gmP
-gmP
-vRj
+wji
+wji
+wji
+pSt
 oDi
 heY
 dXr
 dXr
 hBx
-vAJ
+qBM
 jHs
 vcE
 uZo
@@ -155291,9 +155188,9 @@ cny
 rni
 iAI
 hlw
-rVT
+nUX
 sRu
-jFE
+iHj
 hlw
 iAI
 dvj
@@ -155301,9 +155198,9 @@ lwn
 "}
 (82,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -155412,7 +155309,7 @@ tND
 vTo
 nGN
 kWW
-tAY
+ieq
 lIw
 xAq
 eCf
@@ -155420,12 +155317,12 @@ nNt
 kgG
 gkK
 qev
-qTg
+cQl
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -155504,9 +155401,9 @@ lwn
 "}
 (83,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
@@ -155615,20 +155512,20 @@ kKH
 vYj
 sxL
 iXw
-tAY
+ieq
 iLe
 gpA
-qTg
+cQl
 kgG
 kgG
 kgG
-qTg
+cQl
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 eSq
@@ -155674,14 +155571,14 @@ kgG
 kRv
 kRv
 sHN
-gmP
-gmP
+wji
+wji
 mPX
 wyt
 oXi
 abx
-iQQ
-hDF
+hoK
+vTi
 siK
 uNd
 jHs
@@ -155697,9 +155594,9 @@ erb
 wFj
 rni
 hlw
-dce
+bef
 hlw
-dce
+bef
 hlw
 rni
 dZd
@@ -155707,9 +155604,9 @@ lwn
 "}
 (84,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 miQ
@@ -155827,11 +155724,11 @@ kgG
 uiF
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 kRv
@@ -155863,7 +155760,7 @@ tJs
 rni
 oCi
 oCi
-lYR
+tSX
 dOL
 dOL
 xjG
@@ -155875,10 +155772,10 @@ fdb
 siK
 gpA
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 svA
 kRv
 hKx
@@ -155910,18 +155807,18 @@ lwn
 "}
 (85,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 ilO
 pjR
 pjR
 miQ
 ouc
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 eBP
 edq
 vdZ
@@ -156030,10 +155927,10 @@ kRv
 kRv
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -156047,17 +155944,17 @@ kRv
 kRv
 umq
 kRv
-gmP
+wji
 kRv
 kRv
-gmP
+wji
 kRv
 kRv
 kqj
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 sTI
 fTo
@@ -156079,10 +155976,10 @@ kgG
 kgG
 kRv
 bLF
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 pbh
 kPD
 hVK
@@ -156113,19 +156010,19 @@ lwn
 "}
 (86,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aiX
 ixA
 pjR
 iSB
 pjR
 aSK
-wPV
-wPV
-wPV
-wPV
-tHT
+cMi
+cMi
+cMi
+cMi
+vHW
 xpF
 gnw
 pKe
@@ -156220,28 +156117,28 @@ pzo
 iMu
 vTo
 uER
-tAY
-tAY
-tAY
-tAY
-tAY
-nQG
+ieq
+ieq
+ieq
+ieq
+ieq
+mMV
 nQW
 kRv
-stz
+aYy
 kRv
 umq
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 lIc
 lIc
-ert
+ome
 lIc
 fdb
 kRv
@@ -156249,18 +156146,18 @@ kRv
 kRv
 kqj
 kRv
-gmP
-gmP
+wji
+wji
 lIc
-gmP
-gmP
-gmP
+wji
+wji
+wji
 lIc
-vUg
+sOn
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 erb
 wFj
@@ -156282,18 +156179,18 @@ kgG
 mPX
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kRv
 kgG
 gpA
 kgG
 fdb
 ocK
-iHj
+umH
 jHs
 hNH
 vcE
@@ -156316,18 +156213,18 @@ lwn
 "}
 (87,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 aSK
 aSK
 aSK
 aSK
-nyW
+aQh
 byv
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 eBP
 rYG
 nqf
@@ -156423,47 +156320,47 @@ tnx
 uER
 edW
 uER
-tAY
+ieq
 kqj
 kqj
 kqj
 kqj
-mqJ
+cwm
 kRv
-flR
+nQX
 lIc
 lIc
 lIc
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 lIc
 lIc
-flR
+nQX
 lIc
 lIc
 lIc
 kRv
 mDf
 kRv
-gmP
-gmP
-gmP
+wji
+wji
+wji
 lIc
 pqj
 lIc
-gmP
+wji
 lIc
 dIp
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 vcE
 nEa
@@ -156483,12 +156380,12 @@ kRv
 umq
 kgG
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 uFb
 kRv
 mDf
@@ -156519,18 +156416,18 @@ lwn
 "}
 (88,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-nyW
-nyW
+cMi
+cMi
+cMi
+aQh
+aQh
 mBc
 kzI
-nyW
+aQh
 mgH
-nyW
-wPV
-wPV
+aQh
+cMi
+cMi
 eBP
 ahz
 kRj
@@ -156626,22 +156523,22 @@ nMU
 poI
 yjV
 wnU
-hNF
+eiw
 kqj
 kqj
 kqj
 kqj
 kRv
-flR
+nQX
 lIc
 lIc
 lIc
 lIc
 lIc
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -156653,9 +156550,9 @@ lIc
 lIc
 lIc
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 bUj
@@ -156664,9 +156561,9 @@ fMZ
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 hQY
@@ -156688,19 +156585,19 @@ kgG
 kgG
 kRv
 oAc
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 mDf
 kRv
 siK
 kgG
 ocK
-iHj
+umH
 jHs
 vcE
 vcE
@@ -156713,8 +156610,8 @@ vcE
 vcE
 vcE
 vcE
-gOR
-gOR
+lYR
+lYR
 vcE
 vcE
 vcE
@@ -156722,18 +156619,18 @@ lwn
 "}
 (89,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-mta
-hoK
-stJ
-mta
-mta
-stJ
-mta
-wPV
-wPV
+cMi
+cMi
+cMi
+phE
+upU
+wIM
+phE
+phE
+wIM
+phE
+cMi
+cMi
 hTt
 pnl
 qcn
@@ -156829,12 +156726,12 @@ ubG
 wTx
 tpX
 otr
-hNF
+eiw
 kqj
 kqj
 kqj
 lIc
-ert
+ome
 lIc
 lIc
 lIc
@@ -156856,8 +156753,8 @@ lIc
 lIc
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 oSZ
 oJM
@@ -156867,11 +156764,11 @@ kRv
 fTY
 oSZ
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 fTE
@@ -156891,13 +156788,13 @@ kgG
 kgG
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 lIc
 umq
 kRv
@@ -156925,18 +156822,18 @@ lwn
 "}
 (90,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-nyW
+cMi
+cMi
+cMi
+cMi
+aQh
 tMn
 tWt
 tDE
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 hTt
 ury
 xtS
@@ -156947,7 +156844,7 @@ hTt
 tzX
 qwL
 qwL
-oty
+jib
 qwL
 uQQ
 vOL
@@ -157032,17 +156929,17 @@ wMm
 wMm
 iNU
 vNc
-hNF
+eiw
 kqj
 kqj
 lIc
-fYW
+gPk
 lIc
 kRv
 kRv
 kRv
 umq
-icp
+eay
 lIc
 kqj
 kqj
@@ -157058,9 +156955,9 @@ kRv
 lIc
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 fGo
 dnv
@@ -157070,11 +156967,11 @@ knC
 ybI
 bFe
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 gkI
 mDQ
 vcE
@@ -157092,20 +156989,20 @@ siK
 siK
 gpA
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 lIc
 lIc
 lIc
 kRv
-gmP
-gmP
+wji
+qvx
 deK
 vcE
 vcE
@@ -157117,21 +157014,21 @@ vcE
 vcE
 vcE
 qOz
-jfd
+xXw
 rBH
-iwK
+aqg
 dnu
 rBH
 ajB
-vHx
+hRC
 lwn
 "}
 (91,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 mUL
@@ -157139,7 +157036,7 @@ hms
 aSK
 aSK
 ouc
-wPV
+cMi
 hTt
 uvw
 oJz
@@ -157235,7 +157132,7 @@ mKf
 xLj
 pIS
 qKT
-hNF
+eiw
 kqj
 kqj
 lIc
@@ -157245,7 +157142,7 @@ kRv
 kgG
 kRv
 kRv
-icp
+eay
 lIc
 kRv
 kqj
@@ -157261,24 +157158,24 @@ kRv
 kRv
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 kqj
 dXr
-eSb
+eOw
 rxA
 bdG
 fwU
 imG
 tdH
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 gkI
-gmP
+wji
 vcE
 vcE
 vcE
@@ -157295,20 +157192,20 @@ kRv
 kgG
 mDf
 kRv
-flR
-gmP
-gmP
-gmP
-gmP
+nQX
+wji
+wji
+wji
+wji
 kRv
 kgG
 kRv
 kRv
 lIc
 lIc
-gmP
+wji
 hgt
-gmP
+oyW
 jHs
 vcE
 uZo
@@ -157325,15 +157222,15 @@ iia
 jLt
 jLt
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (92,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -157342,8 +157239,8 @@ pjR
 pjR
 jpn
 fWa
-wPV
-pCl
+cMi
+tMM
 gNE
 ppu
 gHe
@@ -157438,7 +157335,7 @@ mGZ
 vKt
 bKa
 pIS
-hNF
+eiw
 kqj
 kqj
 kRv
@@ -157447,8 +157344,8 @@ kgG
 gpA
 cwL
 kRv
-gmP
-icp
+wji
+eay
 lIc
 kRv
 kRv
@@ -157464,7 +157361,7 @@ umq
 kRv
 kRv
 kqj
-gmP
+wji
 kqj
 kqj
 qRJ
@@ -157478,10 +157375,10 @@ oSZ
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 sHN
 kRv
@@ -157500,8 +157397,8 @@ jZc
 lIc
 lIc
 lIc
-gmP
-gmP
+wji
+wji
 kRv
 gpA
 siK
@@ -157510,7 +157407,7 @@ umq
 kRv
 lIc
 lIc
-gmP
+qvx
 deK
 vcE
 vcE
@@ -157528,14 +157425,14 @@ gYy
 jll
 jLt
 jll
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (93,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 sBL
 aSK
 pjR
@@ -157552,7 +157449,7 @@ ovl
 dBd
 pFF
 hTt
-uPs
+taD
 dFa
 tpT
 trZ
@@ -157641,7 +157538,7 @@ vjM
 vjM
 eGi
 qVx
-hNF
+eiw
 kqj
 tok
 kRv
@@ -157650,10 +157547,10 @@ kRv
 kgG
 kRv
 kRv
-gmP
-gmP
+wji
+wji
 kRv
-tTd
+kRv
 abx
 siK
 siK
@@ -157667,7 +157564,7 @@ kRv
 kRv
 mDf
 kqj
-gmP
+wji
 kqj
 riV
 qOg
@@ -157681,9 +157578,9 @@ dXr
 kqj
 pIz
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 umq
@@ -157699,8 +157596,8 @@ kgG
 uNd
 deK
 wxD
-rjX
-pNG
+nHx
+jom
 lIc
 kRv
 kRv
@@ -157711,9 +157608,9 @@ siK
 kgG
 kgG
 kqj
-ybk
-gmP
-gmP
+jYA
+wji
+qvx
 sQn
 vcE
 vcE
@@ -157727,21 +157624,21 @@ vcE
 vcE
 cYG
 gnl
-wDF
+mKv
 jll
 jll
 jll
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (94,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 hqC
 aSK
-lXN
+rpT
 pjR
 wnF
 aSK
@@ -157755,7 +157652,7 @@ hTt
 hTt
 hTt
 hTt
-uPs
+taD
 tpT
 tpT
 bVj
@@ -157844,7 +157741,7 @@ ssA
 ykK
 iqP
 kPu
-hNF
+eiw
 kqj
 kqj
 kqj
@@ -157852,10 +157749,10 @@ kRv
 umq
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
@@ -157870,7 +157767,7 @@ kgG
 kRv
 kRv
 kqj
-gmP
+wji
 kqj
 bpq
 kqj
@@ -157884,8 +157781,8 @@ kSq
 xXb
 vzy
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 kRv
 oAc
@@ -157903,7 +157800,7 @@ tNw
 jHs
 hNH
 wxD
-fPa
+ddR
 mDf
 kRv
 abx
@@ -157915,9 +157812,9 @@ abx
 kqj
 kqj
 lIc
-gmP
+wji
 iVR
-xZZ
+jtv
 sQn
 xIp
 xIp
@@ -157930,36 +157827,36 @@ xIp
 xIp
 qOz
 gnl
-wDF
+mKv
 wmB
-jUH
+qfd
 fTZ
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (95,1,1) = {"
 lwn
-wPV
+cMi
 iFQ
 bGi
 pjR
 ilO
 aSK
 aSK
-wPV
+cMi
 ujX
 gsL
 pjR
 dzd
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
-uPs
-uPs
+cMi
+cMi
+cMi
+cMi
+taD
+taD
 aND
 kHC
 lmn
@@ -158047,17 +157944,17 @@ lCe
 eUY
 pIS
 bax
-hNF
-kcZ
+eiw
+hXu
 kqj
-kGb
+hIJ
 kgG
 kRv
 mDf
 kRv
 kRv
-gmP
-gmP
+wji
+wji
 kRv
 kRv
 gpA
@@ -158073,7 +157970,7 @@ siK
 kRv
 kRv
 kqj
-icp
+eay
 lIc
 kRv
 kRv
@@ -158087,8 +157984,8 @@ oSZ
 hfI
 kRv
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 svA
 kRv
@@ -158117,10 +158014,10 @@ ril
 kgG
 kgG
 kRv
-flR
+nQX
 lIc
 hvU
-kEQ
+sML
 jug
 jug
 jug
@@ -158132,38 +158029,38 @@ jfo
 jfo
 jfo
 jfo
-cMi
-wDF
+iBn
+mKv
 gYy
 jLt
 vbb
-dnu
-wDF
+gYy
+mKv
 lwn
 "}
 (96,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 aSK
 aSK
 pjR
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 pjR
 sCy
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
-uPs
-uPs
-uPs
+cMi
+cMi
+cMi
+cMi
+taD
+taD
+taD
 jUs
 eDR
 iKs
@@ -158250,7 +158147,7 @@ vwp
 eUY
 pIS
 leL
-szw
+kEQ
 aMG
 nko
 kgG
@@ -158258,15 +158155,15 @@ kgG
 kRv
 kRv
 kRv
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 kgG
 kgG
 kRv
-gmP
-gmP
+wji
+wji
 kqj
 kRv
 kRv
@@ -158276,7 +158173,7 @@ kRv
 gKT
 kRv
 kRv
-icp
+eay
 kqj
 kqj
 umq
@@ -158291,9 +158188,9 @@ kqj
 vzy
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 pPh
 kgG
 abx
@@ -158324,47 +158221,47 @@ lIc
 lIc
 jll
 gYy
-usC
-usC
-usC
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
+tau
+tau
+tau
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
 xFE
 gYy
 gYy
 gYy
 qjg
 gYy
-wDF
+mKv
 lwn
 "}
 (97,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 oth
 aSK
 pjR
 ujX
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 ujX
 pjR
 sCy
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
-uPs
+cMi
+cMi
+cMi
+taD
 tpT
 tpT
 qwL
@@ -158453,7 +158350,7 @@ vjM
 vgj
 fCH
 imP
-szw
+kEQ
 coZ
 nko
 kgG
@@ -158461,16 +158358,16 @@ kgG
 umq
 kRv
 kRv
-gmP
-gmP
+wji
+wji
 lIc
 kRv
 kgG
 kRv
 kRv
 mYE
-gmP
-gmP
+wji
+wji
 pPh
 umq
 kgG
@@ -158494,9 +158391,9 @@ rfV
 vzy
 eSq
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 kgG
 kgG
@@ -158528,15 +158425,15 @@ lIc
 gYy
 gYy
 gYy
-usC
-wDF
+tau
+mKv
 gYy
-wDF
-wDF
-wDF
-wDF
-aso
-wDF
+mKv
+mKv
+mKv
+mKv
+dMr
+mKv
 jll
 gYy
 gYy
@@ -158544,19 +158441,19 @@ cmr
 sTZ
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (98,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
 iFQ
-pyy
+hEn
 gsL
 aSK
 pjR
@@ -158564,11 +158461,11 @@ jKV
 aSK
 aSK
 ujX
-wPV
-wPV
-wPV
-uPs
-uPs
+cMi
+cMi
+cMi
+taD
+taD
 tpT
 qwL
 qMY
@@ -158664,15 +158561,15 @@ kgG
 kgG
 kRv
 kRv
-gmP
-icp
+wji
+eay
 lIc
 kRv
 kgG
 kRv
 svA
 kRv
-gmP
+wji
 oFM
 kRv
 kRv
@@ -158686,20 +158583,20 @@ kqj
 kqj
 kqj
 kqj
-gmP
+wji
 lIc
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 tyC
 cPV
 kRv
 kqj
 kqj
 kqj
-gmP
+wji
 kRv
 kgG
 kgG
@@ -158717,25 +158614,25 @@ jHs
 vcE
 hNH
 wxD
-nRX
+fPa
 frc
 hKx
 wxi
-eue
+urj
 kRv
 kgG
 kRv
 kRv
-ert
+ome
 lIc
 gYy
-dPb
+huh
 gYy
 gYy
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 nvd
 gYy
 jvG
@@ -158747,14 +158644,14 @@ qvK
 qvK
 sTZ
 gYy
-wDF
+mKv
 lwn
 "}
 (99,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 wnF
 pjR
@@ -158767,9 +158664,9 @@ dzd
 aSK
 aSK
 ujX
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 xBH
 uQQ
 iga
@@ -158859,7 +158756,7 @@ wMm
 llK
 swa
 mqn
-hNF
+eiw
 axg
 nko
 kgG
@@ -158868,7 +158765,7 @@ kgG
 umq
 kRv
 lIc
-pWx
+eay
 umq
 fdb
 siK
@@ -158884,17 +158781,17 @@ siK
 fdb
 kRv
 kRv
-boy
+fLw
 kqj
 kqj
 kRv
 kqj
 lIc
-ert
-gmP
-gmP
-gmP
-gmP
+ome
+wji
+wji
+wji
+wji
 czV
 dJy
 bAa
@@ -158927,9 +158824,9 @@ wkf
 kgG
 kRv
 uFb
-gmP
-gmP
-flR
+wji
+wji
+nQX
 jll
 gYy
 gYy
@@ -158948,17 +158845,17 @@ wbg
 tQe
 qvK
 qvK
-hMK
+kog
 gYy
-wDF
+mKv
 lwn
 "}
 (100,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 pjR
 miQ
 pjR
@@ -158969,10 +158866,10 @@ pjR
 sCy
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 xBH
 miA
 ljE
@@ -159087,7 +158984,7 @@ siK
 kRv
 umq
 lIc
-icp
+eay
 lIc
 kRv
 kRv
@@ -159102,7 +158999,7 @@ eJE
 bSD
 fmc
 lIc
-ert
+ome
 kqj
 kRv
 kRv
@@ -159129,10 +159026,10 @@ kfi
 hVK
 kRv
 kRv
-gmP
-gmP
-gmP
-usC
+wji
+wji
+wji
+tau
 jll
 vbb
 gYy
@@ -159142,26 +159039,26 @@ gYy
 vbb
 gYy
 prS
-xix
+rJP
 gYy
-wMR
+sBJ
 jll
 wbg
 wbg
 gYy
-gUa
-hMK
+tAY
+kog
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (101,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 ilO
 pjR
@@ -159172,10 +159069,10 @@ miQ
 kDw
 nbd
 xBH
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 xBH
 ufK
 tkm
@@ -159273,8 +159170,8 @@ dDr
 kgG
 mDf
 kRv
-pVw
-icp
+qpO
+eay
 lIc
 kRv
 kRv
@@ -159289,16 +159186,16 @@ kgG
 kgG
 kRv
 kRv
-flR
-icp
+nQX
+eay
 lIc
 kRv
 umq
 abx
 kRv
 kRv
-ldZ
-qek
+aEf
+xkr
 kqj
 kqj
 kqj
@@ -159332,11 +159229,11 @@ dpM
 oFM
 kqj
 kRv
-gmP
-gmP
-usC
-usC
-usC
+wji
+wji
+tau
+tau
+tau
 gYy
 gYy
 gYy
@@ -159355,16 +159252,16 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (102,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 wnF
 pjR
@@ -159468,19 +159365,19 @@ kvk
 pch
 uVU
 gSs
-psk
-psk
-psk
-psk
-qTg
+vcG
+vcG
+vcG
+vcG
+cQl
 kgG
 kRv
 kRv
 lIc
-gmP
+wji
 lIc
-gmP
-gmP
+wji
+wji
 kRv
 kRv
 fdb
@@ -159493,7 +159390,7 @@ kRv
 kRv
 kqj
 kqj
-boy
+fLw
 kRv
 kRv
 siK
@@ -159501,15 +159398,15 @@ kgG
 kgG
 kRv
 kRv
-lCQ
+keo
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 kRv
 kgG
@@ -159531,19 +159428,19 @@ uZo
 dQM
 dQM
 wxD
-oua
+qTg
 kqj
 kqj
 kqj
-gmP
-gmP
-usC
-usC
-usC
-usC
+wji
+wji
+tau
+tau
+tau
+tau
 gYy
-dPb
-tTu
+huh
+bFv
 qvK
 qvK
 sTZ
@@ -159552,21 +159449,21 @@ jLt
 gYy
 gYy
 gYy
-nlp
-wmo
-wDF
-wDF
+ert
+xor
+mKv
+mKv
 rjU
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
 lwn
 "}
 (103,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 ujX
 aSK
 gne
@@ -159674,16 +159571,16 @@ yfI
 ggy
 wAu
 gVn
-psk
+vcG
 brt
 kgG
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 lIc
 kRv
 kRv
@@ -159706,13 +159603,13 @@ mPX
 kRv
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 kRv
 fdb
@@ -159734,16 +159631,16 @@ uZo
 vcE
 vcE
 cYG
-oua
-gmP
-gmP
-gmP
-gmP
-gmP
-usC
-usC
-usC
-wDF
+qTg
+wji
+wji
+wji
+wji
+wji
+tau
+tau
+tau
+mKv
 gYy
 nsZ
 tQe
@@ -159751,25 +159648,25 @@ qvK
 qvK
 gOg
 jLt
-wMR
+sBJ
 jLt
 gYy
 nXO
-wDF
+mKv
 jll
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
 lwn
 "}
 (104,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 ujX
 iFQ
 aSK
@@ -159877,17 +159774,17 @@ eut
 wMk
 oxx
 rHO
-psk
+vcG
 brt
 kgG
 umq
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-ert
+wji
+wji
+wji
+wji
+wji
+wji
+ome
 lIc
 kqj
 kqj
@@ -159897,8 +159794,8 @@ kqj
 kRv
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 umq
 kRv
@@ -159906,10 +159803,10 @@ siK
 kRv
 kRv
 kRv
-nrL
+pMf
 kqj
 kqj
-gmP
+wji
 kqj
 kqj
 kqj
@@ -159939,41 +159836,41 @@ vcE
 cYG
 bDk
 kKn
-usC
-usC
-usC
-usC
-usC
-usC
-usC
-wDF
-wDF
+tau
+tau
+tau
+tau
+tau
+tau
+tau
+mKv
+mKv
 hBB
 iia
 tQe
-hMK
+kog
 gYy
 gYy
 jLt
 gYy
 iia
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
 lwn
 "}
 (105,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 gsL
 aSK
 aSK
@@ -160080,15 +159977,15 @@ nCT
 obU
 rHO
 fkh
-psk
+vcG
 kNK
 kgG
 kRv
 kRv
 pPh
-gmP
-gmP
-gmP
+wji
+wji
+wji
 lIc
 lIc
 lIc
@@ -160099,27 +159996,27 @@ kqj
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 umq
 kgG
 kgG
 kgG
 umq
-iub
+jsY
 wxj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kqj
 kqj
 kRv
 kqj
 kqj
-ert
+ome
 lIc
 lIc
 lIc
@@ -160142,15 +160039,15 @@ vcE
 vcE
 wxD
 gnl
-usC
-usC
-usC
-usC
-usC
-usC
-usC
-usC
-wDF
+tau
+tau
+tau
+tau
+tau
+tau
+tau
+tau
+mKv
 wSe
 gYy
 jLt
@@ -160161,21 +160058,21 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
 lwn
 "}
 (106,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 mZi
 agL
 nWv
@@ -160283,38 +160180,38 @@ pXc
 yhb
 eEl
 hsI
-psk
+vcG
 kgG
 kgG
 kgG
 kRv
 kRv
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 kRv
 lIc
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kgG
 siK
 kgG
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 fLE
@@ -160346,39 +160243,39 @@ vcE
 cYG
 bDk
 kKn
-usC
-usC
-usC
-usC
-usC
-wDF
-wDF
-wDF
+tau
+tau
+tau
+tau
+tau
+mKv
+mKv
+mKv
 gYy
 vbb
 gYy
 jLt
 gYy
-dPb
+huh
 jLt
 gYy
 vbb
 jll
 jll
-wDF
+mKv
 gYy
 gYy
 gYy
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
 lwn
 "}
 (107,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 aSK
 ekA
@@ -160486,27 +160383,27 @@ sIQ
 hEB
 wFP
 hNP
-psk
-qTg
+vcG
+cQl
 rwW
 abx
 kRv
 kRv
-gmP
-gmP
-gmP
+wji
+wji
+wji
 wfl
 wfl
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kRv
 kRv
@@ -160514,10 +160411,10 @@ dsm
 siK
 fdb
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kRv
 mDf
@@ -160525,12 +160422,12 @@ kRv
 kgG
 kgG
 kgG
-cSw
+qGn
 kRv
-flR
+nQX
 kqj
 kqj
-gmP
+wji
 qvx
 jHs
 vcE
@@ -160549,14 +160446,14 @@ vcE
 vcE
 wxD
 gnl
-usC
-usC
-usC
-usC
-wDF
-wDF
+tau
+tau
+tau
+tau
+mKv
+mKv
 pbr
-ddR
+nkS
 gYy
 gYy
 gYy
@@ -160570,18 +160467,18 @@ jll
 jll
 jll
 gYy
-dPb
+huh
 iia
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (108,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 aSK
 aSK
 ptv
@@ -160701,24 +160598,24 @@ kRv
 kRv
 umq
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
-gmP
-gmP
+wji
+wji
 kRv
 kRv
 kgG
 siK
 kRv
 kRv
-gmP
-gmP
+wji
+wji
 kqj
 kqj
 kqj
@@ -160733,7 +160630,7 @@ kRv
 umq
 kRv
 kqj
-gmP
+wji
 qvx
 jHs
 vcE
@@ -160752,41 +160649,41 @@ vcE
 vcE
 cYG
 bDk
-usC
-usC
-usC
-wDF
-wDF
+tau
+tau
+tau
+mKv
+mKv
 jfx
 gYy
 rgd
 jLt
 jLt
 gYy
-usC
+tau
 gYy
 gYy
 wbg
 jll
 jll
-vDk
+aUf
 wPt
 gYy
 gYy
 vbb
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (109,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -160900,16 +160797,16 @@ kRv
 kRv
 lIc
 lIc
-ert
+ome
 lIc
 lIc
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 kRv
@@ -160956,18 +160853,18 @@ vcE
 vcE
 wxD
 gnl
-usC
-usC
-wDF
+tau
+tau
+mKv
 kmO
 tCd
 obL
 gYy
 jLt
 jLt
-dPb
-usC
-usC
+huh
+tau
+tau
 jll
 jll
 wPt
@@ -160980,17 +160877,17 @@ gYy
 gYy
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (110,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 pjR
 pjR
@@ -161103,16 +161000,16 @@ kRv
 kRv
 kRv
 lIc
-flR
+nQX
 lIc
-flR
-qBM
+nQX
+lsv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 kqj
@@ -161159,20 +161056,20 @@ vcE
 vcE
 qYd
 dEC
-usC
-usC
-wDF
-wDF
+tau
+tau
+mKv
+mKv
 nXO
-jAm
+mOU
 vbb
 gYy
 iia
 vbb
 gYy
-usC
-usC
-usC
+tau
+tau
+tau
 jll
 gYy
 gYy
@@ -161183,17 +161080,17 @@ gYy
 gYy
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (111,1,1) = {"
 lwn
-wPV
+cMi
 sBL
-wPV
+cMi
 gsL
-wPV
-nyW
+cMi
+aQh
 aSK
 aSK
 ilO
@@ -161308,12 +161205,12 @@ umq
 kRv
 umq
 kRv
-ert
+ome
 lIc
 lIc
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 kqj
 kqj
@@ -161330,7 +161227,7 @@ kqj
 kqj
 soO
 lIc
-ruu
+cSw
 kmd
 fdb
 vzy
@@ -161363,18 +161260,18 @@ vcE
 cYG
 bDk
 lIb
-usC
-wDF
-wDF
-wDF
+tau
+mKv
+mKv
+mKv
 rjU
 gYy
 jLt
 jLt
 gYy
-usC
-usC
-usC
+tau
+tau
+tau
 wSe
 gYy
 gYy
@@ -161386,18 +161283,18 @@ bKX
 gWK
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (112,1,1) = {"
 lwn
-wPV
+cMi
 hqC
 iUP
-qwD
-nyW
-nyW
-nyW
+aSK
+aQh
+aQh
+aQh
 aSK
 aSK
 pjR
@@ -161500,7 +161397,7 @@ kDZ
 gSs
 kwc
 kwc
-sBI
+biP
 kwc
 hpm
 cwL
@@ -161515,8 +161412,8 @@ kRv
 lIc
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 kqj
 umq
@@ -161528,21 +161425,21 @@ kgG
 kgG
 kRv
 kqj
-gmP
-gmP
+wji
+wji
 xlQ
 vZS
-gCY
+ruu
 lIc
-boy
+fLw
 tJy
 txy
 xlQ
 kqj
 kRv
 kRv
-grJ
-xXm
+xPp
+ybk
 fhs
 kRv
 kqj
@@ -161567,7 +161464,7 @@ vcE
 wxD
 gnl
 jll
-wDF
+mKv
 gYy
 gYy
 gYy
@@ -161575,9 +161472,9 @@ gYy
 jLt
 jLt
 gYy
-wDF
-usC
-usC
+mKv
+tau
+tau
 gYy
 gYy
 gYy
@@ -161589,19 +161486,19 @@ jey
 jey
 hku
 gYy
-wDF
+mKv
 lwn
 "}
 (113,1,1) = {"
 lwn
-wPV
+cMi
 ggC
 vxL
 aSK
 aSK
-uIa
-nyW
-nyW
+uvk
+aQh
+aQh
 aSK
 wnF
 aSK
@@ -161705,7 +161602,7 @@ kwc
 wFR
 tds
 pch
-kGb
+hIJ
 nny
 xLF
 nny
@@ -161717,9 +161614,9 @@ kgG
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 kRv
 kRv
@@ -161731,21 +161628,21 @@ siK
 siK
 kRv
 kqj
-gmP
-gmP
-kcZ
+wji
+wji
+hXu
 hhN
 hhN
 hhN
 hhN
 hhN
 hhN
-kcZ
+hXu
 kqj
 kqj
 lZw
 kRa
-lwO
+qdT
 iOH
 kRv
 kRv
@@ -161769,7 +161666,7 @@ vcE
 vcE
 cYG
 gnl
-tnq
+lXN
 gYy
 gYy
 gYy
@@ -161778,9 +161675,9 @@ gYy
 gYy
 vbb
 gYy
-usC
-usC
-usC
+tau
+tau
+tau
 hyC
 gYy
 gYy
@@ -161792,24 +161689,24 @@ jey
 xra
 gKr
 vGj
-wDF
+mKv
 lwn
 "}
 (114,1,1) = {"
 lwn
-wPV
+cMi
 aSK
-tau
+xEq
 aSK
 ixA
 aSK
-iwx
-nyW
+xXm
+aQh
 aSK
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 qnK
 qTj
 qnK
@@ -161903,26 +161800,26 @@ tXV
 asC
 aAp
 nOk
-dVA
+kOC
 pch
 ajr
 cNs
 pch
-xrP
+wnt
 itT
 iao
-rJP
+aMh
 rUT
 fiL
 dKh
 rUT
-mMV
+aAi
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 kqj
 kRv
@@ -161933,17 +161830,17 @@ kgG
 siK
 siK
 kRv
-gmP
-gmP
-gmP
-kcZ
+wji
+wji
+wji
+hXu
 rfY
 gtc
 rfY
 gtc
 rfY
 gtc
-kcZ
+hXu
 kqj
 kqj
 kqj
@@ -161953,7 +161850,7 @@ kqj
 kqj
 kqj
 uei
-hZc
+jMi
 jHs
 dQM
 cYG
@@ -161972,7 +161869,7 @@ vcE
 vcE
 cYG
 qyJ
-tnq
+lXN
 gYy
 gYy
 jLt
@@ -161980,10 +161877,10 @@ jLt
 jLt
 vbb
 gYy
-usC
-wDF
-usC
-usC
+tau
+mKv
+tau
+tau
 vYy
 gYy
 gYy
@@ -161994,25 +161891,25 @@ gJk
 veN
 rnb
 jtU
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (115,1,1) = {"
 lwn
-wPV
+cMi
 aSK
 aSK
 aSK
 aSK
 fME
-nyW
-wPV
-wPV
+aQh
+cMi
+cMi
 aSK
 aSK
 iFQ
-wPV
+cMi
 qnK
 qTj
 qnK
@@ -162137,25 +162034,25 @@ cwL
 gpA
 kRv
 lIc
-gmP
-gmP
-kcZ
+wji
+wji
+hXu
 bEE
 bEE
 bEE
 bEE
 bEE
 bEE
-kcZ
-gmP
-gmP
+hXu
+wji
+wji
 kqj
 kqj
 fLE
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 vzo
 jHs
 dQM
@@ -162176,17 +162073,17 @@ cZK
 cYG
 urg
 wbg
-jWi
+kwZ
 gYy
-dPb
+huh
 gYy
-dPb
+huh
 gYy
 gYy
-usC
-wDF
-usC
-usC
+tau
+mKv
+tau
+tau
 vKw
 iWx
 gYy
@@ -162197,25 +162094,25 @@ lEl
 xJf
 jey
 jtU
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (116,1,1) = {"
 lwn
-wPV
+cMi
 hqC
 gsL
 aSK
 aSK
 aSK
-nyW
-wPV
-wPV
-wPV
+aQh
+cMi
+cMi
+cMi
 iUP
-wPV
-wPV
+cMi
+cMi
 qnK
 qTj
 qnK
@@ -162339,26 +162236,26 @@ mDf
 kgG
 kRv
 kRv
-flR
+nQX
 lIc
-gmP
-qfd
+wji
+wXm
 gNa
 lIc
 lIc
-gCY
-gCY
+ruu
+ruu
 txy
-kcZ
-gmP
-gmP
-gmP
+hXu
+wji
+wji
+wji
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 vzo
 jHs
 dQM
@@ -162377,7 +162274,7 @@ xnc
 iAI
 cZK
 cYG
-wpf
+czc
 wbg
 fbF
 vbb
@@ -162387,10 +162284,10 @@ gYy
 jLt
 iia
 gYy
-usC
-usC
-usC
-usC
+tau
+tau
+tau
+tau
 iia
 gYy
 rjd
@@ -162400,25 +162297,25 @@ hjz
 qCJ
 jey
 tIY
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (117,1,1) = {"
 lwn
-wPV
-wPV
+cMi
+cMi
 iFQ
 aSK
 aSK
-nyW
-nyW
-nyW
-wPV
-wPV
-wPV
-wPV
-wPV
+aQh
+aQh
+aQh
+cMi
+cMi
+cMi
+cMi
+cMi
 qnK
 qTj
 qnK
@@ -162538,30 +162435,30 @@ kgG
 siK
 siK
 kgG
-gmP
+wji
 kRv
 kRv
-boy
-boy
+fLw
+fLw
 kRv
 umq
 vzy
 kRv
+cSw
+umq
+umq
 ruu
-umq
-umq
-gCY
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 jHs
 dQM
@@ -162581,7 +162478,7 @@ vcE
 vcE
 cYG
 jEo
-tnq
+lXN
 gYy
 gYy
 gYy
@@ -162590,9 +162487,9 @@ gYy
 jLt
 gYy
 rjU
-usC
-usC
-usC
+tau
+tau
+tau
 jll
 gYy
 gYy
@@ -162604,24 +162501,24 @@ jey
 xra
 nFf
 vGj
-wDF
+mKv
 lwn
 "}
 (118,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-nyW
-uIa
-nyW
+cMi
+cMi
+cMi
+cMi
+aQh
+uvk
+aQh
 aSK
 oth
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 qnK
 qnK
 qnK
@@ -162741,10 +162638,10 @@ kgG
 kgG
 kgG
 kgG
-gmP
-gmP
+wji
+wji
 lIc
-boy
+fLw
 fdb
 kRv
 kgG
@@ -162753,18 +162650,18 @@ siK
 siK
 fdb
 vzy
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 jHs
 dQM
@@ -162784,8 +162681,8 @@ vcE
 vcE
 cYG
 uIQ
-usC
-wDF
+tau
+mKv
 gYy
 gYy
 gYy
@@ -162794,7 +162691,7 @@ jUp
 vbb
 gYy
 kxt
-usC
+tau
 jll
 vMa
 gYy
@@ -162807,26 +162704,26 @@ jey
 cPN
 hku
 gYy
-wDF
+mKv
 lwn
 "}
 (119,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wne
-nyW
+cMi
+cMi
+cMi
+cMi
+gZK
+aQh
 aSK
 aSK
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 qnK
 ubD
 jsH
@@ -162941,11 +162838,11 @@ eRb
 eRb
 eRb
 eRb
-goC
+vNw
 bBk
 bBk
 bBk
-gmP
+wji
 lIc
 umq
 kRv
@@ -162960,14 +162857,14 @@ kRv
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 sQn
 dQM
@@ -162987,11 +162884,11 @@ vcE
 vcE
 cYG
 kHO
-usC
-wDF
-wDF
-wDF
-wDF
+tau
+mKv
+mKv
+mKv
+mKv
 gYy
 gYy
 wyd
@@ -163010,26 +162907,26 @@ wbH
 hrh
 gYy
 gYy
-wDF
+mKv
 lwn
 "}
 (120,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 aSK
 aSK
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 rfe
 tET
 nGa
@@ -163148,7 +163045,7 @@ jVa
 rOE
 vYx
 bBk
-gmP
+wji
 lIc
 kRv
 kRv
@@ -163163,14 +163060,14 @@ fdb
 kRv
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 sQn
@@ -163190,9 +163087,9 @@ vcE
 ldY
 cYG
 kHO
-usC
-wDF
-wDF
+tau
+mKv
+mKv
 gYy
 oLp
 gYy
@@ -163212,17 +163109,17 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (121,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 aSK
@@ -163230,9 +163127,9 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 lji
 cLY
 exS
@@ -163351,8 +163248,8 @@ fmR
 jre
 xFH
 bBk
-gmP
-gmP
+wji
+wji
 kRv
 mDf
 kRv
@@ -163367,14 +163264,14 @@ fdb
 mDf
 xoe
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 jHs
@@ -163393,8 +163290,8 @@ vcE
 vcE
 cYG
 kHO
-usC
-wDF
+tau
+mKv
 nXO
 vUz
 gYy
@@ -163402,7 +163299,7 @@ gYy
 tQe
 qvK
 qvK
-huh
+vQB
 iia
 gYy
 gYy
@@ -163415,15 +163312,15 @@ gYy
 iia
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (122,1,1) = {"
 lwn
-cJt
-cJt
-cJt
+pyy
+pyy
+pyy
 ijb
 nHF
 nHF
@@ -163435,7 +163332,7 @@ ilO
 aSK
 aSK
 aSK
-wPV
+cMi
 qnK
 iSb
 inf
@@ -163554,9 +163451,9 @@ eZv
 lgG
 mFg
 bBk
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 kRv
 gpA
@@ -163570,15 +163467,15 @@ kgG
 kRv
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 sQn
 dQM
@@ -163596,9 +163493,9 @@ vcE
 vcE
 cYG
 kAL
-usC
-wDF
-wDF
+tau
+mKv
+mKv
 gYy
 gYy
 gdU
@@ -163618,14 +163515,14 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (123,1,1) = {"
 lwn
-cJt
-wPV
+pyy
+cMi
 oth
 aSK
 aSK
@@ -163638,7 +163535,7 @@ pjR
 pjR
 aSK
 aSK
-wPV
+cMi
 xUF
 xoA
 lkh
@@ -163724,7 +163621,7 @@ leb
 snY
 ycc
 vZa
-phE
+dce
 tyO
 eWO
 oTb
@@ -163757,9 +163654,9 @@ cqM
 qqi
 fyH
 bBk
-gmP
-gmP
-gmP
+wji
+wji
+wji
 lhB
 ucq
 kRv
@@ -163773,16 +163670,16 @@ kgG
 kgG
 umq
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 osn
 jHs
 vcE
@@ -163800,10 +163697,10 @@ vcE
 vcE
 wxD
 kHO
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
 kxt
 gYy
 iia
@@ -163813,21 +163710,21 @@ jLt
 jLt
 gYy
 gYy
-dPb
+huh
 jll
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
 gYy
 gYy
 gYy
-wDF
-wDF
+mKv
+mKv
 lwn
 "}
 (124,1,1) = {"
 lwn
-cJt
+pyy
 hqC
 iFQ
 aSK
@@ -163840,8 +163737,8 @@ miQ
 pjR
 pjR
 pjR
-wPV
-wPV
+cMi
+cMi
 qnK
 qnK
 qnK
@@ -163960,11 +163857,11 @@ lwK
 bBk
 bBk
 bBk
-gmP
-gmP
-gmP
-nQG
-nQG
+wji
+wji
+wji
+mMV
+mMV
 uKd
 kRv
 kRv
@@ -163976,16 +163873,16 @@ siK
 kgG
 kRv
 kRv
-boy
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+fLw
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 qvx
 jHs
 vcE
@@ -164003,11 +163900,11 @@ vcE
 vcE
 cYG
 kAL
-usC
-usC
-usC
-wDF
-wDF
+tau
+tau
+tau
+mKv
+mKv
 gYy
 gYy
 gYy
@@ -164019,18 +163916,18 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
 lwn
 "}
 (125,1,1) = {"
 lwn
-cJt
+pyy
 vxL
 gsL
 aSK
@@ -164044,11 +163941,11 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 pPw
 vih
 wcP
@@ -164130,7 +164027,7 @@ rSm
 qLW
 ycc
 bJY
-phE
+dce
 flc
 atQ
 ueO
@@ -164167,7 +164064,7 @@ vNa
 vNa
 vNa
 vNa
-jib
+kRm
 vNa
 kaG
 ybU
@@ -164178,17 +164075,17 @@ siK
 kgG
 kRv
 kRv
-icp
-boy
-boy
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+eay
+fLw
+fLw
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 qvx
 sQn
 dQM
@@ -164207,9 +164104,9 @@ vcE
 vcE
 wxD
 kHO
-usC
-usC
-wDF
+tau
+tau
+mKv
 fGw
 gYy
 gYy
@@ -164223,18 +164120,18 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
-wDF
-wDF
-wDF
-usC
+mKv
+mKv
+mKv
+mKv
+mKv
+tau
 lwn
 "}
 (126,1,1) = {"
 lwn
-cJt
-wPV
+pyy
+cMi
 aSK
 aSK
 aSK
@@ -164249,9 +164146,9 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 kjm
 bbp
 oku
@@ -164333,7 +164230,7 @@ awp
 awp
 ycc
 gVh
-fQy
+qwf
 lpG
 afx
 ueO
@@ -164380,19 +164277,19 @@ kRv
 kRv
 kRv
 gKT
-ert
-icp
+ome
+eay
 lIc
 kRv
 umq
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 osn
 sQn
 dQM
@@ -164410,9 +164307,9 @@ vcE
 vcE
 cYG
 kAL
-usC
-usC
-wDF
+tau
+tau
+mKv
 gYy
 gYy
 jLt
@@ -164427,18 +164324,18 @@ gYy
 vbb
 gYy
 gYy
-wDF
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (127,1,1) = {"
 lwn
-cJt
-wPV
-wPV
+pyy
+cMi
+cMi
 iFQ
 aSK
 aSK
@@ -164453,8 +164350,8 @@ aSK
 aSK
 aSK
 ujX
-wPV
-wPV
+cMi
+cMi
 kjm
 kjm
 tAJ
@@ -164536,7 +164433,7 @@ vEt
 gkO
 nMG
 qvd
-phE
+dce
 pFq
 bbc
 ueO
@@ -164579,12 +164476,12 @@ rzt
 ybU
 xmq
 kRv
-gmP
-gmP
-gmP
+wji
+wji
+wji
 nzN
-boy
-icp
+fLw
+eay
 kRv
 kRv
 kgG
@@ -164593,11 +164490,11 @@ kRv
 kRv
 kRv
 kRv
-gmP
-gmP
-gmP
-gmP
-icp
+wji
+wji
+wji
+wji
+eay
 kRv
 umq
 vyq
@@ -164614,35 +164511,35 @@ vcE
 vcE
 wxD
 kHO
-wDF
-wDF
+mKv
+mKv
 gYy
 gYy
 gYy
 jLt
-xzl
-gYy
-gYy
-jLt
+iJa
 gYy
 gYy
 jLt
 gYy
 gYy
+jLt
 gYy
 gYy
 gYy
-wDF
-usC
-usC
+gYy
+gYy
+mKv
+tau
+tau
 lwn
 "}
 (128,1,1) = {"
 lwn
-cJt
-wPV
-wPV
-wPV
+pyy
+cMi
+cMi
+cMi
 aSK
 aSK
 aSK
@@ -164656,8 +164553,8 @@ pjR
 aSK
 gsL
 ujX
-wPV
-wPV
+cMi
+cMi
 pHv
 waR
 sne
@@ -164739,7 +164636,7 @@ vEt
 gkO
 dLk
 kKW
-phE
+dce
 mgI
 fsN
 ueO
@@ -164781,12 +164678,12 @@ qqT
 xRP
 vzn
 vzn
-mqJ
-gmP
-gmP
-gmP
-gmP
-boy
+cwm
+wji
+wji
+wji
+wji
+fLw
 kRv
 kRv
 kgG
@@ -164795,12 +164692,12 @@ kgG
 kgG
 gpA
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 lIc
-icp
+eay
 mDf
 kRv
 kRv
@@ -164826,7 +164723,7 @@ gYy
 gYy
 gYy
 gYy
-dPb
+huh
 gYy
 jLt
 jLt
@@ -164835,20 +164732,20 @@ gYy
 gYy
 gYy
 gYy
-wDF
-usC
-usC
+mKv
+tau
+tau
 lwn
 "}
 (129,1,1) = {"
 lwn
-cJt
-cJt
-cJt
-cJt
-cJt
+pyy
+pyy
+pyy
+pyy
+pyy
 ijb
-cJt
+pyy
 nHF
 nHF
 wnF
@@ -164857,9 +164754,9 @@ pjR
 pjR
 wnF
 iFQ
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 kjm
 kjm
 lCz
@@ -164942,7 +164839,7 @@ ycc
 iZx
 czK
 tvp
-phE
+dce
 lpG
 atQ
 ueO
@@ -164985,11 +164882,11 @@ fLj
 oxr
 rqg
 jbf
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kRv
 umq
 fdb
@@ -164998,11 +164895,11 @@ fdb
 kgG
 kgG
 kRv
-gmP
-gmP
-gmP
-flR
-ert
+wji
+wji
+wji
+nQX
+ome
 vjk
 lIc
 kRv
@@ -165021,7 +164918,7 @@ vcE
 vcE
 wxD
 gnl
-czc
+jll
 jll
 tmW
 lRP
@@ -165037,21 +164934,21 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (130,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 alg
 aSK
@@ -165059,10 +164956,10 @@ pjR
 pjR
 pjR
 aSK
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 kjm
 xMs
 ifI
@@ -165145,7 +165042,7 @@ oCx
 lVL
 dwT
 dwT
-phE
+dce
 pFq
 afx
 ueO
@@ -165187,13 +165084,13 @@ dpJ
 qgb
 rMx
 vNa
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kRv
 siK
@@ -165206,8 +165103,8 @@ kRv
 lIc
 lIc
 lIc
-icp
-gmP
+eay
+wji
 deK
 dQM
 dQM
@@ -165225,47 +165122,47 @@ jUd
 vcE
 uUL
 jll
-vDk
+aUf
 wbg
 wbg
-tnq
+lXN
 iia
 gYy
 jLt
-wMR
+sBJ
 jLt
-dPb
+huh
 iia
-xzl
+iJa
 gYy
 vbb
 gYy
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (131,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
-xdu
+odl
 pjR
 ilO
 pjR
 aSK
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 kjm
 pYa
 kFN
@@ -165348,7 +165245,7 @@ eIb
 tix
 dwT
 xyk
-phE
+dce
 pFq
 bbc
 ueO
@@ -165390,13 +165287,13 @@ qqT
 vyv
 jBK
 vNa
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
@@ -165407,9 +165304,9 @@ kRv
 kRv
 mDf
 umq
-flR
-gmP
-gmP
+nQX
+wji
+wji
 qvx
 sQn
 dQM
@@ -165443,29 +165340,29 @@ gYy
 gYy
 gYy
 gYy
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (132,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
-tnB
+izL
 pjR
 pjR
 aSK
 ejS
 ejS
-wPV
+cMi
 wQk
 wQk
 wQk
@@ -165551,7 +165448,7 @@ ycc
 vVU
 lxU
 qzY
-phE
+dce
 fbw
 afx
 ueO
@@ -165593,13 +165490,13 @@ qqT
 gkM
 oxr
 vNa
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
@@ -165611,9 +165508,9 @@ kRv
 kRv
 kRv
 lIc
-gmP
-gmP
-gmP
+wji
+wji
+wji
 osn
 jHs
 dQM
@@ -165646,23 +165543,23 @@ gYy
 pjX
 gYy
 gYy
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (133,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
-tnB
+izL
 pjR
 pjR
 xwH
@@ -165754,7 +165651,7 @@ ycc
 ycc
 eRx
 kKW
-phE
+dce
 lpG
 atQ
 ueO
@@ -165798,11 +165695,11 @@ rMx
 vNa
 oNo
 oNo
-gmP
-gmP
-gmP
-gmP
-qek
+wji
+wji
+wji
+wji
+xkr
 kRv
 kRv
 kgG
@@ -165815,8 +165712,8 @@ kRv
 kRv
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 qvx
 jHs
 dQM
@@ -165837,35 +165734,35 @@ iAI
 vyq
 wxD
 jll
-vDk
+aUf
 wbg
 wbg
 jll
 jll
 tmW
-wDF
-wDF
+mKv
+mKv
 kxt
 gYy
 gYy
 gYy
-wDF
-wDF
-usC
-usC
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (134,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 pSi
 pSi
 pSi
 pSi
-lLm
+syS
 pjR
 pjR
 lMt
@@ -165957,7 +165854,7 @@ ycc
 eiS
 bJp
 tix
-phE
+dce
 pFq
 eKd
 ueO
@@ -166001,13 +165898,13 @@ rnY
 oNo
 oNo
 oNo
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 sHN
 kRv
-gmP
+wji
 kRv
 mDf
 kgG
@@ -166018,8 +165915,8 @@ mDf
 kqj
 kqj
 kqj
-gmP
-gmP
+wji
+wji
 qvx
 sQn
 dQM
@@ -166044,31 +165941,31 @@ jll
 jll
 jll
 jll
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
 keG
 nXO
 gYy
-wDF
-wDF
-usC
-usC
-usC
+mKv
+mKv
+tau
+tau
+tau
 lwn
 "}
 (135,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 pSi
 ask
 hIc
 vxV
-lLm
+syS
 miQ
 pVa
 rVW
@@ -166160,7 +166057,7 @@ ycc
 ubd
 cJZ
 tix
-phE
+dce
 ftA
 atQ
 ueO
@@ -166204,14 +166101,14 @@ uUT
 ajo
 oNo
 oNo
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 wxj
-gmP
-gmP
+wji
+wji
 kRv
 kRv
 siK
@@ -166221,9 +166118,9 @@ kRv
 sHN
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 fvu
 jHs
 dQM
@@ -166246,32 +166143,32 @@ vyq
 wxD
 jvG
 jll
-wDF
-wDF
-wDF
-wDF
-wDF
+mKv
+mKv
+mKv
+mKv
+mKv
 eVy
-wDF
-wDF
-wDF
-usC
-usC
-usC
-usC
+mKv
+mKv
+mKv
+tau
+tau
+tau
+tau
 lwn
 "}
 (136,1,1) = {"
 lwn
-urj
-urj
+dPb
+dPb
 pSi
 pSi
 pSi
 uuU
 hIc
 wEf
-lLm
+syS
 pjR
 juj
 mDv
@@ -166407,14 +166304,14 @@ uUT
 xya
 oNo
 oNo
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 kRv
 kRv
@@ -166424,9 +166321,9 @@ kRv
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 vzo
 sQn
 dQM
@@ -166450,31 +166347,31 @@ pcJ
 pcJ
 bua
 kKn
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-usC
-usC
-usC
-usC
-usC
-usC
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+tau
+tau
+tau
+tau
+tau
+tau
 lwn
 "}
 (137,1,1) = {"
 lwn
-urj
-pHh
+dPb
+sBI
 fUW
 sYn
 jvA
 qAa
 fio
 vxV
-lLm
+syS
 pjR
 qvE
 wst
@@ -166609,15 +166506,15 @@ kPF
 dSv
 aBV
 oNo
-osL
+azJ
 nwx
 nwx
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 fdb
 umq
@@ -166627,9 +166524,9 @@ kRv
 mPX
 wxj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
 fvu
 sQn
@@ -166653,23 +166550,23 @@ vcE
 vcE
 wxD
 bDk
-wDF
-wDF
-wDF
-wDF
-wDF
-wDF
-usC
-usC
-usC
-usC
-usC
-usC
+mKv
+mKv
+mKv
+mKv
+mKv
+mKv
+tau
+tau
+tau
+tau
+tau
+tau
 lwn
 "}
 (138,1,1) = {"
 lwn
-urj
+dPb
 mAc
 nNv
 fsP
@@ -166677,11 +166574,11 @@ pQA
 ojZ
 oOP
 cHA
-lLm
+syS
 pjR
-htG
+bbj
 ouc
-wPV
+cMi
 jdt
 ueK
 nOw
@@ -166769,7 +166666,7 @@ fGi
 ycc
 tmO
 ppS
-fQy
+qwf
 xYy
 eWO
 oTb
@@ -166817,10 +166714,10 @@ nwx
 nwx
 nwx
 nwx
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 kRv
 kRv
@@ -166830,10 +166727,10 @@ kgG
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
 fvu
 jHs
@@ -166857,22 +166754,22 @@ mlU
 vcE
 wxD
 bDk
-wDF
-wDF
-wDF
-wDF
-wDF
-usC
-usC
-usC
-usC
-usC
-usC
+mKv
+mKv
+mKv
+mKv
+mKv
+tau
+tau
+tau
+tau
+tau
+tau
 lwn
 "}
 (139,1,1) = {"
 lwn
-urj
+dPb
 mAc
 iLd
 ufo
@@ -166880,11 +166777,11 @@ dpX
 uBE
 uBE
 uBE
-lLm
+syS
 pjR
-qtK
-wPV
-wPV
+dVA
+cMi
+cMi
 wQk
 kLx
 nOw
@@ -166913,11 +166810,11 @@ fWW
 ybf
 aQX
 hfO
-biP
+iwx
 owo
 drN
 hfO
-biP
+iwx
 owo
 drN
 hfO
@@ -167020,11 +166917,11 @@ dZE
 cqf
 nsv
 nwx
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kRv
 fdb
 siK
@@ -167032,12 +166929,12 @@ siK
 gpA
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 sQn
 dQM
@@ -167061,21 +166958,21 @@ dQM
 vcE
 wxD
 bDk
-wDF
-wDF
-wDF
-wDF
-usC
-usC
-usC
-usC
-usC
-usC
+mKv
+mKv
+mKv
+mKv
+tau
+tau
+tau
+tau
+tau
+tau
 lwn
 "}
 (140,1,1) = {"
 lwn
-urj
+dPb
 mAc
 ffc
 jdA
@@ -167085,9 +166982,9 @@ tXf
 lqA
 avu
 pjR
-wIM
-wPV
-wPV
+wxR
+cMi
+cMi
 wQk
 skS
 ole
@@ -167222,12 +167119,12 @@ qtd
 dZE
 nwx
 nwx
-osL
-nrL
-gmP
-gmP
-gmP
-gmP
+azJ
+pMf
+wji
+wji
+wji
+wji
 kRv
 kRv
 siK
@@ -167235,12 +167132,12 @@ cwL
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 jHs
@@ -167265,20 +167162,20 @@ mlU
 dQM
 wxD
 bDk
-cMe
-cMe
-wDF
-wDF
-wDF
-wDF
-wDF
-usC
-usC
+xrP
+xrP
+mKv
+mKv
+mKv
+mKv
+mKv
+tau
+tau
 lwn
 "}
 (141,1,1) = {"
 lwn
-urj
+dPb
 mAc
 iLd
 uBE
@@ -167289,8 +167186,8 @@ uBE
 leF
 iSB
 pjR
-wPV
-wPV
+cMi
+cMi
 wQk
 iAc
 poB
@@ -167425,11 +167322,11 @@ uCN
 iNn
 abD
 nsv
-osL
+azJ
 wxj
 oFM
-gmP
-gmP
+wji
+wji
 lIc
 kRv
 kgG
@@ -167437,14 +167334,14 @@ kgG
 kgG
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 sQn
 dQM
@@ -167471,17 +167368,17 @@ pnY
 pnY
 wxD
 bDk
-cMe
-cMe
-cMe
-cMe
-usC
-usC
+xrP
+xrP
+xrP
+xrP
+tau
+tau
 lwn
 "}
 (142,1,1) = {"
 lwn
-urj
+dPb
 mAc
 nNv
 riz
@@ -167493,7 +167390,7 @@ aSK
 pjR
 pjR
 aGA
-wPV
+cMi
 wQk
 wQk
 wQk
@@ -167628,11 +167525,11 @@ bLb
 vHo
 nwx
 nwx
-osL
+azJ
 kgG
 kRv
 kRv
-qBM
+lsv
 lIc
 kRv
 siK
@@ -167641,13 +167538,13 @@ kgG
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 sQn
@@ -167679,13 +167576,13 @@ pnY
 pnY
 wxD
 bDk
-cMe
+xrP
 lwn
 "}
 (143,1,1) = {"
 lwn
-urj
-pHh
+dPb
+sBI
 pkP
 mda
 fsP
@@ -167696,9 +167593,9 @@ aSK
 pjR
 ryd
 mUL
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 vPu
 uJA
 bHa
@@ -167831,12 +167728,12 @@ msd
 iyW
 aAJ
 wkX
-osL
+azJ
 gpA
 kgG
 kRv
 lIc
-ert
+ome
 fdb
 siK
 siK
@@ -167845,13 +167742,13 @@ mDf
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 sQn
@@ -167887,8 +167784,8 @@ lwn
 "}
 (144,1,1) = {"
 lwn
-urj
-urj
+dPb
+dPb
 pSi
 pSi
 lFR
@@ -167900,8 +167797,8 @@ pjR
 pjR
 aSK
 iFQ
-wPV
-wPV
+cMi
+cMi
 vPu
 jHx
 ddk
@@ -168034,7 +167931,7 @@ nwx
 iyW
 aAJ
 bal
-osL
+azJ
 kgG
 kgG
 kRv
@@ -168048,14 +167945,14 @@ kRv
 kRv
 kRv
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 jHs
@@ -168090,9 +167987,9 @@ lwn
 "}
 (145,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 pSi
 iFQ
 aSK
@@ -168104,7 +168001,7 @@ pjR
 pjR
 aSK
 ujX
-wPV
+cMi
 vPu
 txq
 gNi
@@ -168237,12 +168134,12 @@ daU
 cci
 daU
 daU
-coE
+rTR
 kgG
 kgG
 kRv
 lIc
-gmP
+wji
 kRv
 kRv
 kgG
@@ -168251,14 +168148,14 @@ umq
 kgG
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 vzo
 sQn
@@ -168293,11 +168190,11 @@ lwn
 "}
 (146,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 iUP
 aSK
@@ -168307,7 +168204,7 @@ miQ
 pjR
 aSK
 ujX
-wPV
+cMi
 vPu
 vPu
 tgX
@@ -168440,28 +168337,28 @@ daU
 ufU
 jAk
 qwu
-coE
+rTR
 kgG
 kgG
 pPh
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 siK
-lSp
+xnl
 siK
 kgG
 kRv
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
 kqj
 fvu
@@ -168481,7 +168378,7 @@ iAI
 nHz
 iAI
 hrH
-hnn
+xlO
 mHI
 vcE
 vcE
@@ -168496,11 +168393,11 @@ lwn
 "}
 (147,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 ggC
 sbZ
 fME
@@ -168510,8 +168407,8 @@ pjR
 ilO
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 vPu
 cvW
 nbr
@@ -168647,25 +168544,25 @@ wqQ
 kgG
 kgG
 wxj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 gpA
 siK
 kgG
 kRv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
-iLK
-iLK
-iLK
+xxz
+xxz
+xxz
 kqj
 kqj
 fvu
@@ -168699,11 +168596,11 @@ lwn
 "}
 (148,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aiX
 aSK
 gsL
@@ -168713,8 +168610,8 @@ pjR
 pjR
 pjR
 aSK
-wPV
-wPV
+cMi
+cMi
 vPu
 vPu
 paL
@@ -168849,28 +168746,28 @@ ogc
 wqQ
 kgG
 wxj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
 kgG
 kgG
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
 kqj
-imu
+dLQ
 deK
 pnY
 wxD
-iLK
-iLK
+xxz
+xxz
 kqj
 fvu
 sQn
@@ -168902,10 +168799,10 @@ lwn
 "}
 (149,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 aSK
@@ -169049,24 +168946,24 @@ daU
 cci
 daU
 gtW
-coE
+rTR
 gpA
 mPX
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kRv
 kgG
 kgG
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 deK
 vcE
@@ -169074,8 +168971,8 @@ vcE
 vcE
 pnY
 wxD
-iLK
-iLK
+xxz
+xxz
 mgb
 jHs
 dQM
@@ -169105,11 +169002,11 @@ lwn
 "}
 (150,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 uJQ
 tgD
@@ -169255,21 +169152,21 @@ wRF
 wqQ
 kgG
 kRv
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kRv
 kRv
 kgG
 abx
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 vzo
 jHs
 vcE
@@ -169308,17 +169205,17 @@ lwn
 "}
 (151,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 mZi
 agL
 vww
 pjR
 pjR
-lXN
+rpT
 pjR
 aSK
 hcc
@@ -169455,24 +169352,24 @@ daU
 kwI
 wRF
 niu
-oyv
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+cJt
+wji
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 gpA
 kgG
 kgG
-gmP
-gmP
+wji
+wji
 kRv
 aEv
 kqj
-gmP
+wji
 qvx
 sQn
 vcE
@@ -169493,7 +169390,7 @@ vcE
 vcE
 kaP
 mHI
-ice
+wQY
 azd
 vyq
 vyq
@@ -169502,7 +169399,7 @@ vyq
 vyq
 vyq
 vyq
-fRu
+pdr
 vyq
 vcE
 vcE
@@ -169511,11 +169408,11 @@ lwn
 "}
 (152,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 gsL
 aSK
 ekA
@@ -169658,14 +169555,14 @@ vZi
 tkJ
 acL
 jen
-oyv
-hvd
-gmP
-gmP
-gmP
-gmP
-gmP
-gmP
+cJt
+iub
+wji
+wji
+wji
+wji
+wji
+wji
 kRv
 fdb
 siK
@@ -169675,8 +169572,8 @@ kRv
 kRv
 kRv
 kqj
-gmP
-gmP
+wji
+wji
 fvu
 sQn
 vcE
@@ -169714,11 +169611,11 @@ lwn
 "}
 (153,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 avr
 aSK
@@ -169728,8 +169625,8 @@ pjR
 pjR
 aSK
 aGA
-wPV
-wPV
+cMi
+cMi
 oNf
 moU
 hQE
@@ -169862,13 +169759,13 @@ tMT
 tGL
 sFz
 tGL
-hvd
-hvd
-gmP
-gmP
-gmP
-gmP
-gmP
+iub
+iub
+wji
+wji
+wji
+wji
+wji
 kRv
 kRv
 fdb
@@ -169879,7 +169776,7 @@ kRv
 kRv
 kRv
 kqj
-gmP
+wji
 kqj
 fvu
 sQn
@@ -169917,10 +169814,10 @@ lwn
 "}
 (154,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 iFQ
 aSK
@@ -169931,8 +169828,8 @@ ilO
 pjR
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 oNf
 aTX
 inU
@@ -170066,13 +169963,13 @@ brR
 cXZ
 sqA
 tGL
-hvd
-hvd
-hvd
-hvd
-hvd
+iub
+iub
+iub
+iub
+iub
 wup
-kcZ
+hXu
 ylT
 kRv
 kgG
@@ -170082,8 +169979,8 @@ kgG
 kRv
 kRv
 kqj
-gmP
-gmP
+wji
+wji
 kqj
 fvu
 sQn
@@ -170120,10 +170017,10 @@ lwn
 "}
 (155,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 eze
 pjR
@@ -170133,9 +170030,9 @@ pjR
 miQ
 pjR
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 oNf
 tle
 hQE
@@ -170285,11 +170182,11 @@ umq
 pPh
 kqj
 kqj
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kqj
-umk
+jEj
 fvu
 sQn
 vcE
@@ -170323,10 +170220,10 @@ lwn
 "}
 (156,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 aSK
 gne
 pjR
@@ -170335,10 +170232,10 @@ pjR
 pjR
 pjR
 fME
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 oNf
 oNf
 gkB
@@ -170488,11 +170385,11 @@ mDf
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
+wji
 kqj
 fvu
 sQn
@@ -170526,9 +170423,9 @@ lwn
 "}
 (157,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 iFQ
 aSK
 aSK
@@ -170538,9 +170435,9 @@ pjR
 pjR
 ilO
 aSK
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 jfn
 jfn
 gvw
@@ -170681,7 +170578,7 @@ xsz
 hWc
 lfb
 pAy
-kcZ
+hXu
 hqO
 kRv
 kgG
@@ -170693,13 +170590,13 @@ kRv
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
-gmP
+wji
+wji
+wji
+wji
 kqj
-bfa
-aFM
+jkX
+liu
 sQn
 xIp
 vcE
@@ -170729,9 +170626,9 @@ lwn
 "}
 (158,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 sBL
 oth
 pjR
@@ -170741,8 +170638,8 @@ vRE
 pjR
 pjR
 aSK
-wPV
-wPV
+cMi
+cMi
 sWE
 bIn
 jOl
@@ -170883,9 +170780,9 @@ tbK
 fBY
 gnA
 lfb
-gmP
-gmP
-gmP
+wji
+wji
+wji
 kRv
 umq
 siK
@@ -170897,14 +170794,14 @@ kRv
 kqj
 kqj
 kqj
-gmP
-gmP
-gmP
-qpO
-qpO
+wji
+wji
+wji
+tLh
+tLh
 aWQ
-bfa
-aFM
+jkX
+liu
 sQn
 xIp
 vcE
@@ -170932,10 +170829,10 @@ lwn
 "}
 (159,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 gsL
 pjR
 pjR
@@ -170946,7 +170843,7 @@ pjR
 bdS
 qtJ
 fpp
-wIM
+wxR
 rlN
 aqv
 bEs
@@ -171085,11 +170982,11 @@ iWt
 ePh
 wfD
 rit
-hvd
-qpO
-qpO
-qpO
-qpO
+iub
+tLh
+tLh
+tLh
+tLh
 fMT
 vjb
 iaZ
@@ -171101,15 +170998,15 @@ fMT
 qdm
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
 aWQ
-bfa
-aFM
+jkX
+liu
 sQn
 vcE
 vcE
@@ -171135,10 +171032,10 @@ lwn
 "}
 (160,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 pjR
 aiX
@@ -171288,11 +171185,11 @@ wfD
 vLI
 pFK
 oHJ
-hvd
-qpO
-qpO
-qpO
-qpO
+iub
+tLh
+tLh
+tLh
+tLh
 fMT
 fMT
 usF
@@ -171305,15 +171202,15 @@ fMT
 wfP
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
-waF
+hZc
 sQn
 xIp
 xIp
@@ -171323,11 +171220,11 @@ vcE
 vcE
 vcE
 qOz
-sDl
+jfd
 aWQ
-bfa
-bfa
-aFM
+jkX
+jkX
+liu
 sQn
 xIp
 xIp
@@ -171338,10 +171235,10 @@ lwn
 "}
 (161,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 ilO
 iUP
@@ -171354,7 +171251,7 @@ kio
 mCH
 yez
 coN
-wPV
+cMi
 gvw
 oKg
 dvm
@@ -171491,12 +171388,12 @@ oQO
 pHK
 fMk
 hAN
-hvd
-qpO
-qpO
-qpO
-qpO
-qpO
+iub
+tLh
+tLh
+tLh
+tLh
+tLh
 wfP
 fMT
 iaZ
@@ -171508,32 +171405,32 @@ fMT
 fMT
 fMT
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
-bfa
-bfa
-bfa
-aFM
+jkX
+jkX
+jkX
+liu
 sQn
 xIp
 xIp
 qOz
-sDl
+jfd
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
-bfa
-bfa
-aFM
+jkX
+jkX
+liu
 sQn
 xIp
 vcE
@@ -171541,11 +171438,11 @@ lwn
 "}
 (162,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 pjR
 pjR
 pjR
@@ -171557,7 +171454,7 @@ ryd
 jTi
 qtJ
 qtJ
-wPV
+cMi
 gvw
 lan
 cgi
@@ -171694,13 +171591,13 @@ tGL
 tGL
 tGL
 tGL
-hvd
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+iub
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 kXA
 gSJ
 iaZ
@@ -171711,43 +171608,43 @@ gSJ
 fMT
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
 aWQ
-bfa
-bfa
-bfa
-bfa
-aWQ
-aWQ
-aWQ
+jkX
+jkX
+jkX
+jkX
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
-bfa
-aFM
+aWQ
+aWQ
+aWQ
+jkX
+liu
 sQn
 lwn
 "}
 (163,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 pjR
 pjR
 pjR
@@ -171758,9 +171655,9 @@ pjR
 ilO
 pjR
 ueX
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 gvw
 ndy
 ryz
@@ -171897,13 +171794,13 @@ tGL
 uMz
 wUy
 cPG
-hvd
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
+iub
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
 fMT
 qpy
 vjb
@@ -171913,44 +171810,44 @@ vjb
 fGY
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
 aWQ
 aWQ
-aFM
+liu
 lwn
 "}
 (164,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 pjR
 pjR
@@ -171962,8 +171859,8 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 gvw
 tUs
 thp
@@ -172100,13 +171997,13 @@ eig
 rVA
 swo
 qjS
-hvd
-aEf
-aEf
-qpO
-qpO
-qpO
-qpO
+iub
+dTb
+dTb
+tLh
+tLh
+tLh
+tLh
 fMT
 fMT
 gSJ
@@ -172118,42 +172015,42 @@ fMT
 aWQ
 aWQ
 aWQ
-qpO
-qpO
+tLh
+tLh
 aWQ
 aWQ
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-tMM
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+kGb
 lwn
 "}
 (165,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 ujX
 aSK
 aSK
@@ -172165,7 +172062,7 @@ pjR
 pjR
 aSK
 aSK
-wPV
+cMi
 max
 gvw
 gvw
@@ -172303,14 +172200,14 @@ tGL
 fen
 kTL
 wEJ
-hvd
-wQY
-aEf
-aEf
-qpO
-qpO
-qpO
-qpO
+iub
+uIa
+dTb
+dTb
+tLh
+tLh
+tLh
+tLh
 fMT
 vjb
 iaZ
@@ -172327,37 +172224,37 @@ aWQ
 cQD
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (166,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 kOb
 lMt
@@ -172368,7 +172265,7 @@ giV
 miQ
 ixA
 aSK
-wPV
+cMi
 max
 dvn
 lpR
@@ -172506,14 +172403,14 @@ tGL
 oGg
 tGL
 tGL
-hvd
-wQY
-wQY
-aEf
-aEf
-qpO
-qpO
-qpO
+iub
+uIa
+uIa
+dTb
+dTb
+tLh
+tLh
+tLh
 fMT
 fMT
 vjb
@@ -172530,37 +172427,37 @@ dXT
 sRK
 dXT
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (167,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 mZi
 agL
 vww
@@ -172570,8 +172467,8 @@ pjR
 pjR
 aSK
 aSK
-wPV
-wPV
+cMi
+cMi
 max
 tRD
 aJC
@@ -172707,16 +172604,16 @@ qZK
 mxH
 kCx
 rVY
-eeq
-eeq
-aEf
-wQY
-wQY
-wQY
-aEf
-qpO
-qpO
-qpO
+mrH
+mrH
+dTb
+uIa
+uIa
+uIa
+dTb
+tLh
+tLh
+tLh
 fMT
 fMT
 iaZ
@@ -172733,37 +172630,37 @@ fMT
 hAw
 yiD
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (168,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aym
 yje
 mfQ
@@ -172772,9 +172669,9 @@ khM
 pjR
 aSK
 jpn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 max
 hnM
 dvn
@@ -172909,17 +172806,17 @@ iIJ
 wca
 mxH
 qsS
-dKa
 mrH
-qln
-aEf
-aEf
-aEf
-aEf
-aEf
-qpO
-qpO
-qpO
+mrH
+vrP
+dTb
+dTb
+dTb
+dTb
+dTb
+tLh
+tLh
+tLh
 fMT
 fMT
 qXI
@@ -172937,35 +172834,35 @@ fMT
 aWQ
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (169,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 iFQ
 pjR
 lMt
@@ -173119,9 +173016,9 @@ hpI
 tzj
 wQO
 ugh
-aEf
-qpO
-qpO
+dTb
+tLh
+tLh
 fMT
 xGB
 fMT
@@ -173141,33 +173038,33 @@ aWQ
 aWQ
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (170,1,1) = {"
 lwn
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
 gsL
 aSK
 aSK
@@ -173317,14 +173214,14 @@ svq
 pcs
 mrH
 ouq
-qln
-aEf
+vrP
+dTb
 tEU
 cGE
 ugh
-aEf
-qpO
-qpO
+dTb
+tLh
+tLh
 fMT
 fMT
 szi
@@ -173345,33 +173242,33 @@ dXT
 aWQ
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 lwn
 "}
 (171,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
 hqC
 gne
 pjR
@@ -173521,22 +173418,22 @@ xyS
 pzN
 mrH
 gXK
-aEf
+dTb
 lVZ
 bPA
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
 fMT
 wfP
 sRK
 fMT
 fMT
-qpO
-qpO
+tLh
+tLh
 fMT
 vjb
 vjb
@@ -173544,7 +173441,7 @@ iaZ
 vjb
 gdc
 fMT
-fDJ
+vTI
 wfP
 aWQ
 aWQ
@@ -173553,17 +173450,17 @@ aWQ
 aWQ
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 aWQ
 aWQ
 aWQ
@@ -173571,11 +173468,11 @@ lwn
 "}
 (172,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -173724,22 +173621,22 @@ crS
 hyn
 gXK
 gXK
-aEf
+dTb
 okK
 rpf
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
 aWQ
 qdm
 yiD
 fMT
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
 dXT
 fMT
 vjb
@@ -173750,19 +173647,19 @@ fMT
 fMT
 aWQ
 aWQ
-vQw
+ldK
 aWQ
-vQw
+ldK
 aWQ
-vQw
-aWQ
-aWQ
+ldK
 aWQ
 aWQ
-qpO
-qpO
-qpO
-qpO
+aWQ
+aWQ
+tLh
+tLh
+tLh
+tLh
 aWQ
 aWQ
 aWQ
@@ -173774,12 +173671,12 @@ lwn
 "}
 (173,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
 pjR
@@ -173927,23 +173824,23 @@ fDh
 gXK
 gXK
 gXK
-iEH
+tHT
 kpV
 wUA
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 yiD
 vjb
 vjb
@@ -173952,12 +173849,12 @@ iaZ
 vjb
 fMT
 fMT
-eCq
-vQw
-vQw
-vQw
-vQw
-bcr
+kwO
+ldK
+ldK
+ldK
+ldK
+xKA
 nmI
 fMT
 aWQ
@@ -173977,12 +173874,12 @@ lwn
 "}
 (174,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 iUP
 aSK
 pjR
@@ -174130,26 +174027,26 @@ rir
 kRk
 gXK
 gXK
-aEf
-aEf
+dTb
+dTb
 tWF
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 qdm
 vjb
-pAE
+dDI
 gSJ
 iaZ
 iaZ
@@ -174180,18 +174077,18 @@ lwn
 "}
 (175,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 aSK
 aSK
-tnB
+izL
 wnF
-bvE
+iQQ
 bBo
 oVd
 oST
@@ -174333,22 +174230,22 @@ nQK
 gdk
 mgd
 gXK
-aEf
-aEf
+dTb
+dTb
 aUm
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 hAw
 fMT
 vjb
@@ -174364,7 +174261,7 @@ eqz
 cWZ
 iJK
 nmI
-gxw
+buV
 qXI
 fMT
 fMT
@@ -174383,18 +174280,18 @@ lwn
 "}
 (176,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 ile
 ciT
 leF
-tnB
+izL
 aSK
-bvE
+iQQ
 leF
 max
 dBC
@@ -174536,22 +174433,22 @@ pbo
 rlL
 tFU
 gXK
-aEf
-aEf
+dTb
+dTb
 cIq
 ugh
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 fMT
 vjb
 vjb
@@ -174568,17 +174465,17 @@ fWb
 iJK
 nmI
 qXI
-kkG
+klV
 iaZ
 vjb
 fGY
 hNU
 vjb
 gdc
-klV
+eIP
 eAy
 fMT
-klV
+eIP
 fMT
 aWQ
 twA
@@ -174586,13 +174483,13 @@ lwn
 "}
 (177,1,1) = {"
 lwn
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
-wPV
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
+cMi
 vfk
 rhZ
 ecd
@@ -174738,22 +174635,22 @@ jAd
 mxH
 mxH
 kJw
-qln
-aEf
-aEf
-aEf
-aEf
-aEf
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+vrP
+dTb
+dTb
+dTb
+dTb
+dTb
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 fMT
 fMT
 gSJ
@@ -174780,8 +174677,8 @@ vjb
 iQN
 fMT
 qPy
-klV
-klV
+eIP
+eIP
 gdc
 aWQ
 twA
@@ -174908,7 +174805,7 @@ mrH
 hto
 gXK
 qsS
-bIp
+xsf
 gXK
 gJs
 qsS
@@ -174945,20 +174842,20 @@ crf
 pTI
 crf
 fAz
-xJg
+xjI
 mKe
 mKe
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 vjb
-xlZ
+gxw
 fGY
 vjb
 qpy
@@ -174967,12 +174864,12 @@ aWQ
 aWQ
 aWQ
 cQD
-vJb
-jcQ
+mLs
+boy
 eqz
 fWb
 iJK
-jcQ
+boy
 nmI
 fMT
 vjb
@@ -174984,7 +174881,7 @@ vjb
 vjb
 rdR
 kda
-klV
+eIP
 fMT
 fMT
 twA
@@ -175148,41 +175045,41 @@ lVw
 jxl
 crf
 fLp
-xJg
-jWQ
+xjI
+eja
 mKe
 mKe
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
-xlZ
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
+gxw
 vjb
 fGY
 vjb
-gxw
+buV
 fMT
 gdc
 fMT
 aWQ
 aWQ
 hAw
-jSn
-vQw
-vQw
-vQw
-vQw
-bcr
-buV
+sDt
+ldK
+ldK
+ldK
+ldK
+xKA
+vtj
 fMT
 iaZ
 fMT
-jEj
-vrP
-oiz
+tTd
+nQG
+eGB
 fMT
 vjb
 rdR
@@ -175351,17 +175248,17 @@ crf
 tsF
 dAF
 qJO
-xJg
-jWQ
-jWQ
+xjI
+eja
+eja
 mKe
 mKe
-qpO
-qpO
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
+tLh
+tLh
 bCJ
 cmp
 myt
@@ -175374,18 +175271,18 @@ aWQ
 aWQ
 aWQ
 aWQ
-vQw
+ldK
 aWQ
-vQw
+ldK
 aWQ
-vQw
+ldK
 fMT
 slp
 iaZ
 vjb
 fMT
 tjF
-vTI
+vAJ
 fMT
 clS
 efW
@@ -175554,21 +175451,21 @@ oAi
 leO
 adX
 lZU
-xJg
-jWQ
-jWQ
-jWQ
+xjI
+eja
+eja
+eja
 mKe
 mKe
-qpO
-qpO
-qpO
-qpO
+tLh
+tLh
+tLh
+tLh
 xbX
-iBn
+vKq
 sjH
 inw
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -175593,7 +175490,7 @@ gSJ
 vjb
 bYY
 fMT
-klV
+eIP
 fMT
 aWQ
 twA
@@ -175755,9 +175652,9 @@ gtj
 tEZ
 crf
 crf
-fbG
 crf
-xJg
+crf
+xjI
 mKe
 mKe
 mKe
@@ -175765,13 +175662,13 @@ mKe
 mKe
 mKe
 mKe
-iBn
-iBn
-iBn
-iBn
+vKq
+vKq
+vKq
+vKq
 qZA
 wPv
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -175960,7 +175857,7 @@ wPF
 xMc
 gcj
 ann
-nCx
+wPF
 wHl
 iYv
 tUa
@@ -175971,10 +175868,10 @@ emf
 aWt
 vbT
 nKD
-iBn
+vKq
 bgH
 hSf
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -176174,10 +176071,10 @@ jcp
 tSE
 mQO
 baT
-iBn
+vKq
 sjH
 sjH
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -176380,12 +176277,12 @@ vHG
 fPH
 sVl
 cqo
-iBn
-iBn
-iBn
-iBn
-iBn
-iBn
+vKq
+vKq
+vKq
+vKq
+vKq
+vKq
 aWQ
 aWQ
 aWQ
@@ -176406,7 +176303,7 @@ vjb
 bYY
 gdc
 fMT
-pAE
+dDI
 aWQ
 aWQ
 lwn
@@ -176588,7 +176485,7 @@ fPH
 uug
 xsk
 iOb
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -176791,7 +176688,7 @@ cGI
 siY
 hJX
 eDW
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -176994,7 +176891,7 @@ xsO
 xSL
 cod
 ixI
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -177008,7 +176905,7 @@ fMT
 xLT
 bYY
 fMT
-eGB
+mTA
 fMT
 vjb
 vjb
@@ -177197,7 +177094,7 @@ xsO
 iPs
 cod
 haP
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -177210,8 +177107,8 @@ xfZ
 vjb
 bYY
 rdR
-oiz
-jEj
+eGB
+tTd
 gdc
 iaZ
 fMT
@@ -177400,8 +177297,8 @@ xsO
 fPH
 oKc
 fPH
-iBn
-iBn
+vKq
+vKq
 aWQ
 aWQ
 aWQ
@@ -177411,9 +177308,9 @@ aWQ
 nhE
 fMT
 vjb
-azJ
+mED
 rdR
-jSn
+sDt
 qDK
 fMT
 iaZ
@@ -177604,7 +177501,7 @@ vLP
 sMi
 xZw
 iDo
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -177617,7 +177514,7 @@ gSJ
 bYY
 rdR
 fMT
-eGB
+mTA
 fMT
 iaZ
 fMT
@@ -177807,7 +177704,7 @@ tkD
 cjb
 llt
 dvM
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -178010,7 +177907,7 @@ oae
 iuo
 xYN
 iDo
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -178089,7 +177986,7 @@ dji
 ggn
 wxJ
 wxJ
-xQu
+rux
 rMO
 clf
 njQ
@@ -178122,10 +178019,10 @@ qtz
 qoU
 qtz
 qtz
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 pVN
 rMa
 vWu
@@ -178213,7 +178110,7 @@ knc
 aiH
 cMH
 sDp
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -178291,8 +178188,8 @@ wxJ
 gEu
 vXZ
 wxJ
-xQu
-xQu
+rux
+rux
 rMO
 uWf
 tcV
@@ -178325,10 +178222,10 @@ muF
 eZT
 sua
 qtz
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 pVN
 nUI
 nUI
@@ -178416,7 +178313,7 @@ cma
 rIA
 dSS
 slU
-iBn
+vKq
 aWQ
 aWQ
 aWQ
@@ -178494,8 +178391,8 @@ wxJ
 qsd
 qlM
 wxJ
-xQu
-xQu
+rux
+rux
 rMO
 rzs
 tqc
@@ -178528,10 +178425,10 @@ cbY
 suD
 hnP
 qtz
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 ncS
 iEN
 uve
@@ -178619,9 +178516,9 @@ tzy
 tzy
 mRy
 uYz
-vQB
-vQB
-vQB
+tnB
+tnB
+tnB
 aWQ
 aWQ
 aWQ
@@ -178697,8 +178594,8 @@ wxJ
 uLk
 qwl
 wxJ
-xQu
-xQu
+rux
+rux
 rMO
 aXy
 mQa
@@ -178731,10 +178628,10 @@ tbD
 dRI
 lvK
 qtz
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 qJN
 qJN
 lVE
@@ -178815,16 +178712,16 @@ jCr
 icq
 igk
 qEI
-dpm
-dpm
-dpm
+hly
+hly
+hly
 tzy
 cqT
 dmP
 ppf
 rzi
 mym
-vQB
+tnB
 aWQ
 aWQ
 vjb
@@ -178834,7 +178731,7 @@ ctS
 mlH
 mlH
 dFW
-klV
+eIP
 nhE
 aWQ
 fMT
@@ -178900,8 +178797,8 @@ wxJ
 mWH
 fWO
 akU
-xQu
-xQu
+rux
+rux
 rMO
 kKY
 rsJ
@@ -178934,9 +178831,9 @@ pfC
 dRI
 nwZ
 qtz
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
 fQP
 qJN
 qJN
@@ -179018,16 +178915,16 @@ xRW
 icq
 dmA
 qac
-cwm
-dpm
-dpm
+eTF
+hly
+hly
 dfm
 gjn
 wtv
 xLm
 tRP
 jJm
-vQB
+tnB
 aWQ
 aWQ
 vjb
@@ -179036,7 +178933,7 @@ xLT
 pTU
 bUC
 sDI
-klV
+eIP
 aWQ
 aWQ
 aWQ
@@ -179137,9 +179034,9 @@ win
 quE
 hnP
 qtz
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
 qJN
 qJN
 qJN
@@ -179221,18 +179118,18 @@ ggl
 jXj
 icq
 qac
-cwm
-dpm
-dpm
+eTF
+hly
+hly
 dfm
 ddC
 bBS
 xEw
 lbh
 inv
-vQB
+tnB
 aWQ
-vhM
+eCq
 clS
 clS
 uxF
@@ -179340,9 +179237,9 @@ lXV
 dIf
 vUs
 qtz
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
 qJN
 qJN
 qJN
@@ -179426,14 +179323,14 @@ icq
 qac
 bQZ
 wUr
-dpm
+hly
 dfm
 aXe
 wtv
 iel
 sxt
 jJm
-vQB
+tnB
 aWQ
 xvk
 ycG
@@ -179441,10 +179338,10 @@ brz
 bYY
 udn
 clS
-eIP
-eIP
-eIP
-eIP
+qOy
+qOy
+qOy
+qOy
 aWQ
 nhE
 fMT
@@ -179543,10 +179440,10 @@ qtz
 qtz
 qtz
 qtz
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 lCD
 qJN
 qvi
@@ -179636,18 +179533,18 @@ bwm
 cfe
 wIO
 oMQ
-vQB
-eIP
-eIP
+tnB
+qOy
+qOy
 sIR
 wSa
 mpt
 ogH
-eIP
-eIP
+qOy
+qOy
 lYi
 xpG
-eIP
+qOy
 aWQ
 qXI
 qXI
@@ -179739,18 +179636,18 @@ gEQ
 kOJ
 oKR
 mTT
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 qJN
 qJN
 qJN
@@ -179759,7 +179656,7 @@ lVE
 lVE
 kcm
 swU
-sji
+yle
 arM
 pKW
 jED
@@ -179850,7 +179747,7 @@ naY
 wRa
 bVq
 isk
-eIP
+qOy
 aWQ
 qXI
 iaZ
@@ -179864,12 +179761,12 @@ lwn
 "}
 (203,1,1) = {"
 lwn
-oKL
-jtv
-jtv
-jtv
-jtv
-jtv
+gCY
+gOR
+gOR
+gOR
+gOR
+gOR
 cbE
 cbE
 cbE
@@ -179942,19 +179839,19 @@ rBi
 uEL
 xOL
 mTT
-iiF
-iiF
+wvl
+wvl
 lyR
 tQn
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 qJN
 qJN
 qJN
@@ -180053,7 +179950,7 @@ gto
 bpw
 dNh
 emh
-eIP
+qOy
 rAM
 fMT
 vjb
@@ -180067,7 +179964,7 @@ lwn
 "}
 (204,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
 tBt
 tBt
@@ -180145,20 +180042,20 @@ fuM
 mTT
 mTT
 mTT
-iiF
+wvl
 qJN
 ewT
 qJN
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 qJN
 iqm
 lVE
@@ -180237,7 +180134,7 @@ aHo
 dmA
 qEI
 wdn
-bzq
+cfi
 bQZ
 ugW
 iYY
@@ -180256,7 +180153,7 @@ gRM
 eNK
 dNh
 iHD
-eIP
+qOy
 vjb
 vjb
 vjb
@@ -180270,36 +180167,36 @@ lwn
 "}
 (205,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 rpP
-xPp
-xPp
+wyb
+wyb
 rBT
-gZK
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+iwK
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 iFt
 iFt
-kwZ
+nhc
 aVz
 cEw
 fsm
@@ -180353,15 +180250,15 @@ qJN
 qJN
 qJN
 nni
-iiF
-iiF
-iiF
-aiG
-iiF
-iiF
-iiF
-iiF
-aiG
+wvl
+wvl
+wvl
+cFA
+wvl
+wvl
+wvl
+wvl
+cFA
 itS
 txG
 dAg
@@ -180473,36 +180370,36 @@ lwn
 "}
 (206,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-xnl
-arS
-arS
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+fmk
+tTu
+tTu
 noU
-gZK
+iwK
 tUK
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 iFt
 iFt
-kwZ
+nhc
 aVz
 pyG
 pyG
@@ -180548,7 +180445,7 @@ bpe
 qJN
 qJN
 qJN
-wFG
+qJN
 lVE
 lVE
 eae
@@ -180557,14 +180454,14 @@ lVE
 lVE
 qJN
 qJN
-iiF
-iiF
-aiG
-aiG
-aiG
-aiG
-aiG
-aiG
+wvl
+wvl
+cFA
+cFA
+cFA
+cFA
+cFA
+cFA
 qQY
 uWe
 dAg
@@ -180676,36 +180573,36 @@ lwn
 "}
 (207,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-xnl
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+fmk
 ray
-cUS
+tHI
 noU
-gZK
+iwK
 iFt
 ohG
 ofO
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
 tUK
 iFt
 iFt
 iFt
-kwZ
+nhc
 aVz
 uKi
 uKi
@@ -180761,7 +180658,7 @@ dAg
 lVE
 qJN
 qJN
-iiF
+wvl
 wsD
 wsD
 wsD
@@ -180879,36 +180776,36 @@ lwn
 "}
 (208,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 asD
 nsD
-cUS
-pkl
+tHI
+reL
 nkl
 mTe
-xvy
-xvy
-xvy
-xvy
+uAk
+uAk
+uAk
+uAk
 nsA
 aNo
-xvy
-xvy
-xvy
+uAk
+uAk
+uAk
 rfz
-kwZ
+nhc
 aVz
 uKi
 uKi
@@ -180943,11 +180840,11 @@ kzF
 hIY
 vAC
 wjz
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
 qJN
 gxr
 lVE
@@ -181082,36 +180979,36 @@ lwn
 "}
 (209,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 ibi
 dAZ
-xnl
-arS
-cUS
-arS
+fmk
+tTu
+tHI
+tTu
 nKt
-arS
-cUS
-arS
-arS
-arS
-bkn
-arS
-arS
-cUS
-arS
-kwZ
+tTu
+tHI
+tTu
+tTu
+tTu
+vcV
+tTu
+tTu
+tHI
+tTu
+nhc
 aVz
 uKi
 uKi
@@ -181146,7 +181043,7 @@ tHZ
 qoL
 iGS
 wjz
-iiF
+wvl
 rzy
 qJN
 qJN
@@ -181160,8 +181057,8 @@ qJN
 qJN
 qJN
 qJN
-iiF
-iiF
+wvl
+wvl
 nni
 qJN
 uve
@@ -181175,7 +181072,7 @@ fIA
 dMT
 wsD
 xzt
-fuq
+pWx
 dAg
 oCD
 lVE
@@ -181199,7 +181096,7 @@ nOc
 vpY
 fig
 cmV
-iAz
+pHh
 nkZ
 bQZ
 bQZ
@@ -181271,7 +181168,7 @@ tOv
 vxf
 xsg
 sDr
-eIP
+qOy
 ycG
 vjb
 vjb
@@ -181285,36 +181182,36 @@ lwn
 "}
 (210,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 pwL
 qRT
-xnl
-arS
-arS
-arS
+fmk
+tTu
+tTu
+tTu
 oqz
 bCE
-arS
-arS
-arS
-arS
-cUS
-bkn
-arS
+tTu
+tTu
+tTu
+tTu
+tHI
+vcV
+tTu
 aLt
-kwZ
-kwZ
+nhc
+nhc
 aVz
 uKi
 uKi
@@ -181322,9 +181219,9 @@ uKi
 uKi
 uKi
 uKi
-nSM
-nSM
-iiF
+slM
+slM
+wvl
 lld
 syJ
 syJ
@@ -181349,7 +181246,7 @@ kNF
 vHT
 llm
 wjz
-iiF
+wvl
 rzy
 qJN
 lVE
@@ -181359,13 +181256,13 @@ gxr
 qJN
 rzy
 rzy
-iiF
-iiF
+wvl
+wvl
 phr
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 fQP
 qJN
 lVE
@@ -181385,7 +181282,7 @@ lVE
 vSi
 vSi
 tSq
-iiF
+wvl
 arM
 uVA
 htD
@@ -181474,7 +181371,7 @@ tYL
 kiS
 lQO
 tYL
-eIP
+qOy
 fFN
 jmm
 fMT
@@ -181488,36 +181385,36 @@ lwn
 "}
 (211,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 vqC
 qRT
-xnl
-qSF
-cUS
-arS
+fmk
+sMe
+tHI
+tTu
 nKt
 ray
-cUS
+tHI
 hgL
-arS
-pMN
-arS
-arS
-arS
+tTu
+cTN
+tTu
+tTu
+tTu
 mGz
-kwZ
-kwZ
+nhc
+nhc
 aVz
 tBt
 tBt
@@ -181525,9 +181422,9 @@ tBt
 tBt
 tBt
 tBt
-nSM
-nSM
-iiF
+slM
+slM
+wvl
 lld
 rMa
 vWu
@@ -181552,23 +181449,23 @@ hBF
 hBF
 iFX
 mSn
-iiF
+wvl
 qJN
 lVE
 lVE
 lVE
 qJN
 nni
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
 mEq
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 rzy
 qJN
 lVE
@@ -181585,10 +181482,10 @@ owE
 eae
 gxr
 gwN
-sji
+yle
 inX
-iiF
-iiF
+wvl
+wvl
 vYn
 uVA
 eqM
@@ -181658,7 +181555,7 @@ hNz
 icq
 qEI
 bQZ
-cJw
+yaO
 bQZ
 lVu
 ejQ
@@ -181677,7 +181574,7 @@ xoG
 oUw
 mXZ
 xoG
-eIP
+qOy
 dcd
 aWQ
 nhE
@@ -181691,46 +181588,46 @@ lwn
 "}
 (212,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 hfL
-xnl
-arS
-xlO
-arS
+fmk
+tTu
+sum
+tTu
 uOP
-arS
-xlO
-arS
-xlO
+tTu
+sum
+tTu
+sum
 gyk
-xlO
-arS
-xlO
+sum
+tTu
+sum
 xls
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 vpt
-nSM
-nSM
-iiF
+slM
+slM
+wvl
 lld
 nUI
 nUI
@@ -181755,23 +181652,23 @@ vqD
 xwx
 bja
 jwW
-iiF
+wvl
 qJN
 lVE
 lVE
 lVE
 lVE
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 rzy
 qJN
 oyO
@@ -181788,10 +181685,10 @@ sYl
 dAg
 qJN
 qJN
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 vYn
 rWW
 jdN
@@ -181880,7 +181777,7 @@ dNh
 ncg
 dNh
 kCC
-eIP
+qOy
 aWQ
 aWQ
 aWQ
@@ -181894,53 +181791,53 @@ lwn
 "}
 (213,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-xnl
-arS
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+fmk
+tTu
 bak
-arS
+tTu
 uOP
-arS
-xlO
-arS
-xlO
-arS
-xlO
-arS
-xlO
+tTu
+sum
+tTu
+sum
+tTu
+sum
+tTu
+sum
 lTA
 sgS
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 vpt
-nSM
-nSM
-iiF
+slM
+slM
+wvl
 xIL
-eTF
+fUG
 lVE
 lVE
 lVE
 qJN
-jMi
+dKa
 dHd
 dHd
 dHd
@@ -181964,18 +181861,18 @@ lVE
 lVE
 laD
 lVE
-iiF
+wvl
 qJN
 iSm
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 qJN
 owE
 lVE
@@ -181990,7 +181887,7 @@ ooW
 dAg
 dAg
 cyp
-iiF
+wvl
 jDY
 jDY
 jDY
@@ -182073,17 +181970,17 @@ tBo
 eFK
 xMV
 ejQ
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
-eIP
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
+qOy
 aWQ
 aWQ
 aWQ
@@ -182097,10 +181994,10 @@ lwn
 "}
 (214,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 cBk
 vUR
 pcb
@@ -182110,7 +182007,7 @@ iFt
 keQ
 keQ
 wlz
-kwZ
+nhc
 roQ
 ocT
 tnG
@@ -182128,14 +182025,14 @@ tnG
 nWs
 izK
 iFt
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
 vpt
-nSM
-nSM
+slM
+slM
 rzy
 fQP
 qJN
@@ -182145,9 +182042,9 @@ lVE
 qJN
 qJN
 qJN
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
 ego
 jlW
 kIR
@@ -182170,13 +182067,13 @@ lVE
 mEq
 cTB
 qJN
-iiF
-iiF
+wvl
+wvl
 rzy
 rzy
-iiF
+wvl
 qJN
-iiF
+wvl
 fek
 qJN
 qJN
@@ -182193,7 +182090,7 @@ ooW
 dix
 vIu
 vSi
-iiF
+wvl
 jDY
 hjw
 vjN
@@ -182276,7 +182173,7 @@ fmS
 wke
 xMV
 ejQ
-ldK
+rtv
 aWQ
 aWQ
 aWQ
@@ -182300,10 +182197,10 @@ lwn
 "}
 (215,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 cBk
 vUR
 bsO
@@ -182313,7 +182210,7 @@ myI
 eXs
 eXs
 jnp
-kwZ
+nhc
 rRt
 hGO
 qZV
@@ -182337,8 +182234,8 @@ kMd
 lYd
 ePp
 vpt
-nSM
-nSM
+slM
+slM
 rzy
 qJN
 qJN
@@ -182351,7 +182248,7 @@ qJN
 qJN
 rzy
 rzy
-iiF
+wvl
 roM
 iwB
 wes
@@ -182395,8 +182292,8 @@ wsD
 mGM
 eZD
 qJN
-sji
-iiF
+yle
+wvl
 bDq
 qpN
 cyx
@@ -182470,7 +182367,7 @@ aHo
 icq
 qac
 wdn
-jcw
+gOl
 uhh
 ejQ
 qKo
@@ -182479,7 +182376,7 @@ czk
 lBk
 knZ
 ejQ
-ldK
+rtv
 aWQ
 aWQ
 aWQ
@@ -182503,9 +182400,9 @@ lwn
 "}
 (216,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 cBk
 pqY
@@ -182540,9 +182437,9 @@ eyU
 wBR
 dsJ
 vkM
-nSM
-nSM
-iiF
+slM
+slM
+wvl
 wHe
 lVE
 lVE
@@ -182588,7 +182485,7 @@ uYg
 dAg
 lVE
 lVE
-iiF
+wvl
 wsD
 wsD
 wsD
@@ -182620,7 +182517,7 @@ tkP
 cUe
 twr
 eof
-dpm
+hly
 pIe
 szM
 tJe
@@ -182674,7 +182571,7 @@ icq
 qac
 wdn
 wdn
-dpm
+hly
 ejQ
 ktl
 qEg
@@ -182682,7 +182579,7 @@ hOu
 pkG
 jdm
 ejQ
-ldK
+rtv
 aWQ
 aWQ
 aWQ
@@ -182706,9 +182603,9 @@ lwn
 "}
 (217,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 cBk
 cBk
 vUR
@@ -182743,8 +182640,8 @@ otU
 tIR
 cBk
 kXE
-nSM
-nSM
+slM
+slM
 cyp
 qJN
 hik
@@ -182789,14 +182686,14 @@ qJN
 lVE
 lVE
 qJN
-iiF
-iiF
-iiF
-aiG
-aiG
-aiG
-aiG
-aiG
+wvl
+wvl
+wvl
+cFA
+cFA
+cFA
+cFA
+cFA
 mzl
 tYZ
 nlt
@@ -182823,7 +182720,7 @@ sUO
 rxN
 gUy
 eof
-dpm
+hly
 szM
 szM
 iZU
@@ -182875,9 +182772,9 @@ mAC
 tVM
 icq
 qac
-cwm
-dpm
-dpm
+eTF
+hly
+hly
 ejQ
 pjO
 pjO
@@ -182885,7 +182782,7 @@ czk
 rvo
 ten
 ejQ
-ldK
+rtv
 aWQ
 aWQ
 aWQ
@@ -182909,9 +182806,9 @@ lwn
 "}
 (218,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 vUR
@@ -182946,8 +182843,8 @@ sxQ
 tIR
 hfL
 vkM
-nSM
-nSM
+slM
+slM
 uND
 psl
 whD
@@ -182975,10 +182872,10 @@ lVE
 lVE
 qJN
 qJN
-iiF
-iiF
+wvl
+wvl
 qJN
-iiF
+wvl
 qJN
 kbj
 jqU
@@ -182989,18 +182886,18 @@ qJN
 mEq
 lCD
 qJN
-iiF
+wvl
 ewT
-iiF
-iiF
-iiF
-iiF
-aiG
-iiF
-iiF
-iiF
-iiF
-aiG
+wvl
+wvl
+wvl
+wvl
+cFA
+wvl
+wvl
+wvl
+wvl
+cFA
 npL
 mrO
 amJ
@@ -183026,7 +182923,7 @@ eof
 iXa
 slV
 eof
-dpm
+hly
 szM
 jfY
 aoj
@@ -183078,9 +182975,9 @@ jCr
 czy
 icq
 qEI
-dpm
-dpm
-dpm
+hly
+hly
+hly
 azm
 pzJ
 nKl
@@ -183088,7 +182985,7 @@ nKl
 nKl
 qnt
 ejQ
-ldK
+rtv
 aWQ
 aWQ
 aWQ
@@ -183112,10 +183009,10 @@ lwn
 "}
 (219,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 cBk
 vUR
 pul
@@ -183147,10 +183044,10 @@ mvW
 qiA
 sxQ
 tIR
-aqg
+jcQ
 aVz
-nSM
-iiF
+slM
+wvl
 qJN
 qJN
 lVE
@@ -183179,30 +183076,30 @@ lVE
 lVE
 gxr
 qJN
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 lCD
 qJN
-iiF
-iiF
+wvl
+wvl
 nni
-iiF
+wvl
 fQP
 nni
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 epm
 hYL
@@ -183281,20 +183178,20 @@ oyX
 aTY
 icq
 qEI
-ldK
-ldK
-ldK
-ldK
+rtv
+rtv
+rtv
+rtv
 tII
 tII
 tII
 tII
 tII
-ldK
-ldK
-ldK
-ldK
-ldK
+rtv
+rtv
+rtv
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -183315,10 +183212,10 @@ lwn
 "}
 (220,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 hfL
 vUR
 pul
@@ -183350,10 +183247,10 @@ xFj
 dpj
 sxQ
 tIR
-aqg
+jcQ
 aVz
-nSM
-iiF
+slM
+wvl
 qJN
 lVE
 lVE
@@ -183376,36 +183273,36 @@ lVE
 lVE
 lVE
 qJN
-iiF
+wvl
 qJN
 qJN
 qJN
 qJN
 qJN
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 vNK
 eOL
@@ -183483,10 +183380,10 @@ hIC
 mWR
 bPy
 icq
-ldK
-ldK
-lhZ
-ldK
+rtv
+rtv
+vUg
+rtv
 dss
 gIW
 wep
@@ -183495,10 +183392,10 @@ gIW
 wep
 wep
 gIW
-ldK
-lhZ
-ldK
-ldK
+rtv
+vUg
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -183518,10 +183415,10 @@ lwn
 "}
 (221,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 cBk
 vUR
 pul
@@ -183553,7 +183450,7 @@ sBz
 rVO
 sxQ
 tIR
-aqg
+jcQ
 ntt
 rzy
 qJN
@@ -183578,37 +183475,37 @@ oFb
 lVE
 lVE
 qJN
-iiF
-iiF
+wvl
+wvl
 ewT
 nni
 qJN
 qJN
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 vIX
 hWj
@@ -183685,11 +183582,11 @@ iJc
 aEG
 jCr
 cGw
-ldK
-ldK
-lhZ
-lhZ
-ldK
+rtv
+rtv
+vUg
+vUg
+rtv
 prf
 kXx
 kXx
@@ -183698,11 +183595,11 @@ kXx
 kXx
 oGZ
 gCW
-ldK
-lhZ
-lhZ
-ldK
-ldK
+rtv
+vUg
+vUg
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -183721,9 +183618,9 @@ lwn
 "}
 (222,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 vUR
@@ -183762,56 +183659,56 @@ qJN
 qJN
 lVE
 lVE
-qGn
+mIe
 rzy
 rzy
-iiF
-iiF
+wvl
+wvl
 rzy
 rzy
-iiF
+wvl
 qJN
 qJN
 qJN
 qJN
-rbR
+oKL
 kvA
 oQW
-rbR
+oKL
 qJN
 oRI
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
 rzy
 rzy
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 wOl
 qap
@@ -183887,12 +183784,12 @@ bnk
 gVO
 wEB
 sbK
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-ldK
+rtv
+rtv
+vUg
+vUg
+vUg
+rtv
 jin
 jER
 mZj
@@ -183901,12 +183798,12 @@ jER
 mZj
 eCS
 vQW
-ldK
-lhZ
-lhZ
-lhZ
-ldK
-ldK
+rtv
+vUg
+vUg
+vUg
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -183924,9 +183821,9 @@ lwn
 "}
 (223,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 cBk
 pqY
@@ -183964,57 +183861,57 @@ vkM
 lVE
 lVE
 lVE
-cfi
+wDF
 qJN
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-rbR
-rbR
-rbR
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+oKL
+oKL
+oKL
 dOy
 dOy
-rbR
-rbR
-rbR
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+oKL
+oKL
+oKL
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 fyv
 fyv
@@ -184089,28 +183986,28 @@ xHn
 xHn
 rLe
 pKF
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
-ldK
+rtv
+rtv
+vUg
+vUg
+vUg
+vUg
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+vUg
+vUg
+vUg
+vUg
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -184127,7 +184024,7 @@ lwn
 "}
 (224,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
 hfL
 cBk
@@ -184168,56 +184065,56 @@ lVE
 lVE
 qJN
 eZD
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-rbR
-rbR
-rbR
-rbR
-rbR
-rbR
-rbR
-rbR
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+oKL
+oKL
+oKL
+oKL
+oKL
+oKL
+oKL
+oKL
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 fyv
 fyv
 fyv
@@ -184292,28 +184189,28 @@ pKF
 pKF
 pKF
 pKF
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
+rtv
 aWQ
 aWQ
 aWQ
@@ -184330,9 +184227,9 @@ lwn
 "}
 (225,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 vUR
@@ -184369,73 +184266,73 @@ wQF
 kXE
 qJN
 qJN
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -184533,10 +184430,10 @@ lwn
 "}
 (226,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
+nhc
+nhc
 cBk
 vUR
 pul
@@ -184570,75 +184467,75 @@ sxQ
 wQF
 wQF
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -184736,9 +184633,9 @@ lwn
 "}
 (227,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 vUR
@@ -184771,77 +184668,77 @@ fwX
 jcG
 sxQ
 wQF
-kwZ
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -184939,9 +184836,9 @@ lwn
 "}
 (228,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 vUR
@@ -184974,77 +184871,77 @@ dlI
 jzf
 sxQ
 wQF
-kwZ
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -185142,7 +185039,7 @@ lwn
 "}
 (229,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
 hfL
 cBk
@@ -185177,77 +185074,77 @@ dlI
 kVi
 agJ
 wQF
-kwZ
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -185345,9 +185242,9 @@ lwn
 "}
 (230,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 cBk
 cBk
 pye
@@ -185380,77 +185277,77 @@ qVV
 yed
 aip
 wQF
-kwZ
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -185548,9 +185445,9 @@ lwn
 "}
 (231,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
+nhc
 hfL
 hfL
 cBk
@@ -185583,77 +185480,77 @@ myI
 hnW
 wQF
 wQF
-kwZ
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -185751,112 +185648,112 @@ lwn
 "}
 (232,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
 hfL
 hfL
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 hfL
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
 hfL
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
-kwZ
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
+nhc
 vpt
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -185954,7 +185851,7 @@ lwn
 "}
 (233,1,1) = {"
 lwn
-aqg
+jcQ
 aVz
 tBt
 tBt
@@ -185991,75 +185888,75 @@ tBt
 tBt
 tBt
 aVz
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ
@@ -186157,112 +186054,112 @@ lwn
 "}
 (234,1,1) = {"
 lwn
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-aqg
-nSM
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
-iiF
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+jcQ
+slM
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
+wvl
 aWQ
 aWQ
 aWQ

--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -81,12 +81,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/hospital/reception)
-"abh" = (
-/obj/structure/bed/roller,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/urban/decal/road/lines2,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
 "abm" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/urban,
@@ -129,9 +123,6 @@
 /area/lv759/indoors/colonial_marshals/restroom)
 "abJ" = (
 /obj/machinery/landinglight/lz2,
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -378,7 +369,7 @@
 /area/lv759/indoors/power_plant/equipment_east)
 "adQ" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "adW" = (
 /obj/effect/landmark/weed_node,
@@ -411,9 +402,6 @@
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
 "aej" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/largecrate/random/barrel/black,
 /turf/open/floor/kutjevo/colors/orange,
 /area/lv759/indoors/spaceport/docking_bay_1)
@@ -477,9 +465,6 @@
 	},
 /area/lv759/indoors/nt_office/hallway)
 "aeO" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -674,21 +659,12 @@
 /obj/structure/prop/mainship/sensor_computer3/white,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/xenoarcheology)
-"agk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "agl" = (
 /turf/open/floor/prison,
 /area/lv759/indoors/garage_workshop)
 "ago" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "agv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -716,9 +692,9 @@
 /turf/open/floor/plating,
 /area/lv759/outdoors/landing_zone_2)
 "agJ" = (
-/obj/structure/cargo_container/green,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/obj/structure/largecrate/random/case/double,
+/turf/open/urban/street/cement3,
+/area/lv759/outdoors/landing_zone_1)
 "agL" = (
 /obj/structure/prop/mainship/cannon_cables{
 	pixel_y = 12
@@ -869,12 +845,9 @@
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "aip" = (
-/obj/item/stack/sandbags_empty,
-/obj/effect/urban/decal/dirt,
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/prop/urban/containersextended/medicalleft,
+/turf/open/urban/street/cement3,
+/area/lv759/outdoors/landing_zone_1)
 "aiz" = (
 /obj/structure/prop/urban/containersextended/blackwyleft,
 /turf/open/floor/orange_edge{
@@ -892,9 +865,8 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/casino)
 "aiG" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/east)
 "aiH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -918,7 +890,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/barricade/handrail/strata,
 /turf/open/floor/floorthree,
 /area/lv759/indoors/power_plant/power_storage)
 "aiX" = (
@@ -957,9 +928,6 @@
 	},
 /area/lv759/indoors/mining_outpost/north_maint)
 "ajj" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -971,11 +939,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/changing_room)
 "ajr" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1;
-	layer = 3.33;
-	pixel_y = 2
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/lv759/indoors/meridian/meridian_office)
@@ -1013,7 +976,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "ajC" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/trashbag{
@@ -1342,9 +1305,6 @@
 /obj/structure/barricade/handrail/urban/road/plastic/red{
 	dir = 8
 	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -1445,7 +1405,7 @@
 "ana" = (
 /obj/structure/sign/safety/blast_door,
 /turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "ane" = (
 /obj/structure/window/framed/urban,
 /turf/open/floor/plating,
@@ -1470,7 +1430,7 @@
 "anj" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "ann" = (
 /obj/structure/disposalpipe/segment,
@@ -1734,11 +1694,9 @@
 	},
 /area/lv759/indoors/power_plant/telecomms)
 "apx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/engineership/engineer_floor13{
-	dir = 5
-	},
-/area/lv759/oob)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "apy" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -1798,11 +1756,8 @@
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "aqg" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/landing_zone_1)
 "aql" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/metal/grated,
@@ -1839,7 +1794,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "aqy" = (
 /obj/effect/spawner/random/misc/structure/girder,
@@ -1950,6 +1905,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -2023,25 +1979,13 @@
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/bunker,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
-"arQ" = (
-/obj/structure/barricade/handrail/urban/handrail,
-/turf/open/floor/prison/cellstripe{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "arR" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/urban,
 /area/lv759/indoors/spaceport/cuppajoes)
 "arS" = (
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 8
-	},
-/obj/effect/urban/decal/engineership_corners{
-	dir = 8
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "arU" = (
 /obj/structure/bed/chair/sofa/corsat/left,
 /turf/open/floor/urban_wood,
@@ -2072,10 +2016,6 @@
 	dir = 4;
 	pixel_x = 1;
 	pixel_y = -1
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
 	},
 /obj/machinery/light{
 	dir = 4
@@ -2109,10 +2049,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "aso" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/machinery/floodlight,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "asv" = (
 /obj/structure/window/framed/urban/marshalls/cell,
 /turf/open/floor/plating,
@@ -2137,12 +2076,9 @@
 	},
 /area/lv759/indoors/meridian/meridian_foyer)
 "asD" = (
-/obj/structure/largecrate/random/barrel/red{
-	layer = 4;
-	pixel_y = 12
-	},
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/structure/cargo_container/green,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/landing_zone_1)
 "asR" = (
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
@@ -2196,7 +2132,7 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "atE" = (
 /obj/effect/urban/decal/road/lines1,
@@ -2240,9 +2176,6 @@
 /turf/open/floor/plate,
 /area/lv759/indoors/meridian/meridian_factory)
 "atV" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -2367,7 +2300,6 @@
 /area/lv759/indoors/nt_office/hallway)
 "avk" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration/shiva,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "avl" = (
@@ -2427,7 +2359,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "avy" = (
 /obj/structure/janitorialcart,
@@ -2511,15 +2443,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/central_hallway)
-"awj" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/recycling_plant/synthetic_storage)
 "awn" = (
 /obj/item/reagent_containers/food/drinks/coffee,
 /obj/item/tool/pen/blue{
@@ -2665,9 +2588,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "axQ" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -2684,7 +2604,6 @@
 /turf/open/floor/urban/metal/bluemetal1,
 /area/lv759/indoors/nt_office)
 "axS" = (
-/obj/structure/barricade/handrail/strata,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
 	},
@@ -2771,9 +2690,6 @@
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
 "ayW" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4
@@ -2851,11 +2767,14 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/garage_workshop_storage)
 "azJ" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab"
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/obj/structure/closet/crate/miningcar{
+	layer = 3
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/east_caves)
 "azU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -2877,12 +2796,6 @@
 	},
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"aAi" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "aAo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -2981,7 +2894,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/changing_room)
 "aCj" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/item/trash/trashbag{
 	pixel_x = 2;
 	pixel_y = 20
@@ -3193,12 +3105,8 @@
 /turf/open/floor/squares,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "aEf" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/hobosecret)
 "aEh" = (
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone{
@@ -3355,9 +3263,6 @@
 	},
 /area/lv759/indoors/hospital/operation)
 "aFp" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -4;
 	pixel_y = 8
@@ -3441,11 +3346,12 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/power_plant/south_hallway)
 "aFM" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating{
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 8
 	},
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "aFP" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/ai_node,
@@ -3503,9 +3409,7 @@
 /area/lv759/indoors/power_plant/workers_canteen_kitchen)
 "aGA" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "aGC" = (
 /obj/machinery/door/airlock/mainship/security/glass,
@@ -3686,18 +3590,7 @@
 	},
 /obj/structure/cable,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
-"aHU" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/lv759/indoors/nt_research_complex/hangarbay)
+/area/lv759/outdoors/landing_zone_1)
 "aHW" = (
 /obj/structure/table/black,
 /obj/item/ashtray/bronze{
@@ -3862,7 +3755,7 @@
 "aJn" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/northeast)
 "aJp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -4154,7 +4047,7 @@
 "aLt" = (
 /obj/structure/cargo_container/hd,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "aLv" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/urban,
@@ -4232,7 +4125,9 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "aMd" = (
 /obj/structure/disposalpipe/segment,
@@ -4246,13 +4141,6 @@
 /obj/item/toy/deck/kotahi,
 /turf/open/floor/grimy,
 /area/lv759/indoors/apartment/westhallway)
-"aMh" = (
-/obj/structure/largecrate/random/barrel/black{
-	layer = 3.1;
-	pixel_y = 8
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "aMq" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/item/clothing/mask/facehugger/dead,
@@ -4352,12 +4240,6 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"aNi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "aNo" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
@@ -4368,7 +4250,7 @@
 	layer = 4
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "aNw" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4402,9 +4284,6 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "aNP" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -4470,9 +4349,6 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
 "aOi" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -4486,7 +4362,7 @@
 	pixel_x = -16;
 	pixel_y = 34
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/north_street)
 "aOy" = (
 /obj/structure/barricade/handrail/urban/handrail{
@@ -4497,12 +4373,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "aOB" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
-/turf/open/floor/prison/cellstripe{
-	dir = 4
-	},
+/obj/structure/fence/dark,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "aOC" = (
 /obj/structure/closet/secure_closet/security,
@@ -4515,33 +4387,14 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"aOR" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
-	},
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/blue{
-	dir = 4;
-	pixel_y = -4
-	},
-/obj/effect/urban/decal/trash/six{
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "aOS" = (
-/obj/structure/platform_decoration,
 /obj/structure/prop/mainship/gelida/lightstick{
 	layer = 5;
 	level = 3;
 	pixel_x = 16
 	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "aOZ" = (
 /turf/open/urban/street/sidewalk{
@@ -4584,15 +4437,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"aPm" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/firehydrant{
-	dir = 1
-	},
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/central_streets)
 "aPp" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -4709,9 +4553,8 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/emergency_room)
 "aQh" = (
-/obj/structure/prop/urban/fakeplatforms/platform1,
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_west_caves)
 "aQn" = (
 /obj/effect/urban/decal/dirt{
 	pixel_y = 12
@@ -5162,10 +5005,6 @@
 "aUc" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/casino/casino_restroom)
-"aUf" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
 "aUi" = (
 /obj/structure/bed/chair{
 	dir = 4;
@@ -5195,14 +5034,11 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "aUq" = (
-/obj/structure/stairs/seamless{
-	color = "#6e6e6e";
-	dir = 8
+/obj/structure/barricade/metal/deployable,
+/turf/open/floor/prison{
+	dir = 10
 	},
-/turf/open/floor/prison/ramptop{
-	dir = 8
-	},
-/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+/area/lv759/indoors/caves/north_west_caves)
 "aUs" = (
 /obj/structure/closet/crate/trashcart{
 	layer = 6
@@ -5396,7 +5232,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/landing_zone_1/flight_control_room)
+/area/lv759/outdoors/landing_zone_1)
 "aVA" = (
 /obj/machinery/light,
 /obj/effect/urban/decal/dirt,
@@ -5533,7 +5369,7 @@
 /area/lv759/indoors/apartment/northapartments)
 "aWQ" = (
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/east_caves)
 "aWT" = (
 /obj/effect/urban/decal/trash/four{
 	pixel_y = 14
@@ -5542,7 +5378,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "aWX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "aWZ" = (
 /obj/structure/sink{
@@ -5558,12 +5394,6 @@
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/processing)
-"aXg" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
-/turf/open/floor/urban/metal/grated,
-/area/lv759/outdoors/colony_streets/central_streets)
 "aXm" = (
 /obj/machinery/floodlight/landing,
 /turf/open/urban/street/sidewalk{
@@ -5717,12 +5547,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_security/checkpoint_northeast)
-"aYy" = (
-/obj/effect/urban/decal/road/road_edge/two,
-/obj/effect/urban/decal/road/lines4,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_west_street)
 "aYz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5867,7 +5691,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "bal" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5991,7 +5815,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/barricade/handrail/strata,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/power_plant/power_storage)
 "bbb" = (
@@ -6008,13 +5831,13 @@
 /turf/open/floor/plate,
 /area/lv759/indoors/meridian/meridian_factory)
 "bbj" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
+/obj/structure/largecrate/random/mini{
+	layer = 4;
+	pixel_x = 1;
+	pixel_y = 14
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/west_caves)
 "bbm" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/medical{
@@ -6090,12 +5913,11 @@
 /turf/open/floor/mainship,
 /area/lv759/indoors/spaceport/horizon_runner)
 "bcr" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 8
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
 	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/east_caves)
 "bcs" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/asphalt,
@@ -6256,12 +6078,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "bef" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "beo" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/paper,
@@ -6339,17 +6159,11 @@
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "bfa" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
 	},
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8;
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/turf/open/floor/officetiles,
-/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "bff" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 1;
@@ -6371,9 +6185,6 @@
 	},
 /area/lv759/indoors/hospital/outgoing)
 "bft" = (
-/obj/machinery/streetlight/street{
-	pixel_y = -8
-	},
 /obj/structure/concrete_planter{
 	dir = 8;
 	pixel_y = 8
@@ -6565,7 +6376,7 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /obj/structure/cable,
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "bhi" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/urban/colony,
@@ -6672,12 +6483,6 @@
 	},
 /area/lv759/indoors/meridian/meridian_showroom)
 "bik" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_edge/nine,
@@ -6764,10 +6569,7 @@
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "biP" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/prop/urban/vehicles/meridian/green{
-	dir = 1;
-	pixel_x = -4
-	},
+/obj/effect/spawner/random/misc/structure/large/car,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "bja" = (
@@ -6910,11 +6712,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "bkn" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/orange_edge,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "bkt" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/orange_edge,
@@ -6928,9 +6728,6 @@
 "bkC" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards{
 	dir = 9;
 	layer = 8;
@@ -7103,7 +6900,7 @@
 "bmL" = (
 /obj/structure/sign/safety/blast_door,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/cargo)
 "bmO" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7216,10 +7013,8 @@
 	},
 /area/lv759/indoors/hospital/operation)
 "bnJ" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/north_street)
 "bnQ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -7281,11 +7076,9 @@
 /turf/open/floor/urban/tile/beige_bigtile,
 /area/lv759/indoors/power_plant/workers_canteen)
 "boy" = (
-/obj/machinery/light/small/blue{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "boB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/structure/lattice/autosmooth,
@@ -7331,9 +7124,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "bpu" = (
 /obj/effect/spawner/random/misc/structure/girder,
@@ -7370,7 +7161,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cargo_container/gorg,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "bpM" = (
 /turf/closed/wall/urban/colony,
@@ -7594,9 +7385,7 @@
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
 	pixel_y = 20
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "bry" = (
 /obj/machinery/light{
@@ -7614,11 +7403,11 @@
 "brz" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "brE" = (
 /obj/structure/rock/dark/large,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/south_west_caves)
 "brF" = (
 /obj/effect/urban/decal/road/road_edge/two,
@@ -7849,9 +7638,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "btB" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/largecrate/random/case/double,
 /turf/open/urban/street/sidewalk{
 	dir = 10
@@ -7909,7 +7695,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "bub" = (
 /obj/structure/prop/urban/misc/machinery/screens/bluemultimonitormedium_on{
 	pixel_x = 1
@@ -7945,8 +7731,8 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/floor/plating{
-	dir = 8
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/central_caves)
 "bux" = (
@@ -8044,10 +7830,7 @@
 /area/lv759/indoors/landing_zone_1/flight_control_room)
 "buV" = (
 /obj/item/stack/rods,
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "buW" = (
 /obj/machinery/streetlight/traffic_alt{
@@ -8061,7 +7844,7 @@
 "buY" = (
 /obj/machinery/door/poddoor,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/cargo)
 "buZ" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/reagent_containers/glass/bucket{
@@ -8079,12 +7862,12 @@
 /obj/item/tool/wet_sign,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/kutjevo,
-/area/lv759/indoors/spaceport/janitor)
+/area/lv759/indoors/spaceport/heavyequip)
 "bvf" = (
 /obj/structure/stairs{
 	color = "#a6aeab"
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "bvg" = (
 /obj/structure/rack,
@@ -8137,7 +7920,7 @@
 "bvE" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "bvJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -8282,7 +8065,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "bwU" = (
-/obj/structure/barricade/handrail/strata,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
 	pixel_x = 2
@@ -8493,7 +8275,7 @@
 /area/lv759/indoors/hospital/cmo_office)
 "byv" = (
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "byK" = (
 /obj/structure/cable,
@@ -8520,14 +8302,9 @@
 /turf/open/floor/wood/variable,
 /area/lv759/indoors/jacks_surplus)
 "bzq" = (
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 4
-	},
-/obj/effect/urban/decal/engineership_corners{
-	dir = 4
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/large,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "bzA" = (
 /obj/machinery/floodlight{
 	layer = 4;
@@ -8540,16 +8317,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/derelict_ship)
-"bzH" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/colony_streets/central_streets)
 "bzI" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 4;
@@ -8587,7 +8354,7 @@
 	pixel_y = 21
 	},
 /obj/item/ammo_casing/bullet,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "bAj" = (
 /obj/item/reagent_containers/food/drinks/milk,
@@ -8652,14 +8419,6 @@
 	},
 /turf/open/floor/floorthree,
 /area/lv759/indoors/spaceport/docking_bay_2)
-"bAH" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/north_street)
 "bAK" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal_solid{
@@ -8704,10 +8463,18 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/colonial_marshals/hallway_north)
 "bBa" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_west_street)
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8;
+	layer = 3.3
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "bBe" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -8730,7 +8497,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "bBx" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -8747,12 +8514,6 @@
 /obj/structure/window/framed/urban,
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/kitchen)
-"bBO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "bBS" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 7
@@ -8792,24 +8553,6 @@
 /obj/structure/prop/mainship/sensor_computer3,
 /turf/open/floor/urban/metal/bluemetalfull,
 /area/lv759/indoors/spaceport/flight_control_room)
-"bCh" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	layer = 3.33
-	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_2)
-"bCi" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/multi_tiles{
-	dir = 6
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
 "bCj" = (
 /obj/structure/table/mainship{
 	color = "#EBD9B7"
@@ -8835,11 +8578,8 @@
 "bCE" = (
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "bCF" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/machinery/conveyor,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8903,7 +8643,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "bDq" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/bunker,
@@ -8992,14 +8732,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"bEf" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 8
-	},
-/area/lv759/indoors/meridian/meridian_factory)
 "bEm" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt{
@@ -9069,7 +8801,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "bEH" = (
-/obj/structure/barricade/handrail/strata,
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/lines1,
@@ -9159,12 +8890,6 @@
 	dir = 10
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
-"bFv" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
-/obj/item/flashlight,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "bFC" = (
 /obj/effect/urban/decal/tiretrack{
 	dir = 6;
@@ -9229,20 +8954,9 @@
 /turf/open/floor/prison,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "bGi" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
+/obj/structure/rock/dark/wide/two,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
-"bGl" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/urban/handrail,
-/turf/open/floor/prison/cellstripe{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "bGn" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -9315,9 +9029,6 @@
 /area/lv759/indoors/colonial_marshals/holding_cells)
 "bGP" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -9361,9 +9072,6 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_mainroom)
 "bHf" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
 	pixel_x = -1;
@@ -9544,20 +9252,20 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "bIp" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/rock/dark/small{
+	layer = 4
 	},
-/turf/open/floor/mainship/tcomms,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/turf/open/urbanshale/layer2,
+/area/lv759/outdoors/colony_streets/south_east_street)
 "bIu" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
+/obj/structure/prop/urban/misc/machinery/screens/multimonitormedium_off{
+	dir = 1
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/engineering)
 "bIz" = (
 /obj/structure/platform/mineral{
 	dir = 1
@@ -9575,11 +9283,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
 "bIG" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_security/checkpoint_northwest)
 "bIJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/interior_wall,
@@ -9728,9 +9433,10 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
 "bJQ" = (
-/obj/structure/platform_decoration,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/power_plant)
+/obj/structure/rock/dark/stalagmite/five,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "bJR" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -9796,9 +9502,6 @@
 /obj/effect/decal/cleanable/greenglow{
 	color = "#140400";
 	name = "dirt"
-	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
 	},
 /obj/structure/prop/urban/vehicles/meridian/pink/damagethree,
 /turf/open/urban/street/sidewalkcenter{
@@ -9942,9 +9645,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/lv759/indoors/nt_research_complex/xenoarcheology)
 "bLt" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/orange_edge{
 	dir = 8
@@ -9988,9 +9688,6 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "bLP" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 4;
 	pixel_y = 18
@@ -10277,6 +9974,7 @@
 	layer = 3.33;
 	pixel_y = 2
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/lv759/indoors/caves/central_caves)
 "bOG" = (
@@ -10359,9 +10057,6 @@
 /area/lv759/indoors/casino)
 "bPu" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
 "bPv" = (
@@ -10490,7 +10185,7 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/central_streets)
 "bRn" = (
 /turf/open/urban/street/sidewalk{
@@ -10631,20 +10326,8 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
-"bSH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/rock/dark/stalagmite,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/indoors/caves/central_caves)
 "bSJ" = (
 /obj/structure/prop/urban/misc/fake/pipes/pipe5{
 	dir = 4;
@@ -10794,12 +10477,6 @@
 /obj/effect/urban/decal/road/lines1,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"bUd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
 "bUe" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -10823,12 +10500,7 @@
 "bUj" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "bUm" = (
 /obj/machinery/door/poddoor/shutters/urban/security_lockdown{
@@ -10930,13 +10602,8 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "bVc" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "bVd" = (
 /obj/item/shard,
@@ -11121,10 +10788,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "bWn" = (
-/obj/structure/rock/dark/large,
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/rock/dark/large,
-/turf/open/floor/officetiles,
+/obj/structure/prop/urban/vehicles/large/van/hyperdynevan{
+	dir = 1
+	},
+/turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "bWo" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall2{
@@ -11235,18 +10902,6 @@
 	},
 /turf/open/floor/mainship/sterile/plain,
 /area/lv759/indoors/nt_research_complex/xenoarcheology)
-"bWZ" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "bXf" = (
 /obj/structure/girder/reinforced,
 /obj/effect/urban/decal/dirt,
@@ -11319,18 +10974,6 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/lv759/indoors/colonial_marshals/interrogation)
-"bXG" = (
-/obj/machinery/streetlight/street{
-	level = 7;
-	pixel_y = 12
-	},
-/obj/structure/barricade/handrail/urban/road/plastic/blue{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/landing_zone_1)
 "bXJ" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/landmark/weed_node,
@@ -11442,9 +11085,8 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "bYt" = (
-/obj/item/lightstick/anchored,
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "bYu" = (
 /obj/effect/urban/decal/road/lines2,
@@ -11918,14 +11560,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/south_west_caves)
-"ccg" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/landing_zone_1)
 "cci" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -11933,17 +11567,6 @@
 	},
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/southwest_public_restroom)
-"ccl" = (
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/blue{
-	dir = 4;
-	pixel_y = -4
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "ccm" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4;
@@ -12011,13 +11634,6 @@
 /obj/item/toy/inflatable_duck,
 /turf/open/liquid/water/river/autosmooth,
 /area/lv759/indoors/apartment/westentertainment)
-"ccP" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 1
-	},
-/obj/structure/lattice/autosmooth,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
 "ccT" = (
 /obj/structure/table/reinforced/prison{
 	color = "#6b675e"
@@ -12056,13 +11672,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/north_east_street)
-"cdk" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/lv759/outdoors/landing_zone_1)
 "cdm" = (
 /obj/machinery/door/poddoor/shutters/urban/secure_red_door{
 	dir = 2;
@@ -12103,14 +11712,14 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "cdy" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 8
+/obj/structure/window/framed/urban/colony{
+	dir = 4
 	},
-/obj/structure/sign/safety/medical{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
+	dir = 4
 	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/open/floor/plating,
+/area/lv759/indoors/caves/west_caves)
 "cdC" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/spawner/random/misc/structure/large/car{
@@ -12172,6 +11781,7 @@
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "cer" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison{
 	dir = 9
 	},
@@ -12210,7 +11820,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "ceZ" = (
-/obj/structure/platform_decoration,
 /obj/effect/urban/decal/dirt,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
@@ -12224,12 +11833,10 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/mining_outpost/processing)
 "cfi" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 10
+/obj/structure/ore_box{
+	layer = 2
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "cfj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12555,9 +12162,6 @@
 /obj/item/clothing/head/warning_cone{
 	pixel_y = 19
 	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -12565,7 +12169,7 @@
 "ciy" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "ciA" = (
 /turf/open/floor/plating,
@@ -12601,11 +12205,6 @@
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
 "ciO" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3;
-	pixel_x = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
@@ -12619,7 +12218,7 @@
 	pixel_x = 3
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/mining_outpost/northeast)
+/area/lv759/indoors/caves/north_caves)
 "ciY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
@@ -12699,13 +12298,6 @@
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 2;
 	pixel_y = 9
-	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
 	},
 /obj/effect/urban/decal/road/road_edge/four,
 /obj/effect/urban/decal/doubleroad/lines3{
@@ -12950,9 +12542,10 @@
 /area/lv759/indoors/caves/east_caves)
 "cmr" = (
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/obj/effect/urban/decal/grate{
+	dir = 4
 	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "cmv" = (
 /obj/item/clothing/head/warning_cone{
@@ -12996,7 +12589,9 @@
 /obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
 	dir = 2
 	},
-/obj/structure/window/framed/urban/junk_window,
+/obj/structure/window/framed/urban/colony/engineering{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "cmX" = (
@@ -13210,9 +12805,6 @@
 /turf/open/floor/kutjevo/grey,
 /area/lv759/indoors/garage_workshop)
 "coC" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
 	pixel_x = -1;
@@ -13221,10 +12813,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "coE" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/southwest_public_restroom)
 "coH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -13245,7 +12835,7 @@
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "coR" = (
 /obj/item/clothing/head/warning_cone,
@@ -13262,10 +12852,6 @@
 /obj/item/cell/hyper,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/researchanddevelopment)
-"coU" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_caves)
 "coY" = (
 /obj/machinery/light{
 	dir = 1
@@ -13339,12 +12925,6 @@
 	},
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/jacks_surplus)
-"cpp" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "cpq" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -13455,7 +13035,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance)
 "cqs" = (
-/obj/structure/platform_decoration,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
 	},
@@ -13579,12 +13158,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_office/breakroom)
-"cro" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "crp" = (
 /turf/open/floor/urban/metal/greenmetal1{
 	dir = 6
@@ -13624,9 +13197,6 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "crD" = (
 /obj/item/shard,
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
 /obj/machinery/door/window,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13783,9 +13353,7 @@
 	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "csj" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/west_caves)
 "csk" = (
 /obj/structure/largecrate/random/mini/ammo{
@@ -13938,7 +13506,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 5
 	},
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "ctW" = (
@@ -14087,15 +13655,8 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"cvQ" = (
-/turf/closed/wall/wood,
-/area/lv759/oob)
 "cvU" = (
 /obj/effect/landmark/weed_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/central_streets)
 "cvV" = (
@@ -14147,10 +13708,9 @@
 	},
 /area/lv759/indoors/caves/north_west_caves)
 "cwm" = (
-/obj/item/stack/rods,
-/obj/item/tool/shovel,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/colonial_marshals/south_maintenance)
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "cwn" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic{
@@ -14234,9 +13794,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "cxv" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -14246,11 +13803,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_office/vip)
-"cxE" = (
-/obj/effect/urban/decal/dirt,
-/obj/machinery/miner/damaged,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "cxH" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
 /obj/structure/prop/urban/misc/fake/wire/blue{
@@ -14297,7 +13849,7 @@
 /area/lv759/indoors/spaceport/security_office)
 "cyp" = (
 /obj/effect/urban/decal/dirt,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "cyu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14334,9 +13886,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "cyL" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 8
 	},
@@ -14464,9 +14013,7 @@
 	},
 /obj/effect/urban/decal/dirt,
 /obj/structure/largecrate/random/barrel/black,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "cAc" = (
 /turf/open/floor/officetiles,
@@ -14737,12 +14284,6 @@
 	},
 /turf/open/floor/urban/tile/yellow_bigtile,
 /area/lv759/indoors/power_plant/workers_canteen)
-"cCJ" = (
-/obj/structure/stairs/seamless{
-	color = "#6e6e6e"
-	},
-/turf/open/floor/plating/kutjevo,
-/area/lv759/outdoors/landing_zone_1)
 "cCO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/fertilizer{
@@ -14936,12 +14477,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/meridian/meridian_factory)
-"cEn" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
 "cEq" = (
 /obj/structure/bed/chair/sofa/corsat/verticaltop,
 /obj/structure/cable,
@@ -15112,13 +14647,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/northeast)
-"cFA" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
 "cFD" = (
 /obj/item/stack/sheet/wood,
 /obj/item/stack/sheet/cardboard{
@@ -15182,10 +14710,6 @@
 /obj/structure/table/reinforced/prison,
 /obj/machinery/computer/marine_card,
 /obj/structure/cable,
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/electical_systems/substation2)
 "cGk" = (
@@ -15365,21 +14889,11 @@
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/hospital/outgoing)
 "cHQ" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/largecrate/random/case/small,
 /obj/structure/cable,
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "cHU" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk{
@@ -15564,21 +15078,13 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/north_west_caves)
 "cJt" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/north_caves)
 "cJw" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
+/obj/structure/rock/dark/wide/two,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
+/area/lv759/outdoors/landing_zone_2)
 "cJD" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/shard,
@@ -15742,9 +15248,7 @@
 	pixel_y = 28
 	},
 /obj/structure/largecrate/random/barrel/brown,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "cLt" = (
 /obj/effect/acid_hole,
@@ -15809,17 +15313,17 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "cMe" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
 	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/mining_outpost/northeast)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "cMi" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "cMj" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15901,7 +15405,7 @@
 /obj/effect/urban/decal/road/road_edge/four,
 /obj/effect/urban/decal/road/lines2,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_2)
 "cNn" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/urban,
@@ -16093,12 +15597,6 @@
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/botany/botany_mainroom)
-"cPa" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
 "cPf" = (
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
@@ -16212,8 +15710,8 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/nt_research_complex_entrance)
 "cPN" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -16237,7 +15735,7 @@
 /area/lv759/indoors/nt_research_complex/researchanddevelopment)
 "cPV" = (
 /obj/item/ammo_casing/bullet,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "cPX" = (
 /obj/effect/urban/decal/dirt,
@@ -16248,7 +15746,7 @@
 	light_range = 5
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/security)
 "cPY" = (
 /obj/structure/stairs/edge{
 	color = "#a6aeab"
@@ -16278,9 +15776,6 @@
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "cQd" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -16307,14 +15802,6 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"cQl" = (
-/obj/structure/rock/dark/stalagmite/four,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "cQr" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16339,7 +15826,7 @@
 "cQv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/smooth/engineerwall/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "cQw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -16543,7 +16030,7 @@
 /area/lv759/indoors/NTmart)
 "cRR" = (
 /obj/item/tool/wirecutters,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "cRU" = (
 /obj/structure/window/framed/urban/marshalls/cell,
@@ -16576,14 +16063,10 @@
 	},
 /area/lv759/indoors/caves/north_west_caves)
 "cSw" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
+/obj/effect/urban/decal/dirt,
+/obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/central_caves)
 "cSI" = (
 /turf/open/floor/tile/dark/brown3{
 	dir = 1
@@ -16726,9 +16209,6 @@
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
 "cTF" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
@@ -16760,16 +16240,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
-"cTN" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
-	},
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "cTO" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16917,9 +16387,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "cUS" = (
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "cUV" = (
 /obj/structure/bed/urban/chairs/black,
 /obj/effect/landmark/weed_node,
@@ -16979,10 +16449,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"cVP" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
-/turf/open/floor/urban/metal/grated,
-/area/lv759/outdoors/colony_streets/central_streets)
 "cVQ" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -17170,13 +16636,6 @@
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -21;
 	pixel_y = 3
-	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
 	},
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -17404,10 +16863,6 @@
 "cZd" = (
 /turf/closed/shuttle/dropship4/brokenconsoleone,
 /area/lv759/indoors/spaceport/horizon_runner)
-"cZk" = (
-/obj/item/paper/crumpled,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
 "cZm" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 4;
@@ -17469,9 +16924,6 @@
 /turf/open/engineership/engineer_floor2,
 /area/lv759/indoors/derelict_ship)
 "cZO" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
 	},
@@ -17527,9 +16979,7 @@
 "dab" = (
 /obj/item/tool/shovel,
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "dae" = (
 /obj/effect/urban/decal/road/lines4,
@@ -17574,9 +17024,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/east)
 "dap" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
 /obj/item/trash/cigbutt{
 	pixel_x = 7
 	},
@@ -17702,7 +17149,7 @@
 /obj/machinery/light/blue{
 	dir = 1
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "dbs" = (
 /obj/effect/urban/decal/dirt,
@@ -17790,16 +17237,13 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "dce" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor2,
+/area/lv759/indoors/derelict_ship)
 "dcg" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17814,17 +17258,8 @@
 	pixel_x = -8
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
-"dci" = (
-/obj/effect/urban/decal/grate{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/central_caves)
 "dck" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/urban/tile/tilegreen,
@@ -18001,10 +17436,6 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
 "ddO" = (
@@ -18028,11 +17459,9 @@
 	},
 /area/lv759/indoors/hospital/emergency_room)
 "ddR" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
+/obj/item/inflatable/wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "ddZ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -18123,7 +17552,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 9
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "deL" = (
 /obj/structure/prop/urban/misc/fake/lattice/full,
 /obj/structure/prop/urban/misc/fake/pipes/pipe1{
@@ -18224,10 +17653,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"dgi" = (
-/obj/item/lightstick/anchored,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
 "dgj" = (
 /obj/structure/table/wood/fancy,
 /obj/item/photo{
@@ -18304,13 +17729,6 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"dgT" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cargo_container/ch_red{
-	dir = 4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "dgW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -18457,10 +17875,10 @@
 "dis" = (
 /obj/structure/platform_decoration/urban/rockdark,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "dix" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "diC" = (
 /obj/effect/urban/decal/dirt,
@@ -18539,7 +17957,7 @@
 "diV" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "diW" = (
 /obj/effect/urban/decal/dirt,
@@ -18685,10 +18103,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "djY" = (
-/turf/open/engineership/engineer_floor13{
-	dir = 5
-	},
-/area/lv759/oob)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "dkb" = (
 /obj/item/reagent_containers/food/snacks/muffin,
 /obj/structure/table/reinforced/prison{
@@ -18787,9 +18204,6 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
 "dkM" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -18834,7 +18248,6 @@
 /turf/open/floor/mainship/stripesquare,
 /area/lv759/indoors/nt_research_complex/researchanddevelopment)
 "dlA" = (
-/obj/structure/barricade/handrail/strata,
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 1
 	},
@@ -19077,12 +18490,12 @@
 	},
 /area/lv759/indoors/spaceport/heavyequip)
 "dnq" = (
-/obj/item/storage/box/lightstick/red{
-	pixel_x = -4;
-	pixel_y = 10
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/central_caves)
 "dnu" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 1
@@ -19092,9 +18505,6 @@
 "dnv" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration/shiva{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -19192,9 +18602,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -19260,14 +18667,8 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/landing_zone_1)
 "dpm" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/colony_streets/north_street)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/landing_zone_2)
 "dpq" = (
 /obj/structure/rock/dark/large{
 	layer = 4
@@ -19300,10 +18701,8 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/north_street)
 "dpF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "dpI" = (
 /obj/effect/urban/decal/road/road_stop,
@@ -19366,9 +18765,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "dqB" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -19406,10 +18802,6 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods,
 /obj/effect/ai_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "dqM" = (
@@ -19422,9 +18814,6 @@
 /area/lv759/indoors/colonial_marshals/garage)
 "dqP" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	pixel_x = -1
-	},
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /turf/open/floor/prison{
 	dir = 8
@@ -19481,9 +18870,6 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "drk" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 4
@@ -19609,28 +18995,15 @@
 /obj/effect/urban/decal/road/road_edge/six,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"dsc" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
 "dse" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 8
+/obj/effect/urban/decal/road/lines3,
+/obj/structure/barricade/handrail/strata,
+/obj/structure/table/reinforced/prison,
+/obj/item/megaphone,
+/turf/open/floor/mainship{
+	dir = 5
 	},
-/obj/effect/urban/decal/road/road_edge,
-/obj/effect/urban/decal/road/lines1,
-/obj/effect/urban/decal/road/road_stop/five{
-	dir = 4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/area/lv759/indoors/nt_office/pressroom)
 "dsg" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/urban/decal/bloodtrail{
@@ -19660,7 +19033,7 @@
 	pixel_x = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "dsv" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/urban/street/sidewalkcenter{
@@ -19668,11 +19041,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "dsJ" = (
-/obj/structure/barricade/handrail/strata,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/north_east_street)
+/obj/structure/prop/urban/containersextended/medicalright,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/landing_zone_1)
 "dsK" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 10;
@@ -19758,7 +19129,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "dtx" = (
 /obj/effect/urban/decal/dirt,
@@ -19995,16 +19366,6 @@
 	},
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
-"dvq" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/engineership/engineer_floor3,
-/area/lv759/indoors/derelict_ship)
-"dvt" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/hospital/east_hallway)
 "dvu" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -20227,7 +19588,6 @@
 "dxV" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "dyi" = (
@@ -20270,7 +19630,7 @@
 	pixel_x = 6;
 	pixel_y = 11
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "dyu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -20322,7 +19682,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods,
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "dzb" = (
 /obj/effect/urban/decal/dirt,
@@ -20502,14 +19862,16 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "dAZ" = (
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/colony_streets/north_east_street)
-"dBc" = (
-/obj/structure/platform_decoration/urban/rockdark{
+/obj/structure/cargo_container/green{
 	dir = 4
 	},
 /turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/outdoors/landing_zone_1)
+"dBc" = (
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/indoors/nt_research_complex/xenobiology)
 "dBd" = (
 /obj/effect/urban/decal/trash,
 /turf/open/floor/urban/carpet/carpetbeigedeco,
@@ -20571,13 +19933,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/mainlabs)
-"dBr" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "dBs" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/blood,
@@ -20847,10 +20202,11 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "dDI" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/largecrate/random/barrel/red{
+	layer = 4
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "dDP" = (
 /obj/structure/bed/urban/bunkbed2,
 /turf/open/floor/urban/wood/redwood,
@@ -20892,9 +20248,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/power_plant/power_storage)
 "dEe" = (
@@ -20912,11 +20265,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_west)
 "dEg" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3;
-	pixel_x = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 4
@@ -20950,7 +20298,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "dEN" = (
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/light/small/blue{
@@ -20973,7 +20321,7 @@
 	light_range = 2
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/engineering)
 "dFk" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light/blue{
@@ -21018,15 +20366,6 @@
 "dFY" = (
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/spaceport/heavyequip)
-"dGd" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/urban/street/sidewalkcenter{
-	dir = 1
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "dGe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -21149,7 +20488,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/east_caves)
 "dHl" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaynorth)
@@ -21292,7 +20631,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "dIp" = (
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "dIv" = (
 /obj/structure/bed/chair/office/light{
@@ -21377,9 +20716,8 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "dJA" = (
 /obj/effect/urban/decal/dirt,
@@ -21438,7 +20776,7 @@
 /area/lv759/indoors/caves/north_caves)
 "dKa" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "dKc" = (
 /obj/effect/urban/decal/dirt,
@@ -21460,10 +20798,8 @@
 "dKh" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "dKr" = (
 /obj/structure/sink{
 	pixel_y = 16
@@ -21530,19 +20866,6 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
-"dKK" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
-	},
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/item/trash/cigbutt{
-	pixel_y = 8
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "dKQ" = (
 /obj/structure/platform_decoration/urban/engineer_corner,
 /turf/open/engineership/engineer_floor8{
@@ -21670,10 +20993,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/hospital/central_hallway)
-"dLQ" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "dLS" = (
 /obj/machinery/door/airlock/vault,
 /obj/structure/cable,
@@ -21730,13 +21049,9 @@
 /turf/open/floor/urban/carpet/carpetbluedeco,
 /area/lv759/indoors/colonial_marshals/north_office)
 "dMr" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/colony_streets/north_west_street)
+/obj/structure/rock/dark/large/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "dMA" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 1
@@ -21865,9 +21180,6 @@
 /turf/open/floor/prison,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "dNE" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/two,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -21886,12 +21198,10 @@
 	},
 /area/lv759/indoors/nt_research_complex/janitor)
 "dNK" = (
-/obj/structure/stairs/seamless{
-	color = "#a6aeab";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/platform_decoration/urban/engineer_corner,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "dNO" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -21978,7 +21288,7 @@
 	name = "\improper Lockdown"
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/north_east_caves)
 "dOE" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -22011,11 +21321,6 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "dOJ" = (
-/obj/structure/barricade/handrail/urban/road/plastic/blue{
-	dir = 1;
-	layer = 3;
-	pixel_x = 12
-	},
 /obj/effect/turf_decal/medical_decals/triage,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/landing_zone_1)
@@ -22056,11 +21361,10 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/hospital/icu)
 "dPb" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "dPk" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -22119,11 +21423,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "dPQ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/item/clothing/head/warning_cone{
+	pixel_x = -9;
+	pixel_y = 20
 	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/hospital/icu)
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "dQd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8
@@ -22181,15 +21486,8 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "dQM" = (
 /turf/closed/wall/r_wall/engineership/invincible,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "dQO" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/landing_zone_2)
 "dQR" = (
@@ -22347,9 +21645,6 @@
 /turf/open/floor/urban/carpet/carpetdarkerblue,
 /area/lv759/indoors/mining_outpost/east_dorms)
 "dSj" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -22359,8 +21654,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/structure/cable,
-/obj/structure/platform_decoration/shiva,
-/turf/open/floor/plating,
+/turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "dSq" = (
 /obj/effect/decal/cleanable/blood,
@@ -22415,23 +21709,17 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_security/checkpoint_west)
-"dSC" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
 "dSF" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/mining_outpost/northeast)
 "dSH" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+	dir = 4
 	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/west_caves)
 "dSL" = (
 /obj/structure/platform_decoration/shiva{
 	dir = 1
@@ -22494,15 +21782,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"dTb" = (
-/obj/item/storage/briefcase/inflatable,
-/obj/item/inflatable/door,
-/obj/structure/largecrate/random/mini{
-	pixel_x = 6;
-	pixel_y = 18
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "dTf" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison{
@@ -22583,7 +21862,7 @@
 "dTK" = (
 /obj/item/device/flashlight/lamp/tripod,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "dTL" = (
 /obj/machinery/light{
@@ -22630,9 +21909,6 @@
 /obj/effect/urban/decal/tiretrack{
 	dir = 1;
 	pixel_x = -7
-	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
 	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
@@ -22683,8 +21959,8 @@
 "dUp" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/turf/open/floor/prison{
+	dir = 10
 	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "dUs" = (
@@ -22730,12 +22006,11 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "dVd" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
+/obj/structure/prop/urban/vehicles/large/van/vanmining{
+	dir = 1;
+	pixel_x = -8
 	},
-/obj/item/trash/eat,
-/turf/open/floor/officetiles,
+/turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "dVj" = (
 /obj/effect/ai_node,
@@ -22781,11 +22056,15 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "dVA" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/area/lv759/indoors/caves/central_caves)
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/lv759/indoors/meridian/meridian_office)
 "dVE" = (
 /obj/structure/stairs/seamless/edge{
 	color = "#a6aeab";
@@ -23212,9 +22491,7 @@
 "eae" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "eal" = (
 /turf/open/floor/marked,
@@ -23224,7 +22501,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "eaC" = (
 /obj/effect/urban/decal/dirt,
@@ -23236,10 +22513,6 @@
 /area/lv759/indoors/mining_outpost/east_dorms)
 "eaM" = (
 /obj/item/smallDelivery,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "eaU" = (
@@ -23424,16 +22697,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/northeast)
-"eci" = (
-/obj/item/clipboard,
-/obj/item/paper,
-/obj/item/tool/pen/blue,
-/obj/structure/table/reinforced/prison,
-/obj/structure/barricade/handrail/strata,
-/turf/open/floor/mainship{
-	dir = 5
-	},
-/area/lv759/indoors/nt_office/pressroom)
 "eco" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -23446,9 +22709,6 @@
 /turf/open/floor/plating,
 /area/lv759/outdoors/landing_zone_2)
 "ecu" = (
-/obj/structure/barricade/sandbags{
-	dir = 1
-	},
 /obj/structure/barricade/handrail/urban/road/plastic/red,
 /obj/structure/prop/mainship/gelida/smallwire,
 /turf/open/urban/street/sidewalk{
@@ -23487,9 +22747,6 @@
 /turf/open/floor/urban/misc/spaceport2,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "edn" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/barricade/handrail/wire{
 	dir = 8
 	},
@@ -23665,15 +22922,10 @@
 	},
 /area/lv759/indoors/spaceport/cargo)
 "eeA" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/hospital/virology)
+/obj/machinery/door/poddoor,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/docking_bay_1)
 "eeE" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/prop/mainship/sensor_computer2/black,
 /turf/open/floor/prison/cellstripe{
 	dir = 1
@@ -23717,11 +22969,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "eeP" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -6
-	},
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
 "eeQ" = (
@@ -23759,18 +23006,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/floorthree,
 /area/lv759/indoors/power_plant/geothermal_generators)
-"efq" = (
-/obj/structure/barricade/sandbags{
-	dir = 4
-	},
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/road/road_edge/two,
-/obj/effect/urban/decal/road/lines4,
-/obj/effect/urban/decal/doubleroad/lines1{
-	pixel_x = -4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
 "efs" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -23908,7 +23143,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/north_east_caves)
 "egt" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -4;
@@ -23997,15 +23232,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/eastfoyer)
-"egN" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
 "egT" = (
 /obj/structure/prop/urban/misc/trash/green,
 /obj/effect/urban/decal/trash/twelve{
@@ -24114,10 +23340,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/garage)
-"eiw" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/engineership/engineer_floor2,
-/area/lv759/indoors/derelict_ship)
 "eiB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -24193,9 +23415,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
-"eja" = (
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "ejc" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -24248,7 +23467,7 @@
 	pixel_x = 2
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/flight_control_room)
 "eju" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -24294,7 +23513,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 9
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "ejH" = (
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/urban/decal/road/lines1,
@@ -24324,7 +23543,7 @@
 "ejS" = (
 /obj/effect/urban/decal/dirt,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/north_caves)
 "ejU" = (
 /turf/open/urban/street/roadlines4,
 /area/lv759/outdoors/colony_streets/east_central_street)
@@ -24385,9 +23604,10 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ekI" = (
-/obj/structure/rock/dark/stalagmite/three,
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "ekL" = (
 /obj/effect/urban/decal/dirt,
@@ -24896,7 +24116,7 @@
 "eoP" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/northeast)
 "eoQ" = (
 /obj/machinery/streetlight/street{
 	level = 7;
@@ -25206,9 +24426,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "ert" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "erF" = (
 /obj/item/stool{
 	pixel_x = -4;
@@ -25395,11 +24615,9 @@
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "esT" = (
-/obj/effect/urban/decal/trash/eleven{
-	dir = 1
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "esW" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -25416,10 +24634,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/power_plant/south_hallway)
-"etc" = (
-/obj/structure/platform_decoration,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "eti" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -25437,10 +24651,6 @@
 /area/lv759/indoors/nt_research_complex/janitor)
 "eto" = (
 /obj/effect/ai_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/central_streets)
 "etp" = (
@@ -25525,12 +24735,9 @@
 	},
 /area/lv759/indoors/colonial_marshals/hallway_south)
 "eue" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1;
-	layer = 2
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "eug" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/trash/green,
@@ -25631,17 +24838,6 @@
 	},
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/press_room)
-"euT" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_2)
 "euU" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/rack,
@@ -25760,7 +24956,7 @@
 	pixel_x = -6
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "ewu" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light{
@@ -25817,7 +25013,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ewQ" = (
-/obj/structure/platform_decoration,
 /turf/open/floor/urban/metal/zbrownfloor1{
 	dir = 4
 	},
@@ -25864,7 +25059,7 @@
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "exE" = (
 /obj/structure/barricade/handrail/medical,
 /obj/effect/urban/decal/road/lines3,
@@ -26084,10 +25279,6 @@
 	},
 /area/lv759/indoors/nt_office)
 "ezu" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -26189,7 +25380,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "eAL" = (
 /obj/effect/urban/decal/dirt,
@@ -26294,9 +25485,6 @@
 /obj/item/stack/rods,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -26307,9 +25495,7 @@
 	pixel_x = 4;
 	pixel_y = 7
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "eCj" = (
 /obj/effect/ai_node,
@@ -26329,9 +25515,7 @@
 /area/lv759/outdoors/landing_zone_2)
 "eCq" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "eCw" = (
 /obj/structure/barricade/handrail/medical{
@@ -26385,7 +25569,7 @@
 	pixel_x = -4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "eCW" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreeblies/greeble10{
@@ -26399,9 +25583,6 @@
 "eCX" = (
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration/shiva{
-	dir = 8
-	},
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "eDb" = (
@@ -26435,7 +25616,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "eDl" = (
 /obj/item/stack/sheet/cardboard,
 /obj/item/paper{
@@ -26500,11 +25681,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "eDK" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3;
-	pixel_x = 6
-	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "eDO" = (
@@ -26592,13 +25768,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/north)
 "eEq" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "eEw" = (
 /obj/structure/prop/urban/signs/high_voltage{
@@ -26647,13 +25818,6 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/power_plant/geothermal_generators)
 "eEG" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
 /obj/item/trash/cigbutt{
 	pixel_x = 7
 	},
@@ -26697,9 +25861,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
 "eEO" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -26783,19 +25944,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"eFt" = (
-/obj/structure/platform_decoration,
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/bluethree{
-	dir = 1
-	},
-/area/lv759/indoors/spaceport/docking_bay_2)
 "eFB" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/largecrate,
@@ -26900,16 +26048,14 @@
 	},
 /area/lv759/indoors/hospital/reception)
 "eGB" = (
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "eGN" = (
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/power_plant/workers_canteen_kitchen)
 "eGO" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/floorthree,
@@ -27111,9 +26257,8 @@
 /turf/open/floor/redone,
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "eIP" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/vehicledeployment)
 "eIU" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/logo_wall/four,
@@ -27158,9 +26303,9 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
 "eJp" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "eJv" = (
 /obj/item/reagent_containers/food/drinks/bottle/tomatojuice{
 	pixel_x = 5;
@@ -27202,9 +26347,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "eJM" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -27406,7 +26549,6 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/apartment/westrestroom)
 "eLk" = (
-/obj/item/stack/sandbags/large_stack,
 /obj/item/stool{
 	pixel_x = -4;
 	pixel_y = 23
@@ -27451,12 +26593,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "eLE" = (
-/obj/effect/urban/decal/road/roadmiddle{
-	dir = 1;
-	pixel_y = 14
-	},
 /obj/effect/landmark/weed_node,
-/turf/open/urban/street/asphalt,
+/turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "eLK" = (
 /obj/effect/urban/decal/dirt,
@@ -27554,9 +26692,6 @@
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/colonial_marshals/armory_foyer)
 "eMN" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/spawner/random/misc/structure/girder,
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/power_storage)
@@ -27585,11 +26720,9 @@
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/eastbedrooms)
 "eNf" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/prop/urban/containersextended/blackwyleft,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "eNg" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/urban/street/sidewalk,
@@ -27693,10 +26826,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/power_plant/fusion_generators)
-"eOw" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
 "eOy" = (
 /obj/structure/closet/bombclosetsecurity,
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
@@ -27712,7 +26841,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "eOC" = (
 /obj/structure/cargo_container/gorg,
@@ -27832,18 +26963,15 @@
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
 "ePp" = (
-/obj/structure/closet/crate/secure/surgery{
-	layer = 3;
-	pixel_y = 12
+/obj/structure/barricade/handrail/strata{
+	dir = 4
 	},
-/obj/structure/barricade/handrail/urban/road/plastic/blue,
-/turf/open/urban/street/cement1,
+/obj/structure/prop/urban/containersextended/medicalleft,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/outdoors/landing_zone_1)
 "ePr" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /obj/effect/ai_node,
 /turf/open/shuttle/escapepod{
 	dir = 1
@@ -27882,10 +27010,6 @@
 	},
 /area/lv759/indoors/spaceport/communications_office)
 "ePK" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
 "ePR" = (
@@ -28198,14 +27322,9 @@
 	},
 /area/lv759/indoors/spaceport/starglider)
 "eSb" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/obj/structure/prop/mainship/gelida/railbumper{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/lv759/indoors/caves/central_caves)
 "eSo" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -28336,12 +27455,6 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
-"eTx" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/central_caves)
 "eTB" = (
 /obj/structure/largecrate/random/barrel/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -28352,9 +27465,11 @@
 	},
 /area/lv759/indoors/power_plant)
 "eTF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/janitor)
+/obj/machinery/light/small/blue{
+	dir = 1
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "eTN" = (
 /obj/structure/prop/urban/signs/high_voltage/small,
 /obj/structure/prop/urban/signs/high_voltage/small,
@@ -28392,9 +27507,7 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "eUg" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "eUj" = (
 /obj/item/clothing/head/warning_cone{
@@ -28524,10 +27637,10 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/casino/casino_restroom)
 "eWc" = (
-/obj/structure/platform_decoration,
 /obj/machinery/light/blue{
 	dir = 4
 	},
+/obj/structure/largecrate/random/barrel/red,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "eWg" = (
@@ -28584,9 +27697,6 @@
 /area/lv759/indoors/spaceport/cargo)
 "eWO" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 1
-	},
 /turf/open/floor/prison/ramptop{
 	dir = 4
 	},
@@ -28667,7 +27777,6 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "eXs" = (
-/obj/structure/barricade/handrail/strata,
 /turf/open/floor/prison{
 	dir = 10
 	},
@@ -28989,9 +28098,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "faz" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -29006,10 +28112,9 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "faB" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/ai_node,
-/turf/open/floor/prison/plate,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "faC" = (
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/structure/cable,
@@ -29135,7 +28240,7 @@
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 8
 	},
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "fbG" = (
@@ -29440,7 +28545,7 @@
 	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/lv759/indoors/jacks_surplus)
+/area/lv759/indoors/caves/central_caves)
 "fef" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -29507,9 +28612,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "feA" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/urban/metal/zbrownfloor1{
 	dir = 9
@@ -29671,7 +28773,8 @@
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/caveplateau)
 "fgg" = (
 /obj/structure/barricade/handrail/strata,
@@ -29813,9 +28916,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "fhF" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -29891,15 +28991,6 @@
 /obj/structure/prop/urban/misc/trash/green,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/central_streets)
-"fhY" = (
-/obj/structure/stairs{
-	color = "#a6aeab"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/floor/urban/tile/darkgrey_bigtile,
-/area/lv759/indoors/botany/botany_mainroom)
 "fib" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/reception)
@@ -30024,10 +29115,8 @@
 "fiL" = (
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "fiN" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/trash,
@@ -30194,11 +29283,8 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "fkr" = (
-/obj/structure/prop/urban/misc/fake/heavydutywire/heavy4,
-/obj/structure/prop/urban/misc/floorprops/grate,
-/obj/structure/platform_decoration,
-/turf/open/floor/plating,
-/area/lv759/indoors/power_plant/power_storage)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/hallwayeast)
 "fkw" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -30321,7 +29407,9 @@
 /area/lv759/indoors/spaceport/docking_bay_1)
 "flH" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "flO" = (
 /obj/machinery/door/airlock/mainship/secure,
@@ -30334,7 +29422,7 @@
 /area/lv759/indoors/electical_systems/substation2)
 "flR" = (
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "flS" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -30372,16 +29460,8 @@
 	pixel_y = 21
 	},
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
-"fmk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/indoors/caves/central_caves)
 "fmx" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/item/stack/rods{
@@ -30416,7 +29496,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "fmR" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/medical/pillbottle,
@@ -30435,9 +29515,6 @@
 /turf/open/floor/prison/red,
 /area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "fmS" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
 /turf/open/shuttle/escapepod{
 	dir = 1
 	},
@@ -30719,7 +29796,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "foE" = (
-/obj/structure/platform_decoration,
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/kutjevo/colors/orange,
 /area/lv759/indoors/spaceport/docking_bay_1)
@@ -30747,14 +29823,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/meridian/meridian_office)
-"foZ" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/landing_zone_1)
 "fpd" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison{
@@ -30786,7 +29854,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/structure/grille,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "fps" = (
 /obj/machinery/streetlight/traffic_alt{
@@ -30927,7 +29995,7 @@
 /obj/structure/prop/urban/vehicles/large/colonycrawlers/science/science1{
 	dir = 1
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "fre" = (
 /obj/effect/urban/decal/dirt,
@@ -31038,9 +30106,6 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/spaceport/heavyequip)
 "frY" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
 /obj/structure/stairs/corner_seamless{
 	color = "#b8b8b0"
 	},
@@ -31164,15 +30229,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/changingroom)
-"fsI" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/central_caves)
 "fsJ" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/sign/safety/hazard,
@@ -31251,12 +30307,8 @@
 	},
 /area/lv759/indoors/colonial_marshals/hallway_north_locker)
 "ftl" = (
-/obj/item/tool/pen{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/turf/open/engineership/engineer_floor3,
-/area/lv759/indoors/derelict_ship)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart)
 "ftr" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -31293,6 +30345,11 @@
 /area/lv759/indoors/meridian/meridian_factory)
 "ftJ" = (
 /obj/effect/urban/decal/road/lines3,
+/obj/structure/barricade/handrail/strata,
+/obj/structure/table/reinforced/prison,
+/obj/item/paper,
+/obj/item/clipboard,
+/obj/item/tool/pen/blue,
 /turf/open/floor/mainship{
 	dir = 5
 	},
@@ -31342,9 +30399,12 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_security)
 "fuq" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/urban/decal/dirt,
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_east_caves)
 "fur" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -31377,15 +30437,6 @@
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison/darkred/full,
 /area/lv759/outdoors/colony_streets/north_street)
-"fuH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "fuI" = (
 /obj/machinery/flasher{
 	id = "Containment Cell 5";
@@ -31477,7 +30528,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "fvv" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -31500,7 +30551,7 @@
 /area/lv759/indoors/power_plant/telecomms)
 "fvF" = (
 /turf/open/engineership/pillars/north/pillar4,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "fvH" = (
 /obj/effect/ai_node,
 /turf/open/floor/urban/tile/tilewhitecheckered,
@@ -32002,9 +31053,11 @@
 /turf/open/floor/urban/carpet/carpetblue,
 /area/lv759/indoors/hospital/virology)
 "fAu" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/electical_systems/substation1)
 "fAv" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/tool/kitchen/tray{
@@ -32128,13 +31181,6 @@
 	},
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/spaceport/baggagehandling)
-"fBg" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
-/turf/open/urban/street/sidewalkfull,
-/area/lv759/outdoors/colony_streets/north_street)
-"fBn" = (
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
 "fBv" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_stop/five{
@@ -32325,7 +31371,7 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "fCZ" = (
 /obj/effect/urban/decal/road/road_edge/three,
@@ -32403,11 +31449,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "fDJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/hospital/janitor)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/east_caves)
 "fDT" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
@@ -32440,14 +31484,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetdarkerblue,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"fEh" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/road/roadmiddle{
-	dir = 1;
-	pixel_y = 14
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
 "fEo" = (
 /obj/structure/table/mainship,
 /obj/structure/window/reinforced{
@@ -32625,9 +31661,7 @@
 /area/lv759/indoors/nt_research_complex/xenoarcheology)
 "fFN" = (
 /obj/structure/cargo_container/gorg,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "fFO" = (
 /obj/structure/foamedmetal,
@@ -32793,7 +31827,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "fGJ" = (
-/obj/structure/platform_decoration,
 /obj/effect/turf_decal/warning_stripes/thin{
 	pixel_y = -1
 	},
@@ -33090,7 +32123,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "fJn" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/prison/cellstripe{
@@ -33228,12 +32261,6 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
-"fKs" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_caves)
 "fKx" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -33355,14 +32382,7 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/south_public_restroom)
-"fLw" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "fLz" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -33540,8 +32560,7 @@
 	pixel_y = 16
 	},
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "fNe" = (
 /obj/effect/urban/decal/dirt,
@@ -33561,9 +32580,6 @@
 /area/lv759/indoors/spaceport/cargo)
 "fNh" = (
 /obj/item/shard,
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
 /obj/machinery/door/window,
 /obj/machinery/door/window{
 	dir = 4
@@ -33781,7 +32797,7 @@
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 1
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "fPh" = (
 /obj/effect/urban/decal/dirt,
@@ -33967,9 +32983,6 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/spaceport/heavyequip)
 "fQy" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -34040,11 +33053,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
-"fQM" = (
-/turf/open/engineership/engineer_floor13{
-	dir = 6
-	},
-/area/lv759/oob)
 "fQP" = (
 /obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
@@ -34090,11 +33098,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "fRu" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/xeno/tunnel,
+/turf/open/engineership/engineer_floor2,
+/area/lv759/indoors/derelict_ship)
 "fRv" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -34124,7 +33130,7 @@
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/kutjevo,
-/area/lv759/indoors/spaceport/janitor)
+/area/lv759/indoors/spaceport/heavyequip)
 "fRL" = (
 /turf/open/floor/orange_edge{
 	dir = 1
@@ -34146,7 +33152,6 @@
 /turf/open/floor/kutjevo/grey,
 /area/lv759/indoors/garage_workshop)
 "fRR" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -34155,18 +33160,12 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
 "fRT" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 4
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate{
+	dir = 8
 	},
-/turf/open/floor/urban_plating,
-/area/lv759/indoors/caves/north_west_caves)
-"fRU" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/nt_security/checkpoint_northeast)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "fRW" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/structure/cable,
@@ -34359,7 +33358,7 @@
 /area/lv759/indoors/derelict_ship)
 "fTI" = (
 /obj/structure/largecrate/random,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "fTU" = (
 /obj/structure/cable,
@@ -34387,7 +33386,7 @@
 "fUi" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer2,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_west_caves)
 "fUk" = (
 /obj/effect/urban/decal/dirt,
@@ -34419,7 +33418,7 @@
 /obj/machinery/light/blue{
 	dir = 1
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "fUD" = (
 /obj/machinery/door_control{
@@ -34441,10 +33440,7 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
 "fUG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "fUI" = (
 /obj/structure/extinguisher_cabinet,
@@ -34717,10 +33713,7 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsbedroom)
 "fWW" = (
-/obj/structure/prop/urban/vehicles/large/ambulance{
-	pixel_x = -8;
-	pixel_y = 6
-	},
+/obj/effect/spawner/random/misc/structure/large/car,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "fWZ" = (
@@ -34920,11 +33913,9 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/landing_zone_2)
 "fYW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "fYX" = (
 /obj/machinery/vending/cola{
 	pixel_y = 16
@@ -34937,7 +33928,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "fZc" = (
 /obj/structure/cable,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "fZd" = (
 /obj/structure/cable,
@@ -35296,10 +34287,6 @@
 	},
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/apartment/northapartments)
-"gcD" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "gcE" = (
 /obj/structure/prop/urban/misc/phonebox/lightup{
 	pixel_x = 4;
@@ -35509,10 +34496,6 @@
 /obj/effect/acid_hole,
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/westrestroom)
-"geq" = (
-/obj/structure/barricade/handrail/strata,
-/turf/open/floor/urban/tile/darkgrey_bigtile,
-/area/lv759/indoors/botany/botany_mainroom)
 "geA" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -35667,9 +34650,6 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/apartment/eastrestroomsshower)
 "gfL" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
 /turf/open/floor/prison/cellstripe{
 	dir = 1
 	},
@@ -35691,9 +34671,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/central_streets)
 "gfV" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -35864,12 +34841,11 @@
 	},
 /area/lv759/indoors/colonial_marshals/armory_foyer)
 "ggP" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
 	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_west_caves)
 "ggS" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -36259,9 +35235,6 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
 "gkB" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/urban/decal/dirt,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 6;
@@ -36300,7 +35273,7 @@
 "gkI" = (
 /obj/structure/platform_decoration/urban/engineer_corner,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "gkK" = (
 /obj/item/tool/shovel,
 /turf/open/ground/sandrock,
@@ -36395,8 +35368,7 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_east)
 "glD" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/obj/structure/rock/dark/stalagmite,
+/obj/structure/rock/dark/large/three,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_west_caves)
 "glG" = (
@@ -36603,9 +35575,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "gmP" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/central_caves)
 "gmT" = (
 /obj/structure/sign/poster,
 /obj/structure/sign/poster{
@@ -36647,7 +35618,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "gnp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -36805,9 +35776,6 @@
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/colonial_marshals/head_office)
 "gox" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
 	layer = 3.33
@@ -36817,11 +35785,9 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
 "goC" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/effect/spawner/random/misc/structure/girder,
+/turf/open/floor/plating,
+/area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "goD" = (
 /obj/structure/table/reinforced/prison,
 /obj/structure/window/reinforced/toughened,
@@ -37228,11 +36194,9 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/mining_outpost/east_command)
 "grJ" = (
-/obj/structure/girder,
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/largecrate/random/barrel/brown,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "grK" = (
 /obj/structure/stairs{
 	color = "#a6aeab"
@@ -37253,11 +36217,9 @@
 /turf/open/floor/floorthree,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "gse" = (
-/obj/machinery/light/blue{
-	dir = 4
-	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/caves/south_west_caves)
 "gsj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -37627,10 +36589,6 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "gvC" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/central_streets)
 "gvE" = (
@@ -37749,16 +36707,11 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
-"gwK" = (
-/obj/machinery/light,
-/obj/structure/largecrate/random,
-/turf/open/floor/prison/whitegreen,
-/area/lv759/indoors/hospital/central_hallway)
 "gwN" = (
 /obj/machinery/floodlight{
 	layer = 1
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "gwS" = (
 /obj/machinery/conveyor{
@@ -37787,13 +36740,6 @@
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/north_street)
 "gxf" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/landing_zone_2)
@@ -37835,7 +36781,7 @@
 /area/lv759/outdoors/colony_streets/north_west_street)
 "gxw" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "gxx" = (
 /obj/structure/prop/urban/misc/fake/pipes/pipe1,
@@ -37970,7 +36916,7 @@
 	dir = 4
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "gyl" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalkfull,
@@ -38137,12 +37083,6 @@
 /obj/structure/noticeboard,
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/recycling_plant/garage)
-"gAp" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
 "gAB" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_edge/four,
@@ -38225,10 +37165,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/meridian/meridian_office)
-"gBb" = (
-/obj/structure/prop/urban/containersextended/medicalright,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/landing_zone_1)
 "gBe" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/prison/blue{
@@ -38321,12 +37257,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"gBF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "gBH" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 1;
@@ -38379,12 +37309,6 @@
 "gCi" = (
 /turf/closed/wall/r_wall/white_research_wall,
 /area/lv759/indoors/nt_research_complex/weaponresearchlab)
-"gCo" = (
-/obj/structure/cargo_container/ch_red{
-	dir = 1
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "gCp" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -38451,7 +37375,7 @@
 	},
 /obj/machinery/light/blue,
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "gCX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -38469,13 +37393,9 @@
 /turf/open/floor/prison/kitchen,
 /area/lv759/indoors/spaceport/kitchen)
 "gCY" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/urban/decal/dirt,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "gDf" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -38593,7 +37513,9 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "gEm" = (
 /obj/effect/urban/decal/dirt,
@@ -38911,10 +37833,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/changing_room)
 "gHr" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
@@ -38926,10 +37844,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/floor)
-"gHL" = (
-/obj/structure/largecrate/random/barrel/black,
-/turf/open/urban/street/sidewalk,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "gHM" = (
 /obj/effect/urban/decal/road/road_edge/two,
 /obj/effect/urban/decal/road/lines4,
@@ -38966,12 +37880,6 @@
 /obj/machinery/vending/nanomed,
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/cmo_office)
-"gIB" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
 "gIL" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
@@ -39016,7 +37924,7 @@
 	pixel_x = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "gJc" = (
 /obj/effect/urban/decal/road/road_edge/eight,
 /obj/effect/urban/decal/road/lines4,
@@ -39050,21 +37958,10 @@
 	},
 /area/lv759/indoors/caves/north_west_caves)
 "gJs" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 4
+/obj/structure/rock/dark/small{
+	layer = 4
 	},
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
-	},
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/officetiles,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "gJu" = (
 /obj/effect/urban/decal/dirt,
@@ -39120,7 +38017,6 @@
 /turf/open/floor/wood,
 /area/lv759/indoors/jacks_surplus)
 "gKc" = (
-/obj/item/lightstick/anchored,
 /obj/structure/platform_decoration/urban/rockdark,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
@@ -39288,11 +38184,6 @@
 /obj/structure/stairs/seamless{
 	color = "#6e6e6e"
 	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -6
-	},
 /obj/structure/lattice/autosmooth,
 /turf/open/floor/prison{
 	dir = 8
@@ -39389,7 +38280,7 @@
 /obj/machinery/light/small/blue{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "gNc" = (
 /obj/effect/landmark/weed_node,
@@ -39489,7 +38380,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/urbanshale/layer0_plate,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "gOi" = (
 /obj/machinery/light,
@@ -39501,12 +38393,6 @@
 /obj/structure/platform/urban/metalplatform2,
 /turf/closed/wall/urban/colony,
 /area/lv759/outdoors/colony_streets/central_streets)
-"gOl" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "gOo" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -39576,11 +38462,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "gOR" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/engineership/engineer_floor2,
+/area/lv759/indoors/derelict_ship)
 "gPc" = (
 /turf/open/floor/urban/metal/stripe_red{
 	dir = 4
@@ -39603,9 +38487,8 @@
 /turf/open/floor/urban/carpet/carpetred,
 /area/lv759/indoors/casino)
 "gPk" = (
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/north_west_caves)
 "gPp" = (
 /obj/item/reagent_containers/glass/rag{
 	desc = "A pile of clothing, these need washing...";
@@ -39684,13 +38567,6 @@
 "gPC" = (
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/colonial_marshals/north_office)
-"gPF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "gPO" = (
 /obj/structure/lattice/autosmooth,
 /turf/open/floor/orange_cover,
@@ -39851,21 +38727,13 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/north_east_street)
-"gRF" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "gRK" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_y = 17
 	},
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "gRM" = (
 /obj/item/stack/rods{
@@ -39932,8 +38800,11 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_research_complex/cafeteria)
 "gSz" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "gSE" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -40068,12 +38939,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "gUa" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/urban/decal/grate{
+	dir = 8
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/outdoors/caveplateau)
 "gUe" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
@@ -40211,9 +39082,6 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/nt_security/checkpoint_west)
 "gVD" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -40227,12 +39095,6 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
-"gVI" = (
-/obj/structure/cargo_container/green{
-	dir = 4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "gVJ" = (
 /obj/structure/window/framed/urban,
 /obj/machinery/door/poddoor/shutters/urban/shutters/opened{
@@ -40402,9 +39264,6 @@
 /turf/open/floor/plating/kutjevo,
 /area/lv759/indoors/spaceport/maintenance_east)
 "gXh" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -40441,23 +39300,7 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "gXK" = (
-/obj/item/trash/crushed_bottle/sixpackcrushed_1,
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/blue{
-	dir = 4;
-	pixel_y = -4
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/effect/urban/decal/trash/fourteen{
-	pixel_y = 14
-	},
-/turf/open/floor/officetiles,
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "gXM" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -40488,7 +39331,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/engineering)
 "gYe" = (
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/urban/decal/road/lines1,
@@ -40697,12 +39540,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/landing_zone_2)
 "gZK" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/bluethree,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/turf/open/urban/street/cement1,
+/area/lv759/outdoors/landing_zone_1)
 "gZQ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -40891,16 +39731,10 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/recycling_plant)
 "hbh" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
 /obj/structure/prop/urban/misc/buildinggreebliessmall2{
 	pixel_y = 25
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "hbn" = (
 /obj/item/reagent_containers/food/snacks/meat{
@@ -40924,8 +39758,12 @@
 	},
 /area/lv759/indoors/hospital/icu)
 "hbu" = (
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/obj/effect/urban/decal/grate{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "hbz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -40975,13 +39813,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"hbN" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/urban/street/sidewalkfull,
-/area/lv759/outdoors/colony_streets/north_west_street)
 "hbR" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/excavation_site_spawner,
@@ -41014,9 +39845,7 @@
 	pixel_x = -13;
 	pixel_y = 11
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "hce" = (
 /obj/effect/urban/decal/dirt,
@@ -41073,10 +39902,8 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "hcp" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "hcs" = (
 /obj/structure/sign/nosmoking_1,
@@ -41118,13 +39945,6 @@
 	},
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
-"hcF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
 "hcG" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -41246,7 +40066,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/urban/decal/dirt,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/outdoors/colony_streets/north_west_street)
 "hdr" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 8
@@ -41286,19 +40106,6 @@
 	},
 /turf/open/floor/prison/red,
 /area/lv759/indoors/nt_security/checkpoint_northeast)
-"hdN" = (
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "hdP" = (
 /obj/effect/spawner/random/engineering/toolbox{
 	layer = 4
@@ -41435,9 +40242,6 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/spaceport/starglider)
 "hfE" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/largecrate/random/mini/small_case/c{
 	layer = 3.1
 	},
@@ -41457,8 +40261,8 @@
 "hfI" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/floor/plating{
-	dir = 8
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/central_caves)
 "hfL" = (
@@ -41472,13 +40276,6 @@
 "hfR" = (
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/mining_outpost/northeast)
-"hfW" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "hfY" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -41576,7 +40373,7 @@
 "hgt" = (
 /obj/structure/platform_decoration/urban/rockdark,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "hgv" = (
 /turf/open/urban/dropship/dropship3,
 /area/lv759/indoors/spaceport/horizon_runner)
@@ -41622,7 +40419,7 @@
 "hgL" = (
 /obj/structure/prop/urban/vehicles/large/van/hyperdynevan,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "hgM" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/asphalt,
@@ -41913,10 +40710,6 @@
 	},
 /area/lv759/indoors/power_plant/south_hallway)
 "hjq" = (
-/obj/structure/stairs/seamless{
-	color = "#6e6e6e";
-	dir = 4
-	},
 /turf/open/floor/prison/ramptop{
 	dir = 8
 	},
@@ -42003,17 +40796,10 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/central_streets)
 "hkm" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/colony_streets/south_east_street)
 "hku" = (
 /obj/structure/lattice/autosmooth,
 /obj/machinery/prop/structurelattice{
@@ -42191,11 +40977,6 @@
 "hlx" = (
 /turf/open/floor/urban/metal/bluemetal1,
 /area/lv759/indoors/spaceport/flight_control_room)
-"hly" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/item/clothing/mask/facehugger/dead,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "hlA" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -42410,12 +41191,13 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "hnn" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+/obj/structure/platform_decoration/urban/engineer_corner,
+/obj/structure/platform_decoration/urban/engineer_corner{
+	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/engineership/engineer_floor9,
+/area/lv759/indoors/derelict_ship)
 "hno" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/lines1,
@@ -42499,9 +41281,12 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "hnW" = (
-/obj/structure/cable,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/landing_zone_2)
+/obj/structure/closet/crate/secure/surgery{
+	layer = 3;
+	pixel_y = 12
+	},
+/turf/open/urban/street/cement1,
+/area/lv759/outdoors/landing_zone_1)
 "hoh" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/effect/urban/decal/trash/ten{
@@ -42572,9 +41357,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "hoK" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/grille,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "hoM" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
@@ -42624,13 +41409,6 @@
 	},
 /turf/closed/wall/r_wall/bunker,
 /area/lv759/indoors/NTmart)
-"hpa" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/spaceport/docking_bay_2)
 "hpc" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -42677,9 +41455,7 @@
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
 	pixel_y = 20
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "hpu" = (
 /obj/structure/closet/crate/weapon,
@@ -42863,7 +41639,7 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "hqI" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "hqJ" = (
 /obj/structure/barricade/sandbags{
@@ -42893,7 +41669,6 @@
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 1
 	},
-/obj/structure/largecrate/random,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/landing_zone_1)
 "hqV" = (
@@ -42984,7 +41759,7 @@
 	color = "#a6aeab"
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/meridian/meridian_showroom)
 "hrH" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
 	dir = 1
@@ -43157,18 +41932,10 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "hto" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
+/obj/structure/rock/dark/large{
+	layer = 4
 	},
-/obj/item/trash/c_tube,
-/obj/item/trash/cigbutt{
-	pixel_x = 7
-	},
-/obj/effect/urban/decal/trash/four{
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/turf/open/floor/officetiles,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "htt" = (
 /obj/effect/landmark/weed_node,
@@ -43220,11 +41987,12 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "htG" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_y = 17
+/obj/effect/spawner/random/engineering/metal,
+/obj/item/tool/shovel{
+	pixel_y = 12
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "htH" = (
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/lines2,
@@ -43281,9 +42049,11 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "huh" = (
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/obj/effect/urban/decal/grate{
+	dir = 1
 	},
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "hui" = (
 /obj/effect/turf_decal/medical_decals/triage{
@@ -43390,21 +42160,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "hvd" = (
-/obj/item/stack/rods,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
-"hvi" = (
-/obj/effect/urban/decal/dirt_2,
-/obj/item/clothing/head/warning_cone{
-	layer = 4
-	},
-/obj/structure/barricade/handrail/urban/road/plastic/red{
-	dir = 1;
-	layer = 3;
-	pixel_y = 4
-	},
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/jacks_surplus)
 "hvj" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/faxmachine,
@@ -43469,9 +42226,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "hvK" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor/glass,
 /turf/open/floor/kutjevo/colors/red,
 /area/lv759/indoors/spaceport/security)
@@ -43778,9 +42532,6 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/lv759/indoors/nt_research_complex_entrance)
 "hyw" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -43908,7 +42659,7 @@
 	pixel_x = 8;
 	pixel_y = 28
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "hzH" = (
 /obj/structure/barricade/handrail/strata{
@@ -44081,11 +42832,8 @@
 /turf/open/floor/wood/variable,
 /area/lv759/indoors/jacks_surplus)
 "hAO" = (
-/obj/item/trash/cigbutt{
-	pixel_x = 7
-	},
 /obj/effect/urban/decal/trash/fifteen,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "hAQ" = (
 /obj/structure/sign/poster,
@@ -44149,9 +42897,7 @@
 "hBv" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "hBx" = (
 /obj/effect/urban/decal/grate,
@@ -44159,7 +42905,6 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "hBB" = (
-/obj/item/lightstick/anchored,
 /obj/item/reagent_containers/jerrycan,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
@@ -44316,7 +43061,9 @@
 /turf/open/floor/mainship,
 /area/lv759/indoors/nt_office/pressroom)
 "hCP" = (
-/obj/structure/window/framed/urban/junk_window,
+/obj/structure/window/framed/urban/colony/engineering{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lv759/indoors/NTmart)
 "hCR" = (
@@ -44344,7 +43091,9 @@
 /area/lv759/indoors/hospital/operation)
 "hDb" = (
 /obj/structure/cable,
-/turf/open/urbanshale/layer1,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "hDm" = (
 /obj/structure/sign/safety/maintenance{
@@ -44388,11 +43137,13 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/botany/botany_mainroom)
 "hDF" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
+/obj/effect/urban/decal/grate{
+	dir = 1
 	},
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "hDK" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -44429,6 +43180,7 @@
 	pixel_y = 9
 	},
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -44456,10 +43208,6 @@
 	},
 /turf/open/floor/urban/wood/redwood,
 /area/lv759/indoors/nt_office/floor)
-"hEn" = (
-/obj/structure/rock/dark/stalagmite,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "hEq" = (
 /obj/item/storage/briefcase,
 /obj/structure/largecrate/random/case/small{
@@ -44469,13 +43217,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
-"hEt" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/rock/dark/stalagmite/five,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "hEy" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/officetiles,
@@ -44829,9 +43570,6 @@
 	},
 /area/lv759/indoors/power_plant/south_hallway)
 "hHU" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -44848,7 +43586,7 @@
 	dir = 8;
 	pixel_x = 16
 	},
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "hIc" = (
@@ -44879,9 +43617,8 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsfoyer)
 "hIq" = (
-/turf/open/floor/plating{
-	dir = 8
-	},
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "hIt" = (
 /obj/structure/stairs/seamless{
@@ -44925,16 +43662,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/landing_zone_2)
-"hIJ" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -9;
-	pixel_y = 20
-	},
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
 "hIN" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 4
@@ -45226,7 +43953,9 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "hLA" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
@@ -45387,7 +44116,7 @@
 /obj/effect/urban/decal/grate{
 	dir = 1
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "hMP" = (
 /obj/effect/urban/decal/dirt,
@@ -45476,12 +44205,9 @@
 /turf/open/floor/urban/tile/asteroidfloor_bigtile,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "hNC" = (
-/obj/structure/largecrate/random/mini/small_case/c{
-	pixel_x = 11;
-	pixel_y = 15
-	},
-/turf/open/engineership/engineer_floor1,
-/area/lv759/indoors/derelict_ship)
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "hND" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -45490,10 +44216,8 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office/supervisor)
 "hNF" = (
-/turf/open/floor/bluethree{
-	dir = 1
-	},
-/area/lv759/indoors/spaceport/docking_bay_2)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_showroom)
 "hNG" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "autoname"
@@ -45659,7 +44383,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "hOI" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
@@ -45716,13 +44440,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"hPe" = (
-/obj/machinery/power/geothermal,
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
-	},
-/turf/open/floor/urban_plating,
-/area/lv759/indoors/electical_systems/substation2)
 "hPf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mre_pack/meal1{
@@ -45751,21 +44468,11 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"hPx" = (
-/obj/machinery/streetlight/street{
-	level = 7;
-	pixel_y = 12
-	},
-/obj/structure/barricade/handrail/urban/road/plastic/black{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalk,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "hPA" = (
 /obj/item/tool/pickaxe,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "hPB" = (
 /obj/structure/barricade/handrail{
@@ -45831,17 +44538,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
-"hPW" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/turf/open/floor/urban/metal/grated{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/central_streets)
 "hQa" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_stop/five,
@@ -45923,7 +44619,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "hQY" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
@@ -45932,9 +44628,6 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "hRc" = (
-/obj/structure/barricade/sandbags{
-	dir = 1
-	},
 /obj/structure/barricade/handrail/urban/road/plastic/red,
 /obj/structure/prop/mainship/gelida/smallwire,
 /obj/effect/urban/decal/road/roadmiddle{
@@ -45988,10 +44681,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner,
 /area/lv759/indoors/colonial_marshals/armory)
-"hRC" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
 "hRD" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard2{
@@ -46156,7 +44845,6 @@
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/road_edge/twelve,
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "hTc" = (
@@ -46535,16 +45223,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_west_caves)
-"hXi" = (
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/platform1{
-	dir = 1
-	},
-/obj/structure/platform_decoration,
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/derelict_ship)
 "hXm" = (
 /obj/structure/prop/urban/fakeplatforms/platform1,
 /obj/structure/prop/urban/fakeplatforms/platform1{
@@ -46561,10 +45239,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "hXu" = (
-/obj/structure/rock/dark/stalagmite/five,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "hXz" = (
 /obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
@@ -46691,15 +45368,6 @@
 "hYt" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/eastfoyer)
-"hYz" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/lv759/indoors/spaceport/docking_bay_1)
 "hYD" = (
 /obj/structure/largecrate/random/mini/small_case,
 /obj/machinery/light/spot/blue{
@@ -46781,8 +45449,8 @@
 	dir = 8
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/central_caves)
 "hZe" = (
 /obj/item/device/flashlight/lamp/tripod/grey,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -46892,8 +45560,8 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "iar" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
@@ -46969,12 +45637,8 @@
 /turf/open/floor/urban/tile/tileblue,
 /area/lv759/indoors/mining_outpost/east_dorms)
 "ibi" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -6
-	},
-/turf/open/floor/prison,
+/obj/structure/cargo_container/ch_red,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_1)
 "ibo" = (
 /obj/item/tool/pen,
@@ -47021,9 +45685,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "ibK" = (
 /obj/machinery/door_control{
@@ -47091,9 +45753,14 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "ice" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor13{
+	dir = 10
+	},
+/area/lv759/indoors/derelict_ship)
 "icf" = (
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/landmark/weed_node,
@@ -47118,21 +45785,11 @@
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "icp" = (
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "icq" = (
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/landing_zone_2)
-"ict" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/obj/machinery/streetlight/street{
-	level = 7;
-	pixel_y = 12
-	},
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/central_streets)
 "icu" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalk{
@@ -47277,15 +45934,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/landing_zone_2)
-"idU" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = 7
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "idY" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -47337,10 +45985,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/mining_outpost/processing)
-"ieq" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/central_caves)
 "ieu" = (
 /obj/machinery/conveyor_switch{
 	id = "cargo_storage"
@@ -47404,9 +46048,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ifc" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -47604,12 +46245,9 @@
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "igF" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/obj/structure/lattice/autosmooth,
+/obj/structure/rock/dark/stalagmite/four,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/caves/west_caves)
 "igG" = (
 /obj/machinery/light{
 	dir = 8
@@ -47827,10 +46465,8 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/colonial_marshals/armory_firingrange)
 "iiF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/north_east_caves)
 "iiI" = (
 /obj/machinery/door/poddoor/shutters/urban/biohazard/white{
 	dir = 2
@@ -48062,7 +46698,7 @@
 "ile" = (
 /obj/structure/sign/safety/blast_door,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/north_caves)
 "ilh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/officetiles,
@@ -48091,13 +46727,6 @@
 	},
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
-"ilr" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
 "ils" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/structure/barricade/handrail/urban/road/plastic/blue{
@@ -48206,19 +46835,14 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "imu" = (
-/obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1{
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 4
 	},
-/turf/open/engineership/engineer_floor13{
-	dir = 10
-	},
-/area/lv759/oob)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/central_caves)
 "imz" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
@@ -48240,7 +46864,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "imG" = (
-/obj/structure/platform_decoration/shiva,
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
@@ -48577,7 +47200,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "iqm" = (
 /obj/item/flashlight/lantern,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "iqr" = (
 /turf/open/floor/urban/tile/tilegreen,
@@ -48813,7 +47436,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "irR" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "irU" = (
 /obj/effect/urban/decal/dirt,
@@ -48880,12 +47503,8 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/hospital/pharmacy)
 "isz" = (
-/obj/structure/stairs{
-	color = "#a6aeab";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "isB" = (
 /obj/structure/largecrate/random/mini/small_case,
 /obj/effect/ai_node,
@@ -48912,7 +47531,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/heavyequip)
 "isM" = (
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard1{
 	dir = 8;
@@ -49015,11 +47634,6 @@
 	},
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/supervisor)
-"itR" = (
-/obj/effect/urban/decal/road/lines2,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_west_street)
 "itS" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/storage/box/lightstick/red{
@@ -49027,7 +47641,7 @@
 	pixel_y = 10
 	},
 /obj/structure/largecrate/random,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "itT" = (
 /obj/effect/urban/decal/dirt,
@@ -49035,12 +47649,11 @@
 	pixel_x = 2;
 	pixel_y = 9
 	},
-/obj/item/stack/rods,
 /obj/machinery/light/blue{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "itU" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/fake/lattice/full,
@@ -49062,11 +47675,9 @@
 /turf/open/floor/urban/metal/zbrownfloor1,
 /area/lv759/indoors/meridian/meridian_office)
 "iub" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
+/obj/structure/rock/dark/stalagmite/two,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/central_caves)
 "iug" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
@@ -49224,16 +47835,9 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_2)
 "ivG" = (
-/obj/structure/barricade/handrail/urban/road/plastic/blue,
-/obj/structure/largecrate/random/barrel/white{
-	layer = 7;
-	pixel_x = 8;
-	pixel_y = 18
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/landing_zone_1)
+/obj/effect/landmark/weed_node,
+/turf/open/urban/street/sidewalkcenter,
+/area/lv759/outdoors/colony_streets/north_west_street)
 "ivI" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/ai_node,
@@ -49307,10 +47911,9 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "iwx" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/prop/urban/vehicles/meridian/purple,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "iwy" = (
 /obj/structure/window/framed/urban/reinforced,
 /obj/structure/curtain/temple{
@@ -49325,12 +47928,14 @@
 "iwC" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "iwK" = (
-/obj/structure/lattice/autosmooth,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 4
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "iwO" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -49359,23 +47964,6 @@
 /obj/item/trash/cigbutt,
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
-"iwX" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/west_caves)
-"ixj" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "ixm" = (
 /obj/structure/disposalpipe/tagger{
 	dir = 4
@@ -49516,13 +48104,8 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "iyx" = (
-/obj/structure/stairs{
-	color = "#a6aeab"
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_west_caves)
 "iyz" = (
 /obj/effect/urban/decal/dirt,
@@ -49672,22 +48255,8 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "izK" = (
-/obj/effect/urban/decal/road/roadmiddle{
-	dir = 1;
-	pixel_y = 14
-	},
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/central_streets)
-"izL" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/floor/plating/kutjevo,
+/area/lv759/outdoors/landing_zone_1)
 "izN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1
@@ -49710,9 +48279,7 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "iAc" = (
 /obj/effect/urban/decal/dirt,
@@ -49764,16 +48331,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
 "iAz" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 1
-	},
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/obj/structure/prop/mainship/gelida/smallwire,
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/obj/effect/landmark/weed_node,
 /turf/open/ground/sandrock,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/outdoors/landing_zone_2)
 "iAA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/ammo_casing/bullet,
@@ -49872,9 +48432,8 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/hallwaycentral)
 "iBn" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance)
 "iBq" = (
 /obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
@@ -49959,9 +48518,11 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/meridian/meridian_showroom)
 "iCB" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
+	},
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "iCD" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/medical,
@@ -50162,11 +48723,9 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "iEH" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/hobosecret)
 "iEN" = (
 /obj/machinery/light/small/blue{
 	dir = 1
@@ -50274,9 +48833,6 @@
 /area/lv759/indoors/nt_research_complex/changingroom)
 "iFO" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/urban/metal/grated{
 	dir = 4
@@ -50412,14 +48968,6 @@
 /obj/structure/fence/dark,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"iGP" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/item/trash/eat,
-/obj/effect/urban/decal/trash/sixteen,
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "iGS" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/handrail{
@@ -50463,7 +49011,7 @@
 	dir = 8
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "iHr" = (
 /obj/effect/landmark/weed_node,
@@ -50624,11 +49172,9 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/hospital/medical_storage)
 "iJa" = (
-/obj/item/inflatable/wall,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/caveplateau)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "iJb" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -50660,9 +49206,6 @@
 "iJp" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -50829,9 +49372,6 @@
 /area/lv759/indoors/mining_outpost/northeast)
 "iKP" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/sign/nosmoking_2,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/full,
@@ -50849,7 +49389,7 @@
 "iLa" = (
 /obj/structure/prop/urban/signs/high_voltage/small,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation1)
 "iLc" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office)
@@ -50865,9 +49405,7 @@
 /obj/machinery/light/small/blue{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "iLh" = (
 /obj/structure/sign/safety/hazard{
@@ -50930,13 +49468,10 @@
 /area/lv759/outdoors/colony_streets/north_east_street)
 "iLK" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/central_caves)
 "iLP" = (
 /obj/machinery/shower{
 	dir = 8
@@ -51045,17 +49580,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/lv759/indoors/nt_office)
-"iMQ" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
-/obj/effect/urban/decal/road/road_edge/two,
-/obj/effect/urban/decal/road/lines4,
-/obj/effect/urban/decal/road/road_stop/five{
-	dir = 8
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "iMU" = (
 /obj/effect/urban/decal/road/road_edge/two,
 /obj/effect/urban/decal/road/lines4,
@@ -51331,7 +49855,7 @@
 	},
 /obj/structure/prop/mainship/gelida/smallwire,
 /obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "iOO" = (
 /obj/structure/closet/firecloset,
@@ -51409,7 +49933,7 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "iPr" = (
 /obj/effect/decal/cleanable/blood,
@@ -51517,10 +50041,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/meridian/meridian_office)
 "iQG" = (
-/obj/structure/platform_decoration{
-	dir = 1;
-	layer = 3.1
-	},
 /obj/item/clothing/head/warning_cone{
 	layer = 3;
 	pixel_x = -20
@@ -51553,12 +50073,12 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "iQQ" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
+/obj/effect/urban/decal/grate{
 	dir = 8
 	},
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "iQV" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -51654,13 +50174,13 @@
 /turf/open/floor/orange_edge,
 /area/lv759/indoors/spaceport/hallway_east)
 "iRV" = (
-/obj/structure/stairs{
-	color = "#a6aeab"
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/ground/sandrock,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/outdoors/north_west_caves_outdoors)
 "iSb" = (
 /obj/structure/computer3frame{
@@ -51825,7 +50345,7 @@
 	pixel_x = 6
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "iTs" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -52013,7 +50533,8 @@
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 1
 	},
-/turf/open/ground/sandrock,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "iVj" = (
 /obj/structure/table/reinforced,
@@ -52108,7 +50629,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "iVS" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -52154,7 +50675,7 @@
 	pixel_y = 12
 	},
 /turf/open/ground/sandrock,
-/area/lv759/oob)
+/area/lv759/outdoors/north_west_caves_outdoors)
 "iVZ" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 10;
@@ -52202,7 +50723,7 @@
 	pixel_x = -4;
 	pixel_y = 23
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "iWy" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -52357,15 +50878,6 @@
 /obj/structure/table/black,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/floor)
-"iXR" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalkcenter{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/north_street)
 "iXV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52459,15 +50971,6 @@
 /obj/effect/urban/decal/road/road_edge/two,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
-"iYE" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	pixel_y = 9
-	},
-/obj/effect/urban/decal/road/road_edge/four,
-/turf/open/urban/street/sidewalkcenter,
-/area/lv759/outdoors/landing_zone_2)
 "iYL" = (
 /obj/structure/closet,
 /obj/machinery/power/apc/drained{
@@ -52602,13 +51105,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/power_plant)
-"iZP" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "iZT" = (
 /obj/structure/prop/urban/xenobiology/small/hugger,
 /turf/open/floor/podhatch/floor,
@@ -52718,12 +51214,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship,
 /area/lv759/indoors/nt_office/pressroom)
-"jaQ" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
 "jaR" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -52736,14 +51226,6 @@
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 8
-	},
-/obj/structure/largecrate/supply{
-	pixel_x = -4
-	},
-/obj/structure/largecrate/random/mini{
-	layer = 4;
-	pixel_x = 9;
-	pixel_y = 14
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
@@ -52774,11 +51256,12 @@
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/north_street)
 "jbk" = (
-/obj/structure/platform_decoration{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/area/lv759/indoors/nt_research_complex_entrance)
 "jbn" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -52922,9 +51405,9 @@
 /turf/open/urban/dropship/dropship4,
 /area/lv759/indoors/spaceport/horizon_runner)
 "jcw" = (
-/obj/structure/platform/urban/metalplatform2,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_2)
 "jcE" = (
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westentertainment)
@@ -52945,9 +51428,7 @@
 /obj/machinery/light/small/blue{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "jcS" = (
 /obj/structure/extinguisher_cabinet,
@@ -53282,10 +51763,6 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
-"jeZ" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
 "jfb" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic{
@@ -53301,7 +51778,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "jff" = (
 /obj/structure/sign/safety/medical_supplies,
 /turf/closed/wall/r_wall/white_research_wall,
@@ -53325,14 +51802,14 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "jfo" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "jfp" = (
 /obj/machinery/space_heater/radiator/red{
 	dir = 8
@@ -53343,9 +51820,7 @@
 /area/lv759/indoors/colonial_marshals/armory_foyer)
 "jfx" = (
 /obj/structure/largecrate/supply/explosives/mines,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "jfz" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red{
@@ -53623,13 +52098,9 @@
 	},
 /area/lv759/indoors/hospital/medical_storage)
 "jib" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/caveplateau)
+/obj/structure/sign/safety/airlock,
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/colonial_marshals/south_maintenance)
 "jif" = (
 /obj/structure/prop/mainship/gelida/barrier,
 /obj/machinery/light{
@@ -53659,7 +52130,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "jit" = (
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
@@ -53725,9 +52196,7 @@
 	pixel_x = -5;
 	pixel_y = 9
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "jjh" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -53879,7 +52348,7 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/colonial_marshals/hallway_north)
 "jjV" = (
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_west_caves)
 "jjY" = (
 /obj/machinery/vending/coffee,
@@ -54025,13 +52494,6 @@
 	},
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaysoutheast)
-"jkT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
 "jkU" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -54040,17 +52502,12 @@
 	},
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
-"jkX" = (
-/obj/structure/ore_box,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "jlb" = (
 /turf/open/urban/street/sidewalk{
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "jlj" = (
-/obj/structure/platform_decoration,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship,
@@ -54112,7 +52569,6 @@
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "jlT" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 1
 	},
@@ -54356,7 +52812,6 @@
 /turf/open/floor/urban/carpet/carpetfadedred,
 /area/lv759/indoors/apartment/eastbedrooms)
 "jnQ" = (
-/obj/structure/platform_decoration,
 /obj/item/stool{
 	layer = 5;
 	pixel_x = 2;
@@ -54402,11 +52857,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/colonial_marshals/wardens_office)
-"jom" = (
-/obj/structure/platform_decoration,
-/obj/effect/ai_node,
-/turf/open/floor/orange_edge,
-/area/lv759/indoors/spaceport/docking_bay_1)
 "joy" = (
 /obj/machinery/floodlight{
 	layer = 5
@@ -54430,15 +52880,12 @@
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
 "joH" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
+/obj/machinery/streetlight/street{
+	level = 7;
+	pixel_y = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/lv759/indoors/colonial_marshals/press_room)
+/turf/open/urban/street/sidewalkfull,
+/area/lv759/outdoors/landing_zone_1)
 "joQ" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/barricade/handrail/kutjevo{
@@ -54525,7 +52972,6 @@
 	dir = 4
 	},
 /obj/structure/sign/safety/storage,
-/obj/structure/window/framed/urban/junk_window,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "jpU" = (
@@ -54647,9 +53093,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "jqU" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
 /obj/item/tool/pickaxe{
 	pixel_y = 10
 	},
@@ -54920,12 +53363,6 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"jsY" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
 "jsZ" = (
 /obj/structure/barricade/handrail/urban/handrail{
 	dir = 1
@@ -54955,8 +53392,8 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "jtv" = (
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/derelict_ship)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/mining_outpost/northeast)
 "jtw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -55090,7 +53527,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "juh" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -55106,9 +53543,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "juk" = (
 /obj/effect/landmark/weed_node,
@@ -55234,7 +53669,7 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "jvz" = (
 /turf/closed/shuttle/dropship4/corners,
-/area/lv759/indoors/spaceport/horizon_runner)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "jvA" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -55312,9 +53747,6 @@
 /turf/closed/wall/urban/colony/ribbed,
 /area/lv759/indoors/casino/casino_vault)
 "jwM" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -55428,14 +53860,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/caves/north_west_caves)
-"jxM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/south_west_caves)
 "jxR" = (
 /obj/machinery/door/poddoor/shutters/urban/security_lockdown{
 	dir = 2;
@@ -55518,9 +53942,6 @@
 "jyx" = (
 /obj/effect/spawner/random/engineering/tool,
 /obj/structure/cable,
-/obj/structure/platform_decoration/shiva{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/lv759/indoors/hospital/maintenance)
 "jyz" = (
@@ -55683,9 +54104,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwayeast)
 "jzL" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
 /obj/structure/prop/urban/misc/firehydrant{
 	dir = 1
 	},
@@ -55780,10 +54198,8 @@
 	},
 /area/lv759/indoors/colonial_marshals/reception)
 "jAm" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/urbanshale/layer0_plate,
+/obj/structure/xeno/tunnel,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "jAq" = (
 /obj/machinery/landinglight/lz2{
@@ -55864,12 +54280,6 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"jBh" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
-/turf/open/urban/street/sidewalk,
-/area/lv759/outdoors/colony_streets/north_street)
 "jBn" = (
 /obj/structure/rock/dark/stalagmite/three,
 /turf/open/urbanshale/layer1,
@@ -56100,12 +54510,7 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "jDH" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/obj/structure/largecrate/random/barrel{
-	layer = 4;
-	pixel_x = 6;
-	pixel_y = -16
-	},
+/obj/structure/rock/dark/stalagmite/two,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "jDI" = (
@@ -56148,13 +54553,9 @@
 /turf/open/floor/urban/tile/asteroidfloor_bigtile,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "jEj" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/central_streets)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "jEm" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 8;
@@ -56209,7 +54610,7 @@
 	pixel_x = -4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "jEV" = (
 /obj/structure/prop/urban/containersextended/tanright,
 /turf/open/urban/street/sidewalk,
@@ -56274,17 +54675,13 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "jFE" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor4,
+/area/lv759/indoors/derelict_ship)
 "jFU" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "jGb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -56433,7 +54830,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 1
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "jHt" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light,
@@ -56451,10 +54848,6 @@
 	},
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/botany/botany_mainroom)
-"jHI" = (
-/obj/machinery/floodlight,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "jHK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -56944,9 +55337,9 @@
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "jMi" = (
-/obj/structure/platform_decoration,
+/obj/machinery/light/small/blue,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/caves/north_east_caves)
 "jMk" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/effect/decal/cleanable/blood,
@@ -57204,9 +55597,7 @@
 /obj/structure/cable,
 /obj/item/stack/rods,
 /obj/structure/sign/safety/airlock,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "jOn" = (
 /obj/effect/urban/decal/dirt,
@@ -57480,7 +55871,7 @@
 /area/lv759/indoors/meridian/meridian_factory)
 "jRp" = (
 /obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/south_west_caves)
 "jRq" = (
 /turf/open/floor/prison/whitegreen{
@@ -57549,7 +55940,7 @@
 	pixel_y = 20
 	},
 /obj/effect/ai_node,
-/turf/open/floor/prison/plate,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "jSm" = (
 /obj/structure/barricade/handrail{
@@ -57568,14 +55959,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "jSn" = (
-/obj/effect/urban/decal/engineership_corners{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/stalagmite,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "jSq" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red{
 	dir = 4
@@ -57627,10 +56013,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "jTd" = (
-/obj/structure/barricade/handrail/urban/road/plastic/red{
-	dir = 4
-	},
-/obj/structure/largecrate/random/barrel/red,
 /turf/open/urban/street/sidewalk{
 	dir = 5
 	},
@@ -57647,7 +56029,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "jTk" = (
 /obj/structure/closet/crate/trashcart,
@@ -57731,7 +56113,7 @@
 "jTS" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "jTT" = (
 /obj/item/clothing/head/warning_cone{
 	layer = 4
@@ -57760,7 +56142,7 @@
 "jUd" = (
 /obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1,
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "jUi" = (
 /obj/machinery/streetlight/engineer_circular,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -57776,7 +56158,7 @@
 /area/lv759/indoors/mining_outpost/east)
 "jUp" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "jUs" = (
 /obj/item/clothing/head/warning_cone{
@@ -57829,9 +56211,12 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "jUH" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "jUJ" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -57846,9 +56231,6 @@
 	},
 /area/lv759/indoors/colonial_marshals/wardens_office)
 "jUK" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
 /obj/structure/stairs/corner_seamless{
 	color = "#b8b8b0";
 	dir = 4
@@ -57893,11 +56275,10 @@
 /turf/open/floor/urban/wood/redwood,
 /area/lv759/indoors/nt_office/floor)
 "jVy" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco2{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/rock/dark/small,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "jVG" = (
 /obj/structure/bed/stool,
 /obj/effect/ai_node,
@@ -57957,12 +56338,16 @@
 /obj/structure/prop/mainship/gelida/railbumper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "jWi" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/mainship/tcomms,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/structure/prop/mainship/gelida/smallwire,
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "jWk" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/medical_decals/triage/bottom,
@@ -58063,13 +56448,8 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/garage_workshop_storage)
 "jWQ" = (
-/obj/structure/rock/dark/stalagmite,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "jWU" = (
 /obj/effect/ai_node,
 /turf/open/urban/street/cement3,
@@ -58114,9 +56494,9 @@
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/north_street)
 "jXe" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/ground/sandrock,
+/obj/effect/urban/decal/dirt,
+/obj/structure/rock/dark/large/three,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "jXj" = (
 /obj/effect/urban/decal/dirt,
@@ -58172,9 +56552,6 @@
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/apartment/northapartments)
 "jXy" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -58275,10 +56652,6 @@
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/kutjevo/colors/orange,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"jYA" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_caves)
 "jYB" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -58518,7 +56891,7 @@
 "kaE" = (
 /obj/structure/grille,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "kaG" = (
 /obj/effect/urban/decal/dirt,
@@ -58607,9 +56980,6 @@
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/spaceport/engineering)
 "kbj" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
 /obj/structure/ore_box,
 /obj/item/clothing/head/hardhat/dblue{
 	pixel_x = -3;
@@ -58687,7 +57057,7 @@
 	pixel_y = 18
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "kcn" = (
 /obj/structure/bed/urban/bunkbed3{
@@ -58770,12 +57140,11 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "kcZ" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/central_caves)
 "kda" = (
 /obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "kdb" = (
 /obj/structure/largecrate/random/case/double,
@@ -58869,13 +57238,7 @@
 	},
 /area/lv759/outdoors/north_west_caves_outdoors)
 "kdV" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
 	dir = 8
 	},
 /turf/open/floor/urban/metal/zbrownfloor1{
@@ -58901,9 +57264,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/hospital/emergency_room)
-"keo" = (
-/turf/closed/mineral/smooth/engineerwall/indestructible,
-/area/lv759/oob)
 "key" = (
 /obj/machinery/streetlight/street{
 	level = 7;
@@ -58931,7 +57291,7 @@
 	pixel_x = 12;
 	pixel_y = 4
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "keJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -58951,7 +57311,6 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/hallway_south)
 "keQ" = (
-/obj/structure/barricade/handrail/strata,
 /turf/open/floor/prison{
 	dir = 8
 	},
@@ -59147,9 +57506,6 @@
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "kgQ" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/two,
 /obj/docking_port/stationary/crashmode,
 /turf/open/urban/street/sidewalkcenter{
@@ -59230,7 +57586,9 @@
 /area/lv759/indoors/nt_research_complex/cargo)
 "khA" = (
 /obj/effect/ai_node,
-/turf/open/ground/sandrock,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "khE" = (
 /obj/effect/decal/cleanable/dirt{
@@ -59303,7 +57661,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "kiv" = (
 /obj/structure/prop/urban/misc/fake/lattice/full,
@@ -59554,17 +57912,11 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "kkG" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
+/obj/effect/urban/decal/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/indoors/caves/east_caves)
 "kkI" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/landmark/weed_node,
@@ -59595,10 +57947,6 @@
 /area/lv759/indoors/nt_office/pressroom)
 "kle" = (
 /obj/machinery/landinglight/lz2,
-/obj/structure/barricade/handrail/strata,
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -59662,9 +58010,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "klV" = (
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "klX" = (
 /obj/structure/flora/pottedplant{
@@ -59695,9 +58041,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_west)
 "kmd" = (
-/turf/open/floor/plating{
-	dir = 8
-	},
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "kmm" = (
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -59758,7 +58104,7 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "kmO" = (
 /obj/structure/largecrate/mule,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "kmS" = (
 /obj/structure/rack,
@@ -59791,14 +58137,6 @@
 /obj/structure/prop/urban/misc/buildinggreeblies/greeble7,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance)
-"knl" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/north_street)
 "kno" = (
 /obj/item/shard,
 /obj/effect/urban/decal/dirt,
@@ -59882,10 +58220,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_research_complex/mainlabs)
-"kog" = (
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "koh" = (
 /obj/structure/sign/safety/vent{
 	desc = "Semiotic Standard denoting the nearby presence of a weapon research lab.";
@@ -59907,12 +58241,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/hospital/emergency_room)
-"kol" = (
-/obj/structure/barricade/handrail/urban/road/plastic/blue,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/landing_zone_1)
 "kot" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -59934,13 +58262,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/electical_systems/substation3)
-"kow" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -9;
-	pixel_y = 20
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
 "koy" = (
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt,
@@ -60161,7 +58482,7 @@
 	pixel_y = -12
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/spaceport/cuppajoes)
+/area/lv759/indoors/spaceport/docking_bay_1)
 "kqA" = (
 /obj/item/tool/shovel{
 	pixel_y = 12
@@ -60363,7 +58684,6 @@
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/nt_research_complex/cargo)
 "ksj" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/effect/urban/decal/trash/eleven{
 	dir = 1
 	},
@@ -60605,12 +58925,11 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/fusion_generators)
 "kva" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
 	},
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "kvd" = (
 /obj/item/paper/crumpled,
 /obj/machinery/light{
@@ -60801,14 +59120,6 @@
 /area/lv759/indoors/southwest_public_restroom)
 "kwL" = (
 /obj/structure/prop/urban/containersextended/whitewyright,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/west_caves)
-"kwO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "kwP" = (
@@ -60835,9 +59146,8 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "kwZ" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/landing_zone_1)
 "kxb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60848,13 +59158,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/nt_research_complex/securitycommand)
-"kxf" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
 "kxj" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalk,
@@ -61082,9 +59385,6 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/power_plant/telecomms)
 "kzj" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -61097,11 +59397,8 @@
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "kzn" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "kzo" = (
 /turf/closed/wall/urban,
@@ -61181,7 +59478,7 @@
 "kzI" = (
 /obj/item/stack/rods,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "kzK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -61285,7 +59582,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "kAM" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/lines2,
@@ -61378,19 +59675,12 @@
 "kBD" = (
 /obj/effect/urban/decal/grate,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "kBK" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"kBL" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "kBM" = (
 /obj/structure/rack,
 /obj/item/tank/oxygen/yellow,
@@ -61406,7 +59696,7 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "kBV" = (
 /obj/item/stack/sheet/cardboard{
@@ -61649,12 +59939,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
-"kDD" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "kDF" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/road_edge/four,
@@ -61713,13 +59997,6 @@
 /area/lv759/outdoors/colony_streets/north_west_street)
 "kEG" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/landing_zone_2)
 "kEK" = (
@@ -61737,14 +60014,11 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "kEQ" = (
-/obj/structure/closet/crate/miningcar{
-	layer = 3
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 1
 	},
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/caveplateau)
 "kFb" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/iv_drip,
@@ -61759,7 +60033,6 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/item/device/flashlight/lamp/tripod/grey,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -61862,17 +60135,12 @@
 	},
 /area/lv759/indoors/hospital/reception)
 "kGb" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -9;
 	pixel_y = 20
 	},
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "kGd" = (
 /obj/effect/landmark/weed_node,
@@ -62089,7 +60357,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "kHP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62156,12 +60424,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"kIU" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/lv759/indoors/colonial_marshals/press_room)
 "kJd" = (
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeige,
@@ -62274,16 +60536,10 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "kKt" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
 /obj/item/trash/eat,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "kKv" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -62446,9 +60702,6 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "kLR" = (
-/obj/structure/barricade/sandbags{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/two,
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/doubleroad/lines1{
@@ -62458,12 +60711,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"kLS" = (
-/obj/structure/ore_box{
-	pixel_x = 5
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
 "kMa" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
@@ -62606,9 +60853,6 @@
 /turf/open/floor/urban/tile/tileblackcheckered,
 /area/lv759/indoors/casino)
 "kNz" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -62661,9 +60905,7 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "kNN" = (
 /obj/effect/urban/decal/road/road_edge/four,
@@ -62725,7 +60967,7 @@
 /obj/structure/barricade/handrail/wire{
 	layer = 3
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
 "kOt" = (
 /obj/structure/largecrate/random/mini/small_case{
@@ -62746,17 +60988,8 @@
 	},
 /area/lv759/indoors/caves/central_caves)
 "kOC" = (
-/obj/item/stock_parts/matter_bin/adv{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/structure/largecrate/random/mini/small_case/c{
-	pixel_x = 11;
-	pixel_y = 15
-	},
-/turf/open/engineership/engineer_floor2,
-/area/lv759/indoors/derelict_ship)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/west_caves)
 "kOG" = (
 /obj/effect/urban/decal/road/roadmiddle{
 	dir = 8;
@@ -62809,9 +61042,8 @@
 	},
 /area/lv759/indoors/recycling_plant/garage)
 "kPk" = (
-/obj/structure/largecrate/random/case/small,
-/turf/open/engineership/engineer_floor1,
-/area/lv759/indoors/derelict_ship)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart/backrooms)
 "kPn" = (
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/urban/decal/road/lines1,
@@ -62898,7 +61130,7 @@
 "kPM" = (
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "kPT" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -62943,9 +61175,6 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_mainroom)
 "kQo" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards{
 	dir = 6;
 	layer = 8;
@@ -63013,9 +61242,8 @@
 	},
 /area/lv759/indoors/electical_systems/substation1)
 "kQM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/dormsbedroom)
 "kQU" = (
 /obj/machinery/space_heater/radiator/red{
 	dir = 8
@@ -63073,13 +61301,16 @@
 "kRl" = (
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/road_edge/three,
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "kRm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/urban/decal/dirt,
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/urban/metal/stripe_red{
+	dir = 1
+	},
+/area/lv759/outdoors/colony_streets/north_west_street)
 "kRv" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
@@ -63119,7 +61350,6 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/obj/structure/prop/urban/fakeplatforms/platform3,
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "kSc" = (
@@ -63156,9 +61386,6 @@
 /area/lv759/indoors/colonial_marshals/north_office)
 "kSq" = (
 /obj/effect/spawner/random/weaponry/ammo,
-/obj/structure/stairs{
-	color = "#a6aeab"
-	},
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "kSv" = (
@@ -63199,14 +61426,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/casino/casino_vault)
-"kSN" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -6
-	},
-/turf/open/floor/prison,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "kSS" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -63239,10 +61458,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "kTf" = (
-/obj/structure/largecrate/random/mini/small_case/c{
-	pixel_x = 11;
-	pixel_y = 15
-	},
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/engineership/engineer_floor2,
 /area/lv759/indoors/derelict_ship)
@@ -63643,10 +61858,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv759/indoors/nt_security/checkpoint_central)
-"kVE" = (
-/obj/effect/spawner/random/engineering/wood,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "kVH" = (
 /obj/effect/urban/decal/dirt_2,
 /turf/open/urban/street/sidewalk,
@@ -63673,14 +61884,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/logo_wall/two,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
-"kWj" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
 "kWm" = (
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 4
@@ -63692,7 +61895,7 @@
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "kWr" = (
 /obj/effect/urban/decal/dirt,
@@ -63833,9 +62036,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "kXu" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison{
 	dir = 8
@@ -63845,7 +62045,7 @@
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
 /obj/structure/monorail,
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "kXz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -64063,11 +62263,9 @@
 /turf/open/floor/officesquares,
 /area/lv759/indoors/NTmart)
 "kZt" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
 "kZw" = (
 /obj/structure/closet/crate/medical,
@@ -64139,7 +62337,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 4
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "lad" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -64179,16 +62377,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/garage_workshop)
 "laD" = (
-/obj/structure/barricade/handrail/urban/road/plastic/black{
-	dir = 1
-	},
-/obj/effect/urban/decal/road/road_edge/four,
-/obj/effect/urban/decal/road/lines2,
-/obj/effect/urban/decal/doubleroad/lines3{
-	pixel_y = -4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/machinery/miner/damaged,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "laJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -64308,14 +62499,6 @@
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/northeast)
-"lbU" = (
-/obj/structure/barricade/handrail/urban/road/plastic/blue{
-	dir = 1;
-	layer = 2.99
-	},
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/landing_zone_1)
 "lcc" = (
 /obj/machinery/light/blue{
 	dir = 8
@@ -64381,7 +62564,7 @@
 	pixel_x = 12
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/northeast)
 "lcD" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
@@ -64461,13 +62644,14 @@
 	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "ldj" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8;
+	layer = 3.3
 	},
-/turf/open/floor/prison{
-	dir = 8
-	},
-/area/lv759/outdoors/landing_zone_1)
+/turf/open/floor/plating,
+/area/lv759/outdoors/colony_streets/east_central_street)
 "ldo" = (
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
@@ -64513,7 +62697,7 @@
 /area/lv759/indoors/apartment/northfoyer)
 "ldK" = (
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "ldQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64535,20 +62719,19 @@
 	pixel_x = 6;
 	pixel_y = 25
 	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/north_street)
 "ldY" = (
 /obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1{
 	dir = 8
 	},
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "ldZ" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/caveplateau)
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "leb" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -64673,7 +62856,7 @@
 "lfb" = (
 /obj/effect/spawner/random/misc/structure/girder,
 /turf/open/floor/plating,
-/area/lv759/oob)
+/area/lv759/indoors/jacks_surplus)
 "lfc" = (
 /obj/structure/prop/urban/containersextended/blueright,
 /turf/open/floor/mainship/cargo,
@@ -64760,14 +62943,7 @@
 "lga" = (
 /obj/item/shard,
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "lgb" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -64838,9 +63014,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/meridian/meridian_office)
 "lgF" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -64949,7 +63122,7 @@
 /obj/effect/decal/cleanable/dirt{
 	name = "impact"
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "lhE" = (
 /obj/effect/ai_node,
@@ -64996,7 +63169,7 @@
 /area/lv759/indoors/power_plant/telecomms)
 "lhZ" = (
 /turf/closed/wall/r_wall/kutjevo,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "lie" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/r_wall/urban,
@@ -65062,12 +63235,9 @@
 	},
 /area/lv759/indoors/nt_office/pressroom)
 "liu" = (
-/obj/structure/stairs/seamless{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/sign/safety/blast_door,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/docking_bay_2)
 "liy" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/urban,
@@ -65168,7 +63338,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "ljn" = (
 /obj/item/trash/cigbutt{
@@ -65541,12 +63711,12 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/apartment/eastrestroomsshower)
 "lmj" = (
-/obj/structure/rock/dark/stalagmite/one,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/urban/metal/stripe_red{
+	dir = 1
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
+/area/lv759/outdoors/colony_streets/north_west_street)
 "lmn" = (
 /obj/structure/ore_box,
 /turf/open/urban/street/cement3,
@@ -65635,9 +63805,6 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/central_streets)
 "lni" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/nine,
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/lines1,
@@ -65756,7 +63923,7 @@
 /area/lv759/indoors/hospital/virology)
 "lol" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "loy" = (
 /obj/effect/urban/decal/dirt,
@@ -66076,13 +64243,6 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
 "lsb" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
 /obj/effect/urban/decal/road/road_edge/four,
 /obj/effect/urban/decal/doubleroad/lines3{
 	pixel_y = -4
@@ -66124,9 +64284,12 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "lsv" = (
-/obj/structure/platform/urban/metalplatform2,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/urban/decal/grate{
+	dir = 4
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "lsw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/platform_decoration/mineral{
@@ -66610,17 +64773,15 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/armory_evidenceroom)
 "lwO" = (
-/obj/structure/platform_decoration{
+/obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
 	},
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin{
+/obj/structure/prop/mainship/gelida/smallwire{
 	dir = 8
 	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "lwQ" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -66638,7 +64799,7 @@
 /area/lv759/indoors/nt_office/vip)
 "lwX" = (
 /obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "lwY" = (
 /obj/effect/ai_node,
@@ -66883,7 +65044,7 @@
 "lzB" = (
 /obj/machinery/floodlight,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "lzF" = (
 /obj/effect/urban/decal/road/lines4,
@@ -66965,19 +65126,11 @@
 /obj/structure/window/framed/urban/reinforced,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
-"lAB" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
 "lAC" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/orange_edge,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "lAP" = (
 /obj/item/stack/sheet/cardboard{
 	layer = 1
@@ -67192,23 +65345,16 @@
 /turf/open/floor/kutjevo/colors/orange,
 /area/lv759/indoors/spaceport/hallway_east)
 "lCP" = (
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
 /obj/effect/urban/decal/road/road_edge/twelve,
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "lCQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
+/obj/structure/rock/dark/large,
+/obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/area/lv759/indoors/caves/central_caves)
 "lCS" = (
 /obj/effect/landmark/nuke_spawn,
 /turf/open/ground/sandrock,
@@ -67300,8 +65446,12 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/central_streets)
 "lDN" = (
-/turf/open/floor/bluethree,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab";
+	dir = 4
+	},
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "lDQ" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/doubleroad/lines3{
@@ -67356,7 +65506,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/engineering/metal,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "lEl" = (
 /obj/structure/cable,
@@ -67515,9 +65665,6 @@
 	},
 /turf/open/floor/urban/tile/green_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
-"lFr" = (
-/turf/open/engineership/engineer_floor2,
-/area/lv759/oob)
 "lFG" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -67606,7 +65753,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "lGu" = (
 /obj/effect/urban/decal/road/road_stop/three,
@@ -67687,7 +65834,6 @@
 /area/lv759/indoors/hospital/outgoing)
 "lGT" = (
 /obj/effect/decal/cleanable/blood/xeno,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 1
 	},
@@ -67798,22 +65944,15 @@
 	},
 /turf/open/floor/urban/tile/cuppajoesfloor,
 /area/lv759/indoors/spaceport/cuppajoes)
-"lHZ" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 8
-	},
-/obj/structure/prop/mainship/gelida/smallwire,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "lIb" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "lIc" = (
-/turf/open/urbanshale/layer1,
-/area/lv759/oob)
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "lIf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/wood/darkerwood,
@@ -67883,9 +66022,7 @@
 	dir = 8;
 	layer = 2.5
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "lIF" = (
 /obj/item/clothing/head/warning_cone{
@@ -68057,7 +66194,7 @@
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/heavyequip)
 "lJZ" = (
 /obj/structure/cable,
 /turf/open/urban/street/sidewalk,
@@ -68161,7 +66298,7 @@
 	pixel_x = 3
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/engineering)
 "lKX" = (
 /obj/structure/prop/urban/vehicles/large/mega_hauler_truck/blue_stripe{
 	layer = 3;
@@ -68177,7 +66314,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "lLo" = (
 /turf/closed/mineral/smooth/black_stone,
@@ -68426,7 +66563,7 @@
 "lNl" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/northeast)
 "lNn" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/blood,
@@ -68527,13 +66664,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/hospital/maintenance)
-"lNM" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 4
-	},
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "lNU" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -68615,12 +66745,6 @@
 /obj/effect/urban/decal/road/lines2,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"lOW" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/colony_streets/north_street)
 "lPa" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -68749,9 +66873,6 @@
 /turf/open/floor/prison/darkbrown,
 /area/lv759/indoors/power_plant/south_hallway)
 "lPH" = (
-/obj/structure/barricade/sandbags{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -69105,20 +67226,10 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/hallway_north)
 "lSp" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/barricade/handrail/wire{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/prison/cellstripe{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "lSt" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison/darkyellow{
@@ -69136,16 +67247,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/hallway_reception)
-"lSG" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -2
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/electical_systems/substation1)
 "lSH" = (
 /obj/item/paper{
 	layer = 2
@@ -69275,7 +67376,7 @@
 	layer = 4
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "lTG" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/door/airlock/mainship/engineering{
@@ -69308,14 +67409,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/colonial_marshals/garage)
 "lTO" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
 /obj/structure/fence/dark,
-/turf/open/urban/street/cement3,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/north_street)
 "lTR" = (
 /obj/effect/turf_decal/medical_decals/triage/top,
@@ -69449,9 +67544,6 @@
 /turf/open/floor/grimy,
 /area/lv759/indoors/apartment/westhallway)
 "lVf" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -69476,7 +67568,7 @@
 /obj/machinery/light/blue{
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "lVw" = (
 /obj/effect/urban/decal/dirt,
@@ -69763,9 +67855,10 @@
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/power_plant)
 "lXN" = (
-/obj/structure/prop/mainship/gelida/smallwire,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "lXU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -69798,12 +67891,11 @@
 /turf/open/floor/officesquares,
 /area/lv759/indoors/recycling_plant_waste_disposal_incinerator)
 "lYd" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/open/urban/street/sidewalkcenter,
-/area/lv759/outdoors/colony_streets/central_streets)
+/area/lv759/outdoors/landing_zone_1)
 "lYf" = (
 /obj/structure/toilet{
 	dir = 1
@@ -69838,7 +67930,7 @@
 	light_range = 5
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/flight_control_room)
 "lYA" = (
 /obj/structure/largecrate/random/barrel/black,
 /turf/open/floor/mainship,
@@ -69859,11 +67951,10 @@
 /area/lv759/indoors/hospital/virology)
 "lYR" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/turf/open/engineership/engineer_floor8{
+	dir = 4
 	},
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/derelict_ship)
 "lYU" = (
 /obj/structure/table/mainship,
 /obj/effect/urban/decal/gold/line2,
@@ -70035,12 +68126,8 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/westhallway)
 "mai" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 1
-	},
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/wall/urban/colony/ribbed,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "man" = (
 /obj/structure/prop/urban/containersextended/redright,
 /turf/open/urban/street/sidewalk{
@@ -70155,7 +68242,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "mbM" = (
 /obj/effect/urban/decal/dirt,
@@ -70188,7 +68275,7 @@
 /obj/structure/barricade/handrail/wire{
 	layer = 3
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
 "mcc" = (
 /obj/effect/urban/decal/dirt,
@@ -70290,7 +68377,7 @@
 	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/lv759/indoors/jacks_surplus)
+/area/lv759/indoors/caves/central_caves)
 "mcZ" = (
 /obj/machinery/floodlight/landing,
 /turf/open/urban/street/sidewalkfull,
@@ -70359,8 +68446,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/NTmart/maintenance)
 "mdC" = (
-/turf/open/ground/sandrock,
-/area/lv759/oob)
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "mdI" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -70518,13 +68606,6 @@
 /turf/open/floor/urban/metal/grated,
 /area/lv759/outdoors/colony_streets/central_streets)
 "mfy" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -70539,9 +68620,7 @@
 /obj/machinery/light/small/blue{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "mfD" = (
 /obj/effect/urban/decal/dirt,
@@ -70625,7 +68704,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "mgd" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/reagent_containers/syringe,
@@ -70699,7 +68778,7 @@
 "mgH" = (
 /obj/structure/girder,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "mgI" = (
 /obj/structure/prop/urban/factory/robotic_arm{
@@ -70803,6 +68882,10 @@
 /obj/item/stock_parts/matter_bin/adv{
 	pixel_x = 6;
 	pixel_y = 13
+	},
+/obj/item/tool/pen{
+	pixel_x = 4;
+	pixel_y = -4
 	},
 /turf/open/engineership/engineer_floor2,
 /area/lv759/indoors/derelict_ship)
@@ -70977,7 +69060,9 @@
 	color = "#a6aeab";
 	dir = 1
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "miU" = (
 /obj/structure/bed/roller/hospital_empty/bigrollerempty3{
@@ -71074,7 +69159,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/outdoors/colony_streets/north_west_street)
 "mjL" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -71364,7 +69449,7 @@
 "mlU" = (
 /obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1,
 /turf/closed/wall/r_wall/engineership/invincible,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "mlY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -71396,7 +69481,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 4
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "mmq" = (
 /turf/open/floor/prison/ramptop{
 	dir = 4
@@ -71626,9 +69711,6 @@
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/cafeteria)
 "moq" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/item/tool/wrench{
 	pixel_x = 1;
 	pixel_y = 10
@@ -71655,14 +69737,6 @@
 	},
 /turf/open/floor/urban/tile/tileblue,
 /area/lv759/indoors/mining_outpost/east_dorms)
-"mox" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/nt_research_complex_entrance)
 "moD" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -71937,7 +70011,7 @@
 "mqJ" = (
 /obj/item/stack/rods,
 /obj/item/tool/shovel,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "mqQ" = (
 /obj/effect/urban/decal/trash/two{
@@ -72166,13 +70240,6 @@
 /obj/machinery/light,
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
-"msJ" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -9;
-	pixel_y = 20
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
 "msK" = (
 /obj/structure/bed/chair{
 	pixel_x = 3;
@@ -72211,12 +70278,9 @@
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
 "mta" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/girder,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "mtd" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/fake/wire/red{
@@ -72299,6 +70363,9 @@
 "mtM" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 8
+	},
+/obj/structure/rock/dark/small{
+	layer = 4
 	},
 /turf/open/urbanshale/layer2,
 /area/lv759/outdoors/landing_zone_2)
@@ -72467,7 +70534,7 @@
 "mvJ" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cargo_container/gorg,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "mvP" = (
 /obj/structure/stairs/seamless/edge{
@@ -72585,9 +70652,7 @@
 	layer = 3.33;
 	pixel_y = 2
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "mwK" = (
 /obj/effect/urban/decal/road/corner{
@@ -72754,7 +70819,9 @@
 "mxY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "mxZ" = (
 /obj/structure/bed/chair{
@@ -72910,7 +70977,7 @@
 "mzl" = (
 /obj/structure/sign/safety/maintenance,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/east)
 "mzt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -72960,15 +71027,6 @@
 /obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"mzJ" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "mzP" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -73012,7 +71070,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/bunker,
-/area/lv759/oob)
+/area/lv759/indoors/caves/north_caves)
 "mAi" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -73064,13 +71122,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"mAR" = (
-/obj/structure/barricade/handrail/strata,
-/obj/effect/urban/decal/road/road_edge/three,
-/obj/effect/urban/decal/road/lines3,
-/obj/effect/urban/decal/road/lines2,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "mAT" = (
 /obj/structure/largecrate/random/mini/small_case{
 	layer = 4
@@ -73095,7 +71146,7 @@
 "mBc" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "mBd" = (
 /obj/structure/filingcabinet/nondense{
@@ -73212,9 +71263,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_security/checkpoint_northwest)
 "mBU" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -73238,7 +71286,7 @@
 "mCk" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/mining_outpost/northeast)
 "mCo" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 5;
@@ -73261,7 +71309,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "mCp" = (
-/obj/structure/platform_decoration,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -73277,12 +71324,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/spaceport/flight_control_room)
-"mCC" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/south_west_caves)
 "mCH" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -73291,7 +71332,7 @@
 	pixel_x = -13;
 	pixel_y = 11
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "mCK" = (
 /obj/item/clothing/head/warning_cone{
@@ -73360,10 +71401,6 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mDo" = (
 /obj/effect/ai_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mDv" = (
@@ -73371,7 +71408,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "mDx" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
@@ -73437,11 +71474,8 @@
 /obj/effect/urban/decal/engineership_corners{
 	dir = 4
 	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "mEd" = (
 /turf/open/floor/box,
 /area/lv759/indoors/power_plant/gas_generators)
@@ -73493,11 +71527,12 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "mED" = (
-/obj/structure/platform_decoration{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_1)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/south_west_caves)
 "mEE" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/urban/street/sidewalk{
@@ -73582,7 +71617,7 @@
 	dir = 1
 	},
 /turf/open/floor/urban_plating,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "mFs" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
@@ -73658,18 +71693,6 @@
 /obj/item/tool/weldpack,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"mGm" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/blue{
-	dir = 4;
-	pixel_y = -4
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "mGn" = (
 /obj/machinery/light/spot/blue,
 /turf/open/floor/plating/plating_catwalk{
@@ -73701,7 +71724,7 @@
 	dir = 1
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "mGK" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -73726,7 +71749,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "mGQ" = (
 /obj/structure/table/reinforced,
@@ -73838,9 +71861,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mHY" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/item/trash/mre,
 /obj/effect/urban/decal/trash/fourteen{
 	pixel_y = 15
@@ -73871,9 +71891,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mIe" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -73925,11 +71942,8 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_research_complex/dormsbedroom)
 "mIs" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_security/checkpoint_west)
 "mIH" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/lattice_prop/lattice_6{
@@ -74092,12 +72106,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
-"mKv" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
 "mKx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -74200,12 +72208,6 @@
 /obj/structure/sign/safety/airlock,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
-"mLs" = (
-/obj/effect/urban/decal/engineership_corners{
-	dir = 1
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/oob)
 "mLt" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -74401,10 +72403,8 @@
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "mMV" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "mMW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -74492,7 +72492,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "mNO" = (
 /obj/effect/urban/decal/dirt,
@@ -74647,15 +72647,11 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "mOU" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison{
+	dir = 10
 	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/indoors/nt_research_complex_entrance)
 "mOV" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt,
@@ -74726,9 +72722,6 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "mPq" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -74986,9 +72979,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/northeast)
 "mRK" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
 	layer = 3.33
@@ -75045,7 +73035,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
-/turf/open/floor/urban/tile/darkgrey_bigtile,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/hospital/morgue)
 "mSb" = (
 /obj/effect/spawner/random/misc/structure/girder,
@@ -75138,7 +73128,7 @@
 	},
 /obj/structure/cable,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "mTh" = (
 /obj/structure/prop/urban/misc/machinery/screens/redalert{
 	light_color = "#FF0000";
@@ -75168,9 +73158,15 @@
 /turf/open/floor/floorthree,
 /area/lv759/indoors/NTmart)
 "mTA" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	pixel_y = -1
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "mTE" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/lattice/autosmooth,
@@ -75251,12 +73247,6 @@
 /obj/item/trash/cigbutt,
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"mUw" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
 "mUz" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/nt_mre,
@@ -75308,11 +73298,6 @@
 	dir = 10
 	},
 /area/lv759/indoors/meridian/meridian_office)
-"mUS" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "mUW" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/dirt/grime4{
@@ -75686,9 +73671,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/weaponresearchlabtesting)
 "mXV" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
@@ -75747,9 +73729,6 @@
 /turf/open/engineership/engineer_floor4,
 /area/lv759/indoors/derelict_ship)
 "mYw" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -75812,7 +73791,6 @@
 /turf/open/floor/plate,
 /area/lv759/indoors/colonial_marshals/garage)
 "mYP" = (
-/obj/structure/platform_decoration,
 /obj/effect/urban/decal/dirt,
 /obj/item/prop/paint{
 	pixel_x = 8;
@@ -75884,7 +73862,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "mZm" = (
 /turf/open/floor/multi_tiles{
 	dir = 8
@@ -76040,7 +74018,7 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "naA" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "naB" = (
 /obj/structure/stairs{
@@ -76202,9 +74180,6 @@
 /obj/effect/urban/decal/road/road_edge/two,
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_northwest)
-"nbI" = (
-/turf/open/engineership/engineer_floor13,
-/area/lv759/indoors/caves/central_caves)
 "nbK" = (
 /obj/item/storage/briefcase{
 	pixel_y = -2
@@ -76393,7 +74368,7 @@
 "ncS" = (
 /obj/structure/prop/urban/signs/high_voltage/small,
 /turf/closed/wall/urban/colony,
-/area/lv759/indoors/nt_security/checkpoint_east)
+/area/lv759/indoors/caves/north_east_caves)
 "ncW" = (
 /obj/machinery/photocopier,
 /turf/open/floor/urban/wood/blackwood,
@@ -76406,7 +74381,6 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "ndc" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -76583,10 +74557,6 @@
 "neT" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/central_streets)
 "nfc" = (
@@ -76888,12 +74858,9 @@
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/power_plant/equipment_west)
 "nhc" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/obj/machinery/door/poddoor,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/docking_bay_2)
 "nhe" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office/supervisor)
@@ -76997,12 +74964,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/lv759/indoors/bar/entertainment)
-"nig" = (
-/obj/structure/barricade/handrail/strata,
-/obj/effect/urban/decal/road/road_edge/three,
-/obj/effect/urban/decal/road/lines3,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "nil" = (
 /obj/structure/table/reinforced{
 	layer = 1.9
@@ -77182,7 +75143,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "njj" = (
 /turf/open/floor/urban/tile/tilewhite,
@@ -77305,12 +75266,9 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "nkb" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nkc" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/metal,
@@ -77337,13 +75295,14 @@
 "nkl" = (
 /obj/effect/urban/decal/road/road_edge/six,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nkn" = (
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_stop/five,
 /obj/effect/urban/decal/road/road_stop{
 	pixel_x = -6
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "nko" = (
@@ -77381,11 +75340,8 @@
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "nkS" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer1,
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "nkU" = (
 /obj/machinery/space_heater/radiator/red{
@@ -77408,14 +75364,9 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "nlp" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "nlr" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/lines2,
@@ -77467,7 +75418,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "nlU" = (
 /obj/structure/bed/urban/chairs/black{
@@ -77606,9 +75557,7 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/meridian/meridian_office)
 "nmI" = (
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "nmJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -77834,7 +75783,7 @@
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "noW" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light,
@@ -77862,7 +75811,7 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "npi" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -77907,7 +75856,6 @@
 /obj/structure/barricade/handrail/strata{
 	dir = 8
 	},
-/obj/structure/barricade/handrail/strata,
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 4
@@ -78091,9 +76039,8 @@
 	},
 /area/lv759/outdoors/landing_zone_2)
 "nqO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
+/obj/structure/rock/dark/stalagmite/four,
+/obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "nre" = (
@@ -78163,11 +76110,9 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "nrL" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
+/obj/structure/rock/dark/stalagmite/three,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/area/lv759/indoors/caves/central_caves)
 "nrT" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light{
@@ -78254,9 +76199,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/hospital/maintenance_north)
 "nst" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -78275,10 +76217,6 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/south_maintenance)
-"nsz" = (
-/obj/structure/xeno/tunnel,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "nsA" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
@@ -78287,14 +76225,14 @@
 	},
 /obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nsD" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_edge/four,
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nsF" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/urban/decal/bloodtrail,
@@ -78305,7 +76243,6 @@
 /area/lv759/indoors/nt_research_complex_entrance)
 "nsI" = (
 /obj/machinery/landinglight/lz2,
-/obj/structure/barricade/handrail/strata,
 /obj/structure/barricade/handrail/strata{
 	dir = 4
 	},
@@ -78366,7 +76303,6 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "nte" = (
-/obj/structure/barricade/handrail/strata,
 /obj/structure/barricade/handrail/strata{
 	dir = 8
 	},
@@ -78393,7 +76329,7 @@
 	dir = 2
 	},
 /turf/closed/wall/wood,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_1)
 "ntz" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/urban/colony/ribbed,
@@ -78414,10 +76350,9 @@
 "ntK" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
-/obj/structure/platform_decoration/shiva{
-	dir = 4
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/open/floor/plating,
 /area/lv759/indoors/caves/central_caves)
 "ntL" = (
 /obj/effect/urban/decal/dirt,
@@ -78485,7 +76420,7 @@
 "nuk" = (
 /obj/item/flashlight,
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "num" = (
 /obj/effect/urban/decal/dirt,
@@ -79016,14 +76951,7 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "nyW" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "nzd" = (
 /obj/item/clothing/glasses/science{
@@ -79121,7 +77049,7 @@
 "nzN" = (
 /obj/effect/ai_node,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "nzO" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods{
@@ -79264,7 +77192,7 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "nBi" = (
 /obj/structure/closet/crate,
@@ -79332,10 +77260,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "nBw" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -79388,11 +77312,8 @@
 /obj/machinery/floodlight/colony,
 /obj/structure/sign/safety/blast_door,
 /turf/open/floor/mech_bay_recharge_floor,
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "nCm" = (
-/obj/machinery/streetlight/street{
-	pixel_y = -8
-	},
 /obj/structure/concrete_planter{
 	dir = 8;
 	pixel_y = 8
@@ -79413,10 +77334,9 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab"
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/turf/open/floor/urban_plating,
 /area/lv759/indoors/caves/north_west_caves)
 "nCx" = (
 /obj/structure/platform_decoration/urban/rockdark{
@@ -79500,9 +77420,7 @@
 /obj/machinery/light/small/blue{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "nDj" = (
 /turf/open/floor/plating/plating_catwalk{
@@ -79512,9 +77430,7 @@
 "nDm" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "nDF" = (
 /obj/structure/cable,
@@ -79633,9 +77549,9 @@
 	},
 /area/lv759/indoors/colonial_marshals/changing_room)
 "nEL" = (
-/obj/effect/urban/decal/dirt,
+/obj/structure/rock/dark/stalagmite/five,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/indoors/caves/west_caves)
 "nER" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red{
 	dir = 1
@@ -79719,9 +77635,7 @@
 "nFG" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "nFJ" = (
 /obj/effect/urban/decal/dirt,
@@ -79795,7 +77709,7 @@
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
 	pixel_y = 20
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "nGr" = (
 /obj/structure/rack,
@@ -79872,10 +77786,7 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/apartment/eastrestroomsshower)
 "nGY" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "nHa" = (
 /obj/structure/cable,
@@ -79918,13 +77829,6 @@
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"nHx" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/obj/structure/prop/urban/fakeplatforms/platform1{
-	dir = 1
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/derelict_ship)
 "nHz" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/engineership/engineer_floor9,
@@ -79967,9 +77871,7 @@
 /obj/machinery/light/small/blue{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "nIq" = (
 /obj/effect/acid_hole,
@@ -80198,7 +78100,7 @@
 "nKt" = (
 /obj/structure/cable,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nKx" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -80216,9 +78118,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/north_west_caves_outdoors)
-"nKA" = (
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "nKB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -80274,9 +78173,7 @@
 "nKM" = (
 /obj/item/stack/rods,
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "nKO" = (
 /obj/machinery/light{
@@ -80322,13 +78219,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/hallwaynorthexit)
-"nLj" = (
-/obj/structure/barricade/handrail/urban/road/plastic/blue,
-/obj/structure/largecrate/random/case/double{
-	pixel_x = 12
-	},
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/landing_zone_1)
 "nLo" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/platform_decoration/urban/metalplatformdeco4,
@@ -80346,7 +78236,7 @@
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/south_west_caves)
 "nLt" = (
 /obj/structure/prop/urban/lattice_prop/lattice_4{
 	pixel_y = 16
@@ -80426,9 +78316,6 @@
 "nMc" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/rods,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -80553,7 +78440,7 @@
 "nNt" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "nNu" = (
 /obj/structure/largecrate/random/barrel{
@@ -80569,12 +78456,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/caves/north_caves)
-"nNx" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "nNz" = (
 /obj/structure/sign/safety/storage,
 /turf/closed/wall/r_wall/urban,
@@ -80593,10 +78474,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/cuppajoes)
 "nNO" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/nt_research_complex_entrance)
 "nNR" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
 	dir = 8
@@ -80813,7 +78692,8 @@
 	color = "#a6aeab";
 	dir = 1
 	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "nPR" = (
 /obj/item/tool/weldingtool,
@@ -80911,13 +78791,9 @@
 /turf/open/floor/officesquares,
 /area/lv759/outdoors/colony_streets/central_streets)
 "nQG" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/girder,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "nQI" = (
 /obj/structure/stairs/seamless/edge{
 	color = "#a6aeab";
@@ -80972,24 +78848,16 @@
 /area/lv759/indoors/power_plant/gas_generators)
 "nQW" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "nQX" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "nQY" = (
 /obj/machinery/miner/damaged,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
-"nRd" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "nRh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -81072,10 +78940,6 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "nRI" = (
 /obj/structure/window/framed/urban/reinforced,
-/obj/structure/platform_decoration{
-	dir = 8;
-	layer = 4
-	},
 /obj/machinery/door/poddoor/shutters/urban/shutters/opened{
 	dir = 8
 	},
@@ -81120,9 +78984,11 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "nRX" = (
-/obj/structure/platform_decoration,
-/turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/power_plant/power_storage)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "nSf" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -81195,10 +79061,6 @@
 /obj/effect/decal/cleanable/blood{
 	pixel_y = -8
 	},
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
 "nSy" = (
@@ -81220,13 +79082,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "nSM" = (
-/obj/structure/prop/urban/fakeplatforms/platform1{
-	dir = 4
-	},
-/turf/open/engineership/engineer_floor13{
-	dir = 10
-	},
-/area/lv759/oob)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/north_east_caves)
 "nSU" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -81416,13 +79273,6 @@
 /obj/item/trash/cigbutt,
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
-"nUX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
 "nUZ" = (
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_stop/five{
@@ -81559,10 +79409,7 @@
 /obj/item/clothing/head/warning_cone{
 	pixel_y = 19
 	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "nWr" = (
 /obj/effect/urban/decal/dirt,
@@ -81573,11 +79420,10 @@
 "nWs" = (
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_edge/two,
-/obj/structure/largecrate/random{
-	layer = 4
-	},
+/obj/effect/urban/decal/road/lines3,
+/obj/effect/urban/decal/road/lines5,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "nWv" = (
 /obj/structure/prop/mainship/cannon_cable_connector{
 	pixel_y = 15
@@ -81674,6 +79520,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "nXb" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -81835,7 +79682,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/flight_control_room)
 "nYQ" = (
 /obj/structure/largecrate/random/case/double,
 /obj/structure/cable,
@@ -81854,7 +79701,6 @@
 /obj/item/reagent_containers/glass/bucket{
 	pixel_y = 10
 	},
-/obj/structure/barricade/handrail/strata,
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/northeast)
 "nYX" = (
@@ -82095,9 +79941,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "oaO" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -82210,9 +80053,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "obL" = (
 /obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "obN" = (
 /turf/open/floor/grimy,
@@ -82251,7 +80092,6 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "ocj" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
 	pixel_y = 13
@@ -82334,7 +80174,7 @@
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_edge/two,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "ode" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -82345,18 +80185,11 @@
 /turf/open/floor/plating/heatinggrate,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "odf" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
 /area/lv759/outdoors/landing_zone_2)
-"odl" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
 "odp" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -82394,11 +80227,6 @@
 /obj/effect/urban/decal/trash/thirteen,
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"odO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "odY" = (
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard3{
 	dir = 8;
@@ -82555,7 +80383,7 @@
 /turf/open/floor/urban/metal/stripe_red{
 	dir = 1
 	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/outdoors/colony_streets/north_west_street)
 "ofA" = (
 /obj/item/reagent_containers/food/drinks/coffee{
 	pixel_x = -8;
@@ -82586,7 +80414,7 @@
 "ofO" = (
 /obj/structure/ore_box,
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "ofS" = (
 /obj/structure/barricade/handrail/urban/road/plastic/red,
 /obj/structure/prop/mainship/gelida/smallwire,
@@ -82661,13 +80489,10 @@
 	},
 /area/lv759/indoors/nt_research_complex/cargo)
 "ogz" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
 /obj/structure/platform_decoration/urban/metalplatformdeco2{
 	dir = 1
 	},
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
 "ogA" = (
 /obj/effect/urban/decal/dirt,
@@ -82686,12 +80511,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/vehicledeployment)
-"ogJ" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "ogM" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -82853,7 +80672,7 @@
 	pixel_y = 16
 	},
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "ohH" = (
 /turf/open/floor/orange_edge{
 	dir = 9
@@ -83002,10 +80821,9 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "oiz" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/lattice/autosmooth,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "oiA" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -83093,11 +80911,9 @@
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/bar)
 "ojk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "ojn" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -11;
@@ -83357,14 +81173,9 @@
 	},
 /area/lv759/indoors/NTmart)
 "ome" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "omh" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/window/reinforced/tinted{
@@ -83451,7 +81262,7 @@
 "onO" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/largecrate/random/barrel/black,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "onV" = (
 /obj/effect/urban/decal/road/lines2,
@@ -83529,13 +81340,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
-"opj" = (
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/south_west_caves)
 "opk" = (
 /obj/item/card/id/guest,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -83642,7 +81448,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "oqA" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/streetlight/street{
@@ -83746,9 +81552,6 @@
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
 "orL" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards{
 	dir = 4;
 	layer = 8;
@@ -83831,7 +81634,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "oso" = (
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -83865,7 +81668,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "osE" = (
 /obj/structure/closet/l3closet/scientist,
@@ -83884,23 +81687,8 @@
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/spaceport/baggagehandling)
 "osL" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/wire{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/machinery/light/small/blue{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/indoors/colonial_marshals/restroom)
 "osM" = (
 /turf/open/floor/mainship/research/containment/floor1,
 /area/lv759/indoors/nt_research_complex/xenobiology)
@@ -83943,7 +81731,9 @@
 	color = "#a6aeab";
 	dir = 9
 	},
-/turf/open/floor/prison,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "otc" = (
 /obj/machinery/botany/editor,
@@ -83966,9 +81756,6 @@
 	},
 /area/lv759/indoors/caves/south_west_caves)
 "otq" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/colonial_marshals/press_room)
@@ -83980,12 +81767,9 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/northhallway)
 "oty" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/orange_edge,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "otA" = (
 /obj/structure/bed/roller,
 /obj/effect/urban/decal/dirt,
@@ -84050,10 +81834,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "oua" = (
-/obj/item/tool/shovel,
-/turf/open/floor/plating{
-	dir = 8
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 1
 	},
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/central_caves)
 "ouc" = (
 /obj/structure/girder,
@@ -84095,7 +81879,6 @@
 /turf/open/floor/urban/misc/spaceport1,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "ouz" = (
-/obj/structure/platform_decoration,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
 	pixel_x = 1
@@ -84143,9 +81926,6 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
-/obj/structure/platform_decoration/shiva{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/lv759/indoors/hospital/maintenance)
 "ouX" = (
@@ -84206,9 +81986,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ovA" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -84277,11 +82054,8 @@
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "owo" = (
-/obj/structure/prop/urban/vehicles/meridian/taxi{
-	pixel_x = 2;
-	pixel_y = -6
-	},
 /obj/effect/urban/decal/road/lines2,
+/obj/effect/spawner/random/misc/structure/large/car,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "ows" = (
@@ -84325,9 +82099,6 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "owG" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -84363,9 +82134,7 @@
 	pixel_x = 3;
 	pixel_y = 12
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "oxp" = (
 /obj/machinery/conveyor,
@@ -84405,10 +82174,6 @@
 	pixel_y = 12
 	},
 /obj/effect/ai_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "oxN" = (
@@ -84481,17 +82246,11 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "oyv" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/rock/dark/stalagmite,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/southwest_public_restroom)
 "oyx" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -84544,12 +82303,6 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/floor)
-"oyW" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_east_caves)
 "oyX" = (
 /obj/item/radio{
 	pixel_x = -5;
@@ -84936,9 +82689,7 @@
 "oCD" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "oCF" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -84960,10 +82711,9 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "oCW" = (
-/turf/open/engineership/engineer_floor13{
-	dir = 4
-	},
-/area/lv759/oob)
+/obj/effect/acid_hole,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_research_complex/changingroom)
 "oCX" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/closet/firecloset,
@@ -85090,13 +82840,6 @@
 /obj/effect/ai_node,
 /turf/open/urban/dropship/dropship4,
 /area/lv759/indoors/spaceport/starglider)
-"oEa" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
 "oEc" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -85114,9 +82857,7 @@
 /area/lv759/indoors/power_plant/telecomms)
 "oEd" = (
 /obj/item/tool/shovel,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "oEl" = (
 /obj/effect/urban/decal/dirt,
@@ -85208,7 +82949,7 @@
 /obj/machinery/light/blue{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "oFh" = (
 /obj/structure/sign/safety/laser,
@@ -85392,7 +83133,7 @@
 	},
 /obj/structure/monorail,
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "oHa" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 1;
@@ -85413,7 +83154,7 @@
 "oHi" = (
 /obj/structure/lattice/autosmooth,
 /obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
 "oHk" = (
 /obj/structure/cable,
@@ -85422,9 +83163,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "oHl" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
 /obj/effect/urban/decal/trash/five{
 	pixel_y = 12
 	},
@@ -85579,13 +83317,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/central_streets)
-"oIu" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "oIv" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/effect/ai_node,
@@ -85696,17 +83427,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/east_hallway)
-"oJk" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/lv759/indoors/nt_research_complex/hangarbay)
 "oJm" = (
 /obj/structure/table/reinforced/prison{
 	layer = 3
@@ -85804,9 +83524,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "oKb" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -85866,12 +83583,6 @@
 /turf/open/floor/urban/metal/bluemetalfull,
 /area/lv759/indoors/nt_research_complex/reception)
 "oKA" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_edge/ten,
@@ -85925,11 +83636,8 @@
 	},
 /area/lv759/indoors/hospital/virology)
 "oKL" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/mining_outpost/northeast)
 "oKM" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -86000,11 +83708,6 @@
 	},
 /area/lv759/indoors/hospital/emergency_room)
 "oLL" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -6
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
@@ -86046,9 +83749,7 @@
 /area/lv759/indoors/NTmart)
 "oMD" = (
 /obj/structure/largecrate/random/barrel/brown,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "oMG" = (
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -86434,9 +84135,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "oPM" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -86480,16 +84178,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"oQl" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 1
-	},
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 8
-	},
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/caveplateau)
 "oQp" = (
 /obj/structure/window/framed/urban/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -86500,9 +84188,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/garage)
 "oQq" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/prop/mainship/sensor_computer1/black,
 /turf/open/floor/prison/cellstripe{
 	dir = 1
@@ -86541,10 +84226,9 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab"
+/turf/open/floor/prison{
+	dir = 10
 	},
-/turf/open/ground/sandrock,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "oQS" = (
 /obj/effect/ai_node,
@@ -86604,7 +84288,7 @@
 "oRG" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/heavyequip)
 "oRI" = (
 /turf/open/floor/plating,
 /area/lv759/indoors/caves/north_east_caves)
@@ -86625,9 +84309,6 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/NTmart)
 "oRU" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/largecrate/supply,
 /turf/open/urban/street/sidewalk{
 	dir = 9
@@ -86656,9 +84337,6 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/lv759/indoors/apartment/westfoyer)
 "oRZ" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -86828,7 +84506,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "oTV" = (
-/obj/structure/barricade/handrail/urban/handrail,
 /obj/machinery/light/small/blue{
 	dir = 1
 	},
@@ -86836,15 +84513,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"oTZ" = (
-/obj/machinery/streetlight/street{
-	level = 7;
-	pixel_y = 12
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/landing_zone_1)
 "oUc" = (
 /obj/structure/prop/vehicle/crane/cranecargo{
 	dir = 8;
@@ -87061,9 +84729,6 @@
 	name = "floor panel"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/fueltank/spacefuel,
 /obj/structure/catwalk,
 /turf/open/floor/plating/heatinggrate,
@@ -87182,7 +84847,7 @@
 	dir = 4
 	},
 /turf/open/urbanshale/layer1,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "oYh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison/cellstripe{
@@ -87390,9 +85055,6 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/eastentrance)
 "oZY" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -87500,10 +85162,6 @@
 /area/lv759/indoors/caves/central_caves)
 "pbl" = (
 /obj/structure/cable,
-/obj/structure/stairs{
-	color = "#a6aeab";
-	dir = 4
-	},
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "pbo" = (
@@ -87671,9 +85329,7 @@
 /obj/structure/bed/bedroll{
 	dir = 9
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pcx" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
@@ -87704,13 +85360,6 @@
 /mob/living/simple_animal/mouse/brown,
 /turf/open/floor/prison,
 /area/lv759/outdoors/colony_streets/central_streets)
-"pcH" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "pcJ" = (
 /obj/structure/prop/urban/fakeplatforms/platform1{
 	dir = 4
@@ -87800,11 +85449,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "pdr" = (
-/obj/structure/stairs/seamless{
-	color = "#a6aeab";
-	dir = 8
+/turf/open/floor/prison{
+	dir = 10
 	},
-/turf/open/floor/urban_plating,
 /area/lv759/indoors/caves/north_west_caves)
 "pdv" = (
 /obj/structure/bed/chair/wood/normal{
@@ -87918,9 +85565,7 @@
 /obj/machinery/light/small/blue{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "pes" = (
 /obj/effect/urban/decal/dirt,
@@ -88263,7 +85908,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/researchanddevelopment)
 "pgG" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -88368,15 +86012,11 @@
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "phC" = (
 /obj/machinery/floodlight,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "phE" = (
-/obj/structure/platform_decoration,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 4
@@ -88410,29 +86050,9 @@
 	},
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/colonial_marshals/head_office)
-"phO" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/effect/urban/decal/trash/five{
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "phU" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "phV" = (
 /turf/closed/wall/urban/colony/ribbed,
@@ -88606,9 +86226,7 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "pjU" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
+/obj/structure/closet/crate/medical,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/landing_zone_1)
 "pjX" = (
@@ -88616,9 +86234,7 @@
 	dir = 1;
 	layer = 4
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "pka" = (
 /obj/structure/closet/crate,
@@ -88635,13 +86251,10 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_maintenance_north)
 "pkl" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
+/obj/effect/urban/decal/dirt,
+/obj/effect/ai_node,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "pkq" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/road/plastic/blue{
@@ -88663,13 +86276,6 @@
 /turf/open/urban/street/sidewalk{
 	dir = 1
 	},
-/area/lv759/outdoors/colony_streets/south_east_street)
-"pky" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/turf/open/floor/officetiles,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pkC" = (
 /obj/structure/bed/stool,
@@ -88733,10 +86339,9 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/apartment/northfoyer)
 "pln" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "plp" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -88882,7 +86487,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "pmv" = (
 /obj/structure/lattice/autosmooth,
@@ -88901,6 +86506,7 @@
 	dir = 4
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/machinery/floodlight,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "pmI" = (
@@ -88998,9 +86604,6 @@
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/colonial_marshals/north_office)
 "pnw" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/clothing/head/hardhat/dblue{
 	pixel_x = 4;
 	pixel_y = 8
@@ -89043,7 +86646,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 8
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "pon" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/urban/decal/road/roadmiddle{
@@ -89331,7 +86934,7 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pqj" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "pqm" = (
 /obj/effect/urban/decal/dirt_2,
@@ -89452,15 +87055,12 @@
 	dir = 1
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "prk" = (
 /obj/structure/cable,
 /turf/open/floor/urban/metal/bluemetal1,
 /area/lv759/indoors/spaceport/flight_control_room)
 "prs" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
 /obj/item/tool/crowbar,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
@@ -89479,24 +87079,13 @@
 	dir = 5
 	},
 /area/lv759/indoors/meridian/meridian_foyer)
-"prF" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
 "prR" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "prS" = (
 /obj/structure/largecrate/random/barrel/red,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "prU" = (
 /obj/structure/bed/chair{
@@ -89571,14 +87160,9 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
-"psh" = (
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/west_caves)
 "psk" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_managersoffice)
 "psl" = (
 /obj/structure/prop/mainship/cannon_cables{
 	pixel_y = 12
@@ -89593,9 +87177,6 @@
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
 "psu" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 4;
 	pixel_y = 14
@@ -89780,10 +87361,6 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ptI" = (
@@ -89914,9 +87491,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street)
 "puT" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_y = 19
 	},
@@ -90043,11 +87617,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/hospital/morgue)
-"pvT" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "pvY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -90136,11 +87705,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "pwL" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 4
+/obj/structure/cargo_container/ch_red{
+	dir = 1
 	},
-/turf/open/floor/prison,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_1)
 "pwN" = (
 /obj/effect/urban/decal/dirt,
@@ -90302,9 +87870,6 @@
 	color = "#140400";
 	name = "dirt"
 	},
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -90374,17 +87939,11 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pyy" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4;
-	layer = 4
-	},
+/obj/structure/rock/dark/wide,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/area/lv759/indoors/caves/north_caves)
 "pyz" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "pyB" = (
@@ -90610,10 +88169,6 @@
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/colonial_marshals/north_office)
 "pzJ" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
@@ -90695,7 +88250,8 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pAu" = (
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "pAx" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -90720,9 +88276,9 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/cafeteriakitchen)
 "pAE" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/east_caves)
 "pAF" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -90767,7 +88323,7 @@
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/caveplateau)
 "pAW" = (
 /turf/closed/wall/r_wall/urban,
@@ -90888,14 +88444,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/spaceport/cargo_maintenance)
-"pCg" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/central_streets)
 "pCk" = (
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
@@ -90911,12 +88459,9 @@
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "pCl" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/obj/structure/prop/mainship/gelida/smallwire,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/garage_managersoffice)
 "pCo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -91173,20 +88718,13 @@
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "pDY" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
+/obj/structure/sign/poster,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/indoors/power_plant/power_storage)
+/area/lv759/indoors/spaceport/security_office)
 "pEe" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/grille,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "pEn" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood/oil/streak,
@@ -91254,14 +88792,6 @@
 "pEI" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/meridian/meridian_foyer)
-"pEW" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 4
-	},
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "pEX" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalk{
@@ -91288,7 +88818,7 @@
 	},
 /area/lv759/indoors/nt_research_complex/dormsbedroom)
 "pFs" = (
-/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -91338,9 +88868,6 @@
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
 "pFN" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -91353,14 +88880,6 @@
 /obj/structure/sign/poster,
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/recycling_plant)
-"pFP" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -20
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "pFW" = (
 /obj/machinery/light,
 /turf/open/floor/prison/red{
@@ -91404,9 +88923,7 @@
 /obj/structure/ore_box{
 	pixel_x = 5
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "pGv" = (
 /obj/effect/urban/decal/engineership_corners{
@@ -91459,10 +88976,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwayeast)
 "pHh" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/effect/urban/decal/dirt,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_caves)
 "pHk" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal_solid_white{
@@ -91538,7 +89054,7 @@
 "pIe" = (
 /obj/structure/sign/safety/maintenance,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_2)
 "pIi" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -91602,7 +89118,7 @@
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "pID" = (
 /obj/machinery/streetlight/traffic_alt{
@@ -91664,22 +89180,12 @@
 	pixel_x = 4;
 	pixel_y = 18
 	},
-/obj/structure/barricade/handrail/strata{
-	pixel_x = -1
-	},
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/effect/turf_decal/medical_decals/triage,
 /obj/effect/turf_decal/medical_decals/triage,
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/landing_zone_1)
-"pJt" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -20
-	},
-/obj/effect/urban/decal/dirt,
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "pJx" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/effect/decal/cleanable/dirt/grime3,
@@ -91690,9 +89196,6 @@
 "pJC" = (
 /obj/structure/largecrate/random/case/double{
 	layer = 2
-	},
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 1
 	},
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
@@ -91766,15 +89269,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
-"pJZ" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/urban/handrail,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "pKe" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -10;
@@ -91785,7 +89279,7 @@
 "pKf" = (
 /obj/item/trash/cigbutt,
 /obj/effect/urban/decal/trash/fourteen,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pKl" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -91931,7 +89425,7 @@
 "pLb" = (
 /obj/structure/prop/urban/signs/high_voltage,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/NTmart/maintenance)
 "pLd" = (
 /obj/machinery/disposal,
 /obj/item/reagent_containers/food/snacks/pizzapasta/margheritaslice{
@@ -92070,11 +89564,8 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "pMf" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/landing_zone_2)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex/changingroom)
 "pMh" = (
 /obj/effect/urban/decal/dirt,
 /obj/vehicle/ridden/wheelchair,
@@ -92109,13 +89600,10 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "pMy" = (
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
+/obj/structure/prop/urban/vehicles/large/mega_hauler_truck/red_stripe,
+/turf/open/urban/street/sidewalkcenter{
+	dir = 1
 	},
-/obj/effect/urban/decal/road/road_edge/three,
-/obj/effect/urban/decal/road/lines3,
-/obj/effect/urban/decal/road/lines2,
-/turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pMB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -92133,11 +89621,9 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/north_west_caves)
 "pMN" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/structure/cargo_container/gorg,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "pMX" = (
 /obj/structure/rock/dark/small/three,
 /obj/structure/rock/dark/small/three,
@@ -92237,9 +89723,6 @@
 /area/lv759/indoors/hospital/morgue)
 "pNw" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -92270,10 +89753,11 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/colonial_marshals/changing_room)
 "pNG" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 8
+	},
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "pNJ" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -92328,7 +89812,7 @@
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/urban_plating,
-/area/lv759/indoors/spaceport/janitor)
+/area/lv759/indoors/spaceport/heavyequip)
 "pOp" = (
 /obj/machinery/door/poddoor/shutters/urban/security_lockdown{
 	dir = 2;
@@ -92445,11 +89929,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/derelict_ship)
-"pPY" = (
-/turf/open/engineership/engineer_floor13{
-	dir = 6
-	},
-/area/lv759/indoors/caves/central_caves)
 "pPZ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -92502,23 +89981,9 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/westshowers)
 "pQt" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/wire{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/machinery/light/small/blue{
-	dir = 4
-	},
-/turf/open/floor/prison/cellstripe{
-	dir = 8
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/colony_streets/north_street)
 "pQz" = (
 /obj/item/tool/kitchen/utensil/spoon{
 	pixel_x = 10
@@ -92720,12 +90185,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/mining_outpost/northeast)
-"pSt" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab"
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
 "pSC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -92821,9 +90280,8 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "pTW" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -92947,7 +90405,6 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "pVb" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/structure/stairs/corner_seamless{
 	color = "#b8b8b0";
 	dir = 1
@@ -92990,16 +90447,10 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "pVw" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "pVG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
@@ -93019,7 +90470,7 @@
 /area/lv759/indoors/apartment/northapartments)
 "pVN" = (
 /turf/closed/wall/urban/colony,
-/area/lv759/indoors/nt_security/checkpoint_east)
+/area/lv759/indoors/caves/north_east_caves)
 "pVO" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/shuttle/dropship_white/top_corner,
@@ -93141,7 +90592,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "pWA" = (
 /obj/structure/closet/crate/miningcar{
@@ -93252,6 +90703,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -93315,12 +90767,6 @@
 	},
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/meridian/meridian_factory)
-"pXS" = (
-/obj/structure/prop/urban/vehicles/large/colonycrawlers/mining{
-	layer = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "pXU" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -93505,10 +90951,10 @@
 /turf/open/floor/freezer,
 /area/lv759/indoors/nt_research_complex/cafeteriakitchen)
 "pZs" = (
-/obj/structure/platform_decoration,
-/obj/effect/spawner/random/misc/structure/girder,
-/turf/open/floor/plating,
-/area/lv759/indoors/power_plant/power_storage)
+/obj/item/stack/rods,
+/obj/structure/grille,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "pZu" = (
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/power_plant/geothermal_generators)
@@ -93564,9 +91010,6 @@
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
 "pZI" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/item/clothing/head/warning_cone{
 	pixel_x = 4;
 	pixel_y = 14
@@ -93588,15 +91031,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysoutheast)
-"pZP" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "pZY" = (
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/urban/colony,
@@ -93605,14 +91039,6 @@
 /obj/structure/fence/dark,
 /turf/open/floor/prison,
 /area/lv759/outdoors/landing_zone_2)
-"qad" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qaf" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -93863,10 +91289,6 @@
 /obj/effect/urban/decal/road/road_edge/four,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"qcD" = (
-/obj/structure/closet/crate/science,
-/turf/open/engineership/engineer_floor1,
-/area/lv759/indoors/derelict_ship)
 "qcF" = (
 /obj/effect/urban/decal/dirt,
 /obj/machinery/light/small{
@@ -93882,13 +91304,6 @@
 	},
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/spaceport/janitor)
-"qcG" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/rock/dark/small/three,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_street)
 "qcJ" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/fake/lattice/full,
@@ -94036,12 +91451,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/electical_systems/substation1)
-"qdG" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/south_west_caves)
 "qdM" = (
 /obj/structure/window/framed/urban/reinforced,
 /obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
@@ -94092,13 +91501,6 @@
 /obj/structure/prop/urban/misc/floorprops/grate,
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/indoors/nt_research_complex/hallwayeast)
-"qdT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_west_caves)
 "qdW" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreeblies/greeble7{
@@ -94149,11 +91551,9 @@
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qek" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/rock/dark/stalagmite/one,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "qep" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -94171,7 +91571,7 @@
 /area/lv759/indoors/apartment/eastbedroomsstorage)
 "qev" = (
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "qez" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
@@ -94190,29 +91590,16 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwaynorth)
 "qeB" = (
-/obj/item/smallDelivery{
-	layer = 5
-	},
-/obj/item/smallDelivery{
-	pixel_x = -12;
-	pixel_y = 22
-	},
 /obj/item/stack/sheet/cardboard,
 /obj/effect/urban/decal/road/lines3,
-/obj/effect/urban/decal/road/road_stop/five{
-	dir = 4
-	},
-/obj/structure/largecrate/random/mini{
-	layer = 4;
-	pixel_x = 1;
-	pixel_y = 14
-	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qeC" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/xeno/tunnel,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
+/area/lv759/indoors/electical_systems/substation1)
 "qeF" = (
 /obj/item/stool,
 /obj/effect/urban/decal/road/lines1,
@@ -94285,11 +91672,11 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "qfd" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
+/obj/structure/prop/urban/signs/high_voltage{
+	desc = null
 	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/central_caves)
 "qfk" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -94419,29 +91806,14 @@
 "qgD" = (
 /turf/open/floor/prison/darkyellow,
 /area/lv759/indoors/nt_research_complex/hallwaynorth)
-"qgH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
 "qgP" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
 /area/lv759/outdoors/landing_zone_2)
 "qgR" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/platform/urban/metalplatform2{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/south_west_caves)
 "qhd" = (
 /obj/structure/prop/mainship/gelida/barrier{
 	pixel_y = -12
@@ -94584,7 +91956,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "qim" = (
 /obj/item/trash/trashbag{
 	pixel_x = -5;
@@ -94818,9 +92190,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "qkn" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -94882,13 +92251,8 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/mining_outpost/northeast)
 "qkB" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/electical_systems/substation1)
 "qkJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -94979,13 +92343,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
 "qln" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/south_east_street)
 "qlo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/multi_tiles,
@@ -94997,7 +92356,7 @@
 	},
 /obj/item/flashlight,
 /obj/item/ammo_casing/bullet,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "qlr" = (
 /obj/machinery/vending/coffee{
@@ -95223,9 +92582,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/spaceport/horizon_runner)
-"qnD" = (
-/turf/open/floor/urban_plating,
-/area/lv759/indoors/caves/north_west_caves)
 "qnH" = (
 /obj/item/ammo_casing/bullet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -95309,9 +92665,6 @@
 /area/lv759/indoors/nt_research_complex/researchanddevelopment)
 "qoI" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -95388,7 +92741,7 @@
 "qpl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/urban/street/roadlines4,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "qpr" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
@@ -95446,11 +92799,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/mining_outpost/east_command)
 "qpO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/colony_streets/north_street)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/east_caves)
 "qpP" = (
 /obj/structure/barricade/handrail,
 /turf/open/floor/prison/darkyellow,
@@ -95581,10 +92931,6 @@
 /area/lv759/indoors/caves/central_caves)
 "qqC" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_street)
 "qqE" = (
@@ -95844,12 +93190,11 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "qtK" = (
-/obj/item/lightstick/anchored,
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_caves)
 "qtL" = (
 /obj/structure/table/mainship{
 	color = "#848484"
@@ -96022,12 +93367,12 @@
 "qvx" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "qvE" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/item/flashlight,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "qvJ" = (
 /obj/structure/cable,
@@ -96083,18 +93428,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/spaceport/engineering)
 "qwc" = (
-/obj/structure/barricade/handrail/urban/handrail,
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/electical_systems/substation1)
-"qwf" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
 "qwl" = (
 /obj/structure/sink{
 	dir = 1;
@@ -96135,10 +93470,6 @@
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/southwest_public_restroom)
 "qwz" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
@@ -96378,12 +93709,6 @@
 /obj/item/tool/wirecutters,
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/caveplateau)
-"qyV" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/central_streets)
 "qyX" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -9;
@@ -96520,12 +93845,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"qzR" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
-/turf/open/urban/street/sidewalk{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/central_streets)
 "qzU" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -96617,17 +93936,12 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/barricade/handrail/strata,
 /obj/structure/cable,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/power_plant/power_storage)
 "qBh" = (
 /turf/open/floor/prison,
 /area/lv759/indoors/NTmart/backrooms)
-"qBp" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/engineership/engineer_floor1,
-/area/lv759/indoors/derelict_ship)
 "qBs" = (
 /obj/structure/table/reinforced/prison{
 	color = "#6b675e"
@@ -96658,30 +93972,16 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
-"qBK" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1{
-	dir = 4
-	},
-/obj/item/trash/trashbag{
-	pixel_x = 2;
-	pixel_y = 20
-	},
-/obj/item/trash/cigbutt,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qBM" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
+/obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/area/lv759/indoors/caves/central_caves)
 "qBR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/south_west_caves)
 "qCg" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -96820,17 +94120,9 @@
 "qDt" = (
 /turf/open/ground/sandrock,
 /area/lv759/indoors/nt_research_complex_entrance)
-"qDG" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/barricade/sandbags{
-	dir = 8
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
 "qDK" = (
 /obj/structure/rock/dark/stalagmite/one,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "qDN" = (
 /obj/structure/prop/urban/misc/machinery/screens/bluemultimonitormedium_on{
@@ -96844,13 +94136,8 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/meridian/meridian_office)
 "qDW" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_west_caves)
 "qEb" = (
 /obj/structure/barricade/handrail/strata{
@@ -96880,7 +94167,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "qEw" = (
 /obj/structure/prop/urban/misc/machinery/screens/bluemultimonitormedium_on{
@@ -97022,11 +94309,11 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "qGn" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/turf/open/floor/prison/ramptop{
-	dir = 4
+/obj/structure/prop/urban/vehicles/large/colonycrawlers/mining{
+	layer = 4
 	},
-/area/lv759/indoors/meridian/meridian_factory)
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_east_caves)
 "qGq" = (
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/meridian/meridian_foyer)
@@ -97043,14 +94330,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
-"qGE" = (
-/obj/effect/urban/decal/grate{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/central_caves)
 "qGH" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt,
@@ -97325,15 +94604,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/power_plant)
-"qJF" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 4
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/recycling_plant/synthetic_storage)
 "qJG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97368,19 +94638,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/spaceport/communications_office)
-"qJM" = (
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/pipes/pipe3{
-	dir = 4
-	},
-/obj/structure/prop/urban/misc/fake/wire/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qJN" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
@@ -97447,7 +94704,7 @@
 "qKr" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "qKt" = (
 /obj/structure/closet,
@@ -97839,8 +95096,8 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating{
-	dir = 8
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/central_caves)
 "qOh" = (
@@ -97875,12 +95132,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_security)
-"qOy" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "qOz" = (
 /turf/open/engineership/engineer_floor13{
 	dir = 6
@@ -97928,9 +95179,7 @@
 	layer = 2;
 	pixel_x = -20
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "qPd" = (
 /obj/item/tool/wet_sign{
@@ -97976,7 +95225,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "qPJ" = (
 /obj/effect/urban/decal/road/road_edge,
@@ -98155,10 +95404,6 @@
 /area/lv759/indoors/nt_security/checkpoint_northwest)
 "qRj" = (
 /obj/effect/landmark/weed_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "qRo" = (
@@ -98212,11 +95457,8 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
 /obj/machinery/power/port_gen,
-/obj/structure/platform_decoration/shiva{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	dir = 8
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/central_caves)
 "qRM" = (
@@ -98241,8 +95483,11 @@
 	},
 /area/lv759/indoors/spaceport/cargo)
 "qRT" = (
+/obj/structure/largecrate/random{
+	layer = 4
+	},
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "qRX" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -98254,7 +95499,7 @@
 /obj/item/tool/shovel{
 	pixel_y = 12
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "qSb" = (
 /obj/item/stack/sheet/cardboard{
@@ -98288,13 +95533,10 @@
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "qSj" = (
-/obj/item/megaphone,
-/obj/structure/table/reinforced/prison,
-/obj/structure/barricade/handrail/strata,
-/turf/open/floor/mainship{
-	dir = 5
-	},
-/area/lv759/indoors/nt_office/pressroom)
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/turf/open/floor/plating,
+/area/lv759/outdoors/colony_streets/east_central_street)
 "qSm" = (
 /obj/structure/prop/urban/misc/phonebox{
 	pixel_x = 6
@@ -98365,11 +95607,10 @@
 /turf/open/floor/prison/blue,
 /area/lv759/indoors/hospital/pharmacy)
 "qSF" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/urban/decal/dirt,
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "qSG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/urban/decal/bloodtrail,
@@ -98389,14 +95630,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"qSL" = (
-/obj/item/trash/trashbag{
-	pixel_x = 2;
-	pixel_y = 20
-	},
-/obj/item/trash/eat,
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qSS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -98409,9 +95642,6 @@
 /turf/open/floor/prison/whitegreen,
 /area/lv759/indoors/hospital/reception)
 "qST" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -98438,14 +95668,11 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "qTe" = (
 /turf/open/engineership/pillars/east/pillareast4,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "qTg" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/central_caves)
 "qTj" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/plating,
@@ -98569,18 +95796,6 @@
 "qUo" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_west_caves)
-"qUu" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 8;
-	layer = 4
-	},
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/landing_zone_2)
 "qUv" = (
 /obj/machinery/streetlight/traffic{
 	dir = 8;
@@ -98671,14 +95886,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
-"qVM" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/urban/street/sidewalkcenter,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qVP" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/generic_solid,
@@ -98708,26 +95915,14 @@
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "qVV" = (
-/obj/structure/closet/crate/medical{
-	pixel_x = -5;
-	pixel_y = 14
+/obj/machinery/streetlight/street{
+	level = 7;
+	pixel_y = 12
 	},
 /turf/open/urban/street/sidewalk{
 	dir = 5
 	},
 /area/lv759/outdoors/landing_zone_1)
-"qVX" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	pixel_y = 9
-	},
-/obj/effect/urban/decal/road/road_edge/four,
-/obj/effect/urban/decal/doubleroad/lines3{
-	pixel_y = -4
-	},
-/turf/open/urban/street/sidewalkcenter,
-/area/lv759/outdoors/landing_zone_2)
 "qVY" = (
 /obj/effect/turf_decal/medical_decals/doc/stripe{
 	dir = 8
@@ -98736,8 +95931,9 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "qWb" = (
 /obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/west_caves)
 "qWe" = (
 /obj/effect/urban/decal/road/lines1,
@@ -98803,16 +95999,6 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"qWD" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/structure/prop/urban/misc/fake/wire/yellow{
-	dir = 1
-	},
-/obj/item/trash/buritto{
-	layer = 2
-	},
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "qWH" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -13;
@@ -98969,7 +96155,7 @@
 "qYd" = (
 /obj/structure/prop/urban/engineer/engineerpillar/smallsouthwest1,
 /turf/open/engineership/engineer_floor13,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "qYg" = (
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -99078,9 +96264,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "qZh" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
 /obj/machinery/streetlight/street{
 	level = 7;
 	pixel_y = 12
@@ -99143,14 +96326,8 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/colonial_marshals/hallway_central)
 "qZF" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "qZG" = (
 /obj/effect/urban/decal/road/road_edge/two,
@@ -99209,20 +96386,17 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "rai" = (
-/obj/structure/platform_decoration,
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/prison{
 	dir = 4
 	},
 /area/lv759/indoors/meridian/meridian_factory)
 "ram" = (
-/obj/machinery/floodlight{
-	layer = 1
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/north_west_street)
 "rar" = (
 /obj/structure/prop/urban/lattice_prop/lattice_4{
 	pixel_y = 16
@@ -99238,7 +96412,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "raC" = (
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
@@ -99367,15 +96541,8 @@
 /turf/open/floor/carpet/orange,
 /area/lv759/indoors/bar/entertainment)
 "rbR" = (
-/obj/structure/largecrate/random/barrel/black{
-	pixel_x = 12;
-	pixel_y = 4
-	},
-/obj/structure/largecrate/random/barrel/black{
-	pixel_x = -6
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_east_caves)
 "rbX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -99474,9 +96641,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "rdb" = (
 /obj/structure/cable,
@@ -99674,16 +96839,11 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/recycling_plant)
 "reL" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab"
-	},
-/turf/open/floor/multi_tiles{
-	dir = 6
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
+/area/lv759/indoors/caves/north_west_caves)
 "reS" = (
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_west_street)
@@ -99795,7 +96955,7 @@
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "rfC" = (
 /obj/structure/prop/urban/misc/redmeter{
 	light_color = "#FF004A";
@@ -99836,7 +96996,7 @@
 	pixel_y = 16
 	},
 /obj/item/ammo_casing/bullet,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "rfY" = (
 /obj/structure/fence{
@@ -99847,11 +97007,9 @@
 	},
 /area/lv759/indoors/caves/central_caves)
 "rgd" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/item/storage/briefcase/inflatable,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "rgf" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 1;
@@ -100182,9 +97340,7 @@
 "riV" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "riW" = (
 /obj/machinery/light{
@@ -100211,10 +97367,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/outdoors/caveplateau)
-"rji" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/marked,
-/area/lv759/indoors/spaceport/docking_bay_2)
 "rjk" = (
 /obj/item/clothing/mask/gas,
 /obj/effect/decal/cleanable/blood{
@@ -100286,12 +97438,13 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/apartment/westhallway)
 "rjL" = (
-/obj/structure/rock/dark/stalagmite,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 6
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "rjT" = (
 /obj/structure/window/framed/urban/reinforced{
@@ -100308,13 +97461,16 @@
 /area/lv759/outdoors/caveplateau)
 "rjX" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 4
+	},
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 1
 	},
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "rke" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -100334,16 +97490,6 @@
 	dir = 10
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"rkm" = (
-/obj/item/lightstick/anchored,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "rko" = (
 /obj/structure/stairs/seamless{
 	dir = 8
@@ -100559,7 +97705,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods,
 /obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "rlO" = (
 /obj/effect/urban/decal/dirt,
@@ -100836,12 +97982,6 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/lv759/indoors/colonial_marshals/press_room)
-"rok" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
 "rol" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
@@ -100933,7 +98073,7 @@
 /obj/effect/urban/decal/road/road_edge/ten,
 /obj/effect/ai_node,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "roT" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -100947,7 +98087,7 @@
 /turf/open/floor/urban/metal/stripe_red{
 	dir = 8
 	},
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "roZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/urban/decal/dirt,
@@ -101051,14 +98191,7 @@
 /obj/effect/urban/decal/road/road_edge/four,
 /obj/effect/urban/decal/road/lines1,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
-"rpT" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/area/lv759/outdoors/landing_zone_1)
 "rpX" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/urban/personal{
@@ -101165,19 +98298,9 @@
 "rqX" = (
 /turf/open/floor/plating,
 /area/lv759/indoors/apartment/westhallway)
-"rri" = (
-/obj/structure/closet/crate/science,
-/obj/effect/spawner/random/medical/pillbottle,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/caveplateau)
 "rrn" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/nt_research_complex/mainlabs)
 "rro" = (
 /obj/effect/urban/decal/doubleroad/lines2{
 	pixel_y = 4
@@ -101296,9 +98419,6 @@
 /area/lv759/indoors/power_plant/fusion_generators)
 "rsx" = (
 /obj/item/stack/rods,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "rsC" = (
@@ -101412,12 +98532,9 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/virology)
 "rtg" = (
-/obj/structure/stairs{
-	color = "#a6aeab";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "rti" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/road_edge,
@@ -101445,14 +98562,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"rtv" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/lv759/outdoors/colony_streets/north_west_street)
 "rtB" = (
 /obj/structure/bed/stool,
 /turf/open/floor/wood,
@@ -101501,7 +98610,8 @@
 /area/lv759/outdoors/landing_zone_2)
 "ruu" = (
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "ruw" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -101510,10 +98620,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/power_plant)
-"rux" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/south_west_caves)
 "ruE" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/urban/tile/darkbrown_bigtile{
@@ -101745,9 +98851,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/floorthree,
 /area/lv759/indoors/power_plant/geothermal_generators)
-"rwp" = (
-/turf/open/engineership/engineer_floor13,
-/area/lv759/oob)
 "rww" = (
 /turf/open/floor/plating,
 /area/lv759/indoors/recycling_plant_office)
@@ -101780,9 +98883,7 @@
 	pixel_x = -9;
 	pixel_y = 20
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "rxa" = (
 /obj/machinery/landinglight/lz2,
@@ -101790,11 +98891,6 @@
 	dir = 5
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
-"rxf" = (
-/obj/effect/urban/decal/grate,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
 "rxn" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -101831,7 +98927,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating,
+/turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "rxB" = (
 /obj/structure/cable,
@@ -102068,9 +99164,6 @@
 "rzD" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/road/plastic/red,
-/obj/structure/barricade/sandbags{
-	dir = 1
-	},
 /turf/open/urban/street/sidewalk{
 	dir = 8
 	},
@@ -102089,9 +99182,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_street)
 "rzR" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -102146,7 +99236,7 @@
 	desc = null
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "rAz" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/metal/metalwhitefull,
@@ -102199,9 +99289,7 @@
 /obj/item/device/flashlight/lamp/tripod{
 	pixel_x = -5
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "rBb" = (
 /obj/item/clothing/head/hardhat/dblue{
@@ -102273,7 +99361,7 @@
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 8
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "rBM" = (
 /obj/effect/urban/decal/dirt,
@@ -102286,7 +99374,7 @@
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/lines1,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "rBX" = (
 /obj/structure/filingcabinet/nondense{
 	pixel_x = -8;
@@ -102381,9 +99469,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/central_streets)
-"rCE" = (
-/turf/closed/wall/urban/colony/engineering,
-/area/lv759/indoors/caves/central_caves)
 "rCF" = (
 /obj/structure/sink{
 	dir = 4;
@@ -102488,7 +99573,7 @@
 /turf/closed/shuttle/dropship4/corners{
 	dir = 1
 	},
-/area/lv759/indoors/spaceport/horizon_runner)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "rDx" = (
 /turf/open/floor/prison/darkyellow{
 	dir = 6
@@ -102497,7 +99582,6 @@
 "rDz" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/tgmc_tray,
-/obj/structure/platform_decoration/urban/metalplatformdeco1,
 /obj/item/trash/mre,
 /obj/item/trash/cigbutt{
 	pixel_x = 4
@@ -102905,16 +99989,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/lv759/indoors/hospital/emergency_room)
-"rHA" = (
-/obj/structure/platform_decoration,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	layer = 3.33
-	},
-/turf/open/floor/multi_tiles{
-	dir = 8
-	},
-/area/lv759/indoors/spaceport/docking_bay_1)
 "rHG" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
 	pixel_x = 20;
@@ -103065,9 +100139,10 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/weaponry/ammo/rifle,
-/obj/structure/platform_decoration/shiva,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/central_caves)
 "rJi" = (
 /turf/open/floor/urban/metal/grated{
@@ -103140,9 +100215,8 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "rJP" = (
-/obj/structure/platform_decoration,
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "rJR" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -103205,9 +100279,6 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
-	},
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "rKx" = (
@@ -103291,7 +100362,7 @@
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_2)
 "rLf" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/urban_plating,
@@ -103313,14 +100384,6 @@
 /obj/item/shard,
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/nt_research_complex/mainlabs)
-"rLo" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "rLu" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable,
@@ -103484,9 +100547,7 @@
 /obj/effect/spawner/random/engineering/toolbox{
 	layer = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "rNi" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -103591,11 +100652,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "rNL" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 1
-	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/south_west_caves)
 "rNP" = (
 /obj/structure/rock/dark/small,
 /turf/open/urbanshale/layer1,
@@ -103674,9 +100733,6 @@
 /turf/open/urban/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "rOs" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/urban/decal/road/road_edge/ten,
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/lines2,
@@ -104143,12 +101199,12 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/outgoing)
 "rSh" = (
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 4
 	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "rSi" = (
 /obj/effect/ai_node,
@@ -104266,7 +101322,7 @@
 /obj/item/stack/rods,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "rTi" = (
 /obj/structure/rack,
@@ -104320,11 +101376,6 @@
 /obj/effect/ai_node,
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
-"rTR" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
 "rTS" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -104376,12 +101427,6 @@
 "rUt" = (
 /turf/open/floor/urban/wood/darkerwood,
 /area/lv759/indoors/apartment/northapartments)
-"rUB" = (
-/obj/structure/ore_box{
-	layer = 2
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "rUD" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/prison/cellstripe,
@@ -104425,10 +101470,9 @@
 /obj/machinery/light/blue{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/girder,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "rUZ" = (
 /turf/closed/shuttle/dropship4/corners{
 	dir = 1
@@ -104524,17 +101568,18 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/urban/street/sidewalkfull,
-/area/lv759/indoors/landing_zone_1/lz1_console)
+/area/lv624/lazarus/console)
 "rVT" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/engineership/engineer_floor4,
+/area/lv759/indoors/derelict_ship)
 "rVW" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "rVY" = (
 /obj/structure/platform_decoration/urban/rockdark,
@@ -104628,12 +101673,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
-"rWL" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
 "rWQ" = (
 /obj/structure/window/framed/urban/reinforced,
 /obj/machinery/door/poddoor/shutters/urban/open_shutters/opened{
@@ -104677,7 +101716,8 @@
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
 	pixel_y = 28
 	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/north_street)
 "rXr" = (
 /obj/structure/closet/crate/trashcart{
@@ -104905,9 +101945,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_research_complex/hangarbay)
 "rZC" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -105028,7 +102065,7 @@
 /area/lv759/indoors/nt_office/floor)
 "saQ" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "saS" = (
 /obj/structure/closet/secure_closet/security,
@@ -105158,13 +102195,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "scC" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/item/stack/sheet/wood{
-	layer = 2.7;
-	pixel_y = 8
-	},
 /obj/machinery/light/blue{
 	dir = 4
 	},
@@ -105293,7 +102323,6 @@
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_south)
 "sdO" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 1
 	},
@@ -105624,9 +102653,6 @@
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/hospital/virology)
 "sgy" = (
-/obj/structure/stairs{
-	color = "#a6aeab"
-	},
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/botany/botany_mainroom)
 "sgC" = (
@@ -105691,9 +102717,10 @@
 /turf/open/urban/street/underground_unweedable,
 /area/lv759/outdoors/colony_streets/central_streets)
 "sgS" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/landing_zone_2)
+/obj/effect/urban/decal/dirt,
+/obj/structure/largecrate/random/barrel/black,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "sgW" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
@@ -105807,7 +102834,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/urban/street/roadlines4,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "shY" = (
 /obj/structure/cable,
 /turf/open/floor/orange_icorner,
@@ -105895,24 +102922,12 @@
 	dir = 8
 	},
 /area/lv759/indoors/meridian/meridian_showroom)
-"siO" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_caves)
 "siP" = (
 /obj/effect/urban/decal/dirt_2,
 /turf/open/urban/street/sidewalk{
 	dir = 4
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"siR" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_west_caves)
 "siV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -105947,7 +102962,7 @@
 /obj/structure/cargo_container/gorg{
 	dir = 4
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "sjj" = (
 /obj/structure/noticeboard,
@@ -106272,18 +103287,12 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "slH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_west_caves)
 "slM" = (
-/obj/machinery/floodlight/colony{
-	layer = 4
-	},
-/turf/open/floor/mech_bay_recharge_floor,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/nt_research_complex_entrance)
 "slN" = (
 /obj/structure/rock/dark/small/two,
 /turf/open/urbanshale/layer1,
@@ -106355,7 +103364,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/flight_control_room)
 "smD" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -106417,9 +103426,6 @@
 	},
 /area/lv759/outdoors/landing_zone_1)
 "smU" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/spawner/random/engineering/toolbox{
 	layer = 4
 	},
@@ -106502,7 +103508,7 @@
 /obj/structure/largecrate/random/case/double{
 	layer = 2
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "snu" = (
 /obj/effect/urban/decal/dirt,
@@ -106647,9 +103653,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "soO" = (
 /obj/structure/largecrate/random/barrel/brown,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "spa" = (
 /obj/effect/urban/decal/dirt,
@@ -106722,15 +103726,6 @@
 	},
 /turf/open/floor/urban/tile/cuppajoesfloor,
 /area/lv759/indoors/spaceport/cuppajoes)
-"spU" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/turf/open/floor/prison/ramptop,
-/area/lv759/outdoors/colony_streets/central_streets)
 "spZ" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/storage/briefcase,
@@ -106882,7 +103877,7 @@
 /obj/structure/sign/safety/hazard{
 	dir = 8
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "sqY" = (
 /obj/structure/table/reinforced/prison,
@@ -107108,10 +104103,6 @@
 /turf/open/floor/kutjevo/colors/blue,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "ssR" = (
-/obj/structure/stairs/seamless{
-	color = "#6e6e6e";
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/ramptop{
 	dir = 8
@@ -107159,20 +104150,12 @@
 "ssY" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "sti" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/mainship,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
-"stk" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/obj/structure/prop/mainship/gelida/smallwire,
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/caveplateau)
 "sto" = (
 /obj/machinery/chem_master,
 /obj/machinery/light/blue{
@@ -107197,13 +104180,9 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/mining_outpost/east_command)
 "stz" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/rock/dark/stalagmite/one,
+/obj/item/stack/rods,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/indoors/caves/central_caves)
 "stH" = (
 /obj/structure/prop/urban/fakeplatforms/platform1{
 	dir = 8
@@ -107212,16 +104191,10 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "stJ" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 4
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/oob)
+/obj/item/stack/rods,
+/obj/structure/grille,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "stL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk{
@@ -107268,7 +104241,7 @@
 "stS" = (
 /obj/item/trash/eat,
 /obj/effect/urban/decal/trash/eleven,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/colony_streets/central_streets)
 "sua" = (
 /obj/structure/rack,
@@ -107297,13 +104270,6 @@
 /obj/machinery/light,
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westbedrooms)
-"sum" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/rock/dark/stalagmite/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
 "suo" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
@@ -107408,12 +104374,6 @@
 /obj/effect/decal/cleanable/dirt/grime1,
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/south_east_street)
-"svv" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
 "svA" = (
 /turf/open/urbanshale/layer2,
 /area/lv759/indoors/caves/central_caves)
@@ -107514,7 +104474,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "swC" = (
 /turf/closed/shuttle/dropship4/cornersalt{
@@ -107556,7 +104516,7 @@
 /obj/structure/prop/urban/vehicles/large/colonycrawlers/mining{
 	dir = 4
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "sxe" = (
 /obj/effect/urban/decal/warningstripes_angled_corner{
@@ -107585,7 +104545,9 @@
 /area/lv759/indoors/mining_outpost/processing)
 "sxv" = (
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/cellstripe,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "sxw" = (
 /turf/open/floor/urban/metal/zbrownfloor1{
@@ -107645,9 +104607,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "syd" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -107769,7 +104728,7 @@
 "syI" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "syJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -107787,15 +104746,6 @@
 	dir = 8
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
-"syS" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_caves)
 "syT" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 6;
@@ -107895,9 +104845,9 @@
 	},
 /area/lv759/indoors/botany/botany_mainroom)
 "szw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/urban/decal/dirt,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/meridian/meridian_showroom)
 "szx" = (
 /obj/structure/bed/urban/bunkbed3{
 	dir = 8
@@ -107951,9 +104901,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_fuel)
 "szN" = (
-/obj/effect/landmark/excavation_site_spawner,
+/obj/item/tool/shovel,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/area/lv759/indoors/caves/central_caves)
 "szQ" = (
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt{
@@ -107983,12 +104933,6 @@
 /obj/structure/closet/walllocker/hydrant,
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
-"szT" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/west_caves)
 "szW" = (
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/urban/colony/engineering,
@@ -108167,6 +105111,9 @@
 /obj/effect/turf_decal/medical_decals/doc/stripe{
 	dir = 8
 	},
+/obj/effect/turf_decal/medical_decals/doc/stripe{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/landing_zone_1)
 "sBA" = (
@@ -108179,16 +105126,7 @@
 "sBI" = (
 /obj/effect/urban/decal/dirt,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
-"sBJ" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/meridian/meridian_office)
 "sBL" = (
 /obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
@@ -108321,10 +105259,12 @@
 /area/lv759/indoors/nt_research_complex/hangarbay)
 "sDl" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/rock/dark/stalagmite/three,
-/turf/open/urbanshale/layer1,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
 /area/lv759/indoors/caves/east_caves)
 "sDm" = (
 /obj/effect/urban/decal/road/road_edge/three,
@@ -108356,16 +105296,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/mining_outpost/vehicledeployment)
-"sDt" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
 "sDu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
@@ -108401,9 +105331,7 @@
 	pixel_x = -11;
 	pixel_y = 6
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "sDK" = (
 /obj/structure/extinguisher_cabinet,
@@ -108414,7 +105342,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
-/obj/structure/prop/urban/fakeplatforms/platform3,
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "sEb" = (
@@ -108663,9 +105590,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "sGk" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard1{
 	dir = 10;
 	layer = 8;
@@ -108800,18 +105724,6 @@
 /obj/structure/rock/dark/small/three,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
-"sHR" = (
-/obj/structure/platform_decoration/shiva{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4;
-	layer = 3.33
-	},
-/turf/open/floor/yellowthree{
-	dir = 4
-	},
-/area/lv759/indoors/spaceport/cargo)
 "sHT" = (
 /turf/open/urban/street/roadlines3,
 /area/lv759/outdoors/colony_streets/north_west_street)
@@ -108876,9 +105788,6 @@
 /turf/open/floor/urban/carpet/carpetbeigedeco,
 /area/lv759/indoors/colonial_marshals/office)
 "sIz" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/nine,
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines2,
@@ -108968,7 +105877,7 @@
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
 "sIZ" = (
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/west_caves)
 "sJd" = (
 /obj/structure/prop/urban/misc/atm{
@@ -108991,7 +105900,9 @@
 	color = "#a6aeab";
 	dir = 4
 	},
-/turf/open/floor/urban_plating,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "sJh" = (
 /obj/structure/prop/urban/misc/redmeter{
@@ -109021,9 +105932,6 @@
 /turf/open/floor/floorthree,
 /area/lv759/indoors/spaceport/security)
 "sJr" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	pixel_y = -1
 	},
@@ -109317,9 +106225,6 @@
 	},
 /area/lv759/indoors/spaceport/horizon_runner)
 "sLS" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/barricade/handrail/wire{
 	dir = 8
 	},
@@ -109347,15 +106252,6 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"sMe" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = 7
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/landing_zone_2)
 "sMg" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -109445,14 +106341,8 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "sML" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/orange_edge{
-	dir = 4
-	},
-/area/lv759/indoors/nt_research_complex/hangarbay)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "sMM" = (
 /turf/closed/shuttle/dropship4/window{
 	dir = 8
@@ -109461,7 +106351,7 @@
 "sMN" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/nt_research_complex/janitor)
 "sMP" = (
 /obj/structure/prop/urban/fakeplatforms/platform1,
 /obj/structure/largecrate/random/mini/small_case{
@@ -109474,12 +106364,6 @@
 /obj/structure/sign/safety/airlock,
 /turf/closed/wall/r_wall/bunker,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"sMY" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/caveplateau)
 "sNb" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy3{
 	dir = 8
@@ -109495,9 +106379,8 @@
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
 "sNe" = (
-/obj/machinery/light/blue,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/landing_zone_2)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/outdoors/colony_streets/central_streets)
 "sNf" = (
 /obj/structure/table/reinforced/prison,
 /obj/machinery/faxmachine,
@@ -109618,16 +106501,12 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "sOn" = (
-/obj/structure/platform_decoration{
-	dir = 8
+/obj/effect/landmark/weed_node,
+/obj/effect/urban/decal/grate{
+	dir = 1
 	},
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -21;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/turf/open/floor/bluethree,
-/area/lv759/indoors/spaceport/docking_bay_2)
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/west_caves)
 "sOt" = (
 /obj/structure/barricade/handrail/urban/handrail,
 /obj/effect/ai_node,
@@ -109787,8 +106666,10 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "sPK" = (
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/landing_zone_1)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "sPL" = (
 /obj/structure/prop/urban/misc/firehydrant{
 	dir = 1
@@ -109846,9 +106727,6 @@
 	},
 /area/lv759/indoors/derelict_ship)
 "sQs" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
 	pixel_x = -1;
@@ -110094,9 +106972,6 @@
 	name = "impact"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/obj/structure/prop/urban/vehicles/large/ambulance{
-	dir = 1
-	},
 /turf/open/floor/plating{
 	dir = 8
 	},
@@ -110175,7 +107050,9 @@
 "sSU" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/urban/street/asphalt,
+/turf/open/urban/street/sidewalkcenter{
+	dir = 1
+	},
 /area/lv759/outdoors/colony_streets/south_east_street)
 "sSY" = (
 /obj/effect/urban/decal/dirt,
@@ -110222,12 +107099,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "sTB" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/east_caves)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "sTC" = (
 /obj/structure/largecrate/random/barrel/red{
 	layer = 4
@@ -110300,7 +107175,7 @@
 /area/lv759/indoors/tcomms_northwest)
 "sTZ" = (
 /obj/effect/urban/decal/grate,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "sUf" = (
 /obj/effect/urban/decal/dirt,
@@ -110362,7 +107237,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "sUI" = (
 /obj/structure/bed/chair{
@@ -110404,14 +107279,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/hospital/icu)
-"sVc" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_y = 17
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/west_caves)
 "sVh" = (
 /obj/structure/prop/mainship/gelida/railbumper{
 	dir = 1
@@ -110592,7 +107459,7 @@
 "sWE" = (
 /obj/structure/cable,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "sWI" = (
 /obj/effect/urban/decal/dirt,
@@ -110641,17 +107508,6 @@
 	allow_construction = 0
 	},
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_north)
-"sWU" = (
-/obj/effect/urban/decal/road/road_stop/five{
-	dir = 4
-	},
-/obj/structure/largecrate/random/mini{
-	layer = 5;
-	pixel_x = -2;
-	pixel_y = 12
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "sXa" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -110691,7 +107547,7 @@
 /turf/closed/shuttle/dropship4/window{
 	dir = 8
 	},
-/area/lv759/indoors/spaceport/horizon_runner)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "sXq" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 8
@@ -110809,9 +107665,6 @@
 	},
 /area/lv759/indoors/hospital/medical_storage)
 "sYH" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
 	pixel_x = -1;
@@ -110901,7 +107754,8 @@
 /obj/machinery/light/blue{
 	dir = 1
 	},
-/turf/open/ground/sandrock,
+/obj/structure/rock/dark/small,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "sZk" = (
 /obj/structure/prop/urban/vehicles/large/van{
@@ -110948,17 +107802,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue/plate,
 /area/lv759/indoors/hospital/outgoing)
-"sZK" = (
-/obj/structure/barricade/sandbags{
-	dir = 4
-	},
-/obj/effect/urban/decal/road/road_edge/two,
-/obj/effect/urban/decal/road/lines4,
-/obj/effect/urban/decal/doubleroad/lines1{
-	pixel_x = -4
-	},
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
 "sZN" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic{
@@ -111041,18 +107884,9 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_2)
 "tau" = (
-/obj/structure/largecrate/random/mini/small_case/c{
-	layer = 3.2;
-	pixel_x = 11;
-	pixel_y = 15
-	},
-/obj/structure/largecrate/random/mini/small_case{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/effect/ai_node,
-/turf/open/engineership/engineer_floor3,
-/area/lv759/indoors/derelict_ship)
+/obj/structure/rock/dark/large/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "tav" = (
 /obj/machinery/streetlight/traffic{
 	dir = 8;
@@ -111062,7 +107896,8 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/central_streets)
 "taw" = (
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/south_west_caves)
 "tay" = (
 /turf/open/urban/street/asphalt,
@@ -111073,11 +107908,6 @@
 	},
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"taD" = (
-/obj/structure/lattice/autosmooth,
-/obj/structure/rock/dark/small/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
 "taF" = (
 /turf/open/floor/urban/metal/bluemetal1{
 	dir = 5
@@ -111116,9 +107946,6 @@
 /turf/closed/wall/urban/colony/engineering,
 /area/lv759/indoors/power_plant/gas_generators)
 "taV" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/urban/decal/road/road_edge,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -111154,7 +107981,7 @@
 /area/lv759/indoors/nt_office/supervisor)
 "tbs" = (
 /obj/structure/reagent_dispensers/fueltank/spacefuel,
-/turf/open/floor/plating,
+/turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "tbD" = (
 /obj/machinery/igniter{
@@ -111186,11 +108013,8 @@
 "tbO" = (
 /obj/machinery/meter,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation1)
 "tbS" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
 /obj/effect/urban/decal/dirt,
 /obj/structure/stairs/corner_seamless{
 	color = "#b8b8b0";
@@ -111208,13 +108032,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetpatternbrown,
 /area/lv759/indoors/apartment/eastbedroomsstorage)
-"tcp" = (
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
-	},
-/obj/structure/rock/dark/small/two,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "tct" = (
 /obj/machinery/conveyor_switch{
 	id = "cargo_landing"
@@ -111682,8 +108499,8 @@
 "tfx" = (
 /obj/effect/spawner/random/engineering/metal,
 /obj/item/stack/rods,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/turf/open/floor/prison{
+	dir = 10
 	},
 /area/lv759/indoors/caves/north_west_caves)
 "tfy" = (
@@ -111774,7 +108591,7 @@
 /obj/structure/prop/urban/engineer/engineerpillar/northwesttop,
 /obj/structure/prop/urban/engineer/engineerpillar/northwesttop,
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "tgu" = (
 /obj/structure/prop/urban/signs/high_voltage{
 	desc = null
@@ -112043,9 +108860,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "tif" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -112068,17 +108882,7 @@
 /obj/effect/urban/decal/road/lines3,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"tik" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/platform/urban/metalplatform2,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
 "tim" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -112189,7 +108993,7 @@
 "tjF" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/east_caves)
 "tjR" = (
 /turf/open/floor/tile/dark/brown3{
@@ -112331,11 +109135,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/botany/botany_mainroom)
 "tlf" = (
-/obj/effect/urban/decal/grate,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_west_caves)
 "tlg" = (
 /obj/effect/mapping_helpers/airlock_autoname,
 /obj/machinery/door/airlock/multi_tile/urban/generic,
@@ -112528,10 +109330,6 @@
 /turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/caveplateau)
 "tng" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "tnh" = (
@@ -112549,9 +109347,7 @@
 /area/lv759/indoors/spaceport/cargo)
 "tnq" = (
 /obj/structure/prop/mainship/gelida/smallwire,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/caveplateau)
 "tnx" = (
 /turf/closed/wall/urban/colony,
@@ -112560,9 +109356,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "tnG" = (
 /obj/effect/urban/decal/road/lines4,
@@ -112571,7 +109365,7 @@
 	dir = 8
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "tnM" = (
 /obj/structure/lattice/autosmooth,
 /obj/structure/largecrate/random/barrel/blue,
@@ -112632,15 +109426,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/lv759/indoors/colonial_marshals/holding_cells)
-"toA" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/electical_systems/substation1)
 "toD" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -112771,7 +109556,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "tpK" = (
-/obj/structure/platform_decoration,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
 	layer = 3.33
@@ -112835,7 +109619,7 @@
 "tpU" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/engineership/pillars/east/pillareast4,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "tpX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -113076,11 +109860,9 @@
 	},
 /area/lv759/indoors/hospital/operation)
 "trR" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/platform_decoration/urban/rockdark,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/south_west_caves)
 "trS" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/prop/urban/misc/trash/green{
@@ -113104,7 +109886,7 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "tsc" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/south_west_caves)
 "tsn" = (
 /obj/machinery/light{
@@ -113232,7 +110014,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "ttN" = (
 /obj/effect/mapping_helpers/airlock_autoname,
@@ -113407,7 +110189,6 @@
 /turf/open/floor/prison/bright_clean,
 /area/lv759/indoors/hospital/outgoing)
 "tuY" = (
-/obj/structure/barricade/handrail/urban/handrail,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/cellstripe,
@@ -113593,7 +110374,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "twt" = (
 /turf/open/floor/prison/whitegreen,
 /area/lv759/indoors/hospital/central_hallway)
@@ -113621,7 +110402,7 @@
 "twA" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/east_caves)
 "twK" = (
 /obj/effect/turf_decal/tile/corsatstraight/brown,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -113735,9 +110516,7 @@
 /area/lv759/outdoors/colony_streets/south_west_street)
 "txy" = (
 /obj/machinery/light/small/blue,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "txC" = (
 /obj/structure/rock/dark/small,
@@ -113852,15 +110631,9 @@
 /area/lv759/indoors/nt_research_complex_entrance)
 "tyJ" = (
 /obj/structure/largecrate/mule,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "tyO" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 4
-	},
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "tyU" = (
@@ -113872,11 +110645,11 @@
 	pixel_y = -1
 	},
 /turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/caves/central_caves)
+/area/lv759/indoors/derelict_ship)
 "tyX" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/floorthree,
-/area/lv759/indoors/spaceport/security_office)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "tza" = (
 /obj/item/trash/tgmc_tray,
 /obj/item/trash/cuppa_joes/lid,
@@ -113893,15 +110666,6 @@
 	},
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/central_streets)
-"tzc" = (
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/turf/open/floor/urban/metal/zbrownfloor_full,
-/area/lv759/indoors/meridian/meridian_factory)
 "tzd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -114134,11 +110898,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "tAY" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/NTmart/maintenance)
 "tBa" = (
 /turf/closed/shuttle/dropship4/damagedconsoleone,
 /area/lv759/indoors/spaceport/starglider)
@@ -114184,7 +110945,7 @@
 "tBt" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_1)
 "tBB" = (
 /obj/structure/stairs/seamless/edge{
 	color = "#a6aeab";
@@ -114222,7 +110983,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "tCd" = (
 /obj/structure/largecrate/random/secure,
@@ -114231,9 +110992,7 @@
 	pixel_x = -7;
 	pixel_y = 16
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "tCr" = (
 /obj/structure/flora/pottedplant{
@@ -114302,6 +111061,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/engineership/engineer_floor3,
 /area/lv759/indoors/derelict_ship)
 "tCW" = (
@@ -114327,11 +111087,6 @@
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/central_streets)
 "tDh" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -2
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
 	},
@@ -114379,7 +111134,7 @@
 /obj/item/stack/rods,
 /obj/effect/spawner/random/engineering/metal,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "tDL" = (
 /obj/machinery/landinglight/lz1,
@@ -114457,7 +111212,9 @@
 	color = "#a6aeab"
 	},
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/cellstripe,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "tEN" = (
 /obj/structure/barricade/handrail{
@@ -114627,7 +111384,7 @@
 /area/lv759/outdoors/colony_streets/east_central_street)
 "tFN" = (
 /obj/structure/cargo_container/gorg,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "tFQ" = (
 /obj/machinery/streetlight/street{
@@ -114805,10 +111562,6 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/prison,
 /area/lv759/indoors/power_plant/telecomms)
-"tHm" = (
-/obj/structure/prop/urban/containersextended/medicalleft,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/landing_zone_1)
 "tHn" = (
 /obj/structure/bedsheetbin,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -114872,12 +111625,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/hospital/east_hallway)
-"tHI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
 "tHJ" = (
 /obj/structure/flora/pottedplant{
 	pixel_y = 6
@@ -114912,7 +111659,7 @@
 "tHT" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/garage_reception)
 "tHU" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
@@ -114963,10 +111710,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "tIA" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "tIG" = (
@@ -114978,7 +111721,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "tIL" = (
 /obj/item/tool/wet_sign{
 	pixel_x = -8;
@@ -115080,7 +111823,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "tJC" = (
 /obj/structure/closet/crate/miningcar{
@@ -115193,9 +111936,6 @@
 "tKE" = (
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy4,
 /obj/structure/prop/urban/misc/floorprops/grate,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/power_storage)
 "tKO" = (
@@ -115205,9 +111945,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "tKP" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/machinery/conveyor,
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -115239,11 +111976,9 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_south_office)
 "tLh" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/north_west_caves_outdoors)
 "tLj" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -115367,7 +112102,7 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "tMn" = (
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "tMp" = (
 /obj/effect/urban/decal/road/lines1,
@@ -115415,11 +112150,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/power_plant/gas_generators)
 "tMM" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/indoors/caves/east_caves)
 "tMN" = (
 /obj/effect/urban/decal/trash/eleven,
 /obj/effect/urban/decal/trash/six{
@@ -115539,16 +112272,6 @@
 	dir = 10
 	},
 /area/lv759/indoors/hospital/operation)
-"tNP" = (
-/obj/item/clothing/head/warning_cone{
-	layer = 2;
-	pixel_x = -13;
-	pixel_y = 19
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/west_caves)
 "tNX" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8;
@@ -115717,9 +112440,6 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/spaceport/engineering)
 "tPt" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
 /obj/structure/platform/urban/metalplatform2,
 /obj/structure/rock/dark/stalagmite/four,
 /turf/open/urbanshale/layer1,
@@ -115764,13 +112484,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"tPU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/south_west_caves)
 "tPY" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -115790,7 +112503,7 @@
 /obj/effect/urban/decal/grate{
 	dir = 8
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "tQf" = (
 /obj/item/device/flashlight/lamp/tripod,
@@ -115965,10 +112678,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "tQY" = (
-/obj/structure/barricade/handrail/strata,
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/lines4,
 /obj/effect/urban/decal/road/road_edge/eleven,
@@ -116183,27 +112892,31 @@
 "tST" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/girder,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "tSW" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "tSX" = (
-/obj/effect/urban/decal/grate{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
 	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
-/area/lv759/indoors/caves/west_caves)
+/area/lv759/outdoors/north_west_caves_outdoors)
 "tTd" = (
 /obj/structure/platform_decoration/urban/rockdark{
 	dir = 4
 	},
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "tTe" = (
 /turf/open/urban/street/cement3,
@@ -116235,10 +112948,9 @@
 /obj/effect/urban/decal/grate{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "tTx" = (
 /obj/structure/fence/dark,
 /obj/structure/cable,
@@ -116401,7 +113113,7 @@
 	layer = 4
 	},
 /turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "tUN" = (
 /obj/structure/prop/urban/containersextended/blackwyright,
 /turf/open/urban/street/asphalt,
@@ -116552,7 +113264,7 @@
 	pixel_y = 12
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "tWw" = (
 /obj/effect/urban/decal/road/lines4,
@@ -116775,7 +113487,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "tXs" = (
 /obj/structure/prop/urban/containersextended/redleft,
 /turf/open/urban/street/sidewalk{
@@ -116862,9 +113574,6 @@
 	pixel_x = -7
 	},
 /obj/effect/decal/cleanable/generic,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -117171,9 +113880,6 @@
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "uaE" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -117192,13 +113898,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetdarkerblue,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"uaL" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "uaN" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -117433,7 +114132,7 @@
 /obj/effect/spawner/random/engineering/toolbox{
 	layer = 4
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "ucA" = (
 /obj/effect/landmark/weed_node,
@@ -117487,7 +114186,7 @@
 /obj/structure/prop/urban/misc/fake/heavydutywire/heavy2,
 /obj/structure/monorail,
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "udi" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -117612,7 +114311,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "uel" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/tiretrack{
@@ -117648,9 +114347,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/nt_office)
 "uey" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
 /obj/item/trash/trashbag{
 	pixel_x = 3;
 	pixel_y = -2
@@ -117736,7 +114432,7 @@
 "ueX" = (
 /obj/structure/girder,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "ufc" = (
 /obj/item/ammo_casing/bullet,
@@ -117994,7 +114690,7 @@
 /obj/machinery/light/blue{
 	dir = 8
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/landing_zone_2)
 "ugX" = (
 /obj/effect/urban/decal/road/road_edge/four,
@@ -118013,7 +114709,7 @@
 "uhh" = (
 /obj/structure/sign/safety/hazard,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_2)
 "uho" = (
 /turf/open/floor/urban/carpet/carpetblue,
 /area/lv759/indoors/apartment/westbedrooms)
@@ -118113,11 +114809,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4;
-	pixel_x = -2
-	},
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -118148,9 +114839,7 @@
 "uiF" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "uiH" = (
 /obj/effect/urban/decal/dirt,
@@ -118450,7 +115139,7 @@
 	layer = 1
 	},
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/east_caves)
 "ukO" = (
 /obj/structure/bed/chair{
@@ -118510,11 +115199,9 @@
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/north_street)
 "ult" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
+/obj/structure/rock/dark/large,
 /turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
+/area/lv759/indoors/caves/north_west_caves)
 "ulA" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -118629,9 +115316,11 @@
 /turf/open/floor/podhatch/floor,
 /area/lv759/indoors/nt_research_complex/mainlabs)
 "umk" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/west_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/central_caves)
 "umn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -118666,14 +115355,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/garage_workshop)
-"umH" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
 "umJ" = (
 /obj/structure/sign/safety/cryogenic,
 /turf/closed/wall/urban,
@@ -118841,7 +115522,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 1
 	},
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "unY" = (
@@ -119073,13 +115754,6 @@
 	color = "#dfcfc0"
 	},
 /area/lv759/indoors/derelict_ship)
-"upU" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
 "upX" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/blood,
@@ -119092,9 +115766,7 @@
 /obj/machinery/light/small/blue{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "uqh" = (
 /obj/machinery/door/airlock/mainship/maint,
@@ -119240,8 +115912,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/north)
 "urj" = (
-/turf/open/urbanshale/layer2,
-/area/lv759/oob)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/north_caves)
 "urk" = (
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/patient_ward)
@@ -119331,9 +116003,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "urM" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -119460,10 +116129,8 @@
 /turf/open/floor/plate,
 /area/lv759/indoors/colonial_marshals/garage)
 "usC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/caveplateau)
 "usF" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/sandrock,
@@ -119575,11 +116242,6 @@
 	dir = 6
 	},
 /area/lv759/indoors/hospital/reception)
-"utX" = (
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/south_west_caves)
 "uua" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/r_wall/white_research_wall,
@@ -119678,12 +116340,9 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "uvk" = (
-/obj/structure/prop/urban/vehicles/meridian/black{
-	pixel_y = -8
-	},
-/obj/effect/urban/decal/road/lines2,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/rock/dark/small/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "uvp" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalk{
@@ -119837,10 +116496,6 @@
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westentertainment)
 "uwD" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "uwG" = (
@@ -119926,7 +116581,6 @@
 	pixel_x = -26;
 	pixel_y = -13
 	},
-/obj/structure/prop/urban/fakeplatforms/platform3,
 /turf/open/floor/prison/ramptop{
 	dir = 4
 	},
@@ -119973,7 +116627,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "uxN" = (
 /obj/structure/cable,
@@ -120052,7 +116706,8 @@
 "uyJ" = (
 /obj/effect/urban/decal/grate,
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/urbanshale/layer0_plate,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "uyN" = (
 /obj/structure/sign/safety/maintenance,
@@ -120094,9 +116749,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "uze" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/orange_edge{
@@ -120191,12 +116843,6 @@
 "uAh" = (
 /turf/open/floor/urban/tile/tilered,
 /area/lv759/indoors/pizzaria)
-"uAk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_east_caves)
 "uAo" = (
 /obj/effect/urban/decal/dirt_2,
 /obj/item/trash/cigbutt,
@@ -120239,7 +116885,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "uAC" = (
 /obj/effect/urban/decal/road/road_edge/four,
@@ -120256,15 +116902,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/east_hallway)
-"uAH" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/lv759/indoors/mining_outpost/vehicledeployment)
 "uAK" = (
 /obj/structure/barricade/handrail/urban/road/plastic/blue,
 /obj/effect/urban/decal/road/road_stop/five,
@@ -120288,15 +116925,6 @@
 /obj/structure/largecrate/random/barrel/black,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
-"uAW" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/platform1{
-	dir = 4
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/derelict_ship)
 "uBc" = (
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/urban_plating,
@@ -120421,13 +117049,6 @@
 "uCf" = (
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/south_west_caves)
-"uCg" = (
-/obj/item/ammo_casing/bullet,
-/obj/effect/urban/decal/road/road_edge/two,
-/obj/effect/urban/decal/road/lines4,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_west_street)
 "uCj" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -120488,7 +117109,6 @@
 	dir = 4
 	},
 /obj/structure/sign/safety/laser,
-/obj/structure/window/framed/urban/junk_window,
 /turf/open/floor/plating,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "uCM" = (
@@ -120507,9 +117127,6 @@
 /turf/open/floor/plating/kutjevo,
 /area/lv759/indoors/colonial_marshals/restroom)
 "uCO" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_edge/four,
 /turf/open/urban/street/asphalt,
@@ -120522,20 +117139,6 @@
 	dir = 1
 	},
 /area/lv759/indoors/spaceport/starglider)
-"uDj" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 1;
-	layer = 7;
-	level = 7;
-	pixel_y = 12;
-	plane = -5
-	},
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/urban/street/sidewalkcenter,
-/area/lv759/outdoors/landing_zone_2)
 "uDn" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
@@ -120740,18 +117343,6 @@
 /obj/machinery/floodlight,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
-"uFh" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 8;
-	layer = 4
-	},
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/lv759/outdoors/landing_zone_2)
 "uFp" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/lines2,
@@ -120925,14 +117516,6 @@
 /obj/structure/prop/mainship/sensor_computer2/white,
 /turf/open/floor/mainship,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
-"uGy" = (
-/obj/structure/barricade/handrail/urban/handrail{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
 "uGz" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -121178,10 +117761,9 @@
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
 "uIa" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/north_caves)
 "uId" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -121249,18 +117831,11 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/outdoors/caveplateau)
 "uIR" = (
 /obj/structure/cable,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
-"uIS" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe2{
-	dir = 1
-	},
-/obj/item/trash/hotdog,
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "uIU" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/barricade/handrail/urban/road/wood/orange{
@@ -121308,9 +117883,6 @@
 /area/lv759/indoors/hospital/central_hallway)
 "uJd" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -121336,14 +117908,8 @@
 /turf/open/engineership/engineer_floor1,
 /area/lv759/indoors/derelict_ship)
 "uJH" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /obj/item/shard,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "uJI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -121432,11 +117998,9 @@
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/landing_zone_1)
 "uKb" = (
-/obj/structure/stairs,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/derelict_ship)
+/obj/structure/rock/dark/stalagmite/three,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "uKc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -121450,18 +118014,11 @@
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/rods,
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "uKi" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/shuttle/escapepod,
-/area/lv759/indoors/electical_systems/substation2)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/colony_streets/north_east_street)
 "uKk" = (
 /obj/structure/prop/urban/misc/machinery/screens/telescreen,
 /turf/closed/wall/r_wall/urban,
@@ -121473,7 +118030,7 @@
 "uKo" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "uKy" = (
 /obj/item/clothing/head/warning_cone{
@@ -121653,7 +118210,7 @@
 	},
 /obj/machinery/light/small/blue,
 /turf/open/floor/urban_plating,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "uMv" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/sign/safety/airlock,
@@ -121667,11 +118224,6 @@
 "uMF" = (
 /obj/structure/stairs/seamless{
 	color = "#6e6e6e"
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3;
-	pixel_x = 6
 	},
 /obj/structure/lattice/autosmooth,
 /obj/structure/sign/safety/hazard{
@@ -121920,12 +118472,6 @@
 /obj/item/trash/used_stasis_bag,
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
-"uOq" = (
-/obj/structure/window/framed/urban/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/colonial_marshals/press_room)
 "uOt" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/engineering/metal,
@@ -121962,7 +118508,9 @@
 "uOH" = (
 /obj/structure/cable,
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/cellstripe,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "uOO" = (
 /obj/machinery/door/poddoor/shutters/urban/security_lockdown{
@@ -121977,7 +118525,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "uOW" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
 	pixel_y = 28
@@ -122020,9 +118568,8 @@
 /turf/open/floor/urban/tile/tilebeige,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "uPs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/colony_streets/north_street)
 "uPD" = (
 /obj/structure/prop/urban/containersextended/whitewyright,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -122338,9 +118885,6 @@
 /obj/item/trash/trashbag{
 	pixel_y = 12
 	},
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/north_street)
 "uSJ" = (
@@ -122392,11 +118936,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/lv759/indoors/hospital/central_hallway)
-"uTe" = (
-/obj/effect/urban/decal/dirt,
-/obj/machinery/floodlight,
-/turf/open/urban/street/cement1,
-/area/lv759/outdoors/colony_streets/east_central_street)
 "uTf" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
@@ -122446,12 +118985,13 @@
 	pixel_x = 4;
 	pixel_y = 7
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "uTE" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/west_caves)
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/item/clothing/mask/facehugger/dead,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/north_west_caves)
 "uTG" = (
 /obj/effect/urban/decal/checkpoint_decal{
 	dir = 4;
@@ -122500,14 +119040,6 @@
 	dir = 8
 	},
 /area/lv759/indoors/spaceport/starglider)
-"uTY" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/north_street)
 "uUa" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/urban/colony,
@@ -122562,16 +119094,10 @@
 	},
 /area/lv759/indoors/nt_research_complex/hangarbay)
 "uUq" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
 /obj/machinery/light/spot/blue{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "uUs" = (
 /obj/effect/urban/decal/dirt,
@@ -122607,7 +119133,7 @@
 /area/lv759/indoors/recycling_plant_office)
 "uUx" = (
 /obj/structure/rock/dark/large/two,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/nt_research_complex_entrance)
 "uUH" = (
 /obj/effect/urban/decal/dirt,
@@ -122630,7 +119156,7 @@
 /turf/open/engineership/engineer_floor13{
 	dir = 10
 	},
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "uUO" = (
 /obj/structure/barricade/handrail/urban/handrail{
 	dir = 1
@@ -122760,7 +119286,7 @@
 /obj/structure/prop/mainship/gelida/rails{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "uWf" = (
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards/billboard1{
@@ -122771,9 +119297,6 @@
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "uWi" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/structure/barricade/handrail/wire{
 	dir = 8
 	},
@@ -122807,7 +119330,6 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "uWE" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/handrail,
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/electical_systems/substation1)
 "uWH" = (
@@ -122945,7 +119467,8 @@
 	pixel_x = 20;
 	pixel_y = 28
 	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "uXz" = (
 /obj/structure/stairs{
@@ -122962,14 +119485,6 @@
 /obj/structure/largecrate/random/mini/small_case,
 /turf/open/floor/mainship/cargo,
 /area/lv759/indoors/spaceport/baggagehandling)
-"uXQ" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
-/turf/open/urban/street/sidewalkcenter{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/north_street)
 "uXT" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/cable,
@@ -122994,9 +119509,7 @@
 "uYg" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "uYj" = (
 /obj/effect/decal/cleanable/blood{
@@ -123122,13 +119635,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "uZx" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
-	},
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
 /turf/open/floor/multi_tiles{
@@ -123170,9 +119676,6 @@
 /turf/closed/wall/r_wall/white_research_wall,
 /area/lv759/indoors/nt_research_complex/weaponresearchlabtesting)
 "uZR" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/docking_port/stationary/crashmode,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -123294,9 +119797,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "vaG" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -123520,7 +120020,7 @@
 /area/lv759/indoors/spaceport/docking_bay_1)
 "vcE" = (
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "vcF" = (
 /obj/structure/bed/chair{
 	dir = 4;
@@ -123542,12 +120042,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/colonial_marshals/armory_foyer)
-"vcG" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "vcM" = (
 /obj/structure/cable,
 /turf/open/floor/redfour,
@@ -123584,9 +120078,8 @@
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
 "vcV" = (
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/outdoors/colony_streets/central_streets)
 "vde" = (
 /obj/item/tool/mop{
 	pixel_x = -6;
@@ -123863,7 +120356,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/communications_office)
 "veS" = (
-/obj/structure/barricade/handrail/strata,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -124015,7 +120507,9 @@
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 4
 	},
-/obj/structure/window/framed/urban/junk_window,
+/obj/structure/window/framed/urban/colony/engineering{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lv759/indoors/NTmart)
 "vgq" = (
@@ -124023,12 +120517,6 @@
 	layer = 2;
 	pixel_x = -4;
 	pixel_y = 5
-	},
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 8
 	},
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
@@ -124193,14 +120681,9 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "vhM" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/caves/east_caves)
 "vhP" = (
 /obj/structure/concrete_planter/seat{
 	dir = 8;
@@ -124238,7 +120721,7 @@
 	pixel_x = -13;
 	pixel_y = 19
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "vif" = (
 /obj/machinery/light{
@@ -124324,9 +120807,6 @@
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/floor)
 "viF" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
 	layer = 3.33;
@@ -124401,7 +120881,7 @@
 "vjk" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "vjl" = (
 /obj/machinery/streetlight/street{
@@ -124457,10 +120937,6 @@
 "vjL" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/weed_node,
-/obj/structure/stairs/seamless{
-	color = "#a6aeab";
-	dir = 4
-	},
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_west_caves)
 "vjM" = (
@@ -124616,9 +121092,6 @@
 /turf/open/floor/urban/tile/asteroidfloor_bigtile,
 /area/lv759/indoors/mining_outpost/east_deploymentbay)
 "vkW" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -124831,7 +121304,7 @@
 /area/lv759/indoors/nt_security/checkpoint_northeast)
 "vmE" = (
 /obj/structure/rock/dark/stalagmite/one,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/south_west_caves)
 "vmI" = (
 /obj/machinery/streetlight/traffic{
@@ -125195,7 +121668,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_1)
 "vpx" = (
 /obj/structure/cable,
 /obj/effect/urban/decal/dirt,
@@ -125216,9 +121689,9 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "vpI" = (
-/obj/structure/rock/dark/stalagmite/two,
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "vpO" = (
 /obj/machinery/floodlight,
@@ -125244,11 +121717,6 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"vqb" = (
-/obj/effect/urban/decal/dirt,
-/obj/structure/cargo_container/ch_red,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "vqf" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/meat/monkey,
@@ -125303,17 +121771,11 @@
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
 "vqC" = (
-/obj/item/folder/black,
-/obj/structure/table/reinforced/prison,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -10;
-	pixel_y = 8
+/obj/structure/cargo_container/ch_red{
+	dir = 4
 	},
-/obj/structure/barricade/handrail/strata,
-/turf/open/floor/mainship{
-	dir = 5
-	},
-/area/lv759/indoors/nt_office/pressroom)
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/landing_zone_1)
 "vqD" = (
 /obj/structure/table,
 /obj/effect/urban/decal/dirt,
@@ -125387,9 +121849,6 @@
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/vip)
 "vrg" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -125474,12 +121933,10 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_office)
 "vrP" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "vrT" = (
 /obj/structure/closet/crate/trashcart{
 	pixel_y = 8
@@ -125609,9 +122066,8 @@
 	},
 /area/lv759/indoors/nt_research_complex/securitycommand)
 "vtj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/east_caves)
+/turf/open/floor/plating,
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "vtk" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 4
@@ -125812,7 +122268,8 @@
 /obj/structure/prop/urban/misc/buildinggreeblies/greeble5{
 	pixel_y = 12
 	},
-/turf/open/floor/plating,
+/obj/effect/urban/decal/dirt,
+/turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
 "vvr" = (
 /obj/effect/urban/decal/warningstripes_angled{
@@ -125830,17 +122287,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/derelict_ship)
-"vvv" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/yellowthree{
-	dir = 1
-	},
-/area/lv759/indoors/spaceport/cargo)
 "vvy" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/bar)
@@ -125966,14 +122412,9 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "vwE" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/platform/urban/metalplatform2{
-	dir = 1
-	},
+/obj/structure/girder,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/caves/west_caves)
 "vwH" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -125986,7 +122427,6 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/structure/bed/roller,
-/obj/item/clothing/suit,
 /turf/open/floor/plating{
 	dir = 8
 	},
@@ -126014,9 +122454,6 @@
 /turf/open/floor/prison/whitered,
 /area/lv759/indoors/hospital/operation)
 "vxf" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/lattice/autosmooth,
 /turf/open/floor/prison{
 	dir = 4
@@ -126262,7 +122699,7 @@
 "vzo" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "vzr" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/red{
@@ -126290,15 +122727,14 @@
 /area/lv759/indoors/spaceport/cargo)
 "vzy" = (
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "vzN" = (
 /obj/effect/urban/decal/engineership_corners{
 	dir = 8
 	},
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/engineership/engineer_floor3,
 /area/lv759/indoors/derelict_ship)
 "vzQ" = (
@@ -126352,11 +122788,8 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
 "vAB" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
-	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "vAC" = (
 /obj/effect/urban/decal/dirt,
@@ -126395,8 +122828,9 @@
 /turf/open/floor/urban/tile/darkgrey_bigtile,
 /area/lv759/indoors/hospital/morgue)
 "vAJ" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/urbanshale/layer2,
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "vAO" = (
 /obj/structure/barricade/handrail/urban/handrail{
@@ -126666,17 +123100,11 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_street)
-"vDh" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/spaceport/docking_bay_2)
 "vDk" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "vDm" = (
 /obj/item/stack/sheet/cardboard{
 	layer = 1
@@ -126758,9 +123186,6 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/meridian/meridian_office)
 "vDU" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/urban/metal/grated{
 	dir = 4
@@ -126768,9 +123193,6 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "vDV" = (
 /obj/effect/turf_decal/warning_stripes/thin,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/machinery/power/apc/drained{
 	dir = 1
 	},
@@ -127160,11 +123582,12 @@
 /turf/open/floor/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "vHx" = (
-/obj/structure/platform_decoration{
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 8
 	},
-/turf/open/floor/mainship/tcomms,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "vHz" = (
 /obj/structure/prop/urban/misc/buildinggreebliessmall3{
 	pixel_y = 28
@@ -127236,9 +123659,9 @@
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/colonial_marshals/holding_cells)
 "vHW" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/structure/rock/dark/wide/two,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/south_west_caves)
 "vIc" = (
 /obj/effect/urban/decal/tiretrack{
 	dir = 1;
@@ -127297,9 +123720,7 @@
 	layer = 4;
 	pixel_x = 4
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "vIC" = (
 /obj/structure/prop/urban/containersextended/greywyright,
@@ -127367,12 +123788,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/indoors/nt_security/checkpoint_west)
 "vJb" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 1
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/effect/landmark/weed_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "vJc" = (
 /obj/item/trash/trashbag{
 	pixel_x = 2;
@@ -127515,11 +123933,9 @@
 /turf/open/floor/urban/tile/greenfull_bigtile,
 /area/lv759/indoors/botany/botany_greenhouse)
 "vKq" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
+/obj/effect/ai_node,
 /turf/open/urbanshale/layer0_plate,
-/area/lv759/indoors/caves/south_west_caves)
+/area/lv759/outdoors/north_west_caves_outdoors)
 "vKt" = (
 /obj/machinery/light/spot/blue,
 /obj/machinery/light/spot/blue{
@@ -127862,18 +124278,9 @@
 /turf/open/urban/street/roadlines4,
 /area/lv759/outdoors/colony_streets/south_east_street)
 "vNw" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8;
-	layer = 3.3
-	},
-/obj/item/device/flashlight/lamp/tripod/grey,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/effect/acid_hole,
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/garage_workshop_storage)
 "vNB" = (
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 4
@@ -128035,7 +124442,7 @@
 	pixel_y = 2
 	},
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "vOQ" = (
 /obj/structure/prop/urban/vehicles/large/ambulance{
@@ -128061,10 +124468,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/blue,
 /area/lv759/indoors/hospital/outgoing)
-"vPa" = (
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_1)
 "vPn" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/catwalk,
@@ -128075,7 +124478,6 @@
 	pixel_x = -9;
 	pixel_y = 20
 	},
-/obj/structure/barricade/handrail/strata,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -128108,12 +124510,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/engineership/engineer_floor3,
 /area/lv759/indoors/derelict_ship)
-"vPP" = (
-/obj/machinery/floodlight,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_east_caves)
 "vPQ" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -128127,15 +124526,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/nt_office/pressroom)
-"vQa" = (
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/engineership/engineer_floor9,
-/area/lv759/oob)
 "vQe" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/ashtray/plastic{
@@ -128212,9 +124602,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/xenobiology)
 "vQw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/central_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/caves/east_caves)
 "vQA" = (
 /obj/item/clothing/head/warning_cone{
 	pixel_x = -4;
@@ -128231,10 +124620,8 @@
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
 "vQB" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/obj/effect/landmark/weed_node,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_caves)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/mining_outpost/processing)
 "vQF" = (
 /turf/open/floor/urban/tile/beige_bigtile,
 /area/lv759/indoors/power_plant/workers_canteen)
@@ -128261,7 +124648,7 @@
 "vQL" = (
 /obj/structure/largecrate/random/case/double,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/marked,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "vQM" = (
 /obj/structure/sink{
@@ -128281,12 +124668,6 @@
 	dir = 10
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
-"vQO" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
 "vQQ" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
@@ -128305,7 +124686,7 @@
 	pixel_x = -4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "vRc" = (
 /obj/structure/window/framed/urban/reinforced{
 	dir = 4
@@ -128316,9 +124697,15 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/bar/bathroom)
 "vRj" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
+/obj/structure/largecrate/random/barrel/black{
+	pixel_x = -6
+	},
+/obj/structure/largecrate/random/barrel/black{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "vRk" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -128370,12 +124757,6 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "vRE" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
 /obj/item/tool/pickaxe{
 	pixel_y = -3
 	},
@@ -128406,9 +124787,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "vRX" = (
 /obj/structure/barricade/handrail/strata{
@@ -128431,7 +124810,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/urban_plating,
-/area/lv759/oob)
+/area/lv759/indoors/caves/west_caves)
 "vSi" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/urbanshale/layer1,
@@ -128490,12 +124869,6 @@
 "vSB" = (
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
-"vSE" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/central_caves)
 "vSF" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/silver,
@@ -128557,7 +124930,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "vSR" = (
 /turf/open/floor/prison,
@@ -128570,10 +124943,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"vTi" = (
-/obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "vTo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -128620,13 +124989,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/reception)
 "vTI" = (
-/obj/structure/prop/mainship/gelida/smallwire{
-	dir = 8
-	},
-/obj/structure/prop/mainship/gelida/smallwire,
-/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/rock/dark/stalagmite/four,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/east_caves)
 "vTL" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -128701,11 +125066,9 @@
 	},
 /area/lv759/indoors/caves/south_west_caves)
 "vUg" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "vUo" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -129058,7 +125421,7 @@
 /obj/item/stack/rods,
 /obj/structure/grille,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "vWP" = (
 /obj/structure/table/reinforced,
@@ -129066,9 +125429,6 @@
 /turf/open/floor/urban/metal/greenmetalfull,
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "vWS" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter{
@@ -129079,9 +125439,7 @@
 /obj/structure/cable,
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "vWW" = (
 /obj/effect/urban/decal/road/road_stop/five{
@@ -129183,9 +125541,6 @@
 /turf/open/floor/officesquares,
 /area/lv759/indoors/recycling_plant_waste_disposal_incinerator)
 "vXD" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4
-	},
 /obj/effect/urban/decal/road/road_edge/eleven,
 /obj/effect/urban/decal/road/lines3,
 /obj/effect/urban/decal/road/lines4,
@@ -129290,7 +125645,7 @@
 	pixel_y = 4
 	},
 /obj/structure/largecrate/random/barrel/red,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "vYz" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -129389,7 +125744,6 @@
 	pixel_x = -5;
 	pixel_y = 9
 	},
-/obj/item/lightstick/anchored,
 /turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "vZi" = (
@@ -129401,19 +125755,7 @@
 	dir = 8
 	},
 /area/lv759/indoors/southwest_public_restroom)
-"vZk" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 4;
-	layer = 4
-	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/east_central_street)
 "vZn" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -129480,9 +125822,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/central_caves)
 "vZT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -129522,7 +125862,7 @@
 /area/lv759/indoors/power_plant/telecomms)
 "wad" = (
 /obj/structure/rock/dark/large/three,
-/turf/open/urbanshale/layer1,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "wag" = (
 /obj/effect/urban/decal/doubleroad/lines2{
@@ -129531,9 +125871,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "wah" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -129563,12 +125900,12 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
 "waF" = (
-/obj/structure/platform_decoration{
-	dir = 1
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/urban_plating,
-/area/lv759/indoors/power_plant/fusion_generators)
+/obj/structure/prop/urban/fakeplatforms/rockplatform,
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/east_caves)
 "waL" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/prison/blue,
@@ -129866,9 +126203,7 @@
 "wdm" = (
 /obj/item/stack/sheet/wood,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "wdn" = (
 /turf/open/urbanshale/layer1,
@@ -129987,7 +126322,7 @@
 	pixel_x = 4
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/lv759/oob)
+/area/lv759/indoors/electical_systems/substation2)
 "weq" = (
 /obj/structure/prop/urban/fakeplatforms/platform1{
 	dir = 8
@@ -130056,7 +126391,7 @@
 "wfm" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/ground/sandrock,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "wfn" = (
 /obj/structure/platform_decoration/urban/metalplatformdeco3{
@@ -130108,21 +126443,15 @@
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2
 	},
-/obj/structure/window/framed/urban/junk_window,
+/obj/structure/window/framed/urban/colony/engineering{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lv759/indoors/NTmart)
 "wfD" = (
 /obj/effect/urban/decal/dirt,
 /turf/open/floor/urban/carpet/carpetgreendeco,
 /area/lv759/indoors/jacks_surplus)
-"wfI" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3;
-	pixel_x = 6
-	},
-/turf/open/floor/prison,
-/area/lv759/outdoors/landing_zone_1)
 "wfN" = (
 /obj/effect/urban/decal/road/road_edge,
 /obj/effect/urban/decal/road/lines1,
@@ -130273,7 +126602,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/barricade/handrail/urban/handrail,
 /turf/open/floor/prison/cellstripe,
 /area/lv759/indoors/electical_systems/substation1)
 "wgX" = (
@@ -130521,13 +126849,6 @@
 /obj/structure/sign/safety/blast_door,
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
-"wji" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/platform/urban/metalplatform2,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
 "wjo" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -130604,15 +126925,6 @@
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
-"wjU" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/shuttle/escapepod,
-/area/lv759/indoors/electical_systems/substation2)
 "wke" = (
 /obj/machinery/power/terminal,
 /obj/effect/ai_node,
@@ -130909,11 +127221,9 @@
 /turf/open/floor/spiralplate,
 /area/lv759/outdoors/colony_streets/central_streets)
 "wmo" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/colony_streets/north_street)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "wmr" = (
 /obj/structure/barricade/handrail/kutjevo,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -131020,11 +127330,8 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
 "wne" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/obj/structure/rock/dark/stalagmite,
-/turf/open/urbanshale/layer1,
+/obj/structure/rock/dark/small/three,
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/north_caves)
 "wng" = (
 /obj/structure/bed/roller/hospital_empty/bigrollerempty2{
@@ -131043,12 +127350,6 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/north_west_street)
-"wnt" = (
-/obj/structure/prop/mainship/gelida/rails{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/east_caves)
 "wnD" = (
 /obj/effect/urban/decal/trash/five,
 /turf/open/urban/street/sidewalk,
@@ -131130,12 +127431,13 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "woq" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "wos" = (
 /obj/effect/urban/decal/road/lines1,
 /obj/effect/urban/decal/road/lines2,
@@ -131199,7 +127501,7 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/vehicledeployment)
 "woR" = (
-/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison{
 	dir = 5
 	},
@@ -131229,11 +127531,12 @@
 /turf/open/floor/squares,
 /area/lv759/indoors/nt_research_complex/cafeteria)
 "wpf" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
+/obj/structure/platform_decoration/urban/rockdark{
+	dir = 8
 	},
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/outdoors/caveplateau)
 "wph" = (
 /obj/item/trash/trashbag{
 	pixel_x = 2;
@@ -131285,9 +127588,7 @@
 /area/lv759/indoors/spaceport/heavyequip)
 "wpK" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer0_plate,
 /area/lv759/indoors/caves/west_caves)
 "wpL" = (
 /obj/structure/table,
@@ -131400,7 +127701,7 @@
 "wqQ" = (
 /obj/effect/spawner/random/misc/structure/girder,
 /turf/open/urbanshale/layer1,
-/area/lv759/oob)
+/area/lv759/indoors/southwest_public_restroom)
 "wqZ" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalk{
@@ -131565,7 +127866,7 @@
 "wst" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "wsv" = (
 /turf/open/floor/carpet,
@@ -131673,9 +127974,6 @@
 	},
 /area/lv759/indoors/power_plant/south_hallway)
 "wtF" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
 	pixel_y = 2
@@ -131756,7 +128054,7 @@
 "wup" = (
 /obj/structure/sign/safety/laser,
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "wuy" = (
 /obj/structure/platform_decoration/metalplatform_deco{
 	dir = 4
@@ -131851,10 +128149,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk,
 /area/lv759/outdoors/colony_streets/north_west_street)
-"wvl" = (
-/obj/item/lightstick/anchored,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/west_caves)
 "wvm" = (
 /obj/structure/stairs{
 	color = "#a6aeab";
@@ -132023,8 +128317,8 @@
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "wxj" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/central_caves)
 "wxo" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -132093,11 +128387,6 @@
 /obj/effect/urban/decal/trash/two,
 /turf/open/floor/urban/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_flight_control_room)
-"wxR" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
 "wxS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -132129,17 +128418,14 @@
 /turf/open/floor/urban/tile/tilegrey,
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "wyb" = (
-/obj/structure/prop/mainship/gelida/miner,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 1
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/obj/machinery/floodlight/colony,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "wyd" = (
 /obj/effect/urban/decal/grate{
 	dir = 4
 	},
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "wyn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -132419,7 +128705,6 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/hospital/paramedics_garage)
 "wAN" = (
-/obj/structure/platform_decoration,
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4;
@@ -132524,7 +128809,7 @@
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "wBR" = (
-/obj/structure/barricade/handrail/strata,
+/obj/structure/largecrate/random,
 /turf/open/floor/plating/plating_catwalk{
 	color = "#dfcfc0"
 	},
@@ -132774,10 +129059,9 @@
 "wDp" = (
 /obj/machinery/floodlight,
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "wDq" = (
-/obj/structure/barricade/handrail/strata,
 /obj/structure/sign/safety/hazard{
 	dir = 8
 	},
@@ -132821,9 +129105,8 @@
 /turf/open/floor/officetiles,
 /area/lv759/indoors/nt_research_complex/vehicledeploymentbay)
 "wDF" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/caveplateau)
 "wDG" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -132862,11 +129145,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/urban_wood,
 /area/lv759/indoors/apartment/westentertainment)
-"wDZ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/central_caves)
 "wEb" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/clothing/head/warning_cone{
@@ -133250,9 +129528,7 @@
 /obj/structure/largecrate/random/barrel/black{
 	layer = 2
 	},
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "wHw" = (
 /obj/effect/urban/decal/road/road_edge/three,
@@ -133284,9 +129560,6 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/north_street)
 "wHK" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 1
-	},
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalk{
@@ -133294,9 +129567,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "wHN" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
 	},
@@ -133391,14 +129661,8 @@
 "wIM" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/ai_node,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
-"wIN" = (
-/obj/structure/platform/urban/metalplatform2{
-	dir = 8
-	},
 /turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/caves/north_caves)
 "wIO" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/ore_box,
@@ -133556,12 +129820,6 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/lv759/indoors/bar/bathroom)
-"wKt" = (
-/obj/structure/barricade/handrail/urban/handrail,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "wKu" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/floorthree,
@@ -133910,12 +130168,10 @@
 	},
 /area/lv759/indoors/hospital/virology)
 "wMR" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/kutjevo/colors/orange,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "wMV" = (
 /turf/open/floor/urban/metal/zbrownfloor1{
 	dir = 5
@@ -134185,9 +130441,6 @@
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
 "wPK" = (
-/obj/structure/platform_decoration/urban/metalplatformdeco1{
-	dir = 8
-	},
 /obj/effect/urban/decal/dirt,
 /obj/machinery/streetlight/street{
 	level = 7;
@@ -134202,11 +130455,8 @@
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/lv759/indoors/nt_research_complex/medical_annex)
 "wPV" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/caves/north_caves)
 "wPY" = (
 /obj/structure/table/reinforced/prison,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -134372,12 +130622,8 @@
 /turf/open/floor/marked,
 /area/lv759/indoors/nt_research_complex/hangarbayshuttle)
 "wQY" = (
-/obj/structure/stairs/seamless/edge{
-	color = "#a6aeab";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/kutjevo,
+/area/lv759/indoors/hobosecret)
 "wRa" = (
 /obj/structure/lattice/autosmooth,
 /obj/item/trash/cigbutt{
@@ -134395,12 +130641,9 @@
 "wRe" = (
 /obj/structure/girder,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "wRh" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/structure/prop/urban/billboardsandsigns/bigbillboards{
 	dir = 4;
 	layer = 8;
@@ -134496,10 +130739,6 @@
 	dir = 9
 	},
 /area/lv759/outdoors/colony_streets/south_east_street)
-"wRO" = (
-/obj/item/tool/shovel,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/central_caves)
 "wRP" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -134747,11 +130986,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "wTG" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/lv759/indoors/spaceport/docking_bay_1)
+/obj/effect/acid_hole,
+/turf/closed/wall/urban/colony/engineering,
+/area/lv759/outdoors/colony_streets/central_streets)
 "wTH" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison{
@@ -134994,10 +131231,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/cuppajoes)
 "wWe" = (
-/obj/structure/stairs/seamless{
-	color = "#6e6e6e";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
 	dir = 4
@@ -135107,10 +131340,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/lv759/indoors/spaceport/docking_bay_1)
-"wXm" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/lv759/indoors/colonial_marshals/south_maintenance)
 "wXo" = (
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/full,
@@ -135232,10 +131461,6 @@
 	},
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
-/obj/structure/stairs{
-	color = "#a6aeab";
-	dir = 1
-	},
 /turf/open/floor/prison,
 /area/lv759/indoors/caves/central_caves)
 "wYy" = (
@@ -135381,9 +131606,6 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "wZB" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/structure/prop/urban/lattice_prop/lattice_6{
 	pixel_y = 16
 	},
@@ -135421,10 +131643,6 @@
 	},
 /turf/closed/wall/r_wall/urban,
 /area/lv759/indoors/nt_research_complex/reception)
-"wZN" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/turf/open/ground/sandrock,
-/area/lv759/indoors/caves/north_west_caves)
 "wZS" = (
 /obj/structure/bed/chair{
 	pixel_x = 3;
@@ -135484,7 +131702,7 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "xaL" = (
 /obj/effect/urban/decal/dirt,
@@ -135589,7 +131807,7 @@
 "xbX" = (
 /obj/structure/sign/safety/airlock,
 /turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/area/lv759/indoors/caves/east_caves)
 "xcc" = (
 /obj/structure/barricade/handrail/urban/handrail,
 /turf/open/floor/plating/plating_catwalk{
@@ -135817,7 +132035,7 @@
 "xdq" = (
 /obj/structure/prop/urban/engineer/engineerpillar/northwesttop,
 /turf/closed/wall/r_wall/engineership,
-/area/lv759/oob)
+/area/lv759/indoors/derelict_ship)
 "xds" = (
 /obj/effect/urban/decal/road/road_edge/three,
 /obj/effect/urban/decal/road/lines3,
@@ -135825,11 +132043,14 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/central_streets)
 "xdu" = (
-/obj/structure/stairs{
-	color = "#a6aeab"
+/obj/structure/closet/crate/miningcar{
+	layer = 3
 	},
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/prop/mainship/gelida/rails{
+	dir = 8
+	},
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/north_caves)
 "xdv" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/turf_decal/medical_decals/doc/stripe{
@@ -135869,10 +132090,6 @@
 	dir = 4;
 	pixel_x = 1;
 	pixel_y = -1
-	},
-/obj/structure/barricade/handrail/strata{
-	dir = 8;
-	layer = 3
 	},
 /turf/open/floor/mainship/black/full,
 /area/lv759/indoors/power_plant/power_storage)
@@ -136071,7 +132288,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "xfn" = (
 /turf/closed/shuttle/dropship4/window,
-/area/lv759/indoors/spaceport/horizon_runner)
+/area/lv759/indoors/spaceport/docking_bay_2)
 "xfq" = (
 /obj/machinery/door_control{
 	id = "hybrisacheckpoint_east";
@@ -136353,9 +132570,6 @@
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
 "xhD" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -136470,9 +132684,13 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "xix" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/platform_decoration,
-/turf/open/urbanshale/layer0_plate,
+/obj/structure/closet/crate/science,
+/obj/effect/spawner/random/medical/pillbottle,
+/obj/item/storage/box/lightstick/red{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "xiy" = (
 /obj/item/tool/wet_sign{
@@ -136641,10 +132859,6 @@
 	},
 /turf/open/floor/wood,
 /area/lv759/indoors/hospital/cmo_office)
-"xjI" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
 "xkb" = (
 /obj/machinery/computer/marine_card,
 /obj/structure/table/black,
@@ -136667,10 +132881,9 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/power_plant/fusion_generators)
 "xki" = (
-/obj/item/stack/rods,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/lv759/indoors/caves/north_caves)
+/obj/structure/rock/dark/stalagmite/five,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/nt_research_complex_entrance)
 "xkj" = (
 /obj/machinery/light{
 	dir = 1
@@ -136699,7 +132912,7 @@
 /obj/effect/urban/decal/grate{
 	dir = 1
 	},
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "xkz" = (
@@ -136734,7 +132947,7 @@
 /area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "xld" = (
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer2,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "xlf" = (
 /obj/structure/cable,
@@ -136769,7 +132982,7 @@
 	dir = 4
 	},
 /turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
+/area/lv759/outdoors/landing_zone_1)
 "xlt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetblue,
@@ -136799,15 +133012,15 @@
 /turf/open/urban/street/cement3,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "xlO" = (
-/obj/effect/ai_node,
-/turf/open/urbanshale/layer2,
-/area/lv759/indoors/caves/north_caves)
+/obj/effect/urban/decal/road/lines5,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "xlQ" = (
 /obj/structure/prop/urban/signs/high_voltage/small{
 	pixel_x = 6
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/caves/central_caves)
 "xlS" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -136835,8 +133048,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "xlZ" = (
 /obj/item/stack/rods,
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "xmc" = (
 /obj/structure/prop/urban/misc/fake/wire/blue{
@@ -136855,7 +133067,7 @@
 /area/lv759/indoors/nt_research_complex/hallwaysouthwest)
 "xmq" = (
 /obj/item/stack/rods,
-/turf/open/urbanshale/layer2,
+/turf/open/floor/plating,
 /area/lv759/indoors/colonial_marshals/south_maintenance)
 "xms" = (
 /obj/machinery/light/small{
@@ -136946,11 +133158,10 @@
 /turf/open/engineership/engineer_floor9,
 /area/lv759/indoors/derelict_ship)
 "xnl" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/black_stone/indestructible,
-/area/lv759/oob)
+/obj/effect/urban/decal/road/lines2,
+/obj/effect/urban/decal/road/road_edge/four,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "xno" = (
 /obj/structure/filingcabinet/nondense{
 	layer = 3.1;
@@ -137064,22 +133275,18 @@
 "xoe" = (
 /obj/effect/landmark/weed_node,
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
-"xof" = (
-/obj/structure/platform_decoration/urban/rockdark,
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/area/lv759/indoors/caves/central_caves)
 "xol" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/east)
 "xor" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/lattice/autosmooth,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison{
+	dir = 10
+	},
+/area/lv759/outdoors/north_west_caves_outdoors)
 "xos" = (
 /obj/structure/closet,
 /turf/open/floor/mainship{
@@ -137213,13 +133420,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/urban/carpet/carpetgreen,
 /area/lv759/indoors/apartment/eastbedrooms)
-"xpz" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 8
-	},
-/obj/structure/rock/dark/stalagmite/four,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/east_caves)
 "xpB" = (
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall/urban,
@@ -137491,21 +133691,22 @@
 	},
 /area/lv759/indoors/hospital/central_hallway)
 "xrP" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/obj/item/stack/rods,
+/turf/open/ground/sandrock,
+/area/lv759/indoors/colonial_marshals/prisoners_recreation_area)
 "xrT" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/spaceport/cargo)
 "xsf" = (
-/turf/open/engineership/engineer_floor13{
-	dir = 10
+/obj/structure/prop/urban/misc/redmeter{
+	light_color = "#FF004A";
+	light_on = 1;
+	light_range = 2
 	},
-/area/lv759/oob)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/spaceport/security)
 "xsg" = (
-/obj/structure/platform_decoration,
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/prison{
 	dir = 4
@@ -137652,7 +133853,9 @@
 	color = "#a6aeab"
 	},
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/cellstripe,
+/turf/open/floor/prison{
+	dir = 10
+	},
 /area/lv759/indoors/nt_research_complex_entrance)
 "xts" = (
 /obj/effect/urban/decal/dirt,
@@ -137760,9 +133963,8 @@
 /turf/open/floor/urban/wood/blackwood,
 /area/lv759/indoors/nt_office/vip)
 "xun" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/indoors/electical_systems/substation1)
 "xup" = (
 /obj/effect/spawner/random/weaponry/ammo/rifle,
 /obj/structure/barricade/metal/deployable{
@@ -137791,14 +133993,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetblack,
 /area/lv759/indoors/casino)
-"xuy" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/effect/urban/decal/dirt,
-/turf/open/urban/street/cement3,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "xuz" = (
 /obj/structure/platform_decoration/urban/metalplatformdeco2{
 	dir = 8
@@ -137894,7 +134088,7 @@
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "xvm" = (
 /obj/machinery/light,
@@ -137937,11 +134131,13 @@
 /turf/open/ground/sandrock,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "xvy" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 8
+/obj/effect/urban/decal/road/lines1,
+/obj/effect/urban/decal/road/road_edge,
+/obj/effect/urban/decal/road/road_stop/five{
+	dir = 4
 	},
-/turf/open/ground/sandrock,
-/area/lv759/outdoors/north_west_caves_outdoors)
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "xvA" = (
 /obj/effect/turf_decal/medical_decals/doc/stripe,
 /obj/structure/cable,
@@ -138056,9 +134252,7 @@
 "xwH" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/girder,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "xwO" = (
 /obj/structure/table,
@@ -138118,7 +134312,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/urbanshale/layer1,
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
+	},
 /area/lv759/indoors/caves/north_west_caves)
 "xxq" = (
 /obj/structure/prop/urban/misc/firehydrant{
@@ -138126,19 +134322,6 @@
 	},
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/central_streets)
-"xxs" = (
-/obj/effect/urban/decal/dirt,
-/obj/item/clothing/head/warning_cone{
-	pixel_x = -13;
-	pixel_y = 11
-	},
-/obj/structure/barricade/handrail/urban/road/plastic/red{
-	dir = 4
-	},
-/turf/open/urban/street/sidewalk{
-	dir = 4
-	},
-/area/lv759/outdoors/colony_streets/south_east_street)
 "xxw" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/urban,
@@ -138148,7 +134331,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/smooth/black_stone,
-/area/lv759/oob)
+/area/lv759/indoors/caves/south_west_caves)
 "xxJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -138317,10 +134500,10 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
 "xzl" = (
-/obj/structure/prop/urban/misc/fake/pipes/pipe1,
-/obj/item/trash/crushed_bottle/sixpackcrushed_1,
-/turf/open/floor/officetiles,
-/area/lv759/outdoors/colony_streets/south_east_street)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/urbanshale/layer1,
+/area/lv759/outdoors/caveplateau)
 "xzn" = (
 /obj/structure/stairs{
 	color = "#a6aeab"
@@ -138346,7 +134529,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_east_caves)
 "xzv" = (
 /obj/effect/urban/decal/dirt,
@@ -138545,9 +134728,7 @@
 /area/lv759/indoors/nt_office)
 "xBm" = (
 /obj/structure/prop/urban/containersextended/whitewyleft,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/west_caves)
 "xBG" = (
 /obj/structure/largecrate/random{
@@ -138573,7 +134754,7 @@
 "xBQ" = (
 /obj/structure/ore_box,
 /obj/structure/cable,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "xBS" = (
 /obj/effect/urban/decal/dirt,
@@ -138642,9 +134823,7 @@
 /area/lv759/outdoors/landing_zone_2)
 "xCz" = (
 /obj/structure/cable,
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_east_caves)
 "xCB" = (
 /obj/machinery/power/apc/drained{
@@ -138689,7 +134868,6 @@
 /turf/open/floor/urban/carpet/carpetfadedred,
 /area/lv759/indoors/apartment/northapartments)
 "xDh" = (
-/obj/item/lightstick/anchored,
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
 /obj/structure/prop/urban/fakeplatforms/rockplatform{
 	dir = 8
@@ -138706,9 +134884,7 @@
 	dir = 1;
 	pixel_y = 22
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "xDz" = (
 /obj/structure/table,
@@ -138772,9 +134948,6 @@
 /area/lv759/outdoors/colony_streets/north_east_street)
 "xDY" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -138789,14 +134962,13 @@
 /obj/structure/prop/urban/misc/buildinggreebliessmall{
 	pixel_y = 28
 	},
-/turf/open/urbanshale/layer2,
+/obj/structure/rock/dark/stalagmite/two,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "xEq" = (
-/obj/structure/platform_decoration/urban/rockdark{
-	dir = 4
-	},
-/turf/open/ground/sandrock,
-/area/lv759/indoors/nt_research_complex_entrance)
+/obj/effect/ai_node,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/west_caves)
 "xEs" = (
 /turf/open/floor/tile/dark/brown3{
 	dir = 9
@@ -138959,6 +135131,9 @@
 /obj/effect/turf_decal/medical_decals/doc/stripe{
 	dir = 8
 	},
+/obj/effect/turf_decal/medical_decals/doc/stripe{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/lv759/outdoors/landing_zone_1)
 "xFl" = (
@@ -139081,10 +135256,8 @@
 "xFY" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/platform_decoration/urban/rockdark,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/urbanshale/layer1,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/ground/sandrock,
 /area/lv759/outdoors/north_west_caves_outdoors)
 "xGm" = (
 /obj/structure/sign/safety/laser,
@@ -139164,10 +135337,6 @@
 /obj/structure/cable,
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
-"xGV" = (
-/obj/structure/window/framed/urban/reinforced,
-/turf/open/floor/plating,
-/area/lv759/indoors/colonial_marshals/holding_cells)
 "xGX" = (
 /obj/structure/lattice/autosmooth,
 /obj/effect/landmark/weed_node,
@@ -139187,7 +135356,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/outdoors/landing_zone_2)
 "xHt" = (
 /obj/machinery/light{
 	dir = 8
@@ -139229,7 +135398,7 @@
 	pixel_x = 2
 	},
 /turf/closed/wall/r_wall/urban,
-/area/lv759/oob)
+/area/lv759/indoors/spaceport/security)
 "xHB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -139299,10 +135468,6 @@
 	dir = 4
 	},
 /area/lv759/indoors/colonial_marshals/prisoners_foyer)
-"xIe" = (
-/obj/structure/largecrate/random/barrel/black,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/north_east_street)
 "xIg" = (
 /turf/open/floor/plating,
 /area/lv759/indoors/NTmart/backrooms)
@@ -139391,12 +135556,6 @@
 /obj/structure/closet/crate/secure/ammo,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_west_street)
-"xIQ" = (
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/lv759/indoors/colonial_marshals/press_room)
 "xIT" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1;
@@ -139422,13 +135581,12 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "xJf" = (
 /obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/kutjevo,
 /area/lv759/outdoors/caveplateau)
 "xJg" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/caveplateau)
+/turf/closed/wall/r_wall/urban,
+/area/lv759/indoors/south_public_restroom)
 "xJi" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 1
@@ -139546,14 +135704,14 @@
 /obj/item/tool/shovel{
 	pixel_y = 12
 	},
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "xKe" = (
 /obj/effect/urban/decal/grate{
 	dir = 1
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/urbanshale/layer0_plate,
+/turf/open/urbanshale/layer1,
 /area/lv759/outdoors/caveplateau)
 "xKf" = (
 /obj/structure/sign/poster,
@@ -139573,9 +135731,6 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/caves/west_caves)
 "xKt" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -139613,13 +135768,9 @@
 /turf/open/urban/street/cement2,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "xKA" = (
-/obj/structure/prop/urban/fakeplatforms/rockplatform,
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4
-	},
-/obj/structure/rock/dark/stalagmite/one,
+/obj/structure/rock/dark/small,
 /turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/north_caves)
+/area/lv759/indoors/caves/north_west_caves)
 "xKG" = (
 /obj/structure/prop/urban/containersextended/redleft,
 /turf/open/floor/urban/metal/zbrownfloor1{
@@ -139755,14 +135906,14 @@
 "xLF" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/dirt,
+/obj/structure/girder,
 /turf/open/ground/sandrock,
 /area/lv759/indoors/caves/central_caves)
 "xLG" = (
-/obj/structure/barricade/handrail/strata{
-	layer = 3.1
-	},
-/turf/open/urbanshale/layer2,
-/area/lv759/outdoors/colony_streets/east_central_street)
+/obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/ground/sandrock,
+/area/lv759/outdoors/landing_zone_2)
 "xLH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -139988,9 +136139,6 @@
 /obj/effect/urban/decal/dirt,
 /obj/effect/decal/cleanable/generic,
 /obj/structure/barricade/handrail/urban/road/plastic/red,
-/obj/structure/barricade/sandbags{
-	dir = 1
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -140050,13 +136198,9 @@
 /turf/open/floor/marked,
 /area/lv759/outdoors/colony_streets/north_street)
 "xOI" = (
-/obj/item/device/flashlight/lamp/tripod/grey,
-/obj/structure/largecrate/random/mini/small_case/c{
-	pixel_x = 11;
-	pixel_y = 15
-	},
-/turf/open/engineership/engineer_floor3,
-/area/lv759/indoors/derelict_ship)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/south_west_caves)
 "xOJ" = (
 /obj/structure/platform_decoration/urban/engineer_corner{
 	dir = 4
@@ -140163,11 +136307,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/landing_zone_2)
 "xPp" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/plating_catwalk{
-	color = "#dfcfc0"
-	},
-/area/lv759/indoors/caves/central_caves)
+/obj/effect/urban/decal/road/road_stop/one,
+/turf/open/urban/street/asphalt,
+/area/lv759/outdoors/landing_zone_1)
 "xPs" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/trash/cigbutt{
@@ -140321,11 +136463,8 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_2)
 "xQu" = (
-/obj/structure/rock/dark/small{
-	layer = 4
-	},
-/turf/open/urbanshale/layer1,
-/area/lv759/outdoors/landing_zone_2)
+/turf/closed/mineral/smooth/black_stone,
+/area/lv759/outdoors/colony_streets/east_central_street)
 "xQB" = (
 /obj/item/stack/rods,
 /obj/effect/urban/decal/dirt,
@@ -140874,7 +137013,7 @@
 	dir = 4
 	},
 /obj/structure/platform/urban/metalplatform2,
-/turf/open/urbanshale/layer2,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/nt_research_complex_entrance)
 "xVE" = (
 /obj/effect/turf_decal/medical_decals/triage{
@@ -140974,24 +137113,25 @@
 /area/lv759/indoors/nt_research_complex/xenoarcheology)
 "xXb" = (
 /obj/effect/urban/decal/dirt,
-/obj/structure/platform_decoration/shiva{
-	dir = 8
-	},
 /obj/structure/barricade/metal/deployable,
-/turf/open/floor/plating{
-	dir = 8
+/turf/open/floor/plating/plating_catwalk{
+	color = "#dfcfc0"
 	},
 /area/lv759/indoors/caves/central_caves)
 "xXe" = (
 /turf/open/floor/prison,
 /area/lv759/indoors/power_plant/telecomms)
 "xXm" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/platform_decoration{
+/obj/structure/prop/mainship/gelida/smallwire{
 	dir = 1
 	},
-/turf/open/urbanshale/layer0_plate,
-/area/lv759/outdoors/caveplateau)
+/obj/structure/prop/mainship/gelida/smallwire{
+	dir = 4
+	},
+/obj/structure/prop/mainship/gelida/planterboxsoilgrid,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/central_caves)
 "xXs" = (
 /turf/closed/wall/urban/colony/ribbed,
 /area/lv759/indoors/nt_security/checkpoint_northeast)
@@ -141006,12 +137146,6 @@
 	},
 /turf/open/floor/mainship/plate,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
-"xXw" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_caves)
 "xXC" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/clipboard,
@@ -141119,10 +137253,6 @@
 /area/lv759/indoors/meridian/meridian_showroom)
 "xYy" = (
 /obj/structure/largecrate/random/barrel/white,
-/obj/structure/prop/urban/fakeplatforms/platform3,
-/obj/structure/prop/urban/fakeplatforms/platform3{
-	dir = 8
-	},
 /turf/open/floor/urban/metal/zbrownfloor_full,
 /area/lv759/indoors/meridian/meridian_factory)
 "xYM" = (
@@ -141251,29 +137381,24 @@
 /obj/structure/rock/dark/small{
 	layer = 4
 	},
-/obj/structure/prop/urban/fakeplatforms/rockplatform{
-	dir = 4;
-	layer = 4
-	},
 /obj/structure/rock/dark/small{
 	layer = 4
 	},
 /turf/open/urbanshale/layer1,
 /area/lv759/outdoors/landing_zone_2)
 "xZG" = (
-/obj/effect/urban/decal/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/urban/decal/road/lines3,
+/obj/structure/barricade/handrail/strata,
+/obj/structure/table/reinforced/prison,
+/obj/item/folder/black,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -10;
+	pixel_y = 8
 	},
-/obj/structure/prop/urban/vehicles/large/van/vanmining{
-	dir = 1;
-	pixel_y = 12
+/turf/open/floor/mainship{
+	dir = 5
 	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/grey,
-/area/lv759/indoors/mining_outpost/northeast)
+/area/lv759/indoors/nt_office/pressroom)
 "xZM" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 4;
@@ -141311,10 +137436,12 @@
 	},
 /area/lv759/outdoors/colony_streets/north_street)
 "xZZ" = (
-/obj/item/lightstick/anchored,
 /obj/structure/prop/urban/fakeplatforms/rockplatform,
-/turf/open/urbanshale/layer1,
-/area/lv759/indoors/caves/central_caves)
+/obj/structure/prop/urban/fakeplatforms/rockplatform{
+	dir = 8
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/caveplateau)
 "yaa" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/landmark/weed_node,
@@ -141368,21 +137495,10 @@
 	dir = 1
 	},
 /area/lv759/outdoors/colony_streets/east_central_street)
-"yaI" = (
-/obj/structure/platform_decoration/urban/engineer_corner{
-	dir = 8
-	},
-/obj/effect/urban/decal/engineership_corners{
-	dir = 8
-	},
-/obj/structure/platform_decoration,
-/turf/open/engineership/engineer_floor9,
-/area/lv759/indoors/derelict_ship)
 "yaK" = (
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
+/obj/structure/prop/urban/containersextended/blackwyright,
+/turf/open/urbanshale/layer1,
+/area/lv759/indoors/caves/west_caves)
 "yaN" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/stack/sheet/cardboard,
@@ -141394,17 +137510,11 @@
 /obj/effect/urban/decal/trash/eight,
 /turf/open/urban/street/cement1,
 /area/lv759/outdoors/colony_streets/east_central_street)
-"yaO" = (
-/obj/effect/urban/decal/dirt,
-/turf/open/floor/prison/cellstripe{
-	dir = 1
-	},
-/area/lv759/outdoors/north_west_caves_outdoors)
 "yaP" = (
 /obj/effect/urban/decal/dirt,
 /obj/structure/girder,
 /obj/effect/spawner/random/engineering/metal,
-/turf/open/floor/plating,
+/turf/open/urbanshale/layer1,
 /area/lv759/indoors/caves/north_caves)
 "ybf" = (
 /obj/effect/urban/decal/road/lines2,
@@ -141424,12 +137534,9 @@
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "ybk" = (
-/obj/effect/urban/decal/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/east_caves)
+/obj/structure/rock/dark/wide,
+/turf/open/urbanshale/layer0_plate,
+/area/lv759/indoors/caves/central_caves)
 "ybw" = (
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 8
@@ -141487,9 +137594,6 @@
 /turf/open/floor/plating,
 /area/lv759/outdoors/colony_streets/east_central_street)
 "ybT" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 8
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 4
@@ -141606,9 +137710,7 @@
 	pixel_x = -21;
 	pixel_y = 3
 	},
-/turf/open/floor/plating{
-	dir = 8
-	},
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/east_caves)
 "ycJ" = (
 /obj/structure/cable,
@@ -141787,10 +137889,7 @@
 	},
 /area/lv759/indoors/spaceport/docking_bay_1)
 "yed" = (
-/obj/item/clothing/head/warning_cone{
-	pixel_x = 4;
-	pixel_y = 14
-	},
+/obj/structure/largecrate/random/barrel/white,
 /turf/open/urban/street/sidewalk{
 	dir = 6
 	},
@@ -141829,7 +137928,7 @@
 	pixel_y = 13
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/north_caves)
 "yeA" = (
 /obj/effect/mapping_helpers/airlock_autoname,
@@ -141936,14 +138035,6 @@
 "yfI" = (
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/meridian/meridian_managersoffice)
-"yfJ" = (
-/obj/structure/barricade/handrail/urban/road/plastic/black{
-	dir = 1
-	},
-/obj/effect/urban/decal/road/road_edge/four,
-/obj/effect/urban/decal/road/lines2,
-/turf/open/urban/street/asphalt,
-/area/lv759/outdoors/colony_streets/south_east_street)
 "yfL" = (
 /obj/effect/urban/decal/dirt,
 /obj/item/shard,
@@ -142156,9 +138247,6 @@
 	},
 /area/lv759/outdoors/colony_streets/central_streets)
 "yhm" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
 	},
@@ -142244,17 +138332,11 @@
 /turf/closed/wall/urban,
 /area/lv759/indoors/nt_office/pressroom)
 "yio" = (
-/obj/structure/closet/crate/trashcart{
-	opened = 1
-	},
 /obj/item/trash/trashbag{
 	pixel_x = 3;
 	pixel_y = -2
 	},
 /obj/effect/urban/decal/dirt,
-/obj/structure/barricade/handrail/strata{
-	dir = 1
-	},
 /obj/effect/urban/decal/trash/seven,
 /obj/effect/urban/decal/trash/eight{
 	pixel_y = 12
@@ -142284,10 +138366,6 @@
 	},
 /area/lv759/indoors/nt_research_complex/dormsfoyer)
 "yix" = (
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/central_streets)
@@ -142418,9 +138496,6 @@
 /turf/closed/wall/urban/colony,
 /area/lv759/indoors/apartment/eastrestroomsshower)
 "yjk" = (
-/obj/structure/barricade/handrail/urban/road/metal/metaldark{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/urban/street/sidewalkcenter{
 	dir = 8
@@ -142514,10 +138589,6 @@
 /area/lv759/indoors/mining_outpost/east_dorms)
 "ykb" = (
 /obj/effect/ai_node,
-/obj/structure/barricade/handrail/urban/road/metal/double{
-	dir = 1;
-	pixel_y = 15
-	},
 /turf/open/urban/street/sidewalkcenter,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "ykc" = (
@@ -142609,16 +138680,9 @@
 	},
 /area/lv759/indoors/nt_research_complex/hallwaycentral)
 "ykJ" = (
-/obj/item/clothing/head/hardhat/dblue{
-	pixel_x = -5;
-	pixel_y = 4
-	},
 /obj/effect/urban/decal/road/lines2,
 /obj/effect/urban/decal/road/road_stop/five{
 	dir = 4
-	},
-/obj/structure/largecrate/supply{
-	pixel_x = -10
 	},
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/south_east_street)
@@ -142654,14 +138718,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/urban/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_street)
-"yle" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	dir = 8
-	},
-/area/lv759/indoors/caves/north_east_caves)
 "ylk" = (
 /obj/structure/bed/urban/chairs/brown{
 	dir = 8
@@ -142678,7 +138734,7 @@
 	color = "#a6aeab";
 	dir = 9
 	},
-/turf/open/urbanshale/layer1,
+/turf/open/ground/sandrock,
 /area/lv759/indoors/caves/south_west_caves)
 "yls" = (
 /obj/structure/sink{
@@ -143015,195 +139071,195 @@ oRG
 lJX
 oRG
 oRG
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-xHn
-xHn
-xHn
-xHn
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+oAK
+oAK
+oAK
+oAK
+oAK
+oAK
+oAK
+oAK
+oAK
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+tro
+ydz
+ydz
+ydz
+ydz
+ydz
+ram
+ram
+ram
+ram
+ydz
+ydz
+ydz
+sML
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+lLo
+lLo
+lLo
+lLo
+lLo
+lLo
+lLo
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+jJd
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
+rrn
 qhg
 qhg
 qhg
 qhg
 qhg
 qhg
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+pAW
+pAW
+pAW
+pAW
+pAW
+pAW
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
 lwn
 "}
 (3,1,1) = {"
@@ -143218,7 +139274,7 @@ mrk
 fQu
 wbT
 oRG
-ldK
+oAK
 oAK
 oAK
 oAK
@@ -143254,73 +139310,73 @@ sko
 sko
 sko
 vLB
-hYz
+opQ
 tro
 tro
 tro
 tro
 tro
-tro
-ldK
-ldK
-ldK
+ydz
+ydz
+ydz
+ydz
 gAT
 pfG
 iFx
 bXf
 wTF
 dmT
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-ldK
+ydz
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+lLo
+lLo
+lLo
+lLo
+lLo
+lLo
+wwX
+wwX
+slM
+wwX
 fzZ
 eMt
 ngy
@@ -143405,8 +139461,8 @@ gvH
 gPO
 dCa
 jht
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (4,1,1) = {"
@@ -143421,7 +139477,7 @@ lRl
 suR
 jYD
 oRG
-ldK
+oAK
 gIr
 bap
 grx
@@ -143433,37 +139489,37 @@ mVZ
 lMn
 uBf
 onz
-ldK
+tro
 gLn
 gLn
-ldK
-ldK
-gLn
-gLn
-gLn
-ldK
-ldK
+tro
+tro
 gLn
 gLn
 gLn
-ldK
-ldK
+tro
+tro
 gLn
 gLn
 gLn
-ldK
-ldK
+tro
+tro
 gLn
 gLn
 gLn
-ldK
+tro
+tro
+gLn
+gLn
+gLn
+tro
 onz
 tro
 tro
 tro
-ldK
-ldK
 tro
+tro
+ydz
 ymg
 imt
 hdp
@@ -143474,58 +139530,58 @@ pCk
 vlX
 nOh
 mjF
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-ldK
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+isz
+isz
+isz
+isz
+isz
+eUg
+eUg
+eUg
+eUg
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+xun
+lLo
+lLo
+lLo
+lLo
+lLo
+wwX
+wwX
+slM
+slM
+wwX
 uzf
-lsv
+tAK
 thn
 ksU
 ksU
@@ -143535,7 +139591,7 @@ ksU
 ksU
 thn
 rto
-lsv
+tAK
 fHI
 rSs
 sfO
@@ -143608,8 +139664,8 @@ aQY
 dcK
 jht
 jht
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (5,1,1) = {"
@@ -143635,7 +139691,7 @@ jzh
 oAK
 lrS
 qto
-jbk
+onz
 lrS
 hzH
 hzH
@@ -143660,13 +139716,13 @@ nzS
 qiq
 hzH
 lrS
-mIs
+onz
 mRt
 dfT
 nbt
-ldK
-ldK
 tro
+tro
+ydz
 doa
 bDS
 wjd
@@ -143677,56 +139733,56 @@ jtO
 eFp
 xXJ
 lHy
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+isz
 auM
 auM
 auM
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-ldK
+isz
+eUg
+eUg
+eUg
+eUg
+xun
+xun
+xun
+xun
+xun
+qkB
+qkB
+qkB
+qkB
+qkB
+qkB
+lLo
+lLo
+lLo
+lLo
+wwX
+wwX
+slM
+slM
+slM
+wwX
 rto
 tAK
 thn
@@ -143811,8 +139867,8 @@ cNW
 dyu
 esn
 gvH
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (6,1,1) = {"
@@ -143880,58 +139936,58 @@ vjg
 uzd
 sTR
 fal
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+isz
 auM
 eHV
 auM
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
+isz
+eUg
+eUg
+eUg
+eUg
+xun
+qkB
+qkB
+qkB
+qkB
 iLa
 rKU
 uih
-rKU
-lSG
-ldK
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+nBw
+qeC
+qkB
+lLo
+lLo
+lLo
+wwX
+wwX
+slM
+slM
+slM
+slM
+wwX
 ngU
-lsv
+tAK
 nMs
 oZj
 kqT
@@ -143940,8 +139996,8 @@ uef
 vvf
 uOp
 nMs
-jsY
-jcw
+rto
+tAK
 fHI
 xWg
 mHe
@@ -144014,8 +140070,8 @@ rxa
 xUi
 mQG
 rkp
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (7,1,1) = {"
@@ -144083,37 +140139,37 @@ esP
 eWy
 fxg
 etp
-ldK
-ldK
-aWQ
-aWQ
+ydz
+sML
+eUg
+eUg
 uLW
 eEq
-nqO
+rLE
 nqO
 vAB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+isz
 auM
 auM
 auM
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+isz
+eUg
+eUg
+eUg
+eUg
+xun
+qkB
 wmD
 aeS
 tDh
@@ -144122,18 +140178,18 @@ lsO
 gbG
 xgB
 lQi
-ldK
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-vwE
+qkB
+lLo
+lLo
+lLo
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+rto
 tPt
 nMs
 nkq
@@ -144143,7 +140199,7 @@ qRg
 wjG
 wPU
 nMs
-jsY
+rto
 tAK
 eVZ
 pzM
@@ -144218,7 +140274,7 @@ xUi
 mQG
 cpN
 fZs
-ldK
+dvN
 eqU
 "}
 (8,1,1) = {"
@@ -144286,37 +140342,37 @@ xiz
 kQr
 sOG
 kEp
-ldK
-ldK
-aWQ
-aWQ
-nqO
-vcG
+ydz
+sML
+eUg
+eUg
 plS
 plS
-vDk
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+plS
+plS
+plS
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+isz
+isz
+isz
+isz
+isz
+eUg
+eUg
+eUg
+eUg
+xun
+qkB
 qdF
 qwc
 xrm
@@ -144325,19 +140381,19 @@ cqd
 xgB
 xgB
 lQi
-ldK
-aWQ
-aWQ
-aWQ
-ldK
-ldK
+qkB
+lLo
+lLo
+lLo
+wwX
+wwX
 vtr
 vtr
 bzZ
-gIB
+laL
 gOq
 bqj
-wji
+tAK
 thn
 baG
 gzl
@@ -144427,10 +140483,10 @@ eqU
 (9,1,1) = {"
 lwn
 oRG
-pqT
-pqT
-pqT
-pqT
+xde
+xde
+xde
+xde
 bNE
 bZF
 suR
@@ -144489,58 +140545,58 @@ uNn
 vyk
 cAg
 sMd
-ldK
-ldK
-rAy
-kDD
-qFA
+ydz
+sML
+iCB
 plS
-szk
-qFA
-mgn
-nqO
-nqO
-nqO
+plS
+plS
+ohD
+plS
+plS
+plS
+uFY
+nGY
 hcp
 kzn
 qFA
 jVP
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+qkB
+qkB
 vYz
 uWE
 rIr
 eeE
 lEQ
-toA
+rKU
 rKU
 nBw
-ldK
-aWQ
-aWQ
-aWQ
-ldK
-ldK
+qkB
+lLo
+lLo
+lLo
+wwX
+wwX
 vtr
 vtr
 slQ
 sCz
 tuV
-pAu
-tik
+sCz
+tAK
 thn
 thn
 ksU
@@ -144550,7 +140606,7 @@ ksU
 thn
 thn
 rto
-lsv
+tAK
 fHy
 uCo
 wbk
@@ -144633,13 +140689,13 @@ oRG
 fRD
 buZ
 pOl
-eTF
+oRG
 sTK
 dnn
 sWO
 sTK
 oRG
-ldK
+oAK
 oAK
 mLc
 oAK
@@ -144670,8 +140726,8 @@ bTB
 bTB
 dNA
 bTB
-ldK
-ldK
+tro
+tro
 adq
 wAY
 vkF
@@ -144692,37 +140748,37 @@ rhc
 tYY
 saD
 gJB
-tKv
+kRm
 fwo
 hMa
-szk
 plS
 gbV
-szk
+plS
+ohD
 ohD
 gbV
 plS
-vTi
 gbV
-gbV
-vHW
+nGY
+nGY
 plS
 plS
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
+plS
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+qkB
+qkB
 iyB
 qwc
 xrm
@@ -144731,28 +140787,28 @@ xFu
 fSO
 ogV
 oEq
-ldK
-aWQ
-aWQ
-aWQ
-ldK
-ldK
+qkB
+lLo
+lLo
+lLo
+wwX
+wwX
 fVI
-aso
+lEh
 oHi
 sCz
 sCz
-sBJ
+sCz
 ogz
-wIN
-cdy
+laL
+wYY
 mbX
 xzb
 nFp
-wIN
+laL
 wYY
 laL
-jVy
+bqj
 job
 fHI
 wUc
@@ -144832,7 +140888,7 @@ eqU
 "}
 (11,1,1) = {"
 lwn
-ldK
+pqT
 wHa
 tWQ
 tMs
@@ -144851,7 +140907,7 @@ vMN
 gEv
 gEv
 abp
-reL
+mzt
 mzt
 mRv
 jYk
@@ -144873,8 +140929,8 @@ jnn
 vug
 kjs
 bTB
-ldK
-ldK
+tro
+tro
 wlg
 ftP
 bbb
@@ -144899,33 +140955,33 @@ ofz
 jdC
 hMa
 szk
-uFY
+mrx
 szk
 szk
-ohD
 ohD
 szk
 plS
-ohD
-ohD
-mgn
-xvy
-nqO
-aWQ
-aWQ
+gbV
+djY
+djY
 plS
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-rAy
+plS
+plS
+eUg
+eUg
+plS
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+qkB
+fAu
 vYz
 uWE
 xrm
@@ -144933,29 +140989,29 @@ ezn
 ezn
 rrM
 ezn
-ldK
-ldK
-aWQ
-aWQ
-qUo
+qkB
+qkB
+lLo
+lLo
+tlf
 wwX
 wwX
 fVI
-igF
-nkS
-oKL
-oKL
-xEq
+lEh
+lEh
+sCz
+sCz
+sCz
 kGQ
-qDt
-pAu
+sCz
+sCz
 kOp
 fqD
 gzI
-qDt
-qDt
-qDt
-qDt
+sCz
+sCz
+sCz
+sCz
 tAK
 jJd
 rhH
@@ -145035,7 +141091,7 @@ eqU
 "}
 (12,1,1) = {"
 lwn
-ldK
+pqT
 gpc
 gfM
 qcF
@@ -145048,9 +141104,9 @@ bsm
 cyu
 bZt
 eIk
-tyX
 cEl
-bkn
+cEl
+nrU
 ftP
 ftP
 pWG
@@ -145098,36 +141154,36 @@ bKA
 ugc
 oqA
 mSe
-tKv
+kRm
 fwo
 hMa
 szk
 szk
-szk
+ohD
 enw
 szk
 szk
-szk
-szk
-szk
-szk
-mrx
-szk
+plS
+plS
+nGY
+djY
+uFY
+plS
 uFY
 szk
 plS
 szk
-vDk
+plS
 rLE
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+eUg
+eUg
+eUg
+eUg
+eUg
 gRU
-aWQ
-aWQ
-ldK
+eUg
+eUg
+qkB
 kut
 fQq
 tuY
@@ -145137,10 +141193,10 @@ cwh
 jxF
 sIA
 jrZ
+hNC
+hBK
+tgV
 qUo
-qUo
-qUo
-fdM
 wwX
 wwX
 wwX
@@ -145238,13 +141294,13 @@ eqU
 "}
 (13,1,1) = {"
 lwn
-ldK
+pqT
 pqT
 uqh
 pqT
 pqT
 tPs
-ldK
+tPs
 rWv
 rnX
 rWv
@@ -145258,7 +141314,7 @@ ftP
 pzw
 pWG
 uBf
-jom
+uBU
 aKN
 aKN
 aKN
@@ -145267,12 +141323,12 @@ aKN
 aKN
 xYX
 mRK
-rHA
+gox
 nrU
 aKN
 xYX
 gox
-rHA
+gox
 nrU
 aKN
 aKN
@@ -145280,7 +141336,7 @@ aKN
 aKN
 fyb
 aKN
-wTG
+onz
 shY
 sOt
 avp
@@ -145304,32 +141360,32 @@ mSe
 ofz
 jdC
 hMa
-szk
-plS
-uxT
-szk
+bgs
+ohD
+ohD
+ohD
 mrx
 szk
-szk
-szk
-bgs
-szk
-szk
-szk
-szk
-szk
-szk
-bgs
-vHW
+ohD
+gbV
+vKq
+nGY
 plS
-qFA
-aWQ
-aWQ
-qFA
-aWQ
+ohD
+szk
+szk
+szk
+bgs
+plS
+plS
+nGY
+eUg
+eUg
+plS
+eUg
 plS
 uLW
-qFA
+plS
 tbO
 hAE
 faN
@@ -145340,10 +141396,10 @@ qNn
 ozF
 tOJ
 cSp
-iyx
-fdM
+iWB
+iWB
 mxY
-fdM
+iWB
 sxv
 gzg
 pru
@@ -145441,13 +141497,13 @@ eqU
 "}
 (14,1,1) = {"
 lwn
-ldK
+tPs
 rsO
 pDL
 cuk
 ydM
 qHN
-sBI
+jOn
 xyq
 hHY
 rhe
@@ -145504,49 +141560,49 @@ uwD
 xns
 lAc
 gYG
-kdP
+lmj
 sin
 kmC
 szk
 szk
-qFA
 ohD
-ohD
-mBt
-gBF
-nGY
-nGY
-gBF
-vUg
 szk
+szk
+gbV
+gbV
+nGY
+nGY
+nGY
+plS
+ohD
 mrx
 ltZ
 mrx
 szk
-mgn
-nqO
-nqO
-aWQ
+plS
+djY
+nGY
+eUg
 plS
 mgn
-aWQ
-nqO
-xvy
-nqO
-ldK
+eUg
+plS
+szk
+plS
+qkB
 sHl
 dwf
-ldK
-ldK
-ldK
+qkB
+qkB
+qkB
 alU
 pbG
 rjk
 tfx
-iyx
+pdr
 khA
-fdM
-qUo
+pdr
+pdr
 uOH
 dUp
 hDS
@@ -145644,13 +141700,13 @@ eqU
 "}
 (15,1,1) = {"
 lwn
-ldK
+tPs
 vEY
 tOO
 wVd
 kbh
 kTH
-ldK
+tPs
 jcb
 fFE
 wjI
@@ -145663,7 +141719,7 @@ wiz
 ouK
 jXu
 pWG
-bCi
+uBf
 nrU
 sqa
 sqa
@@ -145707,51 +141763,51 @@ uwD
 xns
 ybx
 ydr
-tKv
+kRm
 nKy
 kmC
 szk
-plS
+szk
 mrx
+szk
+mBt
+plS
+plS
+nGY
+eUg
+eUg
+plS
+szk
+szk
+szk
+szk
+szk
+gbV
+djY
+nGY
+plS
+szk
+szk
+plS
+szk
 ohD
-pHh
-uaL
-plS
-qFA
-aWQ
-aWQ
-ixj
-vUg
-szk
-szk
-szk
-szk
-szk
-ohD
-szk
-plS
-szk
-szk
-plS
-szk
-szk
 szk
 dgv
 qvL
 eKS
-ldK
-ldK
-ldK
+qkB
+qkB
+qkB
 gJq
 bdC
 pde
-cSp
-iyx
-fdM
+aUq
+pdr
+pdr
 rjL
-lCQ
+eOz
 tEM
-mox
+pPs
 rQv
 eEV
 nsF
@@ -145847,14 +141903,14 @@ eqU
 "}
 (16,1,1) = {"
 lwn
-ldK
+tPs
 wCT
 xqA
 wmt
 kCY
 ngr
-sBI
-tHT
+jOn
+pDY
 wnN
 mVY
 ebY
@@ -145902,7 +141958,7 @@ tro
 tro
 kLg
 aSA
-rtv
+aUG
 laZ
 hmF
 plW
@@ -145910,29 +141966,29 @@ bff
 whb
 jya
 mSe
-tKv
+kRm
 fwo
 kmC
 szk
-gbV
 szk
-mBt
-slH
+szk
+plS
+plS
 plS
 qnq
 uLW
-aWQ
-aWQ
-aWQ
-trR
+eUg
+eUg
+eUg
+plS
+ohD
 szk
-szk
-qFA
+plS
 exb
-szk
-szk
-szk
-szk
+plS
+djY
+nGY
+plS
 bgs
 szk
 szk
@@ -145942,18 +141998,18 @@ szk
 hGa
 jvO
 oSk
-ldK
-ldK
-rAy
+qkB
+qkB
+fAu
 jnr
 guV
 kCh
 sRG
-fdM
-fdM
+iWB
+pdr
 aLY
 hDb
-uOH
+jbk
 gzg
 pru
 nXT
@@ -146045,20 +142101,20 @@ fMS
 wIm
 dRS
 eWX
-ldK
+dvN
 mRP
 "}
 (17,1,1) = {"
 lwn
-ldK
+tPs
 tPs
 jOn
 tPs
 rUL
-ldK
-ldK
-ldK
-ldK
+tPs
+tPs
+rWv
+rWv
 eQe
 qzf
 oIN
@@ -146113,34 +142169,34 @@ uwD
 whb
 aUG
 mSe
-kdP
+lmj
 jdC
 kmC
-szk
-qFA
-plS
-vHW
-qFA
-qFA
-qFA
-aWQ
-aWQ
-aWQ
-aWQ
-trR
-szk
-plS
-aWQ
-aWQ
 plS
 plS
-szk
+plS
+plS
+plS
+qFA
+qFA
+eUg
+eUg
+eUg
+eUg
+plS
+gbV
+plS
+eUg
+eUg
+nGY
+nGY
+nGY
 wfm
+ohD
 szk
-szk
-aWQ
-aWQ
-aWQ
+eUg
+eUg
+eUg
 szk
 hGa
 kgX
@@ -146152,8 +142208,8 @@ pML
 irf
 cGA
 hWX
-siR
-fdM
+iWB
+pdr
 gEj
 xxn
 wwX
@@ -146247,28 +142303,28 @@ pYg
 tcA
 jht
 jht
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (18,1,1) = {"
 lwn
-ldK
+tPs
 uGr
 kOc
 gAd
 kCY
-ldK
-ldK
-buY
+tPs
+tro
+eeA
 qaG
 xsZ
 xKW
 bdm
-wPV
+bdm
 vYh
 xsZ
-bIp
+bdm
 bdm
 teH
 tWx
@@ -146316,36 +142372,36 @@ uwD
 whb
 aUG
 unY
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ydz
+sML
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
 txC
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-trR
-szk
+eUg
+eUg
+eUg
+eUg
+eUg
+plS
+plS
 uFY
-aWQ
-aWQ
-aWQ
-qFA
+eUg
+eUg
+eUg
+nGY
+plS
 gbV
 ohD
-szk
 plS
-qFA
-aWQ
-aWQ
-aWQ
-ldK
+plS
+eUg
+eUg
+eUg
+sML
 eif
 dND
 ejv
@@ -146354,20 +142410,20 @@ ftO
 tgl
 iWB
 eHm
-qUo
-hly
+tlf
+ivr
 flH
-nUX
-fdM
+aLY
+iWB
 bxm
 wwX
 fVI
 lEh
 lEh
 sCz
-aiG
-goC
-jFE
+sCz
+sCz
+sCz
 vtr
 vtr
 liN
@@ -146376,7 +142432,7 @@ mHo
 iPc
 vtr
 vtr
-qDt
+sCz
 tAK
 dez
 wgr
@@ -146450,8 +142506,8 @@ wGS
 tcA
 jht
 jht
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (19,1,1) = {"
@@ -146461,9 +142517,9 @@ sLe
 qwb
 jek
 jPU
-ldK
-ldK
-buY
+tPs
+tro
+eeA
 sFf
 xsZ
 oaj
@@ -146519,36 +142575,36 @@ uwD
 pwz
 wde
 iho
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vhM
-xvy
-jFU
-szk
-szk
-qFA
-aWQ
-aWQ
-aWQ
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+nGY
+plS
+plS
 gbV
+plS
+plS
+eUg
+eUg
+eUg
+plS
+plS
 ohD
-szk
-szk
+ohD
 plS
 plS
-qFA
-aWQ
-ldK
+plS
+eUg
+sML
 wdT
 tvA
 ejv
@@ -146557,20 +142613,20 @@ ftO
 tgl
 iWB
 fdM
-fdM
 qUo
-qUo
+iWB
+pdr
 aLY
-kJD
+reL
 kLy
 wwX
 fVI
-gPk
-taD
-aiG
+lEh
+lEh
+sCz
 ago
 pAu
-rok
+sCz
 vtr
 vtr
 fOd
@@ -146579,7 +142635,7 @@ kXz
 iPc
 vtr
 vtr
-qDt
+sCz
 tAK
 wXc
 oKz
@@ -146654,7 +142710,7 @@ ezX
 ccV
 daz
 hoY
-ldK
+dvN
 sEg
 "}
 (20,1,1) = {"
@@ -146664,17 +142720,17 @@ sLe
 tab
 jek
 uuZ
-ldK
-ldK
-buY
+tPs
+tro
+eeA
 oIi
 tMH
 jsk
 bdm
-jWi
+bdm
 opX
 xsZ
-vHx
+bdm
 bdm
 bdm
 tWx
@@ -146722,30 +142778,30 @@ bff
 rtN
 kth
 laZ
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-nqO
-jFU
-szk
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+nGY
+nGY
+djY
 uFY
-szk
-szk
-szk
 plS
-aWQ
-aWQ
-aWQ
+gbV
+nGY
+nGY
+eUg
+eUg
+eUg
 plS
-szk
+plS
 eUx
 rRj
 wve
@@ -146759,30 +142815,30 @@ tDm
 shA
 cTl
 iWB
-iyx
 fdM
 fdM
+iWB
 khA
 aLY
-qUo
+iWB
 vIC
 wwX
 vtr
 vtr
-xof
-ago
 sCz
+xki
+nNO
 uUx
-ojk
-iwK
+sCz
+sCz
 lEh
 xUg
 wqt
 kXz
 iPc
-iwK
 lEh
-pAu
+lEh
+sCz
 tAK
 wXc
 giP
@@ -146867,10 +142923,10 @@ sLe
 aLK
 jek
 saI
-ldK
-ldK
-ldK
-ldK
+tPs
+hVE
+hVE
+hVE
 mTS
 pUL
 wyB
@@ -146925,29 +142981,29 @@ uwD
 whb
 njo
 fhA
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-jtt
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+mai
 kNJ
-plS
-szk
+gbV
+gbV
 ljm
-plS
-qFA
+djY
+nGY
 wad
+nGY
+tLh
+nGY
+nGY
 plS
-mrx
 plS
-plS
-plS
-qFA
-aWQ
-aWQ
+eUg
+eUg
 plS
 atY
 fhx
@@ -146964,28 +143020,28 @@ pKL
 iWB
 iyx
 fdM
-fdM
-qUo
-cQl
-jjV
+iWB
+pdr
+aLY
+iWB
 kHo
 wwX
 vtr
 vtr
-xor
-lwX
-pAu
 sCz
-vQO
-lEh
+lwX
+nNO
+nNO
+sCz
+sCz
 lEh
 xUg
 wqt
 iDn
 heJ
 lEh
-gPk
-qDt
+lEh
+sCz
 tAK
 wXc
 eUy
@@ -147065,13 +143121,13 @@ eqU
 "}
 (22,1,1) = {"
 lwn
-smy
+bIu
 tTL
 mtd
 jek
 wVA
 ooS
-dFb
+xsf
 nEt
 iXb
 lnV
@@ -147080,7 +143136,7 @@ fpT
 rwS
 wQU
 onz
-wMR
+jYk
 jXu
 jXu
 xVV
@@ -147120,7 +143176,7 @@ tro
 tro
 mJp
 aSA
-dMr
+aUG
 cYR
 mBu
 wYp
@@ -147138,19 +143194,19 @@ jtt
 jtt
 krV
 plS
-szk
-fAu
-uLW
+plS
+nGY
+ojk
+nGY
+nGY
+nGY
+nGY
+nGY
 plS
 plS
-szk
-szk
-qFA
-plS
-szk
 plS
 plS
-qFA
+plS
 exb
 wMG
 sCK
@@ -147165,21 +143221,21 @@ amL
 pbY
 cJr
 iWB
-fdM
 qUo
-jjV
+qDW
+iWB
 ekI
 aLY
-qUo
+iWB
 yjQ
 wwX
-ccP
-gPk
-oiz
-pAu
+fVI
+lEh
+lEh
+sCz
 qZF
-pAu
-rok
+nkS
+sCz
 vtr
 vtr
 nGh
@@ -147274,7 +143330,7 @@ dBO
 tqw
 efF
 cYD
-ldK
+hVE
 oNe
 vjD
 bso
@@ -147287,7 +143343,7 @@ vbj
 aKN
 fyb
 pWG
-qkB
+dmn
 uBU
 sqa
 sqa
@@ -147342,11 +143398,11 @@ dCJ
 cnc
 aAo
 eoQ
-fvM
-fvM
 myS
 myS
-kaX
+myS
+myS
+aAo
 fvM
 myS
 aAo
@@ -147368,21 +143424,21 @@ sqe
 pbY
 cJr
 iWB
-fdM
+qUo
 glD
-pyy
-qUo
+iWB
+pdr
 aLY
-qUo
+iWB
 bxm
 wwX
 dhs
 lEh
-igF
-oKL
-cEn
-oKL
-xEq
+lEh
+sCz
+sCz
+sCz
+sCz
 vtr
 vtr
 nGh
@@ -147391,8 +143447,8 @@ lcE
 iPc
 vtr
 vtr
-qDt
-jcw
+sCz
+tAK
 dez
 juR
 jLZ
@@ -147471,7 +143527,7 @@ cAM
 "}
 (24,1,1) = {"
 lwn
-ldK
+tPs
 oZB
 ese
 rWb
@@ -147545,13 +143601,13 @@ dCJ
 iUF
 uOG
 wlT
-bFF
-bFF
-emW
 emW
 bFF
-bFF
+ngl
 emW
+bFF
+bFF
+bFF
 emW
 ngl
 emW
@@ -147566,17 +143622,17 @@ hTa
 cFf
 fki
 pLs
-ldK
-ldK
-rAy
+aQh
+aQh
+ggP
 hBQ
 iWB
 qUo
-aWQ
 qUo
-qUo
+iWB
+pdr
 aLY
-qUo
+iWB
 wwX
 wwX
 wwX
@@ -147646,7 +143702,7 @@ ddG
 sKW
 phB
 uMF
-aHU
+jPl
 psw
 mQw
 pYL
@@ -147674,7 +143730,7 @@ eqU
 "}
 (25,1,1) = {"
 lwn
-ldK
+tPs
 cnr
 eUp
 hSO
@@ -147694,7 +143750,7 @@ ftP
 ftP
 tSi
 rkz
-oty
+uBU
 jXu
 jXu
 jXu
@@ -147703,7 +143759,7 @@ qpb
 cpX
 iJb
 rZC
-lwO
+rZC
 nrU
 jXu
 xYX
@@ -147716,7 +143772,7 @@ jXu
 jXu
 jXu
 jXu
-mIs
+onz
 voa
 wAY
 igy
@@ -147748,8 +143804,8 @@ qRi
 fcZ
 nyD
 qVd
-guQ
-guQ
+pFs
+pFs
 hIa
 guQ
 guQ
@@ -147764,22 +143820,22 @@ jHu
 fWj
 qVd
 txx
-bBa
+txx
 kRl
 mij
 hCp
 biI
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-jjV
-qUo
+aQh
+aQh
+aQh
+aQh
+aQh
+lLo
+lLo
+iWB
+pdr
 hLx
-hEn
+iWB
 sxv
 gzg
 pru
@@ -147849,7 +143905,7 @@ mWu
 mTF
 mIN
 gLL
-oJk
+jPl
 hib
 hQI
 pYL
@@ -147877,13 +143933,13 @@ cAM
 "}
 (26,1,1) = {"
 lwn
-ldK
+tPs
 tPs
 tPs
 fGy
 yeA
 tPs
-ldK
+hVE
 bSd
 xxR
 goD
@@ -147892,7 +143948,7 @@ mHp
 dZk
 hvK
 uBf
-lAC
+nrU
 ftP
 huX
 pWG
@@ -147950,9 +144006,9 @@ gUt
 qRi
 iUF
 fql
-itR
+qVd
 ndc
-sZb
+qEL
 rHL
 isq
 xKP
@@ -147961,8 +144017,8 @@ awN
 sZb
 nzj
 sZb
-qEL
-qEL
+sZb
+sZb
 qRP
 wIY
 yjd
@@ -147972,19 +144028,19 @@ hgn
 woc
 roc
 biI
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-tgV
-jjV
+lLo
+lLo
+lLo
+lLo
+lLo
+lLo
+xKA
+iWB
+pdr
 miR
 eOz
 xtm
-mox
+pPs
 wqw
 pmQ
 dlL
@@ -148121,8 +144177,8 @@ jnn
 vug
 vdT
 bTB
-ldK
-ldK
+tro
+tro
 jMB
 ftP
 rwG
@@ -148154,7 +144210,7 @@ dCJ
 iUF
 nkn
 uqp
-aYy
+hdB
 bjv
 wvy
 oAP
@@ -148164,8 +144220,8 @@ nfC
 hdB
 tPa
 bjv
-uCg
-aYy
+bjv
+hdB
 ovG
 iUF
 cuN
@@ -148175,19 +144231,19 @@ svL
 uut
 uQf
 lWe
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+lLo
+lLo
 qUo
-cQl
+ult
+lLo
 qUo
-sxv
-gzg
+qUo
+iWB
+pdr
+aLY
+pdr
+mOU
+gkf
 pru
 tkI
 pCQ
@@ -148283,7 +144339,7 @@ eqU
 "}
 (28,1,1) = {"
 lwn
-ldK
+asS
 pWV
 sXi
 wCj
@@ -148295,8 +144351,8 @@ pIs
 sJp
 oct
 iYg
-ldK
-ldK
+hVE
+hVE
 pSI
 xtD
 uOe
@@ -148324,8 +144380,8 @@ wuh
 bTB
 bTB
 bTB
-ldK
-ldK
+tro
+tro
 shY
 fxx
 oAa
@@ -148355,8 +144411,8 @@ naO
 mLx
 dCJ
 nns
-aAo
-aAo
+kaX
+kaX
 aAo
 aAo
 aAo
@@ -148378,17 +144434,17 @@ keE
 fmX
 jQj
 sKm
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-rgd
+lLo
+lLo
 qUo
-nUX
-fdM
+qUo
+iHr
+qUo
+qUo
+iWB
+pdr
+mAs
+iWB
 sxv
 gzg
 pru
@@ -148481,25 +144537,25 @@ mMX
 mQG
 cpN
 hoY
-ldK
+dvN
 eqU
 "}
 (29,1,1) = {"
 lwn
-ldK
+asS
 pWV
 cnB
 kdk
 bXq
-ldK
-ldK
+hVE
+hVE
 wQU
 wQU
 wQU
 wQU
 wQU
-ldK
-ldK
+hVE
+hVE
 pSI
 vAp
 gSd
@@ -148559,20 +144615,20 @@ jtt
 jtt
 vdj
 plS
-gbV
+plS
 szk
 szk
-gbV
-gbV
-plS
-plS
+szk
+szk
+szk
+ohD
 hQP
 tRf
 nzx
 hQP
-plS
-uFY
-plS
+szk
+mrx
+szk
 fFj
 pJX
 rHp
@@ -148581,16 +144637,16 @@ syX
 mqo
 ceO
 bNB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-eNf
-gOl
-hBK
-aLY
+lLo
+lLo
+tlf
+qUo
+qUo
+qUo
+lLo
+iWB
+pdr
+mAs
 fdM
 wwX
 wwX
@@ -148683,19 +144739,19 @@ ykj
 xUi
 mQG
 rkp
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (30,1,1) = {"
 lwn
-ldK
+asS
 asS
 asS
 juh
 bHi
-ldK
-ldK
+asS
+asS
 wJJ
 rxZ
 rxZ
@@ -148762,20 +144818,20 @@ irk
 jLC
 ePf
 plS
-qFA
+plS
 plS
 mrx
+szk
+szk
 ohD
-ohD
-plS
 aOS
 szk
-bWZ
+oQP
 oQP
 xlU
-rrn
-ohD
-ohD
+szk
+szk
+szk
 mch
 kwr
 xkP
@@ -148785,26 +144841,26 @@ txx
 ngp
 bNB
 lLo
-aWQ
-aWQ
-aWQ
-aWQ
-huz
-pEe
-pcH
+lLo
 qUo
-nUX
 qUo
+qUo
+lLo
+lLo
+ubY
+pdr
+mAs
+fdM
 wwX
 wwX
 fVI
-gPk
+lEh
 fPx
-qDt
+sCz
 nQY
-qDt
-jMi
-pAu
+sCz
+sCz
+sCz
 sCz
 kOp
 ddZ
@@ -148864,7 +144920,7 @@ vAY
 mjV
 mjV
 yci
-sML
+qzv
 sKU
 wQt
 knR
@@ -148886,13 +144942,13 @@ mZq
 mEZ
 vdn
 mcI
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (31,1,1) = {"
 lwn
-ldK
+asS
 och
 ggN
 env
@@ -148947,7 +145003,7 @@ qih
 cvr
 mZG
 fqS
-hbN
+lQK
 xFO
 sNM
 plW
@@ -148964,21 +145020,21 @@ wUq
 psf
 jtt
 kNJ
-qFA
-aWQ
-aWQ
-gBF
-nGY
-vUg
+plS
+eUg
+eUg
+plS
+plS
+szk
 szk
 mrx
 kot
-rkJ
+tSX
 rkJ
 ygs
 hQP
-gbV
-ohD
+szk
+szk
 pVV
 doh
 sQN
@@ -148989,24 +145045,24 @@ aVl
 dBV
 lLo
 lLo
-aWQ
-aWQ
-aWQ
-jjV
-fuH
-eNf
-fdM
-jWQ
+lLo
 qUo
-ldK
-ldK
-mai
+qUo
+qUo
+lLo
+iWB
+pdr
+mAs
+fdM
+wwX
+wwX
+fVI
 lEh
-iwK
-qDt
-qDt
-pAu
-qDt
+lEh
+sCz
+sCz
+sCz
+sCz
 vtr
 poQ
 skq
@@ -149040,7 +145096,7 @@ egn
 ycE
 egn
 uFA
-lsI
+dBc
 caA
 vDq
 bor
@@ -149089,13 +145145,13 @@ sKv
 vCm
 qCQ
 qCQ
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (32,1,1) = {"
 lwn
-ldK
+asS
 asS
 gQj
 nYi
@@ -149165,23 +145221,23 @@ ptI
 gnp
 dgH
 tEc
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+bIG
+eUg
+eUg
+eUg
+eUg
+eUg
 sYp
-trR
+plS
+ohD
 szk
-szk
-jcN
+mTA
 cer
-jvO
+xor
 rRP
-iRV
-yaO
-jvO
+woq
+kQg
+szk
 lWe
 qWK
 xdL
@@ -149191,25 +145247,25 @@ txx
 tuI
 xEY
 wVZ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-hfW
-gOl
-fdM
-qdT
+lLo
+lLo
+hNC
+qUo
+iHr
+qUo
+iWB
+pdr
+mAs
 eHm
-ldK
-ldK
+wwX
+wwX
 vtr
 vtr
-iwK
-pAu
+lEh
+sCz
 jBn
 rrT
-qDt
+sCz
 lKK
 hhV
 uYN
@@ -149292,20 +145348,20 @@ pUV
 gCM
 jht
 jht
-ldK
-ldK
+dvN
+dvN
 lwn
 "}
 (33,1,1) = {"
 lwn
-bmL
+liu
 asS
 sKg
 gYs
 aSN
 vjf
-qvg
-qvg
+tKy
+tKy
 tKy
 dob
 eVC
@@ -149348,8 +145404,8 @@ hGh
 tFu
 mtD
 umA
-ldK
-ldK
+tro
+tro
 kqw
 uji
 sqk
@@ -149368,22 +145424,22 @@ eOI
 mOY
 gFT
 poJ
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
+bIG
+eUg
+eUg
+eUg
+eUg
 bXj
 plS
-trR
-szk
+plS
+ohD
 szk
 jcN
 woR
 kMs
 rRP
 iRV
-yaO
+kQg
 kQg
 lWe
 wgF
@@ -149395,24 +145451,24 @@ aVl
 itm
 rMg
 fdM
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-gOl
+lLo
+lLo
+lLo
 qUo
-nUX
+qUo
+iWB
+pdr
+mAs
 fdM
-ldK
-ldK
+wwX
+wwX
 vtr
 vtr
 cAD
 imA
 wWi
 tqX
-qDt
+sCz
 pYC
 pfR
 wKE
@@ -149491,29 +145547,29 @@ mjV
 lxp
 mjV
 uMv
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+mjV
+dvN
+dvN
+dvN
+dvN
+dvN
 lwn
 "}
 (34,1,1) = {"
 lwn
-buY
+nhc
 aga
 oWh
-eFt
+whk
 bUa
-hNF
-bCh
+ssQ
+tKy
+tKy
+ssQ
+tKy
+tKy
+ssQ
 tpK
-lDN
-tKy
-tKy
-hNF
-bCh
 tpK
 ijQ
 fnF
@@ -149521,7 +145577,7 @@ gmu
 ssQ
 vjf
 bUa
-sOn
+xWe
 tlP
 uHf
 aPL
@@ -149551,8 +145607,8 @@ guO
 eRY
 amX
 pNt
-ldK
-ldK
+cOG
+cOG
 cOG
 ymg
 ldR
@@ -149564,29 +145620,29 @@ ykb
 whb
 cXi
 pMB
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
+bIG
+bIG
+bIG
+bIG
+bIG
+bIG
+bIG
+bIG
+eUg
+eUg
+eUg
+eUg
 plS
-qFA
-trR
+plS
+plS
 uxT
 jdW
 mku
+bBa
 vCa
-vNw
 arb
-szk
-nEL
+sPK
+txY
 szk
 lWe
 qWK
@@ -149598,24 +145654,24 @@ ndm
 itm
 iWB
 fdM
-fdM
-aWQ
-aWQ
-aWQ
+lLo
+lLo
+lLo
+lLo
 qUo
-qUo
-qnD
-aLY
+iWB
+pdr
+mAs
 fdM
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-jsY
-qDt
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+rto
+sCz
 pYC
 jCK
 rju
@@ -149694,30 +145750,30 @@ qHX
 bWg
 rfH
 gdd
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+mjV
+dvN
+dvN
+dvN
+dvN
+dvN
 lwn
 "}
 (35,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 whk
 nDT
 nDT
-cJt
-azJ
+nDT
+nDT
 nDT
 mES
 nDT
 nDT
-cJt
-azJ
+wSf
+wSf
 nDT
 mES
 nDT
@@ -149771,26 +145827,26 @@ kdP
 fwo
 hMa
 szk
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+uFY
 plS
-vhM
-aAi
-szk
-iEH
+gbV
+ohD
 szk
 szk
+ohD
 szk
 szk
 xFY
-txY
-ohD
+hQP
+szk
 wDe
 qWK
 ktp
@@ -149801,24 +145857,24 @@ bwR
 lBg
 xOt
 fdM
-jjV
-qUo
 fdM
-jjV
-qUo
-iHr
-qUo
-aLY
+lLo
+lLo
+lLo
+lLo
+ubY
+pdr
+mAs
 fdM
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+wwX
+wwX
+slM
+slM
+slM
+slM
+wwX
 rto
-qDt
+sCz
 svN
 aWu
 hdK
@@ -149897,24 +145953,24 @@ gqh
 exJ
 gwz
 rcI
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+mjV
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (36,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 whk
 nDT
 nDT
-wSf
-wSf
+nDT
+nDT
 gMr
 nPh
 tAv
@@ -149974,26 +146030,26 @@ tKv
 snv
 hMa
 szk
+uFY
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
 plS
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-qFA
-qFA
-rpT
+plS
+plS
 ohD
-szk
+ohD
 enw
-qeC
-nGY
-nGY
-bef
-nGY
-rLo
 ohD
+gbV
+gbV
+plS
+szk
+mrx
+szk
 xVG
 hUe
 oRV
@@ -150006,22 +146062,22 @@ iWB
 fdM
 fdM
 fdM
-fdM
-qUo
-tgV
-huz
-qnD
+lLo
+lLo
+lLo
+iWB
+pdr
 sJg
 fdM
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-ldK
+lLo
+wwX
+wwX
+slM
+slM
+slM
+wwX
 rto
-qDt
+sCz
 jTv
 ifl
 dtN
@@ -150097,20 +146153,20 @@ mjV
 nVF
 cQu
 mjV
-ldK
+mjV
 eFF
 eFF
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+mjV
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (37,1,1) = {"
 lwn
-buY
+nhc
 gWb
 gsV
 iQJ
@@ -150178,24 +146234,24 @@ drp
 hMa
 szk
 plS
+sYp
+eEq
+eUg
 plS
-qFA
-aWQ
-nqO
-nqO
-hcp
-nqO
-nqO
-aEf
-ohD
+plS
+plS
+plS
+gbV
 szk
-mBt
-ggP
-qFA
+szk
+szk
+szk
 plS
-mOU
 plS
-agk
+plS
+plS
+plS
+szk
 szk
 xVG
 ufc
@@ -150211,20 +146267,20 @@ ubY
 bxm
 iWB
 iWB
-fdM
-fRT
+lLo
+iWB
 pdr
 nCv
 fdM
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-ldK
+lLo
+lLo
+wwX
+wwX
+slM
+slM
+wwX
 rto
-pAu
+sCz
 vtr
 bWI
 dXC
@@ -150297,23 +146353,23 @@ mjV
 mjV
 mjV
 mjV
-hcF
-sMN
-ldK
-ldK
+nVF
+cQu
+mjV
+mjV
 mjY
 rfH
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+mjV
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (38,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 tlG
@@ -150379,26 +146435,26 @@ wvh
 tKv
 nKy
 kmC
-szk
-szk
-plS
+ohD
 szk
 plS
 plS
+plS
+plS
+mrx
 szk
+ohD
+ohD
+ohD
 szk
-szk
-szk
-szk
-szk
-szk
-iiF
+ohD
+mrx
 plS
 rLE
-aWQ
-qFA
+eUg
 sYp
-trR
+plS
+plS
 szk
 bNB
 qWK
@@ -150416,26 +146472,26 @@ mpE
 iWB
 iWB
 iWB
-iWB
+pdr
 mAs
-ivr
-aWQ
-aWQ
-lwn
-ldK
-ldK
-lhZ
-ldK
+uTE
+lLo
+lLo
+gPk
+wwX
+wwX
+slM
+wwX
 bXV
-qgR
+imA
 tac
-tac
-tac
-tac
-tac
-tac
-tac
-tac
+imA
+imA
+imA
+imA
+imA
+imA
+imA
 bji
 xVA
 orT
@@ -150495,28 +146551,28 @@ miu
 uTT
 apK
 gzr
-ldK
-ldK
-ldK
-ldK
-ldK
-hcF
-opj
+mjV
+mjV
+mjV
+mjV
+mjV
+nVF
+uCf
 mix
-ldK
+mjV
 eFF
 eFF
-ldK
+mjV
 mix
-utX
-aWQ
+ffF
+ghY
 uhJ
-aWQ
+ghY
 lwn
 "}
 (39,1,1) = {"
 lwn
-buY
+nhc
 gWb
 kqD
 vGU
@@ -150582,26 +146638,26 @@ wTp
 tKv
 sin
 kmC
+ohD
+ohD
+ohD
+exb
 szk
+ohD
+ohD
 bgs
 szk
+ohD
+szk
+szk
+bgs
 plS
-szk
-szk
-mrx
-bgs
-szk
-szk
-szk
-szk
-bgs
-vDk
-qFA
-aWQ
-aWQ
-aWQ
-qFA
-gUa
+plS
+eUg
+eUg
+eUg
+plS
+uFY
 wve
 fjK
 sod
@@ -150621,26 +146677,26 @@ aQV
 bVo
 bVo
 ota
-mpE
-aWQ
-lwn
-lwn
-lwn
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+fdM
+lLo
+gPk
+gPk
+gPk
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
 orT
 cER
 kvE
@@ -150698,28 +146754,28 @@ jIp
 cQw
 bqB
 gzr
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-tPU
-utX
-opj
+gzr
+ghY
+ghY
+ghY
+ghY
+gWH
+uCf
+ffF
 dMA
 vOp
 vOp
 aqN
-opj
+ffF
+ffF
 uCf
 uCf
-uCf
-aWQ
+ghY
 lwn
 "}
 (40,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 vGU
@@ -150786,25 +146842,25 @@ tKv
 nKy
 hMa
 szk
-mrx
-mrx
 ohD
-ohD
+mrx
 szk
 szk
-qFA
+ohD
+ohD
 plS
-ohD
-pvT
+plS
 szk
-gbV
-xrP
-aWQ
-aWQ
-aWQ
-aWQ
-vhM
-jFU
+uFY
+plS
+plS
+rLE
+eUg
+eUg
+eUg
+eUg
+plS
+szk
 wve
 biI
 qWK
@@ -150824,26 +146880,26 @@ vEo
 taJ
 iWB
 bxm
-iWB
-aWQ
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+fdM
+lLo
+gPk
+gPk
+gPk
+lxG
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+wwX
+slM
+slM
+slM
+slM
+slM
+slM
+wwX
 orT
 eOY
 lmW
@@ -150901,28 +146957,28 @@ cpH
 uWJ
 fcm
 gzr
-ldK
-aWQ
-aWQ
-aWQ
-taw
+gzr
+ghY
+ghY
+ghY
+uCf
 gWH
-opj
-opj
+ffF
+ffF
 qBF
 hQQ
 wcJ
 vUf
-opj
-utX
-uCf
-uCf
-uCf
+ffF
+ffF
+ffF
+ccf
+jQO
 lwn
 "}
 (41,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 xQt
@@ -150992,21 +147048,21 @@ szk
 szk
 szk
 ohD
-ohD
 szk
-plS
+szk
+gbV
 plS
 lHl
-xjI
-ohD
-qFA
-ohD
+plS
+gbV
+plS
+gRU
 eUg
-aWQ
-aWQ
-aWQ
-aWQ
-eue
+eUg
+eUg
+eUg
+eUg
+plS
 wve
 eFj
 lWe
@@ -151024,29 +147080,29 @@ pDS
 skG
 iWB
 fdM
-bcr
-vjL
-vJb
 fdM
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+vjL
+fdM
+fdM
+lLo
+gPk
+gPk
+gPk
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+slM
+slM
+slM
+slM
+slM
+wwX
 orT
 mOA
 eje
@@ -151104,28 +147160,28 @@ eXj
 jGU
 xos
 gzr
-ldK
-aWQ
-aWQ
-aWQ
+gzr
+ghY
+ghY
+ghY
 uCf
-tPU
-utX
+gWH
+ffF
 pVe
 hup
 hQQ
 hQQ
 hup
 uvA
+ffF
+ffF
 uCf
-utX
-cat
 uCf
 lwn
 "}
 (42,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 iQJ
@@ -151193,23 +147249,23 @@ jdC
 hMa
 szk
 szk
-szk
-plS
+ohD
+gbV
+ohD
 enw
 szk
-etc
 qFA
 plS
-qFA
-szk
-szk
 plS
-vDk
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+gbV
+plS
+plS
+sYp
+eUg
+eUg
+eUg
+eUg
+eUg
 nMb
 ydj
 iot
@@ -151222,34 +147278,34 @@ aVl
 itm
 iWB
 fdM
-wZN
-qgH
-qgH
-qgH
+fdM
+fdM
+fdM
+fdM
 fdM
 kJD
 fdM
-qgH
+qUo
 qDW
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+lLo
+gPk
+gPk
+gPk
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+slM
+slM
+slM
+slM
+wwX
 orT
 rfQ
 rIn
@@ -151307,35 +147363,35 @@ iDp
 bDA
 iDp
 iDp
-ldK
-aWQ
-aWQ
-taw
+iDp
+ghY
+ghY
 uCf
+dbQ
 rSh
-utX
+ffF
 pVe
 hup
 ars
 hQQ
 hup
 uvA
-utX
-dbQ
-cat
-aWQ
+ffF
+roJ
+uCf
+ghY
 lwn
 "}
 (43,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 whk
 nDT
 nDT
-rji
-wSf
+mES
+nDT
 rQR
 sFK
 sFK
@@ -151397,7 +147453,7 @@ hMa
 szk
 plS
 uFY
-szk
+gbV
 plS
 szk
 six
@@ -151407,13 +147463,13 @@ bxC
 bxC
 bxC
 bxC
-stJ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+bxC
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
 plc
 lWe
 iTF
@@ -151424,35 +147480,35 @@ txx
 dmu
 lBg
 rMg
+fdM
+fdM
+lLo
+lLo
+lLo
 qUo
-vRj
-aWQ
-aWQ
-aWQ
-jjV
 iHr
-jjV
+qUo
 huz
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-ldK
+lLo
+lLo
+gPk
+gPk
+gPk
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+slM
+slM
+slM
+wwX
 bSm
 nIH
 qAj
@@ -151509,42 +147565,42 @@ fVj
 mIq
 iSK
 iDp
-ldK
-ldK
-aWQ
-aWQ
+iDp
+iDp
+ghY
+ghY
 uCf
-dbQ
+rtg
 nPH
-jxM
+mED
 uAB
 otm
 hQQ
 hQQ
 vUf
-opj
-utX
-uCf
-ihu
-cat
+ffF
+ffF
+ffF
+dbQ
+vyc
 lwn
 "}
 (44,1,1) = {"
 lwn
-buY
+nhc
 gWb
 oWh
 djc
 nDT
 nDT
-hpa
-vDh
 nDT
 nDT
 nDT
 nDT
-hpa
-vDh
+nDT
+nDT
+wSf
+wSf
 nDT
 nDT
 nDT
@@ -151594,15 +147650,15 @@ uwD
 rtN
 jgh
 bnQ
-ldK
-ldK
-rAy
+ydz
+sML
+iCB
 plS
-mBt
-bBO
-gBF
-gBF
-aWQ
+plS
+plS
+plS
+plS
+eUg
 fhR
 fhR
 fhR
@@ -151627,35 +147683,35 @@ rHL
 dmu
 mWE
 bVh
-aWQ
-aWQ
-aWQ
-aWQ
-fdM
-qUo
+lLo
+lLo
+lLo
+lLo
 jjV
-iHr
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-lhZ
-lhZ
-ldK
+jjV
+jjV
+slH
+lLo
+lLo
+lLo
+gPk
+gPk
+gPk
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+slM
+slM
+wwX
 tnX
 kfD
 jGT
@@ -151712,41 +147768,41 @@ oeN
 lfA
 reC
 iDp
-ldK
-aWQ
-aWQ
+iDp
 ghY
-taw
-cat
-gWH
+ghY
+ghY
 uCf
-opj
+ffF
+rSh
+ffF
+ffF
 tSo
 snM
 snM
 tSo
-opj
+ffF
+ffF
 uCf
 uCf
-uCf
-aWQ
+ghY
 lwn
 "}
 (45,1,1) = {"
 lwn
-buY
+nhc
 gRx
 oWh
 cyL
 qyl
-hNF
-euT
+ssQ
+lne
+lne
+ssQ
+lne
+lne
+ssQ
 mIe
-lDN
-lne
-lne
-hNF
-euT
 mIe
 ssQ
 qyl
@@ -151754,7 +147810,7 @@ lne
 ssQ
 tat
 qyl
-gZK
+bqv
 kMF
 nvH
 eEz
@@ -151797,15 +147853,15 @@ uwD
 whb
 oqA
 xoH
-ldK
-ldK
-aWQ
-aWQ
-slH
-qFA
+ydz
+sML
+eUg
+eUg
+eEq
+plS
 sYp
-aWQ
-aWQ
+eUg
+eUg
 eWb
 jUy
 eJn
@@ -151829,36 +147885,36 @@ plC
 xIP
 qnn
 lWe
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-qUo
-iHr
+lLo
+lLo
+lLo
+lLo
+lLo
 jjV
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-lhZ
-ldK
+slH
+jjV
+lLo
+lLo
+lLo
+lLo
+gPk
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+slM
+wwX
 djH
 tYO
 qiS
@@ -151891,13 +147947,13 @@ trd
 sQs
 sJr
 hCF
-bfa
+gfV
 coC
 pmv
 smU
 moq
 oKI
-bfa
+gfV
 gfV
 hIU
 bHf
@@ -151915,36 +147971,36 @@ nvW
 nvW
 pFr
 iDp
-ldK
-aWQ
+iDp
+ghY
+vHW
+vyc
 uCf
-qdG
-uCf
-bRq
-jkT
+gme
+lDN
 uCf
 mix
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
 mix
-utX
-rux
+uCf
+ccf
 cat
-aWQ
+ghY
 lwn
 "}
 (46,1,1) = {"
 lwn
-bmL
+liu
 ufw
 paN
 ivB
 aSN
 lne
-qvg
-qvg
+lne
+lne
 lne
 lne
 lne
@@ -152000,15 +148056,15 @@ uwD
 whb
 tpZ
 sVH
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ydz
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
 eWb
 aUc
 aUc
@@ -152032,36 +148088,36 @@ bxk
 iYD
 wuS
 lWe
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-jjV
-fdM
+lLo
+lLo
+lLo
+lLo
+lLo
+qUo
+qUo
 pHF
 qUo
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
-ldK
+lLo
+lLo
+lLo
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
+wwX
 xhx
 xno
 qlK
@@ -152118,29 +148174,29 @@ wAi
 krS
 wGR
 dZP
-bUd
+dZP
 qBR
-lmj
-hkm
 pVG
-aNi
+pVG
+kva
+mED
 ylp
-cat
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
 uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 cat
-aWQ
+cat
+ghY
 lwn
 "}
 (47,1,1) = {"
 lwn
-ldK
+asS
 aSN
 rFi
 iJF
@@ -152203,15 +148259,15 @@ bff
 pwz
 ejL
 hsM
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ydz
+sML
+sML
+eUg
+eUg
+eUg
+eUg
+eUg
+eUg
 eWb
 wIf
 eJn
@@ -152235,36 +148291,36 @@ ukJ
 woc
 woc
 bNB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-pAE
+lLo
+lLo
+lLo
+lLo
+lLo
+czr
 fUi
 ibw
 czr
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-ldK
-ldK
+lLo
+lLo
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+wwX
+wwX
 orT
 tYe
 uEx
@@ -152321,29 +148377,29 @@ fVj
 mIq
 wKM
 iDp
-ldK
-aWQ
-taw
+iDp
+ghY
+qsQ
+ccf
+gse
+gse
 uCf
-mCC
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 cat
-taw
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-uCf
-uCf
 cat
-aWQ
+uCf
+ghY
 lwn
 "}
 (48,1,1) = {"
 lwn
-ldK
+asS
 aSN
 wkR
 vwm
@@ -152409,8 +148465,8 @@ pXs
 dCZ
 jYN
 fcV
-aWQ
-aWQ
+eUg
+eUg
 iVY
 bRy
 imQ
@@ -152438,36 +148494,36 @@ vZT
 myS
 tgB
 aVA
-ldK
-ldK
-ldK
-ldK
-ldK
-pAE
+mIs
+mIs
+mIs
+mIs
+mIs
+czr
+fdM
 qUo
-qUo
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-aWQ
-ldK
-aWQ
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-aWQ
-ldK
+lLo
+lLo
+csj
+csj
+csj
+kOC
+csj
+kOC
+csj
+kOC
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+lxG
+lxG
+csj
+wwX
 orT
 orT
 kZo
@@ -152524,29 +148580,29 @@ diF
 hIj
 aJV
 iDp
-ldK
-aWQ
-rsK
-qsQ
-qdG
-cat
-cat
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-taw
-cat
+iDp
+ghY
+tyX
+uCf
+ffF
+gse
+uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+uCf
+uCf
 uCf
 dbQ
-cat
+uCf
 lwn
 "}
 (49,1,1) = {"
 lwn
-ldK
+dWF
 dWF
 xJp
 xJp
@@ -152645,32 +148701,32 @@ jLB
 jLB
 jLB
 jLB
-ldK
-fdM
+mIs
+qUo
 eHm
-fdM
-aWQ
-aWQ
-aWQ
+qUo
+csj
+csj
+csj
 tHU
 wpK
-ldK
-ldK
-ldK
-ldK
+kOC
+kOC
+kOC
+kOC
 rAy
+fUG
 tHU
-tHU
-aWQ
-aWQ
-udt
+csj
+csj
+nEL
 tHU
 eyS
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+csj
+csj
+csj
+csj
+uhf
 acH
 xAm
 vdB
@@ -152727,24 +148783,24 @@ iDp
 iDp
 iDp
 iDp
-ldK
-aWQ
-taw
-egN
-vKq
+iDp
+ghY
 uCf
-cat
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+vJw
+uCf
+ffF
+uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+uCf
+rtg
+gse
 uCf
 uCf
-cat
-uCf
-cat
 lwn
 "}
 (50,1,1) = {"
@@ -152848,32 +148904,32 @@ lqF
 snT
 cWB
 atI
-qqT
+atI
 aNS
 aNS
-udt
-aNS
-qKE
-udt
-qMq
 tHU
+tHU
+qKE
+tHU
+tHU
+fUG
 peq
 iPP
 wPh
 xlk
 peq
 vic
-udt
-bVc
-fUG
-dgi
 tHU
 tHU
-udt
-aWQ
-aWQ
-aWQ
-ldK
+tHU
+tHU
+tHU
+tHU
+jDH
+csj
+csj
+slN
+uhf
 uhf
 iFM
 aFr
@@ -152918,36 +148974,36 @@ ode
 vJY
 uPD
 obT
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-sMN
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
+iDp
+iDp
+iDp
+iDp
+iDp
+iDp
+iDp
+uCf
+iDp
+iDp
+iDp
+iDp
+iDp
+ghY
+ghY
 ghY
 uCf
-ihu
+roJ
 uCf
 uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
+ghY
 uCf
-cat
-cat
-cat
-taw
+rtg
+gse
+uCf
+uCf
 lwn
 "}
 (51,1,1) = {"
@@ -152957,7 +149013,7 @@ dSL
 eWM
 dTN
 mCM
-sHR
+mCM
 ffR
 fEZ
 mCM
@@ -153051,33 +149107,33 @@ dyO
 tTF
 cQT
 atI
-qqT
+atI
 aNS
-udt
+aNS
+aNS
 tHU
-aNS
-udt
-aNS
-aUH
+tHU
+tHU
+tHU
 nDm
-hIq
+fUG
 iPP
 noQ
 xlk
-hIq
+fUG
 tHU
 ltM
 tHU
-kwO
+tHU
 aNS
-aNS
-pwh
-van
-psh
-aWQ
-aWQ
-ldK
-uhf
+tHU
+ltM
+tHU
+tHU
+tHU
+tHU
+tHU
+oCW
 kAy
 sVL
 unr
@@ -153121,36 +149177,36 @@ oWO
 sYH
 xPa
 obT
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-taw
-ffF
-ffF
-ffF
-aWQ
-aWQ
-aWQ
-aWQ
+iDp
+kQM
+kQM
+kQM
+kQM
+iDp
+iDp
 uCf
 uCf
-bRq
 uCf
-cat
-aWQ
-aWQ
-aWQ
+ccf
+ghY
+ghY
+ghY
+ghY
+uCf
+uCf
+gme
+uCf
+uCf
+ghY
+ghY
+ghY
 rsK
-vyc
-cat
-bRq
-cat
-cat
-aWQ
+jQO
+uCf
+gme
+ffF
+uCf
+ghY
 lwn
 "}
 (52,1,1) = {"
@@ -153254,32 +149310,32 @@ jXp
 wTH
 gVB
 atI
-qqT
-udt
-jUH
-tHU
-udt
+atI
 aNS
+eXS
+aNS
+aNS
+tHU
 pLX
-qES
-hIq
-hIq
+tHU
+tHU
+fUG
 iPP
 wPh
 xlk
-hIq
-hIq
+fUG
 tHU
-udt
-kwO
+tHU
+tHU
+aNS
 pwh
 aNS
-udt
 tHU
-udt
-aWQ
-aWQ
-ldK
+tHU
+tHU
+tHU
+bJQ
+uhf
 uhf
 fhJ
 mcq
@@ -153321,39 +149377,39 @@ uIr
 mpx
 ePF
 uIr
-aUq
-aUq
+hjq
+hjq
 obT
-ldK
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-aWQ
+iDp
+kQM
+kQM
+kQM
+iDp
+iDp
+ghY
 uCf
-ffF
-ffF
-taw
+uCf
+uCf
+cat
 mdC
-aWQ
-aWQ
+ghY
+ghY
 vJw
 uCf
 uCf
+ffF
+rtg
 uCf
-cat
+ccf
 uCf
 uCf
-cat
-taw
 uCf
-cat
-cat
+uCf
+uCf
 adQ
-cat
-cat
-aWQ
+uCf
+uCf
+ghY
 lwn
 "}
 (53,1,1) = {"
@@ -153457,32 +149513,32 @@ xkN
 qkc
 jHt
 atI
-qqT
+atI
 pwh
 aNS
-tHU
-tHU
-ltM
-kQM
 aNS
+aNS
+pwh
+ltM
+tHU
 pLX
-hIq
+fUG
 iPP
 noQ
 xlk
-hIq
+fUG
 pLX
-uTE
+euN
 tHU
-kwO
-lRa
-wxr
 aNS
+aNS
+eXS
 aNS
 aNS
 tHU
-aWQ
-ldK
+van
+csj
+uhf
 uhf
 uhf
 uhf
@@ -153527,36 +149583,36 @@ oHU
 vot
 vot
 obT
-ldK
-lhZ
-lhZ
-ldK
-ldK
-aWQ
-aWQ
-aWQ
+iDp
+kQM
+kQM
+iDp
+iDp
+ghY
+ghY
+ghY
 taw
+cat
+cat
+cat
+ghY
+uCf
+uCf
+uCf
+ffF
+gse
+rtg
+rtg
+uCf
+uCf
+uCf
+gse
+gse
+ffF
 ffF
 uCf
-jQO
-aWQ
-uCf
-cat
 uCf
 uCf
-uCf
-uCf
-cat
-uCf
-uCf
-uCf
-cat
-uCf
-cat
-cat
-cat
-uCf
-cat
 lwn
 "}
 (54,1,1) = {"
@@ -153660,13 +149716,13 @@ dSB
 jMP
 lMS
 atI
-qqT
+atI
 aNS
 aNS
 aNS
-kZP
 aNS
-tHU
+aNS
+aNS
 tHU
 izW
 uqg
@@ -153676,36 +149732,36 @@ xlk
 uqg
 wpK
 tHU
-udt
-kwO
-lRa
-lRa
+tHU
+tHU
+aNS
+aNS
 aSf
 aUH
 aNS
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+csj
+csj
+uhf
+uhf
+uhf
+uhf
+uhf
+uhf
+uhf
+uhf
 rjr
 thC
 nUA
 niN
 glx
 rjr
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+sfu
+sfu
+sfu
+sfu
+sfu
+sfu
+sfu
 hvw
 qnk
 dNJ
@@ -153730,36 +149786,36 @@ lBv
 aep
 mZe
 obT
-ldK
-lhZ
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
+iDp
+kQM
+iDp
+iDp
+csj
+csj
+ghY
+ghY
+pln
+cat
 uCf
-taw
+dbQ
 uCf
+uCf
+ffF
+ffF
+ffF
 roJ
+gse
 uCf
-cat
-cat
+ffF
+ffF
+roJ
+gse
+gse
+uCf
 uCf
 uCf
 dbQ
-cat
-uCf
-cat
-cat
-dbQ
-cat
-cat
-uCf
-cat
-taw
-dbQ
-aWQ
+ghY
 lwn
 "}
 (55,1,1) = {"
@@ -153863,52 +149919,52 @@ vFY
 jMP
 cZQ
 atI
-qqT
+atI
 aNS
-aWQ
-aWQ
-udt
+csj
+csj
 tHU
 aNS
+aNS
 tHU
-tNP
-ldK
-ldK
-ldK
-ldK
+vic
+kOC
+kOC
+kOC
+kOC
 rAy
-lIc
-lIc
+fUG
 tHU
-kwO
-udt
+tHU
+tHU
+tHU
 aSf
 vxK
 vxK
 aUH
 tHU
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+csj
+uhf
+uhf
+pMf
+pMf
+pMf
+pMf
+pMf
+uhf
 rjr
 bst
 ejc
 vne
 alm
 rjr
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+sfu
+fkr
+fkr
+fkr
+fkr
+fkr
+sfu
 uBH
 oDp
 eju
@@ -153933,36 +149989,36 @@ obT
 obT
 obT
 obT
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-uCf
-ffF
-uCf
-uCf
-uCf
+iDp
+iDp
+iDp
+csj
+csj
+csj
+ghY
+ghY
+ghY
 ccf
+uCf
+uCf
+rtg
+gse
+gme
 lol
+gse
+ffF
+ffF
+ffF
+gse
+ffF
+gme
 uCf
-taw
-cat
 uCf
 uCf
-cat
-bRq
-cat
-cat
 uCf
-taw
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
 lwn
 "}
 (56,1,1) = {"
@@ -154066,52 +150122,52 @@ eqc
 hJw
 jjY
 atI
-qqT
-aWQ
-aWQ
-aWQ
-aWQ
+atI
+csj
+csj
+csj
+csj
 aNS
 pwh
 tHU
 tHU
-ldK
-aWQ
-ldK
-aWQ
-ldK
-aWQ
-urj
-aWQ
-aWQ
+kOC
+csj
+kOC
+csj
+kOC
+csj
+tHU
+csj
+csj
 tHU
 pmd
 vxK
 vxK
 qES
 tHU
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+csj
+uhf
+uhf
+pMf
+pMf
+pMf
+pMf
+pMf
+uhf
 rjr
 rHY
 ejc
 vne
 did
 rjr
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+sfu
+fkr
+fkr
+fkr
+fkr
+fkr
+sfu
 hvw
 rNS
 avy
@@ -154127,45 +150183,45 @@ hEy
 jzy
 hEy
 obT
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-taw
+obT
+obT
+obT
+obT
+obT
+obT
+obT
+obT
+obT
+iDp
+iDp
+csj
+csj
+csj
+csj
+csj
+csj
 uCf
 uCf
+rtg
 uCf
-cat
+ffF
+gse
+ffF
+gse
+gse
+gse
+ffF
+gse
+gse
+gse
 uCf
 uCf
-uCf
-uCf
-cat
-uCf
-bRq
-uCf
-uCf
-cat
-cat
-uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+tyX
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (57,1,1) = {"
@@ -154179,7 +150235,7 @@ jtY
 laW
 xNn
 fNg
-vvv
+hpd
 eWM
 fDs
 xcv
@@ -154269,60 +150325,60 @@ jLB
 jLB
 jLB
 atI
-qqT
-qqT
-qqT
-aWQ
-aWQ
+atI
+vcV
+vcV
+csj
+csj
+aNS
+eXS
 tHU
-pLX
 tHU
-udt
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
 tHU
 aNS
 mRe
 qES
 pwh
-udt
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
+tHU
+csj
+csj
+uhf
+uhf
+pMf
+pMf
+pMf
+pMf
+uhf
 rjr
 rHY
 cqX
 vne
 did
 rjr
-ldK
-lhZ
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-ldK
-ldK
+sfu
+fkr
+fkr
+fkr
+fkr
+sfu
+sfu
+hvw
+hvw
 sMN
-ldK
-ldK
-ldK
-ldK
-ldK
+hvw
+hvw
+hvw
+hvw
+obT
 obT
 dFn
 uqM
@@ -154330,45 +150386,45 @@ bYS
 bYS
 pXd
 obT
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-udt
+obT
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
 tHU
+tHU
+uCf
+rtg
+gse
+gse
+ffF
+ffF
 ffF
 uCf
-gme
+rtg
+esT
+uCf
+ffF
+gse
 uCf
 uCf
+vyc
 uCf
-uCf
-cat
-uCf
-adQ
-uCf
-uCf
-cat
-cat
-cat
-uCf
-taw
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (58,1,1) = {"
@@ -154474,58 +150530,58 @@ uZJ
 bYP
 yjf
 qxq
-qqT
-aWQ
+vcV
+csj
 slN
-udt
+aNS
 aNS
 aNS
 ltM
 tHU
-udt
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-udt
-umk
+tHU
+csj
+csj
+csj
+tHU
+wwN
+csj
+fUG
+bLL
 aNS
 aNS
-lRa
-lRa
+aNS
+aNS
 aNS
 tHU
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-lhZ
-ldK
+csj
+csj
+uhf
+uhf
+pMf
+pMf
+pMf
+uhf
 rjr
 sHW
 ejc
 vne
 sJA
 rjr
-ldK
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-aWQ
-aWQ
+sfu
+fkr
+fkr
+fkr
+sfu
+sfu
+csj
+csj
 tHU
 tHU
 tHU
-aWQ
-aWQ
-aWQ
-ldK
+csj
+csj
+csj
+obT
 obT
 vvI
 xRT
@@ -154533,45 +150589,45 @@ xRT
 qVS
 ktf
 obT
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+obT
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
+csj
 tHU
 tHU
-eXS
-tHU
-uCf
-uCf
-uCf
+pLX
+kZP
+ffF
+gme
+gse
 roJ
+uCf
+uCf
+uCf
+uCf
+uCf
+uCf
+ccf
 uCf
 ffF
 uCf
-taw
-uCf
-cat
 ccf
-uCf
-taw
-cat
-uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (59,1,1) = {"
@@ -154603,8 +150659,8 @@ xns
 vCP
 tky
 uAC
-srY
-uwD
+plW
+bff
 xns
 meL
 tky
@@ -154677,58 +150733,58 @@ jUb
 jRt
 hJK
 jIA
-qqT
-aWQ
-tHU
-tHU
-udt
+vcV
+csj
 aNS
 aNS
-udt
+aNS
+aNS
+aNS
+tHU
 tHU
 eyS
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+csj
+csj
+tHU
+tHU
+fUG
+fUG
+fUG
+pLX
 tHU
 aNS
+pwh
 eXS
 tHU
-lRa
-lau
-pLX
-aNS
-udt
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-lhZ
-ldK
+tHU
+csj
+csj
+uhf
+uhf
+pMf
+pMf
+uhf
 rjr
 dqc
 ejc
 vne
 aEk
 rjr
-ldK
-lhZ
-lhZ
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-udt
+sfu
+fkr
+fkr
+sfu
+sfu
+csj
+csj
+csj
 tHU
+ltM
 tHU
 slN
-aWQ
-aWQ
-ldK
+csj
+csj
+obT
 obT
 hEy
 hEy
@@ -154736,45 +150792,45 @@ hEy
 hEy
 hEy
 obT
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+obT
+csj
+csj
+csj
+csj
+csj
+csj
+csj
 slN
-aWQ
-udt
-kZP
-kZP
+csj
 tHU
-aNS
-udt
-aNS
-aNS
+tHU
+ltM
+tHU
+tHU
+kZP
+oXR
+oXR
+ffF
 uCf
 uCf
 uCf
+ccf
 taw
-uCf
-uCf
 jRp
-aWQ
-taw
+ghY
 uCf
-cat
 uCf
-cat
 uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+gse
+ffF
+uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (60,1,1) = {"
@@ -154880,125 +150936,125 @@ wjO
 cmc
 mTE
 aFy
-qqT
-tHU
+vcV
 aNS
-udt
+aNS
+aNS
 aNS
 aNS
 pwh
 ltM
 tHU
 tHU
-aWQ
-aWQ
-aWQ
-aWQ
-udt
-tHU
-aNS
-aNS
-tHU
-psh
-aNS
-aNS
+csj
+csj
 tHU
 tHU
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-lhZ
-ldK
+ltM
+csj
+csj
+fUG
+tHU
+tHU
+aNS
+tHU
+tHU
+fUG
+csj
+csj
+csj
+uhf
+uhf
+pMf
+uhf
 rjr
 rjr
 hiL
 xLD
 rjr
 rjr
-ldK
-lhZ
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-psh
+sfu
+fkr
+sfu
+sfu
+csj
+csj
+csj
 tHU
 tHU
-udt
+tHU
+kZP
 bLL
-aNS
-aWQ
-ldK
-obT
-roY
-roY
-roY
-roY
-roY
-obT
-ldK
-aWQ
-aWQ
-aWQ
-udt
 tHU
-kZP
-kZP
+csj
+obT
+obT
+roY
+roY
+roY
+roY
+roY
+obT
+obT
+csj
+csj
+csj
+tHU
+tHU
+tHU
+tHU
 ltM
 tHU
-aNS
+tHU
+tHU
 kZP
-kZP
 aNS
-tHU
-tHU
 aNS
-tHU
-ffF
-taw
-ffF
+aNS
+oXR
+aNS
 uCf
-taw
 uCf
+uCf
+cat
+cat
+cat
 brE
-aWQ
-aWQ
+ghY
+ghY
 uCf
-cat
-cat
-cat
-cat
-taw
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+rtg
+gse
+gse
+uCf
+uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (61,1,1) = {"
 lwn
-ldK
-ldK
-ldK
-ldK
+dWF
+dWF
+dWF
+dWF
 dWF
 dWF
 sHF
 dWF
 dWF
 dWF
-ldK
-ldK
-ldK
-laB
-laB
-laB
-laB
+dWF
+xfz
+xfz
+xfz
+xfz
+xfz
+xfz
 oVD
 lKn
 aFe
@@ -155010,7 +151066,7 @@ qXy
 ijS
 hmF
 srY
-uwD
+ivG
 vTN
 rSu
 sXI
@@ -155083,121 +151139,121 @@ jPj
 sol
 eyn
 hgA
-qqT
+wTG
 aNS
 aNS
 aNS
-aWQ
+csj
 oXR
 aNS
 aNS
 tHU
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+csj
+csj
+fUG
+fUG
+csj
 tHU
 tHU
-aWQ
-udt
+csj
+fUG
+csj
 tHU
-aNS
-lRa
-lRa
+tHU
+tHU
+fUG
+fUG
 bYt
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
+csj
+csj
+csj
+uhf
+uhf
+uhf
 rjr
 rjr
 owB
 jwE
 rjr
 rjr
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
+sfu
+sfu
+sfu
+csj
+csj
+csj
 tHU
 aNS
 aNS
+oXR
+oXR
+kZP
 tHU
-aNS
 tHU
-udt
-psh
 nCl
 obT
-qMq
-qMq
-qMq
-qMq
+vtj
+vtj
+vtj
+vtj
 ana
 obT
-pmV
-udt
-aWQ
+wyb
+fUG
+csj
+fUG
+tHU
+ltM
+tHU
+tHU
 tHU
 aNS
-pwh
+aNS
 oXR
-gmP
-tHU
-aNS
-aNS
-aNS
-pwh
-hoK
+oXR
+oXR
+gmq
 aNS
 tHU
 tHU
-aNS
-udt
-aWQ
-aWQ
-vJw
+van
+ghY
+ghY
+apx
 vmE
-taw
+cat
+cat
+ghY
+ghY
 uCf
-aWQ
-aWQ
-taw
-cat
-cat
-bRq
-cat
 uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+rtg
+gme
+uCf
+uCf
+ghY
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (62,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 kaE
-fWa
-fWa
-fWa
-fWa
-fWa
-aWQ
-aWQ
-ldK
+pEe
+pjR
+pEe
+pEe
+pEe
+wPV
+wPV
+laB
 laB
 laB
 laB
@@ -155212,8 +151268,8 @@ tig
 vCP
 lhF
 hmF
-plW
-nWg
+srY
+ykb
 whb
 kTc
 jzQ
@@ -155262,7 +151318,7 @@ ekZ
 shs
 tyo
 lUX
-pCg
+tyo
 shs
 shs
 tyo
@@ -155286,121 +151342,121 @@ oTD
 jRt
 wWZ
 wmu
-qqT
+vcV
 aNS
 aNS
-aWQ
-aWQ
+csj
+csj
 oXR
 aNS
 aNS
 tHU
 tHU
-udt
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-udt
-aWQ
-aWQ
-aWQ
+hXu
+fUG
+csj
+csj
 tHU
-lRa
-lRa
-aNS
-aWQ
-udt
-aWQ
-aWQ
-ldK
-ldK
+tHU
+ltM
+fUG
+csj
+csj
+csj
+fUG
+fUG
+tHU
+tHU
+csj
+tHU
+csj
+csj
+uhf
+uhf
 rjr
 lvA
 mAU
 srS
 lXp
 rjr
-ldK
-ldK
-aWQ
-aWQ
-aWQ
+sfu
+sfu
+csj
+csj
+csj
 tHU
 eXS
 aNS
-tHU
 aNS
-pwh
+aNS
+oXR
 aNS
 pLX
 tHU
-udt
+tHU
 hOH
-qMq
-qMq
-qMq
-qMq
-qMq
+vtj
+vtj
+vtj
+vtj
+vtj
 hOH
 tHU
+fUG
+fUG
+xEq
 tHU
-tHU
-eXS
+pLX
+aNS
+aNS
 aNS
 eXS
-tHU
-tHU
-aNS
-eXS
 aNS
 tHU
+kZP
 tHU
-aNS
 tHU
-eXS
+pLX
 tHU
-aNS
-tHU
-aWQ
-aWQ
-aWQ
-aWQ
-taw
-aWQ
-aWQ
-aWQ
-aWQ
+uvk
+iJa
+ghY
+ghY
+ghY
+ghY
+mdC
+ghY
+ghY
+ghY
+ghY
+cat
+uCf
+uCf
 uCf
 cat
 cat
-uCf
 cat
+ghY
 uCf
-kwZ
-aWQ
-taw
 uCf
-aWQ
+ghY
 lwn
 "}
 (63,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
-pQA
-hRC
-pQA
-pQA
-hRC
-pQA
+pjR
+iSB
+pjR
+pjR
+iSB
+pjR
 aSK
-aWQ
-ldK
+wPV
+laB
 qkv
 fcu
 vWi
@@ -155448,7 +151504,7 @@ vgh
 ujL
 jxc
 bhu
-cVP
+jnE
 lcR
 vaB
 wdc
@@ -155489,121 +151545,121 @@ hcD
 wUI
 jSm
 lgh
-qqT
-aWQ
-aWQ
-aWQ
-aWQ
+vcV
+csj
+csj
+csj
+csj
 oXR
 jkj
 ade
 ade
 ade
-ucA
+ark
 kZP
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-pLX
-aNS
-lRa
-wxr
+csj
+csj
+csj
+tHU
+tHU
+slN
+csj
+csj
+csj
+xEq
+tHU
+tHU
+eXS
 aNS
 tHU
 bLL
-aWQ
-aWQ
-ldK
+csj
+csj
+uhf
 rjr
 thC
 fdt
 fdt
 glx
 rjr
-ldK
-aWQ
-aWQ
-aWQ
-udt
-tHU
-aNS
-aNS
-aNS
-tHU
-aNS
-aNS
-aNS
+sfu
+csj
+csj
+csj
 tHU
 tHU
+pwh
+aNS
+oXR
+aNS
+aNS
+aNS
+aNS
 tHU
+tHU
+kZP
 aNS
 aNS
-aNS
-aNS
+aSf
+aUH
 aNS
 tHU
 ltM
+fUG
+fUG
+fUG
 tHU
 tHU
-tHU
+ltM
 aNS
-tHU
-ark
 oXR
-aNS
 pwh
 tHU
-aNS
 tHU
-aNS
-udt
-aWQ
-udt
 tHU
-aWQ
-aWQ
-lwn
-lwn
-aWQ
+tHU
+tHU
+csj
+fUG
+dMr
+csj
+ghY
+qgR
+qgR
 ghY
 ghY
-aWQ
-lwn
-aWQ
-uCf
+ghY
+ghY
+qgR
+ghY
 cat
 cat
 ihu
+xOI
 cat
-ihu
-kwZ
+sTB
 uCf
 uCf
+ccf
 uCf
 uCf
 lwn
 "}
 (64,1,1) = {"
 lwn
-aWQ
-aWQ
-vvA
-fmk
+wPV
+wPV
+aSK
+aSK
 pjR
-pQA
 pjR
-pQA
+pjR
+pjR
 uTs
 aSK
-aWQ
-aWQ
-ldK
+wPV
+wPV
+laB
 kUR
 gOG
 agl
@@ -155692,121 +151748,121 @@ aFy
 nLo
 gmg
 nxH
-ldK
-ldK
-ldK
-ldK
-aWQ
+sNe
+ftl
+ftl
+ftl
+csj
 tHU
 eXS
 aNS
 aNS
 eXS
-oXR
 kZP
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-udt
-lRa
-lRa
+kZP
+csj
+csj
+csj
+csj
+tHU
+csj
+csj
+csj
+csj
+csj
+tHU
 aNS
 aNS
+aSf
+aUH
 pwh
 tHU
-aWQ
-aWQ
+csj
+csj
 rjr
 rjr
 eGd
 tqg
 rjr
 rjr
-aWQ
-aWQ
-psh
+csj
+csj
+tHU
 tHU
 tHU
 aNS
 gmq
+oXR
+kZP
+kZP
+tHU
+aNS
+aNS
 pwh
 oXR
-gmP
-tHU
-aNS
-aNS
-pwh
-tHU
-aNS
-lRa
-lRa
+oXR
+oXR
+aSf
 lau
+lRa
+aUH
 aNS
-aNS
-aNS
-udt
 tHU
-aWQ
-aWQ
+fUG
+csj
+csj
 tHU
-jUH
+pLX
+tHU
 oXR
 oXR
-aNS
+kZP
 tHU
-aNS
-udt
-aWQ
-udt
-aWQ
-aWQ
-aWQ
-udt
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-aWQ
-taw
+tHU
+ltM
+tHU
+csj
+csj
+fUG
+fUG
+csj
+qgR
+qgR
+qgR
+ghY
+ghY
+ghY
+ghY
+qgR
+ghY
 cat
-cat
-uCf
 bRq
-uCf
-aWQ
-taw
+xOI
+xOI
+xOI
+ome
+ghY
+rsK
 vyc
-aWQ
-aWQ
+ghY
+ghY
 lwn
 "}
 (65,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 hqC
-hnn
+ixA
 aSK
 pjR
 rTg
 pjR
 ilO
 aSK
-aWQ
-aWQ
-ldK
+wPV
+wPV
+laB
 tkU
 iNk
 rKz
@@ -155841,8 +151897,8 @@ wbI
 vWA
 nXq
 sYU
-qSj
-ftJ
+gQG
+dse
 mBD
 qIP
 lOA
@@ -155898,32 +151954,32 @@ kvl
 kvl
 kvl
 kvl
-ldK
-ldK
+ftl
+ftl
 tHU
 aNS
 oXR
 aNS
 pwh
-oXR
-gmP
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+kZP
+kZP
+tHU
+tHU
+csj
+csj
+fUG
+fUG
+csj
+csj
+csj
 tHU
 eyS
-tHU
-gmq
 aNS
-rtM
-rxf
-htG
+lsv
+vxK
+vxK
+aUH
+tHU
 xBm
 oxe
 pmV
@@ -155934,82 +151990,82 @@ rjr
 pmV
 tHU
 eyS
-udt
-aNS
+tHU
+tHU
 aNS
 aNS
 aNS
 tHU
 kZP
 csj
-tHU
-udt
-aNS
-udt
 bLL
+tHU
+tHU
 aNS
-lRa
-lRa
-lRa
+aNS
 oXR
+aSf
+lRa
+vxK
+vxK
 qWb
-aNS
+aUH
 tHU
-aWQ
-aWQ
-lwn
-lwn
-aNS
-eXS
+csj
+csj
+lxG
+lxG
 tHU
-aNS
+pLX
+tHU
+oXR
 tHU
 tHU
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
+csj
+csj
+csj
+csj
+lxG
+csj
+csj
+csj
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+ghY
+ghY
+rNL
+rNL
+rtg
 uCf
-cat
-bRq
-cat
 uCf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (66,1,1) = {"
 lwn
-aWQ
-aWQ
-vvA
-fmk
+wPV
+wPV
+aSK
+aSK
 aSK
 wnF
 pjR
 pjR
-vvA
-vvA
-aWQ
-aWQ
-ldK
+aSK
+aSK
+wPV
+wPV
+laB
 khZ
 iZy
 qUK
@@ -156044,8 +152100,8 @@ wbI
 vWA
 qSd
 hww
-vqC
-ftJ
+gQG
+xZG
 mBD
 vPU
 nQu
@@ -156077,7 +152133,7 @@ qnp
 soG
 fAW
 smD
-spU
+fAW
 lmO
 bgQ
 nQn
@@ -156087,7 +152143,7 @@ fgY
 nQn
 vCE
 qTd
-lYd
+aIr
 qfI
 bgQ
 cxl
@@ -156103,30 +152159,30 @@ vxP
 kvl
 kvl
 kvl
-aWQ
+csj
 tHU
 aNS
 aNS
 aNS
+ade
+aNS
+aNS
 tHU
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+tHU
+csj
+csj
+hXu
+csj
+csj
+csj
 udt
 tHU
 aNS
-pwh
-aSf
+fRT
 vxK
 vxK
-aUH
+qES
+tHU
 kwL
 tyJ
 bNs
@@ -156137,82 +152193,82 @@ rjr
 xKk
 udt
 tHU
-aNS
+tHU
 oXR
 ucA
 aNS
-udt
+aNS
 tHU
-aWQ
-udt
-aWQ
+csj
+csj
+csj
 van
-udt
-aNS
-aNS
-aSf
-tlf
-lRa
-lRa
-oXR
-oXR
-pwh
-aNS
-aWQ
-lwn
-lwn
-lwn
-lwn
-aNS
-udt
 tHU
 tHU
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-taw
-cat
-cat
-cat
+tHU
+aNS
+pmd
+lRa
+vxK
+vxK
+lRa
+sOn
+tHU
+csj
+lxG
+lxG
+lxG
+lxG
+tHU
+tHU
+aNS
+tHU
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+jQO
 uCf
+uCf
+ffF
+ffF
 uhJ
-aWQ
-aWQ
-aWQ
-aWQ
+ghY
+ghY
+ghY
+ghY
 lwn
 "}
 (67,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 aSK
 pjR
 pjR
 aSK
 aSK
-aWQ
-aWQ
-aWQ
-ldK
+wPV
+wPV
+wPV
+laB
 wMN
 djn
 djn
@@ -156247,7 +152303,7 @@ wbI
 vWA
 qSd
 tmm
-eci
+gQG
 ftJ
 mBD
 vrX
@@ -156257,7 +152313,7 @@ iyY
 aKu
 qiM
 fbb
-bzH
+bVz
 jxc
 ksj
 jnE
@@ -156281,7 +152337,7 @@ rjI
 rjI
 wMz
 pec
-ict
+lcR
 bgQ
 nQn
 pvJ
@@ -156290,7 +152346,7 @@ onE
 nQn
 oTi
 aWl
-lYd
+aIr
 eKl
 bgQ
 nQn
@@ -156307,31 +152363,31 @@ eui
 fyR
 hnu
 kvl
-ldK
+kPk
 hwN
 hxe
-ldK
-aWQ
-aWQ
+kPk
+csj
 tHU
 aNS
 aNS
-udt
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
 tHU
+tHU
+tHU
+fUG
+csj
+csj
+csj
+csj
+csj
 aNS
 aNS
+pmd
+qES
 aNS
 tHU
-aWQ
 wHv
-pBH
+eNf
 lRx
 hpg
 qMq
@@ -156340,82 +152396,82 @@ wVx
 pvB
 sTC
 slN
-udt
+tHU
 oXR
 koX
-lRa
-lRa
-qES
+aNS
+aNS
+tHU
 wHv
 pBH
 lRx
-hpg
+bbj
+eGj
 qMq
 qMq
-wVx
 pvB
-sTC
-tHU
-eXS
-tHU
+dDI
+pmd
+wxr
+lRa
+qES
 aNS
-tHU
 pLX
-aWQ
-lwn
-lwn
-lwn
-lwn
-pLX
-aNS
-aSf
-lau
-lwn
-kBD
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+csj
 lxG
-lwn
-lwn
-aWQ
-aWQ
-aWQ
+lxG
+lxG
+lxG
+pLX
+aNS
+aNS
+ltM
+lxG
+kBD
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+ghY
+ghY
 uCf
-cat
-ccf
 uCf
-aWQ
-aWQ
-dis
+gme
+uCf
+ghY
+ghY
+trR
 xxz
 lwn
 "}
 (68,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 pjR
 pjR
 pjR
-aSK
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+pjR
+wPV
+wPV
+wPV
+wPV
+laB
 uru
 djn
 dCS
@@ -156484,7 +152540,7 @@ hom
 tuG
 lyG
 iLt
-jEj
+bXE
 wRu
 nQn
 sDv
@@ -156510,31 +152566,31 @@ xKy
 aEb
 oTF
 kvl
-ldK
-gSz
+kPk
 xIg
-ldK
-aWQ
-aWQ
+xIg
+kPk
+csj
+csj
 pLX
 aNS
 pwh
 eXS
-udt
-aWQ
-aWQ
-aWQ
-udt
-tHU
-kwO
-aNS
-aNS
-aNS
 tHU
 tHU
-udt
+csj
+csj
+fUG
+fUG
+tHU
+tHU
+aNS
+aNS
+oXR
+aNS
+tHU
 oMD
-boN
+yaK
 upA
 qMq
 eGj
@@ -156546,59 +152602,59 @@ tHU
 tHU
 aNS
 aNS
-pmd
-tSX
-lRa
+aNS
+aNS
+aNS
 oMD
 boN
 upA
 qMq
-eGj
+qMq
 qMq
 qMq
 xss
 vZd
 aNS
+pmd
+qES
 aNS
 tHU
 tHU
+csj
+lxG
+lxG
+lxG
+bLL
 aNS
-wvl
-aWQ
-lwn
-lwn
-lwn
-jDH
 aNS
 oXR
-koX
-lRa
-lRa
+tHU
+tHU
 qij
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-cat
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+ghY
 uCf
-aWQ
-dis
+uCf
+uCf
+trR
 xxz
 nLp
 deK
@@ -156606,19 +152662,19 @@ lwn
 "}
 (69,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 gsL
 aSK
 aSK
 pjR
-ixA
-pQA
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+ilO
+pjR
+wPV
+wPV
+wPV
+wPV
+laB
 fnl
 pJx
 jpi
@@ -156665,7 +152721,7 @@ nKR
 xBI
 xPs
 hjr
-qzR
+tyo
 akT
 rqX
 tuG
@@ -156687,7 +152743,7 @@ nXz
 tuG
 rqX
 lNC
-pCg
+tyo
 oji
 oji
 sDv
@@ -156696,7 +152752,7 @@ uJM
 nRo
 fYi
 tgM
-lYd
+aIr
 vlM
 kZc
 nQn
@@ -156716,26 +152772,26 @@ kvl
 qSZ
 ruV
 tNX
-ldK
-ldK
-aWQ
-udt
+kPk
+kPk
+csj
+tHU
 tHU
 aNS
 aNS
 pwh
 tHU
-aWQ
+csj
 tHU
+fUG
+bVc
+fUG
 tHU
-tHU
-kwO
-tHU
-pwh
-aNS
+ltM
 oXR
 oXR
-aNS
+oXR
+tHU
 snr
 tup
 kHe
@@ -156744,63 +152800,63 @@ wxa
 wxa
 mif
 dVl
-udt
-hIq
-msJ
-pLX
-aNS
-pwh
-lRa
-wxr
-snr
-tup
-kHe
-qMq
-qMq
-gIP
-mif
-dVl
-udt
+tHU
 tHU
 aNS
+eXS
 aNS
-udt
+pwh
+aNS
+eXS
+tHU
+tHU
+gSz
+qMq
+qMq
+qMq
+mif
+dVl
+tHU
+tHU
+oXR
+aNS
+ltM
 tHU
 wwN
-aWQ
-aWQ
-lwn
-lwn
+csj
+csj
+lxG
+lxG
 uIG
 kCo
 oXR
-vxK
-iwX
-qES
-aNS
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-cat
-cat
-aWQ
+oXR
+oXR
+tHU
+tHU
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+ghY
+rNL
+rNL
+ghY
 nLp
 deK
 pnY
@@ -156809,19 +152865,19 @@ lwn
 "}
 (70,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 oth
-vvA
+aSK
 pjR
 pjR
-pQA
-ouc
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+pjR
+faB
+wPV
+wPV
+wPV
+wPV
+laB
 dKA
 nnx
 sgJ
@@ -156868,7 +152924,7 @@ lme
 vgh
 qyZ
 sDu
-aXg
+jnE
 jnE
 qnp
 qnp
@@ -156890,7 +152946,7 @@ fRc
 vBV
 ieN
 eeQ
-qyV
+dHO
 sEL
 ljq
 mEV
@@ -156920,26 +152976,26 @@ qSZ
 qve
 gNc
 mbm
-ldK
-aWQ
-aWQ
-udt
+kPk
+csj
+csj
+tHU
 hiS
-pLX
-aNS
-aNS
-udt
-tHU
 eXS
+aNS
 tHU
+tHU
+tHU
+kZP
+bVc
 bVc
 fUG
 tHU
 eXS
-ucA
 oXR
 aNS
-aNS
+tHU
+tHU
 tHU
 rkC
 qMq
@@ -156948,62 +153004,62 @@ wxa
 qMq
 xKk
 tHU
-hIq
-eGj
+pwh
+eXS
+tHU
+tHU
+aNS
+aNS
+kZP
+tHU
+tHU
+rkC
+qMq
+qMq
+qMq
+qMq
+xKk
+tHU
+oXR
+bef
+kZP
+tHU
 udt
 tHU
-aNS
-aNS
-aNS
-aNS
-tHU
-rkC
-qMq
-qMq
-qMq
-qMq
-xKk
-tHU
+csj
+csj
+csj
+pDW
 aNS
 pwh
-tHU
-tHU
-udt
-tHU
-aWQ
-aWQ
-aWQ
-pDW
-lRa
-lau
 aNS
-lRa
-lau
-aNS
+rtM
+lAC
 aNS
 aNS
 tHU
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-dis
+tHU
+csj
+csj
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+ghY
+ghY
+trR
 xxz
 xxz
 bRq
 cat
-uCf
+cat
 deK
 vcE
 vcE
@@ -157012,14 +153068,14 @@ lwn
 "}
 (71,1,1) = {"
 lwn
-aWQ
+wPV
 sBL
-vvA
+aSK
 iUW
 giV
 miQ
-pQA
-fWa
+pjR
+pEe
 wPf
 wPf
 wPf
@@ -157102,7 +153158,7 @@ bgQ
 nQn
 oTi
 qTd
-lYd
+aIr
 eKl
 bgQ
 aWT
@@ -157123,43 +153179,43 @@ qSZ
 uGW
 qBh
 mbm
-ldK
-aWQ
-aWQ
-aWQ
+kPk
+csj
+csj
+csj
 nWn
 gay
+eXS
+aNS
+pwh
+aNS
 pLX
-aNS
-aNS
+kZP
+bYt
+fUG
+tHU
+tHU
+eXS
 aNS
 aNS
 tHU
-ltM
-kwO
-udt
-aNS
-pLX
-aNS
-aNS
-aNS
-umk
+bLL
 pmV
 mSC
 mSC
 mSC
 mSC
 pmV
-tHU
-szT
-phU
-sVc
-udt
 aNS
+eXS
+tHU
+tHU
 tHU
 aNS
-aNS
-umk
+kZP
+kZP
+kZP
+bLL
 pmV
 mSC
 mSC
@@ -157168,62 +153224,62 @@ aHh
 pmV
 tHU
 tHU
-aNS
+oXR
 tHU
-aNS
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+tHU
+csj
+csj
+csj
+csj
+csj
 tHU
 jiZ
+aNS
+aSf
 lRa
-aNS
-aNS
-oXR
-ucA
 lRa
-lau
+lAC
 aNS
-lIc
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-dis
+pwh
+aNS
+tHU
+csj
+csj
+lxG
+lxG
+lxG
+qgR
+qgR
+qgR
+qgR
+qgR
+ghY
+trR
 xxz
 xxz
 nLp
 deK
-xsf
+wxD
 cat
 ihu
-taw
+cat
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 lwn
 "}
 (72,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
 pjR
 pjR
-fWa
-wPf
+pjR
+vNw
 jWM
 lED
 xGH
@@ -157305,7 +153361,7 @@ pAB
 vLy
 wKC
 qTd
-lYd
+aIr
 iYq
 wGc
 nQn
@@ -157326,80 +153382,80 @@ fGm
 uUc
 qBh
 mbm
-ldK
-ldK
+kPk
+kPk
 jLF
 bKG
 oEd
-udt
+aNS
+aNS
 tHU
 tHU
+tHU
+tHU
+tHU
+fUG
+csj
+csj
+tHU
+aNS
+oXR
+aNS
 pwh
 aNS
 aNS
-tHU
-udt
-aWQ
-aWQ
-tHU
-tHU
-pwh
 aNS
-lau
-lRa
-kfk
+aNS
 aNS
 aNS
 aNS
 aNS
 tHU
 tHU
-udt
-qMq
-aWQ
-aWQ
-bLL
+csj
+csj
 tHU
-aNS
+tHU
+kZP
 lRa
 lau
-kfk
-aNS
-aNS
-aNS
-aNS
+dPQ
 tHU
 tHU
-aNS
-aNS
-aNS
 tHU
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+tHU
+tHU
+tHU
+tHU
+ltM
+tHU
+tHU
+csj
+csj
+csj
+csj
+csj
 xzU
 wLB
 aNS
-aNS
-aNS
-oXR
-oXR
+pmd
 lRa
 lRa
+qES
+oXR
+oXR
 aNS
 aNS
-lIc
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-dis
+tHU
+csj
+lxG
+lxG
+lxG
+lxG
+qgR
+qgR
+ghY
+trR
 xxz
 nLp
 deK
@@ -157408,23 +153464,23 @@ pnY
 hNH
 vcE
 uCf
-cat
-ihu
+uCf
+dbQ
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 lwn
 "}
 (73,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 gsL
 aSK
 pjR
 ilO
-pQA
+pjR
 vWK
 wPf
 jXc
@@ -157508,7 +153564,7 @@ xZu
 vjc
 oTi
 qTd
-lYd
+aIr
 eKl
 xSw
 imS
@@ -157530,40 +153586,40 @@ fOb
 gNc
 jjZ
 alw
-ldK
+kPk
 wOt
 lRa
 grK
-qMq
-udt
-euN
+aNS
 tHU
-oXR
-oXR
 tHU
-aWQ
-aWQ
-aWQ
+eyS
+nQX
 tHU
-aNS
-aNS
-aNS
-aNS
-aNS
+tHU
+csj
+csj
+csj
+tHU
+kZP
+bef
 oXR
-oXR
+aNS
+aSf
+aUH
+aNS
 aNS
 pwh
 aNS
 aNS
-aNS
-udt
-aWQ
-aWQ
-aWQ
-aWQ
 tHU
-aNS
+tHU
+csj
+csj
+csj
+csj
+tHU
+tHU
 lRa
 lRa
 lRa
@@ -157574,34 +153630,34 @@ xdq
 vcE
 vcE
 vcE
-aNS
+tHU
 bLL
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+csj
+csj
+csj
+csj
+csj
 bLL
 iaX
 dUJ
 eXS
-lau
-lRa
+pwh
+pmd
+qES
 aNS
-aNS
-tHU
-aNS
-aNS
+qKE
+oXR
+oXR
 pwh
 tHU
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-dis
+csj
+lxG
+lxG
+lxG
+lxG
+lxG
+ghY
+trR
 nLp
 deK
 pnY
@@ -157611,24 +153667,24 @@ vcE
 vcE
 vcE
 vcE
-taw
-bRq
+uCf
+ccf
 vcE
 vcE
 vcE
-keo
+uZo
 lwn
 "}
 (74,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
 pjR
-pQA
-oaW
+pjR
+pZs
 wPf
 rlH
 azC
@@ -157733,41 +153789,41 @@ tXg
 muL
 pdI
 jKw
-ldK
+kPk
 eYy
 gCt
 grK
-udt
+aNS
 anj
-qMq
 tHU
+tHU
+tHU
+tHU
+tHU
+csj
+lxG
+csj
+tHU
+ltM
 kZP
-gmP
-tHU
-aWQ
-lwn
-aWQ
-udt
-tHU
 aNS
-kZP
-oXR
-aNS
-oXR
-oXR
-aNS
+aSf
+vxK
+vxK
+aUH
 aNS
 aNS
 tHU
-udt
-aWQ
-aWQ
-lwn
-lwn
-aWQ
-udt
+tHU
+tHU
+csj
+csj
+lxG
+lxG
+csj
+bLL
 pLX
-aNS
+tHU
 lRa
 vcE
 vcE
@@ -157783,39 +153839,39 @@ vcE
 vcE
 vcE
 vcE
-mLs
+hMX
 oYf
 tHU
-tHU
+kZP
 aNS
-wxr
-lRa
+eXS
 aNS
-udt
-psh
-tHU
-wxr
-lRa
+aNS
+jDH
+slN
+hIq
+eXS
+aNS
 aNS
 tHU
-lwn
-lwn
-lwn
-lwn
-lwn
+lxG
+lxG
+lxG
+lxG
+lxG
 dis
 nLp
 deK
 vcE
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
-uCf
-cat
+rNL
+rNL
 vcE
 vcE
 vcE
@@ -157824,14 +153880,14 @@ lwn
 "}
 (75,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+aSK
 pjR
 pjR
 iSB
-oaW
+pZs
 wPf
 wPf
 wPf
@@ -157914,7 +153970,7 @@ kmB
 nQn
 oTi
 qTd
-lYd
+aIr
 eKl
 bgQ
 cxl
@@ -157936,41 +153992,41 @@ ffH
 qBh
 gNc
 jKw
-ldK
+kPk
 bxF
 bKG
-hIq
-kow
-hIq
-hvd
-gay
-tHU
-tHU
-aWQ
-aWQ
-lwn
-aWQ
-aWQ
-tHU
-tHU
-kZP
-oXR
 aNS
-pwh
+kfk
 aNS
-aNS
+euN
+vwE
+tHU
+tHU
+csj
+csj
+lxG
+csj
+csj
+tHU
+tHU
+tHU
+pmd
+vxK
+vxK
+qES
 aNS
 tHU
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
 tHU
-eXS
+csj
+csj
+lxG
+lxG
+lxG
+lxG
+csj
+csj
+fUG
+xEq
 vcE
 vcE
 vcE
@@ -157983,34 +154039,34 @@ weq
 weq
 weq
 weq
-yaI
+wFj
 vcE
-mLs
-vQa
-lFr
-wbi
-psh
-aNS
+hMX
+hQY
+tHU
+dNK
+kZP
+oXR
 aNS
 aNS
 tHU
-lwn
-udt
+lxG
+nEL
 aNS
-lRa
-lau
-udt
-lwn
-lwn
-lwn
-lwn
-lwn
+aNS
+pwh
+tHU
+lxG
+lxG
+lxG
+lxG
+lxG
 dis
-nLp
+dSH
 deK
 hNH
 vcE
-keo
+uZo
 cQv
 cQv
 cQv
@@ -158027,19 +154083,19 @@ lwn
 "}
 (76,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 aSK
 hOK
-pQA
-ouc
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+pjR
+aGA
+wPV
+wPV
+wPV
+wPV
+laB
 xms
 mDA
 fRQ
@@ -158117,7 +154173,7 @@ bXm
 nQn
 oTi
 qTd
-lYd
+aIr
 eKl
 bgQ
 hjr
@@ -158139,43 +154195,43 @@ wtZ
 qBh
 bBZ
 kHZ
-ldK
+kPk
 xRu
 bKG
 phU
 sIZ
-udt
-qMq
-udt
+aNS
+aNS
+aNS
 hiS
-aWQ
-aWQ
-lwn
-lwn
-aWQ
-aWQ
-udt
+csj
+csj
+lxG
+lxG
+csj
+csj
 tHU
-udt
 tHU
-aNS
-aNS
-aNS
-udt
 tHU
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-uIa
-wfl
+tHU
+pmd
+qES
+aNS
+tHU
+tHU
+csj
+csj
+lxG
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+icp
+icp
 vcE
-keo
+uZo
 vcE
 hNH
 qOz
@@ -158192,30 +154248,30 @@ jiU
 fWs
 wbi
 kRv
-kRv
+fdb
 aNS
 eXS
-psh
-lwn
-lwn
-udt
 tHU
-aNS
-aNS
+lxG
+lxG
+igF
+tHU
+oXR
+oXR
 ltM
-udt
-lwn
-lwn
-lwn
+tHU
+lxG
+lxG
+lxG
 dis
-nLp
+dSH
 deK
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 cQv
-keo
+uZo
 vcE
 tws
 hNH
@@ -158230,19 +154286,19 @@ lwn
 "}
 (77,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 iFQ
 pjR
 pjR
 pjR
-szw
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+ixA
+wPV
+wPV
+wPV
+wPV
+laB
 fFU
 gNH
 hMu
@@ -158341,8 +154397,8 @@ tPk
 bif
 xXV
 ibW
-ldK
-ldK
+kPk
+kPk
 auG
 lRa
 jrY
@@ -158351,33 +154407,33 @@ vVH
 vVH
 emB
 vVH
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+csj
+lxG
+lxG
+lxG
+lxG
+csj
+csj
 udt
 ptJ
-udt
+ltM
 tHU
 aNS
 tHU
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-svA
-kRv
+csj
+csj
+csj
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+kqj
+lIc
+lIc
 vcE
 uZo
 eqL
@@ -158398,29 +154454,29 @@ kRv
 kgG
 kgG
 kgG
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
 kRv
 abx
-kgG
+siK
 abx
 kRv
 uFb
-lwn
-lwn
+gmP
+gmP
 vzo
 deK
 hNH
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 cQv
 vcE
 vcE
-fQM
+qOz
 rQx
 xOJ
 rni
@@ -158428,24 +154484,24 @@ sYj
 rni
 erb
 wFj
-apx
+tVi
 lwn
 "}
 (78,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
 pjR
-pQA
-pQA
-lIc
-aWQ
-aWQ
-aWQ
-ldK
+pjR
+aSK
+aSK
+wPV
+wPV
+wPV
+laB
 umB
 oBI
 sQT
@@ -158456,7 +154512,7 @@ laB
 aND
 qwL
 qwL
-pST
+qwL
 geF
 cgd
 tuk
@@ -158544,43 +154600,43 @@ tPI
 pfp
 rqC
 ubm
-ldK
-ldK
+kPk
+kPk
 ewe
-fJl
-fJl
-fJl
-fJl
-fJl
-ldK
+cdy
+cdy
+cdy
+cdy
+cdy
+kOC
 ewe
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-urj
-lIc
-aWQ
-urj
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+csj
+lxG
+lxG
+lxG
+lxG
+csj
+csj
+udt
+tHU
+csj
+tHU
+tHU
+tHU
+uKb
 kqj
-svA
-kmd
-ylT
-svA
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+lIc
+kRv
+umq
+kRv
 vcE
 qOz
 rQx
@@ -158600,35 +154656,35 @@ vcE
 kRv
 heY
 ril
+kgG
 kRv
-kRv
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
 kRv
 kgG
 kgG
-kgG
-svA
+siK
+kRv
 sHN
 hgt
-nLp
+imu
 jHs
 vcE
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 jTS
 vcE
 hNH
 rQx
 xOJ
-qcD
-dvq
-eiw
-tau
+rni
+hlw
+iAI
+kun
 nNi
 erb
 fzA
@@ -158636,29 +154692,29 @@ lwn
 "}
 (79,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 hqC
 aSK
 pjR
 pjR
-pQA
-ouc
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+pjR
+aGA
+wPV
+wPV
+wPV
+wPV
+eBP
 hiU
 jmo
 vBv
 rDt
 wZH
 dSe
-tpT
+bnJ
 tpT
 dpy
-pST
+pQt
 qwL
 geF
 xiF
@@ -158726,7 +154782,7 @@ dLe
 bXU
 oTi
 qTd
-lYd
+aIr
 eKl
 bgQ
 mhr
@@ -158747,8 +154803,8 @@ fWx
 wtZ
 lYY
 lYY
-ldK
-ldK
+kPk
+kPk
 mFl
 vSa
 vSa
@@ -158756,35 +154812,35 @@ vSa
 vSa
 vSa
 uMo
-ldK
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
+kOC
+csj
+lxG
+lxG
+lxG
+lxG
+csj
+csj
+csj
+csj
+jFU
+hXu
+csj
+icp
+jVy
 kqj
-vcV
+kqj
+gmP
+kRv
+oAc
+gmP
+kqj
+kqj
+lIc
 saQ
-gkK
-kmd
-kmd
-pPY
+szN
+kRv
+kRv
+qOz
 rQx
 xOJ
 iEo
@@ -158799,30 +154855,30 @@ fzk
 wXE
 qLZ
 erb
-arS
+wFj
 uYH
 mTt
-dXr
+epS
 ril
 kRv
-svA
-lwn
-lwn
-lwn
-vcV
-dXr
-dXr
-svA
+pPh
+gmP
+gmP
+gmP
 kRv
-svA
+kgG
+siK
+siK
+siK
+kRv
 uNd
 deK
 vcE
 vcE
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 jTS
 fvF
 rQx
@@ -158832,16 +154888,16 @@ nMl
 mhs
 vBl
 iAI
-xHW
+lNp
 rni
 qXj
 lwn
 "}
 (80,1,1) = {"
 lwn
-aWQ
-aWQ
-vvA
+wPV
+wPV
+aSK
 aSK
 ilO
 miQ
@@ -158861,8 +154917,8 @@ wFQ
 qwL
 pST
 tpT
-tpT
-tpT
+eJp
+qwL
 geF
 xiF
 tuk
@@ -158929,7 +154985,7 @@ bNW
 bNh
 kOO
 qTd
-lYd
+aIr
 ill
 pAB
 hjr
@@ -158950,45 +155006,45 @@ eIE
 edW
 eIE
 eIE
-ldK
-ldK
-ldK
+tAY
+tAY
+kcZ
 fJl
 fJl
 fJl
 fJl
 fJl
-ldK
+kcZ
 iTq
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+lIc
+lIc
+lIc
+lIc
 kRv
 kRv
-svA
-lwn
-lwn
-lwn
-lwn
-svA
 kRv
-kgG
-svA
-kmd
-dVA
-kmd
-dXr
-uKb
+sHN
+kRv
+kRv
+gmP
+kRv
+umq
+lIc
+boy
+lIc
+mDf
+kRv
+rni
+rni
 adL
 pGv
 dKQ
@@ -159002,37 +155058,37 @@ vEb
 xRf
 qLZ
 rni
-aQh
+tcF
 hsv
-dXr
-dXr
+epS
+dnq
 xkr
 kRv
 kqj
-lwn
-lwn
-svA
+gmP
+gmP
+oFM
 kgG
-dXr
-mTt
-heY
+kgG
+gpA
+hbu
 uii
-kRv
-odO
+kgG
+uNd
 jHs
 hNH
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 jTS
-rwp
+cYG
 cny
-kPk
-xOI
-kOC
-ftl
+rni
+hlw
+iAI
+hlw
 mYs
 xPJ
 iAI
@@ -159042,9 +155098,9 @@ lwn
 "}
 (81,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 fME
 pjR
 pjR
@@ -159061,11 +155117,11 @@ kge
 iqr
 wZH
 wFQ
-pST
-sUf
-tpT
 qwL
-pST
+sUf
+qwL
+qwL
+qwL
 geF
 dBX
 mHx
@@ -159132,7 +155188,7 @@ aoi
 hkv
 bkh
 qTd
-lYd
+aIr
 ill
 uad
 hjr
@@ -159163,35 +155219,35 @@ uFG
 uFG
 uxf
 uFG
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-svA
-kRv
-kgG
-kgG
-kgG
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
 kRv
 kRv
-vcV
-kRv
-kgG
-kgG
 umq
+kRv
 kgG
-kgG
-svA
-kmd
-dXr
-uKb
+kRv
+kRv
+umq
+kRv
+kRv
+kRv
+kRv
+fdb
+boy
+boy
+lIc
+kRv
+rni
+nNi
 tJs
 lDd
 hlw
@@ -159205,39 +155261,39 @@ crH
 xRf
 qLZ
 hlw
-aQh
+tcF
 kRv
-qGE
-dci
-kgG
+wWc
+xkr
+abx
 kRv
-kRv
-lwn
-lwn
-lwn
-fLE
+oFM
+gmP
+gmP
+gmP
+vRj
 oDi
 heY
 dXr
 dXr
 hBx
-uNd
+vAJ
 jHs
 vcE
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 jTS
-rwp
+cYG
 cny
 rni
 iAI
 hlw
-wAO
+rVT
 sRu
-mYs
+jFE
 hlw
 iAI
 dvj
@@ -159245,9 +155301,9 @@ lwn
 "}
 (82,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 aSK
 pjR
@@ -159335,7 +155391,7 @@ onE
 nQn
 vrE
 qTd
-lYd
+aIr
 qfI
 vjl
 gLO
@@ -159356,44 +155412,44 @@ tND
 vTo
 nGN
 kWW
-ldK
+tAY
 lIw
-soO
+xAq
 eCf
 nNt
-svA
-oua
+kgG
+gkK
 qev
-mMV
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+qTg
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+kqj
+kqj
 kRv
 kRv
 mDf
 kgG
 kgG
 kgG
+cCg
 kgG
 kgG
+abx
 siK
-prF
-kgG
-kgG
-kgG
 kgG
 kRv
 kRv
+fdb
+lIc
 dab
-aWQ
-nbI
+kqj
+cYG
 sTI
 jeF
 kXd
@@ -159408,35 +155464,35 @@ rXv
 ptt
 wCW
 rni
-aQh
+tcF
 kRv
-wpf
-dXr
+abx
 kgG
-fLE
-lwn
-lwn
-lwn
-svA
-rbR
-svA
+kgG
+kRv
+kRv
+lIc
+lIc
+kRv
+kgG
+kgG
 wWc
 dXr
-dXr
+epS
 jmz
-xld
+uNd
 jHs
 vcE
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 jTS
-rwp
+cYG
 cny
-qBp
-kXd
+rni
+hlw
 kTf
 hlw
 mYs
@@ -159448,12 +155504,12 @@ lwn
 "}
 (83,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
-aSK
+pjR
 iSB
 fWa
 ycz
@@ -159559,44 +155615,44 @@ kKH
 vYj
 sxL
 iXw
-ldK
+tAY
 iLe
-uPs
-jbf
-svA
-kmd
-ylT
-mMV
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
-kRv
-aWQ
-kRv
-kRv
-kgG
-kgG
-kgG
-kgG
 gpA
-cCg
+qTg
 kgG
+kgG
+kgG
+qTg
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
+eSq
+kqj
+kRv
+kRv
+siK
 siK
 siK
 kgG
-gpA
+kgG
+siK
 kgG
 kgG
-kgG
+siK
+siK
+siK
+kRv
+kRv
+kRv
 lIc
-aWQ
-aWQ
-nbI
+kqj
+kqj
+cYG
 sTI
 rni
 gqO
@@ -159611,39 +155667,39 @@ xRf
 mYH
 jhG
 rni
-aQh
-kRv
-kgG
-siK
+tcF
 fdb
-svA
+siK
+kgG
 kRv
-lwn
-lwn
+kRv
+sHN
+gmP
+gmP
 mPX
 wyt
 oXi
 abx
-wWc
-jmz
-kRv
+iQQ
+hDF
+siK
 uNd
 jHs
 hNH
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 jTS
 fvF
 erb
 wFj
-hNC
+rni
 hlw
-rgU
+dce
 hlw
-rgU
+dce
 hlw
 rni
 dZd
@@ -159651,13 +155707,13 @@ lwn
 "}
 (84,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
 miQ
-szw
+ilO
 oaW
 ycz
 ycz
@@ -159764,42 +155820,42 @@ tCs
 tKA
 vqp
 vOO
-ylT
-svA
+kgG
+kgG
 qev
-kmd
+kgG
 uiF
-kmd
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
 kRv
 kRv
-svA
+kRv
+kRv
 kgG
-kgG
-kgG
-cwL
-fdb
 siK
+cwL
+kRv
+kgG
 kRv
 kRv
 kgG
 kgG
 kRv
 kRv
-kgG
+umq
 kRv
 lIc
-aWQ
-aWQ
-aWQ
-aWQ
+kqj
+kqj
+kqj
+kqj
 sTI
 tJs
 rni
@@ -159807,37 +155863,37 @@ tJs
 rni
 oCi
 oCi
-dOL
+lYR
 dOL
 dOL
 xjG
 ptt
 pPW
 hlw
-aQh
-kRv
-gpA
-siK
+tcF
 fdb
-lwn
-lwn
-lwn
-lwn
+siK
+gpA
+kRv
+gmP
+gmP
+gmP
+gmP
 svA
 kRv
 hKx
 wxi
-kRv
 gpA
+siK
 kgG
-xld
+uNd
 jHs
 vcE
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 jTS
 vcE
 hNH
@@ -159854,19 +155910,19 @@ lwn
 "}
 (85,1,1) = {"
 lwn
-aWQ
-aWQ
-vvA
+wPV
+wPV
+aSK
 ilO
 pjR
 pjR
-ert
+miQ
 ouc
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+wPV
+wPV
+wPV
+wPV
+eBP
 edq
 vdZ
 eAw
@@ -159967,42 +156023,42 @@ tCs
 hdj
 oCF
 mwE
-svA
+kgG
 nKM
-svA
-svA
+kRv
+kRv
+kRv
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+lIc
+lIc
+kRv
+kRv
+kRv
 kgG
 kRv
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
+kRv
+umq
+kRv
+gmP
 kRv
 kRv
-gpA
-kgG
-kgG
+gmP
 kRv
-kgG
-fdb
-fdb
 kRv
-lwn
-svA
-kRv
-lwn
-svA
-kgG
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-aWQ
+kqj
+kqj
+kqj
+gmP
+gmP
+kqj
 sTI
 fTo
 iBA
@@ -160017,34 +156073,34 @@ dkk
 tmC
 mJI
 rni
-aQh
+tcF
 kRv
 kgG
 kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kRv
+bLF
+gmP
+gmP
+gmP
+gmP
 pbh
 kPD
 hVK
-fdb
-siK
-svA
+kgG
+kgG
+kRv
 uNd
-djY
+sQn
 vcE
 vcE
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 cQv
 vcE
 vcE
-imu
+qrS
 erb
 wFj
 fsk
@@ -160057,18 +156113,18 @@ lwn
 "}
 (86,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 aiX
 ixA
 pjR
-hRC
+iSB
 pjR
-pQA
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
+wPV
 tHT
 xpF
 gnw
@@ -160164,48 +156220,48 @@ pzo
 iMu
 vTo
 uER
-ldK
-ldK
-ldK
-ldK
-ldK
-mMV
+tAY
+tAY
+tAY
+tAY
+tAY
+nQG
 nQW
 kRv
-dDr
-kgG
+stz
+kRv
 umq
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+lIc
+lIc
+ert
+lIc
+fdb
 kRv
 kRv
 kRv
-kgG
-kgG
-gpA
-kgG
+kqj
 kRv
-aWQ
-svA
-lwn
-lwn
-kRv
-lwn
-lwn
-lwn
-kgG
-fLE
-aWQ
-lwn
-lwn
-lwn
-aWQ
+gmP
+gmP
+lIc
+gmP
+gmP
+gmP
+lIc
+vUg
+kqj
+gmP
+gmP
+gmP
+kqj
 erb
 wFj
 pXi
@@ -160220,30 +156276,30 @@ vvr
 mYH
 bzA
 rQx
-bzq
+xOJ
 kRv
 kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+mPX
 kRv
 kRv
-dsm
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+kgG
+gpA
+kgG
 fdb
-kRv
 ocK
 iHj
 jHs
 hNH
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 cQv
 cQv
 jTS
@@ -160260,19 +156316,19 @@ lwn
 "}
 (87,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-vvA
-pQA
-pjR
-pQA
-pjR
+wPV
+wPV
+aSK
+aSK
+aSK
+aSK
+aSK
+nyW
 byv
-aWQ
-aWQ
-aWQ
-ldK
+wPV
+wPV
+wPV
+eBP
 rYG
 nqf
 tOH
@@ -160367,50 +156423,50 @@ tnx
 uER
 edW
 uER
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
+tAY
+kqj
+kqj
+kqj
+kqj
 mqJ
-svA
+kRv
 flR
-kgG
-kgG
+lIc
+lIc
+lIc
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
+lIc
+lIc
+flR
+lIc
+lIc
+lIc
 kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
+mDf
 kRv
-kRv
-nQX
-kgG
-kgG
-kgG
-kRv
-nQX
-kRv
-lwn
-lwn
-lwn
-vcV
+gmP
+gmP
+gmP
+lIc
 pqj
-kRv
-lwn
-kgG
+lIc
+gmP
+lIc
 dIp
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
 vcE
-hXi
+nEa
 dLn
 fTo
 iBA
@@ -160422,34 +156478,34 @@ jnF
 mYH
 sxe
 kYv
-jSn
+mHI
+kRv
+umq
 kgG
 kRv
-kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 uFb
-kgG
-abx
-dXr
-dXr
-kgG
 kRv
-wDp
-djY
+mDf
+kgG
+siK
+siK
+fdb
+uNd
+sQn
 vcE
 vcE
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -160463,19 +156519,19 @@ lwn
 "}
 (88,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-pQA
-pQA
+wPV
+wPV
+wPV
+nyW
+nyW
 mBc
 kzI
-pQA
+nyW
 mgH
-pQA
-aWQ
-aWQ
-ldK
+nyW
+wPV
+wPV
+eBP
 ahz
 kRj
 iRt
@@ -160483,9 +156539,9 @@ eEi
 bJy
 eBP
 kZt
-lOW
 qwL
-pST
+qwL
+qwL
 qwL
 uQQ
 dBX
@@ -160570,49 +156626,49 @@ nMU
 poI
 yjV
 wnU
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-svA
-abx
-kgG
-kgG
+hNF
+kqj
+kqj
+kqj
+kqj
+kRv
+flR
+lIc
+lIc
+lIc
+lIc
+lIc
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
 kRv
 kRv
-svA
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-kRv
-kRv
-siK
-siK
-kgG
-kRv
-kRv
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
+fdb
+lIc
+lIc
+lIc
+lIc
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
 bUj
 vzy
 fMZ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
 hQY
 hMI
 dnf
@@ -160625,26 +156681,26 @@ qPT
 sxe
 xUD
 tyU
+kRv
+kRv
+kRv
 kgG
 kgG
 kRv
-dXr
-kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-kgG
-wpf
-dXr
-kgG
+oAc
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+mDf
+kRv
+siK
 kgG
 ocK
-umH
+iHj
 jHs
 vcE
 vcE
@@ -160657,8 +156713,8 @@ vcE
 vcE
 vcE
 vcE
-cZK
-cZK
+gOR
+gOR
 vcE
 vcE
 vcE
@@ -160666,19 +156722,19 @@ lwn
 "}
 (89,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-ouc
-fWa
-oaW
-ouc
-ouc
-oaW
-ouc
-aWQ
-aWQ
-ldK
+wPV
+wPV
+wPV
+mta
+hoK
+stJ
+mta
+mta
+stJ
+mta
+wPV
+wPV
+hTt
 pnl
 qcn
 qrW
@@ -160686,10 +156742,10 @@ qrW
 hTt
 hTt
 ldV
-dpm
+qwL
 bnJ
 rXh
-tpT
+qwL
 geF
 cgd
 tuk
@@ -160773,51 +156829,51 @@ ubG
 wTx
 tpX
 otr
-ldK
-aWQ
-aWQ
-aWQ
-svA
-gpA
-kgG
-kgG
-kgG
-kgG
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+hNF
+kqj
+kqj
+kqj
+lIc
+ert
+lIc
+lIc
+lIc
+kRv
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
 kRv
 kRv
-kgG
-kgG
-dsm
-siK
-svA
 kRv
-aWQ
-aWQ
-lwn
-lwn
-aWQ
+fdb
+fdb
+fdb
+lIc
+lIc
+kqj
+kqj
+gmP
+gmP
+kqj
 oSZ
 oJM
-kmd
-nny
-kmd
+kRv
+vzy
+kRv
 fTY
 oSZ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
 fTE
 fTE
 fTE
@@ -160828,60 +156884,60 @@ fyP
 rQx
 tyU
 kRv
-kgG
-fdb
-ieq
-dXr
-kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-kgG
-gpA
 kRv
-svA
-vAJ
+siK
+siK
+kgG
+kgG
+kRv
+kRv
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+lIc
+umq
+kRv
+kRv
+gKc
 pmB
 jHs
 vcE
 vcE
 dQM
-keo
+uZo
 dQM
 vcE
 vcE
 vcE
 vcE
-oCW
+xIp
 kZZ
 xIp
 xIp
 mmn
-oCW
-oCW
+xIp
+xIp
 lwn
 "}
 (90,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+nyW
 tMn
 tWt
 tDE
-vvA
-pQA
-aWQ
-aWQ
-ldK
+aSK
+aSK
+wPV
+wPV
+hTt
 ury
 xtS
 prU
@@ -160889,15 +156945,15 @@ xxY
 hTt
 hTt
 tzX
-pST
-qpO
-tpT
-pST
+qwL
+qwL
+oty
+qwL
 uQQ
 vOL
 tuk
+gQX
 hVj
-oNx
 vyp
 jlb
 sOL
@@ -160908,14 +156964,14 @@ sjd
 mIH
 jpU
 iqX
-bAH
+fiT
 mmK
 jzT
 lbs
 nWO
 yck
 gdz
-knl
+fiT
 fiT
 fiT
 kTA
@@ -160944,7 +157000,7 @@ jNl
 pBl
 oji
 wqf
-jEj
+bXE
 oAw
 oAw
 cga
@@ -160976,36 +157032,36 @@ wMm
 wMm
 iNU
 vNc
-ldK
-aWQ
-aWQ
-svA
-oAc
+hNF
+kqj
+kqj
+lIc
+fYW
+lIc
+kRv
+kRv
+kRv
+umq
+icp
+lIc
+kqj
+kqj
+kqj
+kqj
+kRv
 kRv
 kgG
 kgG
 kgG
-gpA
-wfl
-svA
-aWQ
-aWQ
-aWQ
-aWQ
-svA
+fdb
 kRv
-kgG
-kgG
-kgG
-kgG
-kgG
-kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
+lIc
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
 fGo
 dnv
 knC
@@ -161013,12 +157069,12 @@ qqz
 knC
 ybI
 bFe
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
 gkI
 mDQ
 vcE
@@ -161027,64 +157083,64 @@ aNO
 aNO
 aNO
 aNO
-uAW
-bzq
-svA
+aNO
+xOJ
 kRv
-dXr
-fdb
+kRv
+kgG
+siK
 siK
 gpA
-kgG
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-dXr
-dXr
-kgG
-kgG
-lwn
-lwn
+kRv
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+lIc
+lIc
+lIc
+kRv
+gmP
+gmP
 deK
 vcE
 vcE
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
-fQM
+qOz
 jfd
 rBH
-urg
-ogJ
+iwK
+dnu
 rBH
 ajB
-fvu
+vHx
 lwn
 "}
 (91,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-pQA
-vvA
-hRC
+wPV
+wPV
+wPV
+wPV
+aSK
+aSK
+mUL
 hms
-pQA
-pQA
+aSK
+aSK
 ouc
-aWQ
-ldK
+wPV
+hTt
 uvw
 oJz
 aHd
@@ -161092,9 +157148,9 @@ uGk
 hTt
 hTt
 rXn
-cJw
-wmo
-tpT
+qwL
+qwL
+qwL
 qwL
 uQQ
 cgd
@@ -161162,7 +157218,7 @@ tQS
 eNg
 tQp
 vEv
-lYd
+aIr
 wag
 hPr
 pLx
@@ -161179,50 +157235,50 @@ mKf
 xLj
 pIS
 qKT
-ldK
-aWQ
-aWQ
-svA
+hNF
+kqj
+kqj
+lIc
+lIc
+kRv
 kRv
 kgG
-kgG
-kgG
-kgG
+kRv
 kRv
 icp
+lIc
 kRv
+kqj
 kRv
-aWQ
-kRv
-kRv
+umq
 kRv
 kgG
 gpA
 kgG
 kgG
-kgG
-kgG
 kRv
-aWQ
-aWQ
-lwn
-lwn
-aWQ
-aWQ
+kRv
+kRv
+kqj
+kqj
+gmP
+gmP
+kqj
+kqj
 dXr
-mTt
+eSb
 rxA
 bdG
 fwU
 imG
 tdH
-aWQ
-lwn
-lwn
-lwn
-lwn
+kqj
+gmP
+gmP
+gmP
+gmP
 gkI
-lwn
+gmP
 vcE
 vcE
 vcE
@@ -161234,60 +157290,60 @@ uYH
 cgD
 mxw
 kgG
-xPp
+cwL
 kRv
 kgG
-abx
-kgG
 mDf
-lwn
-lwn
-lwn
-lwn
-svA
-siK
-siK
-dXr
-dXr
+kRv
+flR
+gmP
+gmP
+gmP
+gmP
+kRv
 kgG
-lwn
+kRv
+kRv
+lIc
+lIc
+gmP
 hgt
-lwn
+gmP
 jHs
 vcE
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
-rwp
+cYG
 fmM
 eDh
-hvU
-jvG
-vUz
-jll
-aWQ
-aWQ
+iia
+jLt
+jLt
+gYy
+wDF
+wDF
 lwn
 "}
 (92,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-fmk
+wPV
+wPV
+wPV
+aSK
 aSK
 pjR
-aSK
 pjR
 pjR
-xki
+pjR
+jpn
 fWa
-aWQ
-tHT
+wPV
+pCl
 gNE
 ppu
 gHe
@@ -161296,7 +157352,7 @@ hTt
 hTt
 uQQ
 lTO
-geF
+lTO
 geF
 geF
 uQQ
@@ -161314,14 +157370,14 @@ wbU
 gqE
 wbU
 bMe
-fBg
+amT
 kpp
 jzT
 lbs
 nWO
 yck
 bTT
-uTY
+wbU
 wbU
 wbU
 gqE
@@ -161343,14 +157399,14 @@ tyo
 tyo
 tyo
 pBy
-qzR
+tyo
 ltR
 jnE
 jNl
 pBl
 oji
 rGi
-pCg
+tyo
 feJ
 jFh
 tyo
@@ -161365,7 +157421,7 @@ iFe
 qoa
 oTi
 qTd
-lYd
+aIr
 wag
 jRt
 eJv
@@ -161382,20 +157438,20 @@ mGZ
 vKt
 bKa
 pIS
-ldK
-aWQ
-aWQ
+hNF
+kqj
+kqj
 kRv
-svA
+kRv
 kgG
 gpA
 cwL
 kRv
-lwn
-wxj
+gmP
+icp
+lIc
 kRv
-kgG
-svA
+kRv
 kRv
 siK
 siK
@@ -161404,13 +157460,13 @@ kgG
 kkF
 kgG
 kgG
-kgG
-kgG
-svA
-aWQ
-lwn
-aWQ
-aWQ
+umq
+kRv
+kRv
+kqj
+gmP
+kqj
+kqj
 qRJ
 dSn
 wYv
@@ -161419,19 +157475,19 @@ vWV
 vRS
 cJU
 oSZ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
 sHN
 kRv
 vcE
 vcE
-svA
+kgG
 heY
 epS
 epS
@@ -161439,66 +157495,66 @@ ril
 kgG
 gKc
 szp
-eTx
+cON
 jZc
-svA
-kgG
-kgG
-lwn
-lwn
+lIc
+lIc
+lIc
+gmP
+gmP
 kRv
 gpA
 siK
 siK
-gpA
-kgG
-kgG
+umq
 kRv
-lwn
+lIc
+lIc
+gmP
 deK
 vcE
 vcE
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-xsf
+wxD
 gnl
-vUz
 gYy
 jll
-gYy
-aWQ
-aWQ
+jLt
+jll
+wDF
+wDF
 lwn
 "}
 (93,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 sBL
-fmk
-pjR
-vvA
+aSK
 pjR
 pjR
 pjR
 pjR
-hRC
+pjR
+pjR
+mUL
 wRe
 peZ
 ylk
 ovl
 dBd
 pFF
-ldK
-aWQ
+hTt
+uPs
 dFa
-mUw
+tpT
 trZ
 ufK
 lQm
@@ -161517,7 +157573,7 @@ hkI
 syw
 sAc
 bfV
-jBh
+cgd
 nyV
 ozD
 nbx
@@ -161546,14 +157602,14 @@ jvX
 mEs
 lcR
 wVf
-hPW
+mEs
 mEs
 hYt
 kEK
 iSx
 hYt
 ygI
-aPm
+xxq
 uwg
 poN
 vAV
@@ -161568,7 +157624,7 @@ bgQ
 sWI
 oTi
 qTd
-lYd
+aIr
 wag
 bAj
 nLI
@@ -161585,52 +157641,52 @@ vjM
 vjM
 eGi
 qVx
-ldK
-aWQ
+hNF
+kqj
 tok
-svA
+kRv
+kRv
+kRv
 kgG
-kgG
-kgG
-kgG
-svA
-lwn
-lwn
+kRv
+kRv
+gmP
+gmP
 kRv
 tTd
 abx
+siK
+siK
 kgG
-siK
-siK
-kRv
+kgG
 kgG
 kgG
 abx
 kgG
-kgG
-svA
+kRv
+kRv
 mDf
-aWQ
-lwn
-aWQ
+kqj
+gmP
+kqj
 riV
 qOg
 rJa
 xup
 eCX
 eJx
-vSE
+pbl
 viy
 dXr
-aWQ
+kqj
 pIz
-aWQ
-lwn
-lwn
-lwn
-aWQ
-aWQ
-vcV
+kqj
+gmP
+gmP
+gmP
+kqj
+kqj
+umq
 kRv
 kgG
 kgG
@@ -161642,23 +157698,23 @@ jmz
 kgG
 uNd
 deK
-xsf
-dmE
-jZc
-kgG
-dXr
-dXr
-kgG
-kgG
-kgG
-kgG
-kgG
-kgG
-svA
+wxD
+rjX
+pNG
+lIc
 kRv
-lwn
-lwn
-djY
+kRv
+kgG
+kgG
+kgG
+siK
+kgG
+kgG
+kqj
+ybk
+gmP
+gmP
+sQn
 vcE
 vcE
 vcE
@@ -161669,23 +157725,23 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 gnl
-aWQ
+wDF
 jll
-fTZ
-fTZ
-aWQ
-aWQ
+jll
+jll
+wDF
+wDF
 lwn
 "}
 (94,1,1) = {"
 lwn
-aWQ
-aWQ
-iFQ
-fmk
-kLL
+wPV
+wPV
+hqC
+aSK
+lXN
 pjR
 wnF
 aSK
@@ -161695,13 +157751,13 @@ miQ
 qKr
 hTt
 hTt
-ldK
-ldK
-ldK
-ldK
-aWQ
+hTt
+hTt
+hTt
+hTt
+uPs
 tpT
-dSH
+tpT
 bVj
 goV
 doq
@@ -161771,7 +157827,7 @@ bgQ
 nQn
 oTi
 qTd
-lYd
+aIr
 wag
 jRt
 wGX
@@ -161788,37 +157844,37 @@ ssA
 ykK
 iqP
 kPu
-ldK
-aWQ
-aWQ
-aWQ
+hNF
+kqj
+kqj
+kqj
 kRv
-gpA
-kgG
+umq
 kRv
-lwn
-lwn
-lwn
-lwn
 kRv
-kgG
-kgG
+gmP
+gmP
+gmP
+gmP
 kRv
-kgG
-svA
-svA
-kgG
-kgG
-gpA
 kgG
 kgG
 kRv
-aWQ
-lwn
-aWQ
+kRv
+kRv
+kRv
+kgG
+kgG
+siK
+kgG
+kRv
+kRv
+kqj
+gmP
+kqj
 bpq
-aWQ
-aWQ
+kqj
+kqj
 oSZ
 dXr
 pbl
@@ -161826,19 +157882,19 @@ nFG
 avk
 kSq
 xXb
-ruu
-aWQ
-lwn
-lwn
-aWQ
+vzy
+kqj
+gmP
+gmP
+kqj
 kRv
 oAc
 kRv
 abx
-dXr
-wpf
+siK
+abx
 kgG
-kgG
+gpA
 wWc
 jmz
 fMO
@@ -161846,65 +157902,65 @@ kgG
 tNw
 jHs
 hNH
-xsf
+wxD
 fPa
+mDf
+kRv
 abx
-dXr
-wpf
 kgG
 heY
 ril
 lCS
-kgG
-kgG
 abx
-kRv
-lwn
+kqj
+kqj
+lIc
+gmP
 iVR
-osn
-djY
-oCW
-oCW
-oCW
-oCW
-oCW
-oCW
-oCW
-oCW
-oCW
-fQM
+xZZ
+sQn
+xIp
+xIp
+xIp
+xIp
+xIp
+xIp
+xIp
+xIp
+xIp
+qOz
 gnl
-aWQ
-lHZ
-gYy
-gYy
-aWQ
-aWQ
+wDF
+wmB
+jUH
+fTZ
+wDF
+wDF
 lwn
 "}
 (95,1,1) = {"
 lwn
-aWQ
+wPV
+iFQ
 bGi
-bGi
-dBc
+pjR
 ilO
 aSK
-vvA
-aWQ
+aSK
+wPV
 ujX
 gsL
 pjR
 dzd
-pQA
-pQA
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-qcG
+aSK
+aSK
+wPV
+wPV
+wPV
+wPV
+uPs
+uPs
+aND
 kHC
 lmn
 sHu
@@ -161991,57 +158047,57 @@ lCe
 eUY
 pIS
 bax
-ldK
-ldK
-aWQ
+hNF
+kcZ
+kqj
 kGb
-kRv
 kgG
-abx
 kRv
-svA
-lwn
-lwn
-svA
+mDf
+kRv
+kRv
+gmP
+gmP
+kRv
 kRv
 gpA
-kgG
-svA
+kRv
+kRv
 oFM
 kRv
 bLF
-kgG
+kRv
+siK
+siK
+siK
 kRv
 kRv
-kgG
+kqj
+icp
+lIc
 kRv
-svA
-aWQ
-aWQ
-aWQ
 kRv
-kgG
-aWQ
-aWQ
+kqj
+kqj
 buo
 ntK
 dXr
 dmy
 oSZ
 hfI
-kgG
-aWQ
-lwn
-lwn
-aWQ
+kRv
+kqj
+gmP
+gmP
+kqj
 svA
 kRv
 kRv
+siK
+siK
+siK
 kgG
-lYR
-epS
-kgG
-vcV
+kRv
 wTV
 dXr
 jAz
@@ -162049,8 +158105,8 @@ wxi
 uNd
 jHs
 vcE
-rwp
-rkm
+cYG
+bKP
 jZc
 kgG
 kgG
@@ -162058,13 +158114,13 @@ heY
 epS
 epS
 ril
-dXr
-dXr
 kgG
-abx
+kgG
 kRv
-xFE
-iVR
+flR
+lIc
+hvU
+kEQ
 jug
 jug
 jug
@@ -162077,37 +158133,37 @@ jfo
 jfo
 jfo
 cMi
-aWQ
+wDF
 gYy
-jll
+jLt
 vbb
 dnu
-aWQ
+wDF
 lwn
 "}
 (96,1,1) = {"
 lwn
-aWQ
-aWQ
-hqC
+wPV
+wPV
+aSK
 aSK
 pjR
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 pjR
 sCy
-vvA
 aSK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
+wPV
+uPs
+uPs
+uPs
 jUs
 eDR
 iKs
@@ -162177,7 +158233,7 @@ dqD
 xfh
 vCE
 cmc
-izK
+ddm
 cmc
 hOf
 jPj
@@ -162194,55 +158250,55 @@ vwp
 eUY
 pIS
 leL
-sBI
+szw
 aMG
 nko
-kmd
-ylT
 kgG
 kgG
 kRv
-lwn
-lwn
-lwn
+kRv
+kRv
+gmP
+gmP
+gmP
 kRv
 kgG
 kgG
-svA
-lwn
-lwn
+kRv
+gmP
+gmP
 kqj
 kRv
-svA
+kRv
 kgG
-kgG
+siK
 kRv
 gKT
-kgG
-svA
-aWQ
-aWQ
-aWQ
 kRv
-kgG
-aWQ
-aWQ
+kRv
+icp
+kqj
+kqj
+umq
+kRv
+kqj
+kqj
 ibI
-aWQ
-aWQ
-aWQ
-aWQ
+kqj
+kqj
+kqj
+kqj
 vzy
-aWQ
-aWQ
-lwn
-lwn
-lwn
+kqj
+kqj
+gmP
+gmP
+gmP
 pPh
 kgG
 abx
-kgG
-vAJ
+siK
+gKc
 cON
 fXM
 mLZ
@@ -162253,7 +158309,7 @@ uQA
 jHs
 vcE
 vcE
-xsf
+wxD
 kDn
 kRv
 gpA
@@ -162261,56 +158317,56 @@ wWc
 epS
 epS
 pRP
-dXr
-xPp
 kgG
-kgG
-kgG
+cwL
+kRv
+lIc
+lIc
+jll
 gYy
-kog
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-hvU
-cUS
-jll
-jll
-huh
-jey
-aWQ
+usC
+usC
+usC
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+xFE
+gYy
+gYy
+gYy
+qjg
+gYy
+wDF
 lwn
 "}
 (97,1,1) = {"
 lwn
-aWQ
-aWQ
+wPV
+wPV
 oth
 aSK
 pjR
 ujX
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 ujX
 pjR
 sCy
 pjR
 aSK
-vvA
-aWQ
-aWQ
-aWQ
-aWQ
-pST
-mUw
+aSK
+wPV
+wPV
+wPV
+uPs
+tpT
+tpT
 qwL
 eDR
 bdt
@@ -162380,7 +158436,7 @@ bgQ
 qoa
 oTi
 qTd
-lYd
+aIr
 wag
 sZk
 wGX
@@ -162397,66 +158453,66 @@ vjM
 vgj
 fCH
 imP
-sBI
+szw
 coZ
 nko
-kmd
-svA
-gpA
-kgG
-svA
-lwn
-lwn
-svA
 kgG
 kgG
+umq
+kRv
+kRv
+gmP
+gmP
+lIc
+kRv
 kgG
 kRv
+kRv
 mYE
-lwn
-lwn
+gmP
+gmP
 pPh
-kgG
-kRv
-kRv
-kRv
-kgG
-kRv
-svA
-aWQ
-aWQ
-aWQ
-aWQ
-kRv
+umq
 kgG
 kgG
+kRv
+kRv
+kRv
+kRv
+kqj
+kqj
+kqj
+kqj
+kRv
+kRv
+kRv
 irR
 qlq
 cPV
 kRv
 rfV
-ruu
-svA
-aWQ
-lwn
-lwn
-lwn
+vzy
+eSq
+kqj
+gmP
+gmP
+gmP
 kRv
-epS
-epS
+kgG
+kgG
 abx
 uNd
 deK
 pnY
-xsf
+wxD
 dmE
 mpC
 xTm
 kzG
-djY
+sQn
 vcE
 vcE
-rwp
+cYG
 vVr
 ckW
 dyr
@@ -162466,54 +158522,54 @@ jmz
 kgG
 kgG
 kgG
-kgG
-dXr
-dXr
-wyd
-sTZ
-jll
-lwn
-aWQ
-gYy
-aWQ
-aWQ
-aWQ
-aWQ
+kRv
 lIc
-aWQ
+lIc
+gYy
+gYy
+gYy
+usC
+wDF
+gYy
+wDF
+wDF
+wDF
+wDF
+aso
+wDF
 jll
-jll
-jey
+gYy
+gYy
 cmr
-jll
-jey
-jey
-aWQ
+sTZ
+gYy
+gYy
+wDF
 lwn
 "}
 (98,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 aSK
 pjR
 pjR
 iFQ
-vvA
+pyy
 gsL
 aSK
 pjR
 jKV
 aSK
-vvA
+aSK
 ujX
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-dSH
+wPV
+wPV
+wPV
+uPs
+uPs
+tpT
 qwL
 qMY
 pQc
@@ -162583,7 +158639,7 @@ pAB
 vLy
 oTi
 qTd
-lYd
+aIr
 hfa
 jRt
 wGX
@@ -162603,103 +158659,103 @@ mIa
 hrD
 bqa
 nko
-kmd
-kmd
 kgG
 kgG
 kgG
-lwn
-wfl
+kRv
+kRv
+gmP
+icp
+lIc
+kRv
 kgG
-siK
-siK
-kgG
+kRv
 svA
 kRv
-lwn
+gmP
 oFM
 kRv
 kRv
 kgG
+siK
 kRv
-kgG
-gpA
-kgG
+umq
 kRv
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
 kRv
-lwn
-lwn
-lwn
-lwn
-lwn
+kqj
+kqj
+kqj
+kqj
+gmP
+lIc
+gmP
+gmP
+gmP
+gmP
+gmP
 tyC
 cPV
 kRv
-aWQ
-aWQ
-aWQ
-lwn
-svA
-epS
-epS
+kqj
+kqj
+kqj
+gmP
 kRv
-xZZ
+kgG
+kgG
+kgG
+uNd
 jHs
 hNH
 vcE
 pnY
-xsf
+wxD
 dmE
 iVi
 xDh
 jHs
 vcE
 hNH
-xsf
-fPa
+wxD
+nRX
 frc
 hKx
 wxi
-fLE
+eue
 kRv
 kgG
 kRv
-kgG
-mTt
-tTu
-jey
-huh
-sTZ
-xFE
-jll
+kRv
+ert
+lIc
 gYy
-aWQ
-aWQ
-vUz
-gdU
+dPb
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
+nvd
+gYy
 jvG
 jll
 bds
-jll
-cmr
-jey
-jll
 gYy
-vUz
-aWQ
+cmr
+qvK
+qvK
+sTZ
+gYy
+wDF
 lwn
 "}
 (99,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+aSK
 wnF
 pjR
 pjR
@@ -162711,9 +158767,9 @@ dzd
 aSK
 aSK
 ujX
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 xBH
 uQQ
 iga
@@ -162803,106 +158859,106 @@ wMm
 llK
 swa
 mqn
-ldK
+hNF
 axg
 nko
-kmd
-kRv
 kgG
-gpA
+kgG
+kgG
+umq
 kRv
-kRv
+lIc
 pWx
-gpA
+umq
+fdb
 siK
-siK
-kgG
-kgG
-svA
-svA
-svA
-kRv
-kgG
-svA
-siK
-siK
-kgG
 kgG
 kRv
-aWQ
-aWQ
-svA
-aWQ
-fLE
+kRv
+kRv
+kRv
+kRv
 kgG
-lwn
-lwn
-lwn
-lwn
+siK
+siK
+fdb
+kRv
+kRv
+boy
+kqj
+kqj
+kRv
+kqj
+lIc
+ert
+gmP
+gmP
+gmP
+gmP
 czV
 dJy
 bAa
-kgG
+lIc
+lIc
+lIc
+lIc
 kRv
-pPh
-eSq
-kRv
-kgG
-kgG
-kgG
 fMO
+heY
+ril
+abx
 uNd
 jHs
 vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 vVr
 bre
 jHs
 vcE
 vcE
-rwp
+cYG
 bKP
-qSF
+jZc
 nEi
 wkf
 kgG
-svA
+kRv
 uFb
-lwn
-lwn
-abx
-tQe
-jey
-jey
-xKe
-jvG
-vUz
-cUS
+gmP
+gmP
+flR
+jll
+gYy
+gYy
+vbb
+iia
+gYy
+gYy
 xnI
 wgV
-nvd
+gYy
+gYy
+jLt
 jll
-jll
+wbg
+wbg
+tQe
 qvK
 qvK
-jll
+hMK
 gYy
-gYy
-vUz
-gYy
-jll
-aWQ
+wDF
 lwn
 "}
 (100,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 pjR
 miQ
 pjR
@@ -162912,11 +158968,11 @@ pjR
 pjR
 sCy
 aSK
-vvA
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
+wPV
 xBH
 miA
 ljE
@@ -163006,106 +159062,106 @@ hYb
 pch
 cvZ
 fzK
-ldK
+kwc
 jWC
 dXr
 bvf
-kmd
+kgG
 abx
-kgG
 kRv
 kRv
+lIc
 eay
-kgG
-kgG
-kgG
-kgG
-kgG
-kgG
-kgG
 kRv
-kgG
-kgG
-kgG
+fdb
 siK
+kgG
+kgG
 siK
 gpA
 kgG
 kgG
-kRv
-svA
-kRv
-kRv
+abx
 kgG
+siK
+kRv
+umq
+lIc
+icp
+lIc
 kRv
 kRv
-aWQ
-aWQ
-aWQ
+kRv
+kRv
+lIc
+kRv
+kqj
+kqj
+kqj
 eJE
 bSD
 fmc
+lIc
+ert
+kqj
 kRv
-svA
-aWQ
 kRv
-svA
-kgG
-kgG
-kgG
-kgG
-xld
+heY
+epS
+epS
+ril
+uNd
 jHs
 vcE
 dQM
 vcE
 vcE
 vcE
-xsf
+wxD
 elL
 jHs
 vcE
 vcE
 vcE
-xsf
+wxD
 iTo
 kfi
 hVK
-vcV
 kRv
-lwn
-lwn
-lwn
-lwn
+kRv
+gmP
+gmP
+gmP
+usC
 jll
-oEa
-hMK
-jey
-jey
-jll
-wPt
-hvU
+vbb
+gYy
+gYy
+gYy
+gYy
+vbb
+gYy
 prS
-jey
+xix
+gYy
+wMR
 jll
-jll
-qvK
-qvK
+wbg
+wbg
+gYy
+gUa
+hMK
 gYy
 gYy
-qjg
-kog
-gYy
-gYy
-aWQ
+wDF
 lwn
 "}
 (101,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 aSK
 ilO
 pjR
@@ -163116,10 +159172,10 @@ miQ
 kDw
 nbd
 xBH
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 xBH
 ufK
 tkm
@@ -163213,102 +159269,102 @@ uCC
 kOB
 nko
 nDh
-aFM
-ylT
-abx
-kRv
-gKT
-wfl
+dDr
 kgG
-kRv
-svA
 mDf
-kgG
-kgG
-gpA
-kgG
-kgG
-abx
-kgG
-kgG
-kgG
-kgG
-abx
-kgG
-kgG
-kgG
 kRv
-abx
+pVw
+icp
+lIc
 kRv
+kRv
+mDf
 siK
-fdb
-svA
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vcV
-nNO
-heY
-ril
-mDf
+siK
+siK
+kgG
+kgG
+siK
+kgG
+kgG
+kRv
+kRv
+flR
+icp
+lIc
+kRv
+umq
+abx
+kRv
+kRv
+ldZ
+qek
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kRv
+wWc
+epS
+epS
+jmz
 uNd
 jHs
 vcE
 dQM
-keo
+uZo
 vcE
 vcE
-rwp
+cYG
 mwb
 jHs
 vcE
 vcE
 vcE
-rwp
-fsI
+cYG
+bKP
 dpM
 oFM
-aWQ
+kqj
 kRv
-lwn
-lwn
-lwn
-lwn
-lwn
-jll
-jll
-jey
-jey
+gmP
+gmP
+usC
+usC
+usC
+gYy
+gYy
+gYy
+gYy
 wyd
 uyJ
-jll
-jey
-rri
-dnq
-jll
-qjg
-coE
-vUz
-lIc
-vUz
 gYy
+gYy
+gYy
+gYy
+jLt
+qjg
+wPt
 jll
-aWQ
-aWQ
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (102,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 aSK
 wnF
 pjR
@@ -163332,8 +159388,8 @@ jtu
 bjJ
 cgd
 ddH
-hVj
-fEh
+gQX
+mdU
 bgx
 vOT
 rzN
@@ -163412,105 +159468,105 @@ kvk
 pch
 uVU
 gSs
-ldK
-ldK
-ldK
-ldK
-mMV
-kgG
-kgG
-kgG
-svA
-lwn
-kRv
-lwn
-lwn
-kRv
+psk
+psk
+psk
+psk
+qTg
 kgG
 kRv
-kgG
-kgG
 kRv
-svA
-kgG
-kgG
+lIc
+gmP
+lIc
+gmP
+gmP
 kRv
-aWQ
-aWQ
-kgG
-kgG
-kgG
-kgG
-kgG
-kgG
-siK
+kRv
 fdb
+kgG
+kgG
+fdb
+fdb
+siK
 kRv
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-svA
-heY
-epS
-epS
-ril
+kRv
+kqj
+kqj
+boy
+kRv
+kRv
+siK
+kgG
+kgG
+kRv
+kRv
+lCQ
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kRv
+kgG
+wWc
+pRP
+kgG
 wDp
 jHs
 vcE
 dQM
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 pnY
 vcE
 vcE
-keo
+uZo
 dQM
 dQM
-xsf
-gnl
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-kog
-bds
-wyd
-jey
-jey
-sTZ
-kcZ
-jLt
-jll
+wxD
+oua
+kqj
+kqj
+kqj
+gmP
+gmP
+usC
+usC
+usC
+usC
 gYy
-vUz
-kxt
-fGw
-aWQ
-aWQ
+dPb
+tTu
+qvK
+qvK
+sTZ
+gYy
+jLt
+gYy
+gYy
+gYy
+nlp
+wmo
+wDF
+wDF
 rjU
-aWQ
-aWQ
-aWQ
+wDF
+wDF
+wDF
 lwn
 "}
 (103,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 ujX
 aSK
 gne
@@ -163519,7 +159575,7 @@ pjR
 ltk
 pjR
 pjR
-odl
+sCy
 tFN
 xBH
 xBH
@@ -163547,7 +159603,7 @@ mKh
 oso
 sCS
 fxS
-jBh
+cgd
 faP
 yio
 jXd
@@ -163598,7 +159654,7 @@ gTn
 rhF
 vCE
 qTd
-lYd
+aIr
 qfI
 vjl
 wEu
@@ -163618,111 +159674,111 @@ yfI
 ggy
 wAu
 gVn
-ldK
+psk
 brt
 kgG
+kRv
+kRv
+gmP
+gmP
+gmP
+gmP
+gmP
+lIc
+kRv
+kRv
+kRv
+kRv
+umq
+kRv
+kRv
+kRv
+kqj
+kqj
+kqj
+kqj
+kRv
+siK
+siK
+siK
+kRv
+mPX
+kRv
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kRv
+fdb
+siK
 kgG
-kRv
-lwn
-lwn
-lwn
-lwn
-lwn
-kRv
 kgG
-svA
-kRv
-kRv
-kRv
-kRv
-kRv
-kRv
-aWQ
-aWQ
-aWQ
-aWQ
-kRv
-kgG
-kgG
-kgG
-kRv
-svA
-kRv
-svA
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-kRv
-wWc
-epS
-epS
-jmz
 xld
 jHs
 vcE
 dQM
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
 vcE
 vcE
-keo
+uZo
 vcE
 vcE
-rwp
-gnl
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-vUz
+cYG
+oua
+gmP
+gmP
+gmP
+gmP
+gmP
+usC
+usC
+usC
+wDF
+gYy
 nsZ
 tQe
-vqW
-jey
+qvK
+qvK
 gOg
 jLt
-wbg
+wMR
+jLt
 gYy
-vUz
 nXO
-aWQ
-vUz
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wDF
+jll
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
 lwn
 "}
 (104,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 ujX
 iFQ
-pjR
 aSK
-vvA
+pjR
+pjR
 ltk
-aSK
 pjR
-odl
+pjR
+sCy
 fCN
 vll
 sqj
@@ -163773,7 +159829,7 @@ bXE
 bXE
 bXE
 oAw
-jEj
+bXE
 bXE
 iFe
 hhx
@@ -163821,111 +159877,111 @@ eut
 wMk
 oxx
 rHO
-ldK
+psk
 brt
 kgG
 umq
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+ert
+lIc
+kqj
+kqj
 kRv
 kRv
-aWQ
-aWQ
-svA
+kqj
 kRv
-aWQ
-svA
-aWQ
-aWQ
-lwn
-lwn
-aWQ
+kqj
+kqj
+gmP
+gmP
+kqj
+umq
+kRv
+siK
+kRv
+kRv
+kRv
+nrL
+kqj
+kqj
+gmP
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+lIc
+fdb
+fdb
+kRv
 kgG
-kRv
-kgG
-kRv
-kRv
-kRv
-lwn
-aWQ
-aWQ
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-kgG
-kRv
-wWc
-pRP
-vcV
 vzo
 jHs
 vcE
 dQM
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
-rwp
+cYG
 bDk
 kKn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+usC
+usC
+usC
+usC
+usC
+usC
+usC
+wDF
+wDF
 hBB
-cmr
-jib
-hMK
-jll
-jll
-jll
-jll
 iia
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+tQe
+hMK
+gYy
+gYy
+jLt
+gYy
+iia
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
 lwn
 "}
 (105,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 gsL
-pjR
-vvA
 aSK
-ltk
-vvA
+aSK
 pjR
-cPa
+ltk
+pjR
+pjR
+ygU
 nji
 fvJ
 gLJ
@@ -164024,103 +160080,103 @@ nCT
 obU
 rHO
 fkh
-ldK
+psk
 kNK
 kgG
 kRv
-svA
+kRv
 pPh
-lwn
-lwn
-lwn
-svA
+gmP
+gmP
+gmP
+lIc
+lIc
+lIc
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+kRv
 umq
+kgG
+kgG
+kgG
+umq
+iub
+wxj
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
 kRv
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-svA
-siK
-siK
-kgG
-kgG
-gpA
-svA
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-svA
-aWQ
-aWQ
+kqj
+kqj
+ert
+lIc
+lIc
+lIc
 kRv
-dXr
-dXr
-kgG
-kgG
 kRv
 vzo
 jHs
 vcE
 dQM
-keo
-keo
-keo
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-xsf
+wxD
 gnl
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+usC
+usC
+usC
+usC
+usC
+usC
+usC
+usC
+wDF
 wSe
-jey
-jey
-jll
-jey
-jey
-jll
-jll
+gYy
+jLt
+jLt
+jLt
 gYy
 gYy
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+gYy
+gYy
+gYy
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
 lwn
 "}
 (106,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-wyb
+wPV
+wPV
+wPV
+mZi
 agL
 nWv
 aSK
@@ -164227,111 +160283,111 @@ pXc
 yhb
 eEl
 hsI
-ldK
-kmd
-svA
+psk
+kgG
+kgG
 kgG
 kRv
 kRv
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+kRv
+kRv
+lIc
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
 kgG
-svA
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-fdb
 siK
 kgG
-kgG
 kRv
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
 fLE
 kRv
-kgG
-kgG
-kgG
-kgG
-dXr
-dXr
-kgG
-aWQ
-aWQ
+kRv
+kRv
+kRv
+kRv
+kRv
+lIc
+lIc
+kqj
+kqj
 vzo
 jHs
 vcE
 dQM
-keo
-keo
-keo
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-rwp
+cYG
 bDk
 kKn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
+usC
+usC
+usC
+usC
+usC
+wDF
+wDF
+wDF
+gYy
+vbb
+gYy
+jLt
+gYy
+dPb
+jLt
+gYy
+vbb
+jll
+jll
+wDF
 gYy
 gYy
-wbg
-dDI
-jey
-huh
-jey
-jey
-wPt
-xFE
 gYy
-aWQ
-vUz
-aWQ
-vUz
-aWQ
-aWQ
-aWQ
+wDF
+wDF
+wDF
 lwn
 "}
 (107,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-rjX
-qwD
+wPV
+wPV
+wPV
+aSK
+aSK
 ekA
-pjR
+aSK
 pjR
 ltk
 pjR
 pjR
-bvE
+wzk
 qEo
 pFI
 trp
@@ -164372,7 +160428,7 @@ dSO
 rzD
 xZW
 eLk
-aip
+syH
 cXt
 fiT
 bXE
@@ -164430,59 +160486,59 @@ sIQ
 hEB
 wFP
 hNP
-ldK
-mMV
+psk
+qTg
 rwW
 abx
-kgG
-svA
-lwn
-lwn
-lwn
+kRv
+kRv
+gmP
+gmP
+gmP
 wfl
-icp
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
-kRv
-kgG
-gpA
-kgG
+wfl
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
 kRv
-lwn
-lwn
-lwn
-lwn
-aWQ
-svA
+kRv
+dsm
+siK
+fdb
+kRv
+gmP
+gmP
+gmP
+gmP
+kqj
+kRv
 mDf
-kgG
-dXr
-dXr
-dXr
+kRv
 kgG
 kgG
-abx
-aWQ
-aWQ
-lwn
+kgG
+cSw
+kRv
+flR
+kqj
+kqj
+gmP
 qvx
 jHs
 vcE
 dQM
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -164491,45 +160547,45 @@ vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 gnl
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+usC
+usC
+usC
+usC
+wDF
+wDF
 pbr
-vUz
-jey
-jey
-wbg
-wbg
+ddR
 gYy
-nsz
-jey
-jey
-cmr
+gYy
+gYy
+gYy
+vbb
+jLt
+jLt
+jLt
+jvG
+jll
+jll
 jll
 gYy
-gYy
-jll
-qjg
+dPb
 iia
 gYy
-aWQ
-aWQ
+wDF
+wDF
 lwn
 "}
 (108,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-vvA
-fmk
+wPV
+wPV
+wPV
+aSK
+aSK
 ptv
-pjR
+aSK
 pjR
 her
 fjc
@@ -164613,7 +160669,7 @@ pnM
 nQn
 oTi
 odz
-lYd
+aIr
 eKl
 onE
 nQn
@@ -164633,58 +160689,58 @@ gSs
 gSs
 gSs
 gSs
-ldK
+kwc
 tST
 gkK
-kmd
-svA
-gpA
-svA
-kRv
-kRv
 kgG
+kRv
 umq
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-lwn
-lwn
+lIc
+lIc
+kRv
+kRv
+umq
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+gmP
+gmP
+kRv
+kRv
+kgG
+siK
+kRv
+kRv
+gmP
+gmP
+kqj
+kqj
+kqj
+kRv
 kRv
 kgG
 kgG
 kgG
-kgG
-svA
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-vcV
-kgG
-kgG
-epS
-epS
-dXr
+vzy
 jXe
-kgG
-kgG
 kRv
-aWQ
-lwn
+umq
+kRv
+kqj
+gmP
 qvx
 jHs
 vcE
 dQM
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -164694,45 +160750,45 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 bDk
-lwn
-lwn
-lwn
-aWQ
-aWQ
+usC
+usC
+usC
+wDF
+wDF
 jfx
-jey
-hvU
-jey
-jey
-kog
-vUz
-lwn
-hvU
-jey
-jey
+gYy
+rgd
+jLt
+jLt
+gYy
+usC
+gYy
+gYy
+wbg
 jll
-bds
 jll
-hvU
-jll
+vDk
 wPt
 gYy
 gYy
-aWQ
-aWQ
+vbb
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (109,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-cMi
-pjR
-pjR
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
+aSK
 pjR
 pjR
 pjR
@@ -164836,111 +160892,111 @@ gSs
 hyf
 gSs
 rBt
-ldK
+kwc
 xDr
 uKo
-kmd
-kmd
-kgG
-kgG
-kgG
-gpA
 kgG
 kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-svA
-kgG
-abx
-kgG
+kRv
+lIc
+lIc
+ert
+lIc
+lIc
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kRv
+kRv
+mDf
+fdb
 kgG
 kRv
 mDf
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ruu
+kqj
+kqj
+kqj
+kqj
+kqj
+vzy
 kRv
 umq
 kgG
-epS
-lYR
-dXr
+gpA
+oFM
+kRv
+vzy
 kgG
 kgG
 kRv
-kRv
-aWQ
-aWQ
+kqj
+kqj
 qvx
 jHs
 vcE
 dQM
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 qTe
-oCW
-oCW
-oCW
+xIp
+xIp
+xIp
 qTe
 vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 gnl
-lwn
-lwn
-aWQ
+usC
+usC
+wDF
 kmO
 tCd
 obL
-aMh
+gYy
+jLt
+jLt
+dPb
+usC
+usC
 jll
 jll
-qjg
-lwn
-lwn
-lwn
-jll
-jll
-jll
-jll
-jll
-jll
-jll
-jll
+wPt
 jll
 gYy
 gYy
-aWQ
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
 lwn
 "}
 (110,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 pjR
 pjR
 pjR
 pjR
-bvE
+wzk
 nlJ
 qwK
 uri
@@ -165039,56 +161095,56 @@ gSs
 gFn
 gSs
 gFn
-ldK
+kwc
 cLm
-vzy
-kmd
+nny
+kgG
 kRv
-kgG
-kgG
-kgG
-abx
-kgG
-abx
-sHN
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
 kRv
-kgG
-kgG
+kRv
+lIc
+flR
+lIc
+flR
+qBM
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+kRv
+fdb
 siK
 siK
+kgG
 kRv
-aWQ
-aWQ
-aWQ
+kqj
+kqj
+kqj
 onO
-kmd
+kRv
 vzy
-kmd
+fdb
 vzy
 kRv
 kgG
 kgG
+kgG
+kgG
+kgG
+kgG
 kRv
-kgG
-kgG
-kgG
-kgG
-svA
-aWQ
+kRv
+kqj
 qvx
 jHs
 vcE
 dQM
-keo
+uZo
 vcE
 tws
 hNH
@@ -165103,47 +161159,47 @@ vcE
 vcE
 qYd
 dEC
-lwn
-lwn
-aWQ
-aWQ
-gdU
-vUz
+usC
+usC
+wDF
+wDF
 nXO
-jll
-jvG
-vUz
-gYy
-lwn
-lwn
-lwn
-gYy
-gYy
-rJP
-slM
-wQY
-dNK
-pSt
-slM
 jAm
+vbb
+gYy
+iia
+vbb
+gYy
+usC
+usC
+usC
 jll
-aWQ
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
 lwn
 "}
 (111,1,1) = {"
 lwn
-aWQ
+wPV
 sBL
-aWQ
+wPV
 gsL
-aWQ
-vvA
-pjR
-pjR
+wPV
+nyW
+aSK
+aSK
 ilO
 pjR
 ryd
-uBE
+ryd
 mbz
 xBH
 bux
@@ -165164,29 +161220,29 @@ hVj
 icf
 pRv
 dHe
-uXQ
+lPH
 fhF
-uXQ
+lPH
 hVj
-uXQ
-uXQ
-uXQ
+lPH
+lPH
+lPH
 bTS
 dRR
 ckf
 dHe
-uXQ
-iXR
-uXQ
-qDG
+lPH
+mLH
+lPH
+mdU
 mLH
 mLH
 lPH
-uXQ
+lPH
 mdU
 bGP
 atV
-iXR
+mLH
 lFV
 mHv
 jRt
@@ -165222,7 +161278,7 @@ enl
 ths
 vak
 uWT
-lYd
+aIr
 eKl
 bgQ
 nQn
@@ -165242,58 +161298,58 @@ flh
 iQq
 xiP
 yls
-ldK
+kwc
 nGl
-vzy
 nny
-kmd
-svA
-gpA
+nny
 kgG
-gpA
-kgG
-gpA
+kRv
+umq
+kRv
+umq
+kRv
+ert
+lIc
+lIc
+kqj
+gmP
+gmP
+kqj
+kqj
+kqj
 kRv
 kRv
-aWQ
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-svA
-kgG
-kgG
-kgG
-kgG
-dsm
+kRv
+kRv
 siK
-svA
-aWQ
-aWQ
-aWQ
-soO
+gpA
+kgG
 kRv
+kqj
+kqj
+kqj
+soO
+lIc
 ruu
 kmd
+fdb
+vzy
 kRv
-ruu
 kRv
-svA
 kgG
 kRv
 kgG
 gpA
 kRv
-aWQ
-aWQ
+kqj
+kqj
 qvx
 jHs
 vcE
 dQM
 vcE
 vcE
-fQM
+qOz
 rQx
 xOJ
 rni
@@ -165301,50 +161357,50 @@ fsk
 cOs
 erb
 wFj
-djY
+sQn
 vcE
 vcE
-rwp
+cYG
 bDk
 lIb
-lwn
-aWQ
-aWQ
-aWQ
+usC
+wDF
+wDF
+wDF
 rjU
-vUz
-dTb
-jll
 gYy
-lwn
-lwn
-lwn
+jLt
+jLt
+gYy
+usC
+usC
+usC
 wSe
 gYy
-xix
-fBn
+gYy
+gYy
 vED
 reW
 reW
 bKX
 gWK
-fBn
-dBr
-aWQ
+gYy
+gYy
+wDF
 lwn
 "}
 (112,1,1) = {"
 lwn
-aWQ
-vvA
-bSH
+wPV
+hqC
+iUP
 qwD
+nyW
+nyW
+nyW
+aSK
 aSK
 pjR
-pjR
-aSK
-pjR
-aSK
 ryd
 leF
 iVy
@@ -165381,9 +161437,9 @@ uUs
 pmk
 ylc
 hkM
-efq
+hkM
 hHl
-sZK
+hHl
 kLR
 hkM
 hlb
@@ -165442,54 +161498,54 @@ bXX
 gBa
 kDZ
 gSs
-ldK
-ldK
+kwc
+kwc
 sBI
-ldK
+kwc
 hpm
-tMM
-kmd
-svA
-wRO
-svA
+cwL
+kgG
+kgG
+gkK
+kRv
 qPa
-svA
-ylT
-kgG
 kRv
-aWQ
-aWQ
-lwn
-lwn
-aWQ
-aWQ
-aWQ
+kRv
+kRv
+lIc
+kqj
+kqj
+gmP
+gmP
+kqj
+kqj
+umq
 kRv
 fdb
-fdb
+kRv
 kgG
 kgG
 kgG
 kRv
-aWQ
-lwn
-lwn
+kqj
+gmP
+gmP
 xlQ
 vZS
-ruu
-ylT
-kmd
+gCY
+lIc
+boy
 tJy
 txy
 xlQ
-aWQ
-vcV
-kgG
-xAq
-jAz
+kqj
+kRv
+kRv
+grJ
+xXm
 fhs
-vcV
-aWQ
+kRv
+kqj
 vzo
 jHs
 vcE
@@ -165508,49 +161564,49 @@ wFj
 hNH
 vcE
 vcE
-xsf
+wxD
 gnl
-lwn
-aWQ
-gYy
-gYy
-kog
 jll
-iJa
-jey
+wDF
 gYy
-aWQ
-lwn
-lwn
-vUz
 gYy
-fBn
+gYy
+gYy
+jLt
+jLt
+gYy
+wDF
+usC
+usC
+gYy
+gYy
+gYy
 hku
 ePw
 fdd
 hEc
 jey
-ldZ
+jey
 hku
-fBn
-aWQ
+gYy
+wDF
 lwn
 "}
 (113,1,1) = {"
 lwn
-aWQ
+wPV
 ggC
-vvA
-fKs
-pjR
+vxL
+aSK
+aSK
+uIa
+nyW
+nyW
+aSK
 wnF
 aSK
-pjR
-aSK
-xlO
-aSK
 ixA
-vvA
+aSK
 qnK
 qTj
 qnK
@@ -165628,7 +161684,7 @@ iyz
 jBI
 wQL
 xzJ
-lYd
+aIr
 eWH
 eFZ
 nQn
@@ -165645,57 +161701,57 @@ fYz
 kwc
 cvZ
 kwc
-ldK
+kwc
 wFR
 tds
 pch
-hIJ
-vzy
+kGb
+nny
 xLF
 nny
-ruu
-kmd
-kRv
+nny
+kgG
+kgG
 dTK
-kmd
-mMV
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-svA
-kRv
 kgG
-mUS
+kRv
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+kRv
+kRv
+fdb
+fdb
+fdb
+kgG
 siK
-kgG
-kgG
-kgG
+siK
 kRv
-aWQ
-lwn
-lwn
-ldK
+kqj
+gmP
+gmP
+kcZ
 hhN
 hhN
 hhN
 hhN
 hhN
 hhN
-ldK
-aWQ
-aWQ
+kcZ
+kqj
+kqj
 lZw
 kRa
-kfi
+lwO
 iOH
-svA
-svA
-vzo
-djY
-vcE
+kRv
+kRv
+uNd
+sQn
+dQM
 dQM
 fvF
 rQx
@@ -165711,49 +161767,49 @@ erb
 wFj
 vcE
 vcE
-rwp
+cYG
 gnl
-lXN
+tnq
 gYy
-vUz
 gYy
-jll
-wbg
-qvK
-jey
-vUz
-lwn
-lwn
-lwn
+gYy
+jLt
+gYy
+gYy
+vbb
+gYy
+usC
+usC
+usC
 hyC
-jll
-vGj
+gYy
+gYy
 kFc
 hFs
 jmN
-jey
+vqW
 jey
 xra
 gKr
 vGj
-aWQ
+wDF
 lwn
 "}
 (114,1,1) = {"
 lwn
-aWQ
-vvA
-iUP
-fmk
-kRm
-pjR
+wPV
+aSK
+tau
+aSK
 ixA
 aSK
-pjR
-pjR
+iwx
+nyW
 aSK
-aWQ
-aWQ
+aSK
+aSK
+wPV
+wPV
 qnK
 qTj
 qnK
@@ -165847,60 +161903,60 @@ tXV
 asC
 aAp
 nOk
-giZ
+dVA
 pch
 ajr
 cNs
 pch
-mwE
+xrP
 itT
 iao
-kmd
-gse
+rJP
+rUT
 fiL
 dKh
 rUT
 mMV
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
+kRv
+kRv
+fdb
 kRv
 kgG
 siK
 siK
 kRv
-kgG
-kgG
-kRv
-lwn
-lwn
-lwn
-ldK
+gmP
+gmP
+gmP
+kcZ
 rfY
 gtc
 rfY
 gtc
 rfY
 gtc
-ldK
-aWQ
-aWQ
-aWQ
+kcZ
+kqj
+kqj
+kqj
 kRv
 wim
-aWQ
-aWQ
-aWQ
+kqj
+kqj
+kqj
 uei
 hZc
 jHs
 dQM
-rwp
+cYG
 cny
 rni
 hlw
@@ -165914,23 +161970,23 @@ rni
 rHf
 vcE
 vcE
-rwp
+cYG
 qyJ
-lXN
+tnq
 gYy
 gYy
-jey
-jey
-wbg
 jLt
+jLt
+jLt
+vbb
 gYy
-lwn
-aWQ
-lwn
-lwn
+usC
+wDF
+usC
+usC
 vYy
-jll
-isz
+gYy
+gYy
 rjd
 jsw
 mwt
@@ -165938,25 +161994,25 @@ gJk
 veN
 rnb
 jtU
-aWQ
-aWQ
+wDF
+wDF
 lwn
 "}
 (115,1,1) = {"
 lwn
-aWQ
-hqC
-kkG
-mzJ
-pjR
+wPV
 aSK
-pjR
-aWQ
-aWQ
 aSK
-pjR
+aSK
+aSK
+fME
+nyW
+wPV
+wPV
+aSK
+aSK
 iFQ
-aWQ
+wPV
 qnK
 qTj
 qnK
@@ -166051,59 +162107,59 @@ uXk
 pch
 lgE
 koG
-gSz
+pch
 pch
 tds
 lgE
-qqT
-qqT
+cCY
+cCY
 xvf
 xvf
-qqT
+cCY
 xvf
 xvf
-qqT
-qqT
-qqT
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-kRv
+cCY
+cCY
+cCY
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
 kRv
 kgG
-kRv
-kRv
-gKT
+kgG
+kgG
 gpA
-kgG
-svA
-lwn
-lwn
-ldK
+cwL
+gpA
+kRv
+lIc
+gmP
+gmP
+kcZ
 bEE
 bEE
 bEE
 bEE
 bEE
 bEE
-ldK
-lwn
-lwn
-aWQ
-aWQ
+kcZ
+gmP
+gmP
+kqj
+kqj
 fLE
-aWQ
-lwn
-lwn
-lwn
+kqj
+gmP
+gmP
+gmP
 vzo
 jHs
 dQM
-rwp
+cYG
 cny
 rni
 iAI
@@ -166119,21 +162175,21 @@ iAI
 cZK
 cYG
 urg
+wbg
+jWi
 gYy
-pAQ
+dPb
 gYy
-huh
-jey
-bds
-vUz
-kog
-lwn
-aWQ
-lwn
-lwn
+dPb
+gYy
+gYy
+usC
+wDF
+usC
+usC
 vKw
 iWx
-isz
+gYy
 pXk
 tfX
 lEl
@@ -166141,25 +162197,25 @@ lEl
 xJf
 jey
 jtU
-aWQ
-aWQ
+wDF
+wDF
 lwn
 "}
 (116,1,1) = {"
 lwn
-aWQ
-vvA
-vxL
-woq
+wPV
+hqC
+gsL
 aSK
-pjR
-pjR
-aWQ
-aWQ
-aWQ
+aSK
+aSK
+nyW
+wPV
+wPV
+wPV
 iUP
-aWQ
-aWQ
+wPV
+wPV
 qnK
 qTj
 qnK
@@ -166267,46 +162323,46 @@ own
 hSm
 dgm
 eiB
-qqT
-qqT
-qqT
-qqT
-aWQ
-aWQ
-svA
-svA
-kRv
-kRv
-svA
+cCY
+cCY
+cCY
+cCY
+kqj
+kqj
+kgG
+kgG
+kgG
+siK
+siK
 kRv
 mDf
 kgG
-kgG
-kgG
-abx
 kRv
-lwn
-rAy
+kRv
+flR
+lIc
+gmP
+qfd
 gNa
-kmd
-ylT
-ruu
-ruu
+lIc
+lIc
+gCY
+gCY
 txy
-ldK
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
+kcZ
+gmP
+gmP
+gmP
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
 vzo
 jHs
 dQM
-rwp
+cYG
 cny
 fsk
 iAI
@@ -166321,22 +162377,22 @@ xnc
 iAI
 cZK
 cYG
-czc
-gYy
+wpf
+wbg
 fbF
 vbb
-jll
+gYy
 hqI
-jll
-jll
+gYy
+jLt
 iia
-xFE
-lwn
-lwn
-lwn
-lwn
-jvG
-isz
+gYy
+usC
+usC
+usC
+usC
+iia
+gYy
 rjd
 lHA
 xra
@@ -166344,25 +162400,25 @@ hjz
 qCJ
 jey
 tIY
-aWQ
-aWQ
+wDF
+wDF
 lwn
 "}
 (117,1,1) = {"
 lwn
-aWQ
-aWQ
-vvA
-fKs
-pjR
+wPV
+wPV
+iFQ
 aSK
 aSK
-aSK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nyW
+nyW
+nyW
+wPV
+wPV
+wPV
+wPV
+wPV
 qnK
 qTj
 qnK
@@ -166473,43 +162529,43 @@ jjT
 ibY
 emM
 cBq
-qqT
-aWQ
-svA
-svA
+cCY
+kqj
 kgG
 kgG
+gpA
 kgG
-kRv
+siK
+siK
 kgG
-lwn
-kRv
-kgG
-kgG
+gmP
 kRv
 kRv
+boy
+boy
 kRv
+umq
 vzy
 kRv
 ruu
-kRv
-kmd
-vzy
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+umq
+umq
+gCY
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
 jHs
 dQM
-rwp
+cYG
 cny
 rni
 hlw
@@ -166523,23 +162579,23 @@ fsk
 rHf
 vcE
 vcE
-rwp
+cYG
 jEo
-lXN
+tnq
 gYy
 gYy
-jll
-jll
-jll
-jll
-jll
+gYy
+gYy
+gYy
+jLt
+gYy
 rjU
-lwn
-lwn
-lwn
-vUz
+usC
+usC
+usC
 jll
-vGj
+gYy
+gYy
 xsP
 qyU
 uMO
@@ -166548,24 +162604,24 @@ jey
 xra
 nFf
 vGj
-aWQ
+wDF
 lwn
 "}
 (118,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aSK
-miQ
-aSK
+wPV
+wPV
+wPV
+wPV
+nyW
+uIa
+nyW
 aSK
 oth
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 qnK
 qnK
 qnK
@@ -166676,39 +162732,39 @@ jjT
 cYB
 qxo
 mbv
-qqT
-aWQ
-svA
+cCY
+kqj
+kgG
+kgG
+kgG
+kgG
+kgG
+kgG
+kgG
+gmP
+gmP
+lIc
+boy
+fdb
 kRv
 kgG
 kRv
-svA
-kgG
-kgG
-lwn
-lwn
-kRv
-kgG
-kgG
-kgG
-kgG
-kRv
-gpA
-kgG
-kRv
-ruu
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+siK
+siK
+fdb
+vzy
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
 jHs
 dQM
@@ -166726,23 +162782,23 @@ rQx
 xOJ
 vcE
 vcE
-rwp
+cYG
 uIQ
-lwn
-aWQ
-vUz
+usC
+wDF
 gYy
 gYy
-kog
+gYy
+gYy
 jUp
-wPt
+vbb
 gYy
 kxt
-lwn
-gYy
-svv
+usC
 jll
-fBn
+vMa
+gYy
+gYy
 hku
 vfV
 mUz
@@ -166750,27 +162806,27 @@ pOR
 jey
 cPN
 hku
-fBn
-aWQ
+gYy
+wDF
 lwn
 "}
 (119,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-sBL
+wPV
+wPV
+wPV
+wPV
+wne
+nyW
 aSK
-pjR
-pjR
 aSK
-vvA
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+aSK
+wPV
+wPV
+wPV
+wPV
+wPV
 qnK
 ubD
 jsH
@@ -166879,41 +162935,41 @@ jjT
 roP
 peP
 xkY
-qqT
-qqT
-rCE
-rCE
-rCE
-rCE
-pAy
-rCE
-rCE
-qqT
-lwn
+cCY
+eRb
+eRb
+eRb
+eRb
+eRb
+goC
+bBk
+bBk
+bBk
+gmP
+lIc
+umq
 kRv
-gpA
-kgG
-kgG
-kgG
-kRv
-kgG
 kgG
 siK
-fdb
 kRv
-svA
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kgG
+siK
+kgG
+kRv
+kRv
+kRv
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
-djY
+sQn
 dQM
 dQM
 hNH
@@ -166929,51 +162985,51 @@ xOJ
 hNH
 vcE
 vcE
-rwp
+cYG
 kHO
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
+usC
+wDF
+wDF
+wDF
+wDF
 gYy
-jll
+gYy
 wyd
 sTZ
-cUS
 gYy
 gYy
+jll
 hsQ
 jll
-xXm
-fBn
+gYy
+gYy
 lmH
 wbH
 wbH
 wbH
 hrh
-fBn
-nhc
-aWQ
+gYy
+gYy
+wDF
 lwn
 "}
 (120,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
-pjR
 aSK
-pjR
 aSK
-vvA
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+aSK
+aSK
+wPV
+wPV
+wPV
+wPV
 rfe
 tET
 nGa
@@ -167082,7 +163138,7 @@ eVd
 cYB
 kaf
 hWC
-eRb
+cCY
 eRb
 hRy
 jif
@@ -167091,36 +163147,36 @@ eRb
 jVa
 rOE
 vYx
-qqT
-lwn
-svA
-kgG
+bBk
+gmP
+lIc
 kRv
-kgG
-gpA
-kgG
-kgG
-kgG
-dsm
+kRv
+siK
+siK
 siK
 kgG
 kgG
+gpA
+siK
+fdb
 kRv
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
-imu
+qrS
 erb
 wFj
 rni
@@ -167132,51 +163188,51 @@ deK
 vcE
 vcE
 ldY
-rwp
+cYG
 kHO
-lwn
-aWQ
-aWQ
+usC
+wDF
+wDF
 gYy
 oLp
-vUz
+gYy
 wyd
-jey
-jey
-jey
-jll
-jll
+qvK
+qvK
+sTZ
+gYy
+gYy
 jll
 xUm
 jll
-qBM
-slM
-upU
-liu
-cFA
-slM
-nNx
-aWQ
-aWQ
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (121,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
+aSK
 aSK
 pjR
-aSK
-pjR
 pjR
 aSK
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
 lji
 cLY
 exS
@@ -167285,7 +163341,7 @@ qqx
 wBH
 vSn
 crp
-eRb
+cCY
 eRb
 cWH
 rgm
@@ -167294,32 +163350,32 @@ eRb
 fmR
 jre
 xFH
-qqT
-lwn
-lwn
-kRv
-abx
-kRv
-kgG
-kgG
-abx
-kgG
-kgG
-icp
-kgG
+bBk
+gmP
+gmP
 kRv
 mDf
+kRv
+siK
+kgG
+abx
+siK
+kgG
+kgG
+siK
+fdb
+mDf
 xoe
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
 jHs
 dQM
@@ -167335,39 +163391,39 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 kHO
-lwn
-aWQ
+usC
+wDF
 nXO
 vUz
 gYy
-jll
+gYy
 tQe
-jey
-jey
+qvK
+qvK
 huh
-cmr
-jll
-jll
+iia
+gYy
+gYy
 jvG
 jll
 osB
-jll
-jll
-jll
-jvG
-jll
-jll
-aWQ
-aWQ
+gYy
+gYy
+gYy
+iia
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (122,1,1) = {"
 lwn
-twA
-twA
-twA
+cJt
+cJt
+cJt
 ijb
 nHF
 nHF
@@ -167376,10 +163432,10 @@ jxd
 jxd
 pjR
 ilO
-pjR
 aSK
 aSK
-aWQ
+aSK
+wPV
 qnK
 iSb
 inf
@@ -167424,7 +163480,7 @@ bgQ
 uwP
 vCE
 qTd
-lYd
+aIr
 qfI
 vjl
 nQn
@@ -167488,7 +163544,7 @@ lpd
 cCY
 cCY
 cCY
-eRb
+cCY
 eRb
 ipM
 rgm
@@ -167497,34 +163553,34 @@ eRb
 eZv
 lgG
 mFg
-qqT
-lwn
-lwn
-lwn
+bBk
+gmP
+gmP
+gmP
 kRv
-svA
+kRv
+gpA
+kgG
+siK
+siK
+siK
 kgG
 kgG
 kgG
-kgG
-kgG
-icp
-kgG
-kgG
-kgG
-kgG
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kRv
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
-djY
+sQn
 dQM
 dQM
 dQM
@@ -167538,51 +163594,51 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 kAL
-lwn
-aWQ
-aWQ
+usC
+wDF
+wDF
 gYy
-vUz
+gYy
 gdU
-jll
+gYy
 tQe
 xKe
-jvG
-jll
-jll
-jll
-wPt
-jll
+iia
+jLt
 gYy
+gYy
+vbb
+jll
+jll
 vMa
 gYy
 gYy
-jll
-jll
-lXN
-aWQ
-aWQ
+gYy
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (123,1,1) = {"
 lwn
-twA
-aWQ
-hEt
-vvA
+cJt
+wPV
+oth
 aSK
-pjR
+aSK
+aSK
 ilO
 pjR
 jxd
 pjR
 pjR
 pjR
-pjR
-vvA
-aWQ
+aSK
+aSK
+wPV
 xUF
 xoA
 lkh
@@ -167627,7 +163683,7 @@ onE
 nQn
 wKC
 qTd
-lYd
+aIr
 eKl
 onE
 fPm
@@ -167672,7 +163728,7 @@ phE
 tyO
 eWO
 oTb
-qGn
+oTb
 pJC
 cHQ
 fCr
@@ -167700,34 +163756,34 @@ eRb
 cqM
 qqi
 fyH
-qqT
-lwn
-lwn
-lwn
+bBk
+gmP
+gmP
+gmP
 lhB
 ucq
 kRv
 kgG
 kRv
+fdb
 kRv
-kRv
-wDZ
-siK
+gpA
 siK
 kgG
-gpA
+kgG
+umq
 kRv
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-fvu
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+osn
 jHs
 vcE
 dQM
@@ -167742,41 +163798,41 @@ vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 kHO
-aWQ
-aWQ
-aWQ
-aWQ
+wDF
+wDF
+wDF
+wDF
 kxt
-jll
-jvG
-jll
-jll
-jll
-iAz
-hvU
-jll
-qjg
 gYy
-aWQ
-aWQ
-aWQ
-vUz
-aWQ
+iia
 gYy
-aWQ
-aWQ
+jLt
+jLt
+jLt
+gYy
+gYy
+dPb
+jll
+wDF
+wDF
+wDF
+gYy
+gYy
+gYy
+wDF
+wDF
 lwn
 "}
 (124,1,1) = {"
 lwn
-twA
+cJt
 hqC
-woq
+iFQ
 aSK
-pjR
-miQ
+aSK
+wnF
 wPr
 giV
 jxd
@@ -167784,8 +163840,8 @@ miQ
 pjR
 pjR
 pjR
-aWQ
-aWQ
+wPV
+wPV
 qnK
 qnK
 qnK
@@ -167830,7 +163886,7 @@ bgQ
 kxj
 oTi
 qTd
-lYd
+aIr
 vlM
 eFZ
 fPm
@@ -167903,34 +163959,34 @@ eRb
 lwK
 bBk
 bBk
-qqT
-lwn
-lwn
-lwn
-jbf
-jbf
+bBk
+gmP
+gmP
+gmP
+nQG
+nQG
 uKd
-svA
-ylT
 kRv
-kgG
-kgG
+kRv
+kRv
+kRv
 siK
 siK
-kgG
-kgG
-svA
 siK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-vzo
+kgG
+kRv
+kRv
+boy
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+qvx
 jHs
 vcE
 dQM
@@ -167945,41 +164001,41 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 kAL
-lwn
-lwn
-lwn
-aWQ
-aWQ
+usC
+usC
+usC
+wDF
+wDF
 gYy
-jll
-jey
-jey
-jll
-oQl
-stk
-jll
 gYy
-vUz
 gYy
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+gYy
+jLt
+gYy
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
 lwn
 "}
 (125,1,1) = {"
 lwn
-twA
+cJt
 vxL
-gPF
-vvA
+gsL
 aSK
-pjR
+aSK
+aSK
 pjR
 pjR
 aSw
@@ -167988,11 +164044,11 @@ pjR
 pjR
 aSK
 aSK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 pPw
 vih
 wcP
@@ -168074,7 +164130,7 @@ rSm
 qLW
 ycc
 bJY
-pkl
+phE
 flc
 atQ
 ueO
@@ -168109,32 +164165,32 @@ rEU
 vNa
 vNa
 vNa
-qqT
-qqT
-dpJ
-qqT
+vNa
+vNa
+jib
+vNa
 kaG
 ybU
-svA
 kRv
-svA
-icp
-icp
-icp
-icp
-icp
+umq
+kRv
 siK
-fdb
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-vzo
-djY
+kgG
+kRv
+kRv
+icp
+boy
+boy
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+qvx
+sQn
 dQM
 dQM
 dQM
@@ -168149,41 +164205,41 @@ vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 kHO
-lwn
-lwn
-aWQ
+usC
+usC
+wDF
 fGw
-vUz
-jll
-jey
-jey
-jll
-hvU
-vTI
-jll
-jll
 gYy
 gYy
-vUz
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
+jLt
+gYy
+gYy
+gYy
+jLt
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
+wDF
+wDF
+wDF
+usC
 lwn
 "}
 (126,1,1) = {"
 lwn
-twA
-aWQ
-fKs
+cJt
+wPV
 aSK
 aSK
-pjR
-pjR
+aSK
+aSK
+aSK
 pjR
 jxd
 pjR
@@ -168193,9 +164249,9 @@ pjR
 pjR
 aSK
 aSK
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 kjm
 bbp
 oku
@@ -168236,7 +164292,7 @@ bgQ
 bNh
 kOO
 qTd
-lYd
+aIr
 cUx
 pAB
 nQn
@@ -168277,7 +164333,7 @@ awp
 awp
 ycc
 gVh
-qwf
+fQy
 lpG
 afx
 ueO
@@ -168318,27 +164374,27 @@ vjj
 jUx
 aWd
 jOa
-ylT
-kgG
+vzn
 kRv
-wfl
-kgG
-cwL
-kgG
-gpA
-kgG
-kgG
+kRv
+kRv
+kRv
+gKT
+ert
+icp
+lIc
+kRv
 umq
-kgG
 kRv
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kRv
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 osn
-djY
+sQn
 dQM
 dQM
 sTI
@@ -168352,41 +164408,41 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 kAL
-lwn
-lwn
-aWQ
-vUz
-xFE
-jll
-jll
-bds
+usC
+usC
+wDF
 gYy
-jll
-wbg
-wbg
-jll
-jll
-vUz
-kog
 gYy
-aWQ
-aWQ
-aWQ
-lwn
-lwn
+jLt
+jLt
+jLt
+gYy
+jLt
+jLt
+jLt
+gYy
+gYy
+vbb
+gYy
+gYy
+wDF
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (127,1,1) = {"
 lwn
-twA
-aWQ
-aWQ
+cJt
+wPV
+wPV
 iFQ
 aSK
 aSK
-pjR
+aSK
 aSK
 jxd
 pjR
@@ -168394,11 +164450,11 @@ pjR
 pjR
 pjR
 aSK
-vvA
-vvA
+aSK
+aSK
 ujX
-aWQ
-aWQ
+wPV
+wPV
 kjm
 kjm
 tAJ
@@ -168439,7 +164495,7 @@ bgQ
 uwP
 nFe
 qTd
-lYd
+aIr
 cUx
 iew
 kxj
@@ -168480,7 +164536,7 @@ vEt
 gkO
 nMG
 qvd
-dce
+phE
 pFq
 bbc
 ueO
@@ -168522,29 +164578,29 @@ eMp
 rzt
 ybU
 xmq
-ylT
-lwn
-lwn
-lwn
+kRv
+gmP
+gmP
+gmP
 nzN
-kgG
-kgG
-kgG
-kgG
+boy
+icp
+kRv
+kRv
 kgG
 abx
 kRv
 kRv
-kgG
-svA
-lwn
-lwn
-lwn
-lwn
+kRv
+kRv
+gmP
+gmP
+gmP
+gmP
 icp
-kgG
-vQw
-jtv
+kRv
+umq
+vyq
 mDx
 cqS
 dLn
@@ -168556,42 +164612,42 @@ vcE
 vcE
 vcE
 vcE
-xsf
+wxD
 kHO
-aWQ
-aWQ
-vUz
-gYy
-jll
-gYy
-vqW
-jey
-vUz
-xJg
-wbg
-jey
-jey
-jll
+wDF
+wDF
 gYy
 gYy
 gYy
+jLt
+xzl
 gYy
-aWQ
-lwn
-lwn
+gYy
+jLt
+gYy
+gYy
+jLt
+gYy
+gYy
+gYy
+gYy
+gYy
+wDF
+usC
+usC
 lwn
 "}
 (128,1,1) = {"
 lwn
-twA
-aWQ
-aWQ
-aWQ
-vvA
+cJt
+wPV
+wPV
+wPV
 aSK
 aSK
 aSK
-coU
+aSK
+nHF
 pjR
 pjR
 cvV
@@ -168600,8 +164656,8 @@ pjR
 aSK
 gsL
 ujX
-aWQ
-aWQ
+wPV
+wPV
 pHv
 waR
 sne
@@ -168683,7 +164739,7 @@ vEt
 gkO
 dLk
 kKW
-tzc
+phE
 mgI
 fsN
 ueO
@@ -168725,29 +164781,29 @@ qqT
 xRP
 vzn
 vzn
-cwm
-lwn
-lwn
-lwn
-lwn
+mqJ
+gmP
+gmP
+gmP
+gmP
+boy
+kRv
+kRv
 kgG
-kgG
-kgG
-kgG
-kgG
+siK
 kgG
 kgG
 gpA
 kRv
-lwn
-lwn
-lwn
-lwn
-kgG
+gmP
+gmP
+gmP
+gmP
+lIc
 icp
-abx
-kgG
-kgG
+mDf
+kRv
+kRv
 vyq
 mDx
 jSP
@@ -168759,40 +164815,40 @@ vcE
 vcE
 vcE
 vcE
-rwp
+cYG
 kAL
 kKn
-gYy
+jll
 pAQ
-jll
-jll
-jll
-jey
-jey
 gYy
-gdU
-jll
-jey
-jey
-bds
-jll
-jll
-vUz
 gYy
-aWQ
-lwn
-lwn
+gYy
+gYy
+gYy
+gYy
+dPb
+gYy
+jLt
+jLt
+jLt
+gYy
+gYy
+gYy
+gYy
+wDF
+usC
+usC
 lwn
 "}
 (129,1,1) = {"
 lwn
-twA
-twA
-twA
-twA
-twA
+cJt
+cJt
+cJt
+cJt
+cJt
 ijb
-twA
+cJt
 nHF
 nHF
 wnF
@@ -168801,9 +164857,9 @@ pjR
 pjR
 wnF
 iFQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 kjm
 kjm
 lCz
@@ -168851,7 +164907,7 @@ ttC
 nQn
 kQK
 gBr
-waF
+vBD
 oDh
 uhR
 dJQ
@@ -168886,7 +164942,7 @@ ycc
 iZx
 czK
 tvp
-dce
+phE
 lpG
 atQ
 ueO
@@ -168928,27 +164984,27 @@ qqT
 fLj
 oxr
 rqg
-wXm
-lwn
-lwn
-lwn
-lwn
-lwn
-kgG
+jbf
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
 umq
-svA
-kRv
-kRv
-kgG
-siK
 fdb
-lwn
-lwn
-lwn
-abx
-gpA
+fdb
+fdb
+kgG
+kgG
+kRv
+gmP
+gmP
+gmP
+flR
+ert
 vjk
-svA
+lIc
 kRv
 dQM
 dQM
@@ -168963,50 +165019,50 @@ sYa
 vcE
 vcE
 vcE
-xsf
+wxD
 gnl
-qtK
+czc
 jll
 tmW
 lRP
-wmB
-jll
+fTZ
 gYy
-jll
-qjg
-vUz
-jll
-jll
-jll
-jll
-jey
-jey
-aWQ
-aWQ
-lwn
-lwn
+gYy
+gYy
+jLt
+gYy
+gYy
+jLt
+gYy
+gYy
+gYy
+gYy
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (130,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
-eSb
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
+alg
+aSK
 pjR
 pjR
 pjR
-vvA
-aWQ
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
+wPV
 kjm
 xMs
 ifI
@@ -169089,7 +165145,7 @@ oCx
 lVL
 dwT
 dwT
-dce
+phE
 pFq
 afx
 ueO
@@ -169130,28 +165186,28 @@ eFD
 dpJ
 qgb
 rMx
-qqT
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+vNa
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
-fdb
-siK
-icp
-icp
-siK
-siK
 kRv
-svA
-kRv
+siK
 kgG
 kgG
-wxj
-lwn
+kgG
+kgG
+kRv
+kRv
+lIc
+lIc
+lIc
+icp
+gmP
 deK
 dQM
 dQM
@@ -169169,47 +165225,47 @@ jUd
 vcE
 uUL
 jll
-bds
-jll
-jey
+vDk
+wbg
+wbg
 tnq
-jvG
-gYy
-jll
-gYy
-qjg
-jll
 iia
-wPt
-jll
-jey
-jey
-aWQ
-aWQ
-lwn
-lwn
+gYy
+jLt
+wMR
+jLt
+dPb
+iia
+xzl
+gYy
+vbb
+gYy
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (131,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
-pWA
+xdu
 pjR
 ilO
 pjR
 aSK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 kjm
 pYa
 kFN
@@ -169292,7 +165348,7 @@ eIb
 tix
 dwT
 xyk
-dce
+phE
 pFq
 bbc
 ueO
@@ -169333,34 +165389,34 @@ bCO
 qqT
 vyv
 jBK
-qqT
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
-siK
-siK
+vNa
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+kgG
+kgG
 gpA
+siK
 kgG
-kgG
-wxj
+kRv
 kRv
 mDf
-gpA
-mDf
-lwn
-lwn
+umq
+flR
+gmP
+gmP
 qvx
-djY
+sQn
 dQM
 dQM
 vcE
 vcE
-nHx
+sTI
 eYQ
 vyq
 vyq
@@ -169373,43 +165429,43 @@ vcE
 bbQ
 wxD
 jll
+wbg
+wbg
 jll
-jey
-jey
 lmv
-jll
-jll
-jll
+gYy
+gYy
+jLt
 gYy
 gYy
 gYy
 gYy
 gYy
-jll
-jll
-aWQ
-aWQ
-lwn
-lwn
+gYy
+gYy
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (132,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
-ltk
+tnB
 pjR
 pjR
-vvA
+aSK
 ejS
 ejS
-aWQ
+wPV
 wQk
 wQk
 wQk
@@ -169495,7 +165551,7 @@ ycc
 vVU
 lxU
 qzY
-pkl
+phE
 fbw
 afx
 ueO
@@ -169536,28 +165592,28 @@ dzJ
 qqT
 gkM
 oxr
-qqT
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+vNa
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
-icp
 kgG
 kgG
-kgG
+siK
+siK
 fdb
-fdb
-kgG
 kRv
 kRv
-svA
-lwn
-lwn
-lwn
+kRv
+kRv
+lIc
+gmP
+gmP
+gmP
 osn
 jHs
 dQM
@@ -169577,38 +165633,38 @@ eMq
 vyq
 wxD
 jll
-cUS
 jll
 jll
+wbg
 fgb
-fgb
-pCl
+tmW
+lRP
 gYy
 gYy
 gYy
-kog
+gYy
 pjX
-jey
-jll
-aWQ
-aWQ
-lwn
-lwn
+gYy
+gYy
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (133,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 tnB
 pjR
-vvA
+pjR
 xwH
 dyY
 wQk
@@ -169657,7 +165713,7 @@ hjr
 kxj
 fSw
 vEv
-lYd
+aIr
 bHj
 cmc
 faH
@@ -169698,7 +165754,7 @@ ycc
 ycc
 eRx
 kKW
-pkl
+phE
 lpG
 atQ
 ueO
@@ -169739,28 +165795,28 @@ lUI
 dpJ
 rMx
 rMx
-qqT
-qqT
-qqT
-lwn
-lwn
-lwn
-lwn
-svA
+vNa
+oNo
+oNo
+gmP
+gmP
+gmP
+gmP
+qek
 kRv
-wfl
-kgG
+kRv
 kgG
 kgG
 siK
-siK
+kgG
+gpA
 kRv
 kRv
-svA
-aWQ
-aWQ
-lwn
-lwn
+kRv
+kqj
+kqj
+gmP
+gmP
 qvx
 jHs
 dQM
@@ -169781,38 +165837,38 @@ iAI
 vyq
 wxD
 jll
-bds
-gYy
-gYy
+vDk
+wbg
+wbg
 jll
-xFE
-sMY
-aWQ
-aWQ
+jll
+tmW
+wDF
+wDF
 kxt
-jey
-jey
-jll
-aWQ
-aWQ
-lwn
-lwn
+gYy
+gYy
+gYy
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (134,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 pSi
 pSi
 pSi
 pSi
-syS
+lLm
 pjR
-fsP
-fio
+pjR
+lMt
 yaP
 wQk
 htf
@@ -169860,7 +165916,7 @@ bgQ
 nQn
 qzs
 qTd
-lYd
+aIr
 mFf
 sLy
 rSw
@@ -169901,7 +165957,7 @@ ycc
 eiS
 bJp
 tix
-dce
+phE
 pFq
 eKd
 ueO
@@ -169944,28 +166000,28 @@ qoy
 rnY
 oNo
 oNo
-qqT
-lwn
-lwn
-lwn
-lwn
+oNo
+gmP
+gmP
+gmP
+gmP
 sHN
-svA
-lwn
+kRv
+gmP
 kRv
 mDf
 kgG
 kgG
-gpA
+siK
 kgG
 mDf
-aWQ
-aWQ
-aWQ
-lwn
-lwn
+kqj
+kqj
+kqj
+gmP
+gmP
 qvx
-djY
+sQn
 dQM
 dQM
 hMX
@@ -169986,37 +166042,37 @@ vyq
 wxD
 jll
 jll
-cUS
-vUz
-aWQ
-aWQ
-aWQ
-aWQ
+jll
+jll
+wDF
+wDF
+wDF
+wDF
 keG
 nXO
-jey
-aWQ
-aWQ
-lwn
-lwn
-lwn
+gYy
+wDF
+wDF
+usC
+usC
+usC
 lwn
 "}
 (135,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 pSi
 ask
 hIc
 vxV
-syS
-siO
+lLm
+miQ
 pVa
 rVW
-sYn
+xwH
 wQk
 wAk
 iVS
@@ -170026,7 +166082,7 @@ jDT
 ueK
 eyj
 aYz
-geq
+sgy
 tIL
 ivN
 vPu
@@ -170063,7 +166119,7 @@ bgQ
 nQn
 oTi
 qTd
-lYd
+aIr
 fhj
 bPV
 hgi
@@ -170104,7 +166160,7 @@ ycc
 ubd
 cJZ
 tix
-pkl
+phE
 ftA
 atQ
 ueO
@@ -170147,27 +166203,27 @@ eTf
 uUT
 ajo
 oNo
-qqT
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
-lwn
-lwn
+oNo
+gmP
+gmP
+gmP
+gmP
+gmP
+wxj
+gmP
+gmP
 kRv
 kRv
-kgG
-kgG
-kgG
-kgG
-svA
-aWQ
-aWQ
-lwn
-lwn
-lwn
+siK
+siK
+siK
+kRv
+sHN
+kqj
+kqj
+gmP
+gmP
+gmP
 fvu
 jHs
 dQM
@@ -170189,33 +166245,33 @@ eYQ
 vyq
 wxD
 jvG
-gYy
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+jll
+wDF
+wDF
+wDF
+wDF
+wDF
 eVy
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
+wDF
+wDF
+wDF
+usC
+usC
+usC
+usC
 lwn
 "}
 (136,1,1) = {"
 lwn
-ldK
-ldK
+urj
+urj
 pSi
 pSi
 pSi
 uuU
 hIc
 wEf
-syS
+lLm
 pjR
 juj
 mDv
@@ -170230,7 +166286,7 @@ ueK
 eyj
 wxs
 liq
-fhY
+hoF
 uHN
 ppe
 syH
@@ -170350,29 +166406,29 @@ syA
 uUT
 xya
 oNo
-qqT
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
+oNo
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
 kRv
+kRv
+siK
 kgG
-kgG
 kRv
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
 vzo
-djY
+sQn
 dQM
 dQM
 vcE
@@ -170391,27 +166447,27 @@ hQY
 tRT
 cGb
 pcJ
-nSM
+pcJ
 bua
 kKn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+usC
+usC
+usC
+usC
+usC
+usC
 lwn
 "}
 (137,1,1) = {"
 lwn
-ldK
-sBI
+urj
+pHh
 fUW
 sYn
 jvA
@@ -170419,7 +166475,7 @@ qAa
 fio
 vxV
 lLm
-fsP
+pjR
 qvE
 wst
 kWp
@@ -170553,30 +166609,30 @@ kPF
 dSv
 aBV
 oNo
-qqT
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-wfl
-wfl
-wDZ
-siK
-siK
-icp
-wfl
+osL
+nwx
+nwx
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+fdb
+umq
+kgG
+kgG
+kRv
+mPX
 wxj
-aWQ
-lwn
-lwn
-lwn
-aWQ
+kqj
+gmP
+gmP
+gmP
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 kaP
@@ -170595,25 +166651,25 @@ rTP
 mHI
 vcE
 vcE
-xsf
+wxD
 bDk
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+wDF
+wDF
+wDF
+wDF
+wDF
+wDF
+usC
+usC
+usC
+usC
+usC
+usC
 lwn
 "}
 (138,1,1) = {"
 lwn
-ldK
+urj
 mAc
 nNv
 fsP
@@ -170621,11 +166677,11 @@ pQA
 ojZ
 oOP
 cHA
-syS
-fsP
-qSa
+lLm
+pjR
+htG
 ouc
-aWQ
+wPV
 jdt
 ueK
 nOw
@@ -170719,7 +166775,7 @@ eWO
 oTb
 uxu
 vgq
-sDt
+aud
 iUI
 ycc
 oPB
@@ -170758,27 +166814,27 @@ sCh
 nwx
 nwx
 nwx
-ldK
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-svA
-kgG
-kgG
+nwx
+nwx
+nwx
+gmP
+gmP
+gmP
+gmP
+kRv
+kRv
+kRv
 siK
-siK
+kgG
 kgG
 kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
 jHs
 dQM
@@ -170799,24 +166855,24 @@ vcE
 vcE
 mlU
 vcE
-xsf
+wxD
 bDk
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+wDF
+wDF
+wDF
+wDF
+wDF
+usC
+usC
+usC
+usC
+usC
+usC
 lwn
 "}
 (139,1,1) = {"
 lwn
-ldK
+urj
 mAc
 iLd
 ufo
@@ -170826,9 +166882,9 @@ uBE
 uBE
 lLm
 pjR
-mbx
-aWQ
-aWQ
+qtK
+wPV
+wPV
 wQk
 kLx
 nOw
@@ -170854,15 +166910,15 @@ uQQ
 cgd
 hfO
 fWW
-abh
+ybf
 aQX
 hfO
 biP
 owo
 drN
 hfO
-iwx
-uvk
+biP
+owo
 drN
 hfO
 vDI
@@ -170920,7 +166976,7 @@ jeJ
 iQG
 bLP
 bPx
-bEf
+bPx
 feA
 lJg
 iVp
@@ -170963,27 +167019,27 @@ pyI
 dZE
 cqf
 nsv
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
+nwx
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
-kgG
-kgG
-kgG
+fdb
+siK
+siK
 gpA
 kRv
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
-djY
+sQn
 dQM
 dQM
 vcE
@@ -171003,23 +167059,23 @@ sYa
 dQM
 dQM
 vcE
-xsf
+wxD
 bDk
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+wDF
+wDF
+wDF
+wDF
+usC
+usC
+usC
+usC
+usC
+usC
 lwn
 "}
 (140,1,1) = {"
 lwn
-ldK
+urj
 mAc
 ffc
 jdA
@@ -171029,9 +167085,9 @@ tXf
 lqA
 avu
 pjR
-wxR
-aWQ
-aWQ
+wIM
+wPV
+wPV
 wQk
 skS
 ole
@@ -171166,26 +167222,26 @@ qtd
 dZE
 nwx
 nwx
-qqT
-kgG
-lwn
-lwn
-lwn
-lwn
-fdb
+osL
+nrL
+gmP
+gmP
+gmP
+gmP
+kRv
+kRv
 siK
-kgG
 cwL
 kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
 jHs
 dQM
@@ -171207,22 +167263,22 @@ vcE
 dQM
 mlU
 dQM
-xsf
+wxD
 bDk
-xxz
-xxz
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
+cMe
+cMe
+wDF
+wDF
+wDF
+wDF
+wDF
+usC
+usC
 lwn
 "}
 (141,1,1) = {"
 lwn
-ldK
+urj
 mAc
 iLd
 uBE
@@ -171230,11 +167286,11 @@ mbx
 uBE
 dJZ
 uBE
-uBE
-hRC
-pQA
-aWQ
-aWQ
+leF
+iSB
+pjR
+wPV
+wPV
 wQk
 iAc
 poB
@@ -171369,28 +167425,28 @@ uCN
 iNn
 abD
 nsv
-qqT
-svA
+osL
+wxj
+oFM
+gmP
+gmP
+lIc
 kRv
-lwn
-lwn
-svA
-siK
-siK
 kgG
 kgG
-svA
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kgG
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
-djY
+sQn
 dQM
 dQM
 vcE
@@ -171413,19 +167469,19 @@ dQM
 vcE
 pnY
 pnY
-xsf
+wxD
 bDk
-xxz
-xxz
-xxz
-xxz
-lwn
-lwn
+cMe
+cMe
+cMe
+cMe
+usC
+usC
 lwn
 "}
 (142,1,1) = {"
 lwn
-ldK
+urj
 mAc
 nNv
 riz
@@ -171433,11 +167489,11 @@ pQA
 ryj
 sld
 cHA
-pQA
-vvA
-fsP
-ouc
-aWQ
+aSK
+pjR
+pjR
+aGA
+wPV
 wQk
 wQk
 wQk
@@ -171572,29 +167628,29 @@ bLb
 vHo
 nwx
 nwx
-qqT
-kgG
-svA
-kRv
-sHN
-kgG
-kgG
-wxj
-kgG
+osL
 kgG
 kRv
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kRv
+qBM
+lIc
+kRv
+siK
+kgG
+kgG
+kRv
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 vcE
@@ -171621,28 +167677,28 @@ pnY
 pnY
 pnY
 pnY
-xsf
+wxD
 bDk
-xxz
+cMe
 lwn
 "}
 (143,1,1) = {"
 lwn
-ldK
-sBI
+urj
+pHh
 pkP
 mda
 fsP
 uBE
 cDO
 npo
+aSK
 pjR
-pjR
-uBE
-hRC
-aWQ
-aWQ
-aWQ
+ryd
+mUL
+wPV
+wPV
+wPV
 vPu
 uJA
 bHa
@@ -171775,30 +167831,30 @@ msd
 iyW
 aAJ
 wkX
-qqT
-kgG
+osL
+gpA
 kgG
 kRv
-kgG
-svA
-umq
-wfl
-kgG
+lIc
+ert
+fdb
+siK
+siK
 gpA
 mDf
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 vcE
@@ -171831,8 +167887,8 @@ lwn
 "}
 (144,1,1) = {"
 lwn
-ldK
-ldK
+urj
+urj
 pSi
 pSi
 lFR
@@ -171842,10 +167898,10 @@ pSi
 xKb
 pjR
 pjR
-vvA
+aSK
 iFQ
-aWQ
-aWQ
+wPV
+wPV
 vPu
 jHx
 ddk
@@ -171978,29 +168034,29 @@ nwx
 iyW
 aAJ
 bal
-qqT
-kRv
+osL
 kgG
 kgG
 kRv
-kRv
-kRv
-siK
-siK
-kgG
+lIc
+lIc
 kRv
 fdb
-svA
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kgG
+kgG
+kRv
+kRv
+kRv
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
 jHs
 dQM
@@ -172034,21 +168090,21 @@ lwn
 "}
 (145,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 pSi
-kva
-rWL
-rWL
-qwD
+iFQ
+aSK
+aSK
+aSK
+aSK
 pjR
 pjR
 pjR
-pjR
-pjR
+aSK
 ujX
-aWQ
+wPV
 vPu
 txq
 gNi
@@ -172181,31 +168237,31 @@ daU
 cci
 daU
 daU
-qqT
+coE
 kgG
-svA
+kgG
 kRv
-svA
-lwn
-svA
-siK
-siK
+lIc
+gmP
 kRv
+kRv
+kgG
+fdb
 umq
 kgG
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 vzo
-djY
+sQn
 dQM
 dQM
 vcE
@@ -172237,21 +168293,21 @@ lwn
 "}
 (146,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 iUP
-fKs
+aSK
 ixA
 pjR
 miQ
 pjR
-vvA
+aSK
 ujX
-aWQ
+wPV
 vPu
 vPu
 tgX
@@ -172384,32 +168440,32 @@ daU
 ufU
 jAk
 qwu
-qqT
+coE
+kgG
+kgG
+pPh
+gmP
+gmP
+gmP
+kRv
+siK
+lSp
+siK
 kgG
 kRv
-svA
-lwn
-lwn
-lwn
-kRv
-kgG
-kgG
-kgG
-kgG
-svA
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 vcE
@@ -172425,7 +168481,7 @@ iAI
 nHz
 iAI
 hrH
-sZp
+hnn
 mHI
 vcE
 vcE
@@ -172440,22 +168496,22 @@ lwn
 "}
 (147,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 ggC
 sbZ
-kBL
+fME
+aSK
 pjR
-vvA
 pjR
 ilO
 aSK
-vvA
-aWQ
-aWQ
+aSK
+wPV
+wPV
 vPu
 cvW
 nbr
@@ -172589,31 +168645,31 @@ daU
 uDZ
 wqQ
 kgG
+kgG
+wxj
+gmP
+gmP
+gmP
 kRv
-kRv
-lwn
-lwn
-lwn
-svA
 gpA
-kgG
+siK
 kgG
 kRv
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-xxz
-xxz
-xxz
-aWQ
-aWQ
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+iLK
+iLK
+iLK
+kqj
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 vcE
@@ -172643,22 +168699,22 @@ lwn
 "}
 (148,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-stz
+wPV
+wPV
+wPV
+wPV
+wPV
+aiX
 aSK
-gPF
+gsL
+pjR
+pjR
+pjR
+pjR
+pjR
 aSK
-pjR
-pjR
-pjR
-pjR
-aSK
-aWQ
-aWQ
+wPV
+wPV
 vPu
 vPu
 paL
@@ -172774,7 +168830,7 @@ jrx
 qyF
 nRj
 jmW
-xGV
+voA
 oRr
 tEZ
 piD
@@ -172792,32 +168848,32 @@ jAk
 ogc
 wqQ
 kgG
+wxj
+gmP
+gmP
+gmP
+gmP
 kRv
-lwn
-lwn
-lwn
-lwn
-kRv
 kgG
 kgG
 kgG
-siK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-nLp
+kgG
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
+imu
 deK
 pnY
-xsf
-xxz
-xxz
-aWQ
+wxD
+iLK
+iLK
+kqj
 fvu
-djY
+sQn
 dQM
 dQM
 vcE
@@ -172846,20 +168902,20 @@ lwn
 "}
 (149,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
-cpp
-qek
-tLh
+wPV
+wPV
+wPV
+wPV
+aSK
+aSK
+aSK
+aSK
 pjR
 rvE
 pjR
 pjR
 pjR
-ouc
+aGA
 oNf
 oNf
 oNf
@@ -172977,7 +169033,7 @@ wsX
 rLV
 kBm
 nHB
-xGV
+sfZ
 buB
 tEZ
 gEG
@@ -172993,33 +169049,33 @@ daU
 cci
 daU
 gtW
-qqT
+coE
+gpA
+mPX
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
-svA
-lwn
-lwn
-lwn
-lwn
-lwn
-wfl
-icp
-icp
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+kgG
+kgG
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
 deK
 vcE
 vcE
 vcE
 pnY
-xsf
-xxz
-xxz
+wxD
+iLK
+iLK
 mgb
 jHs
 dQM
@@ -173049,20 +169105,20 @@ lwn
 "}
 (150,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
 uJQ
 tgD
 pjR
-vvA
-aSK
-vvA
+pjR
+pjR
+pjR
 qSa
-xXw
+mUL
 oNf
 pHO
 pHO
@@ -173180,7 +169236,7 @@ nUr
 sHj
 hhW
 nUr
-sfZ
+voA
 oRr
 tEZ
 uCO
@@ -173199,25 +169255,25 @@ wRF
 wqQ
 kgG
 kRv
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
 kRv
 kRv
-kRv
+kgG
 abx
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
 vzo
 jHs
 vcE
-keo
+uZo
 vcE
 vcE
 vcE
@@ -173226,8 +169282,8 @@ pnY
 pnY
 vcE
 dQM
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -173252,19 +169308,19 @@ lwn
 "}
 (151,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 mZi
 agL
 vww
-aSK
-aSK
-kLL
 pjR
-vvA
+pjR
+lXN
+pjR
+aSK
 hcc
 lWA
 ovB
@@ -173332,7 +169388,7 @@ kpO
 dWA
 xZe
 baW
-fkr
+tKE
 eyx
 sAd
 sAd
@@ -173399,45 +169455,45 @@ daU
 kwI
 wRF
 niu
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
-umq
-svA
+oyv
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+gpA
 kgG
-lwn
-lwn
+kgG
+gmP
+gmP
 kRv
 aEv
-aWQ
-lwn
+kqj
+gmP
 qvx
-djY
+sQn
 vcE
 vcE
-keo
-keo
-vcE
-vcE
-vcE
+uZo
+uZo
 vcE
 vcE
 vcE
 vcE
-keo
-keo
+vcE
+vcE
+vcE
+uZo
+uZo
 vcE
 vcE
 vcE
 kaP
 mHI
-qrS
+ice
 azd
 vyq
 vyq
@@ -173446,7 +169502,7 @@ vyq
 vyq
 vyq
 vyq
-iAI
+fRu
 vyq
 vcE
 vcE
@@ -173455,19 +169511,19 @@ lwn
 "}
 (152,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 gsL
 aSK
 ekA
 nuk
-vvA
-aSK
-aSK
 pjR
+pjR
+pjR
+aSK
 aGA
 oNf
 oNf
@@ -173602,40 +169658,40 @@ vZi
 tkJ
 acL
 jen
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-svA
-kgG
-kgG
+oyv
+hvd
+gmP
+gmP
+gmP
+gmP
+gmP
+gmP
+kRv
+fdb
+siK
 kgG
 gpA
 kRv
 kRv
 kRv
-aWQ
-lwn
-lwn
+kqj
+gmP
+gmP
 fvu
-djY
+sQn
 vcE
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
 vcE
 vcE
-keo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -173647,7 +169703,7 @@ eYQ
 vyq
 iAI
 vyq
-iAI
+tRT
 vyq
 kkP
 vyq
@@ -173658,22 +169714,22 @@ lwn
 "}
 (153,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 avr
 aSK
 pjR
 pjR
+pjR
+pjR
 aSK
-vvA
-aSK
-ouc
-aWQ
-aWQ
+aGA
+wPV
+wPV
 oNf
 moU
 hQE
@@ -173806,40 +169862,40 @@ tMT
 tGL
 sFz
 tGL
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
+hvd
+hvd
+gmP
+gmP
+gmP
+gmP
+gmP
 kRv
 kRv
-kgG
+fdb
 siK
-siK
 kgG
-svA
-ieq
-lIc
-aWQ
-lwn
-aWQ
+kgG
+kRv
+kRv
+kRv
+kqj
+gmP
+kqj
 fvu
-djY
+sQn
 vcE
 vcE
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -173861,10 +169917,10 @@ lwn
 "}
 (154,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
 iFQ
 aSK
@@ -173873,10 +169929,10 @@ pjR
 pjR
 ilO
 pjR
-pjR
-vvA
-aWQ
-aWQ
+aSK
+aSK
+wPV
+wPV
 oNf
 aTX
 inU
@@ -173997,7 +170053,7 @@ gwe
 pDk
 pTH
 veq
-dGd
+gXd
 tIA
 fbo
 qcL
@@ -174010,40 +170066,40 @@ brR
 cXZ
 sqA
 tGL
-ldK
-ldK
-ldK
-ldK
-ldK
+hvd
+hvd
+hvd
+hvd
+hvd
 wup
-ldK
+kcZ
 ylT
+kRv
 kgG
-siK
-siK
+kgG
 kgG
 kgG
 kRv
-svA
-aWQ
-lwn
-lwn
-aWQ
+kRv
+kqj
+gmP
+gmP
+kqj
 fvu
-djY
-oCW
+sQn
+xIp
 vcE
 vcE
-keo
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -174064,10 +170120,10 @@ lwn
 "}
 (155,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
 eze
 pjR
@@ -174076,10 +170132,10 @@ pjR
 pjR
 miQ
 pjR
-vvA
-aWQ
-aWQ
-aWQ
+aSK
+wPV
+wPV
+wPV
 oNf
 tle
 hQE
@@ -174219,35 +170275,35 @@ bnm
 rCp
 hWc
 fec
-hWc
-vhk
 ylT
-kgG
+vhk
+fdb
+fdb
 kgG
 kgG
 umq
 pPh
-aWQ
-aWQ
-lwn
-lwn
-lwn
-aWQ
-jfo
+kqj
+kqj
+gmP
+gmP
+gmP
+kqj
+umk
 fvu
-djY
+sQn
 vcE
 vcE
 vcE
-keo
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -174267,22 +170323,22 @@ lwn
 "}
 (156,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-fmk
+wPV
+wPV
+wPV
+wPV
+aSK
 gne
 pjR
 pjR
-vvA
 pjR
-aSK
+pjR
+pjR
 fME
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 oNf
 oNf
 gkB
@@ -174332,7 +170388,7 @@ eHG
 jbZ
 bCM
 bCM
-bJQ
+vUS
 vUS
 vUS
 nRI
@@ -174346,18 +170402,18 @@ oeV
 dWX
 fzS
 tUj
-nRX
+tUj
 qTv
 qTv
 eMN
-pZs
+eMN
 qTv
 qTv
-pDY
-nRX
 tUj
 tUj
-pDY
+tUj
+tUj
+tUj
 tUj
 sea
 uBj
@@ -174404,7 +170460,7 @@ ksB
 tZc
 wdE
 gXd
-qVM
+eLE
 raC
 rWD
 jfD
@@ -174422,36 +170478,36 @@ uPE
 lRj
 hWc
 mcY
-hWc
-bOx
-mDf
 ylT
+bOx
+fdb
+fdb
 kgG
 kRv
 mDf
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+gmP
+kqj
 fvu
-djY
-oCW
+sQn
+xIp
 vcE
 vcE
 vcE
-keo
-keo
-keo
-keo
+uZo
+uZo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
 vcE
@@ -174470,21 +170526,21 @@ lwn
 "}
 (157,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 iFQ
-fmk
 aSK
-vQB
-rWL
-qwD
+aSK
+ilO
+pjR
+pjR
 pjR
 ilO
 aSK
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 jfn
 jfn
 gvw
@@ -174606,8 +170662,8 @@ lNv
 vIJ
 riw
 dAM
-vSB
-uwh
+gXd
+tIA
 raC
 trO
 mzQ
@@ -174624,38 +170680,38 @@ sFz
 xsz
 hWc
 lfb
-lfb
-ldK
+pAy
+kcZ
 hqO
-ylT
+kRv
+kgG
 kgG
 siK
-siK
 kgG
-svA
-lIc
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-aWQ
-jfo
-fvu
-djY
-oCW
+kRv
+kRv
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+gmP
+kqj
+bfa
+aFM
+sQn
+xIp
 vcE
 vcE
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 dQM
 dQM
 dQM
@@ -174673,20 +170729,20 @@ lwn
 "}
 (158,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-vvA
-hEt
+wPV
+wPV
+wPV
+sBL
+oth
 pjR
-eJp
-vvA
+pjR
+pjR
 vRE
-qwD
+pjR
 pjR
 aSK
-aWQ
-aWQ
+wPV
+wPV
 sWE
 bIn
 jOl
@@ -174810,7 +170866,7 @@ pDk
 riw
 dAM
 gXd
-tIA
+dVd
 raC
 mdh
 uOt
@@ -174827,42 +170883,42 @@ tbK
 fBY
 gnA
 lfb
-lwn
-lwn
-lwn
-saQ
-svA
-dsm
+gmP
+gmP
+gmP
+kRv
+umq
+siK
+siK
 siK
 kgG
-kgG
 kRv
 kRv
+kqj
+kqj
+kqj
+gmP
+gmP
+gmP
+qpO
+qpO
 aWQ
-aWQ
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-jfo
-fvu
-djY
-oCW
+bfa
+aFM
+sQn
+xIp
 vcE
 vcE
-keo
-keo
-keo
+uZo
+uZo
+uZo
 vcE
 vcE
-keo
-keo
+uZo
+uZo
 vcE
 vcE
-oCW
+xIp
 vcE
 vcE
 vcE
@@ -174876,19 +170932,19 @@ lwn
 "}
 (159,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-nyW
+wPV
+wPV
+wPV
+wPV
+gsL
 pjR
-xun
+pjR
 aSK
 pSM
-fKs
+pjR
 pjR
 bdS
-grJ
+qtJ
 fpp
 wIM
 rlN
@@ -174941,25 +170997,25 @@ urY
 ukW
 wdy
 deq
-pQt
+hnt
 haW
 haW
-lSp
-pQt
+deq
+hnt
 haW
 haW
-lSp
+deq
 hnt
 rEg
 gTI
 dgt
 ofq
 xGz
-osL
+hSs
 oSM
 oSM
 edn
-osL
+hSs
 oSM
 oSM
 sLS
@@ -175012,7 +171068,7 @@ wfT
 aDd
 wuM
 uWM
-srA
+gXd
 tIA
 raC
 iqv
@@ -175029,32 +171085,32 @@ iWt
 ePh
 wfD
 rit
-ldK
-lwn
-lwn
-lwn
-lwn
+hvd
+qpO
+qpO
+qpO
+qpO
 fMT
 vjb
-usF
+iaZ
+vjb
+vjb
 vjb
 fMT
-vjb
-eGB
 fMT
 qdm
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
 aWQ
-jfo
-fvu
-djY
+bfa
+aFM
+sQn
 vcE
 vcE
 vcE
@@ -175064,11 +171120,11 @@ vcE
 vcE
 vcE
 vcE
-fQM
+qOz
 dHk
-djY
-oCW
-oCW
+sQn
+xIp
+xIp
 vcE
 vcE
 vcE
@@ -175079,22 +171135,22 @@ lwn
 "}
 (160,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
-mTA
-xKA
+pjR
+aiX
 vvA
 aSK
-jaQ
+pjR
 pjR
 ryd
 xaB
 lEi
-vvA
-bFv
+pjR
+qvE
 rNd
 gvw
 gvw
@@ -175215,7 +171271,7 @@ qez
 bmf
 rKo
 uWM
-srA
+gXd
 tIA
 raC
 cRF
@@ -175232,49 +171288,49 @@ wfD
 vLI
 pFK
 oHJ
-ldK
-lwn
-lwn
-lwn
-lwn
-eGB
+hvd
+qpO
+qpO
+qpO
+qpO
 fMT
+fMT
+usF
 vjb
+iaZ
+gSJ
 fMT
 fMT
-usC
-qXI
 fMT
-eGB
 wfP
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
-hZc
-djY
-oCW
-oCW
-oCW
+waF
+sQn
+xIp
+xIp
+xIp
 vcE
 vcE
 vcE
 vcE
-fQM
-jfd
+qOz
+sDl
 aWQ
-jfo
-jfo
-fvu
-djY
-oCW
-oCW
+bfa
+bfa
+aFM
+sQn
+xIp
+xIp
 vcE
 vcE
 vcE
@@ -175282,23 +171338,23 @@ lwn
 "}
 (161,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
-pln
+ilO
 iUP
 sBL
 iFQ
-hnn
+ilO
 miQ
 pjR
 kio
 mCH
 yez
 coN
-aWQ
+wPV
 gvw
 oKg
 dvm
@@ -175356,7 +171412,7 @@ sCB
 sCB
 qzP
 ene
-kFU
+ldj
 xIB
 iJQ
 tgv
@@ -175387,7 +171443,7 @@ qjP
 ctc
 aTt
 aAD
-nig
+tXu
 pzd
 ukr
 wkg
@@ -175435,73 +171491,73 @@ oQO
 pHK
 fMk
 hAN
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
+hvd
+qpO
+qpO
+qpO
+qpO
+qpO
 wfP
 fMT
-vjb
-vjb
-qXI
+iaZ
+iaZ
 iaZ
 vjb
+vjb
 fMT
 fMT
-eGB
+fMT
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
-jfo
-jfo
-jfo
-fvu
-djY
-oCW
-oCW
-fQM
-jfd
-aWQ
-aWQ
+bfa
+bfa
+bfa
+aFM
+sQn
+xIp
+xIp
+qOz
+sDl
 aWQ
 aWQ
 aWQ
-jfo
-jfo
-fvu
-djY
-oCW
+aWQ
+aWQ
+bfa
+bfa
+aFM
+sQn
+xIp
 vcE
 lwn
 "}
 (162,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-cpp
-qek
-bGi
-bGi
-dBc
+wPV
+wPV
+wPV
+wPV
+wPV
+pjR
+pjR
+pjR
+pjR
+pjR
 pjR
 pjR
 ryd
 jTi
 qtJ
 qtJ
-aWQ
+wPV
 gvw
 lan
 cgi
@@ -175563,7 +171619,7 @@ jIj
 hLS
 xgW
 hGA
-jIj
+qSj
 uvX
 uvX
 sOP
@@ -175616,7 +171672,7 @@ uOc
 wFN
 jrx
 jrx
-sfZ
+voA
 oRr
 pDk
 fMY
@@ -175638,73 +171694,73 @@ tGL
 tGL
 tGL
 tGL
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+hvd
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 kXA
 gSJ
-fMT
+iaZ
 vjb
 vjb
-fMT
+vjb
 gSJ
 fMT
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
 aWQ
-jfo
-jfo
-jfo
-jfo
-aWQ
-aWQ
-aWQ
+bfa
+bfa
+bfa
+bfa
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
-jfo
-fvu
-djY
+aWQ
+aWQ
+aWQ
+bfa
+aFM
+sQn
 lwn
 "}
 (163,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
-aSK
+wPV
+wPV
+wPV
+wPV
+pjR
+pjR
 pjR
 pjR
 pjR
 hQU
 pjR
 ilO
-aSK
+pjR
 ueX
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 gvw
 ndy
 ryz
@@ -175841,73 +171897,73 @@ tGL
 uMz
 wUy
 cPG
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
+hvd
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
 fMT
-ice
+qpy
 vjb
 vjb
-vjb
+iaZ
 vjb
 fGY
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
 aWQ
 aWQ
-fvu
+aFM
 lwn
 "}
 (164,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
 pjR
-giV
+pjR
 ilO
 pjR
 pWA
-vvA
+pjR
+pjR
 pjR
 aSK
-pjR
-vvA
-aWQ
-aWQ
+aSK
+wPV
+wPV
 gvw
 tUs
 thp
@@ -176022,13 +172078,13 @@ exi
 oDS
 eRe
 fYv
-sfZ
+voA
 oRr
 pDk
 fCD
 uWM
 gXd
-tIA
+bWn
 raC
 hqG
 mNO
@@ -176044,72 +172100,72 @@ eig
 rVA
 swo
 qjS
-ldK
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-eGB
+hvd
+aEf
+aEf
+qpO
+qpO
+qpO
+qpO
+fMT
 fMT
 gSJ
+iaZ
+iaZ
 vjb
-eGB
-fMT
 vjb
 fMT
 aWQ
 aWQ
 aWQ
-lwn
-lwn
+qpO
+qpO
 aWQ
 aWQ
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-qvx
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+tMM
 lwn
 "}
 (165,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
 ujX
 aSK
 aSK
-aSK
-vvA
+pjR
+pjR
 ltk
 ilO
 pjR
+pjR
 aSK
-pjR
-pjR
-aWQ
+aSK
+wPV
 max
 gvw
 gvw
@@ -176230,8 +172286,8 @@ voA
 rvp
 njc
 uWM
-vSB
-uwh
+gXd
+tIA
 acj
 rWD
 bHC
@@ -176247,72 +172303,72 @@ tGL
 fen
 kTL
 wEJ
-ldK
-lhZ
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
+hvd
+wQY
+aEf
+aEf
+qpO
+qpO
+qpO
+qpO
 fMT
-iaZ
-qXI
+vjb
 iaZ
 vjb
 vjb
+iaZ
 fMT
 fMT
-eGB
+fMT
 aWQ
 aWQ
 aWQ
 aWQ
-eGB
+cQD
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (166,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 kOb
 lMt
 miQ
 pWA
 pjR
-jYA
+giV
 miQ
 ixA
 aSK
-aWQ
+wPV
 max
 dvn
 lpR
@@ -176441,7 +172497,7 @@ rKo
 fON
 bhd
 nhL
-pzN
+mrH
 mrH
 sye
 dJK
@@ -176450,61 +172506,61 @@ tGL
 oGg
 tGL
 tGL
-ldK
-lhZ
-lhZ
-ldK
-ldK
-lwn
-lwn
-lwn
+hvd
+wQY
+wQY
+aEf
+aEf
+qpO
+qpO
+qpO
 fMT
-eGB
+fMT
+vjb
+vjb
 iaZ
 iaZ
-vjb
-eGB
-vjb
-usC
-qXI
+iaZ
+gdc
+fMT
+fMT
 aWQ
-aWQ
-eGB
+fMT
 dXT
 sRK
 dXT
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (167,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 mZi
 agL
 vww
@@ -176512,10 +172568,10 @@ wnT
 gLU
 pjR
 pjR
-pjR
 aSK
-aWQ
-aWQ
+aSK
+wPV
+wPV
 max
 tRD
 aJC
@@ -176652,73 +172708,73 @@ mxH
 kCx
 rVY
 eeq
-pMN
-ldK
-lhZ
-lhZ
-lhZ
-ldK
-lwn
-lwn
-lwn
+eeq
+aEf
+wQY
+wQY
+wQY
+aEf
+qpO
+qpO
+qpO
 fMT
 fMT
-vjb
+iaZ
 gSJ
-fMT
 vjb
-fMT
-qXI
+iaZ
+vjb
+vjb
 iaZ
 fMT
 fMT
 fMT
 fMT
 hAw
-eGB
+yiD
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (168,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
 aym
 yje
 mfQ
 leF
 khM
 pjR
-vvA
+aSK
 jpn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 max
 hnM
 dvn
@@ -176855,62 +172911,62 @@ mxH
 qsS
 dKa
 mrH
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-lwn
-lwn
-lwn
-mKv
-nrL
+qln
+aEf
+aEf
+aEf
+aEf
+aEf
+qpO
+qpO
+qpO
 fMT
 fMT
-fMT
+qXI
+qXI
 vjb
 vjb
 vjb
-vjb
-fMT
+iaZ
+iaZ
+iaZ
 gSJ
-vjb
+fGY
 fMT
 fMT
 aWQ
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (169,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-woq
+wPV
+wPV
+wPV
+wPV
+iFQ
 pjR
 lMt
 aSK
@@ -177042,8 +173098,8 @@ fbW
 awc
 rAI
 dAM
-vSB
-uwh
+gXd
+tIA
 acj
 cvB
 cml
@@ -177057,64 +173113,64 @@ ydb
 jAd
 bRk
 afE
-pzN
+mrH
 dyo
 hpI
 tzj
 wQO
 ugh
-ldK
-lwn
-lwn
+aEf
+qpO
+qpO
 fMT
 xGB
-nlp
-xpz
-vjb
+fMT
+fMT
+iaZ
 vjb
 fGY
 gSJ
 vjb
+iaZ
 vjb
 vjb
-vjb
-qpy
 qXI
-iBn
+fMT
+fMT
 aWQ
 aWQ
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (170,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
 gsL
-fmk
-vvA
+aSK
+aSK
 pjR
 ilO
 miQ
@@ -177221,7 +173277,7 @@ vzr
 ibZ
 nON
 sUI
-xIQ
+pzC
 icF
 cbf
 cba
@@ -177245,14 +173301,14 @@ wtj
 nJi
 gtj
 bKD
-gXd
+pMy
 tIA
 kOK
 mhb
 hOG
 jrK
 hOG
-dse
+jrK
 lCP
 pDk
 mON
@@ -177261,62 +173317,62 @@ svq
 pcs
 mrH
 ouq
-ldK
-ldK
+qln
+aEf
 tEU
 cGE
 ugh
-ldK
-lwn
-lwn
+aEf
+qpO
+qpO
 fMT
 fMT
 szi
-fRu
-wfP
-iaZ
+fMT
+fMT
+vjb
+fMT
+fMT
 fMT
 fMT
 vjb
 iaZ
-iaZ
-vjb
-vjb
+vpI
 qXI
-qXI
+fMT
 aWQ
 dXT
 aWQ
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 lwn
 "}
 (171,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-wne
+wPV
+wPV
+wPV
+wPV
+hqC
 gne
 pjR
 pjR
@@ -177447,7 +173503,7 @@ hNr
 xPK
 eNM
 pqm
-laD
+dAM
 gXd
 tIA
 epX
@@ -177456,7 +173512,7 @@ uWy
 xaL
 mOw
 osj
-pMy
+xdB
 bgV
 vdp
 xGC
@@ -177464,31 +173520,31 @@ gYT
 xyS
 pzN
 mrH
-aWQ
-ldK
+gXK
+aEf
 lVZ
 bPA
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
+aEf
+qpO
+qpO
+qpO
+qpO
 fMT
-ome
-sDl
-bIG
-eGB
-lwn
-lwn
-iBn
+wfP
+sRK
+fMT
+fMT
+qpO
+qpO
+fMT
+vjb
+vjb
 iaZ
-vjb
-vjb
 vjb
 gdc
 fMT
-fMT
+fDJ
 wfP
 aWQ
 aWQ
@@ -177497,17 +173553,17 @@ aWQ
 aWQ
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 aWQ
 aWQ
 aWQ
@@ -177515,12 +173571,12 @@ lwn
 "}
 (172,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-vvA
+wPV
+wPV
+wPV
+wPV
+wPV
+aSK
 aSK
 pjR
 pjR
@@ -177649,8 +173705,8 @@ hvj
 hNr
 tEZ
 vom
-gHL
-yfJ
+riw
+wBl
 gXd
 tIA
 qYj
@@ -177666,47 +173722,47 @@ iGB
 iLG
 crS
 hyn
-aWQ
-aWQ
-ldK
+gXK
+gXK
+aEf
 okK
 rpf
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
+aEf
+qpO
+qpO
+qpO
+qpO
 aWQ
-eGB
+qdm
 yiD
-eGB
-lwn
-lwn
-lwn
+fMT
+qpO
+qpO
+qpO
 dXT
 fMT
 vjb
 fGY
 vjb
 vjb
-iBn
-vjb
+fMT
+fMT
 aWQ
 aWQ
-ldK
+vQw
 aWQ
-ldK
+vQw
 aWQ
-ldK
-aWQ
-aWQ
+vQw
 aWQ
 aWQ
-lwn
-lwn
-lwn
-lwn
+aWQ
+aWQ
+qpO
+qpO
+qpO
+qpO
 aWQ
 aWQ
 aWQ
@@ -177718,14 +173774,14 @@ lwn
 "}
 (173,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
-vvA
+aSK
 pjR
 ltk
 pjR
@@ -177759,7 +173815,7 @@ xvX
 tSD
 voS
 ntB
-gwK
+hWn
 lbr
 mqc
 fKo
@@ -177828,7 +173884,7 @@ lwD
 hyl
 eqJ
 pzC
-kIU
+pzC
 pzC
 vjn
 icF
@@ -177852,7 +173908,7 @@ xuO
 ydA
 rOH
 nbz
-hPx
+rGf
 wBl
 vSB
 uwh
@@ -177868,42 +173924,42 @@ srv
 lEN
 sHV
 fDh
-aWQ
-aWQ
-aWQ
-tHT
+gXK
+gXK
+gXK
+iEH
 kpV
 wUA
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-eGB
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+yiD
+vjb
+vjb
+vjb
+iaZ
 vjb
 fMT
-vjb
-gSJ
-vjb
-vjb
 fMT
 eCq
-ldK
-ldK
-ldK
-ldK
-rAy
+vQw
+vQw
+vQw
+vQw
+bcr
 nmI
-xfZ
+fMT
 aWQ
 aWQ
 aWQ
@@ -177921,17 +173977,17 @@ lwn
 "}
 (174,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 iUP
 aSK
 pjR
 ltk
-uBE
+leF
 aSK
 oMO
 max
@@ -178072,42 +174128,42 @@ hTq
 nsU
 rir
 kRk
-aWQ
-aWQ
-ldK
-ldK
+gXK
+gXK
+aEf
+aEf
 tWF
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 qdm
-fMT
-fMT
 vjb
-vjb
+pAE
+gSJ
 iaZ
 iaZ
-azv
-fMT
+vjb
+gdc
+nmI
 mfz
 eqz
 fWb
 iJK
 nIl
-eIP
-kWj
-ybk
+nmI
+gdc
+fMT
 aWQ
 nhE
 ogd
@@ -178124,18 +174180,18 @@ lwn
 "}
 (175,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-fsP
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 aSK
-izL
+aSK
+tnB
 wnF
-iQQ
+bvE
 bBo
 oVd
 oST
@@ -178239,14 +174295,14 @@ pzC
 vjn
 jGF
 jSi
-pZP
-pZP
-pZP
-faB
+qsS
+qsS
+qsS
+hkm
 uUq
-pZP
+qsS
 uJH
-faB
+hkm
 hNr
 tSM
 sUP
@@ -178276,46 +174332,46 @@ eQN
 nQK
 gdk
 mgd
-aWQ
-ldK
-ldK
+gXK
+aEf
+aEf
 aUm
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-hXu
-qXI
-qXI
-vjb
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+hAw
 fMT
 vjb
-iaZ
+vjb
+vjb
 iaZ
 vjb
-nmI
+vjb
+qXI
+fMT
 nmI
 eqz
 cWZ
 iJK
 nmI
-buV
-qXI
+gxw
 qXI
 fMT
-vjb
+fMT
+fMT
 dzq
-bUC
-azv
+ciy
+fMT
 nAY
 jVW
 hPA
@@ -178327,19 +174383,19 @@ lwn
 "}
 (176,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 ile
 ciT
-uBE
-izL
-fsP
+leF
+tnB
+aSK
 bvE
-dJZ
+leF
 max
 dBC
 qpC
@@ -178421,7 +174477,7 @@ apY
 bFc
 eGN
 eGN
-tcp
+dEe
 lnj
 rZK
 mJW
@@ -178439,17 +174495,17 @@ jNk
 ibZ
 ibZ
 vzu
-joH
+vjn
 wpS
-wKt
-xzl
-uIS
-qJM
-pJZ
-pky
-mGm
-bWn
-qad
+qsS
+gJs
+gXK
+gJs
+qsS
+mrH
+hto
+gXK
+qsS
 hNr
 egc
 fVm
@@ -178479,64 +174535,64 @@ bhf
 pbo
 rlL
 tFU
-aWQ
-ldK
-ldK
+gXK
+aEf
+aEf
 cIq
 ugh
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-iBn
-qXI
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+fMT
+vjb
 vjb
 fGY
 vjb
 fMT
+iaF
 fMT
-usF
-gSJ
+qXI
+qXI
 nmI
-azv
 fdP
 fWb
 iJK
 nmI
-eIP
-klV
+qXI
+kkG
+iaZ
 vjb
-vjb
-qpy
+fGY
 hNU
 vjb
-eGB
-eIP
+gdc
+klV
 eAy
-azv
-eIP
-azv
+fMT
+klV
+fMT
 aWQ
 twA
 lwn
 "}
 (177,1,1) = {"
 lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
+wPV
 vfk
 rhZ
 ecd
@@ -178621,10 +174677,10 @@ mUk
 mUk
 udi
 hnT
-cro
+oLq
 oLq
 uRq
-xLG
+oLq
 sxz
 nmu
 mJW
@@ -178644,15 +174700,15 @@ pZa
 pQL
 dQd
 oUL
-wKt
-esT
-qBK
-phO
-pJZ
-iGP
-ccl
-nKA
-qad
+qsS
+gXK
+gXK
+gXK
+qsS
+mrH
+mrH
+gXK
+qsS
 hNr
 hNr
 phN
@@ -178674,7 +174730,7 @@ wAB
 vSB
 wAB
 vSB
-mAR
+xdB
 lEH
 nfL
 hSF
@@ -178682,64 +174738,64 @@ jAd
 mxH
 mxH
 kJw
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-azv
-fMT
-gdc
+qln
+aEf
+aEf
+aEf
+aEf
+aEf
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 fMT
 fMT
-eGB
+gSJ
+vjb
+fMT
+fMT
 aWQ
 aWQ
 fMT
-azv
+fMT
 fMT
 nmI
 uoH
 cWZ
 iJK
 nmI
-fMT
-azv
+gdc
+qXI
 gSJ
 vjb
-fMT
+vjb
 dzq
 vjb
 iQN
-azv
+fMT
 qPy
-clS
-eIP
-azv
+klV
+klV
+gdc
 aWQ
 twA
 lwn
 "}
 (178,1,1) = {"
 lwn
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+vfk
+vfk
+vfk
+vfk
+vfk
+vfk
+vfk
 ibK
 lbL
 oRx
@@ -178847,16 +174903,16 @@ paK
 cvy
 jGF
 jGF
-wKt
-nKA
+qsS
+mrH
 hto
-hdN
-pJZ
-idU
 gXK
-qSL
-qad
-bFl
+qsS
+bIp
+gXK
+gJs
+qsS
+qsS
 ydA
 oHn
 gLz
@@ -178876,7 +174932,7 @@ kKm
 qZG
 qZG
 qZG
-iMQ
+qZG
 vXD
 mdh
 tZS
@@ -178889,54 +174945,54 @@ crf
 pTI
 crf
 fAz
-ldK
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-eGB
-gxw
-ice
-azv
+xJg
+mKe
+mKe
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+vjb
+xlZ
+fGY
+vjb
 qpy
-eGB
-aWQ
-aWQ
-aWQ
 fMT
-nmI
+aWQ
+aWQ
+aWQ
+cQD
+vJb
 jcQ
 eqz
 fWb
 iJK
-boy
+jcQ
+nmI
+fMT
+vjb
+fMT
+fMT
+dQJ
+fMT
+vjb
+vjb
+rdR
+kda
 klV
 fMT
-iaZ
-qXI
-eGB
-dQJ
-vjb
-vjb
-eGB
-wnt
-kda
-eIP
-azv
 fMT
 twA
 lwn
 "}
 (179,1,1) = {"
 lwn
-ldK
+vfk
 nYW
 aSB
 lRd
@@ -179043,23 +175099,23 @@ mJW
 vEt
 jGF
 jGF
-uOq
-uOq
-uOq
-uOq
 jGF
 jGF
-cBz
-arQ
-dVd
-dKK
-gJs
-bGl
-cTN
-aOR
-qWD
+jGF
+jGF
+jGF
+jGF
 aOB
-cBz
+aOB
+mrH
+mrH
+gJs
+aOB
+aOB
+gXK
+gXK
+aOB
+aOB
 hNr
 hNr
 xEC
@@ -179092,54 +175148,54 @@ lVw
 jxl
 crf
 fLp
-ldK
-lhZ
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+xJg
+jWQ
+mKe
+mKe
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 xlZ
-azv
-iCB
-azv
+vjb
+fGY
+vjb
 gxw
-azv
+fMT
 gdc
 fMT
 aWQ
 aWQ
-fMT
-nmI
-ldK
-ldK
-ldK
-ldK
-rAy
+hAw
+jSn
+vQw
+vQw
+vQw
+vQw
+bcr
 buV
-nmI
+fMT
 iaZ
-iaZ
-sRK
-hNU
+fMT
+jEj
+vrP
+oiz
 fMT
 vjb
-fMT
-wnt
+rdR
 ciy
 syI
-azv
+fMT
 fMT
 twA
 lwn
 "}
 (180,1,1) = {"
 lwn
-ldK
+vfk
 pwv
 xzn
 mRH
@@ -179190,7 +175246,7 @@ lbr
 noS
 qWB
 ctc
-cxE
+obH
 aJH
 aJH
 kzD
@@ -179254,15 +175310,15 @@ tEZ
 tEZ
 tEZ
 tEZ
-lNM
-lNM
-pEW
-xuy
-lNM
-lNM
-lNM
 tEZ
-pJt
+tEZ
+cTZ
+cTZ
+tEZ
+tEZ
+tEZ
+tEZ
+cTZ
 tEZ
 jBS
 tEZ
@@ -179295,17 +175351,17 @@ crf
 tsF
 dAF
 qJO
-ldK
-lhZ
-lhZ
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
+xJg
+jWQ
+jWQ
+mKe
+mKe
+qpO
+qpO
+qpO
+qpO
+qpO
+qpO
 bCJ
 cmp
 myt
@@ -179317,32 +175373,32 @@ aWQ
 aWQ
 aWQ
 aWQ
+aWQ
+vQw
+aWQ
+vQw
+aWQ
+vQw
 fMT
-ldK
-aWQ
-ldK
-aWQ
-ldK
-ram
-klV
+slp
+iaZ
 vjb
-vjb
-vjb
+fMT
 tjF
-qdm
-eGB
-eIP
+vTI
+fMT
+clS
 efW
 syI
-vjb
-azv
-azv
+fMT
+fMT
+fMT
 twA
 lwn
 "}
 (181,1,1) = {"
 lwn
-ldK
+vfk
 fym
 vfk
 vkg
@@ -179459,7 +175515,7 @@ nyg
 lyg
 nyg
 lyg
-pFP
+nyg
 nyg
 lyg
 nyg
@@ -179498,21 +175554,21 @@ oAi
 leO
 adX
 lZU
-ldK
-lhZ
-lhZ
-lhZ
-ldK
-ldK
-lwn
-lwn
-lwn
-lwn
+xJg
+jWQ
+jWQ
+jWQ
+mKe
+mKe
+qpO
+qpO
+qpO
+qpO
 xbX
-ldK
+iBn
 sjH
 inw
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -179526,31 +175582,31 @@ aWQ
 aWQ
 aWQ
 aWQ
-nmI
-iaZ
-fuq
-vjb
-gSJ
-rVT
-vjb
-vjb
 fMT
+iaZ
+iaZ
+vjb
+gdc
+dzq
+fMT
+gSJ
+vjb
 bYY
 fMT
-eIP
-gSz
+klV
+fMT
 aWQ
 twA
 lwn
 "}
 (182,1,1) = {"
 lwn
-ldK
+vfk
 srG
 vfk
 lZT
 hCy
-xZG
+hCy
 qmI
 vfk
 wdG
@@ -179701,21 +175757,21 @@ crf
 crf
 fbG
 crf
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+xJg
+mKe
+mKe
+mKe
+mKe
+mKe
+mKe
+mKe
+iBn
+iBn
+iBn
+iBn
 qZA
 wPv
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -179729,17 +175785,17 @@ aWQ
 aWQ
 aWQ
 nhE
-eGB
+fMT
 qXI
 iaZ
 vjb
-vjb
-hNU
+fGY
+dzq
 hNU
 dzq
 hNU
 vKa
-hNU
+dzq
 dzq
 ogd
 twA
@@ -179748,7 +175804,7 @@ lwn
 "}
 (183,1,1) = {"
 lwn
-ldK
+vfk
 aTl
 vfk
 lUQ
@@ -179915,10 +175971,10 @@ emf
 aWt
 vbT
 nKD
-ldK
+iBn
 bgH
 hSf
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -179943,7 +175999,7 @@ vXq
 mlH
 dFW
 fMT
-fGY
+qpy
 nhE
 aWQ
 aWQ
@@ -179951,7 +176007,7 @@ lwn
 "}
 (184,1,1) = {"
 lwn
-ldK
+vfk
 mRg
 vfk
 fFX
@@ -180118,10 +176174,10 @@ jcp
 tSE
 mQO
 baT
-ldK
+iBn
 sjH
 sjH
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -180137,24 +176193,24 @@ aWQ
 kXA
 fMT
 gSJ
-bYY
+udn
 ctS
-mlH
-mlH
+unW
+unW
 mlH
 mlH
 mlH
 jeR
 vjb
-vjb
-lIc
+fMT
+wfP
 aWQ
 aWQ
 lwn
 "}
 (185,1,1) = {"
 lwn
-ldK
+vfk
 wFw
 bmG
 cEb
@@ -180324,33 +176380,33 @@ vHG
 fPH
 sVl
 cqo
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+iBn
+iBn
+iBn
+iBn
+iBn
+iBn
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
 aWQ
-oyv
-dSC
-qfd
-gOR
-rdR
-rdR
-vjb
+dXT
+qdm
 fMT
 vjb
-gSJ
+bYY
+bYY
+iaZ
+vjb
+vjb
+iaZ
 vjb
 bYY
 gdc
-vjb
 fMT
+pAE
 aWQ
 aWQ
 lwn
@@ -180532,7 +176588,7 @@ fPH
 uug
 xsk
 iOb
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -180542,19 +176598,19 @@ aWQ
 aWQ
 cQD
 jEv
-fRu
-rdR
+fMT
+xLT
 bYY
 gSJ
 vjb
 iaZ
 vpI
-fMT
+iaZ
 giG
 oVo
-mlH
+vXq
 sVh
-vjb
+fMT
 aWQ
 lwn
 "}
@@ -180614,7 +176670,7 @@ iGH
 iGH
 iGH
 rMO
-jHI
+kKY
 rvq
 nUN
 ejU
@@ -180735,7 +176791,7 @@ cGI
 siY
 hJX
 eDW
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -180745,19 +176801,19 @@ aWQ
 aWQ
 aWQ
 mhI
-fRu
-bYY
-bYY
+fMT
+xLT
+xLT
 fMT
 fMT
+vjb
 iaZ
-iBn
 usF
 fMT
 fMT
 qpy
-vjb
-vjb
+gdc
+fMT
 aWQ
 lwn
 "}
@@ -180879,7 +176935,7 @@ sMt
 ibO
 sMt
 jTd
-xxs
+rUd
 rUd
 vVI
 nWx
@@ -180938,7 +176994,7 @@ xsO
 xSL
 cod
 ixI
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -180948,15 +177004,15 @@ aWQ
 aWQ
 aWQ
 fMT
-sTB
+fMT
 xLT
 bYY
-vjb
+fMT
 eGB
+fMT
 vjb
 vjb
-vjb
-eGB
+fMT
 aWQ
 aWQ
 fMT
@@ -180966,7 +177022,7 @@ lwn
 "}
 (189,1,1) = {"
 lwn
-tHT
+gQz
 hfR
 sjo
 jjy
@@ -181017,7 +177073,7 @@ dag
 aVn
 nxi
 oLq
-eja
+oLq
 qFN
 oFo
 rzs
@@ -181058,32 +177114,32 @@ obC
 mui
 gjF
 cHU
-dsc
-dsc
-dsc
-dsc
-dsc
+gjF
+gjF
+gjF
+gjF
+gjF
 gjF
 mui
 eTT
 mTq
 tTe
 hrk
-vZk
+hrk
 ezu
-pZP
-pZP
-pZP
-pZP
+jLJ
+jLJ
+jLJ
+jLJ
 jLJ
 jWU
-rCm
 ocM
+rCm
 jFg
 rCm
-gcD
-asD
-hvi
+tEZ
+tEZ
+wFA
 wFA
 atp
 iIy
@@ -181141,7 +177197,7 @@ xsO
 iPs
 cod
 haP
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -181150,14 +177206,14 @@ aWQ
 aWQ
 aWQ
 nhE
-pVw
-kxf
-xLT
-bYY
-eGB
-sRK
-gSJ
+xfZ
 vjb
+bYY
+rdR
+oiz
+jEj
+gdc
+iaZ
 fMT
 nhE
 aWQ
@@ -181169,7 +177225,7 @@ lwn
 "}
 (190,1,1) = {"
 lwn
-ldK
+vfk
 kUZ
 bHk
 iVB
@@ -181259,26 +177315,26 @@ bpm
 pyJ
 phV
 tTe
-ngM
+hrk
 pKf
-eja
+qFN
 tQU
 eAU
-eja
+qFN
 mUu
-uGy
+hrk
 tTe
 gvL
 fef
 htS
-ngM
+hrk
 gTr
 qKh
 lSu
 obE
 qsS
 xLI
-qad
+jLJ
 cTZ
 jaT
 vjA
@@ -181344,8 +177400,8 @@ xsO
 fPH
 oKc
 fPH
-ldK
-ldK
+iBn
+iBn
 aWQ
 aWQ
 aWQ
@@ -181355,12 +177411,12 @@ aWQ
 nhE
 fMT
 vjb
-bYY
-bYY
-dXT
+azJ
+rdR
+jSn
 qDK
+fMT
 iaZ
-vjb
 fMT
 nhE
 aWQ
@@ -181372,7 +177428,7 @@ lwn
 "}
 (191,1,1) = {"
 lwn
-ldK
+vfk
 pSs
 vfD
 brd
@@ -181462,19 +177518,19 @@ cYu
 rTi
 phV
 xlJ
-ngM
-eja
+hrk
+qFN
 gWm
-eja
+qFN
 mUu
-oLq
+qFN
 dEe
-uGy
+hrk
 aAe
 kAM
 bEq
 dGj
-ngM
+hrk
 oLq
 tdj
 tdj
@@ -181485,7 +177541,7 @@ tdj
 eWc
 ykJ
 xHL
-sWU
+xHL
 qeB
 scC
 mUX
@@ -181548,7 +177604,7 @@ vLP
 sMi
 xZw
 iDo
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -181559,11 +177615,11 @@ aWQ
 wfP
 gSJ
 bYY
-bYY
-vjb
+rdR
+fMT
+eGB
+fMT
 iaZ
-iaZ
-vjb
 fMT
 aWQ
 aWQ
@@ -181751,7 +177807,7 @@ tkD
 cjb
 llt
 dvM
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -181759,16 +177815,16 @@ aWQ
 aWQ
 aWQ
 qdm
+fMT
 vjb
-vjb
-kEQ
+xLT
 bYY
 vjb
-eGB
+vjb
 vjb
 gSJ
 vjb
-eGB
+fMT
 aWQ
 aWQ
 aWQ
@@ -181786,7 +177842,7 @@ iNv
 nrY
 eWn
 vCS
-kSN
+eDK
 cbE
 cSO
 cbE
@@ -181830,9 +177886,9 @@ bqW
 gNv
 sto
 vrz
-eja
+oLq
 ghZ
-uTe
+tAa
 bDv
 pkq
 pid
@@ -181895,7 +177951,7 @@ aNe
 crN
 eof
 eof
-rNP
+bQZ
 mtM
 wUr
 uUO
@@ -181954,7 +178010,7 @@ oae
 iuo
 xYN
 iDo
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -181962,17 +178018,17 @@ aWQ
 aWQ
 aWQ
 aWQ
-ice
+qpy
+iaZ
+xLT
+xLT
+usF
 vjb
-bYY
-udn
-iaF
-vjb
-vjb
-vjb
-vjb
+iaZ
+iaZ
+iaZ
 fMT
-eGB
+fMT
 aWQ
 aWQ
 aWQ
@@ -181981,20 +178037,20 @@ lwn
 "}
 (194,1,1) = {"
 lwn
-ldK
+vfk
 cQZ
 bFP
 uNN
 vfk
 lQJ
 imq
-dsJ
+pXW
 cbE
 lyA
 qMG
 xLi
 khn
-gRF
+cbE
 pdz
 pdz
 pdz
@@ -182033,7 +178089,7 @@ dji
 ggn
 wxJ
 wxJ
-aWQ
+xQu
 rMO
 clf
 njQ
@@ -182066,10 +178122,10 @@ qtz
 qoU
 qtz
 qtz
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 pVN
 rMa
 vWu
@@ -182098,9 +178154,9 @@ jyF
 rNx
 xwR
 cmV
+bQZ
 wdn
 dpq
-cZk
 uUO
 jxa
 wII
@@ -182157,7 +178213,7 @@ knc
 aiH
 cMH
 sDp
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -182167,11 +178223,11 @@ aWQ
 aWQ
 fMT
 fMT
-bYY
-bYY
+xLT
+udn
 vjb
 fMT
-eGB
+fMT
 vjb
 vjb
 vjb
@@ -182184,7 +178240,7 @@ lwn
 "}
 (195,1,1) = {"
 lwn
-ldK
+vfk
 rvh
 eJW
 rvh
@@ -182235,8 +178291,8 @@ wxJ
 gEu
 vXZ
 wxJ
-aWQ
-aWQ
+xQu
+xQu
 rMO
 uWf
 tcV
@@ -182269,10 +178325,10 @@ muF
 eZT
 sua
 qtz
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 pVN
 nUI
 nUI
@@ -182301,9 +178357,9 @@ aNe
 uOg
 tXm
 cmV
+bQZ
 vtX
-vtX
-sgS
+wdn
 eon
 btq
 jxa
@@ -182360,7 +178416,7 @@ cma
 rIA
 dSS
 slU
-ldK
+iBn
 aWQ
 aWQ
 aWQ
@@ -182376,7 +178432,7 @@ fMT
 aWQ
 aWQ
 fMT
-vjb
+gSJ
 vjb
 slp
 aWQ
@@ -182387,7 +178443,7 @@ lwn
 "}
 (196,1,1) = {"
 lwn
-ldK
+vfk
 dSF
 tQr
 dSF
@@ -182438,8 +178494,8 @@ wxJ
 qsd
 qlM
 wxJ
-aWQ
-aWQ
+xQu
+xQu
 rMO
 rzs
 tqc
@@ -182472,10 +178528,10 @@ cbY
 suD
 hnP
 qtz
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 ncS
 iEN
 uve
@@ -182504,10 +178560,10 @@ gmY
 qdi
 tXm
 cmV
-xQu
-wdn
-vtX
-fZc
+bQZ
+bQZ
+bQZ
+xLG
 uew
 kxl
 aFC
@@ -182536,14 +178592,14 @@ pKq
 pKq
 pKq
 pKq
-uFh
+pKq
 ykg
 frY
 bnp
 bnp
 jUK
 ykg
-qUu
+pKq
 xXE
 pKq
 pKq
@@ -182563,9 +178619,9 @@ tzy
 tzy
 mRy
 uYz
-ldK
-ldK
-ldK
+vQB
+vQB
+vQB
 aWQ
 aWQ
 aWQ
@@ -182575,10 +178631,10 @@ mlH
 mlH
 dFW
 bYY
-eGB
+fMT
 nhE
 aWQ
-vjb
+fMT
 vjb
 qze
 vjb
@@ -182590,7 +178646,7 @@ lwn
 "}
 (197,1,1) = {"
 lwn
-ldK
+vfk
 dSF
 eJW
 dSF
@@ -182641,8 +178697,8 @@ wxJ
 uLk
 qwl
 wxJ
-aWQ
-aWQ
+xQu
+xQu
 rMO
 aXy
 mQa
@@ -182675,17 +178731,17 @@ tbD
 dRI
 lvK
 qtz
-aWQ
-aWQ
-aWQ
-aWQ
-dPb
+iiF
+iiF
+iiF
+iiF
 qJN
-cTB
+qJN
+lVE
 uve
+lVE
+lVE
 qJN
-qJN
-cTB
 arM
 pmR
 mhC
@@ -182710,7 +178766,7 @@ eof
 jpQ
 eof
 dbq
-hnW
+fZc
 wrT
 fIF
 dRO
@@ -182759,29 +178815,29 @@ jCr
 icq
 igk
 qEI
-aWQ
-aWQ
-aWQ
+dpm
+dpm
+dpm
 tzy
 cqT
 dmP
 ppf
 rzi
 mym
-ldK
+vQB
 aWQ
 aWQ
 vjb
-azv
-bYY
-syi
-ddR
+vjb
+xLT
+ctS
+mlH
 mlH
 dFW
 klV
 nhE
 aWQ
-eGB
+fMT
 fMT
 vjb
 vjb
@@ -182793,7 +178849,7 @@ lwn
 "}
 (198,1,1) = {"
 lwn
-ldK
+vfk
 omh
 bFP
 esi
@@ -182844,8 +178900,8 @@ wxJ
 mWH
 fWO
 akU
-aWQ
-aWQ
+xQu
+xQu
 rMO
 kKY
 rsJ
@@ -182878,15 +178934,15 @@ pfC
 dRI
 nwZ
 qtz
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
 fQP
-cSw
-bIu
+qJN
 qJN
 lVE
-qJN
+lVE
+lVE
 lVE
 qJN
 vYn
@@ -182962,30 +179018,30 @@ xRW
 icq
 dmA
 qac
-wdn
-aWQ
-aWQ
+cwm
+dpm
+dpm
 dfm
 gjn
 wtv
 xLm
 tRP
 jJm
-ldK
-aWQ
-aWQ
-nmI
-gSJ
-wnt
-pTU
-mta
-sDI
-eIP
-aWQ
-aWQ
+vQB
 aWQ
 aWQ
 vjb
+gSJ
+xLT
+pTU
+bUC
+sDI
+klV
+aWQ
+aWQ
+aWQ
+aWQ
+fMT
 vjb
 vjb
 vjb
@@ -182996,7 +179052,7 @@ lwn
 "}
 (199,1,1) = {"
 lwn
-ldK
+vfk
 vfk
 bLG
 vfk
@@ -183081,14 +179137,14 @@ win
 quE
 hnP
 qtz
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
 qJN
-cTB
-dPb
+qJN
+qJN
 lVE
-qJN
+lVE
 lVE
 lVE
 qJN
@@ -183165,23 +179221,23 @@ ggl
 jXj
 icq
 qac
-bQZ
-aWQ
-aWQ
+cwm
+dpm
+dpm
 dfm
 ddC
 bBS
 xEw
 lbh
 inv
-ldK
+vQB
 aWQ
-eCq
-eIP
-klV
+vhM
+clS
+clS
 uxF
-qln
-eIP
+bYY
+clS
 aWQ
 aWQ
 aWQ
@@ -183199,7 +179255,7 @@ lwn
 "}
 (200,1,1) = {"
 lwn
-ldK
+vfk
 aIS
 led
 lZG
@@ -183284,20 +179340,20 @@ lXV
 dIf
 vUs
 qtz
-aWQ
-aWQ
-aWQ
-cTB
+iiF
+iiF
+iiF
 qJN
-cSw
-phr
-bIu
-cTB
+qJN
+qJN
+qJN
 lVE
 lVE
+lVE
+qJN
 mNH
 qQY
-vPP
+wHe
 vYn
 mgj
 kcx
@@ -183369,26 +179425,26 @@ stP
 icq
 qac
 bQZ
-bQZ
-aWQ
+wUr
+dpm
 dfm
 aXe
 wtv
 iel
 sxt
 jJm
-ldK
+vQB
 aWQ
 xvk
 ycG
 brz
-wnt
-lAB
+bYY
+udn
+clS
 eIP
-ldK
-ldK
-ldK
-ldK
+eIP
+eIP
+eIP
 aWQ
 nhE
 fMT
@@ -183402,7 +179458,7 @@ lwn
 "}
 (201,1,1) = {"
 lwn
-ldK
+vfk
 dDS
 vJB
 feb
@@ -183487,20 +179543,20 @@ qtz
 qtz
 qtz
 qtz
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 lCD
-cTB
-qvi
-oIu
 qJN
+qvi
+gxr
+lVE
 lVE
 gxr
 uIR
 fTI
-eOw
+vSi
 qNf
 wLW
 yjF
@@ -183519,10 +179575,10 @@ juE
 qdi
 lch
 cmV
-wdn
-vtX
+bQZ
+bQZ
 rNP
-vtX
+bQZ
 wrT
 fIF
 dRO
@@ -183571,29 +179627,29 @@ iHi
 iLH
 icq
 qac
-wdn
-vtX
-wdn
+bQZ
+bQZ
+bQZ
 gft
 hVq
 bwm
 cfe
 wIO
 oMQ
-ldK
-ldK
-ldK
+vQB
+eIP
+eIP
 sIR
 wSa
 mpt
 ogH
-ldK
-ldK
+eIP
+eIP
 lYi
 xpG
-ldK
+eIP
 aWQ
-iBn
+qXI
 qXI
 gSJ
 vjb
@@ -183605,11 +179661,11 @@ lwn
 "}
 (202,1,1) = {"
 lwn
-ldK
-ldK
-ldK
-ldK
-ldK
+vfk
+vfk
+vfk
+vfk
+vfk
 qNU
 srE
 kYz
@@ -183683,27 +179739,27 @@ gEQ
 kOJ
 oKR
 mTT
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-cTB
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 qJN
-dPb
+qJN
+qJN
 lVE
 lVE
 lVE
 kcm
 swU
-yle
+sji
 arM
 pKW
 jED
@@ -183723,9 +179779,9 @@ qdi
 aKt
 cmV
 mUA
-wdn
 bQZ
-wdn
+bQZ
+bQZ
 wrT
 fIF
 dRO
@@ -183734,7 +179790,7 @@ poV
 vIr
 fqP
 eLB
-iYE
+uqS
 pDq
 mKR
 uEo
@@ -183774,8 +179830,8 @@ veG
 wpm
 icq
 qac
-wdn
-wdn
+bQZ
+bQZ
 bQZ
 gft
 dCi
@@ -183794,7 +179850,7 @@ naY
 wRa
 bVq
 isk
-ldK
+eIP
 aWQ
 qXI
 iaZ
@@ -183808,12 +179864,12 @@ lwn
 "}
 (203,1,1) = {"
 lwn
-aWQ
-lwn
-lwn
-lwn
-lwn
-lwn
+oKL
+jtv
+jtv
+jtv
+jtv
+jtv
 cbE
 cbE
 cbE
@@ -183886,26 +179942,26 @@ rBi
 uEL
 xOL
 mTT
-aWQ
-aWQ
+iiF
+iiF
 lyR
 tQn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-iLK
-wFG
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 qJN
-yaK
-cTB
-ilr
-pNG
+qJN
+qJN
+lVE
+lVE
+gzT
+gzT
 gRK
 hQD
 dgC
@@ -183937,9 +179993,9 @@ pKF
 pyC
 vBf
 sjR
-iYE
+uqS
 jlT
-uDj
+dQO
 wHw
 bVu
 qiX
@@ -183977,9 +180033,9 @@ bWR
 jkJ
 icq
 qac
-wdn
 bQZ
-sNe
+bQZ
+suC
 tzy
 tzy
 pJa
@@ -183997,7 +180053,7 @@ gto
 bpw
 dNh
 emh
-ldK
+eIP
 rAM
 fMT
 vjb
@@ -184011,36 +180067,36 @@ lwn
 "}
 (204,1,1) = {"
 lwn
-lwn
-xnl
+aqg
+aVz
 tBt
 tBt
 tBt
 tBt
-psk
-psk
-psk
-psk
-psk
-psk
-psk
+nkb
+nkb
+nkb
+nkb
+nkb
+nkb
+nkb
 exy
 qpl
 qpl
 qpl
 shV
 bhg
-psk
-psk
-psk
+nkb
+nkb
+nkb
 exy
-psk
-psk
-psk
-psk
-psk
-psk
-psk
+nkb
+nkb
+nkb
+nkb
+nkb
+nkb
+nkb
 nkb
 gXO
 iSv
@@ -184089,27 +180145,27 @@ fuM
 mTT
 mTT
 mTT
-aWQ
-qTg
+iiF
+qJN
 ewT
 qJN
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-cTB
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+qJN
 iqm
 lVE
-hDF
+uve
 dAg
 dix
-oRI
+qJN
 nrA
 ryJ
 jED
@@ -184140,9 +180196,9 @@ mze
 vRu
 sUk
 bjm
-qVX
+lsb
 jlT
-uDj
+dQO
 oDv
 vJq
 wxV
@@ -184180,9 +180236,9 @@ hKX
 aHo
 dmA
 qEI
+wdn
+bzq
 bQZ
-wdn
-wdn
 ugW
 iYY
 bmT
@@ -184200,13 +180256,13 @@ gRM
 eNK
 dNh
 iHD
-ldK
-azv
+eIP
+vjb
 vjb
 vjb
 gSJ
 iaZ
-iaZ
+qXI
 nhE
 aWQ
 aWQ
@@ -184214,37 +180270,37 @@ lwn
 "}
 (205,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 rpP
-xKx
-xKx
+xPp
+xPp
 rBT
-rZw
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-cbE
-cbE
-aWQ
-xnl
+gZK
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+iFt
+iFt
+kwZ
+aVz
 cEw
 fsm
 fsm
@@ -184290,29 +180346,29 @@ rww
 rww
 fuM
 hbh
-qOy
-oyW
+qJN
+qJN
 ewT
-rNL
-qOy
-qOy
-sum
-aWQ
-aWQ
-aWQ
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+qJN
+qJN
+qJN
+nni
+iiF
+iiF
+iiF
+aiG
+iiF
+iiF
+iiF
+iiF
+aiG
 itS
 txG
-aqg
-aqg
-aqg
-aUf
-yaK
+dAg
+dAg
+dAg
+cyp
+qJN
 vYn
 vkR
 vkR
@@ -184343,9 +180399,9 @@ lba
 nMp
 jlH
 mNy
-qVX
+lsb
 sdO
-uDj
+dQO
 jIm
 qUj
 dJM
@@ -184386,7 +180442,7 @@ qEI
 xnp
 wdn
 bQZ
-wdn
+bQZ
 ngh
 kbf
 gNU
@@ -184405,7 +180461,7 @@ dNh
 cIa
 fbD
 vjb
-azv
+vjb
 vjb
 fGY
 vjb
@@ -184417,37 +180473,37 @@ lwn
 "}
 (206,1,1) = {"
 lwn
-lwn
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-svh
-tay
-tay
+arS
+arS
 noU
-rZw
+gZK
 tUK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-cbE
-cbE
-aWQ
-xnl
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+iFt
+iFt
+kwZ
+aVz
 pyG
 pyG
 pyG
@@ -184489,33 +180545,33 @@ jxy
 fuM
 fuM
 bpe
-iLK
-qOy
-qOy
+qJN
+qJN
+qJN
 wFG
 lVE
 lVE
+eae
+eae
+lVE
+lVE
 qJN
-lVE
-lVE
-lVE
 qJN
-cTB
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-kLS
+iiF
+iiF
+aiG
+aiG
+aiG
+aiG
+aiG
+aiG
+qQY
 uWe
 dAg
-yaK
+lVE
 iEF
-aqg
-aqg
+dAg
+cyp
 gFp
 uyN
 vYn
@@ -184546,9 +180602,9 @@ xCt
 sRT
 baR
 ulX
-qVX
+lsb
 jlT
-uDj
+dQO
 vEG
 cjY
 tOf
@@ -184607,12 +180663,12 @@ yfa
 dNh
 jxn
 wSa
-eIP
-tHI
+clS
+gSJ
 vjb
 vjb
 vjb
-eGB
+fMT
 aWQ
 aWQ
 aWQ
@@ -184620,39 +180676,39 @@ lwn
 "}
 (207,1,1) = {"
 lwn
-lwn
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-svh
 ray
-hgM
+cUS
 noU
-rZw
-cbE
+gZK
+iFt
 ohG
 ofO
-aWQ
-aWQ
-aWQ
-cbE
-cbE
-cbE
-kVE
-aWQ
-xnl
-aWQ
-aWQ
+kwZ
+kwZ
+kwZ
+tUK
+iFt
+iFt
+iFt
+kwZ
+aVz
+uKi
+uKi
 qMG
 pyG
 qMG
@@ -184690,22 +180746,22 @@ eCI
 rXJ
 rXJ
 fuM
-iLK
-qOy
+qJN
+qJN
 tGX
 lVE
 lVE
+dAg
 lVE
 lVE
 lVE
+eae
+eae
+dAg
 lVE
 qJN
 qJN
-lVE
-qJN
-qJN
-cTB
-aWQ
+iiF
 wsD
 wsD
 wsD
@@ -184714,12 +180770,12 @@ wsD
 wsD
 pGu
 lGm
-aqg
-oRI
-aqg
-aUf
-oRI
-aUf
+dAg
+lVE
+dAg
+dAg
+lVE
+cyp
 qJN
 vYn
 nkG
@@ -184749,9 +180805,9 @@ pKF
 pyC
 dtx
 ncP
-iYE
+uqS
 jlT
-uDj
+dQO
 wEo
 lRL
 fAn
@@ -184810,7 +180866,7 @@ yfa
 dNh
 rQS
 sIR
-nmI
+vjb
 vjb
 vjb
 vjb
@@ -184823,40 +180879,40 @@ lwn
 "}
 (208,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-dAZ
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+asD
 nsD
-hgM
-qqk
+cUS
+pkl
 nkl
 mTe
-dhU
-dhU
-dhU
-dhU
+xvy
+xvy
+xvy
+xvy
 nsA
 aNo
-dhU
-dhU
-dhU
+xvy
+xvy
+xvy
 rfz
-aWQ
-xnl
-aWQ
-aWQ
-aWQ
+kwZ
+aVz
+uKi
+uKi
+uKi
 qMG
 qMG
 rFF
@@ -184887,27 +180943,27 @@ kzF
 hIY
 vAC
 wjz
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-qOy
-iZP
-lVE
-lVE
-cTB
+iiF
+iiF
+iiF
+iiF
+iiF
 qJN
+gxr
+lVE
+lVE
+eae
+eae
 oEX
 lVE
 qJN
 qJN
-cTB
+qJN
 qJN
 lWd
-lVE
-lVE
-qJN
+dAg
+dAg
+cyp
 eae
 ozI
 sed
@@ -184919,11 +180975,11 @@ wdm
 tBX
 jXI
 pmm
-ilr
-gzT
-nQG
+jXI
+jXI
+pmm
 xCz
-wDF
+xCz
 xZc
 aqq
 kgM
@@ -184942,8 +180998,8 @@ xlS
 cmV
 sqX
 bQZ
-vtX
-wdn
+bQZ
+bQZ
 wrT
 fIF
 dRO
@@ -185013,11 +181069,11 @@ yfa
 dNh
 jxn
 fbD
-klV
-nmI
+clS
 vjb
 vjb
-fMT
+vjb
+gdc
 nhE
 aWQ
 aWQ
@@ -185026,42 +181082,42 @@ lwn
 "}
 (209,1,1) = {"
 lwn
-lwn
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+ibi
+dAZ
 xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-dAZ
-dAZ
-svh
-tay
-vqb
-xIe
+arS
+cUS
+arS
 nKt
-tay
-hgM
-tay
-lTA
-tay
-hgy
-bCE
-tay
-hgM
-tay
-aWQ
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+arS
+cUS
+arS
+arS
+arS
+bkn
+arS
+arS
+cUS
+arS
+kwZ
+aVz
+uKi
+uKi
+uKi
+uKi
+uKi
 xXs
 xXs
 xXs
@@ -185081,7 +181137,7 @@ hDY
 veS
 hFJ
 jwJ
-awj
+qwz
 iYy
 qvV
 fkF
@@ -185090,27 +181146,27 @@ tHZ
 qoL
 iGS
 wjz
-aWQ
+iiF
 rzy
-cTB
 qJN
-cTB
+qJN
+qJN
 lVE
 lVE
-cTB
+lVE
 qJN
 qJN
 qJN
-cTB
 qJN
-cTB
-aWQ
-aWQ
+qJN
+qJN
+iiF
+iiF
 nni
-cTB
+qJN
 uve
 lVE
-yaK
+dAg
 swx
 wsD
 jUl
@@ -185119,14 +181175,14 @@ fIA
 dMT
 wsD
 xzt
-uWe
-aqg
+fuq
+dAg
 oCD
-yaK
-yaK
-jkX
-gAp
-cTB
+lVE
+lVE
+eZD
+eZD
+qJN
 vYn
 ccX
 hhU
@@ -185143,10 +181199,10 @@ nOc
 vpY
 fig
 cmV
-aIG
+iAz
 nkZ
 bQZ
-vtX
+bQZ
 wrT
 fIF
 dRO
@@ -185209,18 +181265,18 @@ seP
 oYE
 jnQ
 joB
-uAH
+nXh
 ceZ
 tOv
 vxf
 xsg
 sDr
-ldK
+eIP
 ycG
 vjb
 vjb
 fMT
-vtj
+gdc
 nhE
 aWQ
 aWQ
@@ -185229,46 +181285,46 @@ lwn
 "}
 (210,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-hbu
-dAZ
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+pwL
 qRT
-svh
-tay
-gCo
-agJ
+xnl
+arS
+arS
+arS
 oqz
 bCE
-tay
-hgL
-tay
-tay
-hgM
-hgy
-tay
+arS
+arS
+arS
+arS
+cUS
+bkn
+arS
 aLt
-aWQ
-aWQ
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-lwn
-lwn
-aWQ
+kwZ
+kwZ
+aVz
+uKi
+uKi
+uKi
+uKi
+uKi
+uKi
+nSM
+nSM
+iiF
 lld
 syJ
 syJ
@@ -185283,7 +181339,7 @@ ykA
 mhj
 tYk
 qwz
-qJF
+nqA
 nqA
 rOB
 qvV
@@ -185293,7 +181349,7 @@ kNF
 vHT
 llm
 wjz
-aWQ
+iiF
 rzy
 qJN
 lVE
@@ -185303,18 +181359,18 @@ gxr
 qJN
 rzy
 rzy
-aWQ
-aWQ
+iiF
+iiF
 phr
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 fQP
 qJN
 lVE
-aqg
-rTR
+dAg
+hBv
 aDI
 dak
 fIA
@@ -185322,14 +181378,14 @@ fYC
 qpr
 aDI
 oys
-gCY
-aUf
-yaK
+owE
+dAg
+lVE
 lVE
 vSi
 vSi
 tSq
-aWQ
+iiF
 arM
 uVA
 htD
@@ -185347,9 +181403,9 @@ hyk
 ohx
 eof
 xZF
+vtX
 dpF
-dpF
-sMe
+fSl
 wrT
 rDW
 dRO
@@ -185398,10 +181454,10 @@ wEb
 xGL
 utF
 qEI
-xnp
-wdn
-wdn
-wdn
+fUx
+bQZ
+bQZ
+bQZ
 jkb
 ndI
 jtN
@@ -185418,11 +181474,11 @@ tYL
 kiS
 lQO
 tYL
-ldK
+eIP
 fFN
 jmm
-vjb
-eGB
+fMT
+fMT
 aWQ
 aWQ
 aWQ
@@ -185432,46 +181488,46 @@ lwn
 "}
 (211,1,1) = {"
 lwn
-lwn
+aqg
 aVz
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-hbu
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+vqC
 qRT
-hbu
-svh
-xDO
-dgT
-gVI
+xnl
+qSF
+cUS
+arS
 nKt
 ray
-hgM
-tay
-tay
-aEL
-tay
-tay
-tay
+cUS
+hgL
+arS
+pMN
+arS
+arS
+arS
 mGz
-aWQ
-aWQ
-xnl
+kwZ
+kwZ
+aVz
 tBt
 tBt
 tBt
 tBt
 tBt
 tBt
-lwn
-lwn
-aWQ
+nSM
+nSM
+iiF
 lld
 rMa
 vWu
@@ -185496,27 +181552,27 @@ hBF
 hBF
 iFX
 mSn
-aWQ
-cTB
+iiF
 qJN
-qJN
+lVE
+lVE
 lVE
 qJN
 nni
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
+iiF
 mEq
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 rzy
+qJN
 lVE
 lVE
-yaK
 naA
 fIA
 fuA
@@ -185525,14 +181581,14 @@ fIA
 pwN
 kyx
 ooW
-tAY
+owE
 eae
 gxr
 gwN
 sji
 inX
-aWQ
-aWQ
+iiF
+iiF
 vYn
 uVA
 eqM
@@ -185552,7 +181608,7 @@ eof
 uXy
 vtX
 pls
-pMf
+bQZ
 wrT
 vCx
 pKF
@@ -185563,7 +181619,7 @@ tUN
 bjx
 cXr
 jlT
-uDj
+dQO
 wEo
 xiv
 qCs
@@ -185601,9 +181657,9 @@ jCr
 hNz
 icq
 qEI
-wdn
-vtX
-vtX
+bQZ
+cJw
+bQZ
 lVu
 ejQ
 flO
@@ -185621,7 +181677,7 @@ xoG
 oUw
 mXZ
 xoG
-ldK
+eIP
 dcd
 aWQ
 nhE
@@ -185635,46 +181691,46 @@ lwn
 "}
 (212,1,1) = {"
 lwn
-lwn
-cMe
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-hbu
-svh
-lTA
-kcj
-tay
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+hfL
+xnl
+arS
+xlO
+arS
 uOP
-tay
-kcj
-tay
-kcj
+arS
+xlO
+arS
+xlO
 gyk
-kcj
-tay
-kcj
+xlO
+arS
+xlO
 xls
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 vpt
-lwn
-lwn
-aWQ
+nSM
+nSM
+iiF
 lld
 nUI
 nUI
@@ -185699,23 +181755,23 @@ vqD
 xwx
 bja
 jwW
-aWQ
+iiF
 qJN
 lVE
 lVE
 lVE
-qJN
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+lVE
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 rzy
 qJN
 oyO
@@ -185728,14 +181784,14 @@ hAW
 ljc
 ljY
 vSP
-cfi
-aqg
-yaK
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
+sYl
+dAg
+qJN
+qJN
+iiF
+iiF
+iiF
+iiF
 vYn
 rWW
 jdN
@@ -185755,7 +181811,7 @@ eof
 xEp
 vtX
 aIG
-ult
+bQZ
 wrT
 fIF
 dRO
@@ -185766,7 +181822,7 @@ xYv
 eLB
 ckd
 jlT
-uDj
+dQO
 hSI
 usS
 seU
@@ -185804,7 +181860,7 @@ jCr
 naa
 xGL
 qac
-wdn
+bQZ
 wdn
 suC
 ejQ
@@ -185824,7 +181880,7 @@ dNh
 ncg
 dNh
 kCC
-ldK
+eIP
 aWQ
 aWQ
 aWQ
@@ -185838,53 +181894,53 @@ lwn
 "}
 (213,1,1) = {"
 lwn
-lwn
-dvt
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-svh
-tay
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+xnl
+arS
 bak
-tay
+arS
 uOP
+arS
+xlO
+arS
+xlO
+arS
+xlO
+arS
+xlO
 lTA
-kcj
-tay
-kcj
-tay
-kcj
-tay
-kcj
-lTA
-hgM
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+sgS
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 vpt
-lwn
-lwn
-aWQ
+nSM
+nSM
+iiF
 xIL
-iEN
+eTF
 lVE
 lVE
 lVE
-lVE
-jWB
+qJN
+jMi
 dHd
 dHd
 dHd
@@ -185905,21 +181961,21 @@ jwW
 iPo
 lVE
 lVE
-cTB
-qJN
 lVE
-aWQ
+laD
+lVE
+iiF
 qJN
 iSm
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 qJN
 owE
 lVE
@@ -185931,10 +181987,10 @@ fIA
 qpr
 fIA
 ooW
-aUf
-aUf
-aUf
-aWQ
+dAg
+dAg
+cyp
+iiF
 jDY
 jDY
 jDY
@@ -185969,7 +182025,7 @@ hdd
 eLB
 eEG
 jlT
-uDj
+dQO
 rcn
 lgQ
 pgP
@@ -186008,7 +182064,7 @@ enC
 icq
 qac
 bQZ
-vtX
+bQZ
 bQZ
 nzf
 qTm
@@ -186017,17 +182073,17 @@ tBo
 eFK
 xMV
 ejQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
+eIP
 aWQ
 aWQ
 aWQ
@@ -186041,20 +182097,20 @@ lwn
 "}
 (214,1,1) = {"
 lwn
-lwn
-dPQ
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 cBk
 vUR
 pcb
 tIR
 iFt
 iFt
-ldj
+keQ
 keQ
 wlz
-aWQ
+kwZ
 roQ
 ocT
 tnG
@@ -186070,28 +182126,28 @@ tnG
 tnG
 tnG
 nWs
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+izK
+iFt
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 vpt
-lwn
-lwn
+nSM
+nSM
 rzy
 fQP
-cTB
+qJN
 qJN
 lVE
 lVE
-lVE
-lVE
-cTB
-aWQ
-aWQ
-aWQ
+qJN
+qJN
+qJN
+iiF
+iiF
+iiF
 ego
 jlW
 kIR
@@ -186105,27 +182161,27 @@ qCj
 jwW
 jwW
 jwW
-oRI
 lVE
-qJN
-qJN
-qJN
-qJN
+lVE
+lVE
+lVE
+lVE
+lVE
 mEq
 cTB
 qJN
-aWQ
-aWQ
+iiF
+iiF
 rzy
 rzy
-aWQ
-cTB
-aWQ
+iiF
+qJN
+iiF
 fek
 qJN
-cTB
+qJN
 owE
-aqg
+dAg
 dzz
 aDI
 bJR
@@ -186133,11 +182189,11 @@ fIA
 fIA
 xol
 bhK
-bbj
+ooW
 dix
 vIu
-fLw
-aWQ
+vSi
+iiF
 jDY
 hjw
 vjN
@@ -186160,8 +182216,8 @@ plp
 eof
 wdn
 qNw
-ult
-wdn
+bQZ
+bQZ
 xcO
 btq
 dRO
@@ -186172,7 +182228,7 @@ kqm
 pRq
 lsb
 jlT
-uDj
+dQO
 fFw
 vQI
 cFS
@@ -186211,7 +182267,7 @@ jkJ
 icq
 qac
 bQZ
-wdn
+bQZ
 bQZ
 nzf
 cGj
@@ -186244,20 +182300,20 @@ lwn
 "}
 (215,1,1) = {"
 lwn
-lwn
-eeA
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 cBk
 vUR
 bsO
 tIR
 iFt
 myI
-foZ
+eXs
 eXs
 jnp
-aWQ
+kwZ
 rRt
 hGO
 qZV
@@ -186273,29 +182329,29 @@ wGx
 cli
 cli
 cli
-aWQ
-aWQ
-aWQ
+izK
+iFt
+joH
 rVS
 kMd
-tIR
-smQ
+lYd
+ePp
 vpt
-lwn
-lwn
+nSM
+nSM
 rzy
-cTB
+qJN
 qJN
 lVE
 lVE
 lVE
 lVE
-lVE
-lVE
+qJN
+qJN
 qJN
 rzy
 rzy
-aWQ
+iiF
 roM
 iwB
 wes
@@ -186304,10 +182360,10 @@ pQV
 hke
 yeM
 hzG
-oRI
-oRI
-yaK
-oRI
+lVE
+lVE
+lVE
+lVE
 lVE
 uve
 qcB
@@ -186328,7 +182384,7 @@ dNq
 dNq
 rcU
 sYl
-aqg
+dAg
 aXu
 wsD
 kxH
@@ -186337,10 +182393,10 @@ jXT
 oDa
 wsD
 mGM
-gAp
-lVE
-inX
-aWQ
+eZD
+qJN
+sji
+iiF
 bDq
 qpN
 cyx
@@ -186363,7 +182419,7 @@ oby
 eof
 vtX
 wdn
-ult
+bQZ
 tti
 btq
 szM
@@ -186375,7 +182431,7 @@ oRU
 btB
 uqS
 jlT
-uDj
+dQO
 tOf
 rvn
 kbt
@@ -186413,12 +182469,12 @@ mmg
 aHo
 icq
 qac
-bQZ
-aWQ
+wdn
+jcw
 uhh
 ejQ
 qKo
-hPe
+pjO
 czk
 lBk
 knZ
@@ -186447,52 +182503,52 @@ lwn
 "}
 (216,1,1) = {"
 lwn
-lwn
-fDJ
-aWQ
+aqg
+aVz
+kwZ
 hfL
 cBk
 pqY
 fKD
 tIR
-ccg
+tIR
 abJ
 tIR
 tIR
-ccg
-ccg
-ccg
 tIR
 tIR
-ccg
-ccg
-ccg
 tIR
 tIR
-ccg
-ccg
-ccg
+tIR
+tIR
+tIR
+tIR
+tIR
+tIR
+tIR
+tIR
+tIR
 tIR
 qGL
-ccg
-ccg
+tIR
+tIR
 kle
 iFt
-oTZ
+dlI
 kMd
 eyU
 wBR
-cBk
+dsJ
 vkM
-lwn
-lwn
-aWQ
+nSM
+nSM
+iiF
 wHe
 lVE
-qJN
-qJN
 lVE
-qJN
+lVE
+lVE
+lVE
 lVE
 qJN
 qJN
@@ -186506,22 +182562,22 @@ laz
 jwW
 fcD
 jwW
-oRI
-oRI
-yaK
 lVE
 lVE
 lVE
-qJN
-cTB
+lVE
+lVE
+lVE
+lVE
+lVE
 qJN
 lVE
 uve
 lVE
 lVE
 lVE
-cTB
-gxr
+lVE
+uve
 lVE
 lVE
 lVE
@@ -186529,18 +182585,18 @@ qJN
 lVE
 lVE
 uYg
-aUf
+dAg
 lVE
 lVE
-aWQ
+iiF
 wsD
 wsD
 wsD
 wsD
 wsD
 pZY
-aUf
-jeZ
+cyp
+gxr
 amJ
 amJ
 amJ
@@ -186564,7 +182620,7 @@ tkP
 cUe
 twr
 eof
-aWQ
+dpm
 pIe
 szM
 tJe
@@ -186616,9 +182672,9 @@ bnh
 oPc
 icq
 qac
-bQZ
-aWQ
-aWQ
+wdn
+wdn
+dpm
 ejQ
 ktl
 qEg
@@ -186650,9 +182706,9 @@ lwn
 "}
 (217,1,1) = {"
 lwn
-lwn
-fRU
-aWQ
+aqg
+aVz
+kwZ
 cBk
 cBk
 vUR
@@ -186679,68 +182735,68 @@ aPN
 aPN
 aPN
 ylB
-wBR
-tHm
-ivG
+tIR
+iFt
+dlI
 ylO
 otU
-wBR
+tIR
 cBk
 kXE
-lwn
-lwn
+nSM
+nSM
 cyp
 qJN
 hik
 uve
 lVE
-qJN
 lVE
-qJN
+lVE
+lVE
 lVE
 gxr
 qJN
+qJN
+qJN
 lVE
-oRI
-oRI
-oRI
+lVE
 kvA
 oQW
-oRI
-oRI
-oRI
-oRI
-yaK
 lVE
 lVE
 lVE
-qJN
+lVE
+lVE
+lVE
+lVE
+lVE
+lVE
 qJN
 qJN
 lCD
-cTB
-lVE
-lVE
-szN
-lVE
 qJN
 lVE
 lVE
-dLQ
-phr
-phr
-bIu
+uPK
+lVE
+lVE
+lVE
 lVE
 lVE
 qJN
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
+qJN
+qJN
+lVE
+lVE
+qJN
+iiF
+iiF
+iiF
+aiG
+aiG
+aiG
+aiG
+aiG
 mzl
 tYZ
 nlt
@@ -186767,7 +182823,7 @@ sUO
 rxN
 gUy
 eof
-aWQ
+dpm
 szM
 szM
 iZU
@@ -186819,12 +182875,12 @@ mAC
 tVM
 icq
 qac
-wdn
-aWQ
-aWQ
+cwm
+dpm
+dpm
 ejQ
 pjO
-hPe
+pjO
 czk
 rvo
 ten
@@ -186853,10 +182909,10 @@ lwn
 "}
 (218,1,1) = {"
 lwn
-lwn
-fYW
-aWQ
-sPK
+aqg
+aVz
+kwZ
+hfL
 hfL
 vUR
 pul
@@ -186882,69 +182938,69 @@ wbu
 wbu
 wbu
 fKj
-wBR
-gBb
-kol
+tIR
+iFt
+dlI
 jko
 sxQ
-wBR
+tIR
 hfL
 vkM
-lwn
-lwn
+nSM
+nSM
 uND
 psl
 whD
 lVE
-qJN
+lVE
 lVE
 lVE
 nni
 lVE
 lVE
 lVE
-qJN
-qJN
-oRI
-rtg
+lVE
+lVE
+lVE
+lVE
 kvA
 wnJ
-xdu
-qJN
-oRI
-qJN
-yaK
-qJN
 lVE
 lVE
-cTB
+lVE
+lVE
+lVE
+lVE
+lVE
+lVE
 qJN
-aWQ
-aWQ
 qJN
-aWQ
-uAk
+iiF
+iiF
+qJN
+iiF
+qJN
 kbj
 jqU
 prs
-phr
-uAk
-vrP
+qJN
+qJN
+qJN
 mEq
 lCD
-cSw
-aWQ
+qJN
+iiF
 ewT
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+iiF
+iiF
+iiF
+iiF
+aiG
+iiF
+iiF
+iiF
+iiF
+aiG
 npL
 mrO
 amJ
@@ -186970,7 +183026,7 @@ eof
 iXa
 slV
 eof
-aWQ
+dpm
 szM
 jfY
 aoj
@@ -187022,13 +183078,13 @@ jCr
 czy
 icq
 qEI
-aWQ
-aWQ
-aWQ
+dpm
+dpm
+dpm
 azm
 pzJ
-uKi
-wjU
+nKl
+nKl
 nKl
 qnt
 ejQ
@@ -187056,10 +183112,10 @@ lwn
 "}
 (219,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 cBk
 vUR
 pul
@@ -187090,12 +183146,12 @@ hqT
 mvW
 qiA
 sxQ
-wBR
-lwn
-xnl
-lwn
-aWQ
-cTB
+tIR
+aqg
+aVz
+nSM
+iiF
+qJN
 qJN
 lVE
 lVE
@@ -187103,51 +183159,51 @@ lVE
 lVE
 qJN
 qvi
-cTB
+qJN
+gxr
+lVE
+lVE
+lVE
 uve
 lVE
-lVE
-oRI
-gxr
-rtg
 eQY
 oQW
-xdu
-jeZ
-oRI
-oRI
-qJN
+lVE
 uve
+lVE
+lVE
+qJN
+gxr
 qJN
 lVE
 lVE
 gxr
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
+qJN
+iiF
+iiF
+iiF
+iiF
 lCD
-cTB
-aWQ
-aWQ
+qJN
+iiF
+iiF
 nni
-aWQ
+iiF
 fQP
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+nni
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
 epm
 hYL
 amJ
@@ -187259,10 +183315,10 @@ lwn
 "}
 (220,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 hfL
 vUR
 pul
@@ -187289,68 +183345,68 @@ wbu
 wbu
 gNw
 nft
-wfI
+nft
 xFj
 dpj
 sxQ
-wBR
-lwn
-xnl
-lwn
-aWQ
+tIR
+aqg
+aVz
+nSM
+iiF
 qJN
-eZD
-qJN
-pXS
+lVE
+lVE
+lVE
 uPK
 qJN
 cTB
 qJN
 lCD
-lVE
+qJN
 qJN
 lVE
-qJN
-oRI
-rtg
+lVE
+lVE
+lVE
 eQY
 wnJ
-xdu
-oRI
+lVE
+lVE
 lVE
 lVE
 qJN
-aWQ
-lVE
-lVE
+iiF
 qJN
 qJN
 qJN
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+qJN
+qJN
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
 vNK
 eOL
 cNr
@@ -187462,10 +183518,10 @@ lwn
 "}
 (221,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 cBk
 vUR
 pul
@@ -187492,68 +183548,68 @@ wbu
 wbu
 nJq
 iIT
-pwL
+iIT
 sBz
 rVO
 sxQ
-wBR
-lwn
+tIR
+aqg
 ntt
-cvQ
-cTB
-lVE
-lVE
-rUB
+rzy
 qJN
-cTB
-cTB
+lVE
+lVE
+qJN
+qJN
+qJN
+qJN
 tSq
-cTB
+mEq
 fek
 ewT
 qJN
-cTB
-oRI
-oRI
+qJN
+qJN
+lVE
 oFb
 kvA
 oQW
 oFb
-oRI
+lVE
 lVE
 qJN
-aWQ
-aWQ
+iiF
+iiF
 ewT
 nni
 qJN
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+qJN
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
 vIX
 hWj
 mFB
@@ -187665,9 +183721,9 @@ lwn
 "}
 (222,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
+aqg
+aVz
+kwZ
 hfL
 hfL
 vUR
@@ -187695,68 +183751,68 @@ wbu
 wbu
 gNw
 nft
-cCJ
+nft
 sBz
 dpj
 sxQ
-wBR
+tIR
 wQF
-nRd
-cTB
+vkM
+qJN
 qJN
 lVE
 lVE
+qGn
+rzy
+rzy
+iiF
+iiF
+rzy
+rzy
+iiF
 qJN
-rzy
-rzy
-aWQ
-aWQ
-rzy
-rzy
-aWQ
-cTB
 qJN
-oRI
-oRI
-ldK
+qJN
+qJN
+rbR
 kvA
 oQW
-ldK
+rbR
 qJN
 oRI
-aWQ
-aWQ
-aWQ
-aWQ
+iiF
+iiF
+iiF
+iiF
 rzy
 rzy
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
 wOl
 qap
 hgQ
@@ -187868,9 +183924,9 @@ lwn
 "}
 (223,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
+aqg
+aVz
+kwZ
 hfL
 cBk
 pqY
@@ -187898,141 +183954,141 @@ wbu
 wbu
 nJq
 nft
-cCJ
+nft
 sBz
 rVO
 sxQ
 sxQ
 wQF
-nRd
+vkM
 lVE
 lVE
 lVE
-lVE
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
+cfi
+qJN
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+rbR
+rbR
+rbR
 dOy
 dOy
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+rbR
+rbR
+rbR
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+pKF
+pKF
 cNb
 xHn
 xHn
 rLe
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
 cNb
 xHn
 xHn
 rLe
-ldK
+pKF
 ldK
 ldK
 lhZ
@@ -188071,9 +184127,9 @@ lwn
 "}
 (224,1,1) = {"
 lwn
-lwn
-xnl
-sPK
+aqg
+aVz
+hfL
 cBk
 cBk
 vUR
@@ -188101,141 +184157,141 @@ wbu
 wbu
 gNw
 hZR
-cCJ
+nft
 sBz
 hSM
 sxQ
 sxQ
 wQF
-nRd
+vkM
 lVE
 lVE
-urj
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
-ldK
+qJN
+eZD
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+rbR
+rbR
+rbR
+rbR
+rbR
+rbR
+rbR
+rbR
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+fyv
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+szM
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
 ldK
 ldK
 ldK
@@ -188274,10 +184330,10 @@ lwn
 "}
 (225,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-sPK
+aqg
+aVz
+kwZ
+hfL
 hfL
 vUR
 pul
@@ -188304,82 +184360,82 @@ wbu
 wbu
 jAq
 dWj
-cdk
+iIT
 sBz
 rVO
 sxQ
 sxQ
 wQF
-iub
-cTB
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+kXE
+qJN
+qJN
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -188477,10 +184533,10 @@ lwn
 "}
 (226,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
 cBk
 vUR
 pul
@@ -188507,82 +184563,82 @@ wbu
 wbu
 hQe
 cQt
-ibi
+nft
 sBz
 kjx
 sxQ
-ldK
-ldK
+wQF
+wQF
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -188680,9 +184736,9 @@ lwn
 "}
 (227,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
+aqg
+aVz
+kwZ
 hfL
 hfL
 vUR
@@ -188714,78 +184770,78 @@ dOJ
 fwX
 jcG
 sxQ
-ldK
-aWQ
+wQF
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -188883,10 +184939,10 @@ lwn
 "}
 (228,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-sPK
+aqg
+aVz
+kwZ
+hfL
 hfL
 vUR
 pul
@@ -188912,83 +184968,83 @@ wbu
 wbu
 wbu
 fKj
-wBR
-lbU
+tIR
+iFt
 dlI
 jzf
 sxQ
-ldK
-aWQ
+wQF
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -189086,8 +185142,8 @@ lwn
 "}
 (229,1,1) = {"
 lwn
-lwn
-xnl
+aqg
+aVz
 hfL
 cBk
 cBk
@@ -189115,83 +185171,83 @@ pCI
 pCI
 pCI
 dvG
-wBR
-nLj
-bXG
+tIR
+iFt
+dlI
 kVi
-sxQ
-ldK
-aWQ
+agJ
+wQF
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -189289,9 +185345,9 @@ lwn
 "}
 (230,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
+aqg
+aVz
+kwZ
 cBk
 cBk
 pye
@@ -189319,82 +185375,82 @@ smQ
 smQ
 smQ
 nsI
-tHm
+iFt
 qVV
 yed
-sxQ
-ldK
-aWQ
+aip
+wQF
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -189492,19 +185548,9 @@ lwn
 "}
 (231,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-hfL
-mED
-cBk
-cBk
-cBk
-cBk
-hfL
-cBk
-cBk
-cBk
+aqg
+aVz
+kwZ
 hfL
 hfL
 cBk
@@ -189513,6 +185559,16 @@ cBk
 cBk
 hfL
 cBk
+cBk
+cBk
+hfL
+hfL
+cBk
+cBk
+cBk
+cBk
+hfL
+cBk
 hfL
 cBk
 hfL
@@ -189521,83 +185577,83 @@ cBk
 hfL
 cBk
 cBk
-vPa
+hfL
 pjU
-ePp
-iFt
-ldK
-ldK
-aWQ
+myI
+hnW
+wQF
+wQF
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -189695,112 +185751,112 @@ lwn
 "}
 (232,1,1) = {"
 lwn
-lwn
-xnl
-aWQ
-aWQ
-aWQ
-aWQ
-sPK
-sPK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-sPK
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aqg
+aVz
+kwZ
+kwZ
+kwZ
+kwZ
 hfL
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+hfL
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+hfL
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+hfL
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
+kwZ
 vpt
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -189898,8 +185954,8 @@ lwn
 "}
 (233,1,1) = {"
 lwn
-lwn
-xnl
+aqg
+aVz
 tBt
 tBt
 tBt
@@ -189934,76 +185990,76 @@ tBt
 tBt
 tBt
 tBt
-xnl
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aVz
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ
@@ -190101,112 +186157,112 @@ lwn
 "}
 (234,1,1) = {"
 lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-lwn
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
-aWQ
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+aqg
+nSM
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
+iiF
 aWQ
 aWQ
 aWQ

--- a/code/game/objects/effects/spawners/random/misc_structure.dm
+++ b/code/game/objects/effects/spawners/random/misc_structure.dm
@@ -650,7 +650,7 @@
 	icon_state = "carone"
 	icon = 'icons/effects/random/64x64.dmi'
 	spawn_with_original_direction = TRUE
-	spawn_loot_chance = 35
+	spawn_loot_chance = 25
 	loot = list(
 		/obj/effect/spawner/random/misc/structure/large/car/red,
 		/obj/effect/spawner/random/misc/structure/large/car/black,

--- a/code/game/objects/structures/large_vehicle_props.dm
+++ b/code/game/objects/structures/large_vehicle_props.dm
@@ -74,7 +74,7 @@
 	bound_width = 128
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 1000 //mega hauler trucks are still tanks that soak up fire
-	coverage = 95
+	coverage = 100
 	soft_armor = list(MELEE = 30, BULLET = 90, LASER = 95, ENERGY = 55, BOMB = 60, BIO = 10, FIRE = 10, ACID = 10)
 
 


### PR DESCRIPTION

## About The Pull Request

Makes a lot of changes to LV 759, notable examples:
- Redo of most of LV 759's caves keeping most of the original layout the same while attempting to make the open paths more clear.
- Extreme reduction in the number of "bulbous rock"' tiles that looked a lot like impassable rock.
- Removal of metal barriers in the middle of the road ways that made the roads very annoying for marine vehicles.
- Change to area designations to get rid of the problem with out of bounds areas being accessible.
- Reduction of cars on the roads in most areas to make the roads somewhat more clear.
- Removal of hundreds of platform corners that were not removed along with the full sized platforms.

Other changes were probably spoken about in #mapping, it is difficult to list them all due to the nature of this.

## Why It's Good For The Game

LV 759 Is a map I quite like for the colony part, however the caves have been criticized at length for being difficult to understand which tiles block movement and which do not.
The other major complaint was that vehicles were  massively impeded by all the clutter on the roads.

I've modified the map to address these 2 primary concerns along with a few other smaller ones.

## Changelog

:cl:
qol: Various improvements to LV 759 particularly aimed at the caves and roadway clutter.
/:cl:
