### PR TITLE
Buffs praetorian primo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -131,7 +131,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	action_icon_state = "pounce"
 	action_icon = 'icons/Xeno/actions/runner.dmi'
 	desc = "Instantly dash, tackling the first marine in your path. If you manage to tackle someone, gain another weaker cast of the ability."
-	ability_cost = 250
+	ability_cost = 100
 	cooldown_duration = 30 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ACID_DASH,


### PR DESCRIPTION

## About The Pull Request
Lowers plasma cost from 250 to 100.
## Why It's Good For The Game
This ability is meant to be used twice as an engage/escape tool but it costs half of your plasma so at best you can dash twice, cone spray, then spit two or three times before being empty. This will make the ability actually usable during a fight.
## Changelog
:cl:
balance: Lowered praetorian primo plasma cost from 250 to 100.
/:cl:
