### PR TITLE
Increases rocket sledge price

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -827,7 +827,7 @@ WEAPONS
 /datum/supply_packs/weapons/rocketsledge
 	name = "Rocket Sledge"
 	contains = list(/obj/item/weapon/twohanded/rocketsledge)
-	cost = 600
+	cost = 850
 
 /datum/supply_packs/weapons/chainsaw
 	name = "Chainsaw"


### PR DESCRIPTION

## About The Pull Request
Salt PR? Maybe.
## Why It's Good For The Game
Rocket sledge is sort of analogous to the ZX in that they're both powerful melee weapons with high damage and no ammo costs. Technically the ZX can fit slug but like who cares about slugs

Despite this, rocket sledge's price is radically lower than the ZX's despite the addition of a new feature (stunning t3s). It should have a price tag similar to the ZX, if not identical.
It shouldn't cost literally one t3 at the very least.
## Changelog
:cl:
balance: Rocket sledge price 600 -> 850
/:cl:
