### PR TITLE
Wraith's Timeshift Cancels on Z-Level Change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -727,6 +727,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		target_initial_sunder = xeno_target.sunder
 	rewind_timer = addtimer(CALLBACK(src, PROC_REF(start_rewinding)), start_rewinding, TIMER_STOPPABLE)
 	RegisterSignal(targeted, COMSIG_MOVABLE_MOVED, PROC_REF(save_move))
+	RegisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(target_changed_zlevel))
 	targeted.add_filter("prerewind_blur", 1, radial_blur_filter(0.04))
 	targeted.balloon_alert(targeted, "You feel anchored to the past!")
 	ADD_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
@@ -743,6 +744,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 /datum/action/ability/activable/xeno/rewind/proc/start_rewinding()
 	targeted.remove_filter("prerewind_blur")
 	UnregisterSignal(targeted, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED)
 	if(QDELETED(targeted) || targeted.stat != CONSCIOUS)
 		REMOVE_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
 		targeted = null
@@ -782,7 +784,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	new /obj/effect/temp_visual/after_image(loc_a, targeted)
 	INVOKE_NEXT_TICK(src, PROC_REF(rewind))
 
-// Removes all things associated while someone is being timeshifted, effectively stopping it from happening.
+// Removes all things associated while someone is being timeshifted, effectively stopping it from happening/continuing.
 /datum/action/ability/activable/xeno/rewind/proc/cancel_timeshift()
 	last_target_locs_list = null
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TIMESHIFT_TRAIT)
@@ -792,6 +794,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		targeted.remove_filter("prerewind_blur")
 		targeted.remove_filter("rewind_blur")
 		targeted.status_flags &= ~(INCORPOREAL|GODMODE)
+		UnregisterSignal(targeted, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED)
 		REMOVE_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
 		targeted = null
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -727,7 +727,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		target_initial_sunder = xeno_target.sunder
 	rewind_timer = addtimer(CALLBACK(src, PROC_REF(start_rewinding)), start_rewinding, TIMER_STOPPABLE)
 	RegisterSignal(targeted, COMSIG_MOVABLE_MOVED, PROC_REF(save_move))
-	RegisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(target_changed_zlevel))
+	RegisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(cancel_timeshift))
 	targeted.add_filter("prerewind_blur", 1, radial_blur_filter(0.04))
 	targeted.balloon_alert(targeted, "You feel anchored to the past!")
 	ADD_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
@@ -786,6 +786,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 // Removes all things associated while someone is being timeshifted, effectively stopping it from happening/continuing.
 /datum/action/ability/activable/xeno/rewind/proc/cancel_timeshift()
+	SIGNAL_HANDLER
 	last_target_locs_list = null
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TIMESHIFT_TRAIT)
 	if(rewind_timer)
@@ -798,8 +799,3 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		UnregisterSignal(targeted, COMSIG_MOVABLE_Z_CHANGED)
 		REMOVE_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
 		targeted = null
-
-/// Cancels the timeshift if the target changed z-levels.
-/datum/action/ability/activable/xeno/rewind/proc/target_changed_zlevel()
-	SIGNAL_HANDLER
-	cancel_timeshift()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -690,16 +690,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/rewind_timer
 
 /datum/action/ability/activable/xeno/rewind/Destroy()
-	last_target_locs_list = null
-	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TIMESHIFT_TRAIT)
-	if(rewind_timer)
-		deltimer(rewind_timer)
-	if(!QDELETED(targeted))
-		targeted.remove_filter("prerewind_blur")
-		targeted.remove_filter("rewind_blur")
-		targeted.status_flags &= ~(INCORPOREAL|GODMODE)
-		REMOVE_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
-		targeted = null
+	cancel_timeshift()
 	return ..()
 
 /datum/action/ability/activable/xeno/rewind/can_use_ability(atom/A, silent, override_flags)
@@ -790,3 +781,21 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	targeted.Move(loc_b, get_dir(loc_b, loc_a))
 	new /obj/effect/temp_visual/after_image(loc_a, targeted)
 	INVOKE_NEXT_TICK(src, PROC_REF(rewind))
+
+// Removes all things associated while someone is being timeshifted, effectively stopping it from happening.
+/datum/action/ability/activable/xeno/rewind/proc/cancel_timeshift()
+	last_target_locs_list = null
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TIMESHIFT_TRAIT)
+	if(rewind_timer)
+		deltimer(rewind_timer)
+	if(!QDELETED(targeted))
+		targeted.remove_filter("prerewind_blur")
+		targeted.remove_filter("rewind_blur")
+		targeted.status_flags &= ~(INCORPOREAL|GODMODE)
+		REMOVE_TRAIT(targeted, TRAIT_TIME_SHIFTED, XENO_TRAIT)
+		targeted = null
+
+/// Cancels the timeshift if the target changed z-levels.
+/datum/action/ability/activable/xeno/rewind/proc/target_changed_zlevel()
+	SIGNAL_HANDLER
+	cancel_timeshift()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -661,7 +661,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Time Shift"
 	action_icon_state = "rewind"
 	action_icon = 'icons/Xeno/actions/wraith.dmi'
-	desc = "Save the location and status of the target. When the time is up, the target location and status are restored, unless the target is dead or unconscious."
+	desc = "Save the location and status of the target. When the time is up, the target location and status are restored, unless the target is dead, unconscious, or changed z-levels."
 	ability_cost = 100
 	cooldown_duration = 30 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION
## About The Pull Request
If you change z-levels while affected by Timeshift, it is canceled.
Updates Timeshift's description to mention that it is canceled if target changes z-levels.

## Why It's Good For The Game
Using Timeshift on marines who just barely left into orbit on the TAD and suddenly become marooned when they're pulled from orbit to ground side is apparently "bug abuse". So, bug fixing.

## Changelog
:cl:
fix: Wraith's Timeshift cancels if the target changes z-levels.
/:cl:
