### PR TITLE
Makes xenomorph health/sunder healing, evo progress, maturity, and plasma regen scale based on delta_time/second_per_tick

### DIFF
--- a/code/__DEFINES/_subsystems.dm
+++ b/code/__DEFINES/_subsystems.dm
@@ -185,3 +185,13 @@
 
 /// The timer key used to know how long subsystem initialization takes
 #define SS_INIT_TIMER_KEY "ss_init"
+
+
+/// Mobs subsystem defines
+
+/// The mobs subsystem buckets up mobs to smooth out processing load,
+/// each 5 ticks it fires, but won't actually run Life on every fire()
+/// Instead it buckets mobs and ends up running Life on every mob every 2 seconds
+/// but since subsystem wait only considers the last fire,
+/// we need to multiply wait enough that it matches the 2 second interval Life is actually running on
+#define SS_MOBS_BUCKET_DELAY 4

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -207,3 +207,6 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 
 ///Number of icon states to show health and plasma on the side UI buttons
 #define XENO_HUD_ICON_BUCKETS 16
+
+/// Life runs every 2 seconds, but we don't want to multiply all healing by 2 due to seconds_per_tick
+#define XENO_PER_SECOND_LIFE_MOD 0.5

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -67,7 +67,7 @@ SUBSYSTEM_DEF(mobs)
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 	var/times_fired = src.times_fired
-	var/seconds_per_tick = wait / (1 SECONDS)
+	var/seconds_per_tick = wait / (1 SECONDS) * SS_MOBS_BUCKET_DELAY
 	while(length(currentrun))
 		var/mob/living/L = currentrun[length(currentrun)]
 		currentrun.len--

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -44,7 +44,6 @@ SUBSYSTEM_DEF(mobs)
 		dead_players_by_zlevel[length(dead_players_by_zlevel)] = list()
 
 /datum/controller/subsystem/mobs/fire(resumed = 0)
-	var/seconds = wait * 0.1
 	if (!resumed)
 		if(crate == 1)
 			var/most = -1
@@ -68,11 +67,12 @@ SUBSYSTEM_DEF(mobs)
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 	var/times_fired = src.times_fired
+	var/seconds_per_tick = wait / (1 SECONDS)
 	while(length(currentrun))
 		var/mob/living/L = currentrun[length(currentrun)]
 		currentrun.len--
 		if(L)
-			L.Life(seconds, times_fired)
+			L.Life(seconds_per_tick, times_fired)
 		else
 			processing.Remove(L)
 		if (MC_TICK_CHECK)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -109,7 +109,7 @@
 	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/incapacitating/unconscious/tick()
+/datum/status_effect/incapacitating/unconscious/tick(delta_time)
 	if(owner.getStaminaLoss())
 		owner.adjustStaminaLoss(-0.3) //reduce stamina loss by 0.3 per tick, 6 per 2 seconds
 
@@ -143,7 +143,7 @@
 	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/incapacitating/sleeping/tick()
+/datum/status_effect/incapacitating/sleeping/tick(delta_time)
 	if(!owner.maxHealth)
 		return
 	var/health_ratio = owner.health / owner.maxHealth
@@ -194,7 +194,7 @@
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/incapacitating/repair_mode/tick()
+/datum/status_effect/incapacitating/repair_mode/tick(delta_time)
 	var/sound_to_play
 	if(owner.getBruteLoss())
 		owner.heal_limb_damage(healing_per_tick, 0, TRUE, TRUE)
@@ -348,7 +348,7 @@
 	else
 		CRASH("something applied plasmadrain on a nonxeno, dont do that")
 
-/datum/status_effect/plasmadrain/tick()
+/datum/status_effect/plasmadrain/tick(delta_time)
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	if(xenoowner.plasma_stored >= 0)
 		var/remove_plasma_amount = xenoowner.xeno_caste.plasma_max / 10
@@ -378,7 +378,7 @@
 	REMOVE_TRAIT(owner, TRAIT_NOPLASMAREGEN, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/noplasmaregen/tick()
+/datum/status_effect/noplasmaregen/tick(delta_time)
 	to_chat(owner, span_warning("You feel too weak to summon new plasma..."))
 
 /datum/status_effect/incapacitating/harvester_slowdown
@@ -433,13 +433,13 @@
 	. = ..()
 	to_chat(new_owner, span_danger("The cold vacuum instantly freezes you, maybe this was a bad idea?"))
 
-/datum/status_effect/spacefreeze/tick()
+/datum/status_effect/spacefreeze/tick(delta_time)
 	owner.adjustFireLoss(40)
 
 /datum/status_effect/spacefreeze/light
 	id = "spacefreeze_light"
 
-/datum/status_effect/spacefreeze/light/tick()
+/datum/status_effect/spacefreeze/light/tick(delta_time)
 	owner.fire_stacks = max(owner.fire_stacks - 6, 0)
 	if(owner.stat == DEAD)
 		return
@@ -467,7 +467,7 @@
 	carbon_owner = null
 	return ..()
 
-/datum/status_effect/incapacitating/irradiated/tick()
+/datum/status_effect/incapacitating/irradiated/tick(delta_time)
 	var/mob/living/living_owner = owner
 	//Roulette of bad things
 	if(prob(15))
@@ -530,7 +530,7 @@
 	QDEL_NULL(particle_holder)
 	return ..()
 
-/datum/status_effect/stacking/intoxicated/tick()
+/datum/status_effect/stacking/intoxicated/tick(delta_time)
 	. = ..()
 	if(!debuff_owner)
 		return
@@ -608,7 +608,7 @@
 	QDEL_NULL(visual_fire)
 	return ..()
 
-/datum/status_effect/stacking/melting_fire/tick()
+/datum/status_effect/stacking/melting_fire/tick(delta_time)
 	. = ..()
 	if(!debuff_owner)
 		qdel(src)
@@ -671,7 +671,7 @@
 	duration = set_duration
 	return ..()
 
-/datum/status_effect/dread/tick()
+/datum/status_effect/dread/tick(delta_time)
 	. = ..()
 	var/mob/living/living_owner = owner
 	living_owner.do_jitter_animation(250)
@@ -729,7 +729,7 @@
 	QDEL_NULL(particle_holder)
 	return ..()
 
-/datum/status_effect/stacking/melting/tick()
+/datum/status_effect/stacking/melting/tick(delta_time)
 	. = ..()
 	if(!debuff_owner)
 		return
@@ -814,7 +814,7 @@
 	if(stacks_added > 0 && stacks >= max_stacks) //proc is run even if stacks are not actually added
 		COOLDOWN_START(src, cooldown_microwave_status, MICROWAVE_STATUS_DURATION)
 
-/datum/status_effect/stacking/microwave/tick()
+/datum/status_effect/stacking/microwave/tick(delta_time)
 	. = ..()
 	if(COOLDOWN_CHECK(src, cooldown_microwave_status))
 		return qdel(src)

--- a/code/datums/status_effects/sectoid.dm
+++ b/code/datums/status_effects/sectoid.dm
@@ -58,7 +58,7 @@
 	check_range()
 	return ..()
 
-/datum/status_effect/mindmeld/tick()
+/datum/status_effect/mindmeld/tick(delta_time)
 	check_range()
 
 ///Checks if mob is in buff range and toggles as required
@@ -114,7 +114,7 @@
 	. = ..()
 	owner.remove_filter("[id]")
 
-/datum/status_effect/reknit_form/tick()
+/datum/status_effect/reknit_form/tick(delta_time)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		human_owner.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY //oof ow ouch

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -51,12 +51,12 @@
 		owner = null
 	return ..()
 
-/datum/status_effect/process()
+/datum/status_effect/process(delta_time)
 	if(!owner)
 		qdel(src)
 		return
 	if(tick_interval < world.time)
-		tick()
+		tick(delta_time)
 		tick_interval = world.time + initial(tick_interval)
 	if(duration != -1 && duration < world.time)
 		qdel(src)
@@ -66,7 +66,7 @@
 	return TRUE
 
 ///Called every tick
-/datum/status_effect/proc/tick()
+/datum/status_effect/proc/tick(delta_time)
 
 //Called whenever the buff expires or is removed; do note that at the point this is called, it is out of the owner's status_effects but owner is not yet null
 /datum/status_effect/proc/on_remove()
@@ -213,7 +213,7 @@
 /datum/status_effect/stacking/proc/can_gain_stacks()
 	return owner.stat != DEAD
 
-/datum/status_effect/stacking/tick()
+/datum/status_effect/stacking/tick(delta_time)
 	if(!can_have_status())
 		qdel(src)
 	else

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -32,8 +32,8 @@
 	owner.balloon_alert(owner, "We are vulnerable again")
 	return ..()
 
-/datum/status_effect/resin_jelly_coating/tick()
-	owner.heal_limb_damage(0, 5)
+/datum/status_effect/resin_jelly_coating/tick(delta_time)
+	owner.heal_limb_damage(0, 5 * delta_time)
 	return ..()
 
 // ***************************************
@@ -99,7 +99,7 @@
 	REMOVE_TRAIT(link_target, TRAIT_ESSENCE_LINKED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/stacking/essence_link/tick()
+/datum/status_effect/stacking/essence_link/tick(delta_time)
 	var/within_range = get_dist(link_owner, link_target) <= DRONE_ESSENCE_LINK_RANGE
 	if(within_range != was_within_range) // Toggles the link depending on whether the linked xenos are still in range or not.
 		was_within_range = within_range
@@ -113,8 +113,8 @@
 	var/remaining_health = link_target.maxHealth - (link_target.getBruteLoss() + link_target.getFireLoss())
 	if(stacks < 1 || !was_within_range || remaining_health >= link_target.maxHealth)
 		return
-	var/heal_amount = link_target.maxHealth * (DRONE_ESSENCE_LINK_REGEN * stacks)
-	var/ability_cost = heal_amount * 2
+	var/heal_amount = link_target.maxHealth * (DRONE_ESSENCE_LINK_REGEN * stacks) * delta_time
+	var/ability_cost = heal_amount * 2 * delta_time
 	if(link_owner.plasma_stored < ability_cost)
 		if(!COOLDOWN_CHECK(src, plasma_warning))
 			return
@@ -223,12 +223,12 @@
 	buff_owner.balloon_alert(buff_owner, "Salve regeneration ended")
 	return ..()
 
-/datum/status_effect/salve_regen/tick()
+/datum/status_effect/salve_regen/tick(delta_time)
 	new /obj/effect/temp_visual/healing(get_turf(buff_owner))
-	var/heal_amount = buff_owner.maxHealth * 0.01
+	var/heal_amount = buff_owner.maxHealth * 0.01 * delta_time
 	buff_owner.adjustFireLoss(-max(0, heal_amount - buff_owner.getBruteLoss()), passive = TRUE)
 	buff_owner.adjustBruteLoss(-heal_amount, passive = TRUE)
-	buff_owner.adjust_sunder(-1)
+	buff_owner.adjust_sunder(-1 * delta_time)
 	return ..()
 
 // ***************************************
@@ -293,7 +293,7 @@
 	toggle_buff(FALSE)
 	return ..()
 
-/datum/status_effect/drone_enhancement/tick()
+/datum/status_effect/drone_enhancement/tick(delta_time)
 	var/within_range = get_dist(buffed_xeno, buffing_xeno) <= DRONE_ESSENCE_LINK_RANGE
 	if(within_range != was_within_range)
 		was_within_range = within_range
@@ -302,7 +302,7 @@
 	if(buffing_xeno.plasma_stored < ability_cost)
 		enhancement_action.end_ability()
 		return
-	buffing_xeno.use_plasma(ability_cost)
+	buffing_xeno.use_plasma(ability_cost * delta_time)
 
 /// Toggles the buff on or off.
 /datum/status_effect/drone_enhancement/proc/toggle_buff(toggle)
@@ -556,16 +556,16 @@
 	owner.clear_fullscreen("xeno_feast", 0.7 SECONDS)
 	owner.remove_filter(list("[id]1", "[id]2"))
 
-/datum/status_effect/xeno_feast/tick()
+/datum/status_effect/xeno_feast/tick(delta_time)
 	var/mob/living/carbon/xenomorph/X = owner
-	if(X.plasma_stored < plasma_drain)
+	if(X.plasma_stored < plasma_drain * delta_time)
 		to_chat(X, span_notice("Our feast has come to an end..."))
 		X.remove_status_effect(STATUS_EFFECT_XENO_FEAST)
 		return
-	var/heal_amount = X.maxHealth*0.08
+	var/heal_amount = X.maxHealth * 0.08 * delta_time
 	HEAL_XENO_DAMAGE(X, heal_amount, FALSE)
 	adjustOverheal(X, heal_amount / 2)
-	X.use_plasma(plasma_drain)
+	X.use_plasma(plasma_drain * delta_time)
 
 // ***************************************
 // *********** Plasma Fruit buff
@@ -596,13 +596,13 @@
 	else
 		RegisterSignal(owner, COMSIG_XENOMORPH_PLASMA_REGEN, PROC_REF(plasma_surge_regeneration))
 
-/datum/status_effect/plasma_surge/proc/plasma_surge_regeneration()
+/datum/status_effect/plasma_surge/proc/plasma_surge_regeneration(mob/living/carbon/xenomorph/xeno, plasma_mod, seconds_per_tick)
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/xenomorph/X = owner
 	if(HAS_TRAIT(X,TRAIT_NOPLASMAREGEN)) //No bonus plasma if you're on a diet
 		return
-	var/bonus_plasma = X.xeno_caste.plasma_gain * bonus_regen * (1 + X.recovery_aura * 0.05) //Recovery aura multiplier; 5% bonus per full level
+	var/bonus_plasma = X.xeno_caste.plasma_gain * bonus_regen * (1 + X.recovery_aura * 0.05) * seconds_per_tick //Recovery aura multiplier; 5% bonus per full level
 	X.gain_plasma(bonus_plasma)
 
 /datum/status_effect/plasma_surge/on_remove()
@@ -661,7 +661,7 @@
 	return ..()
 
 ///Called when the target xeno regains HP via heal_wounds in life.dm
-/datum/status_effect/healing_infusion/proc/healing_infusion_regeneration(mob/living/carbon/xenomorph/patient)
+/datum/status_effect/healing_infusion/proc/healing_infusion_regeneration(mob/living/carbon/xenomorph/patient, heal_data, seconds_per_tick)
 	SIGNAL_HANDLER
 
 	if(!health_ticks_remaining)
@@ -672,7 +672,7 @@
 
 	new /obj/effect/temp_visual/healing(get_turf(patient)) //Cool SFX
 
-	var/total_heal_amount = 6 + (patient.maxHealth * 0.03) //Base amount 6 HP plus 3% of max
+	var/total_heal_amount = 6 + (patient.maxHealth * 0.03) * seconds_per_tick //Base amount 6 HP plus 3% of max
 	if(patient.recovery_aura)
 		total_heal_amount *= (1 + patient.recovery_aura * 0.05) //Recovery aura multiplier; 5% bonus per full level
 
@@ -691,7 +691,7 @@
 
 
 ///Called when the target xeno regains Sunder via heal_wounds in life.dm
-/datum/status_effect/healing_infusion/proc/healing_infusion_sunder_regeneration(mob/living/carbon/xenomorph/patient)
+/datum/status_effect/healing_infusion/proc/healing_infusion_sunder_regeneration(mob/living/carbon/xenomorph/patient, seconds_per_tick)
 	SIGNAL_HANDLER
 
 	if(!sunder_ticks_remaining)
@@ -705,7 +705,7 @@
 
 	new /obj/effect/temp_visual/telekinesis(get_turf(patient)) //Visual confirmation
 
-	patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05)) //5% bonus per rank of our recovery aura
+	patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05) * seconds_per_tick) //5% bonus per rank of our recovery aura
 
 /atom/movable/screen/alert/status_effect/healing_infusion
 	name = "Healing Infusion"
@@ -780,7 +780,7 @@
 	///weakref to the puppeteer to set strength
 	var/datum/weakref/puppeteer
 
-/datum/status_effect/blessing/tick()
+/datum/status_effect/blessing/tick(delta_time)
 	var/mob/living/carbon/xenomorph/xeno = puppeteer?.resolve()
 	if(!xeno)
 		return

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -33,7 +33,7 @@
 	return ..()
 
 /datum/status_effect/resin_jelly_coating/tick(delta_time)
-	owner.heal_limb_damage(0, 5 * delta_time)
+	owner.heal_limb_damage(0, 5)
 	return ..()
 
 // ***************************************
@@ -113,8 +113,8 @@
 	var/remaining_health = link_target.maxHealth - (link_target.getBruteLoss() + link_target.getFireLoss())
 	if(stacks < 1 || !was_within_range || remaining_health >= link_target.maxHealth)
 		return
-	var/heal_amount = link_target.maxHealth * (DRONE_ESSENCE_LINK_REGEN * stacks) * delta_time
-	var/ability_cost = heal_amount * 2 * delta_time
+	var/heal_amount = link_target.maxHealth * (DRONE_ESSENCE_LINK_REGEN * stacks)
+	var/ability_cost = heal_amount * 2
 	if(link_owner.plasma_stored < ability_cost)
 		if(!COOLDOWN_CHECK(src, plasma_warning))
 			return
@@ -225,10 +225,10 @@
 
 /datum/status_effect/salve_regen/tick(delta_time)
 	new /obj/effect/temp_visual/healing(get_turf(buff_owner))
-	var/heal_amount = buff_owner.maxHealth * 0.01 * delta_time
+	var/heal_amount = buff_owner.maxHealth * 0.01
 	buff_owner.adjustFireLoss(-max(0, heal_amount - buff_owner.getBruteLoss()), passive = TRUE)
 	buff_owner.adjustBruteLoss(-heal_amount, passive = TRUE)
-	buff_owner.adjust_sunder(-1 * delta_time)
+	buff_owner.adjust_sunder(-1)
 	return ..()
 
 // ***************************************
@@ -302,7 +302,7 @@
 	if(buffing_xeno.plasma_stored < ability_cost)
 		enhancement_action.end_ability()
 		return
-	buffing_xeno.use_plasma(ability_cost * delta_time)
+	buffing_xeno.use_plasma(ability_cost)
 
 /// Toggles the buff on or off.
 /datum/status_effect/drone_enhancement/proc/toggle_buff(toggle)
@@ -558,14 +558,14 @@
 
 /datum/status_effect/xeno_feast/tick(delta_time)
 	var/mob/living/carbon/xenomorph/X = owner
-	if(X.plasma_stored < plasma_drain * delta_time)
+	if(X.plasma_stored < plasma_drain)
 		to_chat(X, span_notice("Our feast has come to an end..."))
 		X.remove_status_effect(STATUS_EFFECT_XENO_FEAST)
 		return
-	var/heal_amount = X.maxHealth * 0.08 * delta_time
+	var/heal_amount = X.maxHealth * 0.08
 	HEAL_XENO_DAMAGE(X, heal_amount, FALSE)
 	adjustOverheal(X, heal_amount / 2)
-	X.use_plasma(plasma_drain * delta_time)
+	X.use_plasma(plasma_drain)
 
 // ***************************************
 // *********** Plasma Fruit buff

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -602,7 +602,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	if(HAS_TRAIT(X,TRAIT_NOPLASMAREGEN)) //No bonus plasma if you're on a diet
 		return
-	var/bonus_plasma = X.xeno_caste.plasma_gain * bonus_regen * (1 + X.recovery_aura * 0.05) * seconds_per_tick //Recovery aura multiplier; 5% bonus per full level
+	var/bonus_plasma = X.xeno_caste.plasma_gain * bonus_regen * (1 + X.recovery_aura * 0.05) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD //Recovery aura multiplier; 5% bonus per full level
 	X.gain_plasma(bonus_plasma)
 
 /datum/status_effect/plasma_surge/on_remove()
@@ -672,7 +672,7 @@
 
 	new /obj/effect/temp_visual/healing(get_turf(patient)) //Cool SFX
 
-	var/total_heal_amount = 6 + (patient.maxHealth * 0.03) * seconds_per_tick //Base amount 6 HP plus 3% of max
+	var/total_heal_amount = 6 + (patient.maxHealth * 0.03) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD //Base amount 6 HP plus 3% of max
 	if(patient.recovery_aura)
 		total_heal_amount *= (1 + patient.recovery_aura * 0.05) //Recovery aura multiplier; 5% bonus per full level
 
@@ -705,7 +705,7 @@
 
 	new /obj/effect/temp_visual/telekinesis(get_turf(patient)) //Visual confirmation
 
-	patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05) * seconds_per_tick) //5% bonus per rank of our recovery aura
+	patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD) //5% bonus per rank of our recovery aura
 
 /atom/movable/screen/alert/status_effect/healing_infusion
 	name = "Healing Infusion"

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,4 +1,4 @@
-/mob/living/brain/Life()
+/mob/living/brain/Life(seconds_per_tick, times_fired)
 	set invisibility = 0
 	set background = 1
 	..()

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -18,7 +18,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	in_use = FALSE
 	return ..()
 
-/mob/living/carbon/human/dummy/Life()
+/mob/living/carbon/human/dummy/Life(seconds_per_tick, times_fired)
 	SSmobs.stop_processing(src)
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/Life()
+/mob/living/carbon/human/Life(seconds_per_tick, times_fired)
 	. = ..()
 
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/Life()
+/mob/living/carbon/Life(seconds_per_tick, times_fired)
 
 	set invisibility = 0
 	set background = 1

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
@@ -33,7 +33,7 @@
 	if(!QDELETED(src))
 		gib()
 
-/mob/living/carbon/xenomorph/puppet/Life()
+/mob/living/carbon/xenomorph/puppet/Life(seconds_per_tick, times_fired)
 	. = ..()
 	var/atom/movable/master = weak_master?.resolve()
 	if(!master)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -3,7 +3,7 @@
 #define XENO_STANDING_HEAL 0.2
 #define XENO_CRIT_DAMAGE 5
 
-/mob/living/carbon/xenomorph/Life()
+/mob/living/carbon/xenomorph/Life(seconds_per_tick, times_fired)
 
 	if(!loc)
 		return
@@ -23,12 +23,12 @@
 		if(xeno_flags & XENO_ZOOMED)
 			if(loc != zoom_turf || lying_angle)
 				zoom_out()
-		update_progression()
-		update_evolving()
+		update_progression(seconds_per_tick)
+		update_evolving(seconds_per_tick)
 
-	handle_living_sunder_updates()
-	handle_living_health_updates()
-	handle_living_plasma_updates()
+	handle_living_sunder_updates(seconds_per_tick)
+	handle_living_health_updates(seconds_per_tick)
+	handle_living_plasma_updates(seconds_per_tick)
 	update_action_button_icons()
 	update_icons(FALSE)
 
@@ -41,9 +41,9 @@
 	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Sanity check; have to be on fire to actually take the damage.
 		apply_damage((fire_stacks + 3), BURN, blocked = FIRE)
 
-/mob/living/carbon/xenomorph/proc/handle_living_health_updates()
+/mob/living/carbon/xenomorph/proc/handle_living_health_updates(seconds_per_tick)
 	if(health < 0)
-		handle_critical_health_updates()
+		handle_critical_health_updates(seconds_per_tick)
 		return
 	if((health >= maxHealth) || on_fire) //can't regenerate.
 		return
@@ -56,18 +56,18 @@
 		ruler_healing_penalty = 1
 	if(loc_weeds_type || xeno_caste.caste_flags & CASTE_INNATE_HEALING) //We regenerate on weeds or can on our own.
 		if(lying_angle || resting || xeno_caste.caste_flags & CASTE_QUICK_HEAL_STANDING)
-			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty * loc_weeds_type ? initial(loc_weeds_type.resting_buff) : 1, TRUE)
+			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty * loc_weeds_type ? initial(loc_weeds_type.resting_buff) : 1, TRUE, seconds_per_tick)
 		else
-			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty, TRUE) //Major healing nerf if standing.
+			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty, seconds_per_tick, TRUE) //Major healing nerf if standing.
 	updatehealth()
 
 ///Handles sunder modification/recovery during life.dm for xenos
-/mob/living/carbon/xenomorph/proc/handle_living_sunder_updates()
+/mob/living/carbon/xenomorph/proc/handle_living_sunder_updates(seconds_per_tick)
 
 	if(!sunder || on_fire) //No sunder, no problem; or we're on fire and can't regenerate.
 		return
 
-	var/sunder_recov = xeno_caste.sunder_recover * -0.5 //Baseline
+	var/sunder_recov = xeno_caste.sunder_recover * -0.5 * seconds_per_tick //Baseline
 
 	if(resting) //Resting doubles sunder recovery
 		sunder_recov *= 2
@@ -78,17 +78,17 @@
 	if(recovery_aura)
 		sunder_recov *= 1 + recovery_aura * 0.1 //10% bonus per rank of recovery aura
 
-	SEND_SIGNAL(src, COMSIG_XENOMORPH_SUNDER_REGEN, src)
+	SEND_SIGNAL(src, COMSIG_XENOMORPH_SUNDER_REGEN, seconds_per_tick)
 
 	adjust_sunder(sunder_recov)
 
-/mob/living/carbon/xenomorph/proc/handle_critical_health_updates()
+/mob/living/carbon/xenomorph/proc/handle_critical_health_updates(seconds_per_tick)
 	if(loc_weeds_type)
-		heal_wounds(XENO_RESTING_HEAL)
+		heal_wounds(XENO_RESTING_HEAL, seconds_per_tick)
 	else if(!endure) //If we're not Enduring we bleed out
-		adjustBruteLoss(XENO_CRIT_DAMAGE)
+		adjustBruteLoss(XENO_CRIT_DAMAGE * seconds_per_tick)
 
-/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE)
+/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE, seconds_per_tick)
 	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 3.75% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%
@@ -96,19 +96,19 @@
 		if(recovery_aura)
 			regen_power = clamp(regen_power + xeno_caste.regen_ramp_amount*30,0,1) //Ignores the cooldown, and gives a 50% boost.
 		else if(regen_power < 0) // We're not supposed to regenerate yet. Start a countdown for regeneration.
-			regen_power += 2 SECONDS //Life ticks are 2 seconds.
+			regen_power += 2 SECONDS //Life ticks are 2 seconds. TODO: Check if I can use seconds_per_tick
 			return
 		else
 			regen_power = min(regen_power + xeno_caste.regen_ramp_amount*20,1)
 		amount *= regen_power
-	amount *= multiplier * GLOB.xeno_stat_multiplicator_buff
+	amount *= multiplier * GLOB.xeno_stat_multiplicator_buff * seconds_per_tick
 
 	var/list/heal_data = list(amount)
-	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, heal_data)
+	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, heal_data, seconds_per_tick)
 	HEAL_XENO_DAMAGE(src, heal_data[1], TRUE)
 	return heal_data[1]
 
-/mob/living/carbon/xenomorph/proc/handle_living_plasma_updates()
+/mob/living/carbon/xenomorph/proc/handle_living_plasma_updates(seconds_per_tick)
 	var/turf/T = loc
 	if(!istype(T)) //This means plasma doesn't update while you're in things like a vent, but since you don't have weeds in a vent or can actually take advantage of pheros, this is fine
 		return
@@ -122,7 +122,7 @@
 			QDEL_NULL(current_aura)
 			src.balloon_alert(src, "Stop emitting, no plasma")
 		else
-			use_plasma(pheromone_cost, FALSE)
+			use_plasma(pheromone_cost * seconds_per_tick, FALSE)
 
 	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN) || !loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
 		if(current_aura) //we only need to update if we actually used plasma from pheros
@@ -136,9 +136,11 @@
 
 	plasma_gain *= loc_weeds_type ? initial(loc_weeds_type.resting_buff) : 1
 
+	plasma_gain *= seconds_per_tick
+
 	var/list/plasma_mod = list(plasma_gain)
 
-	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod)
+	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod, seconds_per_tick)
 
 	plasma_mod[1] = clamp(plasma_mod[1], 0, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit - plasma_stored)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -58,7 +58,7 @@
 		if(lying_angle || resting || xeno_caste.caste_flags & CASTE_QUICK_HEAL_STANDING)
 			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty * loc_weeds_type ? initial(loc_weeds_type.resting_buff) : 1, TRUE, seconds_per_tick)
 		else
-			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty, seconds_per_tick, TRUE) //Major healing nerf if standing.
+			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty, TRUE, seconds_per_tick) //Major healing nerf if standing.
 	updatehealth()
 
 ///Handles sunder modification/recovery during life.dm for xenos
@@ -67,7 +67,7 @@
 	if(!sunder || on_fire) //No sunder, no problem; or we're on fire and can't regenerate.
 		return
 
-	var/sunder_recov = xeno_caste.sunder_recover * -0.5 * seconds_per_tick //Baseline
+	var/sunder_recov = xeno_caste.sunder_recover * -0.5 * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD //Baseline
 
 	if(resting) //Resting doubles sunder recovery
 		sunder_recov *= 2
@@ -86,7 +86,7 @@
 	if(loc_weeds_type)
 		heal_wounds(XENO_RESTING_HEAL, seconds_per_tick)
 	else if(!endure) //If we're not Enduring we bleed out
-		adjustBruteLoss(XENO_CRIT_DAMAGE * seconds_per_tick)
+		adjustBruteLoss(XENO_CRIT_DAMAGE * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD)
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE, seconds_per_tick)
 	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 3.75% max health, with scaling power.
@@ -96,12 +96,12 @@
 		if(recovery_aura)
 			regen_power = clamp(regen_power + xeno_caste.regen_ramp_amount*30,0,1) //Ignores the cooldown, and gives a 50% boost.
 		else if(regen_power < 0) // We're not supposed to regenerate yet. Start a countdown for regeneration.
-			regen_power += 2 SECONDS //Life ticks are 2 seconds. TODO: Check if I can use seconds_per_tick
+			regen_power += seconds_per_tick
 			return
 		else
 			regen_power = min(regen_power + xeno_caste.regen_ramp_amount*20,1)
 		amount *= regen_power
-	amount *= multiplier * GLOB.xeno_stat_multiplicator_buff * seconds_per_tick
+	amount *= multiplier * GLOB.xeno_stat_multiplicator_buff * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD
 
 	var/list/heal_data = list(amount)
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, heal_data, seconds_per_tick)
@@ -122,7 +122,7 @@
 			QDEL_NULL(current_aura)
 			src.balloon_alert(src, "Stop emitting, no plasma")
 		else
-			use_plasma(pheromone_cost * seconds_per_tick, FALSE)
+			use_plasma(pheromone_cost * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD, FALSE)
 
 	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN) || !loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
 		if(current_aura) //we only need to update if we actually used plasma from pheros
@@ -136,7 +136,7 @@
 
 	plasma_gain *= loc_weeds_type ? initial(loc_weeds_type.resting_buff) : 1
 
-	plasma_gain *= seconds_per_tick
+	plasma_gain *= seconds_per_tick * XENO_PER_SECOND_LIFE_MOD
 
 	var/list/plasma_mod = list(plasma_gain)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -241,11 +241,11 @@
 //Stealth handling
 
 
-/mob/living/carbon/xenomorph/proc/update_progression()
+/mob/living/carbon/xenomorph/proc/update_progression(seconds_per_tick)
 	// Upgrade is increased based on marine to xeno population taking stored_larva as a modifier.
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
-	upgrade_stored += 1 + (stored_larva/6) + hive.get_upgrade_boost() //Do this regardless of whether we can upgrade so age accrues at primo
+	upgrade_stored += (1 + (stored_larva/6) + hive.get_upgrade_boost()) * seconds_per_tick //Do this regardless of whether we can upgrade so age accrues at primo
 	if(!upgrade_possible())
 		return
 	if(upgrade_stored < xeno_caste.upgrade_threshold)
@@ -255,7 +255,7 @@
 	upgrade_xeno(upgrade_next())
 
 
-/mob/living/carbon/xenomorph/proc/update_evolving()
+/mob/living/carbon/xenomorph/proc/update_evolving(seconds_per_tick)
 	if(evolution_stored >= xeno_caste.evolution_threshold || !(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		return
 	if(!hive.check_ruler() && caste_base_type != /datum/xeno_caste/larva) // Larva can evolve without leaders at round start.
@@ -265,7 +265,8 @@
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
 	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + hive.get_evolution_boost() + spec_evolution_boost()
-	evolution_stored = min(evolution_stored + evolution_points, xeno_caste.evolution_threshold)
+	var/evolution_points_lag = evolution_points * seconds_per_tick
+	evolution_stored = min(evolution_stored + evolution_points_lag, xeno_caste.evolution_threshold)
 
 	if(!client || !ckey)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -245,7 +245,7 @@
 	// Upgrade is increased based on marine to xeno population taking stored_larva as a modifier.
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
-	upgrade_stored += (1 + (stored_larva/6) + hive.get_upgrade_boost()) * seconds_per_tick //Do this regardless of whether we can upgrade so age accrues at primo
+	upgrade_stored += (1 + (stored_larva/6) + hive.get_upgrade_boost()) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD //Do this regardless of whether we can upgrade so age accrues at primo
 	if(!upgrade_possible())
 		return
 	if(upgrade_stored < xeno_caste.upgrade_threshold)
@@ -265,7 +265,7 @@
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
 	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + hive.get_evolution_boost() + spec_evolution_boost()
-	var/evolution_points_lag = evolution_points * seconds_per_tick
+	var/evolution_points_lag = evolution_points * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD
 	evolution_stored = min(evolution_stored + evolution_points_lag, xeno_caste.evolution_threshold)
 
 	if(!client || !ckey)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,4 +1,4 @@
-/mob/living/proc/Life()
+/mob/living/proc/Life(seconds_per_tick, times_fired)
 	if(stat == DEAD || notransform || HAS_TRAIT(src, TRAIT_STASIS)) //If we're dead or notransform don't bother processing life
 		return
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/ai/Life()
+/mob/living/silicon/ai/Life(seconds_per_tick, times_fired)
 
 	if(notransform) //If we're dead or set to notransform don't bother processing life
 		return

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -89,7 +89,7 @@
 	maxHealth = 200
 
 
-/mob/living/simple_animal/cat/Life()
+/mob/living/simple_animal/cat/Life(seconds_per_tick, times_fired)
 	if(!stat && !buckled && !client)
 		if(prob(1))
 			emote("me", 1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -92,7 +92,7 @@
 	icon_dead = "narsian_dead"
 
 
-/mob/living/simple_animal/corgi/narsie/Life()
+/mob/living/simple_animal/corgi/narsie/Life(seconds_per_tick, times_fired)
 	. = ..()
 	for(var/mob/living/simple_animal/P in range(1, src))
 		if(P == src || !prob(5))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -30,7 +30,7 @@
 	AddComponent(/datum/component/udder)
 
 
-/mob/living/simple_animal/hostile/retaliate/goat/Life()
+/mob/living/simple_animal/hostile/retaliate/goat/Life(seconds_per_tick, times_fired)
 	. = ..()
 	if(!.)
 		return
@@ -136,7 +136,7 @@
 	pixel_y = rand(0, 10)
 
 
-/mob/living/simple_animal/chick/Life()
+/mob/living/simple_animal/chick/Life(seconds_per_tick, times_fired)
 	. =..()
 	if(!.)
 		return
@@ -147,7 +147,7 @@
 			qdel(src)
 
 
-/mob/living/simple_animal/chick/holo/Life()
+/mob/living/simple_animal/chick/holo/Life(seconds_per_tick, times_fired)
 	. = ..()
 	amount_grown = 0
 
@@ -216,7 +216,7 @@
 	else
 		..()
 
-/mob/living/simple_animal/chicken/Life()
+/mob/living/simple_animal/chicken/Life(seconds_per_tick, times_fired)
 	. =..()
 	if(!.)
 		return

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		drop_held_item(0)
 
 
-/mob/living/simple_animal/parrot/Life()
+/mob/living/simple_animal/parrot/Life(seconds_per_tick, times_fired)
 	. = ..()
 
 	//Sprite update for when a parrot gets pulled
@@ -457,7 +457,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	return ..()
 
 
-/mob/living/simple_animal/parrot/Poly/Life()
+/mob/living/simple_animal/parrot/Poly/Life(seconds_per_tick, times_fired)
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)
 		memory_saved = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -52,7 +52,7 @@
 	move_to_delay = rand(3, 7)
 
 
-/mob/living/simple_animal/hostile/carp/megacarp/Life()
+/mob/living/simple_animal/hostile/carp/megacarp/Life(seconds_per_tick, times_fired)
 	. = ..()
 	if(regen_cooldown < world.time)
 		heal_overall_damage(4)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -63,7 +63,7 @@
 	targets_from = null
 	return ..()
 
-/mob/living/simple_animal/hostile/Life()
+/mob/living/simple_animal/hostile/Life(seconds_per_tick, times_fired)
 	. = ..()
 	if(!.) //dead
 		walk(src, 0) //stops walking


### PR DESCRIPTION

## About The Pull Request
Makes xenomorph health/sunder healing, evo progress, maturity, and plasma regen scale based on delta_time/second_per_tick, also makes some of the xenomorph status effect buffs also use this system for their ticking healing 
## Why It's Good For The Game
In cases where lag gets really bad, this can really help, as each tick will heal more based on how much time has passed since the last time it has run. 
## Changelog
:cl:
add: Xenomorph life will now adjust the amount of healing/sunder/plasma/evo/maturity based on any extra time that Life has not run for.
/:cl:
