### PR TITLE
Buffs boiler range ability by 2 tiles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -35,9 +35,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	)
 	use_state_flags = ABILITY_USE_LYING
 	/// The offset in a direction for zoom_in
-	var/tile_offset = 7
+	var/tile_offset = 9
 	/// The size of the zoom for zoom_in
-	var/view_size = 4
+	var/view_size = 5
 
 /datum/action/ability/xeno_action/toggle_long_range/bull
 	tile_offset = 11


### PR DESCRIPTION

## About The Pull Request
Before
![image](https://github.com/user-attachments/assets/7918b76f-3eb7-4abd-9bb4-b9d7ecad25a8)


After
![image](https://github.com/user-attachments/assets/db7ecbd1-eb3e-40d6-8b28-1055a3c1e386)
## Why It's Good For The Game
Boiler is currently in an awkward spot for three reason. 
1, their whole design is slowly becoming more and more obsolete through the changes of the flow of the game(marines on the defensive significantly less)
2, they have more ways than ever to be utterly and completely countered, unlike any other caste in the game, which is fair considering the relative low risk but makes playing it sometimes pointless(antigas, mimir)
3, playing boiler is nearly redundant, as defiler is able to not only apply more gas, do it faster, emit better gas types, but also do it relatively risk free in the instances that marines are pushing into a maze. 

this pr is meant to address the third issue. 2 extra tiles is really not a lot, but it is enough to add just enough range to the boiler that it makes it feel like you're actually capable of shooting globs into impactful positions.
a total rework to boiler might be warranted, but i do not believe any t3 should be this low impact until then. 
its also, ultimately, 2 tiles, which may or may not be that impactful. i dunno, i want to see.
## Changelog
:cl:
balance: increase boiler range ability by 2 tiles
/:cl:
