### PR TITLE
COPE hud fix

### DIFF
--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -79,7 +79,7 @@
 	var/direction_to_deploy
 	var/obj/deployed_machine
 
-	if(user)
+	if(user && item_to_deploy.loc == user) //somethings can be deployed remotely
 		if(!ishuman(user) || HAS_TRAIT(item_to_deploy, TRAIT_NODROP))
 			return
 
@@ -135,7 +135,7 @@
 
 	deployed_machine.update_appearance()
 
-	if(user)
+	if(user && item_to_deploy.loc == user)
 		item_to_deploy.balloon_alert(user, "Deployed!")
 		user.transferItemToLoc(item_to_deploy, deployed_machine, TRUE)
 		if(user.client.prefs.toggles_gameplay & AUTO_INTERACT_DEPLOYABLES)

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -146,7 +146,7 @@
 	var/obj/item/card/id/user_id = user?.get_idcard(TRUE)
 	if(user_id)
 		sentry_iff_signal = user_id?.iff_signal
-	addtimer(CALLBACK(src, PROC_REF(prime)), det_time)
+	addtimer(CALLBACK(src, PROC_REF(prime), user), det_time)
 
 ///Reverts the gun back to it's unarmed state, allowing it to be activated again
 /obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/proc/reset()
@@ -154,11 +154,11 @@
 	icon_state = initial(icon_state)
 
 ///Deploys the weapon into a sentry after activation
-/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/proc/prime()
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/proc/prime(mob/user)
 	if(!isturf(loc)) //no deploying out of bags or in hand
 		reset()
 		return
-	do_deploy()
+	do_deploy(user)
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed
 	item_flags = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE|DEPLOYED_NO_PICKUP


### PR DESCRIPTION

## About The Pull Request
COPE sentries properly display their health/ammo on the currect hudtype if throw deployed.
## Why It's Good For The Game
Currently they only show up if normally deployed, which is basically never, with the COPE.
## Changelog
:cl:
fix: cope sentry hud appears correctly when deployed via throw
/:cl:
