### PR TITLE
HvH melee stun changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -176,8 +176,8 @@ Contains most of the procs that are called when a mob is attacked by something
 
 		switch(hit_area)
 			if("head")//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(applied_damage - 5) && stat == CONSCIOUS)
-					apply_effect(modify_by_armor(10 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				if(prob(applied_damage - 15) && stat == CONSCIOUS)
+					ParalyzeNoChain(modify_by_armor(10 SECONDS, MELEE, def_zone = target_zone) * 100 / maxHealth)
 					visible_message(span_danger("[src] has been knocked unconscious!"),
 									span_danger("You have been knocked unconscious!"), null, 5)
 					hit_report += "(KO)"
@@ -194,8 +194,8 @@ Contains most of the procs that are called when a mob is attacked by something
 						update_inv_glasses(0)
 
 			if("chest")//Easier to score a stun but lasts less time
-				if(prob((applied_damage + 5)) && !incapacitated())
-					apply_effect(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone), WEAKEN)
+				if(prob((applied_damage - 5)) && stat == CONSCIOUS)
+					ParalyzeNoChain(modify_by_armor(6 SECONDS, MELEE, def_zone = target_zone) * 100 / maxHealth)
 					visible_message(span_danger("[src] has been knocked down!"),
 									span_danger("You have been knocked down!"), null, 5)
 					hit_report += "(KO)"


### PR DESCRIPTION

## About The Pull Request
Lowered melee stun chances by a flat 10% (i.e. a 15% stun chance is now 5%).
Melee stuns no longer chain stun.
Melee stun chance now scales with maxhp (i.e. the health perks will make you harder to melee stun).
## Why It's Good For The Game
Less ggnore while still being extremely dangerous.
## Changelog
:cl:
balance: Campaign: Melee stun chance lowered by a flat 10%
balance: Campaign: Melee stun chance scales with max hp
balance: Campaign: Melee stuns can no longer chainstun
/:cl:
