### PR TITLE
Increases the price of SG factory refills

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2275,22 +2275,22 @@ FACTORY
 /datum/supply_packs/factory/smartgun_minigun_box_refill
 	name = "SG-85 ammo bin parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_minigun_box_refill)
-	cost = 250
+	cost = 400
 
 /datum/supply_packs/factory/smartgun_magazine_refill
 	name = "SG-29 ammo drum parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_machinegun_magazine_refill)
-	cost = 250
+	cost = 400
 
 /datum/supply_packs/factory/smartgun_targetrifle_refill
 	name = "SG-62 ammo magazine parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_targetrifle_magazine_refill)
-	cost = 250
+	cost = 400
 
 /datum/supply_packs/factory/smartgun_targetrifle_ammobin_refill
 	name = "SG-62 ammo bin parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_targetrifle_ammobin_refill)
-	cost = 250
+	cost = 400
 
 /datum/supply_packs/factory/autosniper_magazine_refill
 	name = "SR-81 IFF Auto Sniper magazine assembly refill"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2275,12 +2275,12 @@ FACTORY
 /datum/supply_packs/factory/smartgun_minigun_box_refill
 	name = "SG-85 ammo bin parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_minigun_box_refill)
-	cost = 400
+	cost = 350
 
 /datum/supply_packs/factory/smartgun_magazine_refill
 	name = "SG-29 ammo drum parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_machinegun_magazine_refill)
-	cost = 400
+	cost = 350
 
 /datum/supply_packs/factory/smartgun_targetrifle_refill
 	name = "SG-62 ammo magazine parts refill"


### PR DESCRIPTION
## About The Pull Request
Smartgun reqtorio is insanely efficient for how basic SG drums are - each reqtorio refill provides 10 t29 drums or t85 bins for half the price of manually bought drums/bins. With the t62, this is even worse - ~700 points worth of t62 magazines for 250 points (this one is admittedly my fault)

to make things worse, all of the factory parts are available for free within the req vendor, meaning there's no "break-even point" where factory production of SG ammo becomes more efficient than buying it. Reqtorio simply *made sg cheaper*, outright for just a minute of setup.

This PR tones down the efficiency of reqtorio to ~130% (from 200%) for t29&t85 ammo, and 175% (from 280%) for t62 magazines. Still cheaper than just buying it outright, but less so.
## Why It's Good For The Game
2x ammo for sgs dawg 😭 
who merged this shit... 😭 
## Changelog
:cl:
balance: SG-29 reqtorio drum refill 250 -> 350 points
balance: SG-85 reqtorio bin refill 250 -> 350 points
balance: SG-62 reqtorio magazine refill 250 -> 400 points
balance: SG-62 reqtorio ammo bin refill 250 -> 400 points
/:cl:
