### PR TITLE
Buffs HvX tank vision by 2 to be the same as campaign tank

### DIFF
--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -22,6 +22,7 @@
 	max_occupants = 4
 	move_delay = 0.75 SECONDS
 	glide_size = 2.5
+	vis_range_mod = 4
 	ram_damage = 100
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,

--- a/code/modules/vehicles/armored/armored_actions.dm
+++ b/code/modules/vehicles/armored/armored_actions.dm
@@ -124,7 +124,7 @@
 		owner.client.view_size.set_view_radius_to(4.5)
 		SEND_SOUND(owner, sound('sound/mecha/imag_enh.ogg', volume=50))
 	else
-		owner.client.view_size.reset_to_default()
+		owner.client.view_size.set_view_radius_to("[chassis.vis_range_mod]x[chassis.vis_range_mod]")
 	update_button_icon()
 
 /datum/action/vehicle/sealed/armored/zoom/remove_action(mob/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the HvX tank vision by 2 tiles 
before:
![image](https://github.com/user-attachments/assets/61c5901f-5f28-4fe3-8f8f-1f8d29a2bd28)
after:
![image](https://github.com/user-attachments/assets/1cd80293-3ea1-42e6-b108-f91028fb9385)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently tank suffers from essentially reduced vision from his bigger model to vision ratio. Combined with its low mobility and lack of IFF it encourages tank crews to take less risks as one mistake can result in them getting swarmed due to lack of vision and removal from the round.
This change hopes to give tank more situational awareness and reduce those effects.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: HvX tank can see 2 tiles further
/:cl:
