### PR TITLE
Adds Smoker Zombie

### DIFF
--- a/code/modules/ai/presets/zombie_presets.dm
+++ b/code/modules/ai/presets/zombie_presets.dm
@@ -25,6 +25,9 @@
 /mob/living/carbon/human/species/zombie/ai/patrol/strong
 	race = "Strong zombie"
 
+/mob/living/carbon/human/species/zombie/ai/patrol/smoker
+	race = "Smoker zombie"
+
 /obj/effect/zombie_basic_pack
 	name = "Template for 6 basic zombies, plus a leader"
 

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -140,3 +140,32 @@
 	total_health = 200
 	faction = FACTION_SECTOIDS
 	claw_type = /obj/item/weapon/zombie_claw/no_zombium
+
+/datum/species/zombie/smoker
+	name = "Smoker zombie"
+	var/obj/effect/abstract/particle_holder/particle_holder
+
+/particles/smoker_zombie
+	icon = 'icons/effects/particles/smoke.dmi'
+	icon_state = list("smoke_1" = 1, "smoke_2" = 1, "smoke_3" = 2)
+	width = 100
+	height = 100
+	count = 5
+	spawning = 4
+	lifespan = 9
+	fade = 10
+	grow = 0.2
+	velocity = list(0, 0)
+	position = generator(GEN_CIRCLE, 10, 10, NORMAL_RAND)
+	drift = generator(GEN_VECTOR, list(0, -0.15), list(0, 0.15))
+	gravity = list(0, 0.4)
+	scale = generator(GEN_VECTOR, list(0.3, 0.3), list(0.9,0.9), NORMAL_RAND)
+	rotation = 0
+	spin = generator(GEN_NUM, 10, 20)
+
+/datum/species/zombie/smoker/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
+	. = ..()
+	var/datum/action/ability/emit_gas/emit_gas = new
+	emit_gas.give_action(H)
+	particle_holder = new(H, /particles/smoker_zombie)
+	particle_holder.pixel_y = 6

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -143,7 +143,6 @@
 
 /datum/species/zombie/smoker
 	name = "Smoker zombie"
-	var/obj/effect/abstract/particle_holder/particle_holder
 
 /particles/smoker_zombie
 	icon = 'icons/effects/particles/smoke.dmi'
@@ -167,5 +166,3 @@
 	. = ..()
 	var/datum/action/ability/emit_gas/emit_gas = new
 	emit_gas.give_action(H)
-	particle_holder = new(H, /particles/smoker_zombie)
-	particle_holder.pixel_y = 6

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -102,6 +102,7 @@
 /datum/action/ability/emit_gas/on_cooldown_finish()
 	playsound(owner.loc, 'sound/effects/alien/new_larva.ogg', 50, 0)
 	to_chat(owner, span_xenodanger("We feel our smoke filling us once more. We can emit gas again."))
+	toggle_particles(TRUE)
 	return ..()
 
 /datum/action/ability/emit_gas/action_activate()
@@ -110,6 +111,7 @@
 	playsound(T, 'sound/effects/smoke_bomb.ogg', 25, TRUE)
 	smoke.set_up(smokeradius, T, smoke_duration)
 	smoke.start()
+	toggle_particles(FALSE)
 
 	add_cooldown()
 	succeed_activate()
@@ -130,3 +132,15 @@
 	if(!line_of_sight(owner, target))
 		return FALSE
 	return TRUE
+
+/datum/action/ability/emit_gas/proc/toggle_particles(activate)
+	if(!activate)
+		QDEL_NULL(particle_holder)
+		return
+
+	particle_holder = new(owner, /particles/smoker_zombie)
+	particle_holder.pixel_y = 6
+
+/datum/action/ability/emit_gas/give_action(mob/living/L)
+	. = ..()
+	toggle_particles(TRUE)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -95,7 +95,7 @@
 	/// smoke type created when the grenade is primed
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
 	///radius this smoke grenade will encompass
-	var/smokeradius = 6
+	var/smokeradius = 4
 	///The duration of the smoke in 2 second ticks
 	var/smoke_duration = 9
 
@@ -144,3 +144,11 @@
 /datum/action/ability/emit_gas/give_action(mob/living/L)
 	. = ..()
 	toggle_particles(TRUE)
+
+/datum/action/ability/emit_gas/remove_action(mob/living/L)
+	. = ..()
+	QDEL_NULL(particle_holder)
+
+/datum/action/ability/emit_gas/Destroy()
+	. = ..()
+	QDEL_NULL(particle_holder)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -107,9 +107,9 @@
 
 /datum/action/ability/emit_gas/action_activate()
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	var/turf/T = get_turf(owner)
-	playsound(T, 'sound/effects/smoke_bomb.ogg', 25, TRUE)
-	smoke.set_up(smokeradius, T, smoke_duration)
+	var/turf/owner_turf = get_turf(owner)
+	playsound(owner_turf, 'sound/effects/smoke_bomb.ogg', 25, TRUE)
+	smoke.set_up(smokeradius, owner_turf, smoke_duration)
 	smoke.start()
 	toggle_particles(FALSE)
 
@@ -133,6 +133,7 @@
 		return FALSE
 	return TRUE
 
+/// Toggles particles on or off, depending on the defined var.
 /datum/action/ability/emit_gas/proc/toggle_particles(activate)
 	if(!activate)
 		QDEL_NULL(particle_holder)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -133,7 +133,7 @@
 		return FALSE
 	return TRUE
 
-/// Toggles particles on or off, depending on the defined var.
+/// Toggles particles on or off
 /datum/action/ability/emit_gas/proc/toggle_particles(activate)
 	if(!activate)
 		QDEL_NULL(particle_holder)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -76,3 +76,57 @@
 
 /obj/item/weapon/zombie_claw/no_zombium
 	zombium_per_hit = 0
+
+// ***************************************
+// *********** Emit Gas
+// ***************************************
+/datum/action/ability/emit_gas
+	name = "Emit Gas"
+	action_icon_state = "emit_neurogas"
+	action_icon = 'icons/Xeno/actions/defiler.dmi'
+	desc = "Use to emit a cloud of blinding smoke."
+	cooldown_duration = 40 SECONDS
+	keybind_flags = ABILITY_KEYBIND_USE_ABILITY|ABILITY_IGNORE_SELECTED_ABILITY
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_EMIT_NEUROGAS,
+	)
+	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
+	var/obj/effect/abstract/particle_holder/particle_holder
+	/// smoke type created when the grenade is primed
+	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
+	///radius this smoke grenade will encompass
+	var/smokeradius = 6
+	///The duration of the smoke in 2 second ticks
+	var/smoke_duration = 9
+
+/datum/action/ability/emit_gas/on_cooldown_finish()
+	playsound(owner.loc, 'sound/effects/alien/new_larva.ogg', 50, 0)
+	to_chat(owner, span_xenodanger("We feel our smoke filling us once more. We can emit gas again."))
+	return ..()
+
+/datum/action/ability/emit_gas/action_activate()
+	var/datum/effect_system/smoke_spread/smoke = new smoketype()
+	var/turf/T = get_turf(owner)
+	playsound(T, 'sound/effects/smoke_bomb.ogg', 25, TRUE)
+	smoke.set_up(smokeradius, T, smoke_duration)
+	smoke.start()
+
+	add_cooldown()
+	succeed_activate()
+
+	owner.record_war_crime()
+
+/datum/action/ability/emit_gas/ai_should_start_consider()
+	return TRUE
+
+/datum/action/ability/emit_gas/ai_should_use(atom/target)
+	var/mob/living/L = owner
+	if(!iscarbon(target))
+		return FALSE
+	if(get_dist(target, owner) > 2 && L.health > 50)
+		return FALSE
+	if(!can_use_action(override_flags = ABILITY_IGNORE_SELECTED_ABILITY))
+		return FALSE
+	if(!line_of_sight(owner, target))
+		return FALSE
+	return TRUE


### PR DESCRIPTION

## About The Pull Request
Adds a new zombie, the Smoker.
Has an ability to emit a smokescreen to help hordes of zombies close the gap on people with guns.
AI Smokers will use this ability when 2 tiles from a target or when below 50% health.


https://github.com/user-attachments/assets/1ef9d794-b7f7-43b1-b52e-b31738f453a0
## Why It's Good For The Game
More variety for zombie events
## Changelog
:cl:
add: Added new zombie type, the Smoker.
/:cl:
