### PR TITLE
Coilgun bind fix

### DIFF
--- a/code/modules/vehicles/armored/som_armored_weapons.dm
+++ b/code/modules/vehicles/armored/som_armored_weapons.dm
@@ -247,7 +247,7 @@
 
 /datum/action/item_action/coilgun_power
 	keybinding_signals = list(
-		KEYBINDING_ALTERNATE = COMSIG_KB_FIREMODE,
+		KEYBINDING_NORMAL = COMSIG_KB_FIREMODE,
 	)
 	use_obj_appeareance = FALSE
 	///The coilgun associated with this action
@@ -264,6 +264,8 @@
 	if(!.)
 		return
 	update_button_icon()
+
+//
 
 /datum/action/item_action/coilgun_power/update_button_icon()
 	action_icon_state = "coilgun_[holder_gun.power_level]"

--- a/code/modules/vehicles/armored/som_armored_weapons.dm
+++ b/code/modules/vehicles/armored/som_armored_weapons.dm
@@ -265,8 +265,6 @@
 		return
 	update_button_icon()
 
-//
-
 /datum/action/item_action/coilgun_power/update_button_icon()
 	action_icon_state = "coilgun_[holder_gun.power_level]"
 	switch(holder_gun.power_level)


### PR DESCRIPTION

## About The Pull Request
The keybind for cycling through coilgun firemodes (swapping firemode bind) now actually works.

:cl:
fix: Fixed the hovertank coilgun hotkey
/:cl:
