### PR TITLE
Suppressor makes bullets less visible

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -355,7 +355,7 @@
 			set_light_color(ammo.bullet_color)
 			set_light_on(TRUE)
 	else
-		alpha = 32
+		alpha = 64
 
 	START_PROCESSING(SSprojectiles, src) //If no hits on the first moves, enter the processing queue for next.
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -350,9 +350,12 @@
 	if(QDELETED(src))
 		return
 
-	if(!suppress_light && ammo.bullet_color)
-		set_light_color(ammo.bullet_color)
-		set_light_on(TRUE)
+	if(!suppress_light)
+		if(ammo.bullet_color)
+			set_light_color(ammo.bullet_color)
+			set_light_on(TRUE)
+	else
+		alpha = 32
 
 	START_PROCESSING(SSprojectiles, src) //If no hits on the first moves, enter the processing queue for next.
 


### PR DESCRIPTION
## About The Pull Request
This PR gives suppressor a unique mechanic of making fired bullets a bit less visible. Before - After.
![readydefault](https://github.com/user-attachments/assets/86db042b-1ba6-421e-84b2-25655e4e6f24)![ready64](https://github.com/user-attachments/assets/f6d934ef-ad46-4b2a-9b5d-f27c92f9908a)
## Why It's Good For The Game
A suppressor does hide a muzzle flash and bullets don't emit light, but it's almost useless, because they are still obviously visible and it makes almost no noticable difference. It's still like firing tracer bullets. A suppressor doesn't fully represent "spec ops" or "tacticool" (whatever you name it) vibes and it's a bit dissapointing. It has some good points but truly isn't the best choice at anything (either accuracy, recoil or scatter, not even mentioning its noticable downsides). This PR grants a suppressor truly unique feature, perhaps giving marines a bit more subtle way of playing (not just run n' gun).
You may call it "suppressor buff" but I'd insist on calling it "uncovering its potential". Suppressor should be about making a gun more "subtle", more "delicate", more "finesse". Thus a suppressor will become a truly unique attachement, not just "ordinary extended barrel alternative".
## Changelog
:cl:
add: Suppressor makes bullets less visible.
/:cl:
