### PR TITLE
Slightly lowers praetorian's health

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 100
 
 	// *** Health *** //
-	max_health = 420
+	max_health = 390
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD


### PR DESCRIPTION

## About The Pull Request
Lower's praetorian's health by 30.

## Why It's Good For The Game

For quite a while since the blanket xeno buffs, xenos have been a little overturned, so I think a few outstanding examples of overbuffed caste should be nerfed just a little. Praetorian got 60 more extra health, on top of a big acid spray and acid spit damage buff. I think it got a little too much health for how safe this caste is to play in general, and how much utility it has. 

## Changelog
:cl:
balance: slightly lowers Praetorian's health
/:cl:
