### PR TITLE
Removes the underbarrel GL-54 from the AR-55

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1932,7 +1932,6 @@
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/standard_carbine)
 	attachable_allowed = list(
 		/obj/item/attachable/scope/optical,
-		/obj/item/weapon/gun/rifle/tx54/mini,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/lasersight,


### PR DESCRIPTION
## About The Pull Request
Per title. This only removes it from HvX, and not from freelancers and HvH, both of which have their own variants.

## Why It's Good For The Game
Y'all saw it coming. An underbarrel GL-54 with virtually the same wacky wahoo ammo types is largely unbalanced, not to mention, it is also aim mode capable and therefore has IFF. There's a good reason why a lot of people use this nowadays.

## Changelog
:cl: Lewdcifer
balance: HvX SL variant of the AR-55 can no longer have the underbarrel GL-54.
/:cl: