### PR TITLE
Fixes bigred area and barsigns.

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -8541,7 +8541,7 @@
 /area/bigredv2/outside/bar)
 "eed" = (
 /obj/structure/mirror/broken{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/spawner/random/misc/soap/deluxeweighted,
 /obj/effect/landmark/weed_node,

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -5606,8 +5606,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "bkv" = (
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "bkw" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -5655,12 +5656,14 @@
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
 	},
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "bkJ" = (
 /obj/structure/cryofeed,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "bkL" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -5737,8 +5740,9 @@
 /area/bigredv2/outside/bar)
 "blU" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "blV" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -5835,8 +5839,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "bnf" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor,

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -11458,7 +11458,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iWK" = (
-/obj/item/tool/kitchen/tray,
+/obj/item/storage/kitchen_tray,
 /obj/item/clothing/suit/storage/chef/classic,
 /obj/item/clothing/head/chefhat,
 /obj/structure/table/reinforced,
@@ -16381,8 +16381,8 @@
 /area/mainship/engineering/lower_engineering)
 "qGo" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/tool/kitchen/tray,
 /obj/effect/spawner/random/food_or_drink/kitchenknife,
+/obj/item/storage/kitchen_tray,
 /obj/item/storage/box/tgmc_mre,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/mainship/mono,

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -11458,7 +11458,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iWK" = (
-/obj/item/storage/kitchen_tray,
+/obj/item/tool/kitchen/tray,
 /obj/item/clothing/suit/storage/chef/classic,
 /obj/item/clothing/head/chefhat,
 /obj/structure/table/reinforced,
@@ -16381,7 +16381,7 @@
 /area/mainship/engineering/lower_engineering)
 "qGo" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/storage/kitchen_tray,
+/obj/item/tool/kitchen/tray,
 /obj/effect/spawner/random/food_or_drink/kitchenknife,
 /obj/item/storage/box/tgmc_mre,
 /obj/item/book/manual/chef_recipes,

--- a/_maps/modularmaps/big_red/bigredatmosvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar2.dmm
@@ -168,8 +168,9 @@
 /area/bigredv2/outside/s)
 "nU" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "oi" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -617,8 +618,9 @@
 /area/bigredv2/outside/s)
 "JO" = (
 /obj/structure/cryofeed,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/space)
+/area/bigredv2/caves/rock)
 "JQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -687,8 +689,9 @@
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
 	},
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/space)
+/area/bigredv2/caves/rock)
 "PY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -748,8 +751,9 @@
 /area/bigredv2/outside/filtration_plant)
 "Sw" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "Sx" = (
 /obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
@@ -764,6 +768,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"TZ" = (
+/obj/effect/forcefield/allow_bullet_travel,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/rock)
 "Ub" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/warning_stripes,
@@ -1153,10 +1161,10 @@ Gf
 Gf
 wE
 Gf
-Kq
+TZ
 nU
 nU
-Kq
+TZ
 Is
 oU
 Lx
@@ -1180,10 +1188,10 @@ Gf
 Rz
 Im
 xe
-Kq
+TZ
 OF
 OF
-Kq
+TZ
 HO
 Iu
 HO
@@ -1210,7 +1218,7 @@ xe
 Sw
 JO
 JO
-Kq
+TZ
 aI
 Lc
 aI
@@ -1234,10 +1242,10 @@ jW
 Xt
 Im
 dv
-Kq
+TZ
 OF
 OF
-Kq
+TZ
 yq
 oy
 ab
@@ -1261,10 +1269,10 @@ Gf
 Rz
 Im
 xe
-Kq
+TZ
 JO
 JO
-Kq
+TZ
 kO
 Gl
 kO
@@ -1288,10 +1296,10 @@ Gf
 jf
 Im
 jf
-Kq
+TZ
 nU
 nU
-Kq
+TZ
 kO
 MA
 oZ

--- a/_maps/modularmaps/big_red/bigredatmosvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar3.dmm
@@ -347,8 +347,9 @@
 /area/bigredv2/outside/filtration_plant)
 "ux" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "uU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor,
@@ -363,8 +364,9 @@
 /area/bigredv2/outside/filtration_plant)
 "wk" = (
 /obj/structure/cryofeed,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/space)
+/area/bigredv2/caves/rock)
 "wY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -415,8 +417,9 @@
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
 	},
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/engine,
-/area/space)
+/area/bigredv2/caves/rock)
 "yj" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /obj/structure/sign/safety/vent,
@@ -441,6 +444,10 @@
 	dir = 4
 	},
 /area/bigredv2/outside/s)
+"zD" = (
+/obj/effect/forcefield/allow_bullet_travel,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/rock)
 "zX" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 1;
@@ -601,8 +608,9 @@
 /area/bigredv2/outside/s)
 "Ju" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "JF" = (
 /obj/machinery/computer/area_atmos/area,
 /turf/open/floor,
@@ -1116,10 +1124,10 @@ em
 em
 lo
 em
-Ff
+zD
 ux
 ux
-Ff
+zD
 mH
 UP
 mH
@@ -1143,10 +1151,10 @@ em
 HM
 JU
 CJ
-Ff
+zD
 xY
 xY
-Ff
+zD
 nG
 qK
 nG
@@ -1173,7 +1181,7 @@ CJ
 Ju
 wk
 wk
-Ff
+zD
 eH
 oz
 eH
@@ -1197,10 +1205,10 @@ Ru
 UL
 Bq
 Wn
-Ff
+zD
 xY
 xY
-Ff
+zD
 Is
 zq
 Is
@@ -1224,10 +1232,10 @@ em
 HM
 Bq
 CJ
-Ff
+zD
 wk
 wk
-Ff
+zD
 pg
 ME
 pg
@@ -1251,10 +1259,10 @@ em
 HM
 Bq
 HM
-Ff
+zD
 ux
 ux
-Ff
+zD
 pg
 fI
 lK

--- a/_maps/modularmaps/big_red/bigredatmosvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar4.dmm
@@ -4,8 +4,9 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/outside/s)
 "br" = (
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "bJ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -110,8 +111,9 @@
 /area/bigredv2/outside/s)
 "kv" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "kX" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/se)
@@ -444,9 +446,6 @@
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
-"Qd" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/se)
 "Qe" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
 /turf/open/floor/plating,
@@ -499,13 +498,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
-"TB" = (
-/obj/structure/window/framed/colony/reinforced/hull,
-/turf/open/floor/plating,
-/area/bigredv2/outside/se)
 "Uj" = (
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/liquid/water/river,
-/area/space)
+/area/bigredv2/caves/rock)
 "Uu" = (
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor,
@@ -1008,12 +1004,12 @@ IP
 VI
 OJ
 no
-Qd
-TB
-TB
-TB
-TB
-Qd
+br
+kv
+kv
+kv
+kv
+br
 no
 no
 Qi

--- a/_maps/modularmaps/big_red/bigredatmosvar5.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar5.dmm
@@ -38,6 +38,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"dL" = (
+/obj/effect/forcefield/allow_bullet_travel,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/rock)
 "ex" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/filtration_plant)
@@ -531,8 +535,9 @@
 /area/bigredv2/outside/filtration_plant)
 "DK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "DT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -663,8 +668,9 @@
 /area/bigredv2/outside/se)
 "Jm" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/caves/rock)
 "JL" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/landmark/corpsespawner/marine,
@@ -765,8 +771,9 @@
 /area/bigredv2/outside/s)
 "OG" = (
 /obj/structure/cryofeed,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/bcircuit/anim,
-/area/space)
+/area/bigredv2/caves/rock)
 "Qe" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
@@ -897,8 +904,9 @@
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
 	},
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/bcircuit/anim,
-/area/space)
+/area/bigredv2/caves/rock)
 "WO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/weed_node,
@@ -1277,10 +1285,10 @@ Yx
 Yx
 Fr
 Yx
-Au
+dL
 Jm
 Jm
-Au
+dL
 Ld
 FP
 xf
@@ -1304,10 +1312,10 @@ Yx
 Dn
 JV
 ha
-Au
+dL
 WG
 WG
-Au
+dL
 Md
 Dg
 Md
@@ -1334,7 +1342,7 @@ ha
 DK
 OG
 OG
-Au
+dL
 zH
 Oy
 zH
@@ -1358,10 +1366,10 @@ Uv
 Wj
 JV
 Np
-Au
+dL
 WG
 WG
-Au
+dL
 uL
 ba
 uL
@@ -1385,10 +1393,10 @@ Yx
 Dn
 JV
 ha
-Au
+dL
 OG
 OG
-Au
+dL
 Vf
 Ch
 Jk
@@ -1412,10 +1420,10 @@ Yx
 sr
 ov
 sr
-Au
+dL
 Jm
 Jm
-Au
+dL
 Vf
 QR
 Yt

--- a/_maps/modularmaps/big_red/bigredatmosvar6.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar6.dmm
@@ -256,10 +256,6 @@
 	dir = 9
 	},
 /area/bigredv2/outside/se)
-"qK" = (
-/obj/structure/window/framed/colony/reinforced/hull,
-/turf/open/floor/plating,
-/area/bigredv2/outside/se)
 "rd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -386,8 +382,9 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
 "zz" = (
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/liquid/water/river,
-/area/space)
+/area/bigredv2/caves/rock)
 "zI" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -450,9 +447,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/s)
-"Eg" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/se)
 "Eu" = (
 /obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -466,8 +460,9 @@
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/s)
 "EA" = (
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "Fj" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -704,8 +699,9 @@
 /area/bigredv2/outside/filtration_plant)
 "Zk" = (
 /obj/structure/window/framed/colony/reinforced/hull,
+/obj/effect/forcefield/allow_bullet_travel,
 /turf/open/floor/plating,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "Zu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1153,12 +1149,12 @@ jL
 Ok
 Ll
 Xe
-Eg
-qK
-qK
-qK
-qK
-Eg
+EA
+Zk
+Zk
+Zk
+Zk
+EA
 qk
 Wy
 go

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -1,8 +1,6 @@
 /obj/structure/sign/double/barsign
 	icon = 'icons/obj/structures/barsigns.dmi'
 	icon_state = "off"
-	anchored = TRUE
-	directional = FALSE
 
 /obj/structure/sign/double/barsign/carp
 	name = "The Drunk Carp"


### PR DESCRIPTION
## About The Pull Request
The invincible area in Big Red atmos now has enclosed area and forcefields to prevent wraith cheese.

Barsigns now go on walls like they should.

Fixed a stray mirror.
## Why It's Good For The Game
Fixes
## Changelog
:cl:
fix: Wraiths can no longer cheese into the hull area of Big Red atmos.
fix: Barsigns now go on walls again.
fix: Fixed a floating mirror on Big Red.
/:cl:
