### PR TITLE
Xeno structure bound fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -134,8 +134,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	category = "Buildings"
 	///The type of building created
 	var/building_type
-	///The location to spawn the building at. Southwest of the xeno by default.
-	var/building_loc = SOUTHWEST
 	///Building time, in seconds. 10 by default.
 	var/building_time = 10 SECONDS
 
@@ -143,7 +141,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	. = ..()
 	if(!.)
 		return
-	var/turf/buildloc = get_step(buyer, building_loc)
+	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
 
@@ -169,12 +167,10 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!can_buy(buyer, FALSE))
 		return FALSE
 
-	var/turf/buildloc = get_step(buyer, building_loc)
-
-	var/atom/built = new building_type(buildloc, buyer.hivenumber)
+	var/atom/built = new building_type(get_turf(buyer), buyer.hivenumber)
 	to_chat(buyer, span_notice("We build [built] for [psypoint_cost] psy points."))
-	log_game("[buyer] has built \a [built] in [AREACOORD(buildloc)], spending [psypoint_cost] psy points in the process")
-	xeno_message("[buyer] has built \a [built] at [get_area(buildloc)]!", "xenoannounce", 5, buyer.hivenumber)
+	log_game("[buyer] has built \a [built] in [AREACOORD(built)], spending [psypoint_cost] psy points in the process")
+	xeno_message("[buyer] has built \a [built] at [get_area(built)]!", "xenoannounce", 5, buyer.hivenumber)
 	return ..()
 
 /datum/hive_upgrade/building/silo
@@ -190,7 +186,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!.)
 		return
 
-	var/turf/buildloc = get_step(buyer, building_loc)
+	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
 
@@ -229,7 +225,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	gamemode_flags = ABILITY_NUCLEARWAR
 	upgrade_flags = UPGRADE_FLAG_USES_TACTICAL
 	building_type = /obj/structure/xeno/pherotower
-	building_loc = 0 //This results in spawning the structure under the user.
 	building_time = 5 SECONDS
 
 /datum/hive_upgrade/building/spawner
@@ -255,7 +250,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!.)
 		return
 
-	var/turf/buildloc = get_step(buyer, building_loc)
+	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
 
@@ -278,7 +273,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!.)
 		return
 
-	var/turf/buildloc = get_step(buyer, building_loc)
+	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
 
@@ -305,7 +300,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!.)
 		return
 
-	var/turf/buildloc = get_step(buyer, building_loc)
+	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
 

--- a/code/modules/xenomorph/acid_pools.dm
+++ b/code/modules/xenomorph/acid_pools.dm
@@ -6,6 +6,8 @@
 	icon_state = "pool"
 	bound_width = 96
 	bound_height = 64
+	bound_x = -32
+	pixel_x = -32
 	max_integrity = 400
 	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
 

--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -206,6 +206,9 @@
 	icon_state = "maw"
 	bound_width = 96
 	bound_height = 64
+	bound_x = -32
+	pixel_x = -32
+	pixel_y = -8
 	max_integrity = 400
 	appearance_flags = PIXEL_SCALE|LONG_GLIDE
 	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
@@ -282,8 +285,11 @@
 	desc = "A hole in the ground. It's walls are coated with resin and there is some smoke billowing out."
 	icon = 'icons/Xeno/2x2building.dmi'
 	icon_state = "jaws"
-	bound_width = 64
-	bound_height = 64
+	bound_width = 32
+	bound_height = 32
+	bound_x = 0
+	pixel_x = -16
+	pixel_y = -16
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
 	minimap_icon = "acid jaw"
 	maw_options = list(

--- a/code/modules/xenomorph/pherotower.dm
+++ b/code/modules/xenomorph/pherotower.dm
@@ -4,8 +4,6 @@
 	desc = "A resin formation that looks like a small pillar. A faint, weird smell can be perceived from it."
 	icon = 'icons/Xeno/1x1building.dmi'
 	icon_state = "recoverytower"
-	bound_width = 32
-	bound_height = 32
 	obj_integrity = 400
 	max_integrity = 400
 	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -6,12 +6,15 @@
 	desc = "A slimy, oozy resin bed filled with foul-looking egg-like ...things."
 	bound_width = 96
 	bound_height = 96
+	bound_x = -32
+	bound_y = -32
+	pixel_x = -32
+	pixel_y = -24
 	max_integrity = 1000
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | PLASMACUTTER_IMMUNE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE
 	///How many larva points one silo produce in one minute
 	var/larva_spawn_rate = 0.5
-	var/turf/center_turf
 	var/number_silo
 	///For minimap icon change if silo takes damage or nearby hostile
 	var/warning
@@ -20,10 +23,6 @@
 
 /obj/structure/xeno/silo/Initialize(mapload, _hivenumber)
 	. = ..()
-	center_turf = get_step(src, NORTHEAST)
-	if(!istype(center_turf))
-		center_turf = loc
-
 	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
 		for(var/turfs in RANGE_TURFS(XENO_SILO_DETECTION_RANGE, src))
 			RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(resin_silo_proxy_alert))
@@ -44,13 +43,13 @@
 	name = "[siloprefix == "Normal" ? "" : "[siloprefix] "][name] [number_silo]"
 	LAZYADDASSOC(GLOB.xeno_resin_silos_by_hive, hivenumber, src)
 
-	if(!locate(/obj/alien/weeds) in center_turf)
-		new /obj/alien/weeds/node(center_turf)
+	if(!locate(/obj/alien/weeds) in loc)
+		new /obj/alien/weeds/node(loc)
 	if(GLOB.hive_datums[hivenumber])
 		RegisterSignals(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), PROC_REF(is_burrowed_larva_host))
 		if(length(GLOB.xeno_resin_silos_by_hive[hivenumber]) == 1)
 			GLOB.hive_datums[hivenumber].give_larva_to_next_in_queue()
-	var/turf/tunnel_turf = get_step(center_turf, NORTH)
+	var/turf/tunnel_turf = get_step(src, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/xeno/tunnel/newt = new(tunnel_turf, hivenumber)
 		newt.tunnel_desc = "[AREACOORD_NO_Z(newt)]"
@@ -59,7 +58,7 @@
 /obj/structure/xeno/silo/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
 	if(GLOB.hive_datums[hivenumber])
 		UnregisterSignal(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
-		GLOB.hive_datums[hivenumber].xeno_message("A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", "xenoannounce", 5, FALSE,src.loc, 'sound/voice/alien/help2.ogg',FALSE , null, /atom/movable/screen/arrow/silo_damaged_arrow)
+		GLOB.hive_datums[hivenumber].xeno_message("A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", "xenoannounce", 5, FALSE, loc, 'sound/voice/alien/help2.ogg',FALSE , null, /atom/movable/screen/arrow/silo_damaged_arrow)
 		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 		playsound(loc,'sound/effects/alien/egg_burst.ogg', 75)
 	return ..()
@@ -69,8 +68,7 @@
 
 	for(var/i in contents)
 		var/atom/movable/AM = i
-		AM.forceMove(get_step(center_turf, pick(CARDINAL_ALL_DIRS)))
-	center_turf = null
+		AM.forceMove(get_step(src, pick(CARDINAL_ALL_DIRS)))
 
 	STOP_PROCESSING(SSslowprocess, src)
 	return ..()

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -20,10 +20,6 @@
 
 /obj/structure/xeno/silo/Initialize(mapload, _hivenumber)
 	. = ..()
-	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
-		for(var/turfs in RANGE_TURFS(XENO_SILO_DETECTION_RANGE, src))
-			RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(resin_silo_proxy_alert))
-
 	if(SSticker.mode?.round_type_flags & MODE_SILOS_SPAWN_MINIONS)
 		SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(on_spawn)))
 		SSspawning.spawnerdata[src].required_increment = 2 * max(45 SECONDS, 3 MINUTES - SSmonitor.maximum_connected_players_count * SPAWN_RATE_PER_PLAYER)/SSspawning.wait

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -6,6 +6,10 @@
 	icon_state = "spawner"
 	bound_width = 96
 	bound_height = 96
+	bound_x = -32
+	bound_y = -32
+	pixel_x = -32
+	pixel_y = -24
 	max_integrity = 500
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE

--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -4,8 +4,8 @@
 	desc = "A sickly outcrop from the ground. It seems to ooze a strange chemical that shimmers and warps the ground around it."
 	icon = 'icons/Xeno/2x2building.dmi'
 	icon_state = "evotower"
-	bound_width = 64
-	bound_height = 64
+	pixel_x = -16
+	pixel_y = -16
 	obj_integrity = 600
 	max_integrity = 600
 	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
@@ -39,8 +39,8 @@
 	desc = "A sickly outcrop from the ground. It seems to allow for more advanced growth of the Xenomorphs."
 	icon = 'icons/Xeno/2x2building.dmi'
 	icon_state = "maturitytower"
-	bound_width = 64
-	bound_height = 64
+	pixel_x = -16
+	pixel_y = -16
 	obj_integrity = 400
 	max_integrity = 400
 	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL


### PR DESCRIPTION

## About The Pull Request
Cleaned up and deshitcoded various xeno structure hitbox and visual bound stuff.

This means building structures will now actually check YOUR location, not the location to the south west of you. This means there will probably be a few more random little corners you can build in.
Couple of structures were made to only occupy 1 tile since thats visually what it looked like, but there should be no gameplay changes.

I want to make xeno structures actually check the ENTIRE bound area for being valid instead of one tile, but thats a larger change (and for example would mean you couldn't silo in alamo cockpit) so I'll leave it for a separate PR.
## Why It's Good For The Game
Less shitcode, more intuitive building.
## Changelog
:cl:
fix: Xeno structures actually build on your location instead of to the south west
/:cl:
