### PR TITLE
Hunter stat adjustment

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -26,7 +26,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 320
+	max_health = 330
 
 	// *** Evolution *** //
 	evolution_threshold = 225

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -26,7 +26,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 320
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -40,7 +40,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 40, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
+	soft_armor = list(MELEE = 55, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
 
 	// *** Stealth ***
 	stealth_break_threshold = 15


### PR DESCRIPTION

## About The Pull Request
Reduced Hunter health from 360 to 320.
Increased melee armour from 40 back to 55.
## Why It's Good For The Game
The Kuro buffs really made hunter far stronger than it had any business being, with the sole exception of melee (where it should be strongest), where it was actually significantly nerfed.

This change reduces it overall survivability while preserving/restoring its melee toughness.
## Changelog
:cl:
balance: Hunter health reduced from 360 to 320
balance: Hunter melee armour increased from 40 back to 55
/:cl:
