### PR TITLE
Swaps unique action and jump default keybinds.

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -36,7 +36,7 @@
 	quick_equip_slot = 5
 
 /datum/keybinding/human/unique_action
-	hotkey_keys = list("C")
+	hotkey_keys = list("Space")
 	name = "unique_action"
 	full_name = "Perform unique action"
 	keybind_signal = COMSIG_KB_UNIQUEACTION

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -19,7 +19,7 @@
 	return TRUE
 
 /datum/keybinding/living/attempt_jump
-	hotkey_keys = list("Space")
+	hotkey_keys = list("C")
 	name = "Jump"
 	full_name = "Jump"
 	description = "Jumps, if your mob is capable of doing so."


### PR DESCRIPTION

## About The Pull Request
Swaps jump to C and unique action to spacebar.
## Why It's Good For The Game
Jumping being on spacebar by default makes no sense. It isn't a common occurance and usually is a specialized action to deal with a specialized problem while unique action is pretty key to using like an entire subclass of weapons for mahrines and beans. I don't get why unique action was moved instead of jump. This mainly is to help new players. There's also a bunch of critical xeno stuff put on spacebar like charge toggle and rage.
## Changelog
:cl:
tweak: Unique action by default is back on spacebar while jump is on C.
/:cl:
