### PR TITLE
LTB Tank cannon rebalance 

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -75,7 +75,7 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 125
+	damage = 100
 	hud_state = "bigshell_he"
 	sundering = 20
 	barricade_clear_distance = 4

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -75,18 +75,16 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 200
+	damage = 125
 	hud_state = "bigshell_he"
 	sundering = 20
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3)
+	explosion(T, 0, 3, 5, 0, 3)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(target_mob))
-	if(!isxeno(target_mob))
-		target_mob.gib()
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
 	explosion(target_turf, 1, 4, 6, 0, 3)
@@ -508,11 +506,11 @@
 	bonus_projectiles_type = /datum/ammo/bullet/atgun_spread/incendiary
 
 /datum/ammo/bullet/tank_apfds
-	name = "8.8cm APFDS round"
+	name = "1.05cm APFDS round"
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 300
+	damage = 200
 	penetration = 75
 	shell_speed = 4
 	accurate_range = 24
@@ -525,8 +523,6 @@
 
 /datum/ammo/bullet/tank_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	proj.proj_max_range -= 2
-	if(ishuman(target_mob) && prob(35))
-		target_mob.gib()
 
 /datum/ammo/bullet/tank_apfds/on_hit_obj(obj/target_object, obj/projectile/proj)
 	if(!isvehicle(target_object) && !ishitbox(target_object))


### PR DESCRIPTION

## About The Pull Request
LTB rebalance.
First off, none of the rounds gib humans anymore.
HE direct hit now does damage more compareable to an RR rocket than a SADAR rocket. Being 100 damage rather than 200. It now has an extra tile of 'heavy' explosion AoE.
APFDS now does 200 damage rather than 300
## Why It's Good For The Game
The cannon on the tank deals frankly too much damage for how sturdy it is, alongside being unstunnable. I don't think the justification of 'oh it'll gib you AND or a marine if you hit them!' is great justification. As there's other things that could gib on hit as well. I do not think profileration of gibs outside of OB's is a good thing for HvX gameplay.

There should probably be tank ammo specific to HvH, however.

This should also make it less frustrating to deal with lone tanks in cqc who just shoot you at point blank and kill you.
## Changelog
:cl:
balance: LTB no longer gibs, has less direct hit damage on both HE and APFDS.
/:cl:
