### PR TITLE
Explosion block additions

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -73,6 +73,7 @@
 	light_range = 1
 	light_power = 0.5
 	light_color = LIGHT_COLOR_BLUE
+	explosion_block = 1
 
 	///Whether this vendor is active or not.
 	var/active = TRUE

--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -13,6 +13,7 @@
 	bound_y = -32
 	max_integrity = INFINITY
 	move_resist = INFINITY // non forcemoving this could break gliding so lets just say no
+	explosion_block = 1
 	///people riding on this hitbox that we want to move with us
 	var/list/atom/movable/tank_desants
 	///The "parent" that this hitbox is attached to and to whom it will relay damage

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -167,8 +167,8 @@
 	desc = "A gigantic wall of metal designed for maximum SOM destruction. Drag yourself onto it at an entrance to get inside."
 	required_entry_skill = SKILL_LARGE_VEHICLE_DEFAULT
 	max_integrity = 1400
-	soft_armor = list(MELEE = 90, BULLET = 95 , LASER = 95, ENERGY = 95, BOMB = 85, BIO = 100, FIRE = 100, ACID = 75)
-	hard_armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 35, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 90, BULLET = 95 , LASER = 95, ENERGY = 95, BOMB = 80, BIO = 100, FIRE = 100, ACID = 75)
+	hard_armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 40, BIO = 100, FIRE = 0, ACID = 0)
 	facing_modifiers = list(VEHICLE_FRONT_ARMOUR = 0.6, VEHICLE_SIDE_ARMOUR = 1, VEHICLE_BACK_ARMOUR = 1.6)
 	armored_flags = ARMORED_HAS_PRIMARY_WEAPON|ARMORED_HAS_SECONDARY_WEAPON|ARMORED_HAS_UNDERLAY|ARMORED_HAS_HEADLIGHTS|ARMORED_WRECKABLE
 	move_delay = 0.6 SECONDS

--- a/code/modules/vehicles/armored/som_tank.dm
+++ b/code/modules/vehicles/armored/som_tank.dm
@@ -18,8 +18,8 @@
 	pixel_x = -65
 	pixel_y = -80
 	max_integrity = 1200
-	soft_armor = list(MELEE = 90, BULLET = 95 , LASER = 95, ENERGY = 95, BOMB = 85, BIO = 100, FIRE = 100, ACID = 70)
-	hard_armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 30, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 90, BULLET = 95 , LASER = 95, ENERGY = 95, BOMB = 80, BIO = 100, FIRE = 100, ACID = 70)
+	hard_armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 35, BIO = 100, FIRE = 0, ACID = 0)
 	facing_modifiers = list(VEHICLE_FRONT_ARMOUR = 0.55, VEHICLE_SIDE_ARMOUR = 1, VEHICLE_BACK_ARMOUR = 1.6)
 	permitted_weapons = list(/obj/item/armored_weapon/volkite_carronade, /obj/item/armored_weapon/particle_lance, /obj/item/armored_weapon/coilgun, /obj/item/armored_weapon/secondary_mlrs)
 	permitted_mods = list(/obj/item/tank_module/ability/smoke_launcher)

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
@@ -28,6 +28,7 @@
 	internal_damage_probability = 5
 	possible_int_damage = MECHA_INT_FIRE|MECHA_INT_SHORT_CIRCUIT
 	mecha_flags = ADDING_ACCESS_POSSIBLE | CANSTRAFE | IS_ENCLOSED | HAS_HEADLIGHTS | MECHA_SKILL_LOCKED
+	explosion_block = 2
 	/// keyed list. values are types at init, otherwise instances of mecha limbs, order is layer order as well
 	var/list/datum/mech_limb/limbs = list(
 		MECH_GREY_TORSO = null,


### PR DESCRIPTION
## About The Pull Request
Adds explosion block to tanks, mechs and vending machines.
1 for vendors and tank (although being multitile, it will effectively be more for tank)
2 for the fat mechs.

For those unaware, explosion block basically means the range drawn through that obj/turf is reduced by that number.
I.e. with a block of 1, standing behind a vendor will protect you from the 3 tile range grenade in the pic below, but a grenade right next to the vendor would still hit you.
![image](https://github.com/user-attachments/assets/92a4e2be-23bf-403f-afb0-cb0ca53b5a0c)

Also slightly tweaked bomb armour for HvH tanks (5 less soft armour, 5 more hard) to maintain more or less the same damage from actual explosions.
## Why It's Good For The Game
More interesting ways to interact with/mitigate explosions.
## Changelog
:cl:
balance: Added some explosion block to vendors, mechs and tanks
/:cl:
