### PR TITLE
Update beginner shocktrooper (laser) loadout

### DIFF
--- a/code/datums/quick_load_beginners.dm
+++ b/code/datums/quick_load_beginners.dm
@@ -230,7 +230,7 @@
 	human.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank/mini, SLOT_IN_BACKPACK)
 	human.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BACKPACK)
 
-	human.equip_to_slot_or_del(new /obj/item/cell/lasgun/volkite/powerpack/marine, SLOT_IN_SUIT)
+	human.equip_to_slot_or_del(new /obj/item/storage/box/m94, SLOT_IN_SUIT)
 	human.equip_to_slot_or_del(new /obj/item/storage/box/m94, SLOT_IN_SUIT)
 
 	human.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/bicaridine, SLOT_IN_ACCESSORY)

--- a/code/modules/paperwork/beginner_tutorials.dm
+++ b/code/modules/paperwork/beginner_tutorials.dm
@@ -213,8 +213,8 @@
 	name = "Shocktrooper Tutorial"
 	info = {"As a shock trooper, you are a versatile yet powerful frontliner, and aim to change up tactics often to gain the advantage.\
 	You use the multimodal laser rifle, an experimental battery-powered weapon with an underbarrel flamethrower.\
-	Your belt contains spare energy cells for your laser rifle. Your right pocket and body armor contain a powerpack to recharge energy cells.\
-	Your body armor also contains a box of flares. Your left pocket contains a flare gun holster and several flares.\
+	Your belt contains spare energy cells for your laser rifle. Your right pocket contain a powerpack to recharge energy cells.\
+	Your body armor contains two boxes of flares. Your left pocket contains a flare gun holster and several flares.\
 	Your backpack contains a large amount of miniature fuel tanks for use with your underbarrel flamethrower, as well as an inaprovaline autoinjector.\
 	Your webbing contains Bicaridine (heals brute damage), Kelotane (heals burn damage), Tramadol (a painkiller), Tricordrazine (heals all damage, but slowly),\
 	and gauze and ointment, which also heal brute and burn damage, respectively. Your helmet contains protein bars and your boots contain an MRE, in case you get hungry.<BR>
@@ -249,7 +249,7 @@
 	On a similar note, your suit's light can be toggled in the top left - you should almost always keep this on to help your visibility.<BR>
 	<BR>
 	By pressing unique action (default: space bar), you can cycle between the different modes of your laser gun.\
-	Standard mode rapidly fires laser beams, Overcharge mode fires more powerful beams at a lower rate of fire, weakening mode slows the target mildly\
+	Standard mode rapidly fires laser beams, Overcharge mode fires more powerful beams at a lower rate of fire, weakening mode slows the target mildly \
 	as well as draining their plasma, and microwave applies a stacking debuff (up to five times) that deals armor-piercing damage over time.\
 	Note that different modes consume battery charge at different rates.<BR>
 	<BR>


### PR DESCRIPTION
## About The Pull Request

Replace the TE pouch supposed to spawn in the suit storage of the beginner shocktrooper loadout with a second flare pack.
Updated the phamplet accordingly.

## Why It's Good For The Game

The TE pouch cannot fit in the general armor storage module anymore so it's just an empty slot, I replaced it with another flare box to mirror the robot shocktrooper loadout that has 2 flare boxes in the suit storage.

## Changelog

:cl:
add: Added a second flare box in the shocktrooper loadout to replace the TE pouch that can't spawn there anymore
/:cl:
