### PR TITLE
Can't equip loadout before mission selection

### DIFF
--- a/code/datums/gamemodes/campaign/individual_stats.dm
+++ b/code/datums/gamemodes/campaign/individual_stats.dm
@@ -367,6 +367,10 @@
 			if(!istype(user) || user.stat)
 				to_chat(user, span_warning("Must be alive to do this!"))
 				return
+			var/datum/campaign_mission/current_mission = get_current_mission()
+			if(!current_mission || current_mission.mission_state == MISSION_STATE_FINISHED)
+				to_chat(user, span_warning("Wait for the next mission to be selected!"))
+				return
 			var/obj/item/card/id/user_id = user.get_idcard()
 			if(!(user_id.id_flags & CAN_BUY_LOADOUT))
 				to_chat(user, span_warning("You have already selected a loadout for this mission."))


### PR DESCRIPTION

## About The Pull Request
Loadouts can now only be equipt once the next mission is selected.

## Why It's Good For The Game
Encourages players to be more strategic in their loadout choices, based on mission type.
Particular with the secondary kit PR in mind.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Campaign: Loadouts cannot be equipt until the next mission has been selected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
