### PR TITLE
Explosion block fixes

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -108,6 +108,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "smoke"
 	opacity = TRUE
+	explosion_block = INFINITY
 
 /obj/effect/forcefield/fog/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -475,17 +475,10 @@
 	icon = 'icons/turf/shuttle.dmi'
 	plane = FLOOR_PLANE
 	resistance_flags = PLASMACUTTER_IMMUNE
+	explosion_block = 2
 
 /turf/closed/shuttle/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_SPARKS, -15, 8, 1)
-
-/turf/closed/shuttle/re_corner/notdense
-	icon_state = "re_cornergrass"
-	density = FALSE
-
-/turf/closed/shuttle/re_corner/jungle
-	icon_state = "re_cornerjungle"
-	density = FALSE
 
 /turf/closed/shuttle/diagonal
 	icon_state = "diagonalWall"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -840,6 +840,16 @@
 	resistance_flags = RESIST_ALL
 	opacity = TRUE
 	allow_pass_flags = PASS_PROJECTILE|PASS_AIR
+	explosion_block = EXPLOSION_BLOCK_PROC
+
+/obj/structure/dropship_piece/GetExplosionBlock(explosion_dir)
+	if(!density)
+		return 0
+	if(opacity)
+		return 2
+	if(allow_pass_flags & PASS_GLASS)
+		return 2
+	return 0
 
 /obj/structure/dropship_piece/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_SPARKS, -15, 8, 1)


### PR DESCRIPTION
## About The Pull Request
Added explosion block to some stuff that was missing it.
Fixes #16413

Specifically, shuttle walls/structures, and fog blockers.

I'm tempted to add this to more things to make the game more interesting (i.e. hiding behind a vending machine to avoid a grenade explosion or something) but will leave that separate, as a walance change.
## Why It's Good For The Game
Explosions will no longer travel through the walls of the alamo as though it wasn't there at all (big enough explosions will go through, just like normal walls however).
## Changelog
:cl:
fix: Fixed shuttle walls and fog blockers being completely ignored by explosions
/:cl:
