### PR TITLE
Unmanned vehicle fixes

### DIFF
--- a/code/__DEFINES/vehicles.dm
+++ b/code/__DEFINES/vehicles.dm
@@ -73,3 +73,5 @@
 
 ///Not available in the tank fab
 #define TANK_MOD_NOT_FABRICABLE (1<<0)
+
+#define IGUANA_MAX_INTEGRITY 150

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -723,12 +723,10 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return src == proj.original_target
 
 /obj/vehicle/unmanned/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(proj.shot_from == src)
-		return FALSE
 	if(iff_signal & proj.iff_signal)
 		proj.damage -= proj.damage*proj.damage_marine_falloff
 		return FALSE
-	return TRUE
+	return ..()
 
 /obj/vehicle/ridden/motorbike/projectile_hit(obj/projectile/P)
 	if(!buckled_mobs)

--- a/code/modules/vehicles/unmanned/deployable_vehicles.dm
+++ b/code/modules/vehicles/unmanned/deployable_vehicles.dm
@@ -7,6 +7,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 0.3
 	item_flags = IS_DEPLOYABLE
+	max_integrity = IGUANA_MAX_INTEGRITY
 	///The vehicle this deploys into
 	var/deployable_item = /obj/vehicle/unmanned/deployable
 	///The equipped turret
@@ -30,11 +31,14 @@
 	///What it deploys into. typecast version of internal_item
 	var/obj/item/deployable_vehicle/internal_item
 
-/obj/vehicle/unmanned/deployable/Initialize(mapload, _internal_item, deployer)
+/obj/vehicle/unmanned/deployable/Initialize(mapload, _internal_item, mob/deployer)
 	if(!internal_item && !_internal_item)
 		return INITIALIZE_HINT_QDEL
 	internal_item = _internal_item
 	spawn_equipped_type = internal_item.stored_turret_type
+	if(ishuman(deployer))
+		var/mob/living/carbon/human/human_deployer = deployer
+		iff_signal = human_deployer?.wear_id?.iff_signal
 	. = ..()
 	current_rounds = internal_item.stored_ammo
 

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -10,10 +10,10 @@
 	light_power = 3
 	light_system = MOVABLE_LIGHT
 	move_delay = 2.5	//set this to limit the speed of the vehicle
-	max_integrity = 150
+	max_integrity = IGUANA_MAX_INTEGRITY
 	hud_possible = list(MACHINE_HEALTH_HUD, MACHINE_AMMO_HUD)
 	atom_flags = BUMP_ATTACKABLE
-	soft_armor = list(MELEE = 25, BULLET = 85, LASER = 50, ENERGY = 100, BOMB = 50, BIO = 100, FIRE = 25, ACID = 25)
+	soft_armor = list(MELEE = 25, BULLET = 85, LASER = 85, ENERGY = 85, BOMB = 50, BIO = 100, FIRE = 25, ACID = 25)
 	allow_pass_flags = PASS_AIR|PASS_LOW_STRUCTURE|PASS_THROW
 	/// Needed to keep track of any slowdowns and/or diagonal movement
 	var/next_move_delay = 0
@@ -51,7 +51,7 @@
 	var/atom/movable/vis_obj/effect/muzzle_flash/flash
 	COOLDOWN_DECLARE(fire_cooldown)
 
-/obj/vehicle/unmanned/Initialize(mapload)
+/obj/vehicle/unmanned/Initialize(mapload, _internal_item, mob/deployer)
 	. = ..()
 	ammo = GLOB.ammo_list[ammo]
 	name += " " + num2text(serial)
@@ -59,8 +59,6 @@
 	flash = new /atom/movable/vis_obj/effect/muzzle_flash(src)
 	GLOB.unmanned_vehicles += src
 	prepare_huds()
-	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD
-		sentry_status_hud.add_to_hud(src)
 	hud_set_machine_health()
 	if(spawn_equipped_type)
 		turret_path = spawn_equipped_type
@@ -71,7 +69,11 @@
 		max_rounds = initial(spawn_equipped_type.max_rounds)
 		update_icon()
 	hud_set_uav_ammo()
-	SSminimaps.add_marker(src, MINIMAP_FLAG_MARINE, image('icons/UI_icons/map_blips.dmi', null, "uav"))
+	var/faction = deployer?.faction ? deployer.faction : FACTION_TERRAGOV
+	SSminimaps.add_marker(src, GLOB.faction_to_minimap_flag[faction], image('icons/UI_icons/map_blips.dmi', null, "uav"))
+	var/datum/atom_hud/sentry_status_hud = GLOB.huds[GLOB.faction_to_data_hud[faction]]
+	if(sentry_status_hud)
+		sentry_status_hud.add_to_hud(src)
 
 /obj/vehicle/unmanned/Destroy()
 	GLOB.unmanned_vehicles -= src


### PR DESCRIPTION

## About The Pull Request
Fixed deployable Iguana having way more health then the normal one.

Deployable Iguana IFF signal is set off the deploying mob.

Unmanned vehicles now display their hud to the correct faction.

Normalised unmanned vehicle armour so its not immune to energy damage anymore.
## Why It's Good For The Game
## Changelog
:cl:
fix: fixed deployable Iguana HP being higher than intended
add: Unmanned vehicle IFF and hud are based off the deploying mob
balance: Unmanned vehicles no longer have 100 energy armour
/:cl:
