### PR TITLE
Sentry tank fix

### DIFF
--- a/code/modules/projectiles/gun_attachables/rail.dm
+++ b/code/modules/projectiles/gun_attachables/rail.dm
@@ -145,20 +145,6 @@
 	. = ..()
 	ENABLE_BITFIELD(master_gun.item_flags, IS_DEPLOYABLE)
 	master_gun.deployable_item = /obj/machinery/deployable/mounted/sentry/buildasentry
-	master_gun.ignored_terrains = list(
-		/obj/machinery/deployable/mounted,
-		/obj/machinery/miner,
-	)
-	if(master_gun.ammo_datum_type && CHECK_BITFIELD(initial(master_gun.ammo_datum_type.ammo_behavior_flags), AMMO_ENERGY) || istype(master_gun, /obj/item/weapon/gun/energy)) //If the guns ammo is energy, the sentry will shoot at things past windows.
-		master_gun.ignored_terrains += list(
-			/obj/structure/window,
-			/obj/structure/window/reinforced,
-			/obj/machinery/door/window,
-			/obj/structure/window/framed,
-			/obj/structure/window/framed/colony,
-			/obj/structure/window/framed/mainship,
-			/obj/structure/window/framed/prison,
-		)
 	master_gun.turret_flags |= TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
 	master_gun.AddComponent(/datum/component/deployable_item, master_gun.deployable_item, deploy_time, undeploy_time)
 	update_icon()
@@ -168,6 +154,5 @@
 	var/obj/item/weapon/gun/detaching_gun = detaching_item
 	DISABLE_BITFIELD(detaching_gun.item_flags, IS_DEPLOYABLE)
 	qdel(detaching_gun.GetComponent(/datum/component/deployable_item))
-	detaching_gun.ignored_terrains = null
 	detaching_gun.deployable_item = null
 	detaching_gun.turret_flags &= ~(TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -372,8 +372,6 @@
 	var/undeploy_time = 0
 	///If the gun is deployed, change the scatter amount by this number. Negative reduces scatter, positive adds.
 	var/deployed_scatter_change = 0
-	///List of turf/objects/structures that will be ignored in the sentries targeting.
-	var/list/ignored_terrains
 	///Flags that the deployed sentry uses upon deployment.
 	var/turret_flags = NONE
 	///Damage threshold for whether a turret will be knocked down.

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -16,14 +16,6 @@
 	scatter_unwielded = 0
 	burst_scatter_mult = 0
 	burst_amount = 4
-
-	ignored_terrains = list(
-		/obj/machinery/deployable/mounted,
-		/obj/machinery/miner,
-		/obj/hitbox,
-		/obj/vehicle/sealed/armored/multitile,
-	)
-
 	turret_flags = TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
 	gun_features_flags = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_IFF|GUN_SMOKE_PARTICLES
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
@@ -107,13 +99,6 @@
 	sentry_iff_signal = SOM_IFF
 
 	soft_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 80, ACID = 50)
-
-	ignored_terrains = list(
-		/obj/machinery/deployable/mounted,
-		/obj/machinery/miner,
-		/obj/hitbox,
-		/obj/vehicle/sealed/armored/multitile,
-	)
 
 	gun_features_flags = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_ENERGY|GUN_SMOKE_PARTICLES
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_DO_NOT_EJECT_HANDFULS|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE //doesn't autoeject its recharging battery

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -1,3 +1,14 @@
+GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
+
+///Creates the list of atoms that will be ignored by sentry target pathing
+/proc/set_sentry_ignore_List()
+	. = list(
+		/obj/machinery/deployable/mounted,
+		/obj/machinery/miner,
+	)
+	. += typesof(/obj/hitbox)
+	. += typesof(/obj/vehicle/sealed/armored/multitile)
+
 /obj/machinery/deployable/mounted/sentry
 	resistance_flags = UNACIDABLE|XENO_DAMAGEABLE
 	use_power = 0
@@ -22,8 +33,6 @@
 	var/obj/item/radio/radio
 	///Iff signal of the sentry. If the /gun has a set IFF then this will be the same as that. If not the sentry will get its IFF signal from the deployer
 	var/iff_signal = NONE
-	///List of terrains/structures/machines that the sentry ignores for targetting. (If a window is inside the list, the sentry will shot at targets even if the window breaks los) For accuracy, this is on a specific typepath base and not istype().
-	var/list/ignored_terrains
 	///For minimap icon change if sentry is firing
 	var/firing
 
@@ -42,7 +51,6 @@
 
 	knockdown_threshold = gun?.knockdown_threshold ? gun.knockdown_threshold : initial(gun.knockdown_threshold)
 	range = CHECK_BITFIELD(gun.turret_flags, TURRET_RADIAL) ?  gun.turret_range - 2 : gun.turret_range
-	ignored_terrains = gun?.ignored_terrains ? gun.ignored_terrains : initial(gun.ignored_terrains)
 
 	radio = new(src)
 
@@ -478,7 +486,7 @@
 		if(smoke?.opacity)
 			return FALSE
 
-		if(IS_OPAQUE_TURF(T) || T.density && !(T.allow_pass_flags & PASS_PROJECTILE) && !(T.type in ignored_terrains))
+		if(IS_OPAQUE_TURF(T) || T.density && !(T.allow_pass_flags & PASS_PROJECTILE) && !(T.type in GLOB.sentry_ignore_List))
 			return FALSE
 
 		for(var/atom/movable/AM AS in T)
@@ -490,7 +498,7 @@
 				continue
 			if(ismob(AM))
 				continue
-			if(AM.type in ignored_terrains) //todo:accurately populate ignored_terrains
+			if(AM.type in GLOB.sentry_ignore_List) //todo:accurately populate GLOB.sentry_ignore_List
 				continue
 			if(AM.allow_pass_flags & (gun.ammo_datum_type::ammo_behavior_flags & AMMO_ENERGY ? (PASS_GLASS|PASS_PROJECTILE) : PASS_PROJECTILE))
 				continue


### PR DESCRIPTION

## About The Pull Request
Sentries will now properly target tanks, and hostiles behind/on top of them.

Also cleaned up the ignore list by making it a glob instead of a gun var. There should no longer be a need for any snowflake there since I baked in laser checks into the actual targeting proc a while ago.
## Why It's Good For The Game
Bug fix, cleaner code.
## Changelog
:cl:
fix: fixed sentry targetting being blocked by tanks
/:cl:
