### PR TITLE
Sentry density fix

### DIFF
--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -142,7 +142,7 @@
 		span_notice("You set [src] upright."))
 
 	DISABLE_BITFIELD(machine_stat, KNOCKED_DOWN)
-	density = TRUE
+	density = initial(density)
 	set_on(TRUE)
 
 /obj/machinery/deployable/mounted/sentry/reload(mob/user, ammo_magazine)


### PR DESCRIPTION

## About The Pull Request
Putting a sentry back up will no longer make it dense if it wasn't orignally so.
## Why It's Good For The Game
Funny dense COPE sentries.
## Changelog
:cl:
fix: Putting a sentry back up will no longer make it dense if it wasn't orignally so
/:cl:
