### PR TITLE
Officer sword size fix

### DIFF
--- a/code/game/objects/items/weapons/swords.dm
+++ b/code/game/objects/items/weapons/swords.dm
@@ -135,6 +135,7 @@
 	force = 75
 	attack_speed = 11
 	penetration = 15
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/weapon/sword/officersword/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
FC sword lost w_class 4 when I reorg'd the typepaths.

:cl:
fix: fixed FC sword having the wrong weight class
/:cl:
