### PR TITLE
[PORT] Use YTDLP by default instead of YTDL

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -314,14 +314,14 @@ Master controller and performance related.
 /datum/config_entry/flag/tickcomp
 
 /*
-System command that invokes youtube-dl, used by Play Internet Sound.
-You can install youtube-dl with
-"pip install youtube-dl" if you have pip installed
-from https://github.com/rg3/youtube-dl/releases
+System command that invokes youtube-dlp, used by Play Internet Sound.
+You can install youtube-dlp with
+"pip install youtube-dlp" if you have pip installed
+from https://github.com/yt-dlp/yt-dlp/releases
 or your package manager
-The default value assumes youtube-dl is in your system PATH
+The default value assumes youtube-dlp is in your system PATH
 */
-/datum/config_entry/string/invoke_youtubedl
+/datum/config_entry/string/invoke_youtubedlp
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -357,12 +357,12 @@
 	if(!check_rights(R_SOUND))
 		return
 
-	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
+	var/ytdl = CONFIG_GET(string/invoke_youtubedlp)
 	if(!ytdl)
-		to_chat(usr, span_warning("Youtube-dl was not configured, action unavailable."))
+		to_chat(usr, span_warning("Youtube-dlp was not configured, action unavailable."))
 		return
 
-	var/web_sound_input = input("Enter content URL (supported sites only)", "Play Internet Sound via youtube-dl") as text|null
+	var/web_sound_input = input("Enter content URL (supported sites only)", "Play Internet Sound via youtube-dlp") as text|null
 	if(!istext(web_sound_input) || !length(web_sound_input))
 		return
 
@@ -370,7 +370,7 @@
 
 	if(findtext(web_sound_input, ":") && !findtext(web_sound_input, GLOB.is_http_protocol))
 		to_chat(usr, span_warning("Non-http(s) URIs are not allowed."))
-		to_chat(usr, span_warning("For youtube-dl shortcuts like ytsearch: please use the appropriate full url from the website."))
+		to_chat(usr, span_warning("For youtube-dlp shortcuts like ytsearch: please use the appropriate full url from the website."))
 		return
 
 	var/web_sound_url = ""
@@ -384,14 +384,14 @@
 	var/stderr = output[SHELLEO_STDERR]
 
 	if(errorlevel)
-		to_chat(usr, span_warning("Youtube-dl URL retrieval FAILED: [stderr]"))
+		to_chat(usr, span_warning("Youtube-dlp URL retrieval FAILED: [stderr]"))
 		return
 
 	var/list/data = list()
 	try
 		data = json_decode(stdout)
 	catch(var/exception/e)
-		to_chat(usr, span_warning("Youtube-dl JSON parsing FAILED: [e]: [stdout]"))
+		to_chat(usr, span_warning("Youtube-dlp JSON parsing FAILED: [e]: [stdout]"))
 		return
 
 	if(data["url"])


### PR DESCRIPTION
port of https://github.com/tgstation/tgstation/pull/85953
should probally work i think

### About The Pull Request
This replaces references to youtube-dl in the config, pre-compile script, and error messages with yt-dlp.

also wow yt-dlp seems like gibberish after seeing it so much lol

### Why It's Good For The Game
yt-dlp is more reliable and updated more frequently than youtube-dl, and works as a drop-in replacement for the purposes of Play-Internet-Sound.
🆑
fix: Youtube music player should be more reliable now
/:cl: