### PR TITLE
Buffs boiler glob storage CD reduction

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -760,7 +760,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define BOILER_LUMINOSITY_AMMO_NEUROTOXIN_COLOR LIGHT_COLOR_YELLOW
 #define BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR LIGHT_COLOR_GREEN
 #define BOILER_BOMBARD_COOLDOWN_REDUCTION 3 //Amount of seconds each glob stored reduces bombard cooldown by
-#define	BOILER_LUMINOSITY_THRESHOLD 3 //Amount of ammo needed to start glowing
+#define	BOILER_LUMINOSITY_THRESHOLD 2 //Amount of ammo needed to start glowing
 
 //Hivelord defines
 #define HIVELORD_TUNNEL_DISMANTLE_TIME 3 SECONDS

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -759,8 +759,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define BOILER_LUMINOSITY_AMMO 0.5 //don't set this to 0. How much each 'piece' of ammo in reserve glows by.
 #define BOILER_LUMINOSITY_AMMO_NEUROTOXIN_COLOR LIGHT_COLOR_YELLOW
 #define BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR LIGHT_COLOR_GREEN
-#define BOILER_BOMBARD_COOLDOWN_REDUCTION 1.5 //Amount of seconds each glob stored reduces bombard cooldown by
-#define	BOILER_LUMINOSITY_THRESHOLD 2 //Amount of ammo needed to start glowing
+#define BOILER_BOMBARD_COOLDOWN_REDUCTION 3 //Amount of seconds each glob stored reduces bombard cooldown by
+#define	BOILER_LUMINOSITY_THRESHOLD 3 //Amount of ammo needed to start glowing
 
 //Hivelord defines
 #define HIVELORD_TUNNEL_DISMANTLE_TIME 3 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -35,9 +35,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	)
 	use_state_flags = ABILITY_USE_LYING
 	/// The offset in a direction for zoom_in
-	var/tile_offset = 7
+	var/tile_offset = 9
 	/// The size of the zoom for zoom_in
-	var/view_size = 4
+	var/view_size = 5
 
 /datum/action/ability/xeno_action/toggle_long_range/bull
 	tile_offset = 11

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -35,9 +35,9 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	)
 	use_state_flags = ABILITY_USE_LYING
 	/// The offset in a direction for zoom_in
-	var/tile_offset = 9
+	var/tile_offset = 7
 	/// The size of the zoom for zoom_in
-	var/view_size = 5
+	var/view_size = 4
 
 /datum/action/ability/xeno_action/toggle_long_range/bull
 	tile_offset = 11


### PR DESCRIPTION
## About The Pull Request
Stored boiler globs now reduce the CD of a bombard by 3 seconds. (previously 1.5)
This means that at full glob storage, you are able to fire another glob roughly 2 seconds after the gas dissipates, however you glow like a christmas tree. Pre-buff, this would be somewhere around 22 seconds. 
## Why It's Good For The Game
Fun! But actually provides more reward for the risk of exposing your position, and also the position of any xeno near you. Combined with the relatively low range and extremely low survivability of the boiler when in it's more vulnerable positions due to the lesser range, I believe the reward for full glob storage should be greater. There is, for all intents and purposes(even before boiler got it's range nerfed), absolutely no reason to ever store more than 2 globs, which there is now plenty of reason to do so.

Remember that boiler has miniscope range. It is literally incapable of shooting globs deep into marine positions unless marines are holding a static position with no cades or it gets a lucky shot off right as marines push into where the boiler is currently standing. If you want to do REAL damage as a boiler, you will have to put yourself in risky spots, which the glow from storing many globs will make impossible.
credit to [uaioy](https://github.com/uaioy) for the idea
## Changelog
:cl:
balance: boiler glob storage CD bonus buffed from 1.5s to 3s
/:cl:
