### PR TITLE
Xenos can no longer damage their own doors

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -151,6 +151,7 @@
 	icon = 'icons/obj/smooth_objects/resin-door.dmi'
 	icon_state = "resin-door-1"
 	base_icon_state = "resin-door"
+	resistance_flags = NONE
 	layer = RESIN_STRUCTURE_LAYER
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_XENO_STRUCTURES)


### PR DESCRIPTION

## About The Pull Request

Removes `XENO_DAMAGEABLE` from resin doors. Stops minions damaging resin doors. During testing, can still dismantle doors on harm intent, just won't have the slash effect afterwards since you are not attacking it.

## Why It's Good For The Game

Xenos should not be damaging their own doors.

## Changelog
:cl:
fix: Xenos cannot damage resin doors again.
/:cl:
