### PR TITLE
Minor runner evasion description update

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -80,7 +80,7 @@
 	action_icon_state = "evasion_on"
 	action_icon = 'icons/Xeno/actions/runner.dmi'
 	desc = "Take evasive action, forcing non-friendly projectiles that would hit you to miss for a short duration so long as you keep moving. \
-			Alternate use toggles Auto Evasion off or on. Click again while active to deactivate early."
+			Alternate use toggles Auto Evasion off or on. Click again while active to deactivate early. You cannot evade pointblank shots or attack while evading."
 	ability_cost = 75
 	cooldown_duration = 10 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION

## About The Pull Request
Clarifies that you can't attack or dodge point blank shots in the ability description

## Why It's Good For The Game
Less rouny's going "THE ABILITY SAYS I DODGE ALL PROJECTILES SO I SHOULD DODGE THEM AAALL"

## Changelog
:cl:
spellcheck: Runner evasion ability text updated to clarify that you can't slash while evading, and that point blank shots still hit you.
/:cl:
