### PR TITLE
Increases the cost of HPR/SVD to 300.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1715,7 +1715,7 @@ Imports
 /datum/supply_packs/imports/m412l1
 	name = "PR-412L1 Heavy Pulse Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/m412l1_hpr)
-	cost = 150
+	cost = 300
 
 /datum/supply_packs/imports/m412l1/ammo
 	name = "PR-412L1 Heavy Pulse Rifle Ammo"
@@ -1819,7 +1819,7 @@ Imports
 /datum/supply_packs/imports/dragunov
 	name = "SVD Dragunov Sniper"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/svd)
-	cost = 150
+	cost = 300
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/dragunov/ammo


### PR DESCRIPTION

## About The Pull Request
Title literally. This time less scuffed.

But if you *really* need to know.

SVD 150->300
HPR 150->300
Magazines unaffected.
## Why It's Good For The Game
HPR and SVD are killer deals for 150. With both sharing ammo with common street rifles that marines get ammo boxes for (Rifle!Family/Mosin respectively)
This should put them to a higher point value and cost and make it more obvious they're something inbetween a 40 point and the usual imports which either fall into 120 or 50 points respectively.

tl;dr They're way too good of killer deals at 150.
## Changelog
:cl:
balance: SVD and HPR now cost 300 points to buy in Requisitions instead of 150 to reflect their status.
/:cl:
