### PR TITLE
Ravager can endure and rage in fog/dense objects

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -204,7 +204,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ENDURE,
 	)
-	use_state_flags = ABILITY_USE_STAGGERED //Can use this while staggered
+	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_SOLIDOBJECT //Can use this while staggered
 	///How low the Ravager's health can go while under the effects of Endure before it dies
 	var/endure_threshold = RAVAGER_ENDURE_HP_LIMIT
 	///Timer for Endure's duration
@@ -320,6 +320,7 @@
 	ability_cost = 0 //We're limited by cooldowns, not plasma
 	cooldown_duration = 60 SECONDS
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY | ABILITY_IGNORE_SELECTED_ABILITY
+	use_state_flags = ABILITY_USE_SOLIDOBJECT
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RAGE,
 	)


### PR DESCRIPTION

## About The Pull Request
see title.
Preventing the use of abilities in dense objects is probably fine but the implementation is incredibly flawed as it not only keeps you from switching abilities while in dense objects but also applies to the fog from gamemodes like crash, and the use of xeno abilities in the fog is much less problematic than use in constructed walls as the fog is only in a few static locations you can walk away from.

This is an incredibly hacky solution only covering one caste I made because I was malding but I don't have the knowledge required to work out a better solution and nobody else is going to do it.
## Why It's Good For The Game
the fog is made of like nicotine smoke that prevents me from getting mad but vaping is bad for you so I won't breathe it in
## Changelog
:cl:
balance: ravager can rage and endure in solid objects now
/:cl:
