### PR TITLE
Removes confirmation for toggle_sleep verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -214,8 +214,6 @@
 
 	if(L.IsAdminSleeping())
 		L.ToggleAdminSleep()
-	else if(alert("Are you sure you want to sleep [key_name(L)]?", "Toggle Sleeping", "Yes", "No") != "Yes")
-		return
 	else if(!istype(L))
 		to_chat(usr, span_warning("Target is no longer valid."))
 		return


### PR DESCRIPTION

## About The Pull Request
Removes the [Yes / No] prompt from the toggle_sleep verb.
## Why It's Good For The Game
9/10 times this gets used you want it being done as quickly as possible so having a confirmation prompt is not a good thing, and if you are misclicking it you can undo it just as easily.
## Changelog
:cl:
admin: Toggle Sleeping no longer has a confirmation prompt.
/:cl:
