### PR TITLE
FC and Synth loadout vendor tabs + their respective essential kits work with loadout vendors

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -719,6 +719,30 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/pinpointer = 1,
 		/obj/item/clothing/glasses/hud/health = 1,
 		/obj/item/clothing/head/modular/m10x/leader = 1,
+	),
+	FIELD_COMMANDER = list(
+		/obj/item/explosive/plastique = 1,
+		/obj/item/supply_beacon = 1,
+		/obj/item/healthanalyzer = 1,
+		/obj/item/roller/medevac = 1,
+		/obj/item/medevac_beacon = 1,
+		/obj/item/whistle = 1,
+		/obj/item/clothing/glasses/hud/health = 1,
+	),
+	SYNTHETIC = list(
+		/obj/item/stack/sheet/plasteel/medium_stack = 1,
+		/obj/item/stack/sheet/metal/large_stack = 1,
+		/obj/item/tool/weldingtool/hugetank = 1,
+		/obj/item/tool/handheld_charger = 1,
+		/obj/item/defibrillator = 1,
+		/obj/item/medevac_beacon = 1,
+		/obj/item/roller/medevac = 1,
+		/obj/item/roller = 1,
+		/obj/item/bodybag/cryobag = 1,
+		/obj/item/reagent_containers/hypospray/advanced/oxycodone = 1,
+		/obj/item/tweezers = 1,
+		/obj/item/cell/high = 1,
+		/obj/item/circuitboard/apc = 1,
 	)
 ))
 

--- a/tgui/packages/tgui/interfaces/LoadoutManager/index.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutManager/index.tsx
@@ -127,6 +127,18 @@ const JobTabs = (props: LoadoutTabData) => {
             >
               Squad Leader
             </Tabs.Tab>
+            <Tabs.Tab
+              selected={job === 'Field Commander'}
+              onClick={() => setJob('Field Commander')}
+            >
+              Field Commander
+            </Tabs.Tab>
+            <Tabs.Tab
+              selected={job === 'Synthetic'}
+              onClick={() => setJob('Synthetic')}
+            >
+              Synthetic
+            </Tabs.Tab>
           </Tabs>
         </Flex.Item>
         <Flex.Item grow={1}>
@@ -146,7 +158,7 @@ export const LoadoutManager = (props) => {
   const [importNewLoadout, setImportNewLoadout] = useState(false);
 
   return (
-    <Window title="Loadout Manager" width={700} height={400}>
+    <Window title="Loadout Manager" width={800} height={400}>
       <Window.Content>
         <Stack vertical>
           <JobTabs job={job} setJob={setJob} />


### PR DESCRIPTION
## About The Pull Request

Mostly the title

## Why It's Good For The Game

Easier preparation for FC and synth players

## Changelog

:cl:
qol: The loadout vendor now contains two new tabs for the Field Commander and the Synthetic. Loadout vendor now works with their respective essential kits.
/:cl: