### PR TITLE
fixes handcuffs breaking resist when you are un-handcuffed

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -13,7 +13,6 @@
 		wear_mask_update(I)
 		. = ITEM_UNEQUIP_UNEQUIPPED
 	else if(I == handcuffed)
-		handcuffed = null
 		update_handcuffed(null)
 		. = ITEM_UNEQUIP_UNEQUIPPED
 
@@ -37,6 +36,7 @@
 	else if(handcuffed)
 		handcuffed.UnregisterSignal(src, COMSIG_LIVING_DO_RESIST)
 		handcuffed.unequipped(src, SLOT_HANDCUFFED)
+		handcuffed = null
 	update_inv_handcuffed()
 
 ///Updates the mask slot icon


### PR DESCRIPTION

## About The Pull Request
Fixes handcuffs breaking your resist and still trying to resist non-existant handcuffs after you were handcuffed once, super annoying, doesn't let you resist fire.

## Why It's Good For The Game
Fixes a tiny annoyance that nobody has bothered to fix

## Changelog

:cl:
fix: Handcuffs won't break your resist anymore
/:cl:
