### PR TITLE
Revert "Sentry deployer offset"

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -363,7 +363,6 @@
 	icon_state = "sentry_system"
 	dropship_equipment_flags = IS_INTERACTABLE
 	point_cost = 500
-	pixel_y = 32
 	var/deployment_cooldown
 	var/obj/machinery/deployable/mounted/sentry/deployed_turret
 	var/sentry_type = /obj/item/weapon/gun/sentry/big_sentry/dropship


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#15704

This PR caused the sentry deployment structures to be pixel shifted a tile north from where the actual collision is. It is labeled as a fix despite the fact that it only makes it harder to see where the collision is on the structure, so people use these as barricades on the tad due to the fact that its basically an invisible movement blocker.

I don't see any actual reason to keep this "fix", it just just an annoyance for xenos when the sentry deploys are used as barricades. If there is some larger issue with them that I'm missing(which is not elaborated on in the original pr) then my bad but prior to this fix the deployment structures worked fine and now they are pixel shifted for no reason.