### PR TITLE
Increases LV624 quickbuild

### DIFF
--- a/_maps/lv624.json
+++ b/_maps/lv624.json
@@ -6,7 +6,7 @@
 		"basic": 1
 	},
     "armor": "jungle",
-	"quickbuilds": 1400,
+	"quickbuilds": 2000,
 	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a third generation colony, known as LV-624. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
 	"traits":[{
 		"weather_acidrain": true


### PR DESCRIPTION

## About The Pull Request
Increases quickbuild on LV624 (old LV) to 2000 from 1400.
## Why It's Good For The Game
This map has a lot of open space and 1400 is laughably low. On the rare chance this map is run as an event this should help xenos not feel naked the whole time.
## Changelog
:cl:
balance: Increased quickbuild on LV624 to 2000 from 1400.
/:cl:
