### PR TITLE
Plasma ammo to req

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -31,7 +31,6 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
-			/obj/item/cell/lasgun/plasma = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,
@@ -255,7 +254,6 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
-			/obj/item/cell/lasgun/plasma = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,


### PR DESCRIPTION

## About The Pull Request
Plasma gun ammo is no longer free and unlimited from the standard vendor.
## Why It's Good For The Game
Powerful, spammable guns that are balanced around ammo scarcity are unsurprisingly unbalanced when there is no ammo scarcity. This leads to people repeatedly spamming explosive rounds because they can carry 40 mags around in a box with them.

The cannon should also really cost more than the other guns, but I'll leave that for another PR.
## Changelog
:cl:
balance: Plasma gun ammo has been confined to req
/:cl:
