### PR TITLE
AGLS flare/he assembly fix

### DIFF
--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -769,7 +769,7 @@ GLOBAL_LIST_INIT(agls_recipe, list(
 	desc = "An incomplete AGLS HE magazine assembly."
 	result = /obj/item/ammo_magazine/standard_agls
 
-/obj/item/factory_part/obj/item/factory_part/agls_he/Initialize(mapload)
+/obj/item/factory_part/agls_he/Initialize(mapload)
 	. = ..()
 	recipe = GLOB.agls_recipe
 

--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -783,8 +783,8 @@ GLOBAL_LIST_INIT(agls_recipe, list(
 	recipe = GLOB.agls_recipe
 
 /obj/item/factory_part/agls_incendiary
-	name = "\improper AGLS HE magazine assembly"
-	desc = "An incomplete AGLS HE magazine assembly."
+	name = "\improper AGLS Inc. magazine assembly"
+	desc = "An incomplete AGLS Inc. magazine assembly."
 	result = /obj/item/ammo_magazine/standard_agls/incendiary
 
 /obj/item/factory_part/agls_incendiary/Initialize(mapload)
@@ -792,8 +792,8 @@ GLOBAL_LIST_INIT(agls_recipe, list(
 	recipe = GLOB.agls_recipe
 
 /obj/item/factory_part/agls_flare
-	name = "\improper AGLS HE magazine assembly"
-	desc = "An incomplete AGLS HE magazine assembly."
+	name = "\improper AGLS Flare magazine assembly"
+	desc = "An incomplete AGLS Flare magazine assembly."
 	result = /obj/item/ammo_magazine/standard_agls/flare
 
 /obj/item/factory_part/agls_flare/Initialize(mapload)
@@ -801,8 +801,8 @@ GLOBAL_LIST_INIT(agls_recipe, list(
 	recipe = GLOB.agls_recipe
 
 /obj/item/factory_part/agls_cloak
-	name = "\improper AGLS HE magazine assembly"
-	desc = "An incomplete AGLS HE magazine assembly."
+	name = "\improper AGLS Cloak magazine assembly"
+	desc = "An incomplete AGLS Cloak magazine assembly."
 	result = /obj/item/ammo_magazine/standard_agls/cloak
 
 /obj/item/factory_part/agls_cloak/Initialize(mapload)
@@ -810,8 +810,8 @@ GLOBAL_LIST_INIT(agls_recipe, list(
 	recipe = GLOB.agls_recipe
 
 /obj/item/factory_part/agls_tanglefoot
-	name = "\improper AGLS HE magazine assembly"
-	desc = "An incomplete AGLS HE magazine assembly."
+	name = "\improper AGLS Tanglefoot magazine assembly"
+	desc = "An incomplete AGLS Tanglefoot magazine assembly."
 	result = /obj/item/ammo_magazine/standard_agls/tanglefoot
 
 /obj/item/factory_part/agls_tanglefoot/Initialize(mapload)

--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -495,7 +495,7 @@
 /obj/item/factory_refill/agls_flare_refill
 	name = "box of rounded metal plates (AGLS Flare)"
 	desc = "A box with round metal plates inside. Used to refill Unboxers. These will become AGLS Flare magazines for an AGL, once finished."
-	refill_type = /obj/item/factory_part/agls_he
+	refill_type = /obj/item/factory_part/agls_flare
 	refill_amount = 10
 
 /obj/item/factory_refill/agls_cloak_refill


### PR DESCRIPTION
## About The Pull Request
AGLS Flare magazine assembly now correctly create its associated item instead of AGLS HE magazines.
AGLS HE magazine assembly no longer create its associated item immediately on unboxing and must follow its factory recipe.

## Why It's Good For The Game
Bug fixes. AGLS Flare magazine assembly was giving the wrong ammo type and was giving a 100 point discount on the HE mags and the other just ignored the whole point of factory.

## Changelog
:cl:
fix: AGLS Flare magazine assemblies now create AGLS Flare magazines instead of HE magazines.
fix: AGLS HE magazine assemblies now follows its factory recipe instead of immediately finishing on unboxing.
/:cl:
