### PR TITLE
Returns the dark mode ooc color back to blue

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -279,7 +279,7 @@ em {
   font-weight: bold;
 }
 .colorooc {
-  color: #cca300;
+  color: #4c6dff;
   font-weight: bold;
 }
 
@@ -1067,12 +1067,12 @@ $ooc_alert_bg_colors: (
 );
 
 $ooc_alert_border_colors: (
-  'ooc': #cca30070,
-  'game': #db000070,
+  'ooc': #006deb,
+  'game': #db0000,
 );
 
 $ooc_alert_text_colors: (
-  'ooc': #cca300,
+  'ooc': #006deb,
   'game': #db0000,
 );
 

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -10,7 +10,7 @@ $_channel_map: (
   'Say': #a4bad6,
   'Radio': #1fc01f,
   'Me': #5975da,
-  'OOC': #cca300,
+  'OOC': #4c6dff,
   'LOOC': #3a9696,
   'XOOC': #004ed8,
   'MOOC': #004ed8,


### PR DESCRIPTION
## About The Pull Request

My eyes are starting to bleed after looking at it for more than a single round.

## Why It's Good For The Game

Soul revival.

## Changelog

:cl:
qol: dark mode ooc color is blue again
/:cl:
