### PR TITLE
Marine sentries are bulky items again.

### DIFF
--- a/code/datums/storage/subtypes/backpack.dm
+++ b/code/datums/storage/subtypes/backpack.dm
@@ -31,6 +31,9 @@
 	. = ..()
 	set_holdable(storage_type_limits_list = list(
 		/obj/item/weapon/gun/sentry/big_sentry,
+		/obj/item/weapon/gun/sentry/shotgun_sentry,
+		/obj/item/weapon/gun/sentry/flamer_sentry,
+		/obj/item/weapon/gun/sentry/sniper_sentry,
 		/obj/item/weapon/gun/sentry/mini,
 		/obj/item/weapon/gun/hsg_102,
 		/obj/item/ammo_magazine/hsg_102,

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -40,6 +40,7 @@
 	name = "\improper ST-571 sentry gun"
 	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a M30 autocannon and a 500-round drum magazine."
 	icon_state = "sentry"
+	w_class = WEIGHT_CLASS_BULKY
 
 	turret_range = 8
 	deploy_time = 6 SECONDS
@@ -277,6 +278,7 @@
 	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a heavy caliber AM-5 antimaterial rifle and a 75-round drum magazine."
 	icon_state = "sniper_sentry"
 	icon = 'icons/obj/machines/deployable/sentry/sniper.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 
 	turret_range = 12
 	deploy_time = 10 SECONDS
@@ -330,6 +332,7 @@
 	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a heavy caliber SM-10 shotgun and a 100-round drum magazine."
 	icon_state = "shotgun_sentry"
 	icon = 'icons/obj/machines/deployable/sentry/shotgun.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 
 	turret_range = 8
 	deploy_time = 5 SECONDS
@@ -383,6 +386,7 @@
 	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a heavy flamethrower and a 200-round drum magazine."
 	icon_state = "flamer_sentry"
 	icon = 'icons/obj/machines/deployable/sentry/flamer.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 
 	turret_range = 8
 	deploy_time = 5 SECONDS


### PR DESCRIPTION
## About The Pull Request
Marine sentries are bulky items, I also made sure to let the speicalized sentries in tech bags while I was at it.
![image](https://github.com/user-attachments/assets/a441befb-db9d-4685-8039-b4cf7a58c719)
## Why It's Good For The Game
Sentries are honestly not supposed to fit in backpacks like normal items. The fact nobody has noticed this for years is kinda funny.
## Changelog
:cl:
balance: Due to cost cutting, marine sentries are now bulky items again. You can only put them inside specialized tech bags once more.
/:cl:
