### PR TITLE
Tesla rifle can now load rechargables.

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -379,7 +379,7 @@
 	equip_slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	default_ammo_type = /obj/item/cell/lasgun/lasrifle
-	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle)
+	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle, /obj/item/cell/lasgun/lasrifle/recharger)
 	gun_features_flags = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_SHOWS_AMMO_REMAINING
 	muzzle_flash_color = COLOR_TESLA_BLUE
 	ammo_level_icon = "tesla"


### PR DESCRIPTION
## About The Pull Request

Turns out tesla gun is the only energy gun that can not equip recharger batteries. Seems like an oversight of the original pr #12997 since I do not see any mention of it.

## Why It's Good For The Game

Energy gun using standard energy cells should be able to use the side grade energy cells all the other energy guns use.
## Changelog
:cl:
balance: tesla rifle can use recharger batteries
/:cl:
