### PR TITLE
Detpack code randomisation

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -29,6 +29,7 @@
 /obj/item/detpack/Initialize(mapload)
 	. = ..()
 	set_frequency(frequency)
+	code = rand(1, 100)
 
 
 /obj/item/detpack/examine(mob/user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -15,6 +15,7 @@
 /obj/item/assembly/signaler/Initialize(mapload)
 	. = ..()
 	set_frequency(frequency)
+	code = rand(1, 100)
 
 /obj/item/assembly/signaler/Destroy()
 	SSradio.remove_object(src,frequency)


### PR DESCRIPTION

## About The Pull Request
Detpacks and signallers now randomise their signal code when spawned.
## Why It's Good For The Game
While very uncommon, if multiple people are using detpacks at the same time, they'll likely trigger the other guys detpacks because most people don't bother to change the code or freq.

This changes makes it very unlikely to happen accidentally.
## Changelog
:cl:
qol: Detpack and signaller code is randomised upon spawn
/:cl:
