### PR TITLE
Fixes skinks equipping C4 as a weapon

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -262,7 +262,7 @@
 		return FALSE
 	if(istype(target, /obj/vehicle/unmanned))
 		var/obj/vehicle/unmanned/unmanned_target = target
-		if(!unmanned_target.allow_detpacks)
+		if(!unmanned_target.allow_explosives)
 			to_chat(user, "[span_warning("[src] doesnt fit on [unmanned_target]")]!")
 			return FALSE
 	if(istype(target, /obj/structure/window))

--- a/code/modules/vehicles/unmanned/deployable_vehicles.dm
+++ b/code/modules/vehicles/unmanned/deployable_vehicles.dm
@@ -92,7 +92,7 @@
 	unmanned_flags = GIVE_NIGHT_VISION
 	layer = XENO_HIDING_LAYER
 	trigger_gargoyle = FALSE
-	allow_detpacks = FALSE
+	allow_explosives = FALSE
 
 /obj/structure/closet/crate/uvt_crate
 	name = "\improper UV-T Skink Crate"

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -47,8 +47,8 @@
 	var/unmanned_flags = OVERLAY_TURRET|HAS_LIGHTS
 	/// Iff flags, to prevent friendly fire from sg and aiming marines
 	var/iff_signal = TGMC_LOYALIST_IFF
-	/// If detpacks should be usable on the vehicle
-	var/allow_detpacks = TRUE
+	/// If explosives should be usable on the vehicle
+	var/allow_explosives = TRUE
 	/// muzzleflash stuff
 	var/atom/movable/vis_obj/effect/muzzle_flash/flash
 	COOLDOWN_DECLARE(fire_cooldown)
@@ -127,8 +127,11 @@
 	. = ..()
 	if(.)
 		return
-	if(istype(I, /obj/item/uav_turret) || istype(I, /obj/item/explosive/plastique))
+	if(istype(I, /obj/item/uav_turret))
 		return equip_turret(I, user)
+	if(istype(I, /obj/item/explosive/plastique))
+		if(src.allow_explosives)
+			return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)
 

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -130,7 +130,7 @@
 	if(istype(I, /obj/item/uav_turret))
 		return equip_turret(I, user)
 	if(istype(I, /obj/item/explosive/plastique) && allow_explosives)
-			return equip_turret(I, user)
+		return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)
 

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -129,8 +129,7 @@
 		return
 	if(istype(I, /obj/item/uav_turret))
 		return equip_turret(I, user)
-	if(istype(I, /obj/item/explosive/plastique))
-		if(allow_explosives)
+	if(istype(I, /obj/item/explosive/plastique) && allow_explosives)
 			return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -130,7 +130,7 @@
 	if(istype(I, /obj/item/uav_turret))
 		return equip_turret(I, user)
 	if(istype(I, /obj/item/explosive/plastique))
-		if(src.allow_explosives)
+		if(allow_explosives)
 			return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)


### PR DESCRIPTION

## About The Pull Request
Skinks are not meant to have any combat capabilities.
## Why It's Good For The Game
No more unavoidable dev explosive.
## Changelog
:cl:
fix: Skinks can no longer take c4 as a weapon.
/:cl:
