### PR TITLE
Adds details to the eshield module's description

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -292,7 +292,7 @@
 
 /obj/item/armor_module/module/eshield
 	name = "Svalinn Energy Shield System"
-	desc = "A brand new innovation in armor systems, this module creates a shield around the user that is capable of negating all damage. If it sustains too much it will deactivate, and leave the user vulnerable."
+	desc = "A brand new innovation in armor systems, this module creates a shield around the user that is capable of negating all damage at the cost of increased vulnerability to melee, biological, and acid attacks. If it sustains too much it will deactivate, and leave the user vulnerable."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_eshield"
 	worn_icon_state = "mod_eshield_a"


### PR DESCRIPTION
## About The Pull Request

Add a clause to the eshield description, noting that it increases vulnerability to certain damage types.

## Why It's Good For The Game

Of the people that I've pointed this out to in game, it seems virtually no one is aware that using the shield module reduces their armor to certain damage types. Since armor modules don't have a codex link on shift-clicking them, and reviewing your armor's codex link only shows the final stats without any direct indicator of modifications, the only way one might notice this is if they carefully compare stats before and after applying a module.

Which almost no one seems to do and is a kind of hard thing to notice if you don't go in already looking for it.

This just makes the information more accessible.

## Changelog

:cl:
qol: eshield's description now notes that the eshield module reduces a marine's armor to certain damage types. (Resistances on the module are unchanged, this change is strictly informational).
/:cl:
