### PR TITLE
Rocket explosion knockback improvement

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -201,7 +201,9 @@
 	explosion(T, light_impact_range = 2, weak_impact_range = 4)
 
 /datum/ammo/bullet/sarden/high_explosive/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(target_mob))
+	var/target_turf = get_turf(target_mob)
+	staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
+	drop_nade(target_turf)
 
 /datum/ammo/bullet/sarden/high_explosive/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -613,12 +613,18 @@
 /datum/ammo/rocket/coilgun/high/drop_nade(turf/T)
 	explosion(T, 1, 4, 5, 6, 2)
 
+/datum/ammo/rocket/on_hit_mob(mob/target_mob, obj/projectile/proj)
+	var/target_turf = get_turf(target_mob)
+	staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
+	drop_nade(target_turf)
+
 /datum/ammo/rocket/coilgun/high/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	if(ishuman(target_mob) && prob(50))
+	if(ishuman(target_mob) && prob(50)) //it only has AMMO_PASS_THROUGH_MOB so it can keep going if it gibs a mob
 		target_mob.gib()
 		proj.proj_max_range -= 5
 		return
 	proj.proj_max_range = 0
+	staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
 
 /datum/ammo/rocket/icc_lowvel_heat
 	name = "Low Velocity HEAT shell"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -28,7 +28,9 @@
 	explosion(T, 0, 4, 6, 0, 2)
 
 /datum/ammo/rocket/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(target_mob))
+	var/target_turf = get_turf(target_mob)
+	staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
+	drop_nade(target_turf)
 
 /datum/ammo/rocket/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
@@ -84,9 +86,12 @@
 	explosion(T, 0, 2, 5, 0, 3)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(target_mob))
+	var/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
 		target_mob.gib()
+	else
+		staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
+	drop_nade(target_turf)
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
 	explosion(target_turf, 1, 4, 6, 0, 3)
@@ -439,9 +444,10 @@
 	explosion(T, flash_range = 1)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_nade(get_turf(target_mob))
-	proj.proj_max_range -= 5
+	var/target_turf = get_turf(target_mob)
 	staggerstun(target_mob, proj, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
+	drop_nade(target_turf)
+	proj.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	proj.proj_max_range -= 5


### PR DESCRIPTION

## About The Pull Request
If you direct hit a mob with a rocket, you will now knock them back 1 tile BEFORE the explosion happens.
This means direct rocket hits will now knockback the target from the explosion AWAY from the firer, instead of rng any direction, which can easily ggnore xenos when they get rng knocked into the marine blob.
## Why It's Good For The Game
RNG ggnore from funny explosion mechanics is lame as shit.
## Changelog
:cl:
balance: Direct hit explosions from rockets will now reliably throw the victim away from the firer, instead of a random direction
/:cl:
