### PR TITLE
Fixes hunter being able to break the tad console from stealth

### DIFF
--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -175,6 +175,8 @@
 		return
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return
+	if(HAS_TRAIT_FROM(xeno_attacker, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT))
+		return
 	xeno_attacker.visible_message("[xeno_attacker] begins to slash delicately at the computer",
 	"We start slashing delicately at the computer. This will take a while.")
 	if(!do_after(xeno_attacker, 10 SECONDS, NONE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))


### PR DESCRIPTION
## About The Pull Request

This fixes the hunter from being able to break the tad console from stealth

## Why It's Good For The Game

1. Breaking objects from stealth does not appear to have been intentional to begin with:

<details> 
<summary>Original object attack interaction code</summary>

`/datum/action/ability/xeno_action/stealth/proc/on_obj_attack(datum/source, obj/attacked)
	SIGNAL_HANDLER
	if(attacked.resistance_flags & XENO_DAMAGEABLE)
		cancel_stealth()`

</details>

2. Stealth hides the interaction telegraph as pictured in this screenshot. (Which further indicates that "free" kills of the tad was likely never intended).

<details> 
<summary>Interaction telegraph</summary>

![image](https://github.com/user-attachments/assets/1eb7e37b-6677-48e5-a5a2-7dc774e38faf)

</details>

3. Balance considerations:
3.A There is a lack of effective counter to this beyond baby sitting the console constantly, which is anti fun.
3.B Hunter stealth and abilities is so effective, even with a large number of marines nearby - combined with hunter stealth hiding the telegraph - a hunter disabling the console often goes unnoticed.

## Testing

<details> 
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/50b7c505-4c24-4d8e-bf02-cac1a7bd8df4)

</details>

## Changelog

:cl:
fix: Hunters can no longer stealth through tadpole console interaction telegraphs
balance: Hunters can no longer break the tad console while stealthed
/:cl:
