### PR TITLE
Rock density fixes

### DIFF
--- a/code/game/objects/structures/rocks.dm
+++ b/code/game/objects/structures/rocks.dm
@@ -215,7 +215,6 @@
 	icon = 'icons/obj/structures/cave_decor.dmi'
 	icon_state = "stalagmite"
 	icon_variants = 6
-	density = FALSE
 
 /obj/structure/rock/variable/jungle
 	name = "rock"
@@ -282,6 +281,7 @@
 	light_range = 0.5
 	light_power = 0.5
 	light_color = LIGHT_COLOR_EMISSIVE_GREEN
+	density = FALSE
 
 /obj/structure/rock/variable/crystal_mound/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Stalagmites (the normal ones, not the dark ones) are dense again as intended.

Also made the little crystals pushing out of the ground nondense as that was weird.
## Why It's Good For The Game
I pranked Grayson by accidentally making the dark stalagmites dense when he didn't want, then he counterpranked me by making the other ones dense.
## Changelog
:cl:
fix: fixed a couple density issues on some rocks
/:cl:
