### PR TITLE
Sets (most) xenos back to old statistics, with certain castes being buffed.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -16,11 +16,11 @@
 	weeds_speed_mod = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 300
+	plasma_max = 200
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 700
+	max_health = 800
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -33,7 +33,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 60, BIO = 50, FIRE = 50, ACID = 50)
+	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 50, BIO = 50, FIRE = 50, ACID = 50)
 	hard_armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -23,7 +23,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 380
+	max_health = 325
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -54,8 +54,8 @@
 	bomb_delay = 32 SECONDS
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_damage = 30
-	acid_spray_damage_on_hit = 60
+	acid_spray_damage = 20
+	acid_spray_damage_on_hit = 35
 	acid_spray_structure_damage = 45
 
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -9,20 +9,20 @@
 	wound_type = "bull" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 24
+	melee_damage = 21
 
 	// *** Speed *** //
 	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 340 //High plasma is need for charging
-	plasma_gain = 24
+	plasma_max = 270 //High plasma is need for charging
+	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 350
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.9
+	sunder_multiplier = 0.85
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -36,7 +36,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 50, BULLET = 55, LASER = 55, ENERGY = 55, BOMB = 20, BIO = 35, FIRE = 50, ACID = 35)
+	soft_armor = list(MELEE = 40, BULLET = 50, LASER = 40, ENERGY = 40, BOMB = 0, BIO = 35, FIRE = 50, ACID = 35)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "bull"

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -11,17 +11,17 @@
 	wound_type = "carrier" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 22
+	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.2
+	speed = -0.3
 
 	// *** Plasma *** //
 	plasma_max = 1000
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 425
+	max_health = 325
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -36,7 +36,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 5, FIRE = 25, ACID = 5)
+	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 0, BIO = 5, FIRE = 15, ACID = 5)
 
 	// *** Pheromones *** //
 	aura_strength = 2.5
@@ -46,7 +46,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 8
-	hugger_delay = 1.25 SECONDS
+	hugger_delay = 1.5 SECONDS
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -10,18 +10,18 @@
 	wound_type = "crusher" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 25
+	melee_damage = 24
 	attack_delay = 8
 
 	// *** Speed *** //
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 520
+	plasma_max = 400
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 525
+	max_health = 450
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -33,7 +33,7 @@
 	caste_traits = list(TRAIT_STOPS_TANK_COLLISION)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 50, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.7

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 500
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -11,10 +11,10 @@
 	wound_type = "defender" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 22
+	melee_damage = 21
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 200
@@ -33,15 +33,18 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 45, BULLET = 45, LASER = 45, ENERGY = 45, BOMB = 30, BIO = 30, FIRE = 40, ACID = 30)
+	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 20, BIO = 30, FIRE = 40, ACID = 30)
+
+	// *** Sunder *** //
+	sunder_multiplier = 0.85
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defender"
 
 	// *** Defender Abilities *** //
 	crest_defense_armor = 30
-	crest_defense_slowdown = 0.8
-	fortify_armor = 50
+	crest_defense_slowdown = 1
+	fortify_armor = 55
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -14,14 +14,14 @@
 	melee_damage = 26
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 575
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 420
+	max_health = 375
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -35,7 +35,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 40, ACID = 40)
+	soft_armor = list(MELEE = 45, BULLET = 45, LASER = 45, ENERGY = 45, BOMB = 0, BIO = 40, FIRE = 40, ACID = 40)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defiler"

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -12,10 +12,10 @@
 	gib_flick = "gibbed-a-small"
 
 	// *** Melee Attacks *** //
-	melee_damage = 19
+	melee_damage = 18
 
 	// *** Speed *** //
-	speed = -1.1
+	speed = -1.2
 	weeds_speed_mod = -0.4
 
 	// *** Plasma *** //
@@ -23,7 +23,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 380
+	max_health = 300
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -24,7 +24,7 @@
 	plasma_icon_state = "fury"
 
 	// *** Health *** //
-	max_health = 700
+	max_health = 650
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -38,6 +38,9 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 20, FIRE = 20, ACID = 20)
+
+	// *** Sunder *** //
+	sunder_multiplier = 0.85
 
 	// *** Minimap Icon *** //
 	minimap_icon = "gorger"

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -21,7 +21,7 @@
 	plasma_icon_state = "hivelord_plasma"
 
 	// *** Health *** //
-	max_health = 410
+	max_health = 350
 
 
 	// *** Evolution *** //
@@ -37,7 +37,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 35, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
+	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -13,12 +13,12 @@
 	gib_flick = "Hunter Gibbed"
 
 	// *** Melee Attacks *** //
-	melee_damage = 25
+	melee_damage = 24
 	melee_ap = 5
 	attack_delay = 7
 
 	// *** Speed *** //
-	speed = -1.4
+	speed = -1.5
 	weeds_speed_mod = -0.1
 
 	// *** Plasma *** //
@@ -26,7 +26,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 290
 
 	// *** Evolution *** //
 	evolution_threshold = 225

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -10,7 +10,7 @@
 	wound_type = "king" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 33
+	melee_damage = 30
 
 	// *** Speed *** //
 	speed = -0.1
@@ -20,7 +20,7 @@
 	plasma_gain = 90
 
 	// *** Health *** //
-	max_health = 700
+	max_health = 650
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.8

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 100
 
 	// *** Health *** //
-	max_health = 420
+	max_health = 360
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -39,8 +39,8 @@
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_range = 5
-	acid_spray_damage = 25
-	acid_spray_damage_on_hit = 55
+	acid_spray_damage = 20
+	acid_spray_damage_on_hit = 47
 	acid_spray_structure_damage = 69
 
 	// *** Pheromones *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -14,14 +14,14 @@
 	attack_delay = 7
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 325
 	plasma_gain = 25
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 325
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -11,10 +11,10 @@
 	wound_type = "queen" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 28
+	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.2
+	speed = -0.3
 
 	// *** Plasma *** //
 	plasma_max = 1200

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -23,7 +23,7 @@
 	plasma_icon_state = "fury"
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 350
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -12,7 +12,7 @@
 	gib_flick = "gibbed-a-runner"
 
 	// *** Melee Attacks *** //
-	melee_damage = 23
+	melee_damage = 21
 	attack_delay = 6
 
 	// *** Speed *** //
@@ -23,7 +23,7 @@
 	plasma_gain = 11
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 240
 
 	// *** Evolution *** //
 	evolution_threshold = 100
@@ -35,7 +35,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 5, FIRE = 20, ACID = 5)
+	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 5, FIRE = 19, ACID = 5)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "runner"

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -11,17 +11,20 @@
 	wound_type = "shrike" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 25
+	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.6
 
 	// *** Plasma *** //
 	plasma_max = 925
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 400
+
+	// *** Sunder *** //
+	sunder_multiplier = 0.8
 
 	// *** Evolution *** //
 	// The only evolution path does not require threshold

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 310
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -43,7 +43,7 @@
 	spit_types = list(/datum/ammo/xeno/acid/medium) //Gotta give them their own version of heavy acid; kludgy but necessary as 100 plasma is way too costly.
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_damage_on_hit = 45
+	acid_spray_damage_on_hit = 35
 	acid_spray_damage = 20
 	acid_spray_structure_damage = 45
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 310
+	max_health = 340
 
 	// *** Evolution *** //
 	evolution_threshold = 225

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -12,17 +12,17 @@
 	melee_damage = 25
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.5
 
 	// *** Plasma *** //
 	plasma_max = 150
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 380
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.9
+	sunder_multiplier = 0.85
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -36,7 +36,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 60, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 30, BIO = 50, FIRE = 55, ACID = 50)
+	soft_armor = list(MELEE = 40, BULLET = 55, LASER = 55, ENERGY = 40, BOMB = 20, BIO = 50, FIRE = 55, ACID = 50)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "warrior"

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -10,7 +10,7 @@
 	wound_type = "widow"
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 18
 
 	// *** Speed *** //
 	speed = -0.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -9,17 +9,17 @@
 	wound_type = "wraith" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 24
+	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -1.1
+	speed = -1.25
 
 	// *** Plasma *** //
 	plasma_max = 400
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 340
+	max_health = 269
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -33,7 +33,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
+	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "wraith"

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -226,7 +226,7 @@
 	spit_cost = 50
 	ammo_behavior_flags = AMMO_XENO|AMMO_TARGET_TURF
 	armor_type = ACID
-	damage = 22
+	damage = 18
 	max_range = 8
 	bullet_color = COLOR_PALE_GREEN_GRAY
 	///Duration of the acid puddles
@@ -244,14 +244,14 @@
 
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
-	damage = 35
+	damage = 30
 	ammo_behavior_flags = AMMO_XENO
 
 /datum/ammo/xeno/acid/auto
 	name = "light acid spatter"
 	damage = 12
-	damage_falloff = 0.2
-	spit_cost = 20
+	damage_falloff = 0.3
+	spit_cost = 25
 	added_spit_delay = 0
 
 /datum/ammo/xeno/acid/auto/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -275,7 +275,7 @@
 	name = "acid splash"
 	added_spit_delay = 2
 	spit_cost = 70
-	damage = 40
+	damage = 30
 
 /datum/ammo/xeno/acid/heavy/turret
 	damage = 20


### PR DESCRIPTION
## About The Pull Request
TL;DR - Reverts to pre-kurt stats for most things, with certain castes being buffed if I felt they needed the buff in comparison to their old state.
A lot of frontliners gained .85 sunder mult (Gorger/Warrior/Defender) and a decent chunk of them got around ~30ish more HP.
I kept some of the Kurt buffs if I felt they fit. Mostly plasma gain and max changes on a caste per caste basis.
All rulers now have .8 Sunder resist. In practice this means Shrike has it now.
## Why It's Good For The Game
I'd say the Kurt Xeno experiment broke the balance of the game in a bad way, a lot of the castes that ended up being gigabuffed *did not need it.* Castes like Warrior, Carrier, Crusher got huge buffs which they didn't deserve which made them basically broken while ironically underplayed castes ended up with basically next to no changes.
This still didn't fix any of the core design issues we need to tackle anyway like curbing down emplacements (hi me) making droppods less horrific against map flow, and making vehicles less absurdly lethal and basically uninteractable bricks of unstunnable meat in a game built around displacements, movement, and stuns.

On a side note... PR also basically lied, the vast majority of the cast had no speed changes to note of. The only one I saw was shrike losing .2 speed. Like two others lost .1 speed. This was barely a change at all.
Ideally the Sunder multiplier should make the buffed castes more noticeably tougher and able to stay in the fight longer.

If you have anything to add, please say so in the comments, I do feel like a lot of the Pre-Kurt castes needed some buffs and these are mine.
## Changelog
:cl:
balance: Reverted the vast majority of the Kuro020 Xeno Balance changes. Generally Xenos will be easier to kill. Most of the plasma changes are kept. Read PR #16522
/:cl:
