### PR TITLE
Fix: More than one marine can go down rappel at once

### DIFF
--- a/code/game/objects/structures/rappel_system.dm
+++ b/code/game/objects/structures/rappel_system.dm
@@ -123,8 +123,6 @@
 		if(RAPPEL_STATE_RETRACTING)
 			balloon_alert(user, "The rappel is currently retracting!")
 			return
-		if(RAPPEL_STATE_IN_USE)
-			return
 
 	var/turf/target_turf = get_turf(rope)
 	if(target_turf.density)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
More than one marine can now go down the rappel at once, which was supposed to be added in #16576 but I forgot to remove this check.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Properly implements a feature which was supposed to be added in a previous PR.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
fix: Rappel now correctly allows more than one marine to go down at a time.
/:cl:
