### PR TITLE
Increases the price of Scout Rifle reqtorio refills

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2305,17 +2305,18 @@ FACTORY
 /datum/supply_packs/factory/scout_rifle_magazine_refill
 	name = "BR-8 scout rifle magazine assembly refill"
 	contains = list(/obj/item/factory_refill/scout_rifle_magazine_refill)
-	cost = 200
+	cost = 300
 
 /datum/supply_packs/factory/scout_rifle_incen_magazine_refill
 	name = "BR-8 scout rifle incendiary magazine assembly refill"
 	contains = list(/obj/item/factory_refill/scout_rifle_incen_magazine_refill)
-	cost = 200
+	cost = 600
 
 /datum/supply_packs/factory/scout_rifle_impact_magazine_refill
 	name = "BR-8 scout rifle impact magazine assembly refill"
 	contains = list(/obj/item/factory_refill/scout_rifle_impact_magazine_refill)
-	cost = 200
+	cost = 600
+
 /datum/supply_packs/factory/claymorerefill
 	name = "Claymore parts refill"
 	contains = list(/obj/item/factory_refill/claymore_refill)


### PR DESCRIPTION

## About The Pull Request
What a mouthful.
As in the title, this PR increases the costs of scout rifle ammo in reqtorio for all of its magazines
Standard Magazines go from 200 points to 300 (50% cost to 66% cost)
Incendiary and Impact magazines go from 200 points to 600 (**25**% cost to 66% cost)
## Why It's Good For The Game
Similar reasoning as to #16479: The addition of these recipes to reqtorio effectively halved the price of this magazine. All of the requisite reqtorio parts to make them are given for free, so there is no "break-even" point where reqtorio _becomes_ more efficient than just buying the magazines outright; it simply is.

Incendiary and Impact magazines being the same price is some really nasty work as well, given that they cost twice as much as the regular magazines but can be made in reqtorio for a fourth(!) of their usual price
## Changelog
:cl:
balance: Increases the price of scout rifle magazine reqtorio refills from 200 -> 300
balance: Increases the price of scout rifle impact & incendiary magazine reqtorio refills from 200 -> 600
/:cl:
