### PR TITLE
Hunter stealth damage threshold change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -43,7 +43,7 @@
 	soft_armor = list(MELEE = 55, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 30, ACID = 20)
 
 	// *** Stealth ***
-	stealth_break_threshold = 45
+	stealth_break_threshold = 25
 
 	// *** Minimap Icon *** //
 	minimap_icon = "hunter"


### PR DESCRIPTION

## About The Pull Request
Changed damaged threshold to break hunter stealth to 25, from 45.
## Why It's Good For The Game
45 was way too high, taking into account armour.
## Changelog
:cl:
balance: Hunter stealth damage threhold changed to 25 from 45
/:cl:
