### PR TITLE
Plasmacutters one-shot common resin walls as intended

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -54,6 +54,7 @@
 	user.do_attack_animation(src, used_item = plasmacutter)
 	plasmacutter.cut_apart(user, name, src, charge_cost)
 	// 301 damage. Enough to kill normal and thick walls.
+	// Only reason why this is not ChangeTurf is to stop special walls from getting one-shot (e.g more health / melee armor).
 	take_damage(max(0, plasmacutter.force * (2 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 	return TRUE

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -53,7 +53,8 @@
 	user.changeNext_move(plasmacutter.attack_speed)
 	user.do_attack_animation(src, used_item = plasmacutter)
 	plasmacutter.cut_apart(user, name, src, charge_cost)
-	take_damage(max(0, plasmacutter.force * (1 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
+	// 301 damage. Enough to kill normal and thick walls.
+	take_damage(max(0, plasmacutter.force * (2 + PLASMACUTTER_RESIN_MULTIPLIER)), plasmacutter.damtype, MELEE)
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Increases plasma cutter's damage against resin walls from 231 to 301.

## Why It's Good For The Game
Bugfix since I didn't mean for plasma cutters to be nerfed this hard against resin walls.

## Changelog
:cl:
bugfix: Plasmacutters now do 301 damage instead of 231 damage against resin walls. Enough to one-shot thick resin walls as intended.
/:cl:
