### PR TITLE
Tank coilgun tweaks

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -576,13 +576,13 @@
 	accurate_range = 20
 	max_range = 40
 	damage = 300
-	penetration = 40
+	penetration = 50
 	sundering = 10
 	bullet_color = LIGHT_COLOR_TUNGSTEN
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/coilgun/drop_nade(turf/T)
-	explosion(T, 0, 3, 5)
+	explosion(T, 0, 3, 5, 0, 2)
 
 /datum/ammo/rocket/coilgun/holder //only used for tankside effect checks
 	ammo_behavior_flags = AMMO_ENERGY
@@ -590,7 +590,7 @@
 /datum/ammo/rocket/coilgun/low
 	shell_speed = 2
 	damage = 150
-	penetration = 25
+	penetration = 40
 	sundering = 5
 
 /datum/ammo/rocket/coilgun/low/drop_nade(turf/T)


### PR DESCRIPTION

## About The Pull Request
Low power mode now has 40 AP instead of 25.
Medium power has 50 AP instead of 40, and has 2 flash range like high power mode.
## Why It's Good For The Game
Generally low and med power mode aren't that useful currently.

This change means low power mode is now actually the highest DPS option against enemy vehicles, at the cost of burning through ammo exceptionally fast. This means a fully crewed tank can get optimal damage if they have a loader doing their job well. Bonus points if you switch back to high power as the finishing blow.

Med power is now a bit more viable, but still probably the weakest, although when it comes to simply shredding infantry, its likely more effective than high power, but the lack of neuron activation due to no gibs is big.
## Changelog
:cl:
balance: Campaign: Buffed Hovertank coilgun low and medium power modes slightly
/:cl:
