### PR TITLE
Removes Bomb Vest from Marine Vendors

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -733,7 +733,6 @@
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
-			/obj/item/clothing/suit/storage/marine/boomvest = 20,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,
 			/obj/item/radio/headset/mainship/marine/charlie = -1,


### PR DESCRIPTION
## About The Pull Request

Removes Bomb Vest from Marine Vendors

## Why It's Good For The Game

Kuro said he'd merge #16489 if I did this.
![image](https://github.com/user-attachments/assets/6cbe140c-c483-4605-9163-feaf645b92ac)
![image](https://github.com/user-attachments/assets/c91f1294-69b8-4d10-9b76-c013df04b09a)

## Changelog

:cl:
balance: Explosive Vests no longer in marine vendors.
/:cl:
