### PR TITLE
Lowers warriors health

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 400
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.9


### PR DESCRIPTION

## About The Pull Request

Lowers warrior's health by 50.

## Why It's Good For The Game

For quite a while since the blanket xeno buffs, xenos have been a little overturned, so I think a few outstanding examples of overbuffed caste should be nerfed just a little. Warrior got a massive health buff of 100, and not only that, got a huge armor buff of 20 across the board on top of that. Warrior as it stands has more effective health than most t3's while already being a really strong caste that can fish marines or just throw them out of position. 

As it stands warrior is just overpowered right now, this should still leave it really strong, but just a little more killable.

## Changelog
:cl:
balance: lowers warriors health
/:cl:
