### PR TITLE
Tank space fix

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -149,7 +149,10 @@
 	var/new_z = (z != oldloc.z)
 	for(var/mob/living/tank_desant AS in tank_desants)
 		tank_desant.set_glide_size(root.glide_size)
-		tank_desant.forceMove(new_z ? loc : get_step(tank_desant, direction)) //For simplicity we just move desants to the middle of the tank on z change to avoid various issues
+		if(new_z)
+			tank_desant.abstract_move(loc) //todo: have some better code to actually preserve their location
+		else
+			tank_desant.forceMove(get_step(tank_desant, direction))
 		if(isxeno(tank_desant))
 			continue
 		if(move_dist > 1)


### PR DESCRIPTION

## About The Pull Request
You will no longer get a permanent space debuff for riding a tank across z-levels.

:cl:
fix: fixed mobs getting perma space debuff when riding tanks across z-levels
/:cl:
