### PR TITLE
Reduces vali greenblood gain to 1/4

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -378,7 +378,7 @@
 		return
 	if(resource_storage_current >= resource_storage_max)
 		return
-	update_resource(round(20*connected_weapon.attack_speed/11))
+	update_resource(round(5*connected_weapon.attack_speed/11))
 
 ///Adds or removes resource from the suit. Signal gets sent at every 25% of stored resource
 /datum/component/chem_booster/proc/update_resource(amount)


### PR DESCRIPTION
## About The Pull Request
Vali now gains 1/4 the greenblood per hit.

This means that you will be gaining 5/10 per hit with machete/claymore instead of 20/40.

Keep in mind that using the 20 seconds of vali healing consumes 40/100, and so previously the entirety of 2x mode could be paid for in _**6 of those 20 seconds.**_

Now you will lose greenblood while using 2x mode and be forced to gather more before using it again instead of turning it back on the instant the cooldown is over.

5 per hit is still enough to outpace 1x mode and so you will be able to use 1x while profiting on greenblood.
## Why It's Good For The Game
Vali has a built in resource management minigame that you can completely ignore because any amount of fighting will keep you at 200 greenblood permanently.

Reducing the per hit gain will make vali users be more considerate about when they want to use their super healing, and make them put in the effort to farm it up when they want to make a big play.

The choice between 1x and 2x vali will be made meaningful because using 2x will come with a considerable cost to your resources.

<details> 
  <summary>Does this really matter? </summary>
   Here are some videos to illustrate my point:

Current vali starting at 21u of greenblood and getting every hit during the duration of 2x vali ends with 190u of greenblood.

https://github.com/user-attachments/assets/74fd4269-612d-4860-8401-817720e4f641

Nerfed vali starting at 20u of greenblood and getting every hit during the duration of 2x vali ends with 10u of greenblood.

https://github.com/user-attachments/assets/c09b61ee-7ab6-4d15-8821-fbf3f8f70ed1

Current vali starting at 105u of greenblood and getting 7 hits during the duration of 2x vali ends with 141u of greenblood.

https://github.com/user-attachments/assets/3fcd1781-bcbd-45d7-9af8-69b0c426bca3

Nerfed vali starting at 105u of greenblood and getting 7 hits during the duration of 2x vali ends with 40u of greenblood.

https://github.com/user-attachments/assets/7dedfa6f-123b-461f-9234-bb00ef6001f6


</details>

## Changelog
:cl:
balance: Vali now gains 1/4 the greenblood per hit.
/:cl:
