### PR TITLE
Tank vendor fix

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -697,6 +697,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/ammo in veh_ui.secondary_ammo)
 			for(var/i=1 to veh_ui.secondary_ammo[ammo])
 				new ammo(dumploc)
+	SStgui.close_user_uis(user, veh_ui)
 
 /obj/docking_port/stationary/supply/vehicle
 	id = "vehicle_home"
@@ -873,6 +874,12 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 				to_chat(usr, span_danger("A vehicle of this type has already been purchased!"))
 				return
 			current_veh_type = newtype
+			current_primary = null
+			current_secondary = null
+			current_driver_mod = null
+			current_gunner_mod = null
+			primary_ammo = list()
+			secondary_ammo = list()
 			. = TRUE
 
 		if("setprimary")
@@ -952,24 +959,6 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 				return
 			current_gunner_mod = newtype
 			. = TRUE
-
-		if("deploy")
-			if(supply_shuttle.mode != SHUTTLE_IDLE)
-				to_chat(usr, span_danger("Elevator moving!"))
-				return
-			if(is_mainship_level(supply_shuttle.z))
-				to_chat(usr, span_danger("Elevator raised. Lower to deploy vehicle."))
-				return
-			supply_shuttle.buy(usr, src)
-			ui_act("send", params, ui, state)
-			SStgui.close_user_uis(usr, src)
-			current_veh_type = null
-			current_primary = null
-			current_secondary = null
-			current_driver_mod = null
-			current_gunner_mod = null
-			primary_ammo = list()
-			secondary_ammo = list()
 
 	if(.)
 		update_static_data(usr)


### PR DESCRIPTION
## About The Pull Request
Fixed tank vendor ammo duplication.
Fixes #16039

It turns out the UI act where this was supposed to happen is actually never called anywhere, honk.
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: fixed an ammo duplication exploit with the tank vendor
/:cl:
