### PR TITLE
Redoes Kutjevo digsites

### DIFF
--- a/_maps/map_files/kutjevo/kutjevo.dmm
+++ b/_maps/map_files/kutjevo/kutjevo.dmm
@@ -59,6 +59,11 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/botany/east_tech)
+"abY" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/spring)
 "acx" = (
 /obj/structure/window_frame/kutjevo,
 /turf/open/floor/plating/kutjevo,
@@ -749,6 +754,10 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/filtration)
+"aUx" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/telecomm/lz1_south)
 "aUF" = (
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
@@ -964,11 +973,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/kutjevo/exterior/colony_north)
-"bfp" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
-/area/kutjevo/interior/complex/botany/east_tech)
 "bgQ" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -1006,6 +1010,10 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/complex/Northwest_Dorms)
+"bib" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/lz_dunes)
 "biF" = (
 /obj/machinery/light{
 	dir = 1
@@ -2050,6 +2058,10 @@
 	dir = 4
 	},
 /area/kutjevo/interior/complex/botany/east)
+"cqW" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
+/area/kutjevo/exterior/colony_north)
 "cqX" = (
 /obj/structure/stairs/seamless,
 /obj/effect/landmark/weed_node,
@@ -2265,6 +2277,7 @@
 /turf/open/floor/kutjevo/colors/cyan/edge,
 /area/kutjevo/interior/complex/med/auto_doc)
 "cCa" = (
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/rivergrate,
 /area/kutjevo/exterior/colony_north)
 "cCN" = (
@@ -2381,6 +2394,10 @@
 "cGD" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/autosmooth,
 /area/kutjevo/interior/power)
+"cHm" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
+/area/kutjevo/exterior/colony_N_East)
 "cIl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2595,6 +2612,7 @@
 /obj/structure/platform_decoration/metalplatform_deco{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
 "cSR" = (
@@ -3221,6 +3239,7 @@
 "dBO" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/prop/mainship/gelida/propladder,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/carpet,
 /area/kutjevo/interior/colony_South/power2)
 "dCl" = (
@@ -3741,10 +3760,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/autosmooth,
 /area/kutjevo/exterior/Northwest_Colony)
-"ect" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/construction)
 "ecA" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_x = 8;
@@ -4080,10 +4095,6 @@
 	},
 /turf/open/floor/mainship/research/containment/floor1,
 /area/kutjevo/interior/filtration)
-"ett" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/Northwest_Colony)
 "etu" = (
 /obj/machinery/door_control/old{
 	id = "kutjevo_medlock_south2";
@@ -4537,10 +4548,6 @@
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
-"ePb" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/kutjevo/exterior/Northwest_Colony)
 "ePn" = (
 /obj/structure/platform/metalplatform{
 	dir = 8
@@ -4560,6 +4567,10 @@
 "ePx" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
 /area/kutjevo/exterior/runoff_dunes)
+"ePT" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/kutjevo/colors/green,
+/area/kutjevo/interior/complex/botany)
 "ePV" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 1;
@@ -5085,6 +5096,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/colony_South/power2)
 "fqA" = (
@@ -5539,11 +5551,6 @@
 	dir = 4
 	},
 /area/kutjevo/interior/colony_South/power2)
-"fTN" = (
-/obj/structure/rock/variable/tinyrock,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/Northwest_Colony)
 "fTV" = (
 /obj/machinery/computer/emails{
 	dir = 4
@@ -5798,6 +5805,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/power)
 "gic" = (
@@ -6661,6 +6669,10 @@
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
+"hcn" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/rivergrate,
+/area/kutjevo/exterior/colony_central)
 "hcz" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/filtration)
@@ -6713,11 +6725,6 @@
 /obj/structure/cable,
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/operating)
-"hfS" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/construction)
 "hgv" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7269,6 +7276,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/med)
 "hPD" = (
@@ -7988,6 +7996,11 @@
 /obj/item/clothing/tie/armband/hydro,
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
+"iKO" = (
+/obj/structure/flora/ausbushes,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
+/area/kutjevo/interior/complex/botany)
 "iKU" = (
 /obj/structure/flora/grass/tallgrass/autosmooth/desert,
 /obj/structure/rock/variable/tinyrock,
@@ -8653,6 +8666,10 @@
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
+"juS" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
+/area/kutjevo/exterior/construction)
 "juT" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -8961,6 +8978,10 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan/edge,
 /area/kutjevo/interior/complex/med/triage)
+"jQc" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "jQX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -8983,11 +9004,6 @@
 	},
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power_pt2_electric_boogaloo)
-"jSP" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/colony_central)
 "jSQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/effect/mapping_helpers/airlock/welded,
@@ -9239,6 +9255,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/kutjevo/colors,
 /area/kutjevo/interior/complex/botany)
+"khk" = (
+/obj/structure/rock/variable/tinyrock,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/colony_South)
 "khy" = (
 /obj/structure/stairs/seamless,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10456,6 +10477,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/power_pt2_electric_boogaloo)
+"lsh" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/kutjevo/tan/multi_tiles,
+/area/kutjevo/exterior/runoff_bridge)
 "lsy" = (
 /obj/item/storage/belt/marine,
 /turf/open/floor/kutjevo/multi_tiles{
@@ -11175,11 +11200,6 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/kutjevo/colors/orange/edge,
 /area/kutjevo/interior/complex/Northwest_Security_Checkpoint)
-"meA" = (
-/obj/structure/rock/variable/tinyrock,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/scrubland/south)
 "meF" = (
 /turf/open/floor/kutjevo/plate,
 /area/kutjevo/interior/construction)
@@ -12507,6 +12527,10 @@
 	},
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power/comms)
+"nyx" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/interior/construction/two)
 "nyE" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -13858,6 +13882,11 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/power/comms)
+"oRh" = (
+/obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/scrubland/south)
 "oRw" = (
 /obj/structure/platform_decoration/rockcliff_deco/red{
 	dir = 4
@@ -13953,10 +13982,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall/kutjevo,
 /area/kutjevo/interior/oob)
-"oXl" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/scrubland/south)
 "oYc" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/kutjevo/colors/purple/edge{
@@ -16190,6 +16215,10 @@
 /obj/structure/flora/pottedplant/twelve,
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/auto_doc)
+"rqp" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/liquid/water/river/autosmooth/desert,
+/area/kutjevo/exterior/scrubland/south)
 "rqD" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -16579,11 +16608,6 @@
 	},
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/exterior/colony_central)
-"rNv" = (
-/obj/structure/rock/variable/tinyrock,
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/interior/complex/botany/east_tech)
 "rNG" = (
 /obj/item/ammo_magazine/revolver/cmb,
 /obj/structure/cable,
@@ -17551,6 +17575,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
+"sOk" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/complex/botany)
 "sOF" = (
 /obj/item/stack/sheet/wood{
 	pixel_x = -4
@@ -17568,6 +17596,7 @@
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
 /area/kutjevo/exterior/colony_N_East)
 "sPE" = (
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
 /area/kutjevo/interior/power/comms)
 "sPV" = (
@@ -18686,6 +18715,13 @@
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/filtration)
+"tYV" = (
+/obj/structure/prop/mainship/gelida/powerccable{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/colony_central/mine_elevator)
 "tZc" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -19094,11 +19130,6 @@
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
-"urE" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/kutjevo/exterior/stonyfields)
 "usc" = (
 /obj/structure/platform/metalplatform{
 	dir = 1
@@ -19388,10 +19419,6 @@
 /obj/structure/rock/basalt/alt5,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
 /area/kutjevo/exterior/scrubland/south)
-"uGY" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/dirttosand/autosmooth,
-/area/kutjevo/exterior/Northwest_Colony)
 "uHg" = (
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 9
@@ -19928,6 +19955,7 @@
 /area/kutjevo/interior/construction)
 "vfu" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/kutjevo/colors/orange/tile,
 /area/kutjevo/interior/power_pt2_electric_boogaloo)
 "vfZ" = (
@@ -21094,6 +21122,10 @@
 	},
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
+"wrs" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/kutjevo/exterior/lz_river)
 "wrY" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -22198,6 +22230,10 @@
 	},
 /turf/open/floor/mainship/research/containment/floor1,
 /area/kutjevo/exterior/Northwest_Colony)
+"xAG" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt2,
+/area/kutjevo/exterior/complex_border/med_park)
 "xBb" = (
 /obj/structure/platform/metalplatform{
 	dir = 4
@@ -24146,7 +24182,7 @@ ihK
 prJ
 prJ
 vei
-wGH
+bib
 adl
 vei
 vei
@@ -25171,7 +25207,7 @@ prJ
 wGH
 vsS
 vsS
-wGH
+bib
 psL
 dxF
 dxF
@@ -25798,7 +25834,7 @@ dDI
 kVJ
 wGH
 vei
-wGH
+bib
 vei
 gPW
 wgz
@@ -28281,7 +28317,7 @@ dxF
 dxF
 dxF
 xYt
-xYt
+rqp
 xIk
 qyD
 tlN
@@ -30782,7 +30818,7 @@ ddH
 ddH
 ddH
 ddH
-meA
+mda
 vXd
 vXd
 vXd
@@ -30830,7 +30866,7 @@ awv
 xpk
 xpk
 ubV
-ubV
+wrs
 xpk
 awv
 xpk
@@ -31825,7 +31861,7 @@ dxF
 cTz
 cTz
 cTz
-clc
+cTz
 cTz
 tIF
 dxF
@@ -32266,7 +32302,7 @@ soL
 laf
 sVF
 iin
-ett
+sVF
 oWo
 nWo
 soL
@@ -32452,7 +32488,7 @@ ddH
 ddH
 ddH
 ddH
-oXl
+vXd
 vXd
 iCG
 ddH
@@ -32500,7 +32536,7 @@ kIh
 ePx
 ePx
 ePx
-clc
+cTz
 onM
 bIg
 cTz
@@ -33070,7 +33106,7 @@ iin
 sVF
 oTF
 sVF
-ett
+sVF
 sVF
 soL
 soL
@@ -33078,7 +33114,7 @@ soL
 sVF
 sVF
 huR
-ePb
+huR
 huR
 sVF
 sVF
@@ -33319,7 +33355,7 @@ cTz
 cTz
 onM
 cTz
-clc
+cTz
 cTz
 cTz
 cTz
@@ -33422,12 +33458,12 @@ soL
 sVF
 iin
 xrT
-ett
+sVF
 sVF
 sVF
 sVF
 xrT
-ett
+sVF
 sVF
 hLi
 soL
@@ -33607,7 +33643,7 @@ pBi
 nEs
 iin
 oTF
-fTN
+iin
 iin
 tvJ
 soL
@@ -33975,7 +34011,7 @@ ddH
 wBM
 vXd
 pkK
-pkK
+oRh
 pkK
 mhD
 cJg
@@ -33999,7 +34035,7 @@ cTz
 cTz
 tIo
 cTz
-cTz
+clc
 onM
 cTz
 cTz
@@ -34062,7 +34098,7 @@ soL
 soL
 soL
 sVF
-ett
+sVF
 soL
 dxF
 dxF
@@ -34307,7 +34343,7 @@ ddi
 iCG
 ddH
 eDP
-oXl
+vXd
 pkK
 vXd
 ddH
@@ -34356,7 +34392,7 @@ vea
 cDx
 jog
 jog
-jog
+aUx
 jog
 jog
 dxF
@@ -35346,7 +35382,7 @@ cTz
 cTz
 xJg
 xJg
-xOc
+xJg
 xJg
 vea
 vea
@@ -35608,7 +35644,7 @@ dxF
 sVF
 iin
 oTF
-ett
+sVF
 sVF
 sVF
 oTF
@@ -35654,7 +35690,7 @@ fId
 jJe
 cTz
 cTz
-clc
+cTz
 cTz
 cTz
 hii
@@ -36402,7 +36438,7 @@ dxF
 mfD
 sVF
 soL
-uGY
+soL
 soL
 soL
 oTF
@@ -37669,7 +37705,7 @@ vea
 vea
 xJg
 xJg
-xOc
+xJg
 xue
 xJg
 xJg
@@ -37685,7 +37721,7 @@ vea
 vea
 vea
 xJg
-xJg
+xOc
 xue
 cDx
 xJg
@@ -38019,7 +38055,7 @@ xJg
 xJg
 xJg
 xJg
-urE
+xue
 cDx
 xJg
 xJg
@@ -38463,7 +38499,7 @@ cEl
 sYA
 scY
 qgW
-vDS
+ePT
 qgW
 scY
 sYA
@@ -38501,7 +38537,7 @@ xJg
 xJg
 xJg
 xJg
-xJg
+xOc
 xJg
 xJg
 dxF
@@ -38814,7 +38850,7 @@ sVx
 cBq
 sVx
 dMZ
-scY
+sOk
 scY
 scY
 qtN
@@ -39171,7 +39207,7 @@ xJg
 vea
 vcP
 xJg
-xOc
+xJg
 xJg
 xJg
 xJg
@@ -39746,7 +39782,7 @@ dxF
 dxF
 gxD
 cEq
-cEq
+xAG
 mnn
 jcX
 cEq
@@ -41512,7 +41548,7 @@ vea
 vea
 vea
 xJg
-xOc
+xJg
 xJg
 xJg
 lUL
@@ -41994,7 +42030,7 @@ qLM
 scY
 kut
 sZz
-fyD
+lsh
 orF
 cqX
 fyD
@@ -42013,7 +42049,7 @@ xue
 xJg
 xJg
 xJg
-xJg
+xOc
 mfK
 vea
 xJg
@@ -42152,7 +42188,7 @@ jnS
 dzT
 wOU
 sVx
-wOU
+iKO
 sVx
 wOU
 hHi
@@ -42629,7 +42665,7 @@ wff
 cRX
 gCg
 gCg
-ect
+xWK
 xWK
 xWK
 xWK
@@ -42797,7 +42833,7 @@ gCg
 gCg
 gCg
 gCg
-gCg
+juS
 xWK
 xWK
 tFN
@@ -43424,7 +43460,7 @@ dxF
 qaI
 dsP
 mJY
-nJa
+jQc
 xyF
 pzz
 oUP
@@ -44635,7 +44671,7 @@ dpF
 gCg
 mNa
 tFN
-hfS
+wrY
 xWK
 xWK
 dip
@@ -44990,7 +45026,7 @@ mTb
 dnF
 bSs
 rIL
-rNv
+mMf
 qOq
 rIL
 bSs
@@ -45479,7 +45515,7 @@ rIL
 mMf
 bSs
 rIL
-bfp
+bSs
 mTb
 rIL
 nTw
@@ -46299,7 +46335,7 @@ xWK
 tFN
 tlb
 gCg
-gCg
+juS
 gCg
 gCg
 xWK
@@ -46635,7 +46671,7 @@ xWK
 gCg
 gCg
 gCg
-ect
+xWK
 xWK
 gCg
 gCg
@@ -47588,7 +47624,7 @@ wjC
 ykY
 pTI
 ykY
-ykY
+fRN
 bfg
 ykY
 wTt
@@ -49099,7 +49135,7 @@ mhj
 ykY
 ykY
 ykY
-fRN
+ykY
 ykY
 ykY
 kgt
@@ -49128,7 +49164,7 @@ dxF
 dxF
 dxF
 qDu
-rSw
+nyx
 rSw
 lDS
 oMl
@@ -49414,7 +49450,7 @@ ykY
 ykY
 ykY
 ykY
-ykY
+fRN
 ykY
 pTI
 ykY
@@ -49528,7 +49564,7 @@ dxF
 skx
 skx
 skx
-skx
+dEX
 skx
 skx
 skx
@@ -49644,7 +49680,7 @@ mbR
 qDu
 rob
 pae
-rSw
+nyx
 rSw
 rSw
 rob
@@ -50120,7 +50156,7 @@ dxF
 uiK
 mnT
 mnT
-jSP
+iUB
 mnT
 mnT
 mnT
@@ -50952,7 +50988,7 @@ pTI
 ykY
 mnT
 mnT
-mnT
+tXg
 uiK
 uiK
 oqz
@@ -51016,7 +51052,7 @@ xnT
 xnT
 xnT
 xnT
-xnT
+efv
 xnT
 xnT
 xnT
@@ -51310,7 +51346,7 @@ rFR
 rFR
 sUs
 sUs
-sUs
+hcn
 rFR
 rFR
 sUs
@@ -51430,7 +51466,7 @@ dxF
 iCh
 ykY
 ykY
-ykY
+fRN
 wTt
 dxF
 dxF
@@ -51500,7 +51536,7 @@ xnT
 xnT
 tCm
 xnT
-xnT
+efv
 xnT
 xnT
 qOP
@@ -51547,7 +51583,7 @@ xxf
 xxf
 aXU
 nZC
-gHV
+abY
 eCE
 skx
 fne
@@ -51687,7 +51723,7 @@ xnT
 xnT
 xnT
 xnT
-efv
+xnT
 pAS
 xnT
 xnT
@@ -51882,7 +51918,7 @@ xxf
 jac
 xxf
 skx
-dEX
+skx
 kgx
 kgx
 dxF
@@ -52039,7 +52075,7 @@ gxD
 kgx
 kgx
 uzJ
-dEX
+skx
 yic
 xxf
 ogY
@@ -52108,7 +52144,7 @@ auT
 wTt
 wTt
 tyq
-wTt
+cqW
 wTt
 tyq
 dxF
@@ -52250,7 +52286,7 @@ ykY
 ykY
 bfg
 ykY
-fRN
+ykY
 ykY
 pfR
 ykY
@@ -52416,7 +52452,7 @@ ykY
 ykY
 iam
 pfR
-ykY
+fRN
 ykY
 ykY
 ykY
@@ -52873,7 +52909,7 @@ dxF
 gxD
 dxF
 skx
-skx
+dEX
 skx
 skx
 xxf
@@ -53049,7 +53085,7 @@ skx
 skx
 skx
 skx
-dEX
+skx
 xFO
 skx
 kbI
@@ -53456,7 +53492,7 @@ wTt
 wTt
 wTt
 ykY
-mnT
+tXg
 mnT
 mnT
 mnT
@@ -53825,7 +53861,7 @@ nlv
 mnT
 mnT
 mnT
-mnT
+tXg
 iUB
 mnT
 mnT
@@ -53945,7 +53981,7 @@ ykY
 ykY
 ykY
 ykY
-fRN
+ykY
 ykY
 tyq
 ykY
@@ -53975,7 +54011,7 @@ oqz
 mnT
 mnT
 mnT
-tXg
+mnT
 mnT
 mnT
 mnT
@@ -54098,7 +54134,7 @@ goT
 ykY
 ykY
 bfg
-ykY
+fRN
 ykY
 ykY
 ykY
@@ -54111,7 +54147,7 @@ ykY
 ykY
 ykY
 bfg
-ykY
+fRN
 ykY
 ykY
 dql
@@ -54140,7 +54176,7 @@ mnT
 mnT
 mnT
 oqz
-mnT
+tXg
 iUB
 mnT
 mnT
@@ -54675,7 +54711,7 @@ xnT
 xnT
 xnT
 xnT
-xnT
+efv
 xnT
 xnT
 xnT
@@ -55165,7 +55201,7 @@ dxF
 dxF
 uiK
 mnT
-tXg
+mnT
 mnT
 dxF
 lEA
@@ -55192,7 +55228,7 @@ dxF
 dxF
 dxF
 qOP
-xnT
+efv
 pAS
 qOP
 dxF
@@ -55986,7 +56022,7 @@ yjO
 mnT
 mnT
 mnT
-mnT
+tXg
 mnT
 fgo
 fgo
@@ -56133,7 +56169,7 @@ dxF
 wTr
 xRY
 xRY
-xRY
+qHg
 xRY
 avw
 xRY
@@ -56370,7 +56406,7 @@ xnT
 xnT
 xnT
 xnT
-xnT
+efv
 xnT
 tCm
 dxF
@@ -56807,7 +56843,7 @@ wTr
 dxF
 dxF
 dxF
-wTr
+cHm
 wTr
 wTr
 wTr
@@ -56998,7 +57034,7 @@ fMB
 pGc
 cVf
 pGc
-oIv
+tYV
 pGc
 bLa
 vbm
@@ -57016,7 +57052,7 @@ gzI
 xnT
 fll
 xnT
-xnT
+efv
 xnT
 xnT
 xnT
@@ -57682,7 +57718,7 @@ ftk
 xnT
 xnT
 pAS
-efv
+xnT
 xnT
 eEU
 xnT
@@ -58158,7 +58194,7 @@ dxF
 dxF
 vIi
 ioe
-ygm
+gIF
 vIi
 vIi
 wRk
@@ -58169,7 +58205,7 @@ ygm
 ygm
 ygm
 ygm
-ygm
+gIF
 ygm
 ygm
 ioe
@@ -58338,7 +58374,7 @@ lRu
 ygm
 ygm
 ygm
-gIF
+ygm
 ygm
 ygm
 ygm
@@ -58363,7 +58399,7 @@ xnT
 xnT
 xnT
 eEU
-xnT
+efv
 ufN
 ufN
 tCm
@@ -58965,9 +59001,9 @@ xRY
 xRY
 pBH
 xRY
-xRY
-xRY
 qHg
+xRY
+xRY
 xRY
 xRY
 vsP
@@ -59317,8 +59353,8 @@ xRY
 xRY
 xRY
 sNZ
-iDg
 sNZ
+iDg
 sNZ
 xRY
 xRY
@@ -59352,7 +59388,7 @@ qOP
 rzq
 heI
 qOP
-tCm
+khk
 dxF
 dxF
 dxF
@@ -60645,7 +60681,7 @@ xRY
 xRY
 qFK
 xRY
-xRY
+qHg
 xRY
 xRY
 sNZ
@@ -61174,7 +61210,7 @@ ygm
 ygm
 ygm
 ygm
-gIF
+ygm
 ygm
 iiy
 ygm
@@ -61669,7 +61705,7 @@ wRk
 wRk
 ioe
 ygm
-ygm
+gIF
 ygm
 ygm
 ygm


### PR DESCRIPTION

## About The Pull Request
Moved research digsites on Kutjevo to be less marine sided.
## Why It's Good For The Game
Too many digsites in the no-build zone makes research extremely easy.
## Changelog
:cl:
balance: Moved research digsites on Kutjevo to be less marine sided.
/:cl:
