### PR TITLE
Lowers supply drop cooldown.

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -8,7 +8,7 @@
 	interaction_flags = INTERACT_MACHINE_TGUI
 	circuit = /obj/item/circuitboard/computer/supplydrop
 	///Time between two supply drops
-	var/launch_cooldown = 30 SECONDS
+	var/launch_cooldown = 15 SECONDS
 	///The beacon we will send the supplies
 	var/datum/supply_beacon/supply_beacon = null
 	///The linked supply pad of this console


### PR DESCRIPTION
## About The Pull Request
Lowers the cooldown on the supply drop console from 30 seconds to 15.
## Why It's Good For The Game
RO frequently finds themselves overwhelmed by req orders on higher pop as more and more people are around to ask for ammo and other things right as you send a crate. Other shipside roles _should_ be able to help fill in when needed, but the console's long cooldown means even a lone RO will be sitting around staring at the timer tick.

Lowering the cooldown will free ROs to work more efficiently when orders are coming in rapidly, and allow 2 or more people to use the console without wasting time when it is needed on higher pop.
## Changelog
:cl:
balance: Supply drop console cooldown reduced from 30 seconds to 15.
/:cl:
