### PR TITLE
Buffs smg90 firerate

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -134,7 +134,7 @@
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.9
 	scatter = 1
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.125 SECONDS
 	scatter_unwielded = 8
 	aim_slowdown = 0.2
 	burst_amount = 0


### PR DESCRIPTION

## About The Pull Request
Increases smg90 firerate from 400 rpm to 480 rpm.
## Why It's Good For The Game
Smg90 was never a problematic gun and was hit pretty hard by the xeno buffs as many of the low armor castes it was good against (such as runner and carrier) got over a 40% durability buff vs the smg90. This gives a 20% firerate buff to help bring the gun back to a healthy spot.
## Changelog
:cl:
balance: Raised smg90 rpm from 400 to 480.
/:cl:
