### PR TITLE
increases resin jelly duration

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -285,7 +285,7 @@
 	icon = 'icons/Xeno/xeno_materials.dmi'
 	icon_state = "resin_jelly"
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 200, ACID = 0)
-	var/immune_time = 15 SECONDS
+	var/immune_time = 30 SECONDS
 	///Holder to ensure only one user per resin jelly.
 	var/current_user
 


### PR DESCRIPTION
## About The Pull Request
15 seconds -> 30
## Why It's Good For The Game
fifteen fucking seconds is wayyyyy too short of a duration given how slow resin jelly is to produce, how easily spammable fire is, and how many xenos need it at once. Maybe 15 is acceptable for like, a spitter, or something, but xenos' main mode of engagement is still melee.

Not to mention that in the big xeno buff PR, the general trend was to make xenos slower, but have more health. This obviously reduces the effectiveness of resin jelly, as it makes engaging and disengaging much slower.
## Changelog
:cl:
balance: Increases resin jelly duration from 15 seconds to 30 seconds.
/:cl:
