### PR TITLE
Changes Xeno to Marine ratio back to 2.46

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(jobs_fallen_marine, typecacheof(list(/datum/job/fallen/marine),
 #define LARVA_POINTS_SHIPSIDE_STRONG 1.5
 #define LARVA_POINTS_REGULAR 3.25
 ///How many marines per xeno at optimal ratio
-#define XENO_MARINE_RATIO 3
+#define XENO_MARINE_RATIO 2.46
 
 #define SURVIVOR_POINTS_REGULAR 1
 


### PR DESCRIPTION

## About The Pull Request

Changes the Xeno to Marine ratio back to 2.46, down from 3, as it was originally.

## Why It's Good For The Game

I originally suggested that the xeno ratio should be turned down because the stat buffs coupled with how hard they can stack from drains was making them snowball hard once they got a few drains going. The issue now is that both the xeno to marine ratio and the drain points required for a new larva got simultaneously nerfed, and now we're running into the issue where deaths are far more punishing and doom you to the 20 minute long respawn timer if you were hoping to queue up again. I've gone entire rounds without being able to join because of how long the queue takes.

For that reason, I'd rather try reverting the ratio change and keep the drain change to see if this makes it less painful to play xeno.

## Changelog

:cl:
balance: changed xeno to marine ratio back to 2.46, down from 3
/:cl:
