### PR TITLE
Naming a tunnel no longer leaks your ckey

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -216,7 +216,7 @@
 
 	newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y])"
 
-	xeno_message("[key_name(X)] has built a new tunnel at [newt.tunnel_desc]!", "xenoannounce", 5, X.hivenumber)
+	xeno_message("[X.name] has built a new tunnel at [newt.tunnel_desc]!", "xenoannounce", 5, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.
 		var/obj/structure/xeno/tunnel/old_tunnel = X.tunnels[1]


### PR DESCRIPTION

## About The Pull Request
What it says on the title.
## Why It's Good For The Game
This probably shouldn't be happen, no idea why it was changed.
## Changelog
:cl:
fix: Naming a tunnel no longer leaks your ckey
/:cl:
