### PR TITLE
Xenomorphs can walk to ignore portals

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -596,6 +596,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	SIGNAL_HANDLER
 	if(!linked_portal || !COOLDOWN_CHECK(src, portal_cooldown) || crosser.anchored || (crosser.resistance_flags & PORTAL_IMMUNE))
 		return
+	if(isxeno(crosser))
+		var/mob/living/carbon/xenomorph/xeno_crosser = crosser
+		if(xeno_crosser.m_intent == MOVE_INTENT_WALK)
+			return
 	COOLDOWN_START(linked_portal, portal_cooldown, 1)
 	crosser.pass_flags &= ~PASS_MOB
 	RegisterSignal(crosser, COMSIG_MOVABLE_MOVED, PROC_REF(do_teleport_atom))


### PR DESCRIPTION
## About The Pull Request
Xenomorphs who walk now ignore portals.

## Why It's Good For The Game
Prevents accidental wraith grief with portals and to match the fact that marines can move ontop of portals while xenos cannot without entering.

## Changelog
:cl:
balance: Xenomorphs can toggle movement intent to walk in order to bypass/ignore wraith portals.
/:cl:
