### PR TITLE
Slight queen nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -14,14 +14,14 @@
 	melee_damage = 28
 
 	// *** Speed *** //
-	speed = -0.2
+	speed = -0.3
 
 	// *** Plasma *** //
 	plasma_max = 1200
 	plasma_gain = 90
 
 	// *** Health *** //
-	max_health = 650
+	max_health = 600
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.8


### PR DESCRIPTION

## About The Pull Request

Lowers the queens health by 50, but gives her -0.1 speed back.

## Why It's Good For The Game

For quite a while since the blanket xeno buffs, xenos have been a little overturned, so I think a few outstanding examples of overbuffed caste should be nerfed just a little. Queen got a massive health buff of 150, on top of the big slash and acid damage changes, which makes her spit slashing extremely deadly. This should make her have to be a little more careful with her life in general, while still keeping the deadly aspect.

## Changelog
:cl:
balance: slight queen nerf
/:cl:
