### PR TITLE
Tyr HvH buff

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -403,6 +403,14 @@
 
 	return old_component
 
+///Removes a component of a specified type
+/datum/proc/remove_component(datum/component/component_type)
+	if(ispath(component_type))
+		component_type = GetExactComponent(component_type)
+	if(!component_type)
+		return
+	component_type.RemoveComponent()
+
 /**
  * Removes a component source from this datum
  */

--- a/code/datums/components/companion.dm
+++ b/code/datums/components/companion.dm
@@ -111,8 +111,7 @@
 	if(isanimal(parent))
 		var/mob/living/simple_animal/animal_parent = parent
 		animal_parent.toggle_ai(AI_ON)
-	var/datum/component/ai_component = mob_parent.GetComponent(/datum/component/ai_controller)
-	ai_component.RemoveComponent()
+	mob_parent.remove_component(/datum/component/ai_controller)
 
 ///Handles what the slug does on hearing its owner
 /datum/component/companion/proc/handle_mob_master_speech(datum/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -58,8 +58,8 @@
 	parent.AddElement(/datum/element/limb_support, supported_limbs)
 
 /obj/item/armor_module/module/valkyrie_autodoc/on_detach(obj/item/detaching_from, mob/user)
-	qdel(parent.GetComponent(/datum/component/suit_autodoc))
-	parent.RemoveElement(/datum/element/limb_support, supported_limbs)
+	detaching_from.remove_component(/datum/component/suit_autodoc)
+	detaching_from.RemoveElement(/datum/element/limb_support, supported_limbs)
 	return ..()
 
 /obj/item/armor_module/module/valkyrie_autodoc/som
@@ -537,9 +537,7 @@
 	parent.AddComponent(/datum/component/clothing_tint, TINT_5, active)
 
 /obj/item/armor_module/module/welding/on_detach(obj/item/detaching_from, mob/user)
-	parent.GetComponent(/datum/component/clothing_tint)
-	var/datum/component/clothing_tint/tints = parent?.GetComponent(/datum/component/clothing_tint)
-	tints.RemoveComponent()
+	detaching_from.remove_component(/datum/component/clothing_tint)
 	return ..()
 
 /obj/item/armor_module/module/welding/activate(mob/living/user)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -126,6 +126,14 @@
 	slot = ATTACHMENT_SLOT_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_armor_xn")
 
+/obj/item/armor_module/module/tyr_extra_armor/on_attach(obj/item/attaching_to, mob/user)
+	. = ..()
+	attaching_to.AddComponent(/datum/component/stun_mitigation, slot_override = SLOT_WEAR_SUIT, shield_cover = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 50, FIRE = 50, ACID = 50))
+
+/obj/item/armor_module/module/tyr_extra_armor/on_detach(obj/item/detaching_from, mob/user)
+	detaching_from.remove_component(/datum/component/stun_mitigation)
+	return ..()
+
 /obj/item/armor_module/module/tyr_extra_armor/mark1
 	name = "\improper Mark 1 Tyr Armor Reinforcement"
 	desc = "Designed for mounting on modular armor. A substantial amount of additional armor plating designed to grant the user extra protection against threats, ranging from xeno slashes to friendly fire incidents. This older version has worse protection. Will greatly impact mobility."

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -229,8 +229,7 @@
 	xenomorph.AddComponent(/datum/component/bump_attack)
 
 /datum/xeno_caste/proc/on_caste_removed(mob/xenomorph)
-	var/datum/component/bump_attack = xenomorph.GetComponent(/datum/component/bump_attack)
-	bump_attack?.RemoveComponent()
+	xenomorph.remove_component(/datum/component/bump_attack)
 	for(var/trait in caste_traits)
 		REMOVE_TRAIT(xenomorph, trait, XENO_TRAIT)
 


### PR DESCRIPTION

## About The Pull Request
Tyr now has 50% ranged stun mitigation like B18.

Also added a remove_component proc since I noticed the same getcomponent stuff was being used in various places.
## Why It's Good For The Game
Makes Tyr more viable compared to just running overclocked shield mod, by making shotgun stuns unreliable against it.
Also turbo charges stun mitigation if you're packing Tyr and a shield.
## Changelog
:cl:
balance: Campaign: Gave Tyr for both factions 50% ranged stun mitigation like B18
/:cl:
