### PR TITLE
Agls fix but actually epic (rewards the user for the incredible thing known as actually hitting your target)

### DIFF
--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -19,7 +19,9 @@
 	shell_speed = 2
 	accurate_range = 12
 	max_range = 21
-	damage = 15
+	damage = 90
+	penetration = 5
+	sundering = 15
 	shrapnel_chance = 0
 	bonus_projectiles_type = /datum/ammo/bullet/ags_spread
 	bonus_projectiles_scatter = 20
@@ -27,7 +29,7 @@
 
 
 /datum/ammo/ags_shrapnel/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/turf/det_turf = get_turf(target_mob)
+	var/turf/det_turf = get_step_towards(target_mob, proj)
 	playsound(det_turf, SFX_EXPLOSION_MICRO, 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_mob), loc_override = det_turf)
 

--- a/code/modules/projectiles/ammo_types/ags_ammo.dm
+++ b/code/modules/projectiles/ammo_types/ags_ammo.dm
@@ -19,7 +19,7 @@
 	shell_speed = 2
 	accurate_range = 12
 	max_range = 21
-	damage = 90
+	damage = 75
 	penetration = 5
 	sundering = 15
 	shrapnel_chance = 0


### PR DESCRIPTION
## About The Pull Request
Lumi's AGLS fix got it to not instakill benos which was crigne, but also made it a worse, mounted GL-54, with worse TTK and abysmally dogshit damage. This keeps the AGLS from detonating under xenos still and doing massive fuckoff damage (450 damage is the thing of a Marine's wildest wet dreams), but still makes it a usable weapon worth the 700 req point price by rewarding players for actually scoring direct hits with grenades.
## Why It's Good For The Game
Read above. In short, makes a 700 point gun not dogshit but also doesn't make it game breaking. For any kind of actual damage to be done, you need to be parking grenades on beno heads.
## Changelog
:cl:
balance: rebalanced AGLS, Incresed grenade damage to 75 with 5 AP and 15 sunder.
/:cl:
