### PR TITLE
Bullet ping sound chance revert

### DIFF
--- a/code/datums/elements/debris.dm
+++ b/code/datums/elements/debris.dm
@@ -81,7 +81,7 @@
 		debris_visuals.particles.spawning = debris_amount
 		debris_visuals.particles.scale = debris_scale
 	smoke_visuals.layer = ABOVE_OBJ_LAYER + 0.01
-	if(P.ammo.sound_bounce)
+	if(P.ammo.sound_bounce && prob(50))
 		var/pitch = 0
 		if(P.ammo.ammo_behavior_flags & AMMO_SOUND_PITCH)
 			pitch = 55000


### PR DESCRIPTION

## About The Pull Request
Bullet pings are now chance based again, at 50%.
## Why It's Good For The Game
When impact particles was added, ping sounds were made 100%. This has the unfortunate side effect of maxing out sound channels extremely easily.

This isn't a perfect solution but should significantly reduce the funny sound channel maxing you frequently hear.
## Changelog
:cl:
soundadd: Bullet ping sounds changed back to not happening 100% of the time, to reduce sound channel issues
/:cl:
