### PR TITLE
Campaign engineer buff

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -185,6 +185,8 @@
 #define TRAIT_MEDIUM_PAIN_RESIST "medium_pain_resist"
 ///is currently riding an armored vehicle
 #define TRAIT_TANK_DESANT "tank_desant"
+///Builds things better
+#define TRAIT_SUPERIOR_BUILDER "superior_builder"
 
 
 /// Prevents usage of manipulation appendages (picking, holding or using items, manipulating storage).

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -404,11 +404,21 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 
 /datum/perk/skill_mod/construction
 	name = "Advanced construction training"
-	desc = "Faster construction times when building. Some items may no longer have a penalty delay when constructing."
+	desc = "Faster construction times when building. Some items may no longer have a penalty delay when constructing, and engineers exclusively build tougher barricades."
 	ui_icon = "construction"
 	construction = 2
 	all_jobs = TRUE
-	unlock_cost = 300
+	unlock_cost = 350
+
+/datum/perk/skill_mod/construction/apply_perk(mob/living/carbon/owner)
+	. = ..()
+	if(owner.skills.getRating(construction)) < SKILL_CONSTRUCTION_MASTER
+		return
+	ADD_TRAIT(owner, TRAIT_SUPERIOR_BUILDER, type)
+
+/datum/perk/skill_mod/construction/remove_perk(mob/living/carbon/owner)
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_SUPERIOR_BUILDER, type)
 
 /datum/perk/skill_mod/leadership
 	name = "Advanced leadership training"

--- a/code/datums/gamemodes/campaign/perks.dm
+++ b/code/datums/gamemodes/campaign/perks.dm
@@ -412,7 +412,7 @@ Needed both for a purchase list and effected list (if one perk impacts multiple 
 
 /datum/perk/skill_mod/construction/apply_perk(mob/living/carbon/owner)
 	. = ..()
-	if(owner.skills.getRating(construction)) < SKILL_CONSTRUCTION_MASTER
+	if((owner.skills.getRating(SKILL_CONSTRUCTION)) < SKILL_CONSTRUCTION_MASTER)
 		return
 	ADD_TRAIT(owner, TRAIT_SUPERIOR_BUILDER, type)
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -230,7 +230,7 @@
 			return
 		T.PlaceOnTop(R.result_type)
 	else
-		O = new R.result_type(get_turf(user))
+		O = new R.result_type(get_turf(user), user)
 	if(O)
 		O.setDir(user.dir)
 		O.color = color

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -410,6 +410,12 @@
 	///The type of upgrade and corresponding overlay we have attached
 	var/barricade_upgrade_type
 
+/obj/structure/barricade/metal/Initialize(mapload, mob/user)
+	. = ..()
+	if(!user || !HAS_TRAIT(user, TRAIT_SUPERIOR_BUILDER))
+		return
+	modify_max_integrity(max_integrity + 75)
+
 /obj/structure/barricade/metal/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_SPARKS, -15, 8, 1)
 
@@ -735,6 +741,12 @@
 	///ehther we react with other cades next to us ie when opening or so
 	var/linked = FALSE
 	COOLDOWN_DECLARE(tool_cooldown) //Delay to apply tools to prevent spamming
+
+/obj/structure/barricade/plasteel/Initialize(mapload, mob/user)
+	. = ..()
+	if(!user || !HAS_TRAIT(user, TRAIT_SUPERIOR_BUILDER))
+		return
+	modify_max_integrity(max_integrity + 100)
 
 /obj/structure/barricade/plasteel/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_SPARKS, -15, 8, 1)


### PR DESCRIPTION

## About The Pull Request
The construction perk now gives Engineers (and only engineers) an additional bonus:
Metal barricades have an extra 75hp (37.5% more) and plasteel cades have an extra 100hp (20%).

Made the perk a little more expensive.
## Why It's Good For The Game
Engineers are kinda lacking in benefits, and cades in general are rather easy to destroy in HvH, so this should make them a little better at fortifying without just being omega strong.
## Changelog
:cl:
balance: Campaign: Construction perk allows Engineers to build stronger cades
/:cl:
