### PR TITLE
Readds extended and spray nozzles

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -177,6 +177,7 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
+			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,

--- a/code/modules/projectiles/gun_attachables/attachable.dm
+++ b/code/modules/projectiles/gun_attachables/attachable.dm
@@ -120,6 +120,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/ammo_mod = null
 	///how much charge difference it now costs to shoot. negative means more shots per mag.
 	var/charge_mod = 0
+	///whether the attachment adds a windup delay before firing
+	var/windup_delay = 0
 	///what firemodes this attachment allows/adds.
 	var/gun_firemode_list_mod = null
 	///lazylist of attachment slot offsets for a gun.
@@ -205,6 +207,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.min_scatter_unwielded        += min_scatter_unwielded_mod
 		master_gun.aim_speed_modifier			+= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 		master_gun.iff_marine_damage_falloff	+= shot_marine_damage_falloff
+		master_gun.windup_delay                 += windup_delay
 		master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay) * aim_mode_delay_mod)
 		if(add_aim_mode)
 			var/datum/action/item_action/aim_mode/A = new (master_gun)
@@ -258,6 +261,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.min_scatter_unwielded        -= min_scatter_unwielded_mod
 		master_gun.aim_speed_modifier			-= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 		master_gun.iff_marine_damage_falloff	-= shot_marine_damage_falloff
+		master_gun.windup_delay                 -= windup_delay
 		master_gun.remove_aim_mode_fire_delay(name)
 		if(add_aim_mode)
 			var/datum/action/item_action/aim_mode/action_to_delete = locate() in master_gun.actions

--- a/code/modules/projectiles/gun_attachables/flamer.dm
+++ b/code/modules/projectiles/gun_attachables/flamer.dm
@@ -50,6 +50,8 @@
 	pixel_shift_y = 17
 	stream_type = FLAMER_STREAM_CONE
 	burn_time_mod = 0.3
+	delay_mod = -20
+	windup_delay = 3 SECONDS
 
 ///Funny red wide nozzle that can fill entire screens with flames. Admeme only.
 /obj/item/attachable/flamer_nozzle/wide/red
@@ -62,9 +64,10 @@
 /obj/item/attachable/flamer_nozzle/long
 	name = "extended flamer nozzle"
 	icon_state = "long"
-	desc = "Rather than spreading the supplied fuel over an area, this nozzle launches a single fireball to ignite a target at range. Reduced volume per shot also means the next is ready quicker."
+	desc = "Rather than spreading the supplied fuel over an area, this nozzle launches a single fireball to ignite a target at range. Takes a little longer to fire due to needing to pressurize before each shot."
 	stream_type = FLAMER_STREAM_RANGED
-	delay_mod = -10
+	delay_mod = -20
+	windup_delay = 2 SECONDS
 
 /obj/item/attachable/flamer_nozzle/long/on_attach(attaching_item, mob/user)
 	. = ..()

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -874,6 +874,11 @@ WEAPONS
 	contains = list(/obj/item/ammo_magazine/tank/secondary_cupola)
 	cost = 10
 
+/datum/supply_packs/weapons/flamer_spray_nozzle
+	name = "Spray Nozzle"
+	contains = list(/obj/item/attachable/flamer_nozzle/wide)
+	cost = 200
+
 /*******************************************************************************
 EXPLOSIVES
 *******************************************************************************/


### PR DESCRIPTION
## About The Pull Request

Readds the extended and spray nozzles

The extended nozzle is free, but the spray nozzle has been condemmed to req hell for 200 points

## Why It's Good For The Game

The extended nozzle was really just a sidegrade, losing it's ability to penetrate walls for better ammo efficiency. The best argument against it being that you have to be up close to use the flamer because (???). The plasma pistol exists for ranged wall destruction, and the laser sniper HEAT mode exists for setting xenoes on at fire at range so-

The spray nozzle in action could present some problems, being able to deny massive areas to xenoes, especially in cave pushes. While it was expensive in terms of fuel, a dead xeno is a dead xeno, and dead structures are also dead structures, which come both at massive costs to xenoes (while fuel itself is plentiful). Hence the decision to req hell it.

## Changelog
:cl:
add: Readds the extended nozzle (for free) and the spray nozzle (for 200 req points) for the FL-84 flamer.
balance: Extended nozzle now has a 2 second windup before firing. Wide nozzle has a 3 second windup. 
/:cl:
