### PR TITLE
Fixes crusher "anihilate" typo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -297,8 +297,8 @@
 			//There is a chance to do enough damage here to gib certain mobs. Better update immediately.
 			crushed_living.apply_damage(precrush, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
 			if(QDELETED(crushed_living))
-				charger.visible_message(span_danger("[charger] anihilates [preserved_name]!"),
-				span_xenodanger("We anihilate [preserved_name]!"))
+				charger.visible_message(span_danger("[charger] annihilates [preserved_name]!"),
+				span_xenodanger("We annihilate [preserved_name]!"))
 				return COMPONENT_MOVABLE_PREBUMP_PLOWED
 
 		return precrush2signal(crushed_living.post_crush_act(charger, src))


### PR DESCRIPTION
## About The Pull Request
When a Crusher crushes a living being into being QDEL'd, the text correctly says "annihilates" instead of "anihilates".

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/87c2b971-c5e8-4034-8e33-c4f09ca3bd6e)

## Changelog
:cl:
spellcheck: Crusher now annihilates instead of "anihilates".
/:cl:
