### PR TITLE
ICC leaders are once again given loadouts.

### DIFF
--- a/code/datums/jobs/job/icc.dm
+++ b/code/datums/jobs/job/icc.dm
@@ -312,11 +312,11 @@
 /datum/job/icc/leader
 	title = "ICC Leader"
 	paygrade = "ICC2"
-	outfit = /datum/outfit/job/icc/leader/trenchgun
+	outfit = /datum/outfit/job/icc/leader/icc_heavyshotgun
 	skills_type = /datum/skills/sl/icc
 	multiple_outfits = TRUE
 	outfits = list(
-		/datum/outfit/job/icc/leader/trenchgun,
+		/datum/outfit/job/icc/leader/icc_heavyshotgun,
 		/datum/outfit/job/icc/leader/icc_confrontationrifle,
 	)
 
@@ -354,7 +354,7 @@
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_ACCESSORY)
 	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_ACCESSORY)
 
-/datum/outfit/job/icc/leader/ml101
+/datum/outfit/job/icc/leader/icc_heavyshotgun
 	suit_store = /obj/item/weapon/gun/shotgun/pump/icc_heavyshotgun/icc_leader
 	belt = /obj/item/storage/belt/shotgun/icc/mixed
 


### PR DESCRIPTION

## About The Pull Request
I forgor to push this one apperantly while playing HD2. I'm kinda a doofus.
Also renames it from ml101 (why did i do that) in the code to icc_heavyshotgun to fit the rest of the loadout names.
## Why It's Good For The Game
The ICC Leaders are finally no longer loaning their gear to their underlings.
## Changelog
:cl:
fix: Due to budget cuts, ICC ERT Leaders didn't get their loadout upon spawning. This has been rectified. And they should once again have loadouts.
/:cl:
