### PR TITLE
Having 100% Fire Armor Gives You Actual Fire Immunity

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -200,6 +200,8 @@
 
 /mob/living/carbon/fire_act(burn_level)
 	. = ..()
+	if(!.)
+		return
 	adjust_bodytemperature(100, 0, BODYTEMP_HEAT_DAMAGE_LIMIT_ONE+10)
 
 //generates realistic-ish pulse output based on preset levels

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -200,7 +200,7 @@
 		return
 	if(status_flags & (INCORPOREAL|GODMODE)) //Ignore incorporeal/invul targets
 		return FALSE
-	if(hard_armor.getRating(FIRE) >= 100)
+	if(soft_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return FALSE
 	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being affected.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -200,7 +200,7 @@
 		return
 	if(status_flags & (INCORPOREAL|GODMODE)) //Ignore incorporeal/invul targets
 		return FALSE
-	if(soft_armor.getRating(FIRE) >= 100)
+	if(hard_armor.getRating(FIRE) >= 100 || soft_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return FALSE
 	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being affected.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -200,7 +200,7 @@
 		return
 	if(status_flags & (INCORPOREAL|GODMODE)) //Ignore incorporeal/invul targets
 		return FALSE
-	if(hard_armor.getRating(FIRE) >= 100 || soft_armor.getRating(FIRE) >= 100)
+	if(soft_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
 		return FALSE
 	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being affected.

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -171,7 +171,7 @@
 		return FALSE
 	if(human_affected.pass_flags & PASS_FIRE)
 		return FALSE
-	if(human_affected.hard_armor.getRating(FIRE) >= 100)
+	if(human_affected.soft_armor.getRating(FIRE) >= 100)
 		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
 	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -171,7 +171,7 @@
 		return FALSE
 	if(human_affected.pass_flags & PASS_FIRE)
 		return FALSE
-	if(human_affected.hard_armor.getRating(FIRE) >= 100 || human_affected.soft_armor.getRating(FIRE) >= 100)
+	if(human_affected.soft_armor.getRating(FIRE) >= 100)
 		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
 	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -171,7 +171,7 @@
 		return FALSE
 	if(human_affected.pass_flags & PASS_FIRE)
 		return FALSE
-	if(human_affected.soft_armor.getRating(FIRE) >= 100)
+	if(human_affected.hard_armor.getRating(FIRE) >= 100 || human_affected.soft_armor.getRating(FIRE) >= 100)
 		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
 	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)


### PR DESCRIPTION
## About The Pull Request
Fire and the type of fire that Pyrogen uses now considers soft armor (instead of hard armor) and also prevents your body temperature from increasing. This means:
- No more endless screaming for walking through fire.
- No more taking damage for walking through fire.
- No more getting too hot for walking through fire.
- Because of all of the above, your very fragile splints no longer instantly break for walking through fire.

## Why It's Good For The Game
I hope that H-Armor + Surt not getting actual fire immunity is a bug and not a feature.

## Changelog
:cl:
fix: All types of fire no longer damages or heats you up if you have 100% fire soft/hard armor.
/:cl:
