### PR TITLE
Plasma Cutter Changes

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -5,11 +5,11 @@
 #define TOOL_WIRECUTTER "wirecutter"
 #define TOOL_WRENCH "wrench"
 #define TOOL_WELDER "welder"
-#define TOOL_WELD_CUTTER "weld_cutter"
 #define TOOL_ANALYZER "analyzer"
 #define TOOL_MINING "mining"
 #define TOOL_SHOVEL "shovel"
 #define TOOL_FULTON "fulton"
+#define TOOL_PLASMACUTTER "plasmacutter"
 
 
 // If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -3,8 +3,12 @@
 		return
 	if(rightclick)
 		return melee_attack_chain_alternate(user, target, params)
-	if(tool_behaviour && tool_attack_chain(user, target))
-		return
+	if(tool_behaviour)
+		to_chat(world, span_boldannounce("tool behavior initial: [tool_behaviour]"))
+		if(tool_attack_chain(user, target))
+			to_chat(world, span_boldannounce("tool_attack_chain: TRUE"))
+			return
+		to_chat(world, span_boldannounce("tool_attack_chain: FALSE"))
 	if(user.lying_angle)
 		user.balloon_alert(user, "Can't while prone!")
 		return
@@ -33,12 +37,12 @@
 			return target.wirecutter_act(user, src)
 		if(TOOL_WELDER)
 			return target.welder_act(user, src)
-		if(TOOL_WELD_CUTTER)
-			return target.weld_cut_act(user, src)
 		if(TOOL_ANALYZER)
 			return target.analyzer_act(user, src)
 		if(TOOL_FULTON)
 			return target.fulton_act(user, src)
+		if(TOOL_PLASMACUTTER)
+			return target.plasmacutter_act(user, src)
 
 
 ///Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -3,12 +3,8 @@
 		return
 	if(rightclick)
 		return melee_attack_chain_alternate(user, target, params)
-	if(tool_behaviour)
-		to_chat(world, span_boldannounce("tool behavior initial: [tool_behaviour]"))
-		if(tool_attack_chain(user, target))
-			to_chat(world, span_boldannounce("tool_attack_chain: TRUE"))
-			return
-		to_chat(world, span_boldannounce("tool_attack_chain: FALSE"))
+	if(tool_behaviour && tool_attack_chain(user, target))
+		return
 	if(user.lying_angle)
 		user.balloon_alert(user, "Can't while prone!")
 		return

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -761,7 +761,6 @@ directive is properly returned.
 	return TRUE
 
 /atom/proc/plasmacutter_act(mob/living/user, obj/item/I)
-	to_chat(user, span_warning("No plasmacutter_act for this atom."))
 	return FALSE
 
 ///This proc is called on atoms when they are loaded into a shuttle

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -751,9 +751,6 @@ directive is properly returned.
 /atom/proc/welder_act(mob/living/user, obj/item/I)
 	return FALSE
 
-/atom/proc/weld_cut_act(mob/living/user, obj/item/I)
-	return FALSE
-
 /atom/proc/analyzer_act(mob/living/user, obj/item/I)
 	return FALSE
 
@@ -762,6 +759,10 @@ directive is properly returned.
 		return FALSE //Storage screens, worn containers, anything we want to be able to interact otherwise.
 	to_chat(user, span_warning("Cannot extract [src]."))
 	return TRUE
+
+/atom/proc/plasmacutter_act(mob/living/user, obj/item/I)
+	to_chat(user, span_warning("No plasmacutter_act for this atom."))
+	return FALSE
 
 ///This proc is called on atoms when they are loaded into a shuttle
 /atom/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -33,6 +33,9 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "weeds_destroyed")
 	return ..()
 
+/obj/alien/weeds/plasmacutter_act(mob/living/user, obj/item/I)
+	return FALSE // Just attack normally.
+
 /obj/alien/weeds/Initialize(mapload, obj/alien/weeds/node/node, swapped = FALSE)
 	. = ..()
 	var/static/list/connections = list(

--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -97,11 +97,11 @@
 	light_range = 2
 	light_power = 0.6
 	light_color = LIGHT_COLOR_PURPLE
+	tool_behaviour = TOOL_PLASMACUTTER
 	var/cutting_sound = 'sound/items/welder2.ogg'
 	var/powered = FALSE
 	var/dirt_amt_per_dig = 5
 	var/obj/item/cell/rtg/large/cell //The plasma cutter cell is unremovable and recharges over time
-	tool_behaviour = TOOL_WELD_CUTTER
 
 /obj/item/tool/pickaxe/plasmacutter/Initialize(mapload)
 	. = ..()
@@ -290,20 +290,3 @@
 		ST.update_appearance()
 		ST.update_sides()
 		cut_apart(user, target.name, target, 0, "You melt the snow with [src]. ") //costs nothing
-
-
-
-/obj/item/tool/pickaxe/plasmacutter/attack_obj(obj/O, mob/living/user)
-	if(!powered || user.do_actions || CHECK_BITFIELD(O.resistance_flags, INDESTRUCTIBLE) || CHECK_BITFIELD(O.resistance_flags, PLASMACUTTER_IMMUNE))
-		..()
-		return TRUE
-
-	if(!start_cut(user, O.name, O))
-		return TRUE
-
-	if(!do_after(user, calc_delay(user), NONE, O, BUSY_ICON_HOSTILE))
-		return TRUE
-
-	cut_apart(user, O.name, O)
-	O.deconstruct(TRUE)
-	return TRUE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -427,3 +427,22 @@
 		return FALSE
 	SEND_SIGNAL(src, COMSIG_ITEM_UNDEPLOY, user)
 	return TRUE
+
+/obj/plasmacutter_act(mob/living/user, obj/item/I)
+	if(!isplasmacutter(I) || user.do_actions)
+		return FALSE
+	if(!(obj_flags & CAN_BE_HIT) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE) || CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+		return FALSE
+	var/obj/item/tool/pickaxe/plasmacutter/plasmacutter = I
+	if(!plasmacutter.powered || (plasmacutter.item_flags & NOBLUDGEON))
+		return FALSE
+	if(user.a_intent == INTENT_HARM) // Attack normally.
+		return FALSE
+	if(!plasmacutter.start_cut(user, name, src))
+		return FALSE
+	if(!do_after(user, plasmacutter.calc_delay(user), NONE, src, BUSY_ICON_HOSTILE))
+		return TRUE
+
+	plasmacutter.cut_apart(user, name, src)
+	deconstruct(FALSE)
+	return TRUE

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -106,6 +106,12 @@
 
 	take_damage(max(0, attacking_item.force * damage_multiplier), attacking_item.damtype, MELEE)
 
+/obj/structure/mineral_door/Destroy()
+	if(material_type)
+		for(var/i in 1 to rand(1,5))
+			new material_type(get_turf(src))
+	return ..()
+
 ///Takes extra damage if our attacking item does burn damage
 /obj/structure/mineral_door/proc/get_burn_damage_multiplier(obj/item/attacking_item, mob/living/user, def_zone, bonus_damage = 0)
 	if(!isplasmacutter(attacking_item))
@@ -129,11 +135,24 @@
 
 	return bonus_damage
 
-/obj/structure/mineral_door/Destroy()
-	if(material_type)
-		for(var/i in 1 to rand(1,5))
-			new material_type(get_turf(src))
-	return ..()
+/obj/structure/mineral_door/resin/plasmacutter_act(mob/living/user, obj/item/I)
+	if(!isplasmacutter(I) || user.do_actions)
+		return FALSE
+	if(!(obj_flags & CAN_BE_HIT) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE) || CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+		return FALSE
+	var/obj/item/tool/pickaxe/plasmacutter/plasmacutter = I
+	if(!plasmacutter.powered || (plasmacutter.item_flags & NOBLUDGEON))
+		return FALSE
+	var/charge_cost = PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD
+	if(!plasmacutter.start_cut(user, name, src, charge_cost, no_string = TRUE))
+		return FALSE
+
+	user.changeNext_move(plasmacutter.attack_speed)
+	user.do_attack_animation(src, used_item = plasmacutter)
+	plasmacutter.cut_apart(user, name, src, charge_cost)
+	take_damage(max(0, plasmacutter.force * (1 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
+	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
+	return TRUE
 
 /obj/structure/mineral_door/iron
 	name = "iron door"

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -187,7 +187,6 @@
 		toggle_state()
 		return TRUE
 
-
 /obj/structure/mineral_door/resin/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	var/turf/cur_loc = M.loc
 	if(!istype(cur_loc))

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -68,6 +68,25 @@
 			"The stone. The rock. The boulder. Its name matters not when we consume it.",
 			"Delicious, delectable, simply exquisite. Just a few more minerals and it'd be perfect...")), null, 5)
 
+/turf/closed/plasmacutter_act(mob/living/user, obj/item/I)
+	if(!isplasmacutter(I) || user.do_actions)
+		return FALSE
+	if(CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE) || CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+		to_chat(user, span_warning("[I] can't cut through this!"))
+		return FALSE
+	var/obj/item/tool/pickaxe/plasmacutter/plasmacutter = I
+	if(!plasmacutter.powered || (plasmacutter.item_flags & NOBLUDGEON))
+		return FALSE
+	if(!plasmacutter.start_cut(user, name, src))
+		return FALSE
+	if(!do_after(user, PLASMACUTTER_CUT_DELAY, NONE, src, BUSY_ICON_FRIENDLY))
+		return FALSE
+
+	plasmacutter.cut_apart(user, name, src)
+	// Change targetted turf to a new one to simulate deconstruction.
+	ChangeTurf(open_turf_type)
+	return TRUE
+
 /turf/closed/mineral/smooth
 	name = "rock"
 	icon = 'icons/turf/walls/lvwall.dmi'
@@ -360,24 +379,6 @@
 
 /turf/closed/glass/thin/intersection
 	icon_state = "Intersection"
-
-/turf/closed/attackby(obj/item/I, mob/user, params)
-	if(isplasmacutter(I) && !user.do_actions)
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
-			to_chat(user, span_warning("[P] can't cut through this!"))
-			return
-		else if(!P.start_cut(user, name, src))
-			return
-		else if(!do_after(user, PLASMACUTTER_CUT_DELAY, NONE, src, BUSY_ICON_FRIENDLY))
-			return
-		else
-			P.cut_apart(user, name, src) //purely a cosmetic effect
-
-		//change targetted turf to a new one to simulate deconstruction
-		ChangeTurf(open_turf_type)
-		return
-	return ..()
 
 //Ice Thin Wall
 /turf/closed/ice/thin

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -38,6 +38,24 @@
 	ChangeTurf(/turf/closed/wall/resin/thick)
 	return TRUE
 
+/turf/closed/wall/resin/plasmacutter_act(mob/living/user, obj/item/I)
+	if(!isplasmacutter(I) || user.do_actions)
+		return FALSE
+	if(CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE) || CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+		return FALSE
+	var/obj/item/tool/pickaxe/plasmacutter/plasmacutter = I
+	if(!plasmacutter.powered || (plasmacutter.item_flags & NOBLUDGEON))
+		return FALSE
+	var/charge_cost = PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD
+	if(!plasmacutter.start_cut(user, name, src, charge_cost, no_string = TRUE))
+		return FALSE
+
+	user.changeNext_move(plasmacutter.attack_speed)
+	user.do_attack_animation(src, used_item = plasmacutter)
+	plasmacutter.cut_apart(user, name, src, charge_cost)
+	take_damage(max(0, plasmacutter.force * (1 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
+	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
+	return TRUE
 
 /turf/closed/wall/resin/thick
 	name = "thick resin wall"
@@ -115,7 +133,6 @@
 	to_chat(user, span_warning("You scrape ineffectively at \the [src]."))
 	return TRUE
 
-
 /turf/closed/wall/resin/attackby(obj/item/I, mob/living/user, params)
 	if(I.item_flags & NOBLUDGEON || !isliving(user))
 		return
@@ -130,14 +147,8 @@
 	else if(I.damtype == BRUTE)
 		multiplier += 0.75
 
-	if(isplasmacutter(I) && !user.do_actions)
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD, no_string = TRUE))
-			multiplier += PLASMACUTTER_RESIN_MULTIPLIER
-			P.cut_apart(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD)
-
 	damage *= max(0, multiplier)
-	take_damage(damage, BRUTE, MELEE)
+	take_damage(damage, I.damtype, MELEE)
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 
 /turf/closed/wall/resin/dismantle_wall(devastated = 0, explode = 0)

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -132,7 +132,7 @@
 
 	if(isplasmacutter(I) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD))
+		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD, no_string = TRUE))
 			multiplier += PLASMACUTTER_RESIN_MULTIPLIER
 			P.cut_apart(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD)
 

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -246,12 +246,6 @@
 /turf/closed/wall/indestructible/fire_act(burn_level)
 	return
 
-/turf/closed/wall/indestructible/attackby(obj/item/I, mob/user, params)
-	if(isplasmacutter(I)) //needed for user feedback, if not included the user will not receive a message when trying plasma cutter wall/indestructible turfs
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		to_chat(user, span_warning("[P] can't cut through this!"))
-	return
-
 /turf/closed/wall/indestructible/mineral
 	name = "impenetrable rock"
 	icon_state = "rock_dark"

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -68,7 +68,7 @@
 		icon_state = "vent_in"
 
 
-/obj/machinery/atmospherics/components/unary/vent_pump/weld_cut_act(mob/living/user, obj/item/W)
+/obj/machinery/atmospherics/components/unary/vent_pump/plasmacutter_act(mob/living/user, obj/item/W)
 	if(isplasmacutter(W))
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
 		if(!welded)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -65,7 +65,7 @@
 	..()
 	update_icon_nopipes()
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/weld_cut_act(mob/living/user, obj/item/W)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/plasmacutter_act(mob/living/user, obj/item/W)
 	if(isplasmacutter(W))
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
 

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -58,3 +58,22 @@
 	balloon_alert_to_viewers("\The [xeno_attacker] tears down \the [src]!", "We tear down \the [src].")
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 	take_damage(max_integrity) // Ensure its destroyed
+
+/obj/structure/xeno/plasmacutter_act(mob/living/user, obj/item/I)
+	if(!isplasmacutter(I) || user.do_actions)
+		return FALSE
+	if(!(obj_flags & CAN_BE_HIT) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE) || CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+		return FALSE
+	var/obj/item/tool/pickaxe/plasmacutter/plasmacutter = I
+	if(!plasmacutter.powered || (plasmacutter.item_flags & NOBLUDGEON))
+		return FALSE
+	var/charge_cost = PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD
+	if(!plasmacutter.start_cut(user, name, src, charge_cost, no_string = TRUE))
+		return FALSE
+
+	user.changeNext_move(plasmacutter.attack_speed)
+	user.do_attack_animation(src, used_item = plasmacutter)
+	plasmacutter.cut_apart(user, name, src, charge_cost)
+	take_damage(max(0, plasmacutter.force * (1 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
+	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
+	return TRUE

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -128,14 +128,8 @@
 	if(I.damtype == BURN) //Burn damage deals extra vs resin structures (mostly welders).
 		multiplier += 1
 
-	if(isplasmacutter(I) && !user.do_actions)
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD))
-			multiplier += PLASMACUTTER_RESIN_MULTIPLIER
-			P.cut_apart(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD)
-
 	damage *= max(0, multiplier)
-	take_damage(damage, BRUTE, MELEE)
+	take_damage(damage, I.damtype, MELEE)
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 
 ///Signal handler for hard del of hostile


### PR DESCRIPTION
## About The Pull Request
Plasma cutters can be used on resin doors without a delay similar to resin walls.
Closes #16471

Weeds no longer has any plasma cutter interaction (as a normal attack is good enough to kill the weeds).
Closes #15284

By default, trying to use a plasma cutter on a object while on harm intent will try to attack the object normally if possible.
Other intents (or if above doesn't do anything) will try to cut down the object (which comes with the standard 1000 charge cost).

The bonus damage/interaction between plasma cutters and xeno turrets have been expanded to all xeno structures, but now causes 100 charge per attack.
## Why It's Good For The Game
1. I got annoyed that I can't one-shot resin doors with a plasma cutter (its also a bug).
2. I actually just wasted 1000 charge on cutting weeds on walls. I'm coping.
3. "Starts cutting apart" spam is cringe.
4. How come only resin walls (and resin doors later) are generally one-shot, but xeno structure (I'm looking at you, resin pod) requires me to smack it like 10 times with an active plasma cutter (which costs no charge atm).

## Changelog
:cl:
qol: Using harm intent with a plasma cutter on an object tries to attack it normally if possible. Other intents will try to cut it down.
qol: Xeno weeds have no interaction with plasma cutters and thus will not waste nor require 1000 charge on cutting it down.
balance: Plasma cutters now uses charge to deal additional damage to (more) xeno structures similar to how bonus damage is dealt to resin walls.
fix: Plasma cutters now attack resin doors just like resin walls.
/:cl:
