### PR TITLE
Fix xeno icon update runtime

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -100,6 +100,8 @@
 
 	if(!(to_check_flags & ABILITY_USE_SOLIDOBJECT))
 		var/turf/current_turf = get_turf(carbon_owner)
+		if(!current_turf) //we are in nullspace when first spawning in
+			return FALSE
 		if(isclosedturf(current_turf))
 			if(!silent)
 				//Not converted to balloon alert as xeno.dm's balloon alert is simultaneously called and will overlap.


### PR DESCRIPTION

## About The Pull Request
Basically we would runtime on init because we are in nullspace when this runs and therefore don't have a turf
## Why It's Good For The Game
bug bad
## Changelog
:cl:
fix: Fixed a runtime when first spawning in as a xeno with pheros
/:cl:
