### PR TITLE
Hunter pounce nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -347,7 +347,10 @@
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.Immobilize(XENO_POUNCE_STANDBY_DURATION)
 	xeno_owner.forceMove(get_turf(living_target))
-	living_target.Knockdown(XENO_POUNCE_STUN_DURATION)
+	if(!can_sneak_attack)
+		living_target.Knockdown(XENO_POUNCE_STUN_DURATION / 2)
+	else
+		living_target.Knockdown(XENO_POUNCE_STUN_DURATION)
 
 /datum/action/ability/activable/xeno/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Cuts hunter pounce stun time in half if the hunter is unable to sneak attack
## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/b849e551-bc29-4225-a3f5-328de1afbcb5)
ask ori, i'm just a xoder
## Changelog
:cl: Cheese, Ori
balance: Hunter pounce stun time is halved if the hunter is unable to use sneak attack
/:cl:
