### PR TITLE
Changes Powerloader Speed & Fixes Powerloader Skill

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -135,7 +135,7 @@
 #define SKILL_POLICE_FLASH 1
 #define SKILL_POLICE_MP 2
 
-///Powerloader skill; movespeed when using a powerloader (broken currently)
+///Powerloader skill; movespeed when using a powerloader
 #define SKILL_POWERLOADER "powerloader"
 
 #define SKILL_POWERLOADER_DEFAULT 0

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -6,7 +6,7 @@
 	layer = POWERLOADER_LAYER //so the top appears above windows and wall mounts
 	anchored = TRUE
 	allow_pass_flags = NONE
-	move_delay = 8
+	move_delay = 6
 	light_system = HYBRID_LIGHT
 	light_power = 8
 	light_range = 0
@@ -66,7 +66,8 @@
 	playsound(loc, 'sound/mecha/powerloader_buckle.ogg', 25)
 	icon_state = "powerloader"
 	overlays += image(icon_state= "powerloader_overlay", layer = MOB_LAYER + 0.1)
-	move_delay = max(4, move_delay - buckling_mob.skills.getRating(SKILL_POWERLOADER))
+	move_delay = max(2, move_delay - buckling_mob.skills.getRating(SKILL_POWERLOADER))
+	set_vehicle_speed()
 	var/clamp_equipped = 0
 	for(var/obj/item/powerloader_clamp/PC in contents)
 		if(!buckling_mob.put_in_hands(PC))
@@ -83,8 +84,14 @@
 	overlays.Cut()
 	playsound(loc, 'sound/mecha/powerloader_buckle.ogg', 25)
 	move_delay = initial(move_delay)
+	set_vehicle_speed()
 	icon_state = "powerloader_open"
 	buckled_mob.drop_all_held_items() //drop the clamp when unbuckling
+
+/// Sets the powerloader's actual move delay (as it is handled in the component).
+/obj/vehicle/ridden/powerloader/proc/set_vehicle_speed()
+	var/datum/component/riding/vehicle/powerloader/vehicle_component = GetComponent(/datum/component/riding/vehicle/powerloader)
+	vehicle_component.vehicle_move_delay = move_delay
 
 /obj/vehicle/ridden/powerloader/welder_act(mob/living/user, obj/item/I)
 	return welder_repair_act(user, I, 10, 2 SECONDS, fuel_req = 1)


### PR DESCRIPTION
## About The Pull Request
Powerloader skill now affects movement speed while inside of a powerloader as intended where each point decreases movement delay by 0.1 seconds.

For powerloaders, the base movement delay has been increased from 0.4 seconds to 0.6 seconds and the least possible delay is 0.2 seconds. This (plus bugfix) means the following:
Everyone Else: 33% slower
Engineers: 20% slower
FC/SO: Unchanged
PO/TO/Mech/AC/TC: 25% faster
Synths/Captain/CE/RO/ST: 50% faster

## Why It's Good For The Game
Bugfix. As for the balance change, 0.4 seconds became the norm for at least 7 whole months (aka how long this was broken); everyone got used to it or don't care anymore. So, make it worse for marines (who shouldn't be doing this anyways) and better for shipside roles.

## Changelog 
:cl:
balance: Powerloader is now generally slower for marines, but generally faster for shipside roles.
fix: Powerloader Skill now affects Powerloader's movement speed.
/:cl:
