### PR TITLE
Buffs Barricades

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -329,7 +329,7 @@
 	desc = "A wall made out of wooden planks nailed together. Not very sturdy, but can provide some concealment."
 	icon = 'icons/obj/structures/barricades/misc.dmi'
 	icon_state = "wooden"
-	max_integrity = 150
+	max_integrity = 100
 	layer = OBJ_LAYER
 	stack_type = /obj/item/stack/sheet/wood
 	stack_amount = 5

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -81,7 +81,7 @@
 
 	if(is_wired)
 		balloon_alert(xeno_attacker, "Wire slices into us")
-		xeno_attacker.apply_damage(10, blocked = MELEE , sharp = TRUE, updating_health = TRUE)
+		xeno_attacker.apply_damage(15, blocked = MELEE , sharp = TRUE, updating_health = TRUE)
 
 	return ..()
 
@@ -396,7 +396,7 @@
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon = 'icons/obj/structures/barricades/metal.dmi'
 	icon_state = "metal_0"
-	max_integrity = 300
+	max_integrity = 250
 	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/metal

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -507,7 +507,7 @@
 		if(CADE_TYPE_BOMB)
 			soft_armor = soft_armor.modifyRating(bomb = 80)
 		if(CADE_TYPE_MELEE)
-			soft_armor = soft_armor.modifyRating(melee = 40, bullet = 40, laser = 30, energy = 30)
+			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 50, laser = 50, energy = 50)
 		if(CADE_TYPE_ACID)
 			soft_armor = soft_armor.modifyRating(acid = 40)
 			resistance_flags |= UNACIDABLE

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -329,7 +329,7 @@
 	desc = "A wall made out of wooden planks nailed together. Not very sturdy, but can provide some concealment."
 	icon = 'icons/obj/structures/barricades/misc.dmi'
 	icon_state = "wooden"
-	max_integrity = 100
+	max_integrity = 150
 	layer = OBJ_LAYER
 	stack_type = /obj/item/stack/sheet/wood
 	stack_amount = 5
@@ -396,7 +396,7 @@
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon = 'icons/obj/structures/barricades/metal.dmi'
 	icon_state = "metal_0"
-	max_integrity = 200
+	max_integrity = 300
 	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/metal
@@ -505,11 +505,11 @@
 
 	switch(choice)
 		if(CADE_TYPE_BOMB)
-			soft_armor = soft_armor.modifyRating(bomb = 50)
+			soft_armor = soft_armor.modifyRating(bomb = 80)
 		if(CADE_TYPE_MELEE)
-			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30, laser = 30, energy = 30)
+			soft_armor = soft_armor.modifyRating(melee = 40, bullet = 40, laser = 30, energy = 30)
 		if(CADE_TYPE_ACID)
-			soft_armor = soft_armor.modifyRating(acid = 20)
+			soft_armor = soft_armor.modifyRating(acid = 40)
 			resistance_flags |= UNACIDABLE
 
 	barricade_upgrade_type = choice
@@ -717,8 +717,8 @@
 	desc = "A very sturdy barricade made out of plasteel panels, the pinnacle of strongpoints. Use a blowtorch to repair. Can be flipped down to create a path."
 	icon = 'icons/obj/structures/barricades/plasteel.dmi'
 	icon_state = "plasteel_closed_0"
-	max_integrity = 500
-	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
+	max_integrity = 550
+	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 50)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/plasteel
 	stack_amount = 5
@@ -982,7 +982,7 @@
 	desc = "A bunch of bags filled with sand, stacked into a small wall. Surprisingly sturdy, albeit labour intensive to set up. Trusted to do the job since 1914."
 	icon = 'icons/obj/structures/barricades/sandbags.dmi'
 	icon_state = "sandbag_0"
-	max_integrity = 300
+	max_integrity = 325
 	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sandbags
@@ -1047,7 +1047,7 @@
 /obj/structure/barricade/metal/deployable
 	icon = 'icons/obj/structures/barricades/folding.dmi'
 	icon_state = "folding_0"
-	max_integrity = 300
+	max_integrity = 325
 	coverage = 100
 	barricade_type = "folding"
 	can_wire = TRUE

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -509,7 +509,7 @@
 		if(CADE_TYPE_MELEE)
 			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 50, laser = 50, energy = 50)
 		if(CADE_TYPE_ACID)
-			soft_armor = soft_armor.modifyRating(acid = 40)
+			soft_armor = soft_armor.modifyRating(acid = 35)
 			resistance_flags |= UNACIDABLE
 
 	barricade_upgrade_type = choice


### PR DESCRIPTION
## About The Pull Request
To go with https://github.com/tgstation/TerraGov-Marine-Corps/pull/16557.
Buffs most barricade types. Changes are as follows:

> **Barbed Wire Upgrade**
> Damage: 10 -> 15

Meant to compensate for xeno health and armor buffs slightly. Still worse than before.

> **Metal Barricade**
> Health: 200 -> 250(300 with barbed wire)
> Concussive Upgrade: 40 bomb armor -> 80 
> Ballistic Upgrade: 30 bullet/laser/energy armor -> 50(80 with base armor)
> Acid Upgrade: 20 acid armor -> 35(75 with base armor)

My thoughts here are that metal cades are laughably weak in all aspects and their upgrades do not help this feeling. This is probably the biggest buff here, and I am willing to tone it down a bit or perhaps increase the cost to build them to 5 to compensate. 
Firstly, acid cades are the big one: a single ranged caste being able to whittle down marine defenses so effectively is the main problem and is what I wish to nuke. 
Secondly, I honestly believe that the explosive upgrade should grant total explosion immunity to the cade, but this is fine enough. 
Lastly, the ballistic upgrade should simply be very good at stopping guns. It currently isn't, as every marine or sommie can blast through them like paper in hvh. I don't believe melee castes should be punished any more than the health buff, so the +30 melee armor remains the same as previous for this upgrade.
>**Plasteel Barricade**
> Heath: 500 -> 550(600 with barbed wire)
> Acid Armor: 40 -> 50

Health and acid armor buff are meant to also decrease the effectiveness of ranged caste spam, however I don't believe it needs anything else.
> **Sandbags**
> Health: 300 -> 325(375 with barbed wire)

I want sandbags to keep their health advantage over metal barricades so that un-upgraded metal cades are somewhat worse than sandbags, while upgraded metal cades are much better than sandbags. To be honest, this is still the case without the +25 health, but I included it because I wanted to.
> **Deployable Shield**
> Health 300 -> 325

Mostly same as above.
## Why It's Good For The Game
Currently, marine defense is laughably bad due to xeno health buffs, removal of aim mode, and general powercreep/balance shifts in the game since a few years ago. This changes is poised at generally buffing marine defense and specifically lowering the effectiveness of ranged xeno attacks against cades, as currently, it is incredibly easy for a single ranged caste to whittle down a cade line unless marines *leave* their cades to chase it away. 

I do not believe this will completely destroy xeno's balance, as marines tend to get complacent when they sit behind good defenses for too long and are much more likely to make mistakes that xenos can capitalize on; marines sitting behind a cade line doing a disk just slows their momentum, which they need if they want to get all of the disks.

Numbers are not final by any means, and if any of them are too much I will gladly nerf it. However, I think this is a good starting point. 
## Changelog
:cl:
Balance: Increased health of most barricade types(Metal+50, Plasteel+50, Sandbags+25, Deployable+25)
Balance: Doubles armor values of most metal barricade upgrade types with the exception of ballistic armor's melee value
Balance: Increased acid armor value of plasteel barricade(40 -> 50)
/:cl:
