### PR TITLE
HE sadar nerf

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -46,8 +46,8 @@
 	accurate_range = 20
 	max_range = 14
 	damage = 200
-	penetration = 100
-	sundering = 100
+	penetration = 75
+	sundering = 50
 
 /datum/ammo/rocket/he/unguided
 	damage = 100

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -54,7 +54,7 @@
 	ammo_behavior_flags = AMMO_SNIPER // We want this one to specifically go over onscreen range.
 
 /datum/ammo/rocket/he/unguided/drop_nade(turf/T)
-	explosion(T, 0, 7, 0, 0, 2)
+	explosion(T, 0, 7, 0, 0, 2, throw_range = 4)
 
 /datum/ammo/rocket/ap
 	name = "kinetic penetrator"


### PR DESCRIPTION
## About The Pull Request
Reduced HE sadar AP value to 75 from 100.
Reduces HE sadar sunder to 50 from 100.

Semi related change, unguided HE rockets now throw mobs 4 tiles instead of a rediculous 7.
## Why It's Good For The Game
The way sunder interacts with explosions from the rocket means HE rockets actually do MORE direct damage than an AP sadar against all xenos, while also dealing slowdown and stagger.

This means HE rockets are objectively better, other than the possibility of FF splash damage.
## Changelog
:cl:
balance: Reduced HE sadar AP value to 75 from 100
balance: Reduces HE sadar sunder to 50 from 100
balance: Unguided HE sadar rockets throw mobs 4 tiles instead of 7
/:cl:
