### PR TITLE
Async campaign autobalance

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -211,7 +211,7 @@
 	for(var/mob/living/carbon/human/faction_member in GLOB.alive_human_list_faction[autobalance_faction_list[1]])
 		if(stat_list[faction_member.faction].faction_leader == faction_member)
 			continue
-		swap_player_team(faction_member, autobalance_faction_list[2], forced)
+		INVOKE_ASYNC(src, PROC_REF(swap_player_team), faction_member, autobalance_faction_list[2], forced)
 
 	addtimer(CALLBACK(src, PROC_REF(autobalance_bonus)), CAMPAIGN_AUTOBALANCE_DECISION_TIME + 1 SECONDS)
 


### PR DESCRIPTION

## About The Pull Request
I did a dumb and didn't async this, so it was happening ONE PLAYER AT A TIME.


:cl:
fix: Campaign: Autobalance will no longer take much longer to appear for players than intended
/:cl:
