### PR TITLE
Tank desant targeting

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -390,6 +390,8 @@
 	for(var/mob/living/carbon/human/crew AS in occupants)
 		if(crew.wear_id?.iff_signal & proj.iff_signal)
 			return FALSE
+	if(src == proj.shot_from)
+		return FALSE
 	if(src == proj.original_target)
 		return TRUE
 	if(!hitbox)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -390,6 +390,14 @@
 	for(var/mob/living/carbon/human/crew AS in occupants)
 		if(crew.wear_id?.iff_signal & proj.iff_signal)
 			return FALSE
+	if(src == proj.original_target)
+		return TRUE
+	if(!hitbox)
+		return ..()
+	if(proj.firer in hitbox.tank_desants)
+		return FALSE
+	if(proj.original_target in hitbox.tank_desants)
+		return FALSE
 	return ..()
 
 /obj/vehicle/sealed/armored/attack_hand(mob/living/user)


### PR DESCRIPTION

## About The Pull Request
If you are on a tank, you can now shoot without hitting the tank (unless you specifically aim at it).

If you are shooting at someone ON a tank, you will no longer hit the tank either. Note however this requires you to specifically target the desant, so misclicks will hit the tank still.
## Why It's Good For The Game
No more desant weirdness with targeting.
## Changelog
:cl:
balance: Tank riders can shoot, and be shot, freely without projectiles hitting the tank
/:cl:
