### PR TITLE
Increases DMR-37 Aimmode's Aim Delay

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -247,7 +247,7 @@
 	starting_attachment_types = list(/obj/item/attachable/scope/mini/dmr)
 	attachable_offset = list("muzzle_x" = 50, "muzzle_y" = 20,"rail_x" = 21, "rail_y" = 22, "under_x" = 31, "under_y" = 15, "stock_x" = 14, "stock_y" = 10)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.45 SECONDS
+	aim_fire_delay = 0.5 SECONDS
 	aim_speed_modifier = 2
 
 	fire_delay = 0.65 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -247,7 +247,7 @@
 	starting_attachment_types = list(/obj/item/attachable/scope/mini/dmr)
 	attachable_offset = list("muzzle_x" = 50, "muzzle_y" = 20,"rail_x" = 21, "rail_y" = 22, "under_x" = 31, "under_y" = 15, "stock_x" = 14, "stock_y" = 10)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.5 SECONDS
+	aim_fire_delay = 0.45 SECONDS
 	aim_speed_modifier = 2
 
 	fire_delay = 0.65 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -247,7 +247,7 @@
 	starting_attachment_types = list(/obj/item/attachable/scope/mini/dmr)
 	attachable_offset = list("muzzle_x" = 50, "muzzle_y" = 20,"rail_x" = 21, "rail_y" = 22, "under_x" = 31, "under_y" = 15, "stock_x" = 14, "stock_y" = 10)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.2 SECONDS
+	aim_fire_delay = 0.5 SECONDS
 	aim_speed_modifier = 2
 
 	fire_delay = 0.65 SECONDS


### PR DESCRIPTION
## About The Pull Request
Increases the aim delay gained when using aimmode with DMR from 0.2 seconds to 0.5 seconds which is slightly above the aim mode ratio used for SR-127.

## Why It's Good For The Game
DMR is capable of using the sniper rail and is arguably better at sniping than SR-127 when it does a little less damage than the SR-127, can shoot about 3 times for every SR-127 shot when both had aimmode on, and has the flexibility to become a short/mid range weapon. So... just make it worse at sniping than SR-127.

## Changelog
:cl:
balance: DMR-37 now has a significant aim delay when using aim mode going from 0.2s to 0.5s.
/:cl:
