### PR TITLE
Plant Weeds Dynamically Shows Ability Cost

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -41,10 +41,27 @@
 	///The turf that was last weeded
 	var/turf/last_weeded_turf
 
+/datum/action/ability/activable/xeno/plant_weeds/New(Target)
+	. = ..()
+	if(SSmonitor.gamestate == SHUTTERS_CLOSED)
+		RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_SHUTTERS_EARLY), PROC_REF(update_ability_cost_shutters))
+
 /datum/action/ability/activable/xeno/plant_weeds/can_use_action(atom/A, silent = FALSE, override_flags)
-	ability_cost = initial(ability_cost) * initial(weed_type.ability_cost_mult)
-	ability_cost = SSmonitor.gamestate == SHUTTERS_CLOSED ? ability_cost/2 : ability_cost
+	update_ability_cost()
 	return ..()
+
+/// Updates the ability cost based on gamestate.
+/datum/action/ability/activable/xeno/plant_weeds/proc/update_ability_cost(shutters_recently_opened)
+	ability_cost = initial(ability_cost) * initial(weed_type.ability_cost_mult)
+	ability_cost = (!shutters_recently_opened && SSmonitor.gamestate == SHUTTERS_CLOSED) ? ability_cost/2 : ability_cost
+
+/**
+ * Updates the ability cost as if the gamestate was not SHUTTERS_CLOSED.
+ * The signal happens at the same time of gamestate changing, so that variable cannot be depended on.
+ */
+/datum/action/ability/activable/xeno/plant_weeds/proc/update_ability_cost_shutters()
+	update_ability_cost(TRUE)
+	update_button_icon()
 
 /datum/action/ability/activable/xeno/plant_weeds/action_activate()
 	if(max_range)
@@ -102,6 +119,7 @@
 		for(var/obj/alien/weeds/node/weed_type_possible AS in GLOB.weed_type_list)
 			if(initial(weed_type_possible.name) == weed_choice)
 				weed_type = weed_type_possible
+				update_ability_cost()
 				break
 		to_chat(owner, span_xenonotice("We will now spawn <b>[weed_choice]\s</b> when using the plant weeds ability."))
 	update_button_icon()
@@ -132,6 +150,7 @@
 	plant_weeds(owner)
 
 /datum/action/ability/activable/xeno/plant_weeds/update_button_icon()
+	name = "Plant Weeds ([ability_cost])"
 	action_icon_state = initial(weed_type.name)
 	if(auto_weeding)
 		if(!visual_references[VREF_IMAGE_ONTOP])

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -43,6 +43,7 @@
 
 /datum/action/ability/activable/xeno/plant_weeds/can_use_action(atom/A, silent = FALSE, override_flags)
 	ability_cost = initial(ability_cost) * initial(weed_type.ability_cost_mult)
+	ability_cost = SSmonitor.gamestate == SHUTTERS_CLOSED ? ability_cost/2 : ability_cost
 	return ..()
 
 /datum/action/ability/activable/xeno/plant_weeds/action_activate()
@@ -84,7 +85,7 @@
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]
 		personal_statistics.weeds_planted++
 	add_cooldown()
-	return succeed_activate(SSmonitor.gamestate == SHUTTERS_CLOSED ? ability_cost/2 : ability_cost)
+	succeed_activate()
 
 /datum/action/ability/activable/xeno/plant_weeds/alternate_action_activate()
 	INVOKE_ASYNC(src, PROC_REF(choose_weed))

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -60,6 +60,8 @@
  * The signal happens at the same time of gamestate changing, so that variable cannot be depended on.
  */
 /datum/action/ability/activable/xeno/plant_weeds/proc/update_ability_cost_shutters()
+	SIGNAL_HANDLER
+	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE))
 	update_ability_cost(TRUE)
 	update_button_icon()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -44,7 +44,7 @@
 /datum/action/ability/activable/xeno/plant_weeds/New(Target)
 	. = ..()
 	if(SSmonitor.gamestate == SHUTTERS_CLOSED)
-		RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_SHUTTERS_EARLY), PROC_REF(update_ability_cost_shutters))
+		RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE), PROC_REF(update_ability_cost_shutters))
 
 /datum/action/ability/activable/xeno/plant_weeds/can_use_action(atom/A, silent = FALSE, override_flags)
 	update_ability_cost()


### PR DESCRIPTION
## About The Pull Request
When shutters are closed, the ability cost for planting weeds is halved upfront rather than costing half after successful ability usage. 
The ability's button now shows the current ability cost rather than the consistent 75.

This essentially means:
- No more error messages when you try to plant weeds despite having enough plasma to afford the discounted price.
- You can actively see the ability cost of what weed you want to plant.

## Why It's Good For The Game
Bugfix and it is nice to see what the ability costs when you change weeds besides "alot" or "more than normal weeds".

## Changelog
:cl:
qol: Plant Weeds ability's button now dynamically shows its ability cost rather than the consistent 75.
fix: Plants Weeds ability no longer prevents usage if you have more than post-discounted, but less than before-discounted plasma (for before shutters drop).
/:cl:
