### PR TITLE
Reverts Kuro defiler speed change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -14,7 +14,7 @@
 	melee_damage = 26
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 575

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 375
+	max_health = 400
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -35,7 +35,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 45, BULLET = 45, LASER = 45, ENERGY = 45, BOMB = 0, BIO = 40, FIRE = 40, ACID = 40)
+	soft_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 40, ACID = 40)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defiler"

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 375
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -35,7 +35,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 40, ACID = 40)
+	soft_armor = list(MELEE = 45, BULLET = 45, LASER = 45, ENERGY = 45, BOMB = 0, BIO = 40, FIRE = 40, ACID = 40)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defiler"


### PR DESCRIPTION
## About The Pull Request
Undoes #16049 for defiler speed, returning them to -1 speed
## Why It's Good For The Game
Speed is by far the most important stat for defiler and currently a defiler emitting frenzy is _**slower**_ than a light armor marine with a move order.

Defiler has access to many of the best tools for shutting down rusher marines such as neurotoxin and hemodile, both of which are completely useless when they are too slow to slash the marine. 

Making defiler a fat slow gas machine heavily skews its usefulness toward the queen screech -> gas combo, which leaves the caste as almost useless when xenos dont have a queen. Shifting defiler's power to itself instead of its queen combo will leave it in a much healthier state for the game.
## Changelog
:cl:
balance: Defiler: Speed increased by .1
/:cl:
