### PR TITLE
Increase scout cost in campaign

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/equipment.dm
+++ b/code/datums/gamemodes/campaign/rewards/equipment.dm
@@ -158,7 +158,7 @@
 	detailed_desc = "A BR-8 scout rifle and assorted ammo. An accurate, powerful rifle with integrated IFF."
 	ui_icon = "scout"
 	uses = 2
-	cost = 6
+	cost = 10
 	equipment_to_spawn = list(
 		/obj/effect/supply_drop/scout,
 	)


### PR DESCRIPTION

## About The Pull Request
Increased the cost of the scout in campaign from 2 for 6 points to 10 points.
Personal purchase is unaffected.
## Why It's Good For The Game
Its a bit too spammable and effective for its attrition cost
## Changelog
:cl:
balance: Campaign: Increased cost of Scout rifle asset from 6 to 10 attrition for two.
/:cl:
