### PR TITLE
Outrider tad tweaks

### DIFF
--- a/_maps/shuttles/minidropship_outrider.dmm
+++ b/_maps/shuttles/minidropship_outrider.dmm
@@ -33,11 +33,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
-"k" = (
-/obj/structure/window/reinforced/west,
-/obj/machinery/cic_maptable,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/minidropship)
 "l" = (
 /obj/machinery/vending/nanomed/tadpolemed{
 	dir = 8
@@ -86,11 +81,9 @@
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
 "s" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/reinforced/west,
+/obj/machinery/cic_maptable,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "t" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
@@ -124,6 +117,14 @@
 	},
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/minidropship)
+"x" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8;
+	layer = 3
+	},
+/obj/machinery/light,
+/turf/open/floor/mainship/mono,
+/area/shuttle/minidropship)
 "y" = (
 /obj/machinery/light{
 	dir = 8
@@ -148,12 +149,6 @@
 "B" = (
 /obj/effect/attach_point/crew_weapon/minidropship,
 /turf/open/floor/plating/plating_catwalk,
-/area/shuttle/minidropship)
-"C" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "D" = (
 /obj/docking_port/mobile/marine_dropship/minidropship,
@@ -218,6 +213,19 @@
 /obj/machinery/telecomms/relay/preset/telecomms/onboard,
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/minidropship)
+"O" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/minidropship)
+"P" = (
+/obj/machinery/door/poddoor/mainship/open{
+	id = "minidropship_podlock"
+	},
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/minidropship)
 "R" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -265,7 +273,7 @@ A
 a
 u
 u
-a
+P
 A
 X
 "}
@@ -276,7 +284,7 @@ y
 t
 R
 d
-s
+x
 a
 a
 "}
@@ -295,7 +303,7 @@ o
 e
 K
 Y
-C
+O
 D
 S
 I
@@ -305,7 +313,7 @@ L
 (5,1,1) = {"
 n
 n
-k
+s
 E
 F
 B

--- a/_maps/shuttles/minidropship_outrider.dmm
+++ b/_maps/shuttles/minidropship_outrider.dmm
@@ -33,6 +33,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
+"k" = (
+/obj/structure/window/reinforced/west,
+/obj/machinery/cic_maptable,
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/minidropship)
 "l" = (
 /obj/machinery/vending/nanomed/tadpolemed{
 	dir = 8
@@ -80,8 +85,18 @@
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /turf/open/floor/mainship/floor,
 /area/shuttle/minidropship)
+"s" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/mainship/mono,
+/area/shuttle/minidropship)
 "t" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -134,6 +149,12 @@
 /obj/effect/attach_point/crew_weapon/minidropship,
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
+"C" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/minidropship)
 "D" = (
 /obj/docking_port/mobile/marine_dropship/minidropship,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -145,7 +166,6 @@
 "E" = (
 /obj/structure/window/reinforced/west,
 /obj/structure/window/reinforced,
-/obj/machinery/cic_maptable,
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "F" = (
@@ -256,7 +276,7 @@ y
 t
 R
 d
-y
+s
 a
 a
 "}
@@ -275,7 +295,7 @@ o
 e
 K
 Y
-Y
+C
 D
 S
 I
@@ -283,9 +303,9 @@ a
 L
 "}
 (5,1,1) = {"
-a
-a
 n
+n
+k
 E
 F
 B


### PR DESCRIPTION

## About The Pull Request
Removes the un-crushable spot on the outrider tad.
![image](https://github.com/user-attachments/assets/fd56ccdd-c591-4d95-ab53-84c626cfd97a)
The red square is the tile that used to be immune to crusher charges, with the yellow arrows being the lanes that this PR opens up.
A positive of this is that vehicles can now enter/exit from the side entrance, as well as there being 2 new tiles of extra space.
## Why It's Good For The Game
Outrider tad is currently objectively the best tad on the majority of the maps in the game due to its indestructible back wall and very easily defendable choke entrances. It still is, but this makes it slightly less oppressive in spots where it would otherwise be nearly unkillable.
## Changelog
:cl:
balance: uncrushable tile in the outrider tad has been opened (side door made 3 tiles, windows extended to include north side walls)
/:cl:
