### PR TITLE
Nerfs GL54/AR55 Airburst Sunder

### DIFF
--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -136,7 +136,7 @@
 	shell_speed = 3
 	damage = 20
 	penetration = 20
-	sundering = 3
+	sundering = 1.5
 	damage_falloff = 0
 
 /datum/ammo/bullet/tx54_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)


### PR DESCRIPTION
## About The Pull Request
Alternative to #16507.

Reduces the sunder on the tx54 airburst from 3 per pellet to 1.5 (21 total to 10.5). This reduces the sunder per second from 17.5 (higher than scout rifle's 12.5) to 8.75 (higher than flechette's 8.5).
## Why It's Good For The Game
These guns can crit a queen in 6 shots, and even hitting a queen twice is enough to force them to disengage or risk being mowed down by the marines.

Free weapons should not be invalidating all large castes.
## Changelog
:cl:
balance: GL54 and AR55 Airburst sunder reduced from 3 per pellet to 1.5.
/:cl:
