### PR TITLE
Chestbursting can now happen in EORD/Deathmatch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -133,7 +133,7 @@
 		return
 
 	var/area/mob_area = get_area(affected_mob)
-	if(is_centcom_level(affected_mob.z) && istype(mob_area, /area/deathmatch) && !admin)
+	if(is_centcom_level(affected_mob.z) && !istype(mob_area, /area/deathmatch) && !admin)
 		return
 
 	var/mob/picked

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -133,7 +133,7 @@
 		return
 
 	var/area/mob_area = get_area(affected_mob)
-	if(is_centcom_level(affected_mob.z) && mob_area.type != /area/deathmatch && !admin)
+	if(is_centcom_level(affected_mob.z) && istype(mob_area, /area/deathmatch) && !admin)
 		return
 
 	var/mob/picked

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -132,7 +132,8 @@
 	if(!affected_mob)
 		return
 
-	if(is_centcom_level(affected_mob.z) && !admin)
+	var/area/mob_area = get_area(affected_mob)
+	if(is_centcom_level(affected_mob.z) && mob_area.type != /area/deathmatch && !admin)
 		return
 
 	var/mob/picked


### PR DESCRIPTION
## About The Pull Request
Chestbursting can happen in the Deathmatch Area (as in the area where you go to when you EORD Respawn) without admin intervention.

## Why It's Good For The Game
If people wanna play xenos during EORD, they should be allowed to. And the people who don't wanna play xeno should be able to shoot said xenos for existing. Only really happens if EORD lasts ages and not when the round restarts in a couple minutes.

## Changelog
:cl:
add: You can now chestburst while in EORD/Deathmatch Area without requiring admin intervention.
/:cl:
