### PR TITLE
Nade message fix

### DIFF
--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -174,12 +174,12 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 
 	if(grenades_primed)
 		stats += "[grenades_primed] grenade\s thrown."
+	if(grenade_hand_delimbs)
+		stats += "You blew off [grenade_hand_delimbs] hand[grenade_hand_delimbs != 1 ? "s" : ""] while holding grenades like an idiot."
 	if(traps_created)
 		stats += "[traps_created] trap\s/mine\s/hazard\s placed."
 	if(grenades_primed || traps_created)
 		stats += ""
-	if(grenade_hand_delimbs)
-		stats += "You blew off [grenade_hand_delimbs] hand[grenade_hand_delimbs != 1 ? "s" : ""] while trying to throw grenades, like an idiot."
 
 	stats += "Lost [limbs_lost] limb[limbs_lost != 1 ? "s" : ""]."
 	if(delimbs)

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -57,6 +57,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/internal_injuries = 0
 	var/internal_injuries_inflicted = 0
 
+	var/grenade_hand_delimbs = 0
+
 	//Medical
 	var/self_heals = 0
 	var/heals = 0
@@ -176,6 +178,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 		stats += "[traps_created] trap\s/mine\s/hazard\s placed."
 	if(grenades_primed || traps_created)
 		stats += ""
+	if(grenade_hand_delimbs)
+		stats += "You blew off [grenade_hand_delimbs] hand[grenade_hand_delimbs != 1 ? "s" : ""] while trying to throw grenades, like an idiot."
 
 	stats += "Lost [limbs_lost] limb[limbs_lost != 1 ? "s" : ""]."
 	if(delimbs)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -106,7 +106,7 @@
 		else if(idiot.r_hand == src)
 			idiot.amputate_limb(BODY_ZONE_PRECISE_R_HAND)
 			in_hand = TRUE
-		if(in_hand == TRUE)
+		if(in_hand)
 			idiot.visible_message(span_danger("[idiot]'s hand is blown into tiny pieces by [src]!"),
 			span_userdanger("You feel incredible pain and stupidity as [src] blows your hand up."))
 			idiot.emote("scream")

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -99,13 +99,19 @@
 /obj/item/explosive/grenade/proc/prime()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/idiot = loc
+		var/in_hand = FALSE
 		if(idiot.l_hand == src)
 			idiot.amputate_limb(BODY_ZONE_PRECISE_L_HAND)
+			in_hand = TRUE
 		else if(idiot.r_hand == src)
 			idiot.amputate_limb(BODY_ZONE_PRECISE_R_HAND)
-		idiot.visible_message(span_danger("[idiot]'s hand is blown into tiny pieces by [src]!"),
-		span_userdanger("You feel incredible pain and stupidity as [src] blows your hand up."))
-		idiot.emote("scream")
+			in_hand = TRUE
+		if(in_hand == TRUE)
+			idiot.visible_message(span_danger("[idiot]'s hand is blown into tiny pieces by [src]!"),
+			span_userdanger("You feel incredible pain and stupidity as [src] blows your hand up."))
+			idiot.emote("scream")
+			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[idiot.ckey]
+			personal_statistics.grenade_hand_delimbs ++
 	explosion(loc, light_impact_range = src.light_impact_range, weak_impact_range = src.weak_impact_range)
 	qdel(src)
 


### PR DESCRIPTION

## About The Pull Request
Fixes the nade hand exploding message playing if your hand wasn't actually blown off (i.e. a sticky nade on you, or stored directly in a pocket slot etc).

Also added a personal stat to make you feel bad about how many hands you blew off because you threw the pin instead of the nade.

:cl:
fix: fixed the grenade hand explode message playing if your hand wasn't actually blown off
/:cl:
