### PR TITLE
AGLS frag fix

### DIFF
--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -27,7 +27,7 @@
 
 
 /datum/ammo/ags_shrapnel/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/det_turf = get_turf(target_mob)
+	var/turf/det_turf = get_step_towards(target_mob, proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_mob), loc_override = det_turf)
 


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/e0d03f45-89ef-4427-83c9-07d7b25649e1)

xope pr.

AGLS frag wasn't intended to be able to hit one target with 15 projectiles at once (450 damage!), for pretty obvious reasons.
## Why It's Good For The Game
Funny insta kill goes brrr
## Changelog
:cl:
fix: fixed AGLS frag rounds detonating under mobs
/:cl:
