### PR TITLE
Fire fixes

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -276,3 +276,6 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define CATWALK_ROD_REQ 4
 ///Rods needed to reinforce a floor
 #define REINFORCED_FLOOR_ROD_REQ 2
+
+///Amount of fire stacks removed by extinguishers or similar effects
+#define EXTINGUISH_AMOUNT 20

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1095,7 +1095,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 					W.reagents.reaction(atm)
 					if(isfire(atm))
 						var/obj/fire/FF = atm
-						FF.set_fire(FF.burn_ticks - 20)
+						FF.set_fire(FF.burn_ticks - EXTINGUISH_AMOUNT)
 						continue
 					if(isliving(atm)) //For extinguishing mobs on fire
 						var/mob/living/M = atm

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -12,8 +12,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "red_2"
-	plane = FLOOR_PLANE
-	layer = MOB_LAYER
+	layer = BELOW_OBJ_LAYER
 	light_system = MOVABLE_LIGHT
 	light_mask_type = /atom/movable/lighting_mask/flicker
 	light_on = TRUE

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -87,6 +87,16 @@
 
 	update_appearance(UPDATE_ICON)
 
+/obj/fire/effect_smoke(obj/effect/particle_effect/smoke/affecting_smoke)
+	if(!CHECK_BITFIELD(affecting_smoke.smoke_traits, SMOKE_EXTINGUISH))
+		return
+	burn_ticks -= EXTINGUISH_AMOUNT
+	if(burn_ticks <= 0)
+		playsound(affecting_smoke, 'sound/effects/smoke_extinguish.ogg', 20)
+		qdel(src)
+		return
+	update_appearance(UPDATE_ICON)
+
 ///Sets the fire_base object to the correct colour and fire_base values, and applies the initial effects to anything on the turf
 /obj/fire/proc/set_fire(new_burn_ticks, new_burn_level, new_flame_color, fire_stacks = 0, fire_damage = 0)
 	if(new_burn_ticks <= 0)
@@ -115,17 +125,6 @@
 /obj/fire/proc/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
 	SIGNAL_HANDLER
 	affect_atom(crosser)
-
-/// Effects applied from smokes
-/obj/fire/effect_smoke(obj/effect/particle_effect/smoke/affecting_smoke)
-	if(!CHECK_BITFIELD(affecting_smoke.smoke_traits, SMOKE_EXTINGUISH))
-		return
-	burn_ticks -= 20 //Water level extinguish
-	if(burn_ticks <= 0)
-		playsound(affecting_smoke, 'sound/effects/smoke_extinguish.ogg', 20)
-		qdel(src)
-		return
-	update_appearance(UPDATE_ICON)
 
 ///Applies effects to an atom
 /obj/fire/proc/affect_atom(atom/affected)


### PR DESCRIPTION
## About The Pull Request
Fix fire layering under resin walls.

Fixes pyrogen fire not spawning correctly.

Update some arg names as I hate proc args with the same name as vars, it makes it needlessly confusing.

Moved a couple of procs so they're in the right order, and made an extinguish amount define since it's used in two unrelated places.

:cl:
fix: fixed some fire bugs
/:cl:
