### PR TITLE
Slightly lowers crushers health

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 470
+	max_health = 485
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 525
+	max_health = 470
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Lowers the crusher's health by 55.

## Why It's Good For The Game

For quite a while since the blanket xeno buffs, xenos have been a little overturned, so I think a few outstanding examples of overbuffed caste should be nerfed just a little. Crusher is the first one I think of, besides warrior. It got a huge survivability buff of 125 extra hp, which was just complete overkill with how much armor it has, and its utility to its team, not even counting the fact that it can fish people.

This should make them have to be a little more careful with their life, while still being extremely tanky. 

## Changelog
:cl:
balance: slightly lowered crushers health
/:cl:
