### PR TITLE
SH-34 secondary fix

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
@@ -143,6 +143,7 @@
 
 /datum/loadout_item/secondary/gun/marine/db_shotgun/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout, datum/outfit_holder/holder)
 	wearer.equip_to_slot_or_del(new /obj/item/ammo_magazine/shotgun/buckshot, SLOT_IN_HOLSTER)
+	wearer.equip_to_slot_or_del(new item_typepath(wearer), SLOT_IN_HOLSTER)
 
 //non-standard
 /datum/loadout_item/secondary/machete


### PR DESCRIPTION

## About The Pull Request
Fix the SH-34 secondary in campaign for smartgunners actually spawning the gun.

:cl:
fix: Campaign: Fixed SH-34 secondary not spawning
/:cl:
