### PR TITLE
Mission brief popup

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -195,6 +195,9 @@
 	current_mission = new_mission
 	addtimer(CALLBACK(src, PROC_REF(autobalance_cycle)), CAMPAIGN_AUTOBALANCE_DELAY, TIMER_CLIENT_TIME) //we autobalance teams after a short delay to account for slow respawners
 	//TIMER_CLIENT_TIME as loading a new z-level messes with the timing otherwise
+	for(var/faction in factions)
+		for(var/player in GLOB.alive_human_list_faction[faction])
+			stat_list[faction].interact(player) //gives the mission brief
 	current_mission.load_mission()
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, bioscan_interval)
 


### PR DESCRIPTION

## About The Pull Request
When a new mission is selected, the campaign overview screen is opened for all players.

## Why It's Good For The Game
This popup means all players will see (whether they actually read it is another question) the mission briefing/objectives, encouraging them to think about what they're going to do.

## Changelog

:cl:
add: Campaign: Mission briefing pops up when a new mission is chosen
/:cl:
