### PR TITLE
Strappable fix

### DIFF
--- a/code/datums/elements/strappable.dm
+++ b/code/datums/elements/strappable.dm
@@ -7,9 +7,10 @@
 
 /datum/element/strappable/Detach(datum/source, ...)
 	. = ..()
-	UnregisterSignal(source, COMSIG_CLICK_ALT)
+	UnregisterSignal(source, list(COMSIG_CLICK_ALT, COMSIG_ITEM_UNEQUIPPED))
 	REMOVE_TRAIT(source, TRAIT_STRAPPABLE, STRAPPABLE_ITEM_TRAIT)
 
+///Toggles strap state
 /datum/element/strappable/proc/on_alt_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 	var/obj/item/item_source = source
@@ -19,8 +20,16 @@
 		return
 	var/strapped = HAS_TRAIT_FROM(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 	if(!strapped)
+		RegisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED, PROC_REF(on_unequip))
 		ADD_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 		item_source.balloon_alert(user, "Tightened strap")
 	else
+		UnregisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED)
 		REMOVE_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 		item_source.balloon_alert(user, "Loosened strap")
+
+///Unstraps if the target is somehow forcefully unequipped
+/datum/element/strappable/proc/on_unequip(obj/item/item_source, mob/unequipper, slot)
+	SIGNAL_HANDLER
+	UnregisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED)
+	REMOVE_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)


### PR DESCRIPTION

## About The Pull Request
Fixes strappable items not turning off their nodrop if they are forcefully unequipped (such as due to a delimb).
## Why It's Good For The Game
Picking up cursed items is funny but bad.
## Changelog
:cl:
fix: fixed strappable items not turning nodrop off, when forcefully unequipped
/:cl:
