### PR TITLE
Reduce Scout accuracy slightly

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -363,12 +363,12 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 	fire_delay = 0.4 SECONDS
 	burst_amount = 1
-	accuracy_mult = 1.2
+	accuracy_mult = 1.1
 	scatter = -3
 
 /obj/item/weapon/gun/rifle/tx8/scout
 	starting_attachment_types = list(
-		/obj/item/attachable/reddot,
+		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/verticalgrip,
 	)


### PR DESCRIPTION

## About The Pull Request
Should have zero impact in HvX.

Reduces the scout rifle accuracy slightly, and tweaked the campaign scout loadout.
## Why It's Good For The Game
Scout is a little TOO good at delimbing due to its extremely high accuracy. This should make it a bit less reliable at doing so.

No real change in HvX since you already get accuracy bonuses against big stinky xenos.
## Changelog
:cl:
balance: Reduced BR-8 accuracy slighty
/:cl:
