### PR TITLE
Synthetic crit now deals damage by limb

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synthetics.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetics.dm
@@ -36,7 +36,7 @@
 /datum/species/synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= SYNTHETIC_CRIT_THRESHOLD && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
 		H.apply_effect(4 SECONDS, STUTTER) // Added flavor
-		H.adjustFireLoss(rand(5, 16)) // Melting!!!
+		H.adjustFireLossByPart(rand(5, 16), ran_zone(null, 0)) // Melting!!!
 		if(prob(12))
 			H.visible_message(span_boldwarning("[H] shudders violently and shoots out sparks!"), span_warning("Critical damage sustained. Internal temperature regulation systems offline. Shutdown imminent. <b>Estimated integrity: [round(H.health)]%.</b>"))
 			do_sparks(4, TRUE, H)
@@ -107,7 +107,7 @@
 /datum/species/early_synthetic/handle_unique_behavior(mob/living/carbon/human/H)
 	if(H.health <= SYNTHETIC_CRIT_THRESHOLD && H.stat != DEAD) // Instead of having a critical condition, they overheat and slowly die.
 		H.apply_effect(4 SECONDS, STUTTER) // Added flavor
-		H.adjustFireLoss(rand(7, 19)) // Melting even more!!!
+		H.adjustFireLossByPart(rand(7, 19), ran_zone(null, 0)) // Melting even more!!!
 		if(prob(12))
 			H.visible_message(span_boldwarning("[H] shudders violently and shoots out sparks!"), span_warning("Critical damage sustained. Internal temperature regulation systems offline. Shutdown imminent. <b>Estimated integrity: [round(H.health)]%.</b>"))
 			do_sparks(4, TRUE, H)


### PR DESCRIPTION
## About The Pull Request

Instead of applying {0} damage over each limb, deals concentrated damage on a single limb. Damage itself is unchanged.

## Why It's Good For The Game

You aren't sentenced to certain death after going into crit anymore.

## Changelog

:cl:
balance: Synth crit now deals damage by limb instead of applying it all over the body
/:cl: