### PR TITLE
Vendor density fix

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -334,6 +334,7 @@
 	tipped_level = 0
 	allow_pass_flags &= ~(PASS_LOW_STRUCTURE|PASS_MOB)
 	coverage = initial(coverage)
+	density = initial(density)
 
 /obj/machinery/vending/attackby(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Putting a fallen vendor up now makes it dense again.
## Why It's Good For The Game
Spooky ghost vendor bad.
## Changelog
:cl:
fix: fixed vendors being stuck as nondense after falling over
/:cl:
