### PR TITLE
Tadpole no longer considered MARINE_BASE

### DIFF
--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -45,11 +45,6 @@
 	name = "Tadpole Drop Shuttle"
 	area_flags = NO_CONSTRUCTION
 
-/area/shuttle/minidropship/Initialize(mapload, ...)
-	. = ..()
-	var/area/area = get_area(src)
-	area.area_flags |= MARINE_BASE
-
 /area/shuttle/ert
 	name = "Emergency Response Team"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -558,6 +558,9 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	vis_contents += portal_visuals
 	add_filter("border_smoother", 1, gauss_blur_filter(1))
 
+	// The only reason that this is a signal is because: checks fail when using onTransitZ().
+	RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_transit))
+
 /obj/effect/wraith_portal/Destroy()
 	linked_portal?.unlink()
 	linked_portal = null
@@ -577,7 +580,9 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		return
 	user.forceMove(get_turf(linked_portal))
 
-/obj/effect/wraith_portal/onTransitZ(old_z, new_z)
+/// Deletes the portal if it changes z-levels.
+/obj/effect/wraith_portal/proc/on_z_transit(old_z, new_z)
+	SIGNAL_HANDLER
 	qdel(src)
 
 /// Link two portals

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -577,6 +577,11 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		return
 	user.forceMove(get_turf(linked_portal))
 
+/obj/effect/wraith_portal/onTransitZ(old_z, new_z)
+	if(linked_portal)
+		qdel(linked_portal)
+	qdel(src)
+
 /// Link two portals
 /obj/effect/wraith_portal/proc/link_portal(obj/effect/wraith_portal/portal_to_link)
 	linked_portal = portal_to_link

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -511,7 +511,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	succeed_activate()
 	add_cooldown()
 	playsound(owner.loc, 'sound/effects/portal_opening.ogg', 20)
-	if(portal_two && !QDELETED(portal_two))
+	if(!QDELETED(portal_two))
 		link_portals()
 
 /datum/action/ability/xeno_action/portal/alternate_action_activate()
@@ -522,7 +522,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	succeed_activate()
 	add_cooldown()
 	playsound(owner.loc, 'sound/effects/portal_opening.ogg', 20)
-	if(portal_one && !QDELETED(portal_one))
+	if(!QDELETED(portal_one))
 		link_portals()
 
 /// Link the two portals if possible

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -578,8 +578,6 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	user.forceMove(get_turf(linked_portal))
 
 /obj/effect/wraith_portal/onTransitZ(old_z, new_z)
-	if(linked_portal)
-		qdel(linked_portal)
 	qdel(src)
 
 /// Link two portals

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -511,7 +511,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	succeed_activate()
 	add_cooldown()
 	playsound(owner.loc, 'sound/effects/portal_opening.ogg', 20)
-	if(portal_two)
+	if(portal_two && !QDELETED(portal_two))
 		link_portals()
 
 /datum/action/ability/xeno_action/portal/alternate_action_activate()
@@ -522,7 +522,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	succeed_activate()
 	add_cooldown()
 	playsound(owner.loc, 'sound/effects/portal_opening.ogg', 20)
-	if(portal_one)
+	if(portal_one && !QDELETED(portal_one))
 		link_portals()
 
 /// Link the two portals if possible


### PR DESCRIPTION
## About The Pull Request
The Tadpole no longer has the area tag of MARINE_BASE. The effects of this is that:
- AI can directly rail gun on it (as long it is still ground side).
- Ranged weeding abilities can be used on it.
- Wraith can place portals on it.

Wraith portals are deleted if they change z-levels.

## Why It's Good For The Game
I've noticed that everything valuable imaginable is always left on the floor of the TAD and believes that nothing bad can happen to it outside of a marine stealing or placing it on the very edge where an xeno can acid it. Dead xenos, stacks of building metals, unplaced turrets, grenade boxes full of razorwire, and even the occasional SADAR or ZX. Even Corpsmen prefer to revive people on the TAD ontop of billions of items instead one tile away at a clean spot when they see a Wraith. I think that these marines should put a little more thought into where they leave their items instead of dropping all of their valuable garbage on the floor.

## Changelog
:cl:
balance: Tadpole is no longer considered as MARINE_BASE. This means: the AI can directly railgun it, Wraiths can portal onto it, and the Hivemind's ranged weed ability to be used on it.
balance: Wraith portals are automatically destroyed if they change z-levels.
fix: Placing a new portal as a Wraith after your portals were exploded no longer gives an error message.
/:cl:
