### PR TITLE
Rebalances Crash

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -168,8 +168,6 @@ GLOBAL_LIST_INIT(hive_ui_static_data, init_hive_status_lists()) // init by make_
 			"evolution_max" = initial(caste.evolution_threshold)
 		))
 
-///List of castes we dont want to be evolvable.
-GLOBAL_LIST_EMPTY(restricted_castes)
 
 
 /proc/update_config_movespeed_type_lookup(update_mobs = TRUE)

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -168,6 +168,8 @@ GLOBAL_LIST_INIT(hive_ui_static_data, init_hive_status_lists()) // init by make_
 			"evolution_max" = initial(caste.evolution_threshold)
 		))
 
+///List of castes we dont want to be evolvable.
+GLOBAL_LIST_EMPTY(restricted_castes)
 
 
 /proc/update_config_movespeed_type_lookup(update_mobs = TRUE)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -565,7 +565,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		var/mob/living/carbon/human/H = i
 		if(!H.job)
 			continue
-		if(H.stat == DEAD && !H.has_working_organs())
+		if(H.stat == DEAD && HAS_TRAIT(H, TRAIT_UNDEFIBBABLE))
 			continue
 		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
 			continue

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -2,7 +2,6 @@
 #define SERVER_LAST_ROUND "server last round"
 
 GLOBAL_VAR(common_report) //Contains common part of roundend report
-GLOBAL_VAR(tier3_penalty) //Increases the amount of xenos needed to evolve to t3 by the value.
 
 /datum/game_mode
 	var/name = ""
@@ -46,10 +45,10 @@ GLOBAL_VAR(tier3_penalty) //Increases the amount of xenos needed to evolve to t3
 	var/time_between_round = 0
 	///What factions are used in this gamemode, typically TGMC and xenos
 	var/list/factions = list(FACTION_TERRAGOV, FACTION_ALIEN)
-	///Increases the amount of xenos needed to evolve to tier3 by x
-	var/gamemode_tier3_penalty = 0
+	///Increases the amount of xenos needed to evolve to tier three by the value.
+	var/tier_three_penalty = 0
 	///List of castes we dont want to be evolvable depending on gamemode.
-	var/list/gamemode_restricted_castes
+	var/list/restricted_castes
 
 //Distress call variables.
 	var/list/datum/emergency_call/all_calls = list() //initialized at round start and stores the datums.
@@ -112,9 +111,6 @@ GLOBAL_VAR(tier3_penalty) //Increases the amount of xenos needed to evolve to t3
 		if(!job) //dunno how or why but it errored in ci and i couldnt reproduce on local
 			continue
 		job.on_pre_setup()
-
-	GLOB.restricted_castes += gamemode_restricted_castes
-	GLOB.tier3_penalty = gamemode_tier3_penalty
 
 	return TRUE
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -2,6 +2,7 @@
 #define SERVER_LAST_ROUND "server last round"
 
 GLOBAL_VAR(common_report) //Contains common part of roundend report
+GLOBAL_VAR(tier3_penalty) //Increases the amount of xenos needed to evolve to t3 by the value.
 
 /datum/game_mode
 	var/name = ""
@@ -45,6 +46,10 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/time_between_round = 0
 	///What factions are used in this gamemode, typically TGMC and xenos
 	var/list/factions = list(FACTION_TERRAGOV, FACTION_ALIEN)
+	///Increases the amount of xenos needed to evolve to tier3 by x
+	var/gamemode_tier3_penalty = 0
+	///List of castes we dont want to be evolvable depending on gamemode.
+	var/list/gamemode_restricted_castes
 
 //Distress call variables.
 	var/list/datum/emergency_call/all_calls = list() //initialized at round start and stores the datums.
@@ -107,6 +112,9 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 		if(!job) //dunno how or why but it errored in ci and i couldnt reproduce on local
 			continue
 		job.on_pre_setup()
+
+	GLOB.restricted_castes += gamemode_restricted_castes
+	GLOB.tier3_penalty = gamemode_tier3_penalty
 
 	return TRUE
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -569,8 +569,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 			continue
 		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
 			continue
-		if(H.status_flags & XENO_HOST)
-			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue
 		. += H.job.jobworth[/datum/job/xenomorph]

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -561,9 +561,11 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		var/mob/living/carbon/human/H = i
 		if(!H.job)
 			continue
-		if(H.stat == DEAD && HAS_TRAIT(H, TRAIT_UNDEFIBBABLE))
+		if(H.stat == DEAD && !H.has_working_organs())
 			continue
 		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
+			continue
+		if(H.status_flags & XENO_HOST)
 			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -196,7 +196,7 @@
 	if(stored_larva)
 		return //No need for respawns
 	var/num_xenos = xeno_hive.get_total_xeno_number() + stored_larva
-	if(num_xenos < 2)
+	if(!num_xenos)
 		xeno_job.add_job_positions(1)
 		return
 	var/larva_surplus = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
@@ -204,3 +204,13 @@
 		return //Things are balanced, no burrowed needed
 	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
+
+/datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags)
+	. = 0
+
+	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+		if(!H.job)
+			continue
+		if(isspaceturf(H.loc))
+			continue
+		. += H.job.jobworth[/datum/job/xenomorph]

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -22,6 +22,10 @@
 	)
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
+	//We want tier 3s one xeno later.
+	gamemode_tier3_penalty = 1
+	//List of xenos we dont want to be playable.
+	gamemode_restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE
@@ -194,7 +198,7 @@
 	if(stored_larva)
 		return //No need for respawns
 	var/num_xenos = xeno_hive.get_total_xeno_number() + stored_larva
-	if(!num_xenos)
+	if(num_xenos < 2)
 		xeno_job.add_job_positions(1)
 		return
 	var/larva_surplus = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
@@ -203,13 +207,10 @@
 	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
 
-/datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags)
-	. = 0
-
-	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
-		if(!H.job)
-			continue
-		if(isspaceturf(H.loc))
-			continue
-		. += H.job.jobworth[/datum/job/xenomorph]
-
+///This checks to see if we're above our minimum xeno amount so that we get our 3rd xeno at 7 pop instead of 4.
+/datum/game_mode/infestation/crash/proc/check_starter_xenos()
+	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	if(xeno_job.total_positions < 3)
+		xeno_job.job_points_needed *= 2
+	else
+		xeno_job.job_points_needed = CRASH_LARVA_POINTS_NEEDED

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -206,11 +206,3 @@
 		return //Things are balanced, no burrowed needed
 	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
-
-///This checks to see if we're above our minimum xeno amount so that we get our 3rd xeno at 7 pop instead of 4.
-/datum/game_mode/infestation/crash/proc/check_starter_xenos()
-	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	if(xeno_job.total_positions < 3)
-		xeno_job.job_points_needed *= 2
-	else
-		xeno_job.job_points_needed = CRASH_LARVA_POINTS_NEEDED

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -214,3 +214,4 @@
 		if(isspaceturf(H.loc))
 			continue
 		. += H.job.jobworth[/datum/job/xenomorph]
+

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -22,10 +22,8 @@
 	)
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
-	//We want tier 3s one xeno later.
-	gamemode_tier3_penalty = 1
-	//List of xenos we dont want to be playable.
-	gamemode_restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
+	tier_three_penalty = 1
+	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -285,6 +285,10 @@
 		balloon_alert(src, "We can't evolve to that caste from our current one")
 		return FALSE
 
+	if(new_caste_type in GLOB.restricted_castes)
+		balloon_alert(src, "Our weak hive can't support that caste!")
+		return FALSE
+
 	var/no_room_tier_two = length(hive.xenos_by_tier[XENO_TIER_TWO]) >= hive.tier2_xeno_limit
 	var/no_room_tier_three = length(hive.xenos_by_tier[XENO_TIER_THREE]) >= hive.tier3_xeno_limit
 	var/datum/xeno_caste/new_caste = GLOB.xeno_caste_datums[new_caste_type][XENO_UPGRADE_BASETYPE] // tivi todo make so evo takes the strict caste datums

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -285,7 +285,7 @@
 		balloon_alert(src, "We can't evolve to that caste from our current one")
 		return FALSE
 
-	if(new_caste_type in GLOB.restricted_castes)
+	if(new_caste_type in SSticker.mode.restricted_castes)
 		balloon_alert(src, "Our weak hive can't support that caste!")
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1197,7 +1197,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(psychictowers) + 1, 1))
+	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) - GLOB.tier3_penalty) / 3 + length(psychictowers) + 1, 1))
 	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1197,7 +1197,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) - GLOB.tier3_penalty) / 3 + length(psychictowers) + 1, 1))
+	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) - SSticker.mode.tier_three_penalty) / 3 + length(psychictowers) + 1, 1))
 	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************


### PR DESCRIPTION
## About The Pull Request
Various changes to make crash more fair.

- Removes hivemind, hivelord, and wraith from crash.
- Xenos get extra t3 slots one xeno later on crash. (see below)

<details> 
  <summary> How many xenos for a t3 slot? </summary>
 
<img width="613" alt="xenopopsheet" src="https://github.com/user-attachments/assets/02073fae-16eb-4d74-b134-d0fb1ebce41c">

</details>

## Why It's Good For The Game
1. Wraith is the bane of this mode and can very easily cheese the Canterbury, this is not fun gameplay and lowpop suffers from having wraith in this mode. Hivemind is completely unkillable on crash and very annoying when it endlessly spams sticky weeds and walls, and hivelord is in a similar position with its large bulk allowing it to spam endless resin and sticky weeds, while also having the healbeam which can give a queen or other large xeno nearly 100% uptime, which is a bit too strong when marines are so short on staff.
2. Marines are not well equipped to deal with t3s on crash and at 7 marines you can already be dealing with two ravagers. This causes very quick wipes and very little back and forth gameplay. Pushing the extra t3 slots to higher pop should help marines survive lowpop easier.

Discuss below what else you think needs tuned, im still not completely sure whether hivelord should stay or go.
## Changelog
:cl:
balance: Removes hivemind, hivelord, and wraith from crash.
balance: Xenos get extra t3 slots one xeno later on crash.

/:cl:
