### PR TITLE
Standard webbing can't hold powerpacks/powerbackpacks anymore

### DIFF
--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -86,8 +86,10 @@
 			/obj/item/stack/sheet,
 			/obj/item/stack/sandbags,
 			/obj/item/stack/snow,
-			/obj/item/cell/lasgun/volkite/powerpack,
 			/obj/item/cell/lasgun/plasma,
+		),
+		cant_hold_list = list(
+			/obj/item/cell/lasgun/volkite/powerpack
 		),
 		storage_type_limits_list = list(
 			/obj/item/ammo_magazine/rifle,


### PR DESCRIPTION

## About The Pull Request

Not 100% sure this is the best fix, but A: I don't want to dive into inventory code and force weight classes to take priority over the can_hold() list, which would cause a whole bunch of other issues, and B : I can't think of a way to make it specifically ignore all children of a type. Hence this bandaid fix 

## Why It's Good For The Game

Less INFINITE AMMO*

## Changelog
:cl:
balance: Standard webbing can no longer hold powerpacks/powerbackpacks
/:cl:
