### PR TITLE
Fixes xenos building outside LZ on LV759

### DIFF
--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -77015,6 +77015,12 @@
 	},
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/north)
+"nyS" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/black_stone/indestructible,
+/area/lv759/outdoors/colony_streets/north_east_street)
 "nyV" = (
 /turf/open/floor/prison{
 	dir = 10
@@ -181499,7 +181505,7 @@ lwn
 (210,1,1) = {"
 lwn
 jcQ
-aVz
+nyS
 nhc
 nhc
 nhc


### PR DESCRIPTION

## About The Pull Request
Xenos can no longer build outside the LZ
## Why It's Good For The Game
Fixes an oversight and brings it up to standard.
## Changelog
:cl:
Fix: Xenos can no longer build outside the LZ on LV759
/:cl:
