### PR TITLE
Increases devastation damage by 100 against xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -33,7 +33,7 @@
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			ex_damage = rand(190, 210)
+			ex_damage = rand(290, 310)
 			stagger_amount = 4 * bomb_armor_ratio - 1
 			slowdown_amount = 5 * bomb_armor_ratio
 			sunder_amount = 30 * bomb_armor_ratio


### PR DESCRIPTION
## About The Pull Request

See title

## Why It's Good For The Game

Devastation has been somewhat iffy for a while. In general, devastation explosions are hard to land. CAS rockets, OBs, suicide vests etc. are some of the few ways that devastation explosions can occur, but they're also extremely hard to land. Xeno buffs have made devastation less impactful, and it rarely gibs xenomorphs.

## Changelog

:cl: Joe13413
balance: Devastation does 100 more damage to xenomorphs
/:cl:
