### PR TITLE
Warlock blast AOE now makes you jiggle around for a bit

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -45,6 +45,7 @@
 				if(!isxeno(living_victim))
 					living_victim.apply_damage(aoe_damage, BURN, null, ENERGY, FALSE, FALSE, TRUE, penetration)
 					staggerstun(living_victim, P, 10, slowdown = 1)
+					living_victim.do_jitter_animation(500)
 			else if(isobj(target))
 				var/obj/obj_victim = target
 				var/dam_mult = 1


### PR DESCRIPTION

## About The Pull Request
See title
## Why It's Good For The Game
Without knockback it can be kinda hard to immediately tell who's been hit by the AOE and who hasn't if you don't have a medhud or something. It's just nice to know.

You can already tell if the laser beam hits you.
## Changelog
:cl:
qol: Warlock blast now shakes your sprite if the AOE hits you.
/:cl:
