### PR TITLE
Survivening: More survivor content

### DIFF
--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -81,6 +81,10 @@ Good luck, but do not expect to survive."})
 	l_store = /obj/item/flashlight/combat
 	r_hand = /obj/item/weapon/combat_knife
 
+/datum/outfit/job/survivor/assistant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
+
 
 //Scientist
 /datum/job/survivor/scientist
@@ -111,6 +115,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/quickclotplus, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 //Doctor
 /datum/job/survivor/doctor
@@ -155,6 +160,7 @@ Good luck, but do not expect to survive."})
 
 	H.equip_to_slot_or_del(new /obj/item/flashlight, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 	H.equip_to_slot_or_del(new /obj/item/tweezers, SLOT_IN_R_POUCH)
 
@@ -177,6 +183,10 @@ Good luck, but do not expect to survive."})
 	l_hand = /obj/item/flashlight/combat
 	l_store = /obj/item/tool/crowbar
 
+/datum/outfit/job/survivor/liaison/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
+
 //Security Guard
 /datum/job/survivor/security
 	title = "Security Guard Survivor"
@@ -191,7 +201,7 @@ Good luck, but do not expect to survive."})
 	w_uniform = /obj/item/clothing/under/rank/security
 	wear_suit = /obj/item/clothing/suit/armor/patrol
 	head = /obj/item/clothing/head/securitycap
-	shoes = /obj/item/clothing/shoes/marine
+	shoes = /obj/item/clothing/shoes/marine/full
 	back = /obj/item/storage/backpack/security
 	belt = /obj/item/storage/belt/security
 	gloves = /obj/item/clothing/gloves/black
@@ -207,6 +217,9 @@ Good luck, but do not expect to survive."})
 
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/gauze, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/ointment, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Civilian
@@ -229,6 +242,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/flashlight, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/weapon/combat_knife/upp, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Chef
@@ -256,13 +270,13 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/burger/crazy, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/soup/mysterysoup, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/packaged_hdogs, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/organ, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/chocolateegg, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/meat/xeno, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/pastries/xemeatpie, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/pastries/birthdaycakeslice, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/donut/meat, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Botanist
@@ -280,9 +294,9 @@ Good luck, but do not expect to survive."})
 	shoes = /obj/item/clothing/shoes/black
 	back = /obj/item/storage/backpack/hydroponics
 	ears = /obj/item/radio/survivor
-	suit_store = /obj/item/weapon/combat_knife
 	l_store = /obj/item/flashlight
 	r_store = /obj/item/tool/crowbar
+	l_hand = /obj/item/tool/hatchet
 
 /datum/outfit/job/survivor/botanist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -290,6 +304,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/grown/ambrosiadeus, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/grown/ambrosiadeus, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Atmospherics Technician
@@ -327,6 +342,9 @@ Good luck, but do not expect to survive."})
 
 	H.equip_to_slot_or_del(new /obj/item/lightreplacer, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/deployable_floodlight, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/metalfoam, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/metalfoam, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 	H.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/medium_stack, SLOT_IN_L_POUCH)
 	H.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/small_stack, SLOT_IN_L_POUCH)
@@ -347,15 +365,16 @@ Good luck, but do not expect to survive."})
 	shoes = /obj/item/clothing/shoes/black
 	back = /obj/item/storage/backpack/satchel/norm
 	ears = /obj/item/radio/survivor
+	l_hand = /obj/item/weapon/gun/shotgun/double
+	r_hand = /obj/item/ammo_magazine/handful/buckshot
 
 /datum/outfit/job/survivor/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/tool/candle, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/tool/candle, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/tool/candle, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/lighter, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/bible, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Miner
@@ -384,6 +403,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/tool/lighter, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/bottle/whiskey, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary/molotov, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Salesman
@@ -412,6 +432,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/holdout, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/lighter/zippo, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 
 //Colonial Marshal
@@ -442,6 +463,126 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/gauze, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BELT)
 
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
+
+
+//Bartender Survivor
+/datum/job/survivor/bartender
+	title = "Bartender Survivor"
+	outfit = /datum/outfit/job/survivor/bartender
+
+
+/datum/outfit/job/survivor/bartender
+	name = "Bartender Survivor"
+	jobtype = /datum/job/survivor/bartender
+
+	w_uniform = /obj/item/clothing/under/rank/bartender
+	wear_suit = /obj/item/clothing/suit/armor/vest
+	back = /obj/item/storage/backpack/satchel
+	belt = /obj/item/ammo_magazine/shotgun/buckshot
+	shoes = /obj/item/clothing/shoes/laceup
+	head = /obj/item/clothing/head/collectable/tophat
+	ears = /obj/item/radio/survivor
+	glasses = /obj/item/clothing/glasses/sunglasses
+	l_store = /obj/item/flashlight
+	r_store = /obj/item/tool/crowbar
+	suit_store = /obj/item/weapon/gun/shotgun/double/sawn
+
+/datum/outfit/job/survivor/bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/bottle/whiskey , SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/bottle/vodka , SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/beer , SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/beer , SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
+
+
+//Chemist Survivor
+/datum/job/survivor/chemist
+	title = "Pharmacy Technician Survivor"
+	skills_type = /datum/skills/civilian/survivor/scientist
+	outfit = /datum/outfit/job/survivor/chemist
+
+
+/datum/outfit/job/survivor/chemist
+	name = "Pharmacy Technician Survivor"
+	jobtype = /datum/job/survivor/chemist
+
+	w_uniform = /obj/item/clothing/under/rank/chemist
+	wear_suit = /obj/item/clothing/suit/storage/labcoat/chemist
+	back = /obj/item/storage/backpack/satchel/chem
+	belt = /obj/item/storage/belt/hypospraybelt
+	gloves = /obj/item/clothing/gloves/latex
+	shoes = /obj/item/clothing/shoes/white
+	ears = /obj/item/radio/survivor
+	glasses = /obj/item/clothing/glasses/science
+	l_store = /obj/item/flashlight
+	r_store = /obj/item/tool/crowbar
+	suit_store = /obj/item/healthanalyzer
+
+/datum/outfit/job/survivor/chemist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/bicaridine, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/kelotane, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/tramadol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/tricordrazine, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/lemoline/doctor, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/beaker/large, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/beaker/large, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/bicaridine, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/kelotane, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/tramadol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/tricordrazine, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/dylovene, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/inaprovaline, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/hypervene, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/imialky, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/quickclotplus, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/big, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/big, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/storage/syringe_case/empty, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/storage/syringe_case/empty, SLOT_IN_BELT)
+
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/dropper, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/advanced/bruise_pack, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/heal_pack/advanced/burn_pack, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/splint, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/medical/splint, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, SLOT_IN_BACKPACK)
+
+
+//Roboticist Survivor
+/datum/job/survivor/roboticist
+	title = "Roboticist Survivor"
+	skills_type = /datum/skills/civilian/survivor/atmos
+	outfit = /datum/outfit/job/survivor/roboticist
+
+
+/datum/outfit/job/survivor/roboticist
+	name = "Roboticist Survivor"
+	jobtype = /datum/job/survivor/roboticist
+
+	w_uniform = /obj/item/clothing/under/rank/roboticist
+	wear_suit = /obj/item/clothing/suit/storage/labcoat/science
+	belt = /obj/item/storage/belt/utility/full
+	shoes = /obj/item/clothing/shoes/black
+	back = /obj/item/storage/backpack/satchel/tox
+	ears = /obj/item/radio/survivor
+	glasses = /obj/item/clothing/glasses/welding/flipped
+	l_store = /obj/item/storage/pouch/electronics/full
+	r_store = /obj/item/flashlight/combat
+
+/datum/outfit/job/survivor/roboticist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/medium_stack, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/small_stack, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/attachable/buildasentry, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/cell/high, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/cable_coil, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/stack/cable_coil, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
 
 // Rambo Survivor - pretty overpowered, pls spawn with caution
 /datum/job/survivor/rambo

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -374,7 +374,7 @@ Good luck, but do not expect to survive."})
 	H.equip_to_slot_or_del(new /obj/item/tool/lighter, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/bible, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/cup/glass/bottle/holywater , SLOT_IN_BACKPACK)
 
 
 //Miner

--- a/code/game/objects/items/tools/hydro_tools.dm
+++ b/code/game/objects/items/tools/hydro_tools.dm
@@ -97,9 +97,9 @@
 	icon = 'icons/obj/items/tools.dmi'
 	icon_state = "hatchet"
 	atom_flags = CONDUCT
-	force = 25
+	force = 35
 	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 20
+	throwforce = 25
 	throw_speed = 4
 	throw_range = 4
 	sharp = IS_SHARP_ITEM_BIG
@@ -115,7 +115,7 @@
 	desc = "A sharp and curved blade on a long fibremetal handle, this tool makes it easy to reap what you sow."
 	icon = 'icons/obj/items/tools.dmi'
 	icon_state = "scythe"
-	force = 13
+	force = 35
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 3

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -49,7 +49,7 @@
 	desc = "Cut, cut, and once more cut."
 	icon_state = "scalpel"
 	atom_flags = CONDUCT
-	force = 10
+	force = 25
 	sharp = IS_SHARP_ITEM_ACCURATE
 	edge = 1
 	w_class = WEIGHT_CLASS_TINY
@@ -89,7 +89,7 @@
 	icon_state = "saw"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	atom_flags = CONDUCT
-	force = 15
+	force = 30
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 9
 	throw_speed = 3

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -49,7 +49,7 @@
 	desc = "Cut, cut, and once more cut."
 	icon_state = "scalpel"
 	atom_flags = CONDUCT
-	force = 25
+	force = 20
 	sharp = IS_SHARP_ITEM_ACCURATE
 	edge = 1
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -134,6 +134,7 @@
 		cached_outfits += list(outfit_entry("General", /datum/outfit, "Naked", priority=TRUE))
 		cached_outfits += make_outfit_entries("General", subtypesof(/datum/outfit) - typesof(/datum/outfit/job))
 		cached_outfits += make_outfit_entries("Jobs", typesof(/datum/outfit/job))
+		cached_outfits += make_outfit_entries("Survivor", typesof(/datum/outfit/job/survivor))
 
 	data["outfits"] = cached_outfits
 	return data

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -38,6 +38,7 @@
 	armor_protection_flags = CHEST
 	soft_armor = list(MELEE = 20, BULLET = 30, LASER = 25, ENERGY = 10, BOMB = 15, BIO = 0, FIRE = 10, ACID = 10)
 	allowed = list (
+		/obj/item/weapon/gun/,
 		/obj/item/flashlight,
 		/obj/item/binoculars,
 		/obj/item/weapon/combat_knife,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -38,7 +38,7 @@
 	armor_protection_flags = CHEST
 	soft_armor = list(MELEE = 20, BULLET = 30, LASER = 25, ENERGY = 10, BOMB = 15, BIO = 0, FIRE = 10, ACID = 10)
 	allowed = list (
-		/obj/item/weapon/gun/,
+		/obj/item/weapon/gun,
 		/obj/item/flashlight,
 		/obj/item/binoculars,
 		/obj/item/weapon/combat_knife,

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -20,7 +20,9 @@
 		/obj/item/binoculars,
 		/obj/item/weapon/combat_knife,
 		/obj/item/attachable/bayonetknife,
-		/obj/item/storage/holster/blade
+		/obj/item/storage/holster/blade,
+		/obj/item/tool/hatchet,
+		/obj/item/tool/scythe
 	)
 
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -154,9 +154,9 @@
 			adjustToxLoss(4)
 
 	switch(drunkenness) //painkilling effects
-		if(51 to 71)
+		if(6 to 41)
 			reagent_shock_modifier += PAIN_REDUCTION_LIGHT
-		if(71 to 81)
+		if(41 to 81)
 			reagent_shock_modifier += PAIN_REDUCTION_MEDIUM
 		if(81 to INFINITY)
 			reagent_shock_modifier += PAIN_REDUCTION_HEAVY

--- a/code/modules/reagents/chemistry/reagents/other.dm
+++ b/code/modules/reagents/chemistry/reagents/other.dm
@@ -27,7 +27,7 @@
 	color = "#0064C8" // rgb: 0, 100, 200
 	overdose_threshold = REAGENTS_OVERDOSE * 2
 	custom_metabolism = REAGENTS_METABOLISM * 5 //1.0/tick
-	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable)
+	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable, /datum/reagent/zombium)
 	purge_rate = 1
 	taste_description = "water"
 	default_container = /obj/item/reagent_containers/cup/glass/waterbottle


### PR DESCRIPTION
## About The Pull Request
Adds new stuff for survivor and survivor v zombie events.
Water now purges zombium (Mandela effect, I always thought it already did this).
Survivors now have water bottles.
Alcohol now gives pain reduction at lower thresholds.
Hatchets, scythes, scalpels, and circular saws all have decent melee stats now.
Armor vests now fit guns, aprons now fit hatchets and scythes.
Certain survivor loadouts now have more equipment, such as atmos tech getting metal foam nades and chaplain getting a shotgun.

Added a few new survivor loadouts:
Bartender, equipped with a shotgun and lots of alcohol.
Chemist, equipped with hyposprays and medical equipment.
Roboticist, equipped with tools and a build-a-sentry.
![image](https://github.com/user-attachments/assets/2fb0b43d-06fe-47c5-9754-616114360234)

## Why It's Good For The Game
Easier survivor events and more survivor content. Survivors v zombies is now much easier to set up!
## Changelog
:cl:
add: Added more survivor roles and more survivor equipment.
balance: Water now purges zombium.
balance: Alcohol now gives minor pain reduction at lower levels.
balance: Hatchets, scythes, scalpels, and circular saws all have decent melee stats now.
balance: Armor vests now fit guns, aprons now fit hatchets and scythes.
admin: Added a tab in the select equipment menu for survivors.
/:cl:
