### PR TITLE
Partial Railgun (held weapon) Nerf Revert.

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1020,7 +1020,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		slot_l_hand_str = 'icons/mob/inhands/guns/special_left_1.dmi',
 		slot_r_hand_str = 'icons/mob/inhands/guns/special_right_1.dmi',
 	)
-	max_shells = 1 //codex
+	max_shells = 3 //codex
 	caliber = CALIBER_RAILGUN
 	fire_sound = 'sound/weapons/guns/fire/railgun.ogg'
 	fire_rattle = 'sound/weapons/guns/fire/railgun.ogg'
@@ -1044,7 +1044,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	gun_features_flags = GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_AMMO_COUNTER
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
-	fire_delay = 2 SECONDS
+	fire_delay = 3 SECONDS
 	burst_amount = 1
 	accuracy_mult = 2
 	recoil = 3

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -382,7 +382,7 @@
 	icon_state = "railgun"
 	icon = 'icons/obj/items/ammo/misc.dmi'
 	default_ammo = /datum/ammo/bullet/railgun
-	max_rounds = 1
+	max_rounds = 3
 	reload_delay = 20 //Hard to reload.
 	w_class = WEIGHT_CLASS_NORMAL
 	icon_state_mini = "mag_railgun"


### PR DESCRIPTION
## About The Pull Request

Partially reverts #15867

Specifically:
Reverts the ammo per box from 1 to 3.
Reverts the fire delay from 2 to 3.

Note I kept the reduction in Railgun ammo cost. 
50 Points per box is equivalent to a SADAR rocket which a railgun box is certainly not, even with 3 shots.
The seasonal provides enough Railgun ammo additional shots do not need to be 

I also kept the reduction in penetration damage through walls from 85% to 75% as well as the range decrease after penetration.

I'm very willing to discuss reducing this PR's effects somewhat if that is deemed necessary.

## Why It's Good For The Game

Railgun went from somewhat in meta to almost nonexistent with this PR.
I intend to bring railgun back to relevance in a somewhat reduced form from when it was nerfed.

## Changelog

:cl:
balance: Railgun ammo per box 1 => 3.
/:cl:
