### PR TITLE
Fix supply beacon console runtime

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -81,7 +81,7 @@
 					beacon_list -= beacon_name
 					continue
 			var/datum/supply_beacon/supply_beacon_choice = beacon_list[tgui_input_list(ui.user, "Select the beacon to send supplies", "Beacon choice", beacon_list)]
-			if(!istype(supply_beacon_choice) && is_ground_level(supply_beacon.drop_location.z))
+			if(!istype(supply_beacon_choice) && is_ground_level(supply_beacon?.drop_location?.z))
 				return
 			supply_beacon = supply_beacon_choice
 			RegisterSignal(supply_beacon, COMSIG_QDELETING, PROC_REF(clean_supply_beacon), override = TRUE)


### PR DESCRIPTION

## About The Pull Request
Runtime in code/game/objects/machinery/squad_supply/supply_console.dm, line 84: Cannot read null.drop_location
## Why It's Good For The Game
runtime bad
## Changelog
:cl:
fix: Fix a supply beacon console runtime
/:cl:
