### PR TITLE
Mini sentry deploytime buff and bug fix

### DIFF
--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -177,7 +177,7 @@
 		sentry = deployed_machine
 	sentry?.set_on(FALSE)
 	user.balloon_alert(user, "You start disassembling [undeployed_item]")
-	if(!do_after(user, deploy_time, NONE, deployed_machine, BUSY_ICON_BUILD))
+	if(!do_after(user, undeploy_time, NONE, deployed_machine, BUSY_ICON_BUILD))
 		sentry?.set_on(TRUE)
 		return
 

--- a/code/game/objects/machinery/minelayer.dm
+++ b/code/game/objects/machinery/minelayer.dm
@@ -11,7 +11,7 @@
 
 /obj/item/minelayer/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, /obj/machinery/deployable/minelayer, 1 SECONDS)
+	AddComponent(/datum/component/deployable_item, /obj/machinery/deployable/minelayer, 1 SECONDS, 1 SECONDS)
 
 /obj/machinery/deployable/minelayer
 	anchored = TRUE

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -440,7 +440,7 @@
 
 /obj/item/mortar_kit/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, deployable_item, 1 SECONDS)
+	AddComponent(/datum/component/deployable_item, deployable_item, 1 SECONDS, 1 SECONDS)
 
 /obj/item/mortar_kit/attack_self(mob/user)
 	do_unique_action(user)

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -168,7 +168,7 @@
 
 /obj/item/teleporter_kit/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable_item, /obj/machinery/deployable/teleporter, 2 SECONDS)
+	AddComponent(/datum/component/deployable_item, /obj/machinery/deployable/teleporter, 2 SECONDS, 2 SECONDS)
 	cell = new /obj/item/cell/high(src)
 	tele_tag++
 	self_tele_tag = tele_tag

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -368,8 +368,8 @@
 
 	///If the gun is deployable, the time it takes for the weapon to deploy.
 	var/deploy_time = 0
-	///If the gun is deployable, the time it takes for the weapon to undeploy.
-	var/undeploy_time = 0
+	///If the gun is deployable, the time it takes for the weapon to undeploy. Defaults to deploy time
+	var/undeploy_time = null
 	///If the gun is deployed, change the scatter amount by this number. Negative reduces scatter, positive adds.
 	var/deployed_scatter_change = 0
 	///Flags that the deployed sentry uses upon deployment.
@@ -407,7 +407,7 @@
 	muzzle_flash = new(src, muzzleflash_iconstate)
 
 	if(deployable_item)
-		AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, undeploy_time)
+		AddComponent(/datum/component/deployable_item, deployable_item, deploy_time, isnum(undeploy_time) ? undeploy_time : deploy_time)
 
 	GLOB.nightfall_toggleable_lights += src
 

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -91,7 +91,6 @@
 	max_integrity = 225
 	integrity_failure = 50
 	deploy_time = 1 SECONDS
-	undeploy_time = 1 SECONDS
 	turret_flags = TURRET_HAS_CAMERA|TURRET_ALERTS|TURRET_RADIAL
 	deployable_item = /obj/machinery/deployable/mounted/sentry/cope
 	turret_range = 9
@@ -228,7 +227,7 @@
 	extra_delay = 0.3 SECONDS
 	scatter = 3
 
-	deploy_time = 3 SECONDS
+	deploy_time = 1 SECONDS
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 
 /obj/item/weapon/gun/sentry/mini/combat_patrol


### PR DESCRIPTION

## About The Pull Request
Minisentry deploy/undeploy time reduced from 3 seconds to 1 second.

Made the deploy component actually use the undeploy time (previously this did literally nothing as it just checked the deploy time for both deploy and undeploy)
## Why It's Good For The Game
Minisentry is just a straight worse version of the big sentry, this makes them a little bit better for rapid pack/unpack.
## Changelog
:cl:
balance: Minisentry deploy/undeploy time changed from 3 seconds to 1 second
fix: fixed deployables using deploy time for undeploying instead of undeploy time
/:cl:
