### PR TITLE
Mech EMP buffs

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -190,6 +190,8 @@
 	var/ui_y = 600
 	/// ref to screen object that displays in the middle of the UI
 	var/atom/movable/screen/mech_view/ui_view
+	///holds the EMP timer
+	var/emp_timer
 
 /obj/item/radio/mech //this has to go somewhere
 	subspace_transmission = TRUE
@@ -261,8 +263,10 @@
 	QDEL_NULL(smoke_system)
 	QDEL_NULL(ui_view)
 
-	GLOB.mechas_list -= src //global mech list
-	for(var/datum/atom_hud/squad/mech_status_hud in GLOB.huds) //Add to the squad HUD
+	emp_timer = null
+
+	GLOB.mechas_list -= src
+	for(var/datum/atom_hud/squad/mech_status_hud in GLOB.huds)
 		mech_status_hud.remove_from_hud(src)
 	return ..()
 
@@ -398,7 +402,9 @@
 		flick(phase_state, src)
 	return TRUE
 
+///Restores the mech after EMP
 /obj/vehicle/sealed/mecha/proc/restore_equipment()
+	emp_timer = null
 	mecha_flags &= ~MECHA_EMPED
 	equipment_disabled = FALSE
 	update_appearance(UPDATE_OVERLAYS)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -132,22 +132,26 @@
 /obj/vehicle/sealed/mecha/emp_act(severity)
 	. = ..()
 	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
-	use_power((cell.maxcharge * 0.2) / (severity))
-	take_damage(400 / severity, BURN, ENERGY)
+	use_power((cell.maxcharge * 0.4) / (severity))
+	take_damage(500 / severity, BURN, ENERGY)
 
 	for(var/mob/living/living_occupant AS in occupants)
-		living_occupant.Stagger((6 - severity) SECONDS)
+		living_occupant.Stagger((8 - severity) SECONDS)
 
 	log_message("EMP detected", LOG_MECHA, color="red")
 
-	var/disable_time = (4 - severity) SECONDS
+	var/disable_time = (5 - severity) SECONDS
 	if(!disable_time)
 		return
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, span_warning("Error -- Connection to equipment control unit has been lost."))
 	mecha_flags |= MECHA_EMPED
 	update_appearance(UPDATE_OVERLAYS)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), disable_time, TIMER_UNIQUE | TIMER_OVERRIDE)
+	var/time_left = timeleft(emp_timer)
+	if(time_left)
+		disable_time += time_left
+		deltimer(emp_timer)
+	emp_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), disable_time, TIMER_DELETE_ME|TIMER_STOPPABLE)
 	equipment_disabled = TRUE
 	set_mouse_pointer()
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -133,7 +133,7 @@
 	. = ..()
 	playsound(src, 'sound/magic/lightningshock.ogg', 50, FALSE)
 	use_power((cell.maxcharge * 0.4) / (severity))
-	take_damage(500 / severity, BURN, ENERGY)
+	take_damage(600 / severity, BURN, ENERGY)
 
 	for(var/mob/living/living_occupant AS in occupants)
 		living_occupant.Stagger((8 - severity) SECONDS)


### PR DESCRIPTION

## About The Pull Request
Buffed the effects of EMP'ing a mech.

Energy drain base amount increased from 20% to 40%.
Damage base increased from 400 to 600.
Occupant stagger base increased from 6 to 8 seconds.
Weapon disable base time increased from 4 to 5 seconds.

Weapon disable effects now stack in duration, so you can basically chain stun mechs with EMP spam.
## Why It's Good For The Game
Makes EMP's better against what is probably their main target.
## Changelog
:cl:
balance: Buffed EMP effects against mechs
/:cl:
