### PR TITLE
Moves crash landing spots on Research Outpost

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -56,6 +56,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/research)
+"ap" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/south)
 "aq" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2{
@@ -305,10 +309,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/cargo)
-"bG" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/outpost/yard/central)
 "bH" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 5
@@ -1827,6 +1827,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/central)
+"iS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/outpost/dormitories)
 "iT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/cavetodirt,
@@ -5754,7 +5763,6 @@
 "Ba" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
-/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
 	},
@@ -19813,7 +19821,7 @@ yW
 yW
 ai
 RD
-bG
+EA
 EA
 FH
 sY
@@ -21780,7 +21788,7 @@ aN
 ey
 VB
 aN
-bG
+EA
 EA
 oM
 CY
@@ -22330,7 +22338,7 @@ Hs
 Mb
 mN
 ES
-wa
+ap
 Ip
 kJ
 Ab
@@ -23370,7 +23378,7 @@ yb
 yb
 iL
 tK
-ZD
+iS
 ki
 ki
 ki


### PR DESCRIPTION
## About The Pull Request
Moves and removes some of the landing sites that were dysfunctional.
## Why It's Good For The Game
These spots either had sides completely blocked, only open to a one tile gap, or in one case completely crushed one of the disks. These spots will be far less painful to play.
## Changelog
:cl:
balance: Moved some crash landing sites on Research Outpost.
/:cl:
