### PR TITLE
The lobby screen cycles icon states, done properly

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -270,14 +270,18 @@
 	name = "Space Station 13"
 	icon = 'icons/misc/title.dmi'
 	icon_state = "title_painting1"
-//	icon_state = "title_holiday"
 	layer = FLY_LAYER
 	pixel_x = -64
 
-/turf/closed/wall/indestructible/splashscreen/New()
-	..()
-	if(icon_state == "title_painting1")
-		icon_state = "title_painting[rand(0,35)]"
+/turf/closed/wall/indestructible/splashscreen/Initialize(mapload, ...)
+	. = ..()
+	random_splashscreen(TRUE)
+
+/// Changes the icon_state to a random splash screen
+/turf/closed/wall/indestructible/splashscreen/proc/random_splashscreen(initial_run = FALSE)
+	var/list/possible_icon_states = initial_run ? icon_states(icon) : icon_states(icon) - icon_state
+	icon_state = "[pick(possible_icon_states)]"
+	addtimer(CALLBACK(src, PROC_REF(random_splashscreen)), 1 MINUTES)
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"


### PR DESCRIPTION

## About The Pull Request
No vars at all edition.
The lobby screen changes to a random icon state every minute.
## Why It's Good For The Game

Should spice up the lobby screen a bit, make it more dynamic.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
:cl:
add: The lobby screen now changes randomly every minute
/:cl:
