### PR TITLE
reverts kuro shrike speed nerf and also health buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 400
 
 	// *** Evolution *** //
 	// The only evolution path does not require threshold

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -14,7 +14,7 @@
 	melee_damage = 25
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.5
 
 	// *** Plasma *** //
 	plasma_max = 925

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -14,7 +14,7 @@
 	melee_damage = 25
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.6
 
 	// *** Plasma *** //
 	plasma_max = 925


### PR DESCRIPTION
## About The Pull Request
Changes shrike's speed from -0.4 -> -0.6
## Why It's Good For The Game
Shrike losing this much speed really hurts it as a caste especially given that they have no sort of gapclosing ability like, say, warrior does. Its two stuns also move marines away from it, meaning that it's heavily dependent on positioning to make full use of the duration of the stun for things like oze sting.

It's also worth mentioning that 0.2 slowdown for a measly _100 health_ and _2 slash damage_ is nowhere near a worthwhile trade; to bring up warrior again, it got 100 hp, a sunder mult, and three slash damage for _0.1 movespeed._

It may be worthless to point out but shrike is also an essential part of xeno, so being forced into this sluggish ass caste to prevent the hive from collapsing is just really fucking annoying.
## Changelog
:cl:
balance: Buffed shrike's movespeed (-0.4 -> -0.6)
balance: reverted shrike HP buff (500 -> 400)
/:cl:
