### PR TITLE
Prevents early launch of pods/shuttles as soon as evac is triggered

### DIFF
--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -135,6 +135,9 @@
 		if(!M.can_launch)
 			to_chat(usr, span_warning("Evacuation is not enabled!"))
 			return
+		if(SSevacuation.evac_status != EVACUATION_STATUS_IN_PROGRESS)
+			to_chat(usr,span_warning("The pod is not ready to launch yet!"))
+			return
 
 		to_chat(usr, span_highdanger("You slam your fist down on the launch button!"))
 		M.launch(TRUE)


### PR DESCRIPTION

## About The Pull Request
The evac timer now must elapse before the pod can be early launched

## Why It's Good For The Game
No more guaranteed xeno minor
Fixes (possible) unintended oversight

Technicially this means now mashing the button will only launch the pod a couple seconds sooner, since all pods begin auto launching as soon as the evac timer finished, but oh well.

## Changelog
:cl:
fix: Stops pods/shuttles from being launched early before evac timer elapses
/:cl:
