### PR TITLE
Fixes inaccessible buttons on canterbury and bigbury

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -1106,18 +1106,12 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Xb" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	id = "aft_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
+/obj/structure/barricade/plasteel,
 /obj/machinery/door_control{
 	dir = 8;
 	id = "aft_engine_podlock"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "Xf" = (
 /obj/machinery/iv_drip,
@@ -1406,7 +1400,7 @@ Yn
 qE
 XO
 ac
-ar
+gv
 bW
 Uo
 "}
@@ -1538,8 +1532,8 @@ ac
 SA
 RT
 ac
-ar
 Xb
+bW
 Uo
 "}
 (13,1,1) = {"

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -582,20 +582,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/canterbury)
-"cp" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	id = "aft_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
-/obj/machinery/door_control{
-	dir = 8;
-	id = "aft_engine_podlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/canterbury)
 "cs" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2
@@ -718,6 +704,9 @@
 	dir = 8
 	},
 /obj/structure/barricade/plasteel,
+/obj/machinery/air_alarm{
+	dir = 4
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "cZ" = (
@@ -728,10 +717,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/air_alarm{
-	dir = 8
-	},
 /obj/structure/barricade/plasteel,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "aft_engine_podlock"
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "db" = (
@@ -1019,7 +1009,7 @@ KE
 bW
 bW
 da
-cp
+co
 "}
 (10,1,1) = {"
 ac

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -714,9 +714,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "da" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/barricade/plasteel,
 /obj/machinery/door_control{
 	dir = 8;


### PR DESCRIPTION
## About The Pull Request

Fixes the buttons on the south end of the canterbury and bigbury being inaccessible, preventing opening the south entryways.

## Why It's Good For The Game

Being able to open doors is good

## Testing
<details> 
        <summary>screenshot</summary> 

![image](https://github.com/user-attachments/assets/3cb6049e-a8da-44c1-9eb3-9c0da2f378c9)

</details>   

I was not able to test bigbury since I couldn't figure out how to make the server load it, but, since it's a near identical change I think it's safe.

## Changelog

:cl:
fix: fixed buttons on canterbury and bigbury for opening the south entryways
/:cl:
