### PR TITLE
Fire fixes and code improvement

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -51,8 +51,6 @@
 		return
 	if(CHECK_BITFIELD(O.pass_flags, PASS_DEFENSIVE_STRUCTURE))
 		return
-	if(HAS_TRAIT(O, TRAIT_TANK_DESANT))
-		return
 	var/mob/living/M = O
 	if(M.status_flags & INCORPOREAL)
 		return

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -181,7 +181,7 @@
 	if(human_affected.pass_flags & PASS_FIRE)
 		return FALSE
 	if(human_affected.hard_armor.getRating(FIRE) >= 100)
-		to_chat(src, span_warning("You are untouched by the flames."))
+		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
 	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
 	if(debuff)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -159,20 +159,15 @@
 /obj/fire/flamer/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
 	if(!isliving(crosser) || isobj(crosser))
 		return
-	if(HAS_TRAIT(crosser, TRAIT_TANK_DESANT))
-		return
 	crosser.fire_act(burn_level)
 
 /obj/fire/flamer/affect_mob(mob/living/carbon/affected)
-	. = ..()
 	affected.fire_act(burn_level)
 
 /obj/fire/flamer/affect_obj(obj/affected)
-	. = ..()
 	affected.fire_act(burn_level)
 
 /obj/fire/flamer/affect_turf(turf/affected)
-	. = ..()
 	affected.fire_act(burn_level)
 
 /obj/fire/flamer/process()

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -12,7 +12,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "red_2"
-	layer = BELOW_OBJ_LAYER
+	plane = FLOOR_PLANE
+	layer = MOB_LAYER
 	light_system = MOVABLE_LIGHT
 	light_mask_type = /atom/movable/lighting_mask/flicker
 	light_on = TRUE
@@ -50,7 +51,7 @@
 			light_intensity = 2
 		if(10 to 25)
 			light_intensity = 4
-		if(25 to INFINITY) //Change the icons and luminosity based on the fire_base's intensity
+		if(25 to INFINITY)
 			light_intensity = 6
 	set_light_range_power_color(light_intensity, light_power, light_color)
 
@@ -68,66 +69,56 @@
 			icon_state = "[flame_color]_1"
 		if(10 to 25)
 			icon_state = "[flame_color]_2"
-		if(25 to INFINITY) //Change the icons and luminosity based on the fire_base's intensity
+		if(25 to INFINITY)
 			icon_state = "[flame_color]_3"
 
 
-///Sets the fire_base object to the correct colour and fire_base values, and applies the initial effects to any mob on the turf
+///Sets the fire_base object to the correct colour and fire_base values, and applies the initial effects to anything on the turf
 /obj/fire/proc/set_fire(burn_ticks, burn_level, f_color, fire_stacks = 0, fire_damage = 0)
-	if(burn_ticks < 0)
+	if(burn_ticks <= 0)
 		qdel(src)
 		return
 
-	if(f_color && (flame_color != f_color))
+	if(f_color)
 		flame_color = f_color
-
-	if(!GLOB.flamer_particles[flame_color])
-		GLOB.flamer_particles[flame_color] = new /particles/flamer_fire(flame_color)
-
-	particles = GLOB.flamer_particles[flame_color]
 	if(burn_ticks)
 		src.burn_ticks = burn_ticks
 	if(burn_level)
 		src.burn_level = burn_level
+	if(!GLOB.flamer_particles[flame_color])
+		GLOB.flamer_particles[flame_color] = new /particles/flamer_fire(flame_color)
+
+	particles = GLOB.flamer_particles[flame_color]
 	update_appearance(UPDATE_ICON)
 
-	if((fire_stacks+fire_damage)==0)
+	if((fire_stacks + fire_damage) <= 0)
 		return
 
-	for(var/mob/living/C in get_turf(src))
-		affect_mob(C)
+	for(var/thing in get_turf(src))
+		affect_atom(thing)
 
 ///Effects applied to anything that crosses a burning turf
 /obj/fire/proc/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
 	SIGNAL_HANDLER
-	return
+	affect_atom(crosser)
 
 /// Effects applied from smokes
 /obj/fire/effect_smoke(obj/effect/particle_effect/smoke/affecting_smoke)
-	if(!CHECK_BITFIELD(affecting_smoke.smoke_traits, SMOKE_EXTINGUISH)) //Fire suppressing smoke
+	if(!CHECK_BITFIELD(affecting_smoke.smoke_traits, SMOKE_EXTINGUISH))
 		return
 	burn_ticks -= 20 //Water level extinguish
-	if(burn_ticks < 1) //Extinguish if our burn_ticks is less than 1
+	if(burn_ticks <= 0)
 		playsound(affecting_smoke, 'sound/effects/smoke_extinguish.ogg', 20)
 		qdel(src)
 		return
 	update_appearance(UPDATE_ICON)
 
-/// Called on all objects on a turf on process(). Doesn't include the turf itself
-/obj/fire/proc/affect_mob(mob/living/carbon/affected)
-	return
-
-/// Called on the turf we are currently burning
-/obj/fire/proc/affect_turf(turf/affected)
-	return
-
-/// Called on all objs on the turf we are on
-/obj/fire/proc/affect_obj(obj/affected)
+///Applies effects to an atom
+/obj/fire/proc/affect_atom(atom/affected)
 	return
 
 /obj/fire/process()
-	var/turf/burn_turf = loc
-	if(!istype(burn_turf)) //Is it a valid turf?
+	if(!isturf(loc))
 		qdel(src)
 		return
 
@@ -136,14 +127,9 @@
 		qdel(src)
 		return PROCESS_KILL
 
-	affect_turf(burn_turf)
-	for(var/atom/thing AS in burn_turf)
-		if(isliving(thing))
-			affect_mob(thing)
-			continue
-		if(isobj(thing))
-			affect_obj(thing)
-			continue
+	affect_atom(loc)
+	for(var/thing in loc)
+		affect_atom(thing)
 
 	update_appearance(UPDATE_ICON)
 
@@ -161,19 +147,13 @@
 		return
 	crosser.fire_act(burn_level)
 
-/obj/fire/flamer/affect_mob(mob/living/carbon/affected)
-	affected.fire_act(burn_level)
-
-/obj/fire/flamer/affect_obj(obj/affected)
-	affected.fire_act(burn_level)
-
-/obj/fire/flamer/affect_turf(turf/affected)
+/obj/fire/flamer/affect_atom(atom/affected)
 	affected.fire_act(burn_level)
 
 /obj/fire/flamer/process()
 	. = ..()
-	burn_level = max(0, burn_level - 2)
-	if(burn_level == 0)
+	burn_level -= 2
+	if(burn_level <= 0)
 		qdel(src)
 		return PROCESS_KILL
 
@@ -190,28 +170,22 @@
 	burn_ticks = 36
 	burn_decay = 9
 
-/// affecting mobs
-/obj/fire/melting_fire/affect_mob(mob/living/carbon/target)
-	if(isxeno(target))
+/obj/fire/melting_fire/affect_atom(atom/affected)
+	if(!ishuman(affected))
 		return
-	if(target.stat == DEAD)
+	var/mob/living/carbon/human/human_affected = affected
+	if(human_affected.stat == DEAD)
 		return
-	if(status_flags & (INCORPOREAL|GODMODE))
+	if(human_affected.status_flags & (INCORPOREAL|GODMODE))
 		return FALSE
-	if(hard_armor.getRating(FIRE) >= 100)
+	if(human_affected.pass_flags & PASS_FIRE)
+		return FALSE
+	if(human_affected.hard_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return FALSE
-	if(pass_flags & PASS_FIRE)
-		return FALSE
-	var/damage = PYROGEN_MELTING_FIRE_DAMAGE
-	var/datum/status_effect/stacking/melting_fire/debuff = target.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
+	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
 	if(debuff)
 		debuff.add_stacks(PYROGEN_MELTING_FIRE_EFFECT_STACK)
 	else
-		target.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK)
-	target.take_overall_damage(damage, BURN, FIRE, max_limbs = 2)
-
-/obj/fire/melting_fire/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
-	if(!ishuman(crosser))
-		return
-	affect_mob(crosser)
+		human_affected.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK)
+	human_affected.take_overall_damage(PYROGEN_MELTING_FIRE_DAMAGE, BURN, FIRE, max_limbs = 2)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -141,12 +141,6 @@
 	icon_state = "red_2"
 	burn_ticks = 12
 
-///Effects applied to a mob that crosses a burning turf
-/obj/fire/flamer/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
-	if(!isliving(crosser) || isobj(crosser))
-		return
-	crosser.fire_act(burn_level)
-
 /obj/fire/flamer/affect_atom(atom/affected)
 	affected.fire_act(burn_level)
 

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -26,6 +26,8 @@
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,
 	)
+	///pass_flags given to desants, in addition to the vehicle's pass_flags
+	var/desant_pass_flags = PASS_FIRE|PASS_LOW_STRUCTURE
 
 /obj/vehicle/sealed/armored/multitile/enter_locations(atom/movable/entering_thing)
 	return list(get_step_away(get_step(src, REVERSE_DIR(dir)), src, 2))
@@ -40,10 +42,10 @@
 	return (loc_override || (entering_mob.loc in enter_locations(entering_mob)))
 
 /obj/vehicle/sealed/armored/multitile/add_desant(mob/living/new_desant)
-	new_desant.pass_flags |= pass_flags
+	new_desant.pass_flags |= (desant_pass_flags|pass_flags)
 
 /obj/vehicle/sealed/armored/multitile/remove_desant(mob/living/old_desant)
-	old_desant.pass_flags &= ~pass_flags
+	old_desant.pass_flags &= ~(desant_pass_flags|pass_flags)
 
 /obj/vehicle/sealed/armored/multitile/ex_act(severity)
 	if(QDELETED(src))


### PR DESCRIPTION

## About The Pull Request
Fixes tank desants getting burned by fire in some cases but not others

Related fix that makes multitile vehicles have some baseline pass flags given to desant (in addition to the tank's own passflags, as current).
Connected to the above, removed a desant trait check for razorwire that should now be redundant.

Fixed xeno fire incorrectly referencing itself instead of the victim for a couple of checks.

Cleaned up fire code to be a bit simpler/consistant. Mainly there is just a single affect_atom proc instead of 3 different ones that ultimately just did the same thing in all cases. Some code cleanup as well.
## Why It's Good For The Game
Bug fixes and code improvement.
## Changelog
:cl:
fix: Fixed some fire bugs, notably fire will now correctly not effect people on tanks
code: Cleaned up some fire code
/:cl:
