### PR TITLE
Wraith Portals are Lava Immune

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -577,6 +577,9 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		return
 	user.forceMove(get_turf(linked_portal))
 
+/obj/effect/wraith_portal/lava_act()
+	return
+
 /// Link two portals
 /obj/effect/wraith_portal/proc/link_portal(obj/effect/wraith_portal/portal_to_link)
 	linked_portal = portal_to_link


### PR DESCRIPTION
## About The Pull Request
Wraith portals are unaffected by lava.

## Why It's Good For The Game
Bugfix. I don't see why portals should be affected by lava since lava deals direct damage to the portal as opposed to everything else which either does nothing (bullets) or straight up deletes it (grenades). Seems like an oversight.

## Changelog
:cl:
fix: Wraith portals are no longer affected / destroyed by lava.
/:cl:
