### PR TITLE
Arachne Vehicle Bay Access Fix

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -46,7 +46,6 @@
 /area/mainship/hull/starboard_hull)
 "adB" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
@@ -95,6 +94,15 @@
 	dir = 8
 	},
 /area/mainship/squads/req)
+"age" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4;
+	pixel_x = 1
+	},
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "agi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -2147,6 +2155,13 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
+"bVW" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/binoculars,
+/turf/open/floor/mainship/silver{
+	dir = 9
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "bWf" = (
 /obj/structure/table/wood,
 /obj/item/storage/donut_box,
@@ -2188,6 +2203,13 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"bYy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "bYV" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
@@ -2768,6 +2790,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"cwr" = (
+/obj/structure/rack,
+/obj/item/binoculars,
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "cwB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
@@ -2899,6 +2928,12 @@
 	dir = 4
 	},
 /area/mainship/living/grunt_rnr)
+"cBy" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/flight_observation)
 "cBC" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship,
@@ -3002,10 +3037,10 @@
 	},
 /area/mainship/squads/general)
 "cGx" = (
-/obj/machinery/door/airlock/mainship/generic/pilot/quarters{
+/obj/machinery/door/firedoor{
 	dir = 1
 	},
-/obj/machinery/door/firedoor{
+/obj/machinery/door/airlock/mainship/generic/mech_bay{
 	dir = 1
 	},
 /turf/open/floor/mainship/floor,
@@ -3449,15 +3484,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
-"cWR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "cXX" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -3681,6 +3707,13 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"dhn" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/emails,
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "dhE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3799,12 +3832,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical)
-"dkz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
 "dkK" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/paper,
@@ -4980,6 +5007,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eoY" = (
@@ -5638,6 +5666,14 @@
 	dir = 1
 	},
 /area/mainship/living/bridgebunks)
+"ePx" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/paper,
+/obj/item/tool/pen,
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "ePz" = (
 /obj/machinery/vending/dress_supply,
 /turf/open/floor/mainship/sterile/dark,
@@ -5988,6 +6024,15 @@
 	dir = 4
 	},
 /area/mainship/medical/upper_medical)
+"eZP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "eZY" = (
 /obj/effect/ai_node,
 /turf/open/floor/carpet/side{
@@ -6051,6 +6096,16 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
+"feP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/mainship/silver/corner{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "ffq" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/mainship/floor,
@@ -6354,10 +6409,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
-"frL" = (
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "frU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6400,6 +6451,19 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
+"ftJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "fun" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -6604,6 +6668,10 @@
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
+"fAY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/flight_observation)
 "fCj" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -6618,6 +6686,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/mainship/medical/cmo_office)
+"fCm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "fDq" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -6962,12 +7041,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/mainship/medical/lounge)
-"fRf" = (
-/obj/structure/bed/chair/nometal{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "fRv" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -7380,6 +7453,13 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"goc" = (
+/obj/structure/window/framed/mainship/hull,
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar/flight_observation)
 "gou" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7973,19 +8053,6 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
-"gLH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "gMi" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -8592,6 +8659,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/damaged/panel,
 /area/mainship/shipboard/brig_cells)
+"hiQ" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "hjf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8919,6 +8994,12 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/medical/lounge)
+"hvQ" = (
+/obj/structure/bed/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "hvS" = (
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/upper_medical)
@@ -9036,15 +9117,6 @@
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical)
-"hAy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "hAL" = (
 /obj/machinery/door/airlock/mainship/research,
 /obj/machinery/door/firedoor,
@@ -9102,8 +9174,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/area/mainship/hallways/hangar/flight_observation)
 "hDs" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/starboard_hallway)
@@ -9233,6 +9306,17 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"hIo" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/paper,
+/obj/item/tool/pen,
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "hIy" = (
 /obj/effect/turf_decal/warning_stripes/leader,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -9274,6 +9358,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"hMa" = (
+/obj/structure/table/mainship/nometal,
+/obj/structure/prop/urban/misc/coffeestuff/coffeemachine2{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "hMp" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -9915,17 +10011,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "imR" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/poddoor/shutters/mainship/open/hangar{
 	dir = 1
 	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/personalglass,
+/obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ins" = (
@@ -10375,12 +10467,15 @@
 	},
 /area/mainship/medical/upper_medical)
 "iFH" = (
-/obj/structure/bed/chair/nometal{
-	dir = 8
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9;
+	pixel_y = 1
 	},
-/obj/effect/spawner/random/misc/gnome,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/obj/structure/cable,
+/turf/open/floor/mainship/silver/corner{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "iGf" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10500,6 +10595,7 @@
 "iLr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "iMr" = (
@@ -11536,6 +11632,10 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"jEo" = (
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/plating,
+/area/mainship/engineering/starboard_atmos)
 "jFv" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/paper/arachnebrig,
@@ -11864,6 +11964,9 @@
 	dir = 1
 	},
 /area/mainship/living/evacuation)
+"jRa" = (
+/turf/closed/wall/mainship/outer,
+/area/mainship/hallways/hangar/flight_observation)
 "jRr" = (
 /obj/structure/bed/chair,
 /obj/structure/disposalpipe/segment{
@@ -12946,6 +13049,12 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical)
+"kJP" = (
+/obj/machinery/light,
+/turf/open/floor/mainship_hull/dir{
+	dir = 1
+	},
+/area/mainship/powered)
 "kKF" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/poddoor/shutters/mainship/corporate,
@@ -13256,6 +13365,14 @@
 	},
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
+"kUW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "kVH" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor/mainship/floor,
@@ -13347,12 +13464,15 @@
 /area/mainship/squads/general)
 "lbf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/area/mainship/hallways/hangar/flight_observation)
 "lbk" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -14031,6 +14151,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "lzE" = (
@@ -14772,6 +14893,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"mbO" = (
+/obj/structure/window/framed/mainship/hull,
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar/flight_observation)
 "mcJ" = (
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/mainship/sterile/purple,
@@ -15046,6 +15174,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"mpJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "mql" = (
 /obj/machinery/telecomms/server/presets/charlie,
 /turf/open/floor/mainship/tcomms,
@@ -15450,6 +15586,12 @@
 "mDs" = (
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical)
+"mDN" = (
+/obj/structure/bed/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "mDO" = (
 /obj/structure/bed/chair/nometal{
 	dir = 4
@@ -15460,7 +15602,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "mEe" = (
@@ -15755,6 +15896,15 @@
 "mRH" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
+"mRK" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "mSj" = (
 /obj/structure/prop/mainship/sensor_computer3,
 /turf/open/floor/mainship/red{
@@ -15826,6 +15976,9 @@
 "mXB" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/starboard_atmos)
+"mXE" = (
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "mXH" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/lighter/zippo{
@@ -16422,6 +16575,16 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
+"nyJ" = (
+/obj/machinery/firealarm,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4;
+	pixel_x = 1
+	},
+/turf/open/floor/mainship/silver{
+	dir = 5
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "nyM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16564,6 +16727,17 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"nGh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "nGv" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/fuel_cell/full,
@@ -18585,6 +18759,17 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engine_core)
+"pjA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "pkH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -19310,6 +19495,14 @@
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"pTh" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "pTV" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/black{
@@ -19460,8 +19653,13 @@
 	dir = 6
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "qam" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/mainship/red{
@@ -19924,12 +20122,14 @@
 /area/mainship/medical)
 "qrL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/area/mainship/hallways/hangar/flight_observation)
 "qsj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -20216,6 +20416,9 @@
 	dir = 6
 	},
 /area/mainship/shipboard/brig)
+"qGV" = (
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/flight_observation)
 "qHy" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -20270,7 +20473,7 @@
 /area/mainship/hallways/repair_bay)
 "qIC" = (
 /obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "qIG" = (
 /obj/item/storage/briefcase/inflatable,
@@ -20524,6 +20727,12 @@
 "qTV" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"qTY" = (
+/obj/structure/bed/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "qUa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -20700,6 +20909,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "rbL" = (
@@ -21206,7 +21416,6 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "rto" = (
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
@@ -22062,17 +22271,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
 /area/mainship/hallways/starboard_hallway)
-"sbf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "sbO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -23039,6 +23237,15 @@
 /obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"sWH" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "sXw" = (
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/mainship/sterile/corner{
@@ -23428,7 +23635,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment/corner,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ttX" = (
@@ -23767,19 +23973,6 @@
 /obj/structure/prop/tgbrokenvendor/sec,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
-"tHj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "tHD" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black/corner{
@@ -25174,6 +25367,12 @@
 	},
 /turf/open/floor/mainship/sterile/purple,
 /area/mainship/medical/medical_science)
+"uRz" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/mainship/silver{
+	dir = 5
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "uRN" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -25376,7 +25575,7 @@
 /area/mainship/hallways/hangar)
 "vaK" = (
 /obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating,
 /area/mainship/living/evacuation)
 "vbh" = (
 /obj/machinery/door/poddoor/railing{
@@ -25473,7 +25672,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/area/mainship/hallways/hangar/flight_observation)
 "veZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/donut_box,
@@ -25847,6 +26046,16 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
+"vrr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/flight_observation)
 "vrC" = (
 /obj/structure/bed/stool,
 /obj/machinery/camera/autoname/mainship,
@@ -26344,6 +26553,16 @@
 /obj/machinery/power/apc/mainship/hardened,
 /turf/open/floor/plating,
 /area/mainship/command/airoom)
+"vMg" = (
+/obj/machinery/power/apc/mainship,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/silver{
+	dir = 9
+	},
+/area/mainship/hallways/hangar/flight_observation)
 "vMj" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/floor,
@@ -26882,7 +27101,7 @@
 /area/mainship/hull/starboard_hull)
 "wjY" = (
 /obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating,
 /area/mainship/shipboard/brig_cells)
 "wkm" = (
 /obj/structure/table/mainship/nometal,
@@ -27158,6 +27377,10 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
+"wuW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/flight_observation)
 "wvI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -27242,6 +27465,10 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
+"wyz" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar/flight_observation)
 "wza" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/computer/emails,
@@ -28693,6 +28920,12 @@
 "xMF" = (
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
+"xNl" = (
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "xNp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34819,7 +35052,7 @@ vlB
 rnT
 swA
 xNQ
-dkz
+pXS
 lRt
 rbz
 lRt
@@ -35839,8 +36072,8 @@ vlB
 tAd
 szE
 fjG
-lwl
 mPK
+lwl
 adB
 ixI
 ixI
@@ -35943,7 +36176,7 @@ szE
 sfI
 tys
 tys
-mel
+ftJ
 cWr
 kBf
 kBf
@@ -36144,7 +36377,7 @@ bwF
 vlB
 gUe
 pxf
-pxf
+qAQ
 rto
 iyA
 nlT
@@ -36960,8 +37193,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-twS
+qDO
+rIa
 wQg
 tYy
 mGC
@@ -37062,8 +37295,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-twS
+qDO
+rIa
 wQg
 vAL
 mGC
@@ -37164,8 +37397,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-twS
+qDO
+rIa
 wQg
 vAL
 mGC
@@ -37266,8 +37499,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-tHj
+qDO
+sgF
 wQg
 vAL
 uST
@@ -37368,8 +37601,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-twS
+qDO
+rIa
 wQg
 vAL
 mGC
@@ -37470,8 +37703,8 @@ meP
 bwF
 vkb
 vkb
-gSm
-twS
+qDO
+rIa
 wQg
 tYy
 mGC
@@ -37569,11 +37802,11 @@ meP
 meP
 meP
 euV
+idu
 vkb
 vkb
-vkb
-eju
-mMX
+vlB
+wGG
 hIO
 fiz
 tSl
@@ -37670,11 +37903,11 @@ meP
 meP
 meP
 meP
-bwF
-vkb
-vkb
-vkb
-eju
+kJP
+jRa
+mbO
+mbO
+jRa
 veE
 hIO
 bMK
@@ -37773,10 +38006,10 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-vkb
-eju
+goc
+bVW
+sWH
+pTh
 hDj
 imR
 fvt
@@ -37875,12 +38108,12 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-vkb
-eju
-iwz
-hIO
+goc
+ePx
+cBy
+fAY
+mpJ
+xNl
 mHO
 mAq
 mFV
@@ -37977,11 +38210,11 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-eju
-dAd
+goc
+dhn
+qGV
+qGV
+vrr
 hIO
 ssO
 ttX
@@ -38078,12 +38311,12 @@ meP
 meP
 meP
 meP
-bwF
-vkb
-vkb
-eju
-wPp
-dAd
+kJP
+jRa
+hiQ
+qGV
+qGV
+vrr
 hIO
 wog
 mdu
@@ -38181,11 +38414,11 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-wPp
-dAd
+jRa
+nyJ
+age
+feP
+pjA
 hIO
 daV
 fYS
@@ -38283,11 +38516,11 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-pLM
-dAd
+goc
+wyz
+mXE
+eZP
+vrr
 hIO
 kAs
 qkU
@@ -38385,10 +38618,10 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-cWR
+goc
+mXE
+mXE
+eZP
 qrL
 hIO
 daV
@@ -38487,11 +38720,11 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-fRf
-twS
+goc
+hMa
+qTY
+eZP
+qrL
 hIO
 kAs
 cZF
@@ -38589,11 +38822,11 @@ meP
 meP
 meP
 bwF
-vkb
-vkb
-eju
-frL
-sbf
+goc
+hvQ
+mDN
+eZP
+qrL
 hIO
 vEk
 sLf
@@ -38691,11 +38924,11 @@ meP
 meP
 euV
 vkb
-vkb
-vkb
-eju
+jRa
+vMg
+mRK
 iFH
-twS
+fCm
 hIO
 kAs
 vGf
@@ -38792,11 +39025,11 @@ meP
 meP
 euV
 vkb
-vkb
-vkb
-vkb
-eju
-hAy
+act
+jRa
+hiQ
+qGV
+qGV
 lbf
 lry
 gCk
@@ -38895,11 +39128,11 @@ meP
 bwF
 vkb
 vkb
-vkb
-vkb
-eju
-rIp
-twS
+goc
+cwr
+qGV
+qGV
+qrL
 hIO
 vCH
 jGj
@@ -38997,11 +39230,11 @@ meP
 bwF
 vkb
 vkb
-vkb
-eju
-eju
-wPp
-twS
+goc
+hIo
+qGV
+wuW
+kUW
 hIO
 vnY
 jGj
@@ -39099,11 +39332,11 @@ meP
 bwF
 vkb
 vkb
-vkb
-eju
+goc
+uRz
 qal
-jTF
-sai
+nGh
+bYy
 hIO
 hZO
 jKp
@@ -39200,10 +39433,10 @@ meP
 meP
 bwF
 vkb
-vkb
-vkb
-eju
-iwz
+act
+jRa
+jRa
+bUD
 hIO
 cvG
 hIO
@@ -39305,7 +39538,7 @@ vkb
 vkb
 vkb
 eju
-gLH
+iwz
 hIO
 vCN
 vAC
@@ -39407,7 +39640,7 @@ vkb
 vkb
 vkb
 eju
-eiU
+dAd
 hIO
 mjp
 qUa
@@ -40196,7 +40429,7 @@ cOh
 gHi
 ckB
 hVa
-ghp
+jEo
 vkb
 vkb
 vkb
@@ -40298,7 +40531,7 @@ eYl
 eYl
 eYl
 cOh
-ghp
+jEo
 vkb
 vkb
 vkb
@@ -40400,7 +40633,7 @@ cOh
 cOh
 hot
 hVa
-ghp
+jEo
 vkb
 vkb
 vkb

--- a/code/game/area/mainship.dm
+++ b/code/game/area/mainship.dm
@@ -148,9 +148,11 @@
 
 /area/mainship/hallways/hangar/flight_control
 	name = "Flight Control"
-	icon_state = "hangar"
 	minimap_color = MINIMAP_AREA_COMMAND
 
+/area/mainship/hallways/hangar/flight_observation
+	name = "Flight Observation"
+	minimap_color = MINIMAP_AREA_LIVING
 
 /area/mainship/living/tankerbunks
 	name = "Vehicle Crew Bunks"

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -248,7 +248,7 @@
 /obj/machinery/door_control/mainship/vehicle
 	name = "\improper Vehicle Bay Shutters"
 	id = "vehicle_shutters"
-	req_one_access = list(ACCESS_MARINE_ARMORED, ACCESS_MARINE_MECH)
+	req_one_access = list(ACCESS_MARINE_ARMORED, ACCESS_MARINE_MECH, ACCESS_MARINE_ARMORED)
 
 /obj/machinery/door_control/mainship/tcomms
 	name = "Telecommunications Entrance"

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -553,20 +553,26 @@
 
 /obj/machinery/door/airlock/mainship/generic/pilot
 	name = "\improper Pilot's Office"
-	req_access = list(ACCESS_MARINE_PILOT)
+	req_one_access = list(ACCESS_MARINE_PILOT)
 
 /obj/machinery/door/airlock/mainship/generic/pilot/bunk
 	name = "\improper Pilot's Bunks"
 
 /obj/machinery/door/airlock/mainship/generic/pilot/quarters
 	name = "\improper Pilot's Quarters"
+	req_one_access = list(ACCESS_MARINE_MECH, ACCESS_MARINE_ARMORED)
 
-/obj/machinery/door/airlock/mainship/generic/mech_pilot
+/obj/machinery/door/airlock/mainship/generic/mech_bay
+	name = "\improper Mech Bay"
+	req_one_access = list(ACCESS_MARINE_MECH, ACCESS_MARINE_ARMORED)
+
+/obj/machinery/door/airlock/mainship/generic/mech_pilot/office
 	name = "\improper Mech Pilot's Office"
 	req_access = list(ACCESS_MARINE_MECH)
 
 /obj/machinery/door/airlock/mainship/generic/mech_pilot/bunk
 	name = "\improper Mech Pilot's Bunks"
+	req_one_access = list(ACCESS_MARINE_MECH, ACCESS_MARINE_ARMORED)
 
 /obj/machinery/door/airlock/mainship/generic/ert
 	name = "\improper Airlock"


### PR DESCRIPTION
## About The Pull Request

Adds Armored access to Arachne Mech Bay doors.
Modifies Pilot Quarters access to allow for joint Pilot/Mech Pilot/Tank Crew areas through req_one for pilot access instead of flat req.
Re-symmetrizes the fore hangar by adding a fluff room.
![image](https://github.com/user-attachments/assets/a9889162-a264-49f1-a3e9-6107cc908214)

## Why It's Good For The Game

Letting Tank Crew out of the vehicle bay is a good change. Probably.

## Changelog

:cl:
add: Made the Arachne fore hangar mostly symmetrical again.
fix: Fixed Tank Crew access on the Arachne vehicle bay.
/:cl:
