### PR TITLE
Improves Rappel

### DIFF
--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -382,17 +382,22 @@
 
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
+
+	var/turf/target_turf = get_turf(src)
+	for(var/mob/living/carbon/xenomorph/blocker in target_turf)
+		if(blocker.stat == CONSCIOUS)
+			user.balloon_alert(user, "There is a xenomorph blocking you from reaching the rappel rope!")
+			return
+	if(target_turf.density)
+		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
+		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")
 
 	if(user.skills.getRating(SKILL_COMBAT) < SKILL_COMBAT_DEFAULT)
 		if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_UNSKILLED) || user.lying_angle || user.anchored)
 			return
 
-	if(user.buckled_mobs)
-		if(!do_after(user, 8 SECONDS, NONE, src, BUSY_ICON_MEDICAL) || user.lying_angle || user.anchored)
-			return
-
-	if(!do_after(user, 8 SECONDS, NONE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
+	if(!do_after(user, 8 SECONDS * (1 + length(user.buckled_mobs)), NONE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
 		return
 	user.forceMove(get_turf(parent_system))
 

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -141,7 +141,6 @@
 	update_icon_state()
 	flick("rappel_hatch_opening", src)
 
-	step(user, get_dir(user, src))
 	user.client.perspective = EYE_PERSPECTIVE
 	user.client.eye = target_turf
 
@@ -151,7 +150,7 @@
 		if(!do_after(user, 3 SECONDS, NONE, rope, BUSY_ICON_UNSKILLED) && !user.lying_angle && !user.anchored && rappel_state >= RAPPEL_STATE_USABLE && rappel_condition == RAPPEL_CONDITION_GOOD)
 			passed_skillcheck = FALSE
 
-	if(passed_skillcheck && do_after(user, 2 SECONDS, NONE, rope, BUSY_ICON_GENERIC) && !user.lying_angle && !user.anchored && rappel_state >= RAPPEL_STATE_USABLE && rappel_condition == RAPPEL_CONDITION_GOOD)
+	if(passed_skillcheck && do_after(user, 4 SECONDS, NONE, rope, BUSY_ICON_GENERIC) && !user.lying_angle && !user.anchored && rappel_state >= RAPPEL_STATE_USABLE && rappel_condition == RAPPEL_CONDITION_GOOD)
 		playsound(target_turf, 'sound/effects/rappel.ogg', 50, TRUE)
 		playsound(src, 'sound/effects/rappel.ogg', 50, TRUE)
 		user.forceMove(target_turf)
@@ -383,28 +382,17 @@
 
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
-
-	if(user.buckled_mobs)
-		//Drop anyone we're fireman carrying
-		user.unbuckle_all_mobs(TRUE)
-		return
-
-	if(!step(user, get_dir(user, src)))
-		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
-		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")
 
 	if(user.skills.getRating(SKILL_COMBAT) < SKILL_COMBAT_DEFAULT)
 		if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_UNSKILLED) || user.lying_angle || user.anchored)
 			return
 
-	if(!do_after(user, 4 SECONDS, NONE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
+	if(!do_after(user, 8 SECONDS, NONE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
 		return
 	user.forceMove(get_turf(parent_system))
 
 	playsound(get_turf(src), 'sound/effects/rappel.ogg', 50, TRUE)
-	parent_system.rappel_state = RAPPEL_STATE_RETRACTING
-	parent_system.retract_rope()
 
 //Ghosts teleport to the rappel system when they click on the rope
 /obj/effect/rappel_rope/tadpole/attack_ghost(mob/dead/observer/user)

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -383,12 +383,7 @@
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
 
-	var/turf/target_turf = get_turf(src)
-	for(var/mob/living/carbon/xenomorph/blocker in target_turf)
-		if(blocker.stat == CONSCIOUS)
-			user.balloon_alert(user, "There is a xenomorph blocking you from reaching the rappel rope!")
-			return
-	if(target_turf.density)
+	if(LinkBlocked(usr, src, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE))
 		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
 		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -388,6 +388,10 @@
 		if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_UNSKILLED) || user.lying_angle || user.anchored)
 			return
 
+	if(user.buckled_mobs)
+		if(!do_after(user, 8 SECONDS, NONE, src, BUSY_ICON_MEDICAL) || user.lying_angle || user.anchored)
+			return
+
 	if(!do_after(user, 8 SECONDS, NONE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
 		return
 	user.forceMove(get_turf(parent_system))

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -380,13 +380,10 @@
 /obj/effect/rappel_rope/tadpole/attack_hand(mob/living/user)
 	. = ..()
 
-	var/turf/user_turf = get_turf(usr)
-	var/turf/rope_turf = get_turf(src)
-
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
 
-	if(LinkBlocked(user_turf, rope_turf))
+	if(LinkBlocked(get_turf(user), get_turf(src)))
 		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
 		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -383,7 +383,7 @@
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
 
-	if(LinkBlocked(usr, src, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE))
+	if(LinkBlocked(usr, src))
 		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
 		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")

--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -380,10 +380,13 @@
 /obj/effect/rappel_rope/tadpole/attack_hand(mob/living/user)
 	. = ..()
 
+	var/turf/user_turf = get_turf(usr)
+	var/turf/rope_turf = get_turf(src)
+
 	if(parent_system.rappel_condition < RAPPEL_CONDITION_GOOD)
 		return
 
-	if(LinkBlocked(usr, src))
+	if(LinkBlocked(user_turf, rope_turf))
 		user.balloon_alert(user, "Something is blocking you from reaching the rappel rope!")
 		return
 	user.balloon_alert_to_viewers("[user] begins clipping to the rappel...", "You begin clipping to the rappel...")


### PR DESCRIPTION
## About The Pull Request

- Rappel now allows more than one person to use it at once
- Rappel no longer retracts after every person using it
- Rappel takes twice as long.
- Rappel now allows fireman carrying, taking twice as long.

## Why It's Good For The Game
Rappel currently sucks. Only one person can use it at a time, and shuffling the one person is extremely easy. Going up it requires the TO to replace it over and over, making it require constant attention and impossible to use to help small groups retreat. It also disallows fireman carrying so medics get little use out of it. These problems all combine to make it incredibly clunky and hardly worth the same slot as the HSG.

This PR intends to encourage its use in both large and small team play, rather than only as a way to move individuals up and down as it currently is. The time it takes to go up and down has been doubled to compensate, and make xenos capable of shuffling people and keeping them from going up.
## Changelog
:cl:
balance: The rappel system is now far easier to use.
/:cl:
