### PR TITLE
fix sandbag emptying not giving you the last sandbag back

### DIFF
--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -113,7 +113,6 @@
 			break
 		if(amount < 1)
 			user.balloon_alert(user, "You finish emptying [src].")
-			break
 		var/obj/item/stack/sandbag = user.get_inactive_held_item()
 		if(istype(sandbag, /obj/item/stack/sandbags_empty) && sandbag.add(1))
 			continue
@@ -121,4 +120,3 @@
 		if(!sandbag && user.put_in_hands(E))
 			continue
 		E.add_to_stacks(user)
-


### PR DESCRIPTION
## About The Pull Request
Removes a break in the loop that caused you to loose a sandbag
Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/16606
## Why It's Good For The Game
People don't like the last sandbag when they empty
## Changelog
:cl:
fix: You no longer loose the last sandbag when emptying full sandbags
/:cl:
