### PR TITLE
Adds a sunder muiliplier to behemoth

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -22,6 +22,9 @@
 	// *** Health *** //
 	max_health = 700
 
+	// *** Sunder *** //
+	sunder_multiplier = 0.8
+
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 


### PR DESCRIPTION

## About The Pull Request

Gives behemoth a sunder multiplier of 0.8

## Why It's Good For The Game

Behemoth has been in a bit of a sad spot even after the buffs. It got a huge armor buff, but you're so slow, and your sprite so big, that you often can lose most if not all of your armor in one engagement if you got unlucky. This should help them better with the whole heavily armored slow bug thing. 

## Changelog
:cl:
balance: gave behemoth a sunder multiplier
/:cl:
