### PR TITLE
Req lift railing fix

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -489,6 +489,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			if(supply_shuttle.mode != SHUTTLE_IDLE)
 				return
 			if(is_mainship_level(supply_shuttle.z))
+				playsound(supply_shuttle.return_center_turf(), 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+				to_chat(usr, "The Automated Storage and Retrieval System is starting. Stand clear!")
+				sleep(20)
 				if (!supply_shuttle.check_blacklist())
 					to_chat(usr, "For safety reasons, the Automated Storage and Retrieval System cannot store live, friendlies, classified nuclear weaponry or homing beacons.")
 					playsound(supply_shuttle.return_center_turf(), 'sound/machines/buzz-two.ogg', 50, 0)


### PR DESCRIPTION
## About The Pull Request

Fixing the bug that's detailed in this PR: https://github.com/tgstation/TerraGov-Marine-Corps/issues/16730

Added a 2 second delay when sending down the req lift to prevent the two procs that open and close the railings from interfering with eachother. Marine-proofed it by putting the item blacklist check after the delay. 

## Why It's Good For The Game

No more OSHA violations! Huzzah!

## Changelog

:cl:
fix: Fixed requisition lift railings not extending properly
code: Put in a 2 second delay when sending the req lift down
/:cl:
