### PR TITLE
Directional attacks won't hit ghosts

### DIFF
--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -33,11 +33,11 @@
 	var/turf/turf_to_check = get_step(source, angle_to_dir(Get_Angle(source, clicked_atom)))
 	if(!turf_to_check || !source.Adjacent(turf_to_check))
 		return
-	
-	var/mob/target_mob = locate() in turf_to_check
+
+	var/mob/living/target_mob = locate() in turf_to_check
 	if(!target_mob || source.faction == target_mob.faction)
 		return
-	
+
 	//This is here to undo the +1 the click on the distant turf adds so we can click the mob near us
 	source.next_click = world.time - 1
 	INVOKE_ASYNC(source, TYPE_PROC_REF(/mob, ClickOn), target_mob, turf_to_check, click_params)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. This is mainly an issue for various xeno abilities, which will waste their CD on a ghost they can't see or interact with.
## Why It's Good For The Game
Ghost cuck is bad.
## Changelog
:cl:
fix: fixed directional attacks trying to hit ghosts
/:cl:
