### PR TITLE
Reduces friendly fire on support ammo types

### DIFF
--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -34,7 +34,7 @@
 
 /datum/ammo/mortar/smoke/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 3, throw_range = 0)
+	explosion(T, 0, 0, 1, 0, 0, throw_range = 0)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(10, T, 11)
 	smoke.start()

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -167,6 +167,7 @@
 	damage = 5
 	penetration = 0
 	sundering = 0
+	shrapnel_chance = 0
 	///The smoke type loaded in this ammo
 	var/datum/effect_system/smoke_spread/trail_spread_system = /datum/effect_system/smoke_spread/tactical
 


### PR DESCRIPTION

## About The Pull Request
Mortar smokes no longer have any flash.
GL54 smokes no longer deal shrapnel.
## Why It's Good For The Game
Getting flashed by tangle/cloak smoke is super annoying, and it seems like an oversight that mortar has flash range while howie doesnt.
GL54 smokes are hard to use as support because each of the 5 projectiles has a 10% chance to shrap, quickly filling your teammates with metal.

Support ammo types are underused and shouldnt harm your own team when you try to use them.
## Changelog
:cl:
balance: Mortar smokes no longer flash teammates.
balance: GL54 smoke ammos no longer shrapnel teammates.
/:cl:
