### PR TITLE
Buffs Special Resin Walls

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -218,14 +218,14 @@
 /turf/closed/wall/resin/regenerating/special/bulletproof
 	name = "bulletproof resin wall"
 	desc = "Weird slime solidified into a wall. Looks shiny."
-	max_upgradable_health = 350
+	max_upgradable_health = 450
 	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0) //You aren't damaging this with bullets without alot of AP.
 	color = COLOR_WALL_BULLETPROOF
 
 /turf/closed/wall/resin/regenerating/special/fireproof
 	name = "fireproof resin wall"
 	desc = "Weird slime solidified into a wall. Very red."
-	max_upgradable_health = 350
+	max_upgradable_health = 450
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 200, ACID = 0)
 	color = COLOR_WALL_FIREPROOF
 

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -234,5 +234,5 @@
 	desc = "Weird slime soldified into a wall. Looks very strong."
 	max_upgradable_health = 550
 	max_upgrade_per_tick = 12 //Upgrades faster, but if damaged at all it will be put on cooldown still to help against walling in combat.
-	soft_armor = list(MELEE = 100, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 0, ACID = 0)//better bust out the flamer
+	soft_armor = list(MELEE = 50, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 0, ACID = 0)//better bust out the flamer
 	color = COLOR_WALL_HARDY

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -218,18 +218,21 @@
 /turf/closed/wall/resin/regenerating/special/bulletproof
 	name = "bulletproof resin wall"
 	desc = "Weird slime solidified into a wall. Looks shiny."
+	max_upgradable_health = 350
 	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0) //You aren't damaging this with bullets without alot of AP.
 	color = COLOR_WALL_BULLETPROOF
 
 /turf/closed/wall/resin/regenerating/special/fireproof
 	name = "fireproof resin wall"
 	desc = "Weird slime solidified into a wall. Very red."
+	max_upgradable_health = 350
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 200, ACID = 0)
 	color = COLOR_WALL_FIREPROOF
 
 /turf/closed/wall/resin/regenerating/special/hardy
 	name = "hardy resin wall"
 	desc = "Weird slime soldified into a wall. Looks very strong."
-	max_upgradable_health = 450
+	max_upgradable_health = 550
 	max_upgrade_per_tick = 12 //Upgrades faster, but if damaged at all it will be put on cooldown still to help against walling in combat.
+	soft_armor = list(MELEE = 100, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 0, ACID = 0)//better bust out the flamer
 	color = COLOR_WALL_HARDY

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -380,7 +380,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/defence/special_walls
 	name = "Special Resin Walls"
 	desc = "Gives your hive 50 special resin walls to build."
-	psypoint_cost = 100
+	psypoint_cost = 125
 	icon = "specialresin"
 	gamemode_flags = ABILITY_NUCLEARWAR
 	upgrade_flags = UPGRADE_FLAG_USES_TACTICAL


### PR DESCRIPTION
## About The Pull Request
Gives fireproof and bulletproof resin walls +150 max health.
Gives hardy resin walls +100 health, as well as 50 melee armor and 50 bomb armor.
Special Resin walls now cost 125 instead of 100 psy points.
## Why It's Good For The Game
The special resin walls are laughably bad for how limited their uses are, especially considering that they die *in the exact same amount of melee hits* compared to normal resin walls, with the exception of hardy walls because they have more max health.

Well, now that isn't quite the case: all special walls are now actually better than resin walls at least by a marginal amount thanks to *all* of them having extra health, while hardy resin walls are explicitly the counter to melee and make for a good general usage upgrade compared to normal walls. Better get out the flamer or these ones. Or... just continue to instantly delete them with a PC lol.
## Changelog
:cl:
balance: gives +150 max health to fireproof and bulletproof resin walls
balance: gives +100 max health to hardy walls as well as 50 melee and 50 bomb armor
balance: special resin walls now cost +25 psy points
/:cl:
