### PR TITLE
Xeno structure alert fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -549,14 +549,9 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define XENO_HEALTH_ALERT_TRIGGER_PERCENT 0.25 //If a xeno is damaged while its current hit points are less than this percent of its maximum, we send out an alert to the hive
 #define XENO_HEALTH_ALERT_TRIGGER_THRESHOLD 50 //If a xeno is damaged while its current hit points are less than this amount, we send out an alert to the hive
 #define XENO_HEALTH_ALERT_COOLDOWN 60 SECONDS //The cooldown on these xeno damage alerts
-#define XENO_SILO_HEALTH_ALERT_COOLDOWN 30 SECONDS //The cooldown on these xeno damage alerts
 #define XENO_HEALTH_ALERT_POINTER_DURATION 6 SECONDS //How long the alert directional pointer lasts.
 #define XENO_RALLYING_POINTER_DURATION 15 SECONDS //How long the rally hive pointer lasts
-#define XENO_SILO_DAMAGE_POINTER_DURATION 10 SECONDS //How long the alert directional pointer lasts when silos are damaged
-#define XENO_SILO_DETECTION_COOLDOWN 1 MINUTES
-#define XENO_SILO_DETECTION_RANGE 10//How far silos can detect hostiles
-#define XENO_GARGOYLE_DETECTION_COOLDOWN 30 SECONDS
-#define XENO_GARGOYLE_DETECTION_RANGE 10//How far gargoyles can detect hostiles
+
 #define XENO_RESTING_COOLDOWN 2 SECONDS
 #define XENO_UNRESTING_COOLDOWN 0.5 SECONDS
 

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -3,6 +3,7 @@
 #define HAS_OVERLAY (1<<1)
 #define CRITICAL_STRUCTURE (1<<2)
 #define DEPART_DESTRUCTION_IMMUNE (1<<3)
+#define XENO_STRUCT_WARNING_RADIUS (1<<4)
 
 //Weeds defines
 #define WEED "weed sac"

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -3,7 +3,10 @@
 #define HAS_OVERLAY (1<<1)
 #define CRITICAL_STRUCTURE (1<<2)
 #define DEPART_DESTRUCTION_IMMUNE (1<<3)
+///Structure will warn when hostiles are nearby
 #define XENO_STRUCT_WARNING_RADIUS (1<<4)
+///Structure will warn when damaged
+#define XENO_STRUCT_DAMAGE_ALERT (1<<5)
 
 //Weeds defines
 #define WEED "weed sac"
@@ -211,3 +214,12 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 
 /// Life runs every 2 seconds, but we don't want to multiply all healing by 2 due to seconds_per_tick
 #define XENO_PER_SECOND_LIFE_MOD 0.5
+
+//How long the alert directional pointer lasts when structures are damaged
+#define XENO_STRUCTURE_DAMAGE_POINTER_DURATION 10 SECONDS
+///How frequently the damage alert can go off
+#define XENO_STRUCTURE_HEALTH_ALERT_COOLDOWN 30 SECONDS
+///How frequently the proximity alert can go off
+#define XENO_STRUCTURE_DETECTION_COOLDOWN 30 SECONDS
+///Proxy detection radius
+#define XENO_STRUCTURE_DETECTION_RANGE 10

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -744,12 +744,12 @@
 /atom/movable/screen/arrow/silo_damaged_arrow
 	name = "Hive damaged tracker arrow"
 	icon_state = "Red_arrow"
-	duration = XENO_SILO_DAMAGE_POINTER_DURATION
+	duration = XENO_STRUCTURE_DAMAGE_POINTER_DURATION
 
 /atom/movable/screen/arrow/turret_attacking_arrow
 	name = "Turret attacking arrow"
 	icon_state = "Green_arrow"
-	duration = XENO_SILO_DAMAGE_POINTER_DURATION
+	duration = XENO_STRUCTURE_DAMAGE_POINTER_DURATION
 
 /atom/movable/screen/arrow/attack_order_arrow
 	name = "attack order arrow"

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -11,6 +11,7 @@
 	///List of turfs we are checking for hostiles in
 	var/list/prox_warning_turfs = list()
 	COOLDOWN_DECLARE(proxy_alert_cooldown)
+	COOLDOWN_DECLARE(damage_alert_cooldown)
 
 /obj/structure/xeno/Initialize(mapload, _hivenumber)
 	. = ..()
@@ -25,7 +26,7 @@
 		set_proximity_warning()
 
 /obj/structure/xeno/Destroy()
-	prox_warning_turfs = null
+	//prox_warning_turfs = null
 	if(!locate(src) in GLOB.xeno_structures_by_hive[hivenumber]+GLOB.xeno_critical_structures_by_hive[hivenumber]) //The rest of the proc is pointless to look through if its not in the lists
 		stack_trace("[src] not found in the list of (potentially critical) xeno structures!") //We dont want to CRASH because that'd block deletion completely. Just trace it and continue.
 		return ..()
@@ -56,6 +57,11 @@
 /obj/structure/xeno/proc/weed_removed()
 	SIGNAL_HANDLER
 	obj_destruction(damage_flag = MELEE)
+
+/obj/structure/xeno/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob)
+	. = ..()
+	if(xeno_structure_flags & XENO_STRUCT_DAMAGE_ALERT)
+		damage_alert()
 
 /obj/structure/xeno/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(!(HAS_TRAIT(xeno_attacker, TRAIT_VALHALLA_XENO) && xeno_attacker.a_intent == INTENT_HARM && (tgui_alert(xeno_attacker, "Are you sure you want to tear down [src]?", "Tear down [src]?", list("Yes","No"))) == "Yes"))
@@ -91,12 +97,13 @@
 	if((xeno_structure_flags & XENO_STRUCT_WARNING_RADIUS))
 		set_proximity_warning()
 
+///Sets the proxy signals for our loc, removing the old ones if any
 /obj/structure/xeno/proc/set_proximity_warning()
 	for(var/old_turf in prox_warning_turfs)
 		UnregisterSignal(old_turf, COMSIG_ATOM_ENTERED)
 	prox_warning_turfs.Cut()
 
-	for(var/new_turf in RANGE_TURFS(XENO_SILO_DETECTION_RANGE, src))
+	for(var/new_turf in RANGE_TURFS(XENO_STRUCTURE_DETECTION_RANGE, src))
 		RegisterSignal(new_turf, COMSIG_ATOM_ENTERED, PROC_REF(proxy_alert))
 		prox_warning_turfs += new_turf
 
@@ -126,10 +133,20 @@
 
 	threat_warning = TRUE
 	GLOB.hive_datums[hivenumber].xeno_message("Our [name] has detected a nearby hostile [hostile] at [get_area(hostile)] (X: [hostile.x], Y: [hostile.y]).", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien/help1.ogg', FALSE, null, /atom/movable/screen/arrow/leader_tracker_arrow)
-	COOLDOWN_START(src, proxy_alert_cooldown, XENO_SILO_DETECTION_COOLDOWN)
-	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_SILO_DETECTION_COOLDOWN)
+	COOLDOWN_START(src, proxy_alert_cooldown, XENO_STRUCTURE_DETECTION_COOLDOWN)
+	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_STRUCTURE_DETECTION_COOLDOWN)
 	update_minimap_icon()
 	update_appearance(UPDATE_ICON)
+
+///Notifies the hive when we take damage
+/obj/structure/xeno/proc/damage_alert()
+	if(!COOLDOWN_CHECK(src, damage_alert_cooldown))
+		return
+	threat_warning = TRUE
+	update_minimap_icon()
+	GLOB.hive_datums[hivenumber].xeno_message("Our [name] at [AREACOORD_NO_Z(src)] is under attack! It has [obj_integrity]/[max_integrity] Health remaining.", "xenoannounce", 5, FALSE, src, 'sound/voice/alien/help1.ogg',FALSE, null, /atom/movable/screen/arrow/silo_damaged_arrow)
+	COOLDOWN_START(src, damage_alert_cooldown, XENO_STRUCTURE_HEALTH_ALERT_COOLDOWN)
+	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_STRUCTURE_HEALTH_ALERT_COOLDOWN)
 
 ///Clears any threat warnings
 /obj/structure/xeno/proc/clear_warning()

--- a/code/modules/xenomorph/resin_gargoyle.dm
+++ b/code/modules/xenomorph/resin_gargoyle.dm
@@ -4,16 +4,10 @@
 	icon = 'icons/Xeno/2x2building.dmi'
 	icon_state = "gargoyle"
 	max_integrity = 100
-	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL
-	///Bool if we're currently alerting
-	var/is_alerting = FALSE
-	//cd tracking for the alert
-	COOLDOWN_DECLARE(proxy_alert_cooldown)
+	xeno_structure_flags = CRITICAL_STRUCTURE|IGNORE_WEED_REMOVAL|XENO_STRUCT_WARNING_RADIUS
 
 /obj/structure/xeno/resin_gargoyle/Initialize(mapload, _hivenumber, mob/living/carbon/xenomorph/creator)
 	. = ..()
-	for(var/turfs in RANGE_TURFS(XENO_GARGOYLE_DETECTION_RANGE, src))
-		RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(gargoyle_alarm))
 	add_overlay(emissive_appearance(icon, "[icon_state]_emissive"))
 	INVOKE_ASYNC(src, PROC_REF(set_name), creator)
 	update_minimap_icon()
@@ -21,49 +15,10 @@
 /obj/structure/xeno/resin_gargoyle/proc/set_name(mob/living/carbon/xenomorph/creator)
 	name = initial(name) + " (" + tgui_input_text(creator, "Add a gargoyle name", "Naming") + ")"
 
-/// Checks performed every time an atom moves in a turf watched by the gargoyle
-/obj/structure/xeno/resin_gargoyle/proc/gargoyle_alarm(datum/source, atom/movable/hostile, direction)
-	SIGNAL_HANDLER
-
-	if(!COOLDOWN_CHECK(src, proxy_alert_cooldown))
-		return
-
-	if(!iscarbon(hostile) && !isvehicle(hostile))
-		return
-
-	if(iscarbon(hostile))
-		var/mob/living/carbon/carbon_triggerer = hostile
-		if(carbon_triggerer.stat == DEAD)
-			return
-
-	if(isxeno(hostile))
-		var/mob/living/carbon/xenomorph/X = hostile
-		if(X.hive == GLOB.hive_datums[hivenumber]) //Trigger proxy alert only for hostile xenos
-			return
-
-	if(isvehicle(hostile))
-		var/obj/vehicle/vehicle_triggerer = hostile
-		if(vehicle_triggerer.trigger_gargoyle == FALSE)
-			return
-
-	is_alerting = TRUE
-	GLOB.hive_datums[hivenumber].xeno_message("Our [name] has detected a hostile [hostile] at [get_area(hostile)].", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien/talk2.ogg', FALSE, null, /atom/movable/screen/arrow/leader_tracker_arrow)
-	COOLDOWN_START(src, proxy_alert_cooldown, XENO_GARGOYLE_DETECTION_COOLDOWN)
-	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_GARGOYLE_DETECTION_COOLDOWN, TIMER_STOPPABLE)
-	update_minimap_icon()
-	update_appearance()
-
-///resets gargoyle to normal state after yelling
-/obj/structure/xeno/resin_gargoyle/proc/clear_warning()
-	is_alerting = FALSE
-	update_minimap_icon()
-	update_appearance()
-
 /obj/structure/xeno/resin_gargoyle/update_icon_state()
 	. = ..()
-	icon_state = is_alerting ? "gargoyle_alarm" : "gargoyle"
+	icon_state = threat_warning ? "gargoyle_alarm" : "gargoyle"
 
-///resets minimap icon for the gargoyle
-/obj/structure/xeno/resin_gargoyle/proc/update_minimap_icon()
+/obj/structure/xeno/resin_gargoyle/update_minimap_icon()
 	SSminimaps.remove_marker(src)
-	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "gargoyle[is_alerting ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "gargoyle[threat_warning ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -8,11 +8,7 @@
 	bound_height = 96
 	max_integrity = 500
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
-	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS
-	///For minimap icon change if silo takes damage or nearby hostile
-	var/warning
-	COOLDOWN_DECLARE(spawner_damage_alert_cooldown)
-	COOLDOWN_DECLARE(spawner_proxy_alert_cooldown)
+	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS|XENO_STRUCT_DAMAGE_ALERT
 	var/linked_minions = list()
 
 /obj/structure/xeno/spawner/Initialize(mapload, _hivenumber)
@@ -38,22 +34,6 @@
 		if(80 to 100)
 			. += span_info("It appears in good shape, pulsating healthily.")
 
-
-/obj/structure/xeno/spawner/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob)
-	. = ..()
-	spawner_damage_alert()
-
-///Alert if spawner is receiving damage
-/obj/structure/xeno/spawner/proc/spawner_damage_alert()
-	if(!COOLDOWN_CHECK(src, spawner_damage_alert_cooldown))
-		warning = FALSE
-		return
-	warning = TRUE
-	update_minimap_icon()
-	GLOB.hive_datums[hivenumber].xeno_message("Our [name] at [AREACOORD_NO_Z(src)] is under attack! It has [obj_integrity]/[max_integrity] Health remaining.", "xenoannounce", 5, FALSE, src, 'sound/voice/alien/help1.ogg',FALSE, null, /atom/movable/screen/arrow/silo_damaged_arrow)
-	COOLDOWN_START(src, spawner_damage_alert_cooldown, XENO_SILO_HEALTH_ALERT_COOLDOWN) //set the cooldown.
-	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_SILO_DETECTION_COOLDOWN) //clear warning
-
 /obj/structure/xeno/spawner/Destroy()
 	GLOB.xeno_spawners_by_hive[hivenumber] -= src
 	return ..()
@@ -61,7 +41,7 @@
 ///Change minimap icon if spawner is under attack or not
 /obj/structure/xeno/spawner/update_minimap_icon()
 	SSminimaps.remove_marker(src)
-	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "spawner[warning ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "spawner[threat_warning ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))
 
 /// Transfers the spawned minion to the silo's hivenumber.
 /obj/structure/xeno/spawner/proc/on_spawn(list/newly_spawned_things)

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -8,7 +8,7 @@
 	bound_height = 96
 	max_integrity = 500
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
-	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE
+	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS
 	///For minimap icon change if silo takes damage or nearby hostile
 	var/warning
 	COOLDOWN_DECLARE(spawner_damage_alert_cooldown)
@@ -21,8 +21,6 @@
 	SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(on_spawn)))
 	SSspawning.spawnerdata[src].required_increment = max(45 SECONDS, 3 MINUTES - SSmonitor.maximum_connected_players_count * SPAWN_RATE_PER_PLAYER)/SSspawning.wait
 	SSspawning.spawnerdata[src].max_allowed_mobs = max(2, MAX_SPAWNABLE_MOB_PER_PLAYER * SSmonitor.maximum_connected_players_count)
-	for(var/turfs in RANGE_TURFS(XENO_SILO_DETECTION_RANGE, src))
-		RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(spawner_proxy_alert))
 	update_minimap_icon()
 
 /obj/structure/xeno/spawner/examine(mob/user)
@@ -56,43 +54,12 @@
 	COOLDOWN_START(src, spawner_damage_alert_cooldown, XENO_SILO_HEALTH_ALERT_COOLDOWN) //set the cooldown.
 	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_SILO_DETECTION_COOLDOWN) //clear warning
 
-///Alerts the Hive when hostiles get too close to their spawner
-/obj/structure/xeno/spawner/proc/spawner_proxy_alert(datum/source, atom/movable/hostile, direction)
-	SIGNAL_HANDLER
-
-	if(!COOLDOWN_CHECK(src, spawner_proxy_alert_cooldown)) //Proxy alert triggered too recently; abort
-		warning = FALSE
-		return
-
-	if(!isliving(hostile))
-		return
-
-	var/mob/living/living_triggerer = hostile
-	if(living_triggerer.stat == DEAD) //We don't care about the dead
-		return
-
-	if(isxeno(hostile))
-		var/mob/living/carbon/xenomorph/X = hostile
-		if(X.hivenumber == hivenumber) //Trigger proxy alert only for hostile xenos
-			return
-
-	warning = TRUE
-	update_minimap_icon()
-	GLOB.hive_datums[hivenumber].xeno_message("Our [name] has detected a nearby hostile [hostile] at [get_area(hostile)] (X: [hostile.x], Y: [hostile.y]).", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien/help1.ogg', FALSE, null, /atom/movable/screen/arrow/leader_tracker_arrow)
-	COOLDOWN_START(src, spawner_proxy_alert_cooldown, XENO_SILO_DETECTION_COOLDOWN) //set the cooldown.
-	addtimer(CALLBACK(src, PROC_REF(clear_warning)), XENO_SILO_DETECTION_COOLDOWN) //clear warning
-
-///Clears the warning for minimap if its warning for hostiles
-/obj/structure/xeno/spawner/proc/clear_warning()
-	warning = FALSE
-	update_minimap_icon()
-
 /obj/structure/xeno/spawner/Destroy()
 	GLOB.xeno_spawners_by_hive[hivenumber] -= src
 	return ..()
 
 ///Change minimap icon if spawner is under attack or not
-/obj/structure/xeno/spawner/proc/update_minimap_icon()
+/obj/structure/xeno/spawner/update_minimap_icon()
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "spawner[warning ? "_warn" : "_passive"]", ABOVE_FLOAT_LAYER))
 

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -33,7 +33,7 @@
 	var/firing
 
 ///Change minimap icon if its firing or not firing
-/obj/structure/xeno/xeno_turret/proc/update_minimap_icon()
+/obj/structure/xeno/xeno_turret/update_minimap_icon()
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "xeno_turret[firing ? "_firing" : "_passive"]"))
 


### PR DESCRIPTION

## About The Pull Request
Unfucked piles of horrible copy paste code in the pockets of various different xeno structures to instead be universal, and based off flags.

Fixes an issue where proxy alerts remained at the original z-level, even if the structure moved (i.e. silo on alamo) leading to hilarious issues like getting a warning when an ert spawns and knowing exactly what it is.

Also fixes silos not alerting if a vehicle approaches instead of a mob.
## Why It's Good For The Game
Bug fix, no more spaghetti.
## Changelog
:cl:
fix: fixed silos not alerting if a vehicle approached
fix: fixed xeno structures detecting things on old z-levels
code: Reworked some xeno structure damage and proximity alert code
/:cl:
