### PR TITLE
Hunter stealth damage threshold

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -130,7 +130,7 @@
 ///Updates or cancels stealth
 /datum/action/ability/xeno_action/stealth/proc/handle_stealth()
 	SIGNAL_HANDLER
-	total_damage_taken = max(total_damage_taken - 5, 0)
+	total_damage_taken = max(total_damage_taken - 10, 0)
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	//Initial stealth
 	if(last_stealth > world.time - HUNTER_STEALTH_INITIAL_DELAY) //We don't start out at max invisibility

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -130,6 +130,7 @@
 ///Updates or cancels stealth
 /datum/action/ability/xeno_action/stealth/proc/handle_stealth()
 	SIGNAL_HANDLER
+	total_damage_taken = max(total_damage_taken - 5, 0)
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	//Initial stealth
 	if(last_stealth > world.time - HUNTER_STEALTH_INITIAL_DELAY) //We don't start out at max invisibility

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -15,6 +15,8 @@
 	var/stealth = FALSE
 	var/can_sneak_attack = FALSE
 	var/stealth_alpha_multiplier = 1
+	///Damage taken during stealth
+	var/total_damage_taken = 0
 
 /datum/action/ability/xeno_action/stealth/remove_action(mob/living/L)
 	if(stealth)
@@ -109,6 +111,7 @@
 	can_sneak_attack = FALSE
 	REMOVE_TRAIT(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT)
 	owner.alpha = initial(owner.alpha)
+	total_damage_taken = 0
 
 ///Signal wrapper to verify that an object is damageable before breaking stealth
 /datum/action/ability/xeno_action/stealth/proc/on_obj_attack(datum/source, obj/attacked)
@@ -195,8 +198,9 @@
 ///Breaks stealth if sufficient damage taken
 /datum/action/ability/xeno_action/stealth/proc/damage_taken(mob/living/carbon/xenomorph/X, damage_taken)
 	SIGNAL_HANDLER
+	total_damage_taken += damage_taken
 	var/mob/living/carbon/xenomorph/xenoowner = owner
-	if(damage_taken > xenoowner.xeno_caste.stealth_break_threshold)
+	if(total_damage_taken > xenoowner.xeno_caste.stealth_break_threshold)
 		cancel_stealth()
 
 ///Modifier to plasma regen when stealthed

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -43,7 +43,7 @@
 	soft_armor = list(MELEE = 55, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
 
 	// *** Stealth ***
-	stealth_break_threshold = 15
+	stealth_break_threshold = 45
 
 	// *** Minimap Icon *** //
 	minimap_icon = "hunter"


### PR DESCRIPTION

## About The Pull Request
Hunter stealth being broken is now by total damage received in stealth, instead of the damage from a single hit being over a threshold.

The number is now 45 damage (number pulled out of my ass). i.e. a full burst from a rifle will break stealth, but 1-2 shots probably won't.

The damage threshold recovers by 10 damage per sec (i.e. you get hit once or twice so you're 25/45 damage taken, but stay stealthed and wait around a corner for a bit, and that recovers back to 0/45.
## Why It's Good For The Game
Less fucking god awful, certain guns were previously hard locked out of ever breaking stealth.
This is only set to get worse with the new mechanic letting xenos buff their armour, locking out more guns from stealth break.
## Changelog
:cl:
balance: Hunter stealth break from incoming damage is now a total amount (45) instead of a single hit needing to be over 15
/:cl:
