### PR TITLE
Raises silo scaling to 2x

### DIFF
--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/nuclear_war
 	name = "Nuclear War"
 	config_tag = "Nuclear War"
-	silo_scaling = 1.5
+	silo_scaling = 2
 	round_type_flags = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD|MODE_FORCE_CUSTOMSQUAD_UI
 	xeno_abilities_flags = ABILITY_NUCLEARWAR
 	valid_job_types = list(


### PR DESCRIPTION

## About The Pull Request
Raises silo scaling to 2x from 1.5x. 
This will result in the same amount of xenos roundstart while providing 33% more larva gen during the round.

For context, silo scaling was 2x up until #13925 which reduced it during the time of maturity removal.
Since then, 2 major changes have been made to larva gen:
First, the ratio scaling was fixed in #15523 and #15563.
These changes mean that xenos are less likely to reach an overbearing ratio via passive generation alone.

Secondly, points required for a larva was increased with #16572 (and later #16697 making that the only change)
This resulted in 25% less xenos, which was a necessary change roundstart but leaves xenos rarely with enough larva gen to ever have more xenos than roundstart - often xenos will die causing others to die and creating a deathspiral that results in one-sided rounds.

Skilled hives were not as affected by this change, as they can usually survive and get drains leading to a win.
Newer hives are punished far more, and many rounds end at shutters open when two new players die and the remaining 6 xenos are never able to prevent the inevitable 40 minute silo rush while 6 or more xenos sit in larva queue.
## Why It's Good For The Game
Xenos are getting stomped on repeat and larva queues are very long. Raising silo scaling like this will give xenos a better chance at a comeback and give marines more opportunities to sweat with their req weapons without instantly ending the round at 50 minutes.
## Changelog
:cl:
balance: Xeno silo scaling raised to 2x from 1.5x
/:cl:
