### PR TITLE
Weird animate fix

### DIFF
--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -107,13 +107,11 @@
 	jumper.add_filter(JUMP_COMPONENT, 2, drop_shadow_filter(color = COLOR_TRANSPARENT_SHADOW, size = 0.9))
 	var/shadow_filter = jumper.get_filter(JUMP_COMPONENT)
 
+	animate(jumper, pixel_z = jumper.pixel_z + effective_jump_height, layer = max(MOB_JUMP_LAYER, original_layer), time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT, flags = ANIMATION_END_NOW|ANIMATION_PARALLEL)
+	animate(pixel_z = jumper.pixel_z - effective_jump_height, layer = original_layer, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_IN)
 	if(jump_flags & JUMP_SPIN)
 		var/spin_number = ROUND_UP(effective_jump_duration * 0.1)
-		jumper.animation_spin(effective_jump_duration / spin_number, spin_number, jumper.dir == WEST ? FALSE : TRUE)
-
-	animate(jumper, pixel_z = jumper.pixel_z + effective_jump_height, layer = max(MOB_JUMP_LAYER, original_layer), time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT)
-	animate(pixel_z = jumper.pixel_z - effective_jump_height, layer = original_layer, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_IN)
-
+		jumper.animation_spin(effective_jump_duration / spin_number, spin_number, jumper.dir == WEST ? FALSE : TRUE, anim_flags = ANIMATION_PARALLEL)
 	if(jump_flags & JUMP_SHADOW)
 		animate(shadow_filter, y = -effective_jump_height, size = 4, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
 		animate(y = 0, size = 0.9, time = effective_jump_duration / 2, easing = CIRCULAR_EASING|EASE_IN)

--- a/code/modules/animations/animation_library.dm
+++ b/code/modules/animations/animation_library.dm
@@ -116,7 +116,8 @@ Can look good elsewhere as well.*/
 	return speed*2
 
 
-/atom/proc/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3)
+///Spins the atom
+/atom/proc/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, anim_flags = NONE)
 	if(!sections)
 		return
 	var/section = 360/sections
@@ -130,6 +131,6 @@ Can look good elsewhere as well.*/
 	var/matrix/last = matrix(transform)
 	matrix_list += last
 	speed /= sections
-	animate(src, transform = matrix_list[1], time = speed, loop_amount)
+	animate(src, transform = matrix_list[1], time = speed, loop_amount, flags = anim_flags)
 	for(var/i in 2 to sections)
 		animate(transform = matrix_list[i], time = speed)


### PR DESCRIPTION

## About The Pull Request
A better fix to a weird animate interaction.

The previous fix (and someone please tell me why byond has this issue to begin with) meant we critically lost jump spin animations when gravity is turned down.

This fix ensures jumps don't fuck out in water, while jump spin still works.
## Why It's Good For The Game
Spin2win
## Changelog
:cl:
fix: jump spins work again in low grav
/:cl:
