### PR TITLE
Give (some) privacy back to nuke activation

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -59,7 +59,7 @@
 /obj/machinery/nuclearbomb/proc/enable(reason)
 	GLOB.active_nuke_list += src
 	countdown.start()
-	notify_ghosts("[reason] enabled the [src], it has [round(time MILLISECONDS)] seconds on the timer.", source = src, action = NOTIFY_ORBIT, extra_large = TRUE)
+	notify_ghosts("The [src] has been enabled, it has [round(time MILLISECONDS)] seconds on the timer.", source = src, action = NOTIFY_ORBIT, extra_large = TRUE)
 	timer_enabled = TRUE
 	timer = addtimer(CALLBACK(src, PROC_REF(explode)), time, TIMER_STOPPABLE)
 	update_minimap_icon()


### PR DESCRIPTION

## About The Pull Request

Prevent activating nuke from showing both your ic name and ckey in dchat

## Why It's Good For The Game

Good for people that want to keep their IC secret

## Changelog
:cl:
fix: fixed nuke notification in dchat
/:cl:
