### PR TITLE
Jump and related fixes

### DIFF
--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -111,8 +111,8 @@
 		var/spin_number = ROUND_UP(effective_jump_duration * 0.1)
 		jumper.animation_spin(effective_jump_duration / spin_number, spin_number, jumper.dir == WEST ? FALSE : TRUE)
 
-	animate(jumper, pixel_y = jumper.pixel_y + effective_jump_height, layer = MOB_JUMP_LAYER, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-	animate(pixel_y = jumper.pixel_y - effective_jump_height, layer = original_layer, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_IN)
+	animate(jumper, pixel_z = jumper.pixel_z + effective_jump_height, layer = max(MOB_JUMP_LAYER, original_layer), time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT)
+	animate(pixel_z = jumper.pixel_z - effective_jump_height, layer = original_layer, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_IN)
 
 	if(jump_flags & JUMP_SHADOW)
 		animate(shadow_filter, y = -effective_jump_height, size = 4, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -25,9 +25,9 @@
 		changed++
 		ntransform.TurnTo(lying_prev, lying_angle)
 		if(!lying_angle) //Lying to standing
-			final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
+			final_pixel_y = lying_angle ? CARBON_LYING_Y_OFFSET : initial(pixel_y)
 		else if(lying_prev == 0) //Standing to lying down
-			final_pixel_y += lying_angle ? CARBON_LYING_Y_OFFSET : -CARBON_LYING_Y_OFFSET
+			final_pixel_y = lying_angle ? CARBON_LYING_Y_OFFSET : initial(pixel_y)
 			if(dir & (EAST|WEST))
 				final_dir = pick(NORTH, SOUTH)
 


### PR DESCRIPTION
## About The Pull Request
Jumping now uses pixel_z instead of pixel_y (like TG) to represent height. This means it doesn't interfer with anything else that edits (and hard sets) pixel_y, like pull offsets.

Fixed jumping layer being weird if you're on a higherly layer (like being on a tank).

Fixed a small visual bug when jumping in water.

Fixed pixel offsets getting messed up with drags in some situations
## Why It's Good For The Game
Ivan will stop bullying me now
## Changelog
:cl:
fix: fixed some minor visual issues with jumping in some situations
fix: Fixed some drag pixel offset issues
/:cl:
