### PR TITLE
Big Red bookshelf density fix

### DIFF
--- a/_maps/modularmaps/big_red/bigredlibraryvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredlibraryvar1.dmm
@@ -163,9 +163,7 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "A" = (
-/obj/structure/bookcase{
-	density = 0
-	},
+/obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
 "B" = (
@@ -188,9 +186,7 @@
 /turf/open/floor/carpet/side,
 /area/bigredv2/outside/library)
 "F" = (
-/obj/structure/bookcase{
-	density = 0
-	},
+/obj/structure/bookcase,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
@@ -211,9 +207,7 @@
 	},
 /area/bigredv2/outside/library)
 "J" = (
-/obj/structure/bookcase{
-	density = 0
-	},
+/obj/structure/bookcase,
 /obj/machinery/light{
 	dir = 8
 	},


### PR DESCRIPTION

## About The Pull Request
Bookshelves in BR had a funny var edit to be nondense.

I have no idea why this is the case, so cleaning it up.
## Why It's Good For The Game
Mystery var edit bad.
## Changelog
:cl:
fix: fixed some bookshelves on Big Red being nondense
/:cl:
