### PR TITLE
Tac reload change/nerf

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -129,12 +129,9 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		to_chat(user, span_warning("You don't know how to do tactical reloads."))
 		return
 	to_chat(user, span_notice("You start a tactical reload."))
-	var/tac_reload_time = max(0.25 SECONDS, 0.75 SECONDS - user.skills.getRating(SKILL_COMBAT) * 5)
 	if(length(chamber_items))
-		if(!do_after(user, tac_reload_time, IGNORE_USER_LOC_CHANGE, new_magazine) && loc == user)
-			return
 		unload(user)
-	if(!do_after(user, tac_reload_time, IGNORE_USER_LOC_CHANGE, new_magazine) && loc == user)
+	if(!do_after(user, max(0.5 SECONDS, 1.5 SECONDS - user.skills.getRating(SKILL_COMBAT) * 5), IGNORE_USER_LOC_CHANGE, new_magazine) && loc == user)
 		return
 	if(new_magazine.item_flags & IN_STORAGE)
 		var/obj/item/storage/S = new_magazine.loc


### PR DESCRIPTION

## About The Pull Request
Changes tac reload back to a single do_after instead of two.
Now, the unload is instant, while the reload is back to the original duration (i.e. double).
## Why It's Good For The Game
This change was actually a very large stealth buff to tac reloads, as A: tac reloading empty was twice as fast, and B: The skill bonus applied twice, so tac reloads were actually twice as fast AGAIN.

So this returns tac reloads back to their intended duration - the speedy reloads was especially noticable after the change to make it a single click instead of click drag.
## Changelog
:cl:
balance: Tac reload windup time is now purely for the new mag
fix: Fixed tac reload getting the skill bonus twice.
/:cl:
