### PR TITLE
(Some) Unmanned Vehicle No Longer Can Be Suicide Bombers

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -127,7 +127,7 @@
 	. = ..()
 	if(.)
 		return
-	if(istype(I, /obj/item/uav_turret) || istype(I, /obj/item/explosive/plastique))
+	if(istype(I, /obj/item/uav_turret) || (istype(I, /obj/item/explosive/plastique) && allow_detpacks))
 		return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)


### PR DESCRIPTION
## About The Pull Request
The variable called `allow_detpacks` now checks if plastiques can be equipped as the unmanned vehicle's turret/weapon.

## Why It's Good For The Game
Oversight, exploit, bugfix? If this doesn't merged, I'm going to abuse this every single round and gib every resting xeno for a measly 45 req points which assumes you have to buy the vehicle (5 points), the ~~det pack~~ plastique (30 points), and the remote (10 points). Given that engineers can get a remote for free and the ~~det packs~~ plastique from supply are also free... ya know.

## Changelog
:cl:
fix: Unmanned vehicles that disallow detonation packs now correctly also disallow it from as suicide bombs.
/:cl:
