### PR TITLE
Nuke can no longer be portalled

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -14,7 +14,7 @@
 	anchored = TRUE
 	coverage = 20
 	atom_flags = CRITICAL_ATOM
-	resistance_flags = RESIST_ALL
+	resistance_flags = RESIST_ALL|PORTAL_IMMUNE
 	layer = BELOW_MOB_LAYER
 	interaction_flags = INTERACT_MACHINE_TGUI
 	var/deployable = TRUE


### PR DESCRIPTION
## About The Pull Request
You can no longer portal the nuke.
Fixes #12615
## Why It's Good For The Game
Being able to queen scree the marines and have a wraith drop a portal to instantly steal the nuke is cringe.
## Changelog
:cl:
balance: The nuke can no longer travel through portals
/:cl:
