### PR TITLE
V35 nerf

### DIFF
--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -114,7 +114,7 @@
 	if(!isvehicle(target_obj))
 		proj.proj_max_range -= 20 //can shoot through 1 piece of cover
 		return
-	proj.damage *= 2
+	proj.damage *= 1.8
 	proj.proj_max_range = 0
 
 /datum/ammo/bullet/rifle/tx8

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -77,7 +77,7 @@
 	damage_falloff = 0.5
 	accurate_range = 18
 	max_range = 30
-	damage = 65
+	damage = 60
 	penetration = 20
 	sundering = 2
 
@@ -114,7 +114,7 @@
 	if(!isvehicle(target_obj))
 		proj.proj_max_range -= 20 //can shoot through 1 piece of cover
 		return
-	proj.damage *= 1.8
+	proj.damage *= 2
 	proj.proj_max_range = 0
 
 /datum/ammo/bullet/rifle/tx8

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2287,10 +2287,10 @@
 	aim_speed_modifier = 2
 
 /obj/item/weapon/gun/rifle/som_big/standard
-	starting_attachment_types = list(/obj/item/attachable/motiondetector, /obj/item/attachable/extended_barrel, /obj/item/attachable/verticalgrip)
+	starting_attachment_types = list(/obj/item/attachable/motiondetector, /obj/item/attachable/heavy_barrel, /obj/item/attachable/verticalgrip)
 
 /obj/item/weapon/gun/rifle/som_big/support
-	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/extended_barrel, /obj/item/attachable/foldable/bipod)
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/heavy_barrel, /obj/item/attachable/foldable/bipod)
 //-------------------------------------------------------
 // V-41 SOM LMG
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -592,7 +592,7 @@
 	icon_state_mini = "mag_rifle_big"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/som_big
-	max_rounds = 25
+	max_rounds = 20
 	bonus_overlay = "v35_mag"
 	magazine_flags = MAGAZINE_REFILLABLE|MAGAZINE_SHOW_AMMO
 


### PR DESCRIPTION

## About The Pull Request
Small nerf to V-35.
Reduced mag size from 25 to 20.
Swapped out extended barrel for barrel charger.
Normal ammo damage reduced from 65 to 60.
## Why It's Good For The Game
V-35 is a bit too strong, specficially its EXTREMELY good at fraccing and delimbing. This will make it a bit less reliable at that.
Its also very strong against vehicles, so the reduced mag cap means AT mags are that much weaker.
## Changelog
:cl:
balance: Campaign: V-35 reduced mag capacity and normal ammo reduced from 65 to 60 damage
/:cl:
