### PR TITLE
Changes xenomorph rank from prime to primal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -43,7 +43,7 @@
 		if(4201 to 10500)
 			name = prefix + "Ancient Emperor ([nicknumber])"
 		if(10501 to INFINITY)
-			name = prefix + "Prime Emperor ([nicknumber])"
+			name = prefix + "Primal Emperor ([nicknumber])"
 		else
 			name = prefix + "Young King ([nicknumber])"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -89,7 +89,7 @@
 		if(4201 to 10500)
 			name = prefix + "Ancient Empress ([nicknumber])"
 		if(10501 to INFINITY)
-			name = prefix + "Prime Empress ([nicknumber])"
+			name = prefix + "Primal Empress ([nicknumber])"
 		else
 			name = prefix + "Young Queen ([nicknumber])"
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -170,7 +170,7 @@
 		if(4201 to 10500) //70 hours
 			rank_name = "Ancient"
 		if(10501 to INFINITY) //175 hours
-			rank_name = "Prime"
+			rank_name = "Primal"
 		else
 			rank_name = "Young"
 	name = prefix + "[rank_name ? "[rank_name] " : ""][xeno_caste.display_name] ([nicknumber])"


### PR DESCRIPTION
## About The Pull Request
Changes the rank of prime to be primal

## Why It's Good For The Game
Sounds cooler

## Changelog
:cl: Cheese
add: Prime xenomorph rank has been renamed to Primal.
/:cl:
