### PR TITLE
Merges SL and FC prep rooms

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -11857,10 +11857,6 @@
 	},
 /obj/structure/table/mainship/nometal,
 /obj/machinery/keycard_auth,
-/obj/item/minimap_tablet{
-	pixel_x = -1;
-	pixel_y = 10
-	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
 "jLx" = (
@@ -18264,6 +18260,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/item/minimap_tablet,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "oMJ" = (

--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -6172,9 +6172,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1
-	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "fgS" = (
@@ -6288,6 +6285,9 @@
 /obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/drinks/coffee{
 	pixel_x = -7
+	},
+/obj/machinery/firealarm{
+	dir = 1
 	},
 /turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
@@ -15750,7 +15750,6 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "mKW" = (
@@ -20827,6 +20826,10 @@
 /obj/effect/landmark/start/job/synthetic,
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
+"qUw" = (
+/obj/machinery/firealarm,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "qUy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/mainship{
@@ -41262,7 +41265,7 @@ bqt
 psH
 cKw
 tgV
-haG
+qUw
 vTV
 htk
 pDW

--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -265,6 +265,12 @@
 "alF" = (
 /turf/closed/wall/mainship/research/containment/wall/west,
 /area/mainship/medical/medical_science)
+"alG" = (
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "alM" = (
 /obj/machinery/door_control/mainship/ammo{
 	dir = 8
@@ -369,10 +375,10 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "apL" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black{
-	dir = 1
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "apO" = (
 /obj/structure/bed/chair/wood/wings,
@@ -1070,12 +1076,6 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
-"aYf" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "aYg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -1158,16 +1158,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/repair_bay)
 "bdd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -1787,16 +1778,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "bCj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/machinery/computer/marine_card,
+/obj/item/storage/box/ids{
+	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/light/mainship,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "bCG" = (
 /obj/effect/soundplayer/deltaplayer,
@@ -1927,7 +1915,7 @@
 /obj/machinery/door/firedoor{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "bJh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1994,6 +1982,15 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"bMW" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "bNJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -2283,14 +2280,18 @@
 	dir = 10
 	},
 /area/mainship/hull/starboard_hull)
-"cdO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/marine_card,
-/obj/item/storage/box/ids{
-	pixel_x = 6
+"cdK" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/black{
+	dir = 4
 	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
+"cdO" = (
+/obj/structure/bed/chair/comfy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "cec" = (
 /obj/structure/cable,
@@ -2608,9 +2609,8 @@
 /area/mainship/squads/req)
 "cpJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "cpN" = (
 /obj/machinery/camera/autoname/mainship{
@@ -2742,12 +2742,6 @@
 /obj/structure/ship_ammo/cas/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"cuQ" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "cvG" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -3083,10 +3077,11 @@
 /turf/open/floor/mainship/silver,
 /area/mainship/hallways/port_ert)
 "cKw" = (
-/obj/structure/mirror,
-/obj/structure/sink,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
+/obj/effect/spawner/random/misc/plant,
+/turf/open/floor/mainship/black{
+	dir = 10
+	},
+/area/mainship/hallways/starboard_hallway)
 "cKD" = (
 /obj/machinery/marine_selector/clothes/medic,
 /turf/open/floor/mainship/black{
@@ -3246,13 +3241,6 @@
 /obj/item/stack/sheet/glass/glass/large_stack,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
-"cQE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "cRL" = (
 /turf/open/floor/mainship/blue{
 	dir = 8
@@ -3788,6 +3776,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
+"djB" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/black,
+/area/mainship/squads/general)
 "djM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -4579,8 +4571,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "dPt" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship/black{
+/turf/open/floor/mainship/blue/corner{
 	dir = 4
 	},
 /area/mainship/squads/general)
@@ -4692,15 +4683,24 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
+"dXo" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/floor,
+/area/space)
 "dXZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
-"dYw" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/ornamented_cap,
+"dYt" = (
+/obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
+"dYw" = (
+/obj/effect/spawner/random/misc/plant,
+/turf/open/floor/mainship/black{
+	dir = 6
+	},
+/area/mainship/hallways/starboard_hallway)
 "dYN" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -4716,7 +4716,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "eab" = (
-/obj/machinery/marine_selector/clothes/leader,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -4803,6 +4809,10 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"eeE" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/mainship/floor,
+/area/space)
 "eff" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -5182,6 +5192,15 @@
 "etU" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"etW" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "etY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5291,10 +5310,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "eyM" = (
-/obj/machinery/vending/uniform_supply,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
+/obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -5686,9 +5702,8 @@
 /turf/open/floor/wood,
 /area/mainship/shipboard/brig)
 "ePQ" = (
-/obj/machinery/vending/uniform_supply,
 /obj/structure/cable,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "ePS" = (
 /obj/structure/cable,
@@ -6152,6 +6167,16 @@
 	dir = 6
 	},
 /area/mainship/medical/upper_medical)
+"fgI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
 "fgS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6259,6 +6284,13 @@
 /obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship_hull,
 /area/space)
+"fjO" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -7
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/starboard_hallway)
 "fki" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -6534,10 +6566,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/cafeteria_officer)
 "fww" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
@@ -7624,6 +7658,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "gtX" = (
@@ -7712,6 +7749,11 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"gxO" = (
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "gyv" = (
 /obj/machinery/vending/snack,
 /obj/structure/disposalpipe/segment/corner{
@@ -8138,7 +8180,6 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "gOU" = (
-/obj/effect/spawner/random/misc/plant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8238,6 +8279,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"gTw" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/space)
 "gTZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8336,12 +8383,12 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/upper_medical)
 "gWL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4
+/obj/machinery/light/mainship{
+	dir = 8
 	},
+/obj/machinery/marine_selector/clothes/leader,
 /turf/open/floor/mainship/black{
-	dir = 9
+	dir = 8
 	},
 /area/mainship/squads/general)
 "gWY" = (
@@ -8420,11 +8467,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "haG" = (
-/obj/machinery/marine_selector/gear/commander,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "haO" = (
 /obj/structure/window/reinforced{
@@ -8482,7 +8525,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
 "hdl" = (
-/obj/machinery/marine_selector/gear/leader,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
@@ -8923,8 +8966,10 @@
 /area/mainship/shipboard/brig)
 "htk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/mainship/floor,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "htw" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -9336,7 +9381,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/black,
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "hJH" = (
 /turf/open/floor/mainship/silver{
 	dir = 6
@@ -9659,11 +9704,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/brig_cells)
 "hWX" = (
-/obj/structure/bed/chair/comfy,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/filingcabinet,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/mainship{
+	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "hYl" = (
 /obj/machinery/door/poddoor/railing{
@@ -10020,9 +10066,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"ins" = (
-/turf/open/floor/mainship/black,
-/area/mainship/living/numbertwobunks)
 "inv" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -10857,6 +10900,14 @@
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
+"iVk" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/space)
 "iVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -10912,7 +10963,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "iYx" = (
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
 	dir = 1
@@ -11206,8 +11257,8 @@
 /area/mainship/hallways/hangar)
 "jkK" = (
 /obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "jlj" = (
 /obj/structure/bed,
@@ -11369,10 +11420,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/evacuation)
-"jqK" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "jqZ" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light/mainship{
@@ -11382,13 +11429,6 @@
 	dir = 5
 	},
 /area/mainship/engineering/engineering_workshop)
-"jry" = (
-/obj/machinery/cic_maptable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/black,
-/area/mainship/squads/general)
 "jrH" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/faxmachine/brig,
@@ -11887,8 +11927,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "jNz" = (
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/black,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "jNV" = (
 /turf/open/floor/mainship_hull/dir{
@@ -11913,16 +11957,6 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig_cells)
-"jOq" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/window,
-/obj/structure/window/reinforced/tinted,
-/obj/item/tool/soap/nanotrasen,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/numbertwobunks)
 "jOw" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -12790,6 +12824,13 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/starboard_hallway)
+"kzq" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "kAc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13513,18 +13554,11 @@
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "lbR" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"lcp" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 4;
-	name = "Bathroom"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "lcF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -13609,18 +13643,6 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
-"lfz" = (
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/captain,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/obj/effect/landmark/start/job/fieldcommander,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "lfA" = (
 /obj/structure/cable,
 /obj/machinery/disposal,
@@ -13783,6 +13805,10 @@
 	dir = 1
 	},
 /area/mainship/engineering/engineering_workshop)
+"lnT" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/floor,
+/area/space)
 "loy" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -14732,12 +14758,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
-"lXy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "lXD" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -15010,6 +15030,14 @@
 	dir = 8
 	},
 /area/mainship/medical)
+"mhN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "mia" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/purple{
@@ -15717,6 +15745,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
+"mKO" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/firealarm,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "mKW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -16051,16 +16087,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engine_core)
 "nco" = (
-/obj/machinery/door/airlock/mainship/command/FCDRoffice{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
+/obj/structure/bed/fancy,
+/obj/item/bedsheet/captain,
+/obj/effect/landmark/start/job/fieldcommander,
+/obj/machinery/firealarm,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "nct" = (
 /obj/structure/sink{
@@ -16098,11 +16129,6 @@
 	},
 /turf/open/floor/mainship/silver/full,
 /area/mainship/living/evacuation)
-"ndn" = (
-/turf/open/floor/mainship/black{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
 "ndJ" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera/autoname/mainship{
@@ -16134,7 +16160,7 @@
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "neJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/silver{
@@ -16405,6 +16431,20 @@
 "nqR" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
+"nqS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "nqZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16666,6 +16706,13 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
+"nCG" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/space)
 "nCM" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
@@ -16842,13 +16889,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/pilotbunks)
 "nJH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "nKq" = (
 /obj/structure/bed/chair/wood/wings{
@@ -17110,7 +17157,7 @@
 /turf/open/floor/mainship/black{
 	dir = 10
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "nRU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -18213,6 +18260,13 @@
 /obj/structure/sink,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
+"oMq" = (
+/obj/machinery/marine_selector/gear/commander,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "oMJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18740,6 +18794,10 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"pjb" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/space/basic,
+/area/space)
 "pje" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/disposalpipe/segment{
@@ -19207,13 +19265,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "pDW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "pDZ" = (
 /obj/effect/landmark/start/latejoin,
@@ -19568,14 +19622,14 @@
 	},
 /area/mainship/living/grunt_rnr)
 "pWm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "pWt" = (
@@ -19736,13 +19790,6 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"qci" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "qcq" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -19820,6 +19867,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/hallways/starboard_ert)
+"qfF" = (
+/obj/machinery/vending/uniform_supply,
+/obj/structure/cable,
+/turf/open/floor/mainship/floor,
+/area/space)
 "qfK" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clipboard{
@@ -19885,6 +19937,13 @@
 	dir = 5
 	},
 /area/mainship/hallways/starboard_hallway)
+"qjh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mainship/command/FCDRoffice{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "qjt" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -20167,9 +20226,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "qtC" = (
-/obj/structure/bed/chair/nometal,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
@@ -20576,6 +20634,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"qOC" = (
+/obj/machinery/marine_selector/gear/commander,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/space)
 "qOG" = (
 /obj/effect/turf_decal/warning_stripes,
 /obj/vehicle/ridden/powerloader,
@@ -21149,6 +21214,11 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
+"rjk" = (
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -21488,11 +21558,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_ert)
-"rvP" = (
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
-/area/mainship/squads/general)
 "rvR" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/firing_range)
@@ -21528,6 +21593,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical)
+"rxM" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
 "rxN" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted,
 /turf/open/floor/wood,
@@ -22315,11 +22386,10 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "scN" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/paper/arachneresearch2,
@@ -22401,7 +22471,7 @@
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "sgv" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -22619,11 +22689,6 @@
 	dir = 2
 	},
 /area/mainship/command/self_destruct)
-"soJ" = (
-/obj/structure/filingcabinet,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "spr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -23896,22 +23961,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
-"tEC" = (
-/obj/effect/spawner/random/misc/plant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/hallways/starboard_hallway)
 "tEI" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
@@ -24976,6 +25025,12 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
+"uBW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "uCc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25287,6 +25342,16 @@
 	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
+"uOG" = (
+/obj/machinery/vending/weapon,
+/turf/open/space/basic,
+/area/space)
+"uOM" = (
+/obj/machinery/marine_selector/gear/leader,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "uOU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -26292,6 +26357,15 @@
 	dir = 9
 	},
 /area/mainship/hallways/hangar)
+"vDj" = (
+/obj/machinery/loadout_vendor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vDC" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
@@ -26395,11 +26469,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
-"vGD" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "vGM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26457,12 +26526,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
-"vIX" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "vJu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -26564,8 +26627,9 @@
 	},
 /area/mainship/hallways/hangar/flight_observation)
 "vMj" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/floor,
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/ornamented_cap,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "vMk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26616,11 +26680,6 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"vPR" = (
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "vPV" = (
 /obj/structure/sign/biohazard{
 	dir = 4
@@ -26689,12 +26748,13 @@
 /turf/open/floor/wood,
 /area/mainship/shipboard/brig)
 "vRx" = (
-/obj/structure/bed/chair/nometal,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "vSg" = (
@@ -26747,15 +26807,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "vTV" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
-"vTY" = (
-/obj/machinery/marine_selector/gear/leader,
-/turf/open/floor/mainship/black{
-	dir = 5
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/area/mainship/squads/general)
+/obj/item/plantable_flag,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "vUV" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -26945,7 +27002,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "wdF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -26959,6 +27016,10 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"wdM" = (
+/obj/machinery/marine_selector/gear/leader,
+/turf/open/space/basic,
+/area/space)
 "wer" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flipped{
@@ -27816,12 +27877,10 @@
 "wMy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "wME" = (
 /turf/open/floor/mainship/orange,
@@ -27897,10 +27956,8 @@
 /area/mainship/hull/starboard_hull)
 "wPz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "wQg" = (
 /obj/machinery/door/poddoor/mainship/ammo{
@@ -27925,12 +27982,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"wQF" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/black,
-/area/mainship/living/numbertwobunks)
 "wQY" = (
 /obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/orange{
@@ -28085,6 +28136,12 @@
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"xaW" = (
+/obj/machinery/marine_selector/gear/leader,
+/turf/open/floor/mainship/black{
+	dir = 5
+	},
+/area/space)
 "xaX" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/structure/disposalpipe/segment{
@@ -28291,6 +28348,13 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/numbertwobunks)
+"xjO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment/corner,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "xjU" = (
 /obj/effect/landmark/start/job/ai,
 /obj/machinery/camera/autoname/mainship{
@@ -28486,7 +28550,7 @@
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/squads/general)
 "xvk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -28571,9 +28635,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
+/obj/machinery/loadout_vendor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/mainship/black{
-	dir = 10
+	dir = 8
 	},
 /area/mainship/squads/general)
 "xzy" = (
@@ -28584,12 +28651,6 @@
 	dir = 5
 	},
 /area/mainship/command/airoom)
-"xzL" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "xzR" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -28613,15 +28674,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "xAv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/mainship/nometal,
+/obj/item/explosive/grenade,
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/starboard_hallway)
 "xAw" = (
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -28629,12 +28685,13 @@
 /area/mainship/hallways/repair_bay)
 "xAS" = (
 /obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/effect/ai_node,
-/obj/item/plantable_flag,
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "xAU" = (
 /obj/structure/cable,
@@ -28708,14 +28765,13 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "xEA" = (
-/obj/machinery/photocopier,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "xEN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -40491,15 +40547,15 @@ pUk
 pnh
 eQh
 hdl
-xRs
+bMW
 eab
 eyM
 gWL
 bdd
 xyG
-nKA
-aen
-psr
+eQh
+qoI
+oUI
 lbd
 jAF
 eMj
@@ -40593,15 +40649,15 @@ hLz
 fcl
 fiZ
 fiW
-ddi
 kxc
+xjO
 fww
-fiW
+mhN
 vRx
 jNz
-eQh
-qoI
-oUI
+nKA
+aen
+psr
 idZ
 jAF
 ssi
@@ -40694,13 +40750,13 @@ nnu
 dhE
 miz
 aOG
-lqO
+alG
 lqg
-arF
-fWI
+apL
+uBW
 apL
 qtC
-jry
+oTv
 aOG
 eAi
 oUI
@@ -40795,14 +40851,14 @@ xMD
 wIF
 dhE
 pnh
-paV
-sqT
+eQh
+alG
 lqg
 lqg
 lqg
-sqT
-qtC
-oTv
+lqg
+lqg
+djB
 eQh
 sqT
 oUI
@@ -40894,17 +40950,17 @@ boV
 boV
 boV
 boV
-qhi
-wYN
-tjR
-eQh
-vTY
-slK
+dNX
+dhE
+pnh
+paV
+rjk
+rjk
 dPt
-xzL
-rvP
-gng
-eXi
+lqg
+lqg
+pNg
+xTJ
 paV
 hIy
 bAX
@@ -40996,18 +41052,18 @@ mOa
 aHm
 nWx
 boV
-uFw
-wsB
-uFw
-tgV
-tgV
-tgV
-tgV
-tgV
-tgV
-tgV
-tgV
-tgV
+qhi
+wYN
+tjR
+eQh
+dYt
+oMq
+gxO
+uOM
+etW
+cdK
+vDj
+eQh
 sgq
 wcP
 hJf
@@ -41098,18 +41154,18 @@ aHQ
 ylH
 fmj
 boV
-uVk
-tEC
-xsK
+uFw
+wsB
+uFw
+eQh
+eQh
 tgV
-jOq
-vIX
+qjh
 tgV
-jqK
-cQE
-vGD
-soJ
-aJW
+tgV
+tgV
+tgV
+tgV
 lbO
 neB
 nRS
@@ -41202,19 +41258,19 @@ iKE
 fkS
 ePS
 gtJ
-pnh
-tgV
+bqt
+psH
 cKw
-cuQ
 tgV
+haG
 vTV
 htk
 pDW
 hWX
-mYt
-vPR
+aJW
+sqT
 iXT
-ins
+lbd
 jAF
 ock
 eNj
@@ -41304,19 +41360,19 @@ coZ
 aLN
 uow
 dow
-haX
+fgI
+rxM
+fjO
 xgK
-tgV
-lcp
-tgV
+kzq
 haG
 jkK
 xEA
 cdO
-qlT
-aYf
-iXT
-wQF
+mYt
+bzO
+nqS
+idZ
 jAF
 aDL
 pDZ
@@ -41407,18 +41463,18 @@ ukU
 dNX
 pWm
 cpJ
-nco
+rxM
 xAv
-lXy
+tgV
 nco
-lXy
+haG
 wPz
 nJH
 bCj
-qci
-vPR
+qlT
+sqT
 iXT
-ins
+lbd
 jAF
 aJv
 pDZ
@@ -41508,11 +41564,11 @@ irN
 boV
 qhi
 gOU
-tjR
-tgV
+plQ
+plQ
 dYw
-lfz
 tgV
+mKO
 vMj
 ePQ
 xAS
@@ -41520,7 +41576,7 @@ wMy
 bIu
 xuI
 scL
-ndn
+eXi
 jAF
 jAF
 crb
@@ -41611,8 +41667,8 @@ boV
 uSz
 pvv
 uSz
-tgV
-tgV
+mOR
+mOR
 tgV
 tgV
 xjI
@@ -41979,9 +42035,9 @@ meP
 meP
 jzy
 meP
-meP
-meP
-meP
+xaW
+iVk
+gTw
 meP
 kPR
 vkb
@@ -42284,11 +42340,11 @@ meP
 meP
 meP
 jzy
+pjb
 meP
-meP
-meP
-meP
-meP
+wdM
+pjb
+uOG
 meP
 bwF
 vkb
@@ -42489,7 +42545,7 @@ meP
 meP
 jzy
 meP
-meP
+nCG
 meP
 meP
 meP
@@ -42589,7 +42645,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -42691,7 +42747,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -42793,7 +42849,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -42895,7 +42951,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -42997,7 +43053,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43099,7 +43155,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43201,7 +43257,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43303,7 +43359,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43405,7 +43461,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43507,7 +43563,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43609,7 +43665,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43711,7 +43767,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -43813,7 +43869,7 @@ meP
 meP
 meP
 meP
-jzy
+meP
 meP
 meP
 meP
@@ -44118,7 +44174,7 @@ meP
 (144,1,1) = {"
 meP
 meP
-meP
+dXo
 jzy
 meP
 meP
@@ -44220,7 +44276,7 @@ meP
 (145,1,1) = {"
 meP
 meP
-meP
+eeE
 jzy
 jzy
 jzy
@@ -44322,7 +44378,7 @@ meP
 (146,1,1) = {"
 meP
 meP
-meP
+qOC
 meP
 meP
 meP
@@ -44424,12 +44480,12 @@ meP
 (147,1,1) = {"
 meP
 meP
+lnT
+qfF
 meP
 meP
 meP
-meP
-meP
-meP
+eeE
 meP
 meP
 meP
@@ -44531,7 +44587,7 @@ meP
 meP
 meP
 meP
-meP
+qOC
 meP
 meP
 meP

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -158,24 +158,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"alP" = (
-/obj/structure/bed/chair/comfy,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "alY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"amc" = (
-/obj/structure/table/wood/fancy,
-/obj/item/book/codebook,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
 "amE" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -276,14 +264,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"asG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "atc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -425,14 +405,6 @@
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"aDd" = (
-/mob/living/simple_animal/corgi/ian,
-/turf/open/floor/mainship/mono,
-/area/space)
-"aDk" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/wood,
-/area/space)
 "aDz" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black{
@@ -504,13 +476,6 @@
 /obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"aGW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/space)
 "aGZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -549,10 +514,6 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
-"aIW" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship,
-/area/space)
 "aJb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -620,17 +581,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"aKY" = (
-/obj/structure/table/wood/fancy,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/effect/spawner/random/misc/paperbin{
-	pixel_y = 5
-	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/floor,
-/area/space)
 "aLA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/sign/poster{
@@ -696,10 +646,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
-"aPJ" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "aPM" = (
 /obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
@@ -787,10 +733,6 @@
 "aSJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
-"aSP" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "aSV" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -937,10 +879,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"bau" = (
-/obj/structure/bed/chair/comfy,
-/turf/open/floor/mainship/floor,
-/area/space)
 "bax" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/wrench,
@@ -1154,23 +1092,6 @@
 "bpc" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
-"bpr" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/space)
-"bpz" = (
-/obj/machinery/light/mainship,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/squads/general)
 "bpK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship,
@@ -1242,13 +1163,6 @@
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"buQ" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/marine_card,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/space)
 "buS" = (
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
@@ -1333,14 +1247,6 @@
 	dir = 1
 	},
 /area/mainship/medical/chemistry)
-"bAS" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "bAT" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
@@ -1393,20 +1299,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
-"bCW" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/space)
-"bCZ" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "bDg" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -1506,23 +1398,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
-"bGW" = (
-/obj/machinery/cic_maptable/drawable/big{
-	pixel_x = 0
-	},
-/turf/open/floor/mainship,
-/area/space)
 "bHF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"bIl" = (
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -1584,10 +1464,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"bMi" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/wood,
-/area/space)
 "bMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2155,13 +2031,6 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"czt" = (
-/obj/structure/table/wood/fancy,
-/obj/item/newspaper,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/item/reagent_containers/food/drinks/milk,
-/turf/open/floor/wood,
-/area/space)
 "czx" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -2301,21 +2170,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"cJb" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/structure/sign/prop1{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/space)
-"cKa" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "cLc" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -2559,16 +2413,6 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
-"cXs" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/space)
 "cYi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -2651,9 +2495,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"dcv" = (
-/turf/open/floor/mainship/blue,
-/area/space)
 "dcz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -2670,16 +2511,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"dcJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/living/numbertwobunks)
 "dcY" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -2853,15 +2684,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"dlh" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/job/staffofficer,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/space)
 "dlz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile,
@@ -2960,10 +2782,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"dpU" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/space)
 "dpY" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -3061,15 +2879,6 @@
 /obj/effect/spawner/random/misc/gnome,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
-"dxc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "dxg" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -3084,15 +2893,6 @@
 	},
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
-"dyP" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/cigar,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_y = 5
-	},
-/obj/item/storage/box/matches,
-/turf/open/floor/wood,
-/area/space)
 "dzr" = (
 /obj/machinery/air_alarm{
 	dir = 8
@@ -3104,10 +2904,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
-"dBi" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "dBm" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck/kotahi,
@@ -3147,15 +2943,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"dFq" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/staffofficer,
-/turf/open/floor/mainship/emerald{
-	dir = 8
-	},
-/area/space)
 "dFt" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -3245,12 +3032,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"dJU" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "dKF" = (
 /obj/structure/bed/chair/wood/normal,
 /turf/open/floor/mainship/mono,
@@ -3340,15 +3121,6 @@
 "dQG" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_one)
-"dQS" = (
-/obj/structure/table/wood/fancy,
-/obj/item/megaphone,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/item/clothing/head/ornamented_cap,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "dRR" = (
 /obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired,
 /obj/structure/benchpress,
@@ -3361,16 +3133,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"dSQ" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/security/marinemainship_network,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/space)
 "dST" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck,
@@ -3434,6 +3196,9 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
 	name = "\improper Firing Range Airlock"
 	},
@@ -3474,35 +3239,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
-"dYs" = (
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "dYv" = (
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
 /area/mainship/shipboard/firing_range)
-"dZo" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/briefcase,
-/obj/item/clothing/head/bowlerhat{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/weapon/cane{
-	pixel_x = 5
-	},
-/obj/item/binoculars,
-/turf/open/floor/wood,
-/area/space)
-"dZY" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/door/poddoor/shutters/mainship/fc_office{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
 "eaH" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -3542,10 +3283,6 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ecC" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship/mono,
-/area/space)
 "ecW" = (
 /obj/machinery/researchcomp,
 /obj/machinery/researchcomp,
@@ -3558,13 +3295,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/mainship/squads/general)
-"edp" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "edD" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -3614,7 +3344,9 @@
 "eeX" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -3670,17 +3402,6 @@
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
-"ehw" = (
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/leader,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "eiu" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3766,15 +3487,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"elv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
 "elQ" = (
 /obj/structure/sign/poster,
 /turf/open/floor/mainship/yellow_cargo,
@@ -3784,10 +3496,6 @@
 	dir = 4
 	},
 /area/mainship/medical/medical_science)
-"emh" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "emm" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/camera/autoname/mainship{
@@ -3871,10 +3579,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"ewU" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship,
-/area/space)
 "exv" = (
 /obj/machinery/door/poddoor/mainship/mech{
 	dir = 1
@@ -3977,9 +3681,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
-"eCk" = (
-/turf/open/floor/carpet/side,
-/area/mainship/living/numbertwobunks)
 "eCr" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -3999,22 +3700,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"eCH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/space)
-"eCZ" = (
-/obj/machinery/light/mainship,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/space)
 "eDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4023,18 +3708,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"eDM" = (
-/obj/machinery/cic_maptable,
-/turf/open/floor/mainship,
-/area/space)
 "eEb" = (
 /obj/machinery/door/airlock/mainship/research/glass/cell/cell1,
 /obj/machinery/door/poddoor/shutters/mainship/cell/cell1,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"eEV" = (
-/turf/open/floor/mainship/mono,
-/area/space)
 "eEZ" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/computer/security/marinemainship_network,
@@ -4342,17 +4020,6 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"eYO" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 4
-	},
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/communications,
-/turf/open/floor/plating/mainship,
-/area/space)
 "eZd" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/mainship/mono,
@@ -4412,11 +4079,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
-"fbA" = (
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/space)
 "fbC" = (
 /obj/structure/window/reinforced,
 /obj/item/clothing/shoes/marine/som,
@@ -4495,11 +4157,6 @@
 	},
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
-"feU" = (
-/obj/structure/mirror,
-/obj/structure/sink,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "ffi" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
@@ -4541,20 +4198,6 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
-"fhu" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/machinery/computer/camera_advanced/overwatch/main,
-/turf/open/floor/plating/mainship,
-/area/space)
-"fhJ" = (
-/obj/machinery/marine_selector/gear/leader,
-/turf/open/floor/mainship,
-/area/space)
 "fiq" = (
 /obj/structure/closet/secure_closet/pilot_officer,
 /obj/effect/ai_node,
@@ -4690,7 +4333,7 @@
 	},
 /obj/machinery/disposal,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
+/area/mainship/hallways/hangar/droppod)
 "fqs" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/machinery/keycard_auth,
@@ -5083,12 +4726,6 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fIz" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
 "fJI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -5154,11 +4791,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fMS" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/turf/open/floor/mainship,
-/area/space)
 "fNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5210,23 +4842,10 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
+/area/mainship/hallways/hangar/droppod)
 "fRw" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"fRH" = (
-/obj/machinery/door/airlock/mainship/command/FCDRoffice{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship,
-/area/space)
 "fSq" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -5444,15 +5063,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"gcI" = (
-/obj/machinery/power/apc,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/item/plantable_flag,
-/turf/open/floor/mainship/blue{
-	dir = 5
-	},
-/area/mainship/living/numbertwobunks)
 "gcM" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/orange,
@@ -5511,10 +5121,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ghr" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship,
-/area/space)
 "ghV" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
@@ -5795,28 +5401,6 @@
 /obj/machinery/power/apc/mainship,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/brig)
-"gwK" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
-"gxw" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/space)
 "gxL" = (
 /obj/machinery/marine_selector/clothes/engi,
 /turf/open/floor/mainship,
@@ -5858,19 +5442,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
-"gBS" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/security/marinemainship{
-	dir = 8;
-	pixel_x = -17
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/orange{
-	dir = 9
-	},
-/area/space)
 "gCk" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/orange{
@@ -5994,11 +5565,6 @@
 	dir = 5
 	},
 /area/mainship/medical/lower_medical)
-"gNy" = (
-/turf/open/floor/carpet/side{
-	dir = 10
-	},
-/area/space)
 "gPi" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -6106,10 +5672,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
-"gUJ" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "gUS" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -6182,12 +5744,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/chapel)
-"gYL" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/obj/structure/sign/goldenplaque,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "gZf" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
@@ -6211,21 +5767,11 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
-"haj" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/wood,
-/area/space)
 "hap" = (
 /obj/structure/rack,
 /obj/item/frame/table/gambling,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"hbw" = (
-/obj/machinery/photocopier,
-/turf/open/floor/mainship/blue{
-	dir = 9
-	},
-/area/space)
 "hcb" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -6471,11 +6017,6 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
-"hpS" = (
-/turf/open/floor/carpet/side{
-	dir = 5
-	},
-/area/mainship/living/numbertwobunks)
 "hpW" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/mainship/hexagon,
@@ -6543,9 +6084,6 @@
 	dir = 5
 	},
 /area/mainship/living/pilotbunks)
-"hwj" = (
-/turf/open/floor/mainship/floor,
-/area/space)
 "hwp" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -6797,16 +6335,6 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
-"hPR" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "hQD" = (
 /obj/vehicle/unmanned/droid,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -6834,12 +6362,6 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
-"hRK" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "hSb" = (
 /obj/structure/bed/chair/wood/normal,
 /obj/item/reagent_containers/jerrycan,
@@ -6880,19 +6402,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
-"hSU" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/machinery/computer/security/marinemainship{
-	dir = 4;
-	pixel_x = 17
-	},
-/turf/open/floor/mainship/emerald{
-	dir = 5
-	},
-/area/space)
 "hSX" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -7006,10 +6515,6 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
-"iaf" = (
-/obj/machinery/door_control/mainship/fc_shutters,
-/turf/closed/wall/mainship,
-/area/mainship/living/numbertwobunks)
 "iaH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
@@ -7069,12 +6574,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
-"iew" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/space)
 "ieX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -7112,14 +6611,6 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"iht" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "ihU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -7284,12 +6775,6 @@
 "isR" = (
 /turf/open/floor/wood,
 /area/mainship/living/mechpilotquarters)
-"itc" = (
-/obj/structure/mirror{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/space)
 "its" = (
 /obj/machinery/bot/roomba,
 /turf/open/floor/mainship,
@@ -7319,12 +6804,6 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"ivw" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "ivW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7337,16 +6816,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"iwn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/ai_node,
-/obj/machinery/cic_maptable/drawable/big{
-	pixel_x = 0
-	},
-/turf/open/floor/mainship/mono,
-/area/space)
 "iws" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7477,14 +6946,6 @@
 /obj/machinery/marine_selector/clothes/smartgun,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"iHm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "iHy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -7560,12 +7021,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"iJy" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/side{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "iKm" = (
 /obj/structure/prop/mainship/mapping_computer,
 /turf/open/floor/mainship/red{
@@ -7585,16 +7040,6 @@
 	},
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/command/corporateliaison)
-"iKN" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/window,
-/obj/structure/window/reinforced/tinted,
-/obj/item/tool/soap/nanotrasen,
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "iLf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -7666,10 +7111,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"iQy" = (
-/obj/machinery/computer/squad_manager,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "iRM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -7735,16 +7176,6 @@
 	dir = 5
 	},
 /area/mainship/medical/medical_science)
-"iVT" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/structure/sign/prop1{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/general)
 "iWq" = (
 /obj/structure/largecrate/supply/ammo,
 /turf/open/floor/mainship/mono,
@@ -7834,16 +7265,6 @@
 /obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"jaA" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/window,
-/obj/structure/window/reinforced/tinted,
-/obj/item/tool/soap/nanotrasen,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/numbertwobunks)
 "jaF" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -7918,12 +7339,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"jhA" = (
-/obj/structure/bed/chair/nometal{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/space)
 "jhK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/floor,
@@ -7955,13 +7370,6 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"jka" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/camera_advanced/overwatch/charlie,
-/turf/open/floor/mainship/emerald{
-	dir = 4
-	},
-/area/space)
 "jkK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
@@ -7985,20 +7393,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
-"jmC" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/cigar,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_y = 5
-	},
-/obj/item/storage/box/matches,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"jmK" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/squad_changer,
-/turf/open/floor/mainship/mono,
-/area/space)
 "joi" = (
 /obj/machinery/door/poddoor/mainship/mech{
 	dir = 1
@@ -8048,14 +7442,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"jsl" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/blue{
-	dir = 10
-	},
-/area/mainship/living/numbertwobunks)
 "jsw" = (
 /obj/machinery/door_control/mainship/ammo,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8069,14 +7455,6 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"jtB" = (
-/obj/machinery/marine_selector/gear/commander,
-/turf/open/floor/wood,
-/area/space)
-"jvM" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship,
-/area/space)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -8122,10 +7500,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/stern_hallway)
-"jzh" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "jzx" = (
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
@@ -8228,10 +7602,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"jGM" = (
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/space)
 "jHd" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
@@ -8254,10 +7624,6 @@
 "jHU" = (
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"jHZ" = (
-/obj/machinery/marine_selector/gear/leader,
-/turf/open/floor/mainship/mono,
-/area/space)
 "jIc" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -8291,12 +7657,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
-"jLH" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
 "jLS" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/hexagon,
@@ -8362,17 +7722,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"jPy" = (
-/obj/machinery/door/airlock/mainship/command/FCDRquarters,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/space)
 "jPT" = (
 /obj/effect/ai_node,
 /obj/structure/curtain/medical{
@@ -8505,13 +7854,6 @@
 	dir = 5
 	},
 /area/mainship/command/self_destruct)
-"jXK" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/door/window/secure/bridge,
-/turf/open/floor/plating/mainship,
-/area/space)
 "jXN" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
@@ -8525,10 +7867,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"kaI" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/wood,
-/area/space)
 "kbe" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -8549,12 +7887,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"kbB" = (
-/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
-	dir = 1
-	},
-/turf/closed/wall/mainship,
-/area/space)
 "kbE" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -8592,26 +7924,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"kdF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
-"kdG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/space)
-"keK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "kfm" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
@@ -8707,12 +8019,6 @@
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
-/area/mainship/squads/general)
-"kpn" = (
-/obj/structure/bed/chair/nometal{
-	dir = 4
-	},
-/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "kpI" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -9186,16 +8492,6 @@
 /obj/item/fuel_cell/full,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"kNK" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/security/marinemainship_network,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/mainship/living/numbertwobunks)
 "kOe" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -9209,13 +8505,6 @@
 /obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
-"kPH" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/marine_card,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/mainship/living/numbertwobunks)
 "kQn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9279,16 +8568,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
-"kTn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/living/numbertwobunks)
 "kTv" = (
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment/corner{
@@ -9381,17 +8660,6 @@
 	dir = 1
 	},
 /area/mainship/command/airoom)
-"kYp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/space)
 "kYt" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/misc/cigarettes,
@@ -9426,10 +8694,6 @@
 /obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"kZR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/wood,
-/area/space)
 "lal" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/lower_engineering)
@@ -9464,10 +8728,6 @@
 "lcL" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"ldb" = (
-/obj/structure/noticeboard,
-/turf/closed/wall/mainship,
-/area/space)
 "ldA" = (
 /obj/machinery/processor{
 	pixel_y = 5
@@ -9521,13 +8781,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"lfP" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/keycard_auth,
-/turf/open/floor/mainship/emerald{
-	dir = 4
-	},
-/area/space)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -9601,15 +8854,6 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
-"ljg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/space)
 "ljh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -9771,12 +9015,6 @@
 /obj/structure/sign/safety/cryogenic,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/lower_medical)
-"lrc" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "lrn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -10044,9 +9282,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"lFo" = (
-/turf/open/floor/mainship/blue,
-/area/mainship/living/numbertwobunks)
 "lGg" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/orange{
@@ -10092,11 +9327,6 @@
 	dir = 4
 	},
 /area/mainship/living/commandbunks)
-"lHu" = (
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
 "lHG" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -10136,15 +9366,6 @@
 	},
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
-"lIU" = (
-/obj/machinery/air_alarm{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/mainship/living/numbertwobunks)
 "lIW" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/black{
@@ -10155,16 +9376,6 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/living/chapel)
-"lJx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/air_alarm{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/space)
 "lJE" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
@@ -10335,23 +9546,10 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
-"lSB" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/space)
 "lSQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"lST" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/space)
 "lSY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -10442,13 +9640,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
-"lWn" = (
-/obj/structure/table/mainship,
-/obj/item/folder/white,
-/obj/item/pizzabox,
-/obj/item/whistle,
-/turf/open/floor/mainship,
-/area/space)
 "lWz" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -10622,17 +9813,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"mif" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "miR" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
@@ -10642,7 +9822,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
+/area/mainship/hallways/hangar/droppod)
 "mjl" = (
 /obj/machinery/vending,
 /turf/open/floor/mainship/floor,
@@ -10754,9 +9934,6 @@
 /obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"mpL" = (
-/turf/open/floor/mainship,
-/area/space)
 "mqD" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -10764,12 +9941,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_garden)
-"mqJ" = (
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "mqK" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
@@ -10802,14 +9973,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"muR" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "muT" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -10890,14 +10053,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"myv" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/blue{
-	dir = 10
-	},
-/area/space)
 "mzh" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -11235,10 +10390,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"mTH" = (
-/obj/machinery/marine_selector/gear/commander,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "mUU" = (
 /obj/machinery/light/mainship,
 /obj/structure/sink{
@@ -11311,9 +10462,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"mXG" = (
-/turf/open/floor/carpet/side,
-/area/space)
 "mXM" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -11333,9 +10481,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"mXY" = (
-/turf/open/floor/wood,
-/area/space)
 "mZS" = (
 /turf/open/floor/mainship/black/full,
 /area/mainship/command/self_destruct)
@@ -11643,12 +10788,6 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"noA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/space)
 "npN" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
@@ -11823,13 +10962,6 @@
 	dir = 8
 	},
 /area/mainship/medical/upper_medical)
-"nAw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/space)
 "nAM" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -11917,20 +11049,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"nId" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/leader,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "nIj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -11979,19 +11097,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
-"nLn" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/space)
-"nLu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "nMm" = (
 /obj/machinery/door/window,
 /obj/machinery/shower{
@@ -12096,13 +11201,6 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"nSg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "nSH" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
@@ -12266,12 +11364,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"ocu" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "ocE" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/side,
@@ -12395,14 +11487,6 @@
 /obj/item/clothing/under/som,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"ooH" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "ooM" = (
 /obj/item/folder/black_random,
 /obj/item/tool/hand_labeler,
@@ -12478,15 +11562,6 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
-"otv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/space)
 "ouq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -12538,11 +11613,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
-"oyX" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
-/turf/open/floor/mainship/mono,
-/area/space)
 "oyZ" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/side,
@@ -12619,10 +11689,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"oFH" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "oGN" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/landinglight/tadpole{
@@ -12664,10 +11730,6 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
-"oHC" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/space)
 "oHV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12730,24 +11792,10 @@
 	},
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
-"oKm" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "oKO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"oLu" = (
-/obj/structure/mirror,
-/obj/structure/sink,
-/turf/open/floor/mainship/mono,
-/area/space)
 "oNh" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -12835,15 +11883,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"oRo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/emerald{
-	dir = 8
-	},
-/area/space)
 "oRM" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4
@@ -13045,10 +12084,6 @@
 	},
 /turf/open/floor/cult,
 /area/medical/morgue)
-"pcN" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/mono,
-/area/space)
 "pcQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -13120,13 +12155,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/yellow_cargo/arrow,
 /area/mainship/hallways/hangar/droppod)
-"pfV" = (
-/obj/structure/table/mainship,
-/obj/item/folder/white,
-/obj/item/pizzabox,
-/obj/item/whistle,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "pgh" = (
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
@@ -13181,10 +12209,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
-"pir" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
-/area/space)
 "pjB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -13456,16 +12480,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"pyr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/space)
-"pyG" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "pyS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13517,16 +12531,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
-"pBn" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/keycard_auth,
-/obj/item/radio{
-	pixel_x = 6
-	},
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/space)
 "pCd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -13750,14 +12754,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"pOo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/turf/open/floor/mainship,
-/area/space)
 "pOy" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 1
@@ -13819,12 +12815,6 @@
 /obj/machinery/bot/cleanbot,
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
-"pRo" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "pSt" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
@@ -14043,11 +13033,6 @@
 /obj/machinery/power/apc,
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
-"qgg" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/space)
 "qha" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/boxingring)
@@ -14277,13 +13262,6 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
-"qxq" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/door/poddoor/shutters/mainship/fc_office{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/space)
 "qxw" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -14380,22 +13358,10 @@
 /obj/effect/landmark/start/job/cmo,
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
-"qBv" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/mainship,
-/area/space)
 "qDh" = (
 /obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"qEt" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "qEu" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/ammo_magazine/rifle/standard_carbine,
@@ -14497,10 +13463,6 @@
 /obj/structure/bed/stool,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"qKf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "qKp" = (
 /obj/effect/decal/cleanable/blood/writing{
 	desc = "It looks like a writing in blood. It says, 'We live as we dream, alone.'";
@@ -14530,14 +13492,6 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
-"qLW" = (
-/obj/machinery/firealarm{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "qMG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -14704,11 +13658,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
-"qSb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/space)
 "qST" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14720,9 +13669,6 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"qUg" = (
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "qUn" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
@@ -14759,10 +13705,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"qVS" = (
-/obj/machinery/light/mainship,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "qWc" = (
@@ -14816,15 +13758,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"qXL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
-"qYX" = (
-/obj/machinery/computer/squad_manager,
-/turf/open/floor/mainship,
-/area/space)
 "qZw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15121,24 +14054,12 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
-"rtj" = (
-/obj/structure/table/wood/fancy,
-/obj/item/newspaper,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/item/reagent_containers/food/drinks/milk,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "ruM" = (
 /obj/machinery/air_alarm{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"rwt" = (
-/turf/open/floor/carpet/side{
-	dir = 5
-	},
-/area/space)
 "rwK" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15234,10 +14155,6 @@
 	dir = 4
 	},
 /area/mainship/command/self_destruct)
-"rBJ" = (
-/obj/machinery/cic_maptable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "rCb" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/hexagon,
@@ -15575,12 +14492,6 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
-"rYi" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space)
 "rYr" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship,
@@ -15616,10 +14527,6 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"rZM" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "rZR" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 8
@@ -15708,15 +14615,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"seN" = (
-/obj/structure/table/wood/fancy,
-/obj/item/megaphone,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/item/clothing/head/ornamented_cap,
-/turf/open/floor/wood,
-/area/space)
 "sfz" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -15756,21 +14654,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
-"shP" = (
-/obj/machinery/computer/camera_advanced/overwatch/bravo,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/space)
 "sid" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"siu" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship,
-/area/space)
 "sjV" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/red/full,
@@ -15800,10 +14688,6 @@
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/mainship,
 /area/mainship/engineering/ce_room)
-"smG" = (
-/obj/machinery/door_control/mainship/fc_shutters,
-/turf/closed/wall/mainship,
-/area/space)
 "snm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -15895,12 +14779,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"stt" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/obj/structure/sign/goldenplaque,
-/turf/open/floor/mainship,
-/area/space)
 "suU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -15961,9 +14839,6 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"syi" = (
-/turf/open/floor/mainship/yellow_cargo,
-/area/space)
 "syt" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -16039,10 +14914,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"sBT" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/turf/open/floor/wood,
-/area/space)
 "sCk" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -16217,29 +15088,10 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"sQz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "sQI" = (
 /obj/machinery/fuelcell_recycler,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"sRN" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 6
-	},
-/area/space)
 "sRP" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/keycard_auth,
@@ -16257,16 +15109,6 @@
 "sSz" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
-"sSA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/air_alarm{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "sSN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -16586,7 +15428,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
+/area/mainship/hallways/hangar/droppod)
 "tpo" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/surgical_tray,
@@ -16703,10 +15545,6 @@
 /turf/closed/shuttle/ert/engines/left/two{
 	dir = 1
 	},
-/area/space)
-"txg" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/mainship/floor,
 /area/space)
 "txW" = (
 /obj/docking_port/stationary/ert_big,
@@ -16953,15 +15791,6 @@
 "tIn" = (
 /turf/open/floor/plating,
 /area/mainship/engineering/port_atmos)
-"tIy" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
 "tIE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16970,18 +15799,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"tIU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/blue{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
 "tJA" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -17009,19 +15826,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"tLY" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/floor,
-/area/space)
 "tMy" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -17057,42 +15861,6 @@
 	dir = 1
 	},
 /area/mainship/medical/chemistry)
-"tOi" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/structure/table/mainship/nometal,
-/obj/machinery/door_control/old/cic{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/machinery/door_control/old/cic/armory{
-	pixel_x = -4;
-	pixel_y = -5
-	},
-/obj/machinery/light/mainship,
-/obj/machinery/door_control/old/cic/hangar_shutters{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/machinery/door_control/old/medbay{
-	id = "Medbay";
-	name = "Medbay Lockdown";
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/machinery/door_control/old{
-	id = "ROlobby";
-	name = "Requisitions lockdown";
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/minimap_tablet{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/space)
 "tOm" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/mainship/orange/full,
@@ -17118,15 +15886,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"tPx" = (
-/obj/machinery/air_alarm{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/space)
 "tQa" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -17281,10 +16040,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"tXs" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/wood,
-/area/space)
 "tXB" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -17495,13 +16250,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
 /area/medical/morgue)
-"ujQ" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "ukb" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -17620,10 +16368,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"urm" = (
-/obj/machinery/computer/squad_manager,
-/turf/open/space/basic,
-/area/space)
 "urD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17718,12 +16462,6 @@
 /obj/item/camera_film,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"uxI" = (
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "uyy" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
@@ -17766,15 +16504,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"uAI" = (
-/obj/machinery/power/apc,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/item/plantable_flag,
-/turf/open/floor/mainship/blue{
-	dir = 5
-	},
-/area/space)
 "uBn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17848,10 +16577,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"uDs" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/wood,
-/area/space)
 "uDQ" = (
 /obj/machinery/bioprinter/stocked,
 /obj/structure/disposalpipe/segment/corner{
@@ -17868,10 +16593,6 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
-"uEU" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "uFV" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/faxmachine,
@@ -17879,10 +16600,6 @@
 	dir = 4
 	},
 /area/mainship/medical/upper_medical)
-"uGh" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "uGq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18189,10 +16906,6 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"uZJ" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship,
-/area/space)
 "uZR" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/misc/paperbin{
@@ -18375,14 +17088,6 @@
 "vjE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
-"vkn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/space)
 "vkB" = (
 /obj/structure/prop/mainship/mapping_computer,
 /turf/open/floor/mainship/emerald{
@@ -18428,35 +17133,12 @@
 "vou" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
-"voL" = (
-/obj/structure/prop/mainship/mapping_computer,
-/turf/open/floor/mainship/emerald{
-	dir = 9
-	},
-/area/space)
 "voR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"vpm" = (
-/obj/structure/table/wood/fancy,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/effect/spawner/random/misc/paperbin{
-	pixel_y = 5
-	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/numbertwobunks)
-"vpD" = (
-/obj/structure/mirror{
-	dir = 4
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -18651,15 +17333,6 @@
 /obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
-"vDk" = (
-/obj/structure/bed/fancy,
-/obj/effect/landmark/start/job/fieldcommander,
-/obj/item/bedsheet/captain,
-/obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
-/turf/open/floor/carpet/side{
-	dir = 9
-	},
-/area/space)
 "vDr" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -18718,14 +17391,6 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
-"vHq" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "vHw" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 8
@@ -18799,12 +17464,6 @@
 	dir = 1
 	},
 /area/mainship/engineering/engineering_workshop)
-"vPh" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/side{
-	dir = 1
-	},
-/area/space)
 "vPk" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
@@ -18969,10 +17628,6 @@
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
-"wdG" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship,
-/area/space)
 "wej" = (
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
@@ -19110,10 +17765,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"wkZ" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "wml" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
@@ -19153,12 +17804,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"wnI" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "wnJ" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
@@ -19178,11 +17823,6 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
-"wql" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "wqq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -19309,10 +17949,6 @@
 "wuQ" = (
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"wuR" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship,
-/area/space)
 "wvV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -19628,11 +18264,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"wPw" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "wPV" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -19862,12 +18493,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"xct" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/space)
 "xdy" = (
 /obj/effect/landmark/start/job/ai,
 /obj/machinery/camera/autoname/mainship{
@@ -19910,15 +18535,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"xeE" = (
-/obj/machinery/holopad,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "xeM" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -19935,9 +18551,6 @@
 /mob/living/simple_animal/cat/martin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"xfP" = (
-/turf/closed/wall/mainship,
-/area/space)
 "xgv" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/camera/autoname/mainship,
@@ -19978,17 +18591,6 @@
 /obj/structure/showcase/coinpress,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"xiV" = (
-/obj/machinery/door/airlock/mainship/command/FCDRquarters,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "xjs" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -20158,6 +18760,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
+"xth" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "xtk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -20379,10 +18988,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"xBl" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship,
-/area/space)
 "xBM" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/vending/nanomed,
@@ -20516,10 +19121,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"xJn" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship,
-/area/mainship/living/numbertwobunks)
 "xKE" = (
 /obj/machinery/door/poddoor/railing{
 	id = "supply_elevator_railing"
@@ -20643,19 +19244,6 @@
 "xSw" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/evacuation)
-"xSy" = (
-/obj/machinery/door/airlock/mainship/command/FCDRoffice{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship,
-/area/mainship/living/numbertwobunks)
 "xSN" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -20846,10 +19434,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"xYO" = (
-/obj/machinery/marine_selector/gear/commander,
-/turf/open/space/basic,
-/area/space)
 "xZo" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -20941,12 +19525,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"ycO" = (
-/obj/machinery/photocopier,
-/turf/open/floor/mainship/blue{
-	dir = 9
-	},
-/area/mainship/living/numbertwobunks)
 "ydE" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -21089,12 +19667,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ylu" = (
-/obj/structure/prop/mainship/mapping_computer,
-/turf/open/floor/mainship/orange{
-	dir = 5
-	},
-/area/space)
 
 (1,1,1) = {"
 qVo
@@ -55685,7 +54257,7 @@ kMi
 dBu
 hhR
 wtv
-hhR
+xth
 heF
 mxT
 mxT
@@ -55942,7 +54514,7 @@ vmD
 nmm
 gqZ
 wNG
-nmm
+vmD
 rKm
 vmD
 vmD
@@ -56165,7 +54737,7 @@ swv
 wII
 vAn
 mhJ
-iQy
+vAn
 vAn
 vAn
 rAB
@@ -61541,14 +60113,14 @@ qVo
 qVo
 qVo
 qVo
-iKN
-lSB
-xfP
-hbw
 qVo
 qVo
-tPx
-myv
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -61798,14 +60370,14 @@ qVo
 qVo
 qVo
 qVo
-oLu
-lST
-xfP
-nLn
-bau
-txg
-iew
-dcv
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -62055,14 +60627,14 @@ qVo
 qVo
 qVo
 qVo
-xfP
-qgg
-xfP
-gxw
-hwj
-aKY
-tLY
-ljg
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -62314,12 +60886,12 @@ qVo
 qVo
 qVo
 qVo
-xfP
-uAI
-cXs
-bpr
-kYp
-sRN
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -62571,12 +61143,12 @@ qVo
 qVo
 qVo
 qVo
-xfP
-xfP
-xfP
-smG
-jPy
-xfP
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -62829,11 +61401,11 @@ qVo
 qVo
 qVo
 qVo
-jtB
-haj
-kaI
-elv
-uDs
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 hRh
 nWT
@@ -63083,14 +61655,14 @@ qVo
 qVo
 qVo
 qVo
-mXY
-jGM
-kZR
-aGW
-qSb
-qSb
-bCW
-aDk
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 dgj
 qpC
@@ -63340,14 +61912,14 @@ qVo
 qVo
 qVo
 qVo
-mXY
-mXY
-tXs
-czt
-rYi
-sBT
-dpU
-bMi
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -63599,12 +62171,12 @@ qVo
 qVo
 qVo
 qVo
-tXs
-dyP
-rYi
-jLH
-fIz
-mXY
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -67973,13 +66545,13 @@ qVo
 qVo
 qVo
 qVo
-uZJ
-fMS
-xfP
-xfP
-xfP
-pOo
-kbB
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -68230,13 +66802,13 @@ qVo
 qVo
 qVo
 qVo
-xfP
-xct
-ewU
-itc
-siu
-pyr
-kbB
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -68487,24 +67059,24 @@ qVo
 qVo
 qVo
 qVo
-xfP
-ocu
-jvM
-mpL
-mpL
-otv
-kbB
 qVo
 qVo
-urm
 qVo
-uZJ
-fMS
-xfP
-xfP
-xfP
-pOo
-kbB
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -68744,24 +67316,24 @@ qVo
 qVo
 qVo
 qVo
-xfP
-mpL
-xBl
-mpL
-ghr
-lJx
-kbB
 qVo
 qVo
 qVo
 qVo
-xBl
-xBl
-mpL
-mpL
-mpL
-siu
-ewU
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -69001,33 +67573,33 @@ qVo
 qVo
 qVo
 qVo
-ldb
-cKa
-fhJ
-mpL
-fhJ
-iht
-kbB
 qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
 qVo
-iKN
-lSB
-xfP
-hbw
-dSQ
-buQ
-tPx
-myv
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -69258,33 +67830,33 @@ qVo
 qVo
 qVo
 qVo
-xfP
-cJb
-syi
-mpL
-syi
-eCZ
-kbB
 qVo
 qVo
 qVo
 qVo
-pcN
-mpL
-mpL
-mpL
-mpL
-pcN
 qVo
 qVo
-oLu
-lST
-xfP
-nLn
-bau
-txg
-iew
-dcv
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -69515,33 +68087,33 @@ qVo
 qVo
 qVo
 qVo
-uZJ
-muR
-wdG
-mpL
-wdG
-mqJ
-kbB
 qVo
 qVo
 qVo
 qVo
-jHZ
-mpL
-mpL
-bGW
-mpL
-jHZ
 qVo
 qVo
-xfP
-qgg
-xfP
-gxw
-hwj
-aKY
-tLY
-ljg
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -69772,33 +68344,33 @@ qVo
 qVo
 qVo
 qVo
-xfP
-ooH
-jhA
-jhA
-jhA
-aIW
-kbB
 qVo
 qVo
 qVo
 qVo
-ecC
-mpL
-mpL
-mpL
-mpL
-ecC
 qVo
 qVo
-vDk
-gNy
-xfP
-uAI
-cXs
-bpr
-kYp
-sRN
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -70029,33 +68601,33 @@ qVo
 qVo
 qVo
 qVo
-xfP
-wuR
-qYX
-eDM
-lWn
-cKa
-kbB
 qVo
 qVo
 qVo
 qVo
-pcN
-mpL
-mpL
-mpL
-mpL
-pcN
 qVo
 qVo
-vPh
-mXG
-xfP
-xfP
-xfP
-smG
-jPy
-xfP
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -70286,33 +68858,33 @@ qVo
 qVo
 qVo
 qVo
-uZJ
-stt
-xfP
-xfP
-xfP
-fMS
-kbB
 qVo
 qVo
 qVo
 qVo
-jHZ
-mpL
-mpL
-bGW
-mpL
-jHZ
 qVo
 qVo
-rwt
-fbA
-dZo
-jtB
-haj
-kaI
-elv
-uDs
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -70529,16 +69101,6 @@ qVo
 qVo
 qVo
 qVo
-uZJ
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-uZJ
 qVo
 qVo
 qVo
@@ -70554,22 +69116,32 @@ qVo
 qVo
 qVo
 qVo
-ecC
-mpL
-mpL
-mpL
-mpL
-ecC
 qVo
 qVo
-mXY
-jGM
-kZR
-aGW
-qSb
-qSb
-bCW
-aDk
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -70786,16 +69358,6 @@ qVo
 qVo
 qVo
 qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -70811,22 +69373,32 @@ qVo
 qVo
 qVo
 qVo
-xYO
-mpL
-mpL
-mpL
-mpL
-mpL
 qVo
 qVo
-mXY
-mXY
-tXs
-czt
-rYi
-sBT
-dpU
-bMi
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -71043,16 +69615,6 @@ qVo
 qVo
 qVo
 qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qxq
 qVo
 qVo
 qVo
@@ -71068,22 +69630,32 @@ qVo
 qVo
 qVo
 qVo
-qBv
-mpL
-mpL
-mpL
-mpL
-mpL
 qVo
 qVo
-seN
-amc
-tXs
-dyP
-rYi
-jLH
-fIz
-mXY
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -71300,7 +69872,6 @@ qVo
 qVo
 qVo
 qVo
-xfP
 qVo
 qVo
 qVo
@@ -71309,7 +69880,8 @@ qVo
 qVo
 qVo
 qVo
-fRH
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -71557,16 +70129,6 @@ qVo
 qVo
 qVo
 qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qxq
 qVo
 qVo
 qVo
@@ -71590,14 +70152,24 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -71781,49 +70353,6 @@ qVo
 qVo
 qVo
 qVo
-xJn
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-xJn
-qVo
-wPw
-rUF
-rUF
-rUF
-iHm
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -71847,14 +70376,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -72038,49 +70610,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-jaA
-hRK
-uyy
-ycO
-kNK
-kPH
-lIU
-jsl
-uyy
-qVo
-wnI
-pyG
-vpD
-rrh
-nLu
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -72104,14 +70633,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -72295,49 +70867,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-feU
-ujQ
-uyy
-edp
-alP
-gUJ
-pRo
-lFo
-dZY
-qVo
-dJU
-rHh
-cPg
-cPg
-kdF
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -72361,14 +70890,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -72552,49 +71124,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-uyy
-wql
-uyy
-oKm
-qUg
-vpm
-gwK
-tIy
-xSy
-qVo
-cPg
-wkZ
-cPg
-vVG
-sSA
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -72618,14 +71147,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -72809,49 +71381,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-uNy
-hGq
-uyy
-gcI
-kTn
-dcJ
-mif
-tIU
-dZY
-qVo
-mNM
-xWS
-cPg
-xWS
-bAS
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
 qVo
 qVo
 qVo
@@ -72875,14 +71404,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -73066,49 +71638,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-iJy
-eCk
-uyy
-uyy
-uyy
-iaf
-xiV
-uyy
-uyy
-qVo
-iVT
-eMz
-cPg
-eMz
-bpz
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-xfP
-uZJ
 qVo
 qVo
 qVo
@@ -73132,14 +71661,57 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -73323,22 +71895,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-hpS
-lHu
-faC
-mTH
-jzh
-bCZ
-dxc
-emh
-uyy
-qVo
-qEt
-uGh
-cPg
-uGh
-uxI
 qVo
 qVo
 qVo
@@ -73389,14 +71945,30 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -73580,22 +72152,6 @@ qVo
 qVo
 qVo
 qVo
-uyy
-tzF
-dYs
-qKf
-sQz
-keK
-keK
-hPR
-rZM
-uyy
-qVo
-vHq
-kpn
-kpn
-kpn
-gUo
 qVo
 qVo
 qVo
@@ -73646,14 +72202,30 @@ qVo
 qVo
 qVo
 qVo
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
-mpL
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -73837,22 +72409,22 @@ qVo
 qVo
 qVo
 qVo
-uyy
-tzF
-tzF
-aPJ
-rtj
-ivw
-oFH
-uEU
-qVS
-uyy
 qVo
-dBi
-aKr
-rBJ
-pfV
-mNM
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -74094,22 +72666,22 @@ qVo
 qVo
 qVo
 qVo
-uyy
-dQS
-vFb
-aPJ
-jmC
-ivw
-bIl
-lrc
-tzF
-uyy
 qVo
-gYL
-rUF
-rUF
-rUF
-wPw
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -74351,22 +72923,22 @@ qVo
 qVo
 qVo
 qVo
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-xJn
 qVo
-ehw
-xeE
-qLW
-lkH
-nId
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -74657,11 +73229,11 @@ qVo
 qVo
 qVo
 qVo
-gBS
-shP
-pBn
-eEV
-eEV
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -74914,11 +73486,11 @@ qVo
 qVo
 qVo
 qVo
-ylu
-dlh
-eCH
-pir
-vkn
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -75171,11 +73743,11 @@ qVo
 qVo
 qVo
 qVo
-oyX
-eEV
-noA
-eEV
-eEV
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -75428,11 +74000,11 @@ qVo
 qVo
 qVo
 qVo
-pir
-pir
-iwn
-fhu
-tOi
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -75685,11 +74257,11 @@ qVo
 qVo
 qVo
 qVo
-qXL
-qXL
-asG
-eYO
-jXK
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -75942,11 +74514,11 @@ qVo
 qVo
 qVo
 qVo
-jmK
-eEV
-nSg
-oHC
-eEV
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -76199,11 +74771,11 @@ qVo
 qVo
 qVo
 qVo
-voL
-dFq
-oRo
-kdG
-nAw
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -76456,11 +75028,11 @@ qVo
 qVo
 qVo
 qVo
-hSU
-jka
-lfP
-aSP
-aDd
+qVo
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11059,6 +11059,7 @@
 	dir = 1
 	},
 /obj/machinery/marine_selector/gear/commander,
+/obj/item/minimap_tablet,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nIr" = (
@@ -18959,10 +18960,6 @@
 	name = "Requisitions lockdown";
 	pixel_x = 6;
 	pixel_y = 2
-	},
-/obj/item/minimap_tablet{
-	pixel_x = 9;
-	pixel_y = 5
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3861,7 +3861,6 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "eNP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -16,6 +16,12 @@
 	dir = 6
 	},
 /area/mainship/living/pilotbunks)
+"acl" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "acn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -140,11 +146,13 @@
 /obj/machinery/door/window/secure/bridge,
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
-"alz" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/black{
-	dir = 1
+"alq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/smart,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "alH" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -160,6 +168,14 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"amc" = (
+/obj/structure/table/wood/fancy,
+/obj/item/book/codebook,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "amE" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
@@ -260,6 +276,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"asG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "atc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -401,6 +425,14 @@
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"aDd" = (
+/mob/living/simple_animal/corgi/ian,
+/turf/open/floor/mainship/mono,
+/area/space)
+"aDk" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/wood,
+/area/space)
 "aDz" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black{
@@ -472,6 +504,13 @@
 /obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"aGW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/space)
 "aGZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -510,6 +549,10 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
+"aIW" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship,
+/area/space)
 "aJb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -541,6 +584,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
+"aJV" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "aKj" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/landinglight/cas{
@@ -573,11 +620,23 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"aKY" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/obj/effect/spawner/random/misc/paperbin{
+	pixel_y = 5
+	},
+/obj/item/tool/pen,
+/turf/open/floor/mainship/floor,
+/area/space)
 "aLA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/sign/poster{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "aLV" = (
@@ -590,6 +649,16 @@
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
+/area/mainship/squads/general)
+"aMp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/sign/poster,
+/obj/machinery/camera/autoname/mainship{
+	dir = 10
+	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "aME" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -612,13 +681,11 @@
 "aNR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "aOM" = (
@@ -720,6 +787,10 @@
 "aSJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"aSP" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "aSV" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -781,6 +852,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"aWF" = (
+/obj/effect/soundplayer/deltaplayer,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "aXc" = (
 /obj/structure/toilet{
 	dir = 1
@@ -862,6 +937,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"bau" = (
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/mainship/floor,
+/area/space)
 "bax" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/wrench,
@@ -1075,6 +1154,16 @@
 "bpc" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
+"bpr" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/space)
 "bpz" = (
 /obj/machinery/light/mainship,
 /obj/effect/ai_node,
@@ -1153,6 +1242,13 @@
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"buQ" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/marine_card,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/space)
 "buS" = (
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
@@ -1170,6 +1266,15 @@
 	dir = 9
 	},
 /turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"bvM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/mainship/hull/lower_hull)
 "bxv" = (
 /turf/open/floor/mainship/sterile/side,
@@ -1288,6 +1393,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
+"bCW" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/space)
 "bCZ" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/wood,
@@ -1391,6 +1506,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
+"bGW" = (
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
+/turf/open/floor/mainship,
+/area/space)
+"bHF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "bIl" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -1402,6 +1533,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"bJB" = (
+/obj/machinery/marine_selector/clothes/leader,
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "bKn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -1446,6 +1584,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"bMi" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/wood,
+/area/space)
 "bMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1510,15 +1652,6 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
-"bOF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "bOX" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
@@ -1563,6 +1696,17 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/lower_engineering)
+"bRc" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "bRC" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -1574,6 +1718,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bSi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "bSp" = (
 /obj/structure/cable,
 /turf/open/floor/mainship,
@@ -1590,16 +1741,16 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
-"bTe" = (
-/obj/effect/turf_decal/warning_stripes/engineer,
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/turf/open/floor/mainship/black{
+"bTj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "bTo" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/bottle/patron,
@@ -1734,11 +1885,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"cdz" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+"cef" = (
+/obj/structure/table/mainship/nometal,
+/obj/effect/spawner/random/food_or_drink/sugary_snack,
+/obj/effect/spawner/random/food_or_drink/bread,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "cei" = (
 /obj/structure/disposalpipe/segment,
@@ -2004,6 +2155,13 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"czt" = (
+/obj/structure/table/wood/fancy,
+/obj/item/newspaper,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/item/reagent_containers/food/drinks/milk,
+/turf/open/floor/wood,
+/area/space)
 "czx" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -2045,6 +2203,17 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"cBw" = (
+/obj/machinery/door/airlock/mainship/command/FCDRquarters,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "cBW" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/camera_advanced/overwatch/charlie,
@@ -2132,6 +2301,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"cJb" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow,
+/area/space)
+"cKa" = (
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "cLc" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -2293,6 +2477,17 @@
 /obj/item/stack/sheet/glass/glass/large_stack,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"cSy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
+"cSz" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/mainship/living/numbertwobunks)
 "cSX" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -2364,6 +2559,16 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
+"cXs" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/space)
 "cYi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -2446,6 +2651,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"dcv" = (
+/turf/open/floor/mainship/blue,
+/area/space)
 "dcz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -2590,6 +2798,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"diF" = (
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 5
+	},
+/area/mainship/squads/general)
 "diW" = (
 /obj/docking_port/stationary/escape_pod/right{
 	dir = 2
@@ -2637,6 +2853,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"dlh" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/space)
 "dlz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile,
@@ -2701,15 +2926,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"dnf" = (
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mainship/shipboard/firing_range)
 "dnw" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/squadmarine,
@@ -2744,6 +2960,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"dpU" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/space)
 "dpY" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -2864,6 +3084,15 @@
 	},
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
+"dyP" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/cigar,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_y = 5
+	},
+/obj/item/storage/box/matches,
+/turf/open/floor/wood,
+/area/space)
 "dzr" = (
 /obj/machinery/air_alarm{
 	dir = 8
@@ -2918,6 +3147,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dFq" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/mainship/emerald{
+	dir = 8
+	},
+/area/space)
 "dFt" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -2953,12 +3191,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "dIf" = (
@@ -2971,6 +3203,19 @@
 	dir = 5
 	},
 /area/mainship/medical/lower_medical)
+"dIo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/box/small,
+/obj/effect/turf_decal/warning_stripes/smartgunner,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "dIH" = (
 /obj/machinery/atm,
 /turf/closed/wall/mainship,
@@ -3088,6 +3333,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"dPp" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "dQG" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_one)
@@ -3112,6 +3361,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"dSQ" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/security/marinemainship_network,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/space)
 "dST" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck,
@@ -3224,6 +3483,19 @@
 	dir = 1
 	},
 /area/mainship/shipboard/firing_range)
+"dZo" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/briefcase,
+/obj/item/clothing/head/bowlerhat{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/weapon/cane{
+	pixel_x = 5
+	},
+/obj/item/binoculars,
+/turf/open/floor/wood,
+/area/space)
 "dZY" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/poddoor/shutters/mainship/fc_office{
@@ -3270,6 +3542,10 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ecC" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship/mono,
+/area/space)
 "ecW" = (
 /obj/machinery/researchcomp,
 /obj/machinery/researchcomp,
@@ -3446,6 +3722,11 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"ekh" = (
+/obj/machinery/marine_selector/gear/smartgun,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "ekk" = (
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
@@ -3485,6 +3766,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"elv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "elQ" = (
 /obj/structure/sign/poster,
 /turf/open/floor/mainship/yellow_cargo,
@@ -3581,6 +3871,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"ewU" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship,
+/area/space)
 "exv" = (
 /obj/machinery/door/poddoor/mainship/mech{
 	dir = 1
@@ -3705,15 +3999,22 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"eDg" = (
-/obj/structure/cable,
-/obj/structure/sign/securearea/firingrange{
+"eCH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/space)
+"eCZ" = (
+/obj/machinery/light/mainship,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/cargo/arrow{
 	dir = 1
 	},
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
-/area/mainship/squads/general)
+/area/space)
 "eDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3722,11 +4023,23 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"eDM" = (
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship,
+/area/space)
 "eEb" = (
 /obj/machinery/door/airlock/mainship/research/glass/cell/cell1,
 /obj/machinery/door/poddoor/shutters/mainship/cell/cell1,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"eEV" = (
+/turf/open/floor/mainship/mono,
+/area/space)
+"eEZ" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/security/marinemainship_network,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "eFh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -3869,6 +4182,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"eNP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
 "eOG" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/cell_charger,
@@ -3976,6 +4301,13 @@
 	dir = 6
 	},
 /area/mainship/medical/lower_medical)
+"eWu" = (
+/obj/machinery/loadout_vendor,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "eWJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -4010,6 +4342,17 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
+"eYO" = (
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/obj/structure/window/reinforced/toughened{
+	dir = 4
+	},
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/communications,
+/turf/open/floor/plating/mainship,
+/area/space)
 "eZd" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/mainship/mono,
@@ -4069,6 +4412,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
+"fbA" = (
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
+/area/space)
 "fbC" = (
 /obj/structure/window/reinforced,
 /obj/item/clothing/shoes/marine/som,
@@ -4193,6 +4541,20 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
+"fhu" = (
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/obj/structure/window/reinforced/toughened{
+	dir = 8
+	},
+/obj/machinery/computer/camera_advanced/overwatch/main,
+/turf/open/floor/plating/mainship,
+/area/space)
+"fhJ" = (
+/obj/machinery/marine_selector/gear/leader,
+/turf/open/floor/mainship,
+/area/space)
 "fiq" = (
 /obj/structure/closet/secure_closet/pilot_officer,
 /obj/effect/ai_node,
@@ -4271,13 +4633,6 @@
 /obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/brig)
-"foj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "fol" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/ntlogo/nt2,
@@ -4329,6 +4684,13 @@
 /obj/structure/sign/prop4,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"fqj" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "fqs" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/machinery/keycard_auth,
@@ -4508,6 +4870,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"fAy" = (
+/obj/structure/table/mainship/nometal,
+/obj/effect/spawner/random/food_or_drink/sugary_snack,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "fAJ" = (
 /turf/closed/wall/mainship,
 /area/crew_quarters/toilet)
@@ -4674,6 +5041,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"fHj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "fHl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4710,6 +5083,12 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"fIz" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "fJI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -4729,6 +5108,13 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
+"fKo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fKK" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/floor,
@@ -4768,6 +5154,11 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"fMS" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/sl,
+/turf/open/floor/mainship,
+/area/space)
 "fNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4798,6 +5189,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"fPK" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "fQp" = (
 /obj/structure/prop/mainship/name_stencil/C,
 /turf/open/floor/mainship_hull,
@@ -4806,9 +5204,29 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
+"fQR" = (
+/obj/structure/sign/pods,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "fRw" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"fRH" = (
+/obj/machinery/door/airlock/mainship/command/FCDRoffice{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship,
+/area/space)
 "fSq" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -5093,6 +5511,10 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ghr" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship,
+/area/space)
 "ghV" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
@@ -5296,6 +5718,27 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
+"gqZ" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
+"gsd" = (
+/obj/structure/disposalpipe/segment/corner,
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/box/small,
+/obj/effect/turf_decal/warning_stripes/smartgunner,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "gsj" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -5365,6 +5808,15 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/numbertwobunks)
+"gxw" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/space)
 "gxL" = (
 /obj/machinery/marine_selector/clothes/engi,
 /turf/open/floor/mainship,
@@ -5406,6 +5858,19 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
+"gBS" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/security/marinemainship{
+	dir = 8;
+	pixel_x = -17
+	},
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange{
+	dir = 9
+	},
+/area/space)
 "gCk" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/orange{
@@ -5418,12 +5883,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"gCy" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 6
-	},
-/area/mainship/squads/general)
 "gES" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -5431,6 +5890,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"gFh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "gFW" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship,
@@ -5529,6 +5994,11 @@
 	dir = 5
 	},
 /area/mainship/medical/lower_medical)
+"gNy" = (
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
+/area/space)
 "gPi" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -5697,6 +6167,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"gYa" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
+/area/mainship/living/numbertwobunks)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
@@ -5735,11 +6211,21 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"haj" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/space)
 "hap" = (
 /obj/structure/rack,
 /obj/item/frame/table/gambling,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"hbw" = (
+/obj/machinery/photocopier,
+/turf/open/floor/mainship/blue{
+	dir = 9
+	},
+/area/space)
 "hcb" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -5817,6 +6303,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -5835,7 +6322,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "hiq" = (
@@ -5896,11 +6382,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
-"hmH" = (
-/obj/machinery/light/mainship,
-/obj/structure/sign/prop1,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "hmO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -5948,6 +6429,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"hoq" = (
+/obj/structure/cable,
+/obj/structure/sign/securearea/firingrange{
+	dir = 1
+	},
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "hoB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -5962,6 +6453,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
+"hoR" = (
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "hpx" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -6005,15 +6505,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
-"htr" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/squads/general)
 "htZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -6039,12 +6530,22 @@
 	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
+"hvS" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "hvY" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/white{
 	dir = 5
 	},
 /area/mainship/living/pilotbunks)
+"hwj" = (
+/turf/open/floor/mainship/floor,
+/area/space)
 "hwp" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -6379,6 +6880,19 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
+"hSU" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/machinery/computer/security/marinemainship{
+	dir = 4;
+	pixel_x = 17
+	},
+/turf/open/floor/mainship/emerald{
+	dir = 5
+	},
+/area/space)
 "hSX" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -6451,6 +6965,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"hWC" = (
+/obj/machinery/camera/autoname/mainship,
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "hWO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
@@ -6548,6 +7069,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
+"iew" = (
+/obj/structure/bed/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/space)
 "ieX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -6585,6 +7112,14 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"iht" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "ihU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -6737,7 +7272,7 @@
 "isJ" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
-	dir = 9
+	dir = 8
 	},
 /area/mainship/squads/general)
 "isK" = (
@@ -6749,6 +7284,12 @@
 "isR" = (
 /turf/open/floor/wood,
 /area/mainship/living/mechpilotquarters)
+"itc" = (
+/obj/structure/mirror{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/space)
 "its" = (
 /obj/machinery/bot/roomba,
 /turf/open/floor/mainship,
@@ -6789,16 +7330,36 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"iwe" = (
+/turf/open/floor/plating,
+/area/mainship/hull/lower_hull)
 "iwj" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"iwn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
+/turf/open/floor/mainship/mono,
+/area/space)
 "iws" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
+"ixx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
 "ixz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6849,6 +7410,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/boxingring)
+"iBL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "iCT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6969,6 +7538,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"iIT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -7005,6 +7585,16 @@
 	},
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/command/corporateliaison)
+"iKN" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/window,
+/obj/structure/window/reinforced/tinted,
+/obj/item/tool/soap/nanotrasen,
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "iLf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -7076,6 +7666,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"iQy" = (
+/obj/machinery/computer/squad_manager,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "iRM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -7312,13 +7906,6 @@
 	dir = 8
 	},
 /area/mainship/living/pilotbunks)
-"jeQ" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "jfQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7331,6 +7918,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"jhA" = (
+/obj/structure/bed/chair/nometal{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/space)
 "jhK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/floor,
@@ -7362,6 +7955,13 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"jka" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/camera_advanced/overwatch/charlie,
+/turf/open/floor/mainship/emerald{
+	dir = 4
+	},
+/area/space)
 "jkK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
@@ -7394,6 +7994,11 @@
 /obj/item/storage/box/matches,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"jmK" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/squad_changer,
+/turf/open/floor/mainship/mono,
+/area/space)
 "joi" = (
 /obj/machinery/door/poddoor/mainship/mech{
 	dir = 1
@@ -7464,6 +8069,14 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"jtB" = (
+/obj/machinery/marine_selector/gear/commander,
+/turf/open/floor/wood,
+/area/space)
+"jvM" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship,
+/area/space)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -7615,6 +8228,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"jGM" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/space)
 "jHd" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
@@ -7637,6 +8254,10 @@
 "jHU" = (
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
+"jHZ" = (
+/obj/machinery/marine_selector/gear/leader,
+/turf/open/floor/mainship/mono,
+/area/space)
 "jIc" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -7670,6 +8291,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"jLH" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
 "jLS" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/hexagon,
@@ -7711,6 +8338,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"jOQ" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "jOS" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 1
@@ -7729,6 +8362,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"jPy" = (
+/obj/machinery/door/airlock/mainship/command/FCDRquarters,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
+/area/space)
 "jPT" = (
 /obj/effect/ai_node,
 /obj/structure/curtain/medical{
@@ -7774,6 +8418,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"jTU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/smart,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "jTZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -7853,20 +8505,16 @@
 	dir = 5
 	},
 /area/mainship/command/self_destruct)
+"jXK" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/door/window/secure/bridge,
+/turf/open/floor/plating/mainship,
+/area/space)
 "jXN" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
-"jXW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "jZZ" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/floor,
@@ -7877,6 +8525,10 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"kaI" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/space)
 "kbe" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -7897,6 +8549,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"kbB" = (
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
+	},
+/turf/closed/wall/mainship,
+/area/space)
 "kbE" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -7927,6 +8585,13 @@
 /obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
+"kdD" = (
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "kdF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7936,6 +8601,12 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"kdG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
+/area/space)
 "keK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8095,9 +8766,6 @@
 	},
 /area/mainship/shipboard/firing_range)
 "ksd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 4
@@ -8395,6 +9063,10 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
+"kHp" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "kHN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -8709,6 +9381,17 @@
 	dir = 1
 	},
 /area/mainship/command/airoom)
+"kYp" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/space)
 "kYt" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/misc/cigarettes,
@@ -8743,6 +9426,10 @@
 /obj/structure/ship_ammo/cas/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"kZR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/wood,
+/area/space)
 "lal" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/lower_engineering)
@@ -8777,6 +9464,10 @@
 "lcL" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"ldb" = (
+/obj/structure/noticeboard,
+/turf/closed/wall/mainship,
+/area/space)
 "ldA" = (
 /obj/machinery/processor{
 	pixel_y = 5
@@ -8824,6 +9515,19 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
+"lfH" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
+"lfP" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/keycard_auth,
+/turf/open/floor/mainship/emerald{
+	dir = 4
+	},
+/area/space)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -8897,6 +9601,15 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
+"ljg" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/space)
 "ljh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -9140,13 +9853,6 @@
 	dir = 5
 	},
 /area/mainship/living/commandbunks)
-"lvr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "lvw" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -9449,6 +10155,16 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/living/chapel)
+"lJx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/space)
 "lJE" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
@@ -9607,14 +10323,35 @@
 /obj/machinery/tank_part_fabricator,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
+"lSq" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "lSr" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
+"lSB" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/space)
 "lSQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"lST" = (
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/space)
 "lSY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9671,15 +10408,7 @@
 /area/mainship/medical/lower_medical)
 "lTQ" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lUP" = (
@@ -9713,6 +10442,13 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"lWn" = (
+/obj/structure/table/mainship,
+/obj/item/folder/white,
+/obj/item/pizzabox,
+/obj/item/whistle,
+/turf/open/floor/mainship,
+/area/space)
 "lWz" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -9868,6 +10604,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
+"mhJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "mia" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -9891,6 +10637,12 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
+"miU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "mjl" = (
 /obj/machinery/vending,
 /turf/open/floor/mainship/floor,
@@ -9927,6 +10679,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
+"mnb" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "mng" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating,
@@ -9995,6 +10754,9 @@
 /obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"mpL" = (
+/turf/open/floor/mainship,
+/area/space)
 "mqD" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -10002,6 +10764,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_garden)
+"mqJ" = (
+/obj/structure/sign/poster,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "mqK" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
@@ -10034,6 +10802,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"muR" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "muT" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -10114,6 +10890,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"myv" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
+/area/space)
 "mzh" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -10412,6 +11196,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
+"mRy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "mRL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -10517,6 +11311,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"mXG" = (
+/turf/open/floor/carpet/side,
+/area/space)
 "mXM" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -10536,6 +11333,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"mXY" = (
+/turf/open/floor/wood,
+/area/space)
 "mZS" = (
 /turf/open/floor/mainship/black/full,
 /area/mainship/command/self_destruct)
@@ -10566,6 +11366,13 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"ncg" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "ncF" = (
 /obj/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/mainship/mono,
@@ -10657,6 +11464,14 @@
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"ngh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "ngO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10828,6 +11643,12 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"noA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/space)
 "npN" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
@@ -10850,6 +11671,13 @@
 	},
 /turf/open/shuttle/escapepod/zero,
 /area/mainship/command/self_destruct)
+"nsl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "nsC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -10902,9 +11730,6 @@
 /area/mainship/medical/upper_medical)
 "nwt" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
-/obj/structure/sign/securearea/firingrange{
-	dir = 1
-	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nwy" = (
@@ -10998,6 +11823,13 @@
 	dir = 8
 	},
 /area/mainship/medical/upper_medical)
+"nAw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/space)
 "nAM" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -11032,12 +11864,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nDP" = (
@@ -11111,6 +11937,13 @@
 /obj/effect/landmark/start/job/pilotofficer,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"nIn" = (
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/obj/machinery/marine_selector/gear/commander,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "nIr" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -11146,6 +11979,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
+"nLn" = (
+/obj/structure/filingcabinet,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/space)
 "nLu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11160,10 +12000,6 @@
 /obj/item/tool/soap,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/upper_medical)
-"nMA" = (
-/obj/structure/mirror,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "nMG" = (
 /obj/machinery/vending/tool,
 /obj/structure/closet/walllocker/hydrant/extinguisher{
@@ -11260,6 +12096,13 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
+"nSg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "nSH" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
@@ -11423,6 +12266,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"ocu" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "ocE" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/side,
@@ -11433,20 +12282,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"ocY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment/corner,
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/smartgunner,
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "oda" = (
 /obj/structure/sink{
 	dir = 1
@@ -11560,9 +12395,14 @@
 /obj/item/clothing/under/som,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"oop" = (
-/turf/open/floor/plating,
-/area/mainship/shipboard/firing_range)
+"ooH" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "ooM" = (
 /obj/item/folder/black_random,
 /obj/item/tool/hand_labeler,
@@ -11586,22 +12426,6 @@
 /obj/structure/sign/safety/cryogenic,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"oqS" = (
-/obj/machinery/marine_selector/gear/engi,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"orf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/smart,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "orm" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 1
@@ -11654,6 +12478,15 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
+"otv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/space)
 "ouq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -11705,6 +12538,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"oyX" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/mainship/mono,
+/area/space)
 "oyZ" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/side,
@@ -11826,6 +12664,10 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
+"oHC" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/space)
 "oHV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11872,6 +12714,13 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"oIT" = (
+/obj/machinery/marine_selector/gear/engi,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "oJs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11894,6 +12743,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"oLu" = (
+/obj/structure/mirror,
+/obj/structure/sink,
+/turf/open/floor/mainship/mono,
+/area/space)
 "oNh" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -11981,6 +12835,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"oRo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/emerald{
+	dir = 8
+	},
+/area/space)
 "oRM" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4
@@ -12120,16 +12983,6 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
-"pak" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "paw" = (
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /obj/item/paper/memorial,
@@ -12192,6 +13045,10 @@
 	},
 /turf/open/floor/cult,
 /area/medical/morgue)
+"pcN" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/mono,
+/area/space)
 "pcQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -12324,6 +13181,10 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
+"pir" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/space)
 "pjB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12450,15 +13311,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
-"ppB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "ppG" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
@@ -12522,7 +13374,6 @@
 "psq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
@@ -12605,6 +13456,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"pyr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/space)
 "pyG" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship,
@@ -12660,6 +13517,16 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"pBn" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/keycard_auth,
+/obj/item/radio{
+	pixel_x = 6
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/space)
 "pCd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -12689,6 +13556,11 @@
 "pEN" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_two)
+"pEQ" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/engi,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "pFn" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -12715,13 +13587,6 @@
 /area/mainship/engineering/engine_core)
 "pGb" = (
 /turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
-"pGn" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pHl" = (
 /obj/structure/cable,
@@ -12885,6 +13750,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"pOo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/sl,
+/turf/open/floor/mainship,
+/area/space)
 "pOy" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 1
@@ -12952,10 +13825,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/numbertwobunks)
-"pSf" = (
-/obj/structure/window/framed/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "pSt" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
@@ -12968,13 +13837,6 @@
 "pSV" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/mechpilotquarters)
-"pSX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/black{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "pTj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13007,7 +13869,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/black{
-	dir = 5
+	dir = 4
 	},
 /area/mainship/squads/general)
 "pVr" = (
@@ -13181,6 +14043,11 @@
 /obj/machinery/power/apc,
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
+"qgg" = (
+/obj/machinery/door/airlock/mainship/generic/bathroom,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
+/area/space)
 "qha" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/boxingring)
@@ -13410,6 +14277,13 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
+"qxq" = (
+/obj/structure/window/framed/mainship,
+/obj/machinery/door/poddoor/shutters/mainship/fc_office{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/space)
 "qxw" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -13423,6 +14297,12 @@
 	dir = 1
 	},
 /area/mainship/shipboard/firing_range)
+"qyx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "qyE" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13500,6 +14380,10 @@
 /obj/effect/landmark/start/job/cmo,
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
+"qBv" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/mainship,
+/area/space)
 "qDh" = (
 /obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /turf/open/floor/mainship/sterile/dark,
@@ -13525,13 +14409,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"qFl" = (
-/obj/machinery/air_alarm{
-	dir = 1
-	},
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "qFQ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -13616,15 +14493,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"qIG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "qJz" = (
 /obj/structure/bed/stool,
 /turf/open/floor/mainship/mono,
@@ -13774,6 +14642,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"qQf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
 "qQk" = (
 /obj/machinery/light/mainship/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -13827,6 +14704,11 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
+"qSb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/space)
 "qST" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13868,6 +14750,17 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"qVH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "qVS" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/wood,
@@ -13923,6 +14816,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"qXL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
+"qYX" = (
+/obj/machinery/computer/squad_manager,
+/turf/open/floor/mainship,
+/area/space)
 "qZw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14232,6 +15134,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"rwt" = (
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/space)
 "rwK" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14261,6 +15168,13 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"ryY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/mainship/marine/general/sl{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "rzd" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/camera/autoname/mainship,
@@ -14439,11 +15353,13 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"rJe" = (
-/obj/machinery/firealarm{
-	dir = 1
+"rIt" = (
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black{
+	dir = 9
+	},
 /area/mainship/squads/general)
 "rKk" = (
 /obj/structure/cable,
@@ -14476,6 +15392,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"rNX" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "rOr" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
@@ -14560,6 +15481,10 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"rSW" = (
+/obj/item/plantable_flag,
+/turf/open/floor/carpet/side,
+/area/mainship/living/numbertwobunks)
 "rTr" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -14571,6 +15496,7 @@
 /area/mainship/hull/lower_hull)
 "rUm" = (
 /obj/structure/prop/mainship/name_stencil/M,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
@@ -14649,6 +15575,12 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
+"rYi" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
 "rYr" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship,
@@ -14776,6 +15708,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"seN" = (
+/obj/structure/table/wood/fancy,
+/obj/item/megaphone,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/item/clothing/head/ornamented_cap,
+/turf/open/floor/wood,
+/area/space)
 "sfz" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -14815,15 +15756,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"shP" = (
+/obj/machinery/computer/camera_advanced/overwatch/bravo,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/space)
 "sid" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"siu" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship,
+/area/space)
 "sjV" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
+"sjY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "skU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -14843,6 +15800,10 @@
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/mainship,
 /area/mainship/engineering/ce_room)
+"smG" = (
+/obj/machinery/door_control/mainship/fc_shutters,
+/turf/closed/wall/mainship,
+/area/space)
 "snm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14934,6 +15895,12 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"stt" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/sl,
+/obj/structure/sign/goldenplaque,
+/turf/open/floor/mainship,
+/area/space)
 "suU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -14994,22 +15961,15 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"syi" = (
+/turf/open/floor/mainship/yellow_cargo,
+/area/space)
 "syt" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"syD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "syR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15079,6 +16039,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"sBT" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/wood,
+/area/space)
 "sCk" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -15154,6 +16118,12 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
+"sGk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "sGA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -15185,6 +16155,14 @@
 	dir = 6
 	},
 /area/mainship/living/briefing)
+"sKv" = (
+/obj/structure/table/wood/fancy,
+/obj/item/megaphone,
+/obj/item/clothing/head/ornamented_cap,
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/mainship/living/numbertwobunks)
 "sKH" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/yellow_cargo,
@@ -15202,6 +16180,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/port_atmos)
+"sMn" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "sMF" = (
 /obj/vehicle/ridden/powerloader,
 /obj/machinery/light/mainship{
@@ -15246,6 +16228,18 @@
 /obj/machinery/fuelcell_recycler,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"sRN" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
+/area/space)
 "sRP" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/keycard_auth,
@@ -15302,12 +16296,9 @@
 /area/mainship/hallways/hangar)
 "sUT" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/black{
-	dir = 5
+	dir = 4
 	},
 /area/mainship/squads/general)
 "sVc" = (
@@ -15424,9 +16415,7 @@
 "tdE" = (
 /obj/machinery/vending/nanomed,
 /obj/structure/cable,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "teh" = (
 /obj/structure/window/framed/mainship/hull,
@@ -15591,6 +16580,13 @@
 	dir = 1
 	},
 /area/mainship/engineering/ce_room)
+"tpi" = (
+/obj/machinery/light/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "tpo" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/surgical_tray,
@@ -15707,6 +16703,10 @@
 /turf/closed/shuttle/ert/engines/left/two{
 	dir = 1
 	},
+/area/space)
+"txg" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/mainship/floor,
 /area/space)
 "txW" = (
 /obj/docking_port/stationary/ert_big,
@@ -16009,6 +17009,19 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"tLY" = (
+/obj/structure/bed/chair/comfy{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/floor,
+/area/space)
 "tMy" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -16044,6 +17057,42 @@
 	dir = 1
 	},
 /area/mainship/medical/chemistry)
+"tOi" = (
+/obj/structure/window/reinforced/toughened{
+	dir = 8
+	},
+/obj/structure/table/mainship/nometal,
+/obj/machinery/door_control/old/cic{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/machinery/door_control/old/cic/armory{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/obj/machinery/light/mainship,
+/obj/machinery/door_control/old/cic/hangar_shutters{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/door_control/old/medbay{
+	id = "Medbay";
+	name = "Medbay Lockdown";
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/machinery/door_control/old{
+	id = "ROlobby";
+	name = "Requisitions lockdown";
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/minimap_tablet{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/space)
 "tOm" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/mainship/orange/full,
@@ -16069,6 +17118,15 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"tPx" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/space)
 "tQa" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -16223,6 +17281,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"tXs" = (
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/space)
 "tXB" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -16232,20 +17294,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "tXD" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
+/area/mainship/squads/general)
+"tXJ" = (
+/obj/machinery/marine_selector/clothes/smartgun,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "tXZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -16482,6 +17541,14 @@
 /obj/machinery/computer/ordercomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"unO" = (
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "unX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -16553,6 +17620,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"urm" = (
+/obj/machinery/computer/squad_manager,
+/turf/open/space/basic,
+/area/space)
 "urD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16695,6 +17766,15 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"uAI" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/item/plantable_flag,
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
+/area/space)
 "uBn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16768,6 +17848,10 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"uDs" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/wood,
+/area/space)
 "uDQ" = (
 /obj/machinery/bioprinter/stocked,
 /obj/structure/disposalpipe/segment/corner{
@@ -17048,6 +18132,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
+"uVF" = (
+/obj/machinery/loadout_vendor,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "uWB" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
@@ -17098,6 +18189,10 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"uZJ" = (
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/space)
 "uZR" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/misc/paperbin{
@@ -17212,6 +18307,18 @@
 "vfH" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
+"vfL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "vfU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/misc/table_lighting,
@@ -17268,6 +18375,14 @@
 "vjE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
+"vkn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/space)
 "vkB" = (
 /obj/structure/prop/mainship/mapping_computer,
 /turf/open/floor/mainship/emerald{
@@ -17313,6 +18428,12 @@
 "vou" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
+"voL" = (
+/obj/structure/prop/mainship/mapping_computer,
+/turf/open/floor/mainship/emerald{
+	dir = 9
+	},
+/area/space)
 "voR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -17338,14 +18459,6 @@
 	dir = 4
 	},
 /turf/open/floor/mainship,
-/area/mainship/squads/general)
-"vqQ" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
 /area/mainship/squads/general)
 "vrx" = (
 /obj/structure/bed/chair/comfy,
@@ -17402,6 +18515,11 @@
 "vuX" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
+"vvz" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/marine_card,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "vvE" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -17489,16 +18607,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "vzy" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -17539,12 +18651,27 @@
 /obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
+"vDk" = (
+/obj/structure/bed/fancy,
+/obj/effect/landmark/start/job/fieldcommander,
+/obj/item/bedsheet/captain,
+/obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/space)
 "vDr" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"vDF" = (
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "vDH" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -17609,6 +18736,11 @@
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"vIv" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vJq" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -17667,6 +18799,12 @@
 	dir = 1
 	},
 /area/mainship/engineering/engineering_workshop)
+"vPh" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/space)
 "vPk" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
@@ -17752,6 +18890,18 @@
 "vXQ" = (
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
+"vXR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/blue/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vXY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17778,10 +18928,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
-"vYB" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17823,6 +18969,10 @@
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
+"wdG" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship,
+/area/space)
 "wej" = (
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
@@ -17869,6 +19019,12 @@
 	dir = 4
 	},
 /area/mainship/living/chapel)
+"wfO" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "wgn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -17958,16 +19114,6 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"wld" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/sign/prop1{
-	dir = 1
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "wml" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
@@ -18003,12 +19149,8 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "wnI" = (
@@ -18057,10 +19199,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "wqZ" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/structure/sign/pods{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -18170,6 +19309,10 @@
 "wuQ" = (
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"wuR" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship,
+/area/space)
 "wvV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -18258,6 +19401,17 @@
 "wBL" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
+"wCD" = (
+/obj/effect/turf_decal/warning_stripes/engineer,
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/box/small,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "wCX" = (
 /obj/structure/sign/poster,
 /obj/effect/decal/cleanable/cobweb{
@@ -18271,6 +19425,13 @@
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
+/area/mainship/squads/general)
+"wDN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "wDQ" = (
 /obj/machinery/door/airlock/mainship/secure{
@@ -18480,6 +19641,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"wQH" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "wQJ" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/port_umbilical)
@@ -18684,6 +19855,19 @@
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"xbP" = (
+/obj/machinery/marine_selector/gear/engi,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
+"xct" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/space)
 "xdy" = (
 /obj/effect/landmark/start/job/ai,
 /obj/machinery/camera/autoname/mainship{
@@ -18751,6 +19935,9 @@
 /mob/living/simple_animal/cat/martin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"xfP" = (
+/turf/closed/wall/mainship,
+/area/space)
 "xgv" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/camera/autoname/mainship,
@@ -18907,6 +20094,12 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
+"xoE" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 10
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "xpe" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/wood,
@@ -18987,6 +20180,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"xuy" = (
+/obj/machinery/firealarm,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "xuA" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19005,7 +20202,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/black{
-	dir = 6
+	dir = 4
 	},
 /area/mainship/squads/general)
 "xvF" = (
@@ -19182,6 +20379,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"xBl" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship,
+/area/space)
 "xBM" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/vending/nanomed,
@@ -19551,6 +20752,16 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
+"xVU" = (
+/obj/effect/turf_decal/warning_stripes/box/small,
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/leader,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "xWh" = (
 /obj/machinery/power/apc{
 	dir = 8
@@ -19618,11 +20829,6 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
-"xYD" = (
-/obj/effect/ai_node,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black,
-/area/mainship/squads/general)
 "xYE" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clipboard{
@@ -19640,6 +20846,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"xYO" = (
+/obj/machinery/marine_selector/gear/commander,
+/turf/open/space/basic,
+/area/space)
 "xZo" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -19648,6 +20858,17 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
+"xZt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/marine/general/sl,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "xZy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -19720,15 +20941,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"ycH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "ycO" = (
 /obj/machinery/photocopier,
 /turf/open/floor/mainship/blue{
@@ -19877,6 +21089,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ylu" = (
+/obj/structure/prop/mainship/mapping_computer,
+/turf/open/floor/mainship/orange{
+	dir = 5
+	},
+/area/space)
 
 (1,1,1) = {"
 qVo
@@ -47214,7 +48432,7 @@ nzB
 kDx
 kDx
 kDx
-kDx
+lfH
 kDx
 plN
 aql
@@ -53679,13 +54897,13 @@ lMV
 mxT
 bfT
 mxT
+mxT
+mxT
 lwj
 mxT
 mxT
 mxT
-mxT
-mxT
-wtv
+fKo
 ouS
 mxT
 iJa
@@ -53942,11 +55160,11 @@ vmD
 wMh
 vmD
 vmD
-wNG
+vmD
 rKm
 vmD
 vmD
-qIG
+wNG
 rKm
 vmD
 vmD
@@ -54193,17 +55411,17 @@ mBc
 rUF
 vab
 bMm
+rUF
+rUF
 rUK
 rUF
 rUF
 rUF
-hwU
+pEQ
+rUF
+rUF
 rUF
 oXs
-rUF
-rUF
-rUF
-orf
 rUF
 rUF
 vmD
@@ -54450,23 +55668,23 @@ rUF
 swY
 wsR
 fEq
+lJV
+sMn
 mNM
 swY
 rUF
 gFW
 mNM
-jeQ
+fEq
+oIT
+sMn
 pyS
 gFW
 rUF
-eIM
-jXW
-fKK
-rUF
 kMi
 dBu
-mxT
-mxT
+hhR
+wtv
 hhR
 heF
 mxT
@@ -54685,12 +55903,12 @@ wXm
 vgo
 xZy
 ndN
-xZy
+qQf
 iRM
 xZy
-xZy
-vgo
-vgo
+ixx
+eNP
+kVt
 xZy
 psq
 lHS
@@ -54707,23 +55925,23 @@ rUF
 dtI
 kUU
 rOr
+pGb
+pGb
 tVr
 xXT
 rUF
 tKs
 krM
-rHh
+rOr
+eMz
+pGb
 fYB
 xXT
-rUF
-nMA
-syD
-rJe
-rUF
+mBc
 vmD
-lvr
-wMh
-vmD
+nmm
+gqZ
+wNG
 nmm
 rKm
 vmD
@@ -54944,10 +56162,10 @@ vAn
 vAn
 wqZ
 swv
+wII
 vAn
-vAn
-vAn
-vAn
+mhJ
+iQy
 vAn
 vAn
 rAB
@@ -54963,25 +56181,25 @@ vmD
 hme
 qhf
 tkW
-lJV
+pGb
+kHp
+pGb
 pGb
 qhf
 hme
 gxL
 mNM
-pyG
+pGb
+kHp
+pGb
 pyS
 gxL
 hme
-ikM
-jXW
-yhG
-mBc
-wPw
 rUF
+jTU
 rUF
+alq
 rUF
-iHm
 mqK
 xZL
 xZL
@@ -55199,16 +56417,16 @@ xjD
 xvv
 xvv
 xvv
-xJn
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-xJn
+fQR
+rUF
+rUF
+rUF
+xZt
+rUF
+rUF
+rUF
+rUF
+rUF
 rUF
 nDF
 stm
@@ -55220,25 +56438,25 @@ rUF
 mBc
 lRs
 tkW
-wkZ
+pGb
+kHp
+pGb
 pGb
 swY
 rUF
-oqS
+gFW
 pGb
-rrh
+pGb
+kHp
+pGb
 syR
 gFW
 rUF
-cjl
-bOF
-cjl
-rUF
-wnI
-pyG
-vpD
-rrh
-nLu
+sMn
+iBL
+uVF
+pyS
+acl
 mqK
 hPb
 wuQ
@@ -55456,17 +56674,17 @@ kWM
 kWM
 kWM
 xvv
-uyy
-jaA
-hRK
-uyy
-ycO
-kNK
-kPH
-lIU
-jsl
-uyy
+miU
+rUF
+vVG
+cPg
+mRy
+aKr
+hvS
+aJV
+rUF
 wDi
+ngh
 vzy
 khM
 oZY
@@ -55478,24 +56696,24 @@ rUF
 aLA
 rbd
 tgi
+tgi
+tgi
 hPG
-foj
+aMp
 rUF
 tED
 krM
-cPg
+pGb
+eMz
+pGb
 fYB
 elQ
 rUF
-wld
-pak
-hmH
-rUF
-dJU
-rHh
-cPg
-cPg
-kdF
+eIM
+sjY
+rNX
+wDN
+wfO
 mqK
 vHA
 wuQ
@@ -55712,18 +56930,18 @@ xvv
 kHT
 roN
 nIG
-vYB
-uyy
-feU
-ujQ
-uyy
-edp
-alP
-gUJ
-pRo
-lFo
-dZY
-alz
+xvv
+tpi
+rUF
+bJB
+bRc
+iIT
+bSi
+cSy
+gFh
+ryY
+xVU
+cPg
 lTQ
 lOp
 aDz
@@ -55735,24 +56953,24 @@ rUF
 oNs
 wsR
 yhG
+lJV
+fKK
 mNM
 ukJ
 rUF
 pqm
 mNM
-wkZ
+yhG
+xbP
+fKK
 pyS
 hGE
 rUF
-iFI
-bOF
-iFI
-rUF
-cPg
-wkZ
-cPg
-vVG
-sSA
+xuy
+sjY
+pGb
+syR
+fAy
 mqK
 ukb
 wuQ
@@ -55970,16 +57188,16 @@ bbw
 uzy
 tbT
 xvv
-uyy
-uyy
-wql
-uyy
-oKm
-qUg
-vpm
-gwK
-tIy
-xSy
+miU
+rUF
+xWS
+mRy
+hoR
+cPg
+vDF
+fHj
+rUF
+diF
 sUT
 tXD
 ini
@@ -55992,24 +57210,24 @@ mBc
 rUF
 der
 rUF
+rUF
+rUF
 rUK
 rUF
 lpn
 rUF
 hwU
 rUF
+rUF
+rUF
 oXs
 rUF
 ekL
-cjl
-jXW
-cjl
-ekL
-mNM
-xWS
-cPg
-xWS
-bAS
+ikM
+sjY
+ikM
+syR
+cef
 mqK
 lys
 plr
@@ -56227,16 +57445,16 @@ eKC
 kWM
 bLP
 eQb
-uyy
-uNy
-hGq
-uyy
-gcI
-kTn
-dcJ
-mif
-tIU
-dZY
+fqj
+rUF
+hWC
+vXR
+cPg
+cPg
+cPg
+xoE
+rUF
+unO
 isJ
 dfI
 udi
@@ -56249,24 +57467,24 @@ oAD
 cey
 gpa
 cey
+fee
+fee
 eQg
 pVr
 cey
 xxM
-bTe
+wCD
 cey
+fee
+fee
 jqy
 iae
-rUF
-pGn
-ycH
-qFl
-rUF
-iVT
-eMz
-cPg
-eMz
-bpz
+mBc
+tXJ
+sGk
+iFI
+nsl
+jOQ
 mqK
 lRc
 lAn
@@ -56484,17 +57702,17 @@ pdj
 pdj
 pdj
 pdj
-uyy
-iJy
-eCk
-uyy
-uyy
-uyy
-iaf
-xiV
-uyy
-uyy
-htr
+rUF
+rUF
+nIn
+vfL
+cPg
+rHh
+cPg
+cPg
+ryY
+xVU
+bSp
 cPg
 lOp
 eYx
@@ -56507,23 +57725,23 @@ sqc
 kQp
 sqc
 cPg
-cPg
+tis
 sqc
 cPg
 sqc
+cPg
+cPg
+cPg
+cPg
 cPg
 cPg
 llW
 rUF
-iFI
-jXW
-iFI
-mBc
-qEt
-uGh
-cPg
-uGh
-uxI
+ekh
+sjY
+cjl
+syR
+wfO
 mqK
 uKH
 eOT
@@ -56741,16 +57959,16 @@ bFG
 kpI
 cRE
 giN
-uyy
-hpS
-lHu
-faC
-mTH
-jzh
-bCZ
-dxc
-emh
-uyy
+rUF
+rUF
+dPp
+vfL
+cPg
+xWS
+fPK
+vVG
+rUF
+lSq
 tdE
 rrh
 oCN
@@ -56771,16 +57989,16 @@ xLV
 eMz
 jlV
 wiL
-mBc
+aWF
+cPg
+cPg
+lOp
 rUF
-orf
-pSf
-rUF
-vHq
-kpn
-kpn
-kpn
-gUo
+kdD
+sjY
+pGb
+syR
+cef
 mqK
 uKH
 nse
@@ -56999,16 +58217,16 @@ xGl
 xGl
 xGl
 uyy
-tzF
-dYs
-qKf
-sQz
-keK
-keK
-hPR
-rZM
 uyy
-cdz
+uyy
+cBw
+uyy
+uyy
+uyy
+rUF
+rUF
+ncg
+bSp
 cPg
 lOp
 eYx
@@ -57030,14 +58248,14 @@ xYh
 kbg
 cPg
 cPg
-ocY
-bnq
+cPg
+lOp
 rUF
-dBi
-aKr
-rBJ
-pfV
-mNM
+mnb
+sjY
+vIv
+syR
+fAy
 mqK
 uKH
 mka
@@ -57256,16 +58474,16 @@ xGl
 xGl
 xGl
 uyy
-tzF
-tzF
-aPJ
-rtj
-ivw
-oFH
-uEU
-qVS
+uNy
+hGq
+bTj
+eEZ
+vvz
 uyy
-cdz
+aJV
+eMz
+eYx
+bSp
 rrh
 eMJ
 hxc
@@ -57287,14 +58505,14 @@ eMz
 pWo
 cPg
 cPg
-nLu
+cPg
 lOp
 mBc
-gYL
-rUF
-rUF
-rUF
-wPw
+kHp
+iBL
+eWu
+pyS
+jOQ
 mqK
 lRc
 dDg
@@ -57513,15 +58731,15 @@ ygV
 ygV
 oOX
 uyy
-dQS
-vFb
-aPJ
-jmC
-ivw
-bIl
-lrc
-tzF
+sKv
+rSW
+qVH
+qyx
+faC
 uyy
+aJV
+eMz
+mvQ
 pVb
 lkH
 xvA
@@ -57534,7 +58752,7 @@ bby
 lIW
 fJI
 lkH
-gCy
+ini
 rUm
 lIW
 lkH
@@ -57546,12 +58764,12 @@ lkH
 lkH
 ksd
 ini
-vqQ
-ehw
-xeE
-qLW
-lkH
-nId
+rUF
+rUF
+jTU
+rUF
+alq
+rUF
 mqK
 uKH
 jWH
@@ -57770,17 +58988,17 @@ xGl
 xGl
 xGl
 uyy
+cSz
+gYa
+bHF
+tzF
+vFb
 uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-uyy
-xJn
-pSX
-sbB
+aJV
+eMz
+rIt
+isJ
+fee
 aUp
 mEk
 isK
@@ -57801,14 +59019,14 @@ sbB
 ffo
 igO
 fee
-ppB
 fee
 fee
+cey
 fee
+dIo
 fee
-fee
-fee
-fee
+gsd
+bnq
 mqK
 uKH
 lAn
@@ -58026,17 +59244,17 @@ xGl
 xGl
 xGl
 rrj
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
 nJG
-eJL
-hvM
-ibO
-div
-vuc
-lIB
-xRb
-cvj
 nJG
-eDg
+nJG
+bSp
 mng
 xmJ
 xmJ
@@ -58062,7 +59280,7 @@ mxo
 mxo
 mxo
 mxo
-mxo
+wQH
 mxo
 cPg
 cPg
@@ -58284,16 +59502,16 @@ ygV
 ygV
 oOX
 nJG
-rPd
-hZe
-mmh
-hZe
-tDC
-mVr
-kAq
-qEu
-pko
-bSp
+eJL
+hvM
+ibO
+div
+vuc
+lIB
+xRb
+cvj
+nJG
+hoq
 mng
 xmJ
 xmJ
@@ -58541,15 +59759,15 @@ xGl
 xGl
 xGl
 nJG
-bDv
-cEe
-bDv
-bDv
+rPd
+hZe
+mmh
+hZe
 tDC
-fmP
-oHj
-ylc
-dVo
+mVr
+kAq
+qEu
+pko
 bSp
 mng
 xmJ
@@ -58799,14 +60017,14 @@ rKn
 rKn
 nJG
 bDv
-bDv
 cEe
+bDv
 bDv
 tDC
 fmP
-nhn
-nbh
-eeX
+oHj
+ylc
+dVo
 jEy
 nzV
 nwR
@@ -59055,15 +60273,15 @@ hUz
 hUz
 pQt
 nJG
-gXs
 bDv
 bDv
+cEe
 bDv
 tDC
 fmP
-jCY
-ykn
-pko
+nhn
+nbh
+eeX
 tis
 cPg
 rHh
@@ -59076,7 +60294,7 @@ jbe
 cPg
 cPg
 cPg
-xYD
+voa
 hgP
 cPg
 cPg
@@ -59092,8 +60310,8 @@ cPg
 tis
 cPg
 cPg
-cPg
 tis
+cPg
 rKn
 sYv
 sBr
@@ -59312,15 +60530,15 @@ esN
 esN
 unX
 nJG
-pgv
+gXs
 bDv
-eGs
+bDv
 bDv
 tDC
 fmP
 jCY
-vWG
-nJG
+ykn
+pko
 nwt
 hfu
 eHh
@@ -59569,14 +60787,14 @@ nWT
 esN
 unX
 nJG
-nZI
-lHN
-nZI
-nZI
-wtq
+pgv
+bDv
+eGs
+bDv
+tDC
 fmP
 jCY
-eTN
+vWG
 nJG
 rKn
 rKn
@@ -59826,14 +61044,14 @@ nWT
 esN
 unX
 nJG
-nJG
-nJG
-nJG
-wJe
-nJG
-qxw
-jiE
-ylc
+nZI
+lHN
+nZI
+nZI
+wtq
+fmP
+jCY
+eTN
 nJG
 fRw
 vAb
@@ -60083,14 +61301,14 @@ nWT
 esN
 unX
 nJG
-bDv
-aFl
-mjo
-bDv
-bDv
-dYv
-aws
-mQq
+nJG
+nJG
+nJG
+wJe
+nJG
+qxw
+jiE
+ylc
 nJG
 fRw
 nwy
@@ -60323,14 +61541,14 @@ qVo
 qVo
 qVo
 qVo
+iKN
+lSB
+xfP
+hbw
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+tPx
+myv
 qVo
 hRh
 nWT
@@ -60340,14 +61558,14 @@ nWT
 esN
 unX
 nJG
-pgv
-dRR
-uLb
-sGU
+bDv
+aFl
+mjo
+bDv
 bDv
 dYv
-uTv
-wAZ
+aws
+mQq
 nJG
 fRw
 iWR
@@ -60580,14 +61798,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+oLu
+lST
+xfP
+nLn
+bau
+txg
+iew
+dcv
 qVo
 hRh
 nWT
@@ -60597,14 +61815,14 @@ nWT
 esN
 unX
 nJG
-nnF
-qAJ
-kbW
-lTw
-kbW
-vSE
-ksb
-ltX
+pgv
+dRR
+uLb
+sGU
+bDv
+dYv
+uTv
+wAZ
 nJG
 fRw
 hua
@@ -60837,14 +62055,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xfP
+qgg
+xfP
+gxw
+hwj
+aKY
+tLY
+ljg
 qVo
 hRh
 nWT
@@ -60854,14 +62072,14 @@ nWT
 esN
 unX
 nJG
-nJG
-nJG
-nJG
-oop
-dnf
-nJG
-nJG
-nJG
+nnF
+qAJ
+kbW
+lTw
+kbW
+vSE
+ksb
+ltX
 nJG
 rKn
 vSJ
@@ -61096,12 +62314,12 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xfP
+uAI
+cXs
+bpr
+kYp
+sRN
 qVo
 hRh
 nWT
@@ -61109,17 +62327,17 @@ nWT
 nWT
 nWT
 esN
-ssm
-hUz
-hUz
-sAR
-hUz
-nEM
-sAR
-hUz
-hUz
-hUz
-hUz
+unX
+qeW
+rKn
+rKn
+rKn
+iwe
+bvM
+rKn
+rKn
+rKn
+rKn
 rCA
 wHk
 wPV
@@ -61353,12 +62571,12 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xfP
+xfP
+xfP
+smG
+jPy
+xfP
 qVo
 hRh
 nWT
@@ -61366,8 +62584,8 @@ nWT
 nWT
 nWT
 esN
-esN
-esN
+ssm
+hUz
 esN
 esN
 esN
@@ -61611,20 +62829,20 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+jtB
+haj
+kaI
+elv
+uDs
 qVo
 hRh
 nWT
 nWT
 nWT
 nWT
-nWT
-nWT
-nWT
+brL
+brL
+brL
 nWT
 nWT
 nWT
@@ -61865,14 +63083,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mXY
+jGM
+kZR
+aGW
+qSb
+qSb
+bCW
+aDk
 qVo
 dgj
 qpC
@@ -62122,14 +63340,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mXY
+mXY
+tXs
+czt
+rYi
+sBT
+dpU
+bMi
 qVo
 qVo
 qVo
@@ -62381,12 +63599,12 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+tXs
+dyP
+rYi
+jLH
+fIz
+mXY
 qVo
 qVo
 qVo
@@ -66755,13 +67973,13 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+uZJ
+fMS
+xfP
+xfP
+xfP
+pOo
+kbB
 qVo
 qVo
 qVo
@@ -67012,13 +68230,13 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xfP
+xct
+ewU
+itc
+siu
+pyr
+kbB
 qVo
 qVo
 qVo
@@ -67269,24 +68487,24 @@ qVo
 qVo
 qVo
 qVo
+xfP
+ocu
+jvM
+mpL
+mpL
+otv
+kbB
 qVo
 qVo
+urm
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+uZJ
+fMS
+xfP
+xfP
+xfP
+pOo
+kbB
 qVo
 qVo
 qVo
@@ -67526,24 +68744,24 @@ qVo
 qVo
 qVo
 qVo
+xfP
+mpL
+xBl
+mpL
+ghr
+lJx
+kbB
 qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xBl
+xBl
+mpL
+mpL
+mpL
+siu
+ewU
 qVo
 qVo
 qVo
@@ -67783,33 +69001,33 @@ qVo
 qVo
 qVo
 qVo
+ldb
+cKa
+fhJ
+mpL
+fhJ
+iht
+kbB
 qVo
 qVo
 qVo
 qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+iKN
+lSB
+xfP
+hbw
+dSQ
+buQ
+tPx
+myv
 qVo
 qVo
 qVo
@@ -68040,33 +69258,33 @@ qVo
 qVo
 qVo
 qVo
+xfP
+cJb
+syi
+mpL
+syi
+eCZ
+kbB
 qVo
 qVo
 qVo
 qVo
+pcN
+mpL
+mpL
+mpL
+mpL
+pcN
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+oLu
+lST
+xfP
+nLn
+bau
+txg
+iew
+dcv
 qVo
 qVo
 qVo
@@ -68297,33 +69515,33 @@ qVo
 qVo
 qVo
 qVo
+uZJ
+muR
+wdG
+mpL
+wdG
+mqJ
+kbB
 qVo
 qVo
 qVo
 qVo
+jHZ
+mpL
+mpL
+bGW
+mpL
+jHZ
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+xfP
+qgg
+xfP
+gxw
+hwj
+aKY
+tLY
+ljg
 qVo
 qVo
 qVo
@@ -68554,33 +69772,33 @@ qVo
 qVo
 qVo
 qVo
+xfP
+ooH
+jhA
+jhA
+jhA
+aIW
+kbB
 qVo
 qVo
 qVo
 qVo
+ecC
+mpL
+mpL
+mpL
+mpL
+ecC
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+vDk
+gNy
+xfP
+uAI
+cXs
+bpr
+kYp
+sRN
 qVo
 qVo
 qVo
@@ -68811,33 +70029,33 @@ qVo
 qVo
 qVo
 qVo
+xfP
+wuR
+qYX
+eDM
+lWn
+cKa
+kbB
 qVo
 qVo
 qVo
 qVo
+pcN
+mpL
+mpL
+mpL
+mpL
+pcN
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+vPh
+mXG
+xfP
+xfP
+xfP
+smG
+jPy
+xfP
 qVo
 qVo
 qVo
@@ -69068,33 +70286,33 @@ qVo
 qVo
 qVo
 qVo
+uZJ
+stt
+xfP
+xfP
+xfP
+fMS
+kbB
 qVo
 qVo
 qVo
 qVo
+jHZ
+mpL
+mpL
+bGW
+mpL
+jHZ
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+rwt
+fbA
+dZo
+jtB
+haj
+kaI
+elv
+uDs
 qVo
 qVo
 qVo
@@ -69311,6 +70529,16 @@ qVo
 qVo
 qVo
 qVo
+uZJ
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+uZJ
 qVo
 qVo
 qVo
@@ -69326,32 +70554,22 @@ qVo
 qVo
 qVo
 qVo
+ecC
+mpL
+mpL
+mpL
+mpL
+ecC
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mXY
+jGM
+kZR
+aGW
+qSb
+qSb
+bCW
+aDk
 qVo
 qVo
 qVo
@@ -69568,6 +70786,16 @@ qVo
 qVo
 qVo
 qVo
+xfP
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+xfP
 qVo
 qVo
 qVo
@@ -69583,32 +70811,22 @@ qVo
 qVo
 qVo
 qVo
+xYO
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mXY
+mXY
+tXs
+czt
+rYi
+sBT
+dpU
+bMi
 qVo
 qVo
 qVo
@@ -69825,6 +71043,16 @@ qVo
 qVo
 qVo
 qVo
+xfP
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qxq
 qVo
 qVo
 qVo
@@ -69840,32 +71068,22 @@ qVo
 qVo
 qVo
 qVo
+qBv
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+seN
+amc
+tXs
+dyP
+rYi
+jLH
+fIz
+mXY
 qVo
 qVo
 qVo
@@ -70082,6 +71300,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -70090,8 +71309,7 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
+fRH
 qVo
 qVo
 qVo
@@ -70339,6 +71557,16 @@ qVo
 qVo
 qVo
 qVo
+xfP
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qVo
+qxq
 qVo
 qVo
 qVo
@@ -70362,24 +71590,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -70563,7 +71781,22 @@ qVo
 qVo
 qVo
 qVo
+xJn
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+xJn
 qVo
+wPw
+rUF
+rUF
+rUF
+iHm
 qVo
 qVo
 qVo
@@ -70581,6 +71814,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -70589,6 +71823,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -70612,31 +71847,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -70820,7 +72038,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+jaA
+hRK
+uyy
+ycO
+kNK
+kPH
+lIU
+jsl
+uyy
 qVo
+wnI
+pyG
+vpD
+rrh
+nLu
 qVo
 qVo
 qVo
@@ -70838,6 +72071,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -70846,6 +72080,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -70869,31 +72104,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -71077,7 +72295,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+feU
+ujQ
+uyy
+edp
+alP
+gUJ
+pRo
+lFo
+dZY
 qVo
+dJU
+rHh
+cPg
+cPg
+kdF
 qVo
 qVo
 qVo
@@ -71095,6 +72328,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71103,6 +72337,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71126,31 +72361,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -71334,7 +72552,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+uyy
+wql
+uyy
+oKm
+qUg
+vpm
+gwK
+tIy
+xSy
 qVo
+cPg
+wkZ
+cPg
+vVG
+sSA
 qVo
 qVo
 qVo
@@ -71352,6 +72585,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71360,6 +72594,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71383,31 +72618,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -71591,7 +72809,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+uNy
+hGq
+uyy
+gcI
+kTn
+dcJ
+mif
+tIU
+dZY
 qVo
+mNM
+xWS
+cPg
+xWS
+bAS
 qVo
 qVo
 qVo
@@ -71609,6 +72842,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71617,6 +72851,7 @@ qVo
 qVo
 qVo
 qVo
+xfP
 qVo
 qVo
 qVo
@@ -71640,31 +72875,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -71848,7 +73066,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+iJy
+eCk
+uyy
+uyy
+uyy
+iaf
+xiV
+uyy
+uyy
 qVo
+iVT
+eMz
+cPg
+eMz
+bpz
 qVo
 qVo
 qVo
@@ -71866,6 +73099,16 @@ qVo
 qVo
 qVo
 qVo
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+xfP
+uZJ
 qVo
 qVo
 qVo
@@ -71889,39 +73132,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -72105,7 +73323,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+hpS
+lHu
+faC
+mTH
+jzh
+bCZ
+dxc
+emh
+uyy
 qVo
+qEt
+uGh
+cPg
+uGh
+uxI
 qVo
 qVo
 qVo
@@ -72156,29 +73389,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -72362,7 +73580,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+tzF
+dYs
+qKf
+sQz
+keK
+keK
+hPR
+rZM
+uyy
 qVo
+vHq
+kpn
+kpn
+kpn
+gUo
 qVo
 qVo
 qVo
@@ -72413,29 +73646,14 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
+mpL
 qVo
 qVo
 qVo
@@ -72619,22 +73837,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+tzF
+tzF
+aPJ
+rtj
+ivw
+oFH
+uEU
+qVS
+uyy
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+dBi
+aKr
+rBJ
+pfV
+mNM
 qVo
 qVo
 qVo
@@ -72876,22 +74094,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+dQS
+vFb
+aPJ
+jmC
+ivw
+bIl
+lrc
+tzF
+uyy
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+gYL
+rUF
+rUF
+rUF
+wPw
 qVo
 qVo
 qVo
@@ -73133,22 +74351,22 @@ qVo
 qVo
 qVo
 qVo
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+uyy
+xJn
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+ehw
+xeE
+qLW
+lkH
+nId
 qVo
 qVo
 qVo
@@ -73439,11 +74657,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+gBS
+shP
+pBn
+eEV
+eEV
 qVo
 qVo
 qVo
@@ -73696,11 +74914,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+ylu
+dlh
+eCH
+pir
+vkn
 qVo
 qVo
 qVo
@@ -73953,11 +75171,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+oyX
+eEV
+noA
+eEV
+eEV
 qVo
 qVo
 qVo
@@ -74210,11 +75428,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+pir
+pir
+iwn
+fhu
+tOi
 qVo
 qVo
 qVo
@@ -74467,11 +75685,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+qXL
+qXL
+asG
+eYO
+jXK
 qVo
 qVo
 qVo
@@ -74724,11 +75942,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+jmK
+eEV
+nSg
+oHC
+eEV
 qVo
 qVo
 qVo
@@ -74981,11 +76199,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+voL
+dFq
+oRo
+kdG
+nAw
 qVo
 qVo
 qVo
@@ -75238,11 +76456,11 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+hSU
+jka
+lfP
+aSP
+aDd
 qVo
 qVo
 qVo

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -21824,6 +21824,7 @@
 /area/sulaco/disposal)
 "qNF" = (
 /obj/machinery/marine_selector/gear/commander,
+/obj/item/minimap_tablet,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "qOd" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -1502,6 +1502,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/ce)
+"ahg" = (
+/obj/structure/cable,
+/turf/open/floor/prison/green{
+	dir = 8
+	},
+/area/sulaco/marine)
 "ahh" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -2435,10 +2441,9 @@
 /obj/item/storage/backpack/satchel/norm,
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "aor" = (
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
@@ -2914,9 +2919,9 @@
 /area/sulaco/hallway/central_hall)
 "arb" = (
 /obj/structure/cable,
-/obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
 "arc" = (
@@ -6827,6 +6832,10 @@
 /area/sulaco/marine)
 "aLo" = (
 /obj/machinery/vending/nanomed,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -6949,7 +6958,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/prison/green{
@@ -6995,14 +7004,14 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/warning_stripes/box/small,
 /obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/leader,
+/obj/effect/turf_decal/warning_stripes/smartgunner,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/prison/green,
 /area/sulaco/marine)
 "aMg" = (
@@ -7022,9 +7031,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/marine/general/sl,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/marine/general/smart{
+	dir = 8
 	},
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
@@ -7049,9 +7060,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/mainship/marine/general/sl,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/marine/general/smart{
+	dir = 8
 	},
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
@@ -7069,7 +7082,7 @@
 /obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/leader,
+/obj/effect/turf_decal/warning_stripes/smartgunner,
 /turf/open/floor/prison/green{
 	dir = 6
 	},
@@ -7209,12 +7222,6 @@
 	},
 /turf/open/floor/cult,
 /area/sulaco/morgue)
-"aNu" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/green{
-	dir = 4
-	},
-/area/sulaco/marine)
 "aNw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -9451,6 +9458,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo/prep)
+"bwL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/green/full,
+/area/sulaco/marine)
+"bxD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/prison/green{
+	dir = 10
+	},
+/area/sulaco/marine)
 "bxJ" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
@@ -9645,6 +9669,7 @@
 /obj/machinery/light/mainship/small{
 	dir = 8
 	},
+/obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "bKI" = (
@@ -10208,7 +10233,7 @@
 /obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/smartgunner,
+/obj/effect/turf_decal/warning_stripes/leader,
 /turf/open/floor/prison/green{
 	dir = 8
 	},
@@ -10787,12 +10812,6 @@
 /mob/living/simple_animal/cat/martin,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
-"dhK" = (
-/obj/structure/cable,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "djp" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/camera/autoname{
@@ -11337,16 +11356,15 @@
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"dTH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "dTS" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
+"dTY" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "dWh" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -11576,6 +11594,14 @@
 /obj/effect/spawner/random/misc/table_lighting,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"ejw" = (
+/obj/structure/table/wood/fancy,
+/obj/item/book/codebook,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "ejF" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/kitchen_tray,
@@ -11911,7 +11937,7 @@
 "eEh" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/gray,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "eEB" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -12157,6 +12183,15 @@
 /obj/structure/dropship_equipment/shuttle/flare_launcher,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"eSR" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/sulaco/bridge/office)
 "eTC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -12179,10 +12214,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
-"eUc" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship/gray/outer,
-/area/sulaco/bridge/office)
 "eUn" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -12396,6 +12427,19 @@
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
+"fjK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/blue{
+	dir = 1
+	},
+/area/sulaco/marine)
 "fkY" = (
 /turf/open/floor/prison/whitegreen{
 	dir = 4
@@ -12520,7 +12564,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "fqu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -12767,6 +12811,12 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"fEQ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/megaphone,
+/obj/item/clothing/head/ornamented_cap,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "fFh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
@@ -12791,7 +12841,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mainship/gray,
-/area/sulaco/maintenance/lower_maint2)
+/area/mainship/shipboard/weapon_room)
 "fGe" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -13010,6 +13060,19 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)
+"gcj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/marine_card{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "gcp" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -13034,6 +13097,11 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"gdy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "gdR" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -13127,6 +13195,16 @@
 	dir = 6
 	},
 /area/sulaco/bridge)
+"ghw" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/blue/corner{
+	dir = 4
+	},
+/area/sulaco/marine)
 "ghB" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/shotgun/pump,
@@ -13563,6 +13641,19 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"gNz" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/briefcase,
+/obj/item/clothing/head/bowlerhat{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/weapon/cane{
+	pixel_x = 5
+	},
+/obj/item/binoculars,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "gNS" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray/outer,
@@ -13642,15 +13733,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"gSX" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/green{
-	dir = 4
-	},
-/area/sulaco/marine)
 "gTb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -13725,9 +13807,8 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "gXD" = (
-/obj/machinery/marine_selector/clothes/smartgun,
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
 	},
 /turf/open/floor/prison,
 /area/sulaco/marine)
@@ -14089,11 +14170,9 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "hrC" = (
-/obj/effect/landmark/start/job/fieldcommander,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "hrG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -14107,6 +14186,15 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"hrR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/prison/green{
+	dir = 9
+	},
+/area/sulaco/marine)
 "htm" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/prison,
@@ -14144,9 +14232,8 @@
 /area/sulaco/cargo/prep)
 "hwM" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/item/plantable_flag,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "hxe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15470,7 +15557,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "iUQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable,
@@ -15772,6 +15859,11 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"jpy" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "jpD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/structure/cable,
@@ -15933,7 +16025,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/green{
 	dir = 4
 	},
@@ -15975,6 +16066,16 @@
 	dir = 8
 	},
 /area/space)
+"jCD" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/machinery/light/mainship/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "jCJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -16060,11 +16161,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"jGG" = (
-/obj/machinery/marine_selector/gear/smartgun,
-/obj/structure/sign/prop1,
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "jHb" = (
 /obj/structure/window/reinforced/extratoughened,
 /obj/structure/window/reinforced/windowstake{
@@ -16204,6 +16300,16 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"jPV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/security/marinemainship_network{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "jQe" = (
 /obj/structure/ladder{
 	height = 1;
@@ -16632,14 +16738,14 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/command/cic{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/command/FCDRquarters{
+	dir = 1
+	},
 /turf/open/floor/prison,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "kpD" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
@@ -16991,12 +17097,20 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "kNy" = (
-/obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "kOr" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar/storage)
+"kOs" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "kPW" = (
 /obj/structure/cable,
 /obj/item/stool,
@@ -17074,15 +17188,6 @@
 /obj/effect/spawner/random/misc/paperbin,
 /turf/open/floor/wood,
 /area/sulaco/liaison)
-"kUP" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/turf/open/floor/prison/green{
-	dir = 4
-	},
-/area/sulaco/marine)
 "kVc" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/toy/deck,
@@ -17294,9 +17399,14 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/sulaco/cargo)
 "ljR" = (
-/obj/machinery/loadout_vendor,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/paperbin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/tool/pen,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "lkp" = (
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
@@ -18019,6 +18129,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
+"mcF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/marine/general/sl,
+/turf/open/floor/prison/green/full,
+/area/sulaco/marine)
 "mcW" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -18121,7 +18237,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/mainship/marine/general/smart{
+/obj/machinery/door/airlock/mainship/marine/general/sl{
 	dir = 1
 	},
 /turf/open/floor/prison/green/full,
@@ -18164,9 +18280,12 @@
 	},
 /area/sulaco/marine)
 "mmP" = (
-/obj/machinery/marine_selector/gear/commander,
+/obj/structure/table/wood,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "mno" = (
 /obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship_hull/gray,
@@ -18427,20 +18546,15 @@
 "mCS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/misc/table_lighting,
-/obj/effect/spawner/random/misc/paperbin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/item/storage/box/ids,
 /obj/item/folder/blue,
-/obj/item/tool/pen,
 /obj/machinery/firealarm,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "mCT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -18954,6 +19068,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
+"noJ" = (
+/obj/machinery/light/mainship,
+/obj/machinery/vending/armor_supply,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "noQ" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -20049,9 +20171,9 @@
 /area/sulaco/cargo/office)
 "oGX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "oHm" = (
@@ -20144,7 +20266,7 @@
 /turf/closed/wall/mainship/gray,
 /area/mainship/living/pilotbunks)
 "oMd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20379,8 +20501,8 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
 "pdX" = (
-/obj/machinery/marine_selector/gear/smartgun,
-/obj/item/radio/intercom/general,
+/obj/machinery/computer/squad_manager,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "peD" = (
@@ -20435,13 +20557,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
 	},
-/obj/effect/turf_decal/warning_stripes/smartgunner,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -20460,11 +20579,10 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/firingrange)
 "phy" = (
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/sulaco/maintenance/lower_maint2)
+/obj/item/plantable_flag,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "phB" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/prison,
@@ -20661,10 +20779,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/storage)
-"ppY" = (
-/obj/machinery/computer/squad_manager,
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "ptg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
@@ -20828,15 +20942,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/firingrange)
-"pBP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/door/airlock/mainship/marine/general/smart{
-	dir = 2
-	},
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "pDf" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 10
@@ -21064,6 +21169,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"pRw" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/prison/green{
+	dir = 5
+	},
+/area/sulaco/marine)
 "pRK" = (
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/disposal)
@@ -21414,8 +21527,8 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "qwi" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "qwj" = (
@@ -21710,6 +21823,10 @@
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/disposal)
+"qNF" = (
+/obj/machinery/marine_selector/gear/commander,
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "qOd" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -22016,6 +22133,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"rjQ" = (
+/obj/structure/bed/chair/wood/wings,
+/obj/effect/landmark/start/job/fieldcommander,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "rkc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/hexagon,
@@ -22191,6 +22313,9 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"rrU" = (
+/turf/closed/wall/mainship,
+/area/space)
 "rso" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -22384,6 +22509,7 @@
 "rGe" = (
 /obj/machinery/light/mainship/small,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
 "rGn" = (
@@ -22468,6 +22594,17 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
+"rKJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/prison/red,
+/area/sulaco/bridge)
 "rLJ" = (
 /obj/machinery/air_alarm{
 	dir = 4
@@ -22489,6 +22626,18 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
+"rNH" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/security/marinemainship_network{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/space)
 "rOj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -22644,15 +22793,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
-"rXM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/wood,
-/area/sulaco/bridge/office)
 "rYR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "rZU" = (
 /obj/machinery/computer3/server,
 /turf/open/floor/mainship/tcomms,
@@ -22779,6 +22924,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/marine)
+"seq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/prison/green{
+	dir = 8
+	},
+/area/sulaco/marine)
 "seY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
@@ -22795,7 +22947,7 @@
 	},
 /obj/machinery/air_alarm,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "sfh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -22822,7 +22974,6 @@
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "sfW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4
 	},
@@ -23475,11 +23626,14 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
 "sPQ" = (
-/obj/item/radio/intercom/general{
-	dir = 4
+/obj/effect/turf_decal/warning_stripes/leader,
+/obj/effect/turf_decal/warning_stripes/box/small,
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/green{
-	dir = 4
+	dir = 6
 	},
 /area/sulaco/marine)
 "sPT" = (
@@ -23832,6 +23986,7 @@
 /area/mainship/living/tankerbunks)
 "tmj" = (
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "tmE" = (
@@ -23993,6 +24148,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo/prep)
+"twW" = (
+/obj/effect/ai_node,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "txj" = (
 /obj/machinery/light/mainship,
 /obj/structure/rack,
@@ -24016,6 +24178,13 @@
 	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo/prep)
+"tyB" = (
+/obj/machinery/marine_selector/clothes/commander,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "tyQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -24133,6 +24302,20 @@
 	dir = 1
 	},
 /area/sulaco/firingrange)
+"tHA" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/command/FCDRoffice,
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "tIY" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb{
@@ -24400,10 +24583,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
-"tXY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "tZr" = (
 /turf/open/floor/mainship_hull/gray/dir{
 	dir = 5
@@ -24530,12 +24709,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/droppod)
-"uhy" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/sulaco/marine)
 "uif" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/engineering/tech_supply,
@@ -24908,6 +25081,9 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"uFK" = (
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "uFU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 10
@@ -25033,6 +25209,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
+"uOe" = (
+/obj/item/radio/intercom/general{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "uOu" = (
 /obj/vehicle/ridden/motorbike,
 /obj/machinery/door_control/mainship/req{
@@ -25357,7 +25539,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "vkI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /turf/open/floor/prison/green{
 	dir = 10
 	},
@@ -25367,9 +25549,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
 	},
-/obj/structure/cable,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "vln" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -25405,6 +25589,17 @@
 /obj/machinery/marine_selector/clothes/engi,
 /turf/open/floor/prison,
 /area/sulaco/marine)
+"vnk" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "vnU" = (
 /turf/open/floor/tile/chapel{
 	dir = 1
@@ -25555,6 +25750,17 @@
 	dir = 8
 	},
 /area/mainship/shipboard/weapon_room)
+"vyy" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/prison/blue{
+	dir = 8
+	},
+/area/sulaco/marine)
 "vyE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -25642,6 +25848,19 @@
 /obj/machinery/grill/unwrenched,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"vBh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname,
+/turf/open/floor/prison/blue{
+	dir = 8
+	},
+/area/sulaco/marine)
 "vBD" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -25973,7 +26192,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall3)
 "vVz" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/MarineMed,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "vVE" = (
@@ -26064,8 +26286,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "wca" = (
-/obj/machinery/light/mainship,
-/obj/machinery/vending/uniform_supply,
+/obj/machinery/marine_selector/clothes/smartgun,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "wco" = (
@@ -26295,9 +26516,8 @@
 "wtu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "wtB" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Self Destruct Room"
@@ -26308,6 +26528,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
+"wtI" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/marine_card,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/space)
 "wwM" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/wood,
@@ -26378,10 +26605,11 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "wAF" = (
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/marine_selector/clothes/smartgun,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "wCQ" = (
@@ -27016,8 +27244,11 @@
 	dir = 9
 	},
 /obj/machinery/holopad,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge)
 "xxy" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -27140,7 +27371,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/vending/uniform_supply,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "xEH" = (
@@ -42291,8 +42521,8 @@ wRO
 wRO
 vyQ
 aaa
-aaa
-aaa
+rNH
+wtI
 nzi
 aIz
 aFy
@@ -43320,8 +43550,8 @@ aPg
 aPg
 aPg
 aPg
-aPg
-aPg
+aOk
+aOk
 aIz
 aBO
 iCj
@@ -43577,12 +43807,12 @@ aQw
 aQw
 cfA
 aQw
-aQw
-aDK
+eSR
+jCD
 fFy
 aDm
+aDm
 rJl
-aHz
 sft
 orc
 qSH
@@ -43834,12 +44064,12 @@ aQh
 mTu
 aQh
 aQh
-aQh
-aQw
-wLH
+avr
+uFK
+fEQ
+ejw
 aDm
 sgH
-aHz
 aHz
 eCX
 sjB
@@ -44092,11 +44322,11 @@ uux
 xEi
 uux
 aLf
-aQh
-aQw
+twW
+rjQ
+jPV
 aDm
 viB
-aHz
 hKJ
 gXA
 mVd
@@ -44347,13 +44577,13 @@ aeg
 jRj
 xJd
 xJd
-xJd
 jRj
-aQh
-aQw
+aLf
+dTY
+jpy
+gcj
 aDm
 rgZ
-aHz
 abh
 aHz
 lkp
@@ -44604,13 +44834,13 @@ anw
 amf
 xJd
 xJd
-xJd
 efY
-aQh
+aLf
+gNz
 phy
+vnk
 aDm
 hgv
-dhK
 pxD
 tmj
 rGe
@@ -44861,11 +45091,11 @@ anw
 nKD
 aLC
 aMB
-aNX
-cKq
-aQh
-aQw
-aDm
+noJ
+aLf
+aLf
+aLf
+tHA
 aDm
 aDm
 rBM
@@ -45118,13 +45348,13 @@ aJy
 jRj
 xJd
 aMF
-xJd
-jRj
-aQh
-wLH
-aQw
-aQw
-cIE
+rOy
+aLf
+qNF
+tyB
+fjK
+jUJ
+aLf
 knr
 xJd
 qyL
@@ -45377,11 +45607,11 @@ eDb
 aMS
 aLf
 aLf
-aQh
-aQh
-aQh
-aQh
-aQh
+vBh
+vyy
+ghw
+cAK
+aLf
 nOn
 qzc
 mOs
@@ -45633,11 +45863,11 @@ dAr
 iJj
 aMX
 xXD
-kqp
-sRW
+aLf
+kOs
 gXD
 wAF
-sRW
+htm
 aLf
 knr
 xJd
@@ -45892,10 +46122,10 @@ aNd
 cAt
 mkk
 oGX
-tXY
+xJd
 qwi
-uhy
-pBP
+jUJ
+aLf
 pgQ
 xJd
 qyL
@@ -46147,11 +46377,11 @@ xPc
 tsP
 xJd
 fJF
-eDb
+aLf
 oMd
 xJd
-xJd
-dTH
+wYX
+cAK
 aLf
 hlP
 qzc
@@ -46407,8 +46637,8 @@ ayl
 aLf
 pdX
 vVz
-rOy
-jGG
+gdy
+htm
 aLf
 oHm
 aeW
@@ -46664,7 +46894,7 @@ dls
 aLf
 aLf
 aLf
-aLf
+mcF
 aLf
 aLf
 vax
@@ -46916,13 +47146,13 @@ oRM
 abz
 aLk
 aLS
-aNu
+aLF
 jyQ
 sfW
-gSX
-kUP
-sPQ
 qaA
+aLF
+sPQ
+pRw
 pbD
 dmj
 mmI
@@ -47176,13 +47406,13 @@ aLX
 aNw
 jDL
 mWp
-hBd
+aLG
 vkI
-wMp
-lVK
-aLG
-dmj
-aLG
+hrR
+ahg
+seq
+bwL
+ahg
 xla
 aLk
 xtu
@@ -47437,7 +47667,7 @@ cWP
 jej
 ayn
 cWP
-xJd
+uOe
 dmj
 xJd
 wYX
@@ -47942,10 +48172,10 @@ pjA
 fEv
 uwG
 aJy
-jUJ
+rOy
 aMp
-ppY
-cAK
+xJd
+rOy
 kqp
 kNc
 gRR
@@ -48199,7 +48429,7 @@ afG
 afG
 afG
 oEw
-vVz
+wca
 eYn
 aNX
 wca
@@ -48456,10 +48686,10 @@ aKX
 oRM
 buz
 anw
-cAK
+sRW
 npC
 qMk
-jUJ
+sRW
 aLf
 lJH
 lzl
@@ -49490,7 +49720,7 @@ aLG
 lTL
 aLG
 rSe
-vkI
+bxD
 xJd
 wMp
 lVK
@@ -49632,12 +49862,12 @@ nzi
 mDu
 mDu
 mDu
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+aEH
+aEH
+tbJ
+tbJ
+tbJ
+tbJ
 eEh
 aqV
 tbJ
@@ -49889,13 +50119,13 @@ tZr
 vDU
 vDU
 mDu
-aOk
+aEH
 sfc
 iTU
 kNy
 mmP
 ljR
-eUc
+gNS
 atw
 asn
 lpA
@@ -50146,7 +50376,7 @@ aaa
 aaa
 aaa
 nzi
-aOk
+aEH
 mCS
 hrC
 rYR
@@ -50403,14 +50633,14 @@ aaa
 aaa
 aaa
 nzi
-aOk
+aEH
 aop
-rXM
+hwM
 hwM
 xxx
 fqm
-eUc
-atw
+gNS
+rKJ
 avk
 lpA
 aDi
@@ -50660,13 +50890,13 @@ aaa
 aaa
 aaa
 nzi
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+aEH
+aEH
+tbJ
+tbJ
+tbJ
+tbJ
+tbJ
 goL
 tbJ
 aok
@@ -50920,7 +51150,7 @@ nzi
 mDu
 aYZ
 bKr
-aYZ
+aaw
 aoi
 aoi
 aoi
@@ -51176,8 +51406,8 @@ wRO
 mDu
 mDu
 aYZ
-aaW
-aYZ
+cKA
+aaw
 aoi
 aoi
 aOl
@@ -61743,7 +61973,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+rrU
 aaa
 aaa
 aaa

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -14190,7 +14190,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 9
 	},

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1356,12 +1356,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"aop" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "aoC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1824,6 +1818,17 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"aBW" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/mainship/living/numbertwobunks)
 "aCq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1906,6 +1911,20 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"aGj" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/flashlight/combat,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest/lime,
+/obj/item/clothing/suit/storage/hazardvest/blue,
+/obj/item/tool/shovel/etool,
+/obj/item/storage/pouch/medkit/firstaid,
+/obj/item/tool/taperoll/engineering,
+/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sandbags_empty/half,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/pilotbunks)
 "aGn" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Extended Operations Bunks"
@@ -2509,6 +2528,13 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
+"aZQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1;
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "aZR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/red{
@@ -2755,6 +2781,14 @@
 	dir = 1
 	},
 /area/mainship/living/cafeteria_starboard)
+"bdA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/personal,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "bdC" = (
 /obj/machinery/door/airlock/mainship/marine/general/smart{
 	dir = 2
@@ -3705,12 +3739,6 @@
 	dir = 1
 	},
 /area/mainship/medical/operating_room_one)
-"bnr" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "bnx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4813,14 +4841,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/squads/alpha)
-"bAh" = (
-/obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "bAr" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
@@ -5141,16 +5161,6 @@
 "bFL" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"bFX" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
-/obj/machinery/door/window,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/pilotbunks)
 "bGb" = (
 /obj/machinery/door/airlock/mainship/command/CPToffice{
 	dir = 2
@@ -5239,6 +5249,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bHh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/numbertwobunks)
 "bHi" = (
 /obj/machinery/computer/sleep_console,
 /turf/open/floor/mainship/sterile/dark,
@@ -6793,13 +6811,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
-"bYm" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/living/numbertwobunks)
 "bYz" = (
 /turf/open/floor/mainship/orange{
 	dir = 4
@@ -7297,6 +7308,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
+"clO" = (
+/obj/machinery/vending/armor_supply,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "cmC" = (
 /obj/machinery/iv_drip,
 /obj/machinery/air_alarm,
@@ -7335,11 +7356,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
 "coU" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/bedsheetbin,
-/obj/effect/spawner/random/misc/soap,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/obj/effect/landmark/start/job/synthetic,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/pilotbunks)
 "cqq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -7496,13 +7515,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"cyf" = (
-/obj/effect/landmark/start/job/synthetic,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/living/numbertwobunks)
 "cyV" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
@@ -7606,11 +7618,20 @@
 /obj/machinery/door/airlock/mainship/evacuation,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation/pod/two)
-"cNr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"cMJ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
+"cNr" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cNM" = (
@@ -8206,6 +8227,12 @@
 	dir = 10
 	},
 /area/mainship/medical/cmo_office)
+"dJp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "dKa" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 8
@@ -8367,6 +8394,21 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/alpha)
+"dUv" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/flashlight/combat,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest/lime,
+/obj/item/clothing/suit/storage/hazardvest/blue,
+/obj/item/tool/shovel/etool,
+/obj/item/storage/pouch/medkit/firstaid,
+/obj/item/tool/taperoll/engineering,
+/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sandbags_empty/half,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/white,
+/area/mainship/living/pilotbunks)
 "dVK" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/box/MRE,
@@ -8446,6 +8488,13 @@
 "ead" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_emb)
+"eaA" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "eaI" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/folder/black_random,
@@ -8750,6 +8799,10 @@
 	dir = 4
 	},
 /area/mainship/medical/medical_science)
+"eEv" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "eEW" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint{
@@ -8898,6 +8951,10 @@
 	},
 /turf/open/floor/mainship/blue,
 /area/mainship/living/port_emb)
+"ePZ" = (
+/obj/machinery/door/airlock/mainship/command/FCDRoffice,
+/turf/open/floor/mainship/blue,
+/area/mainship/living/numbertwobunks)
 "eQw" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -9016,6 +9073,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
+"fgI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "fim" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -9101,14 +9165,8 @@
 	},
 /area/mainship/living/pilotbunks)
 "fmN" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/pilotbunks)
+/turf/open/floor/mainship/cargo,
+/area/mainship/living/numbertwobunks)
 "fno" = (
 /obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /obj/machinery/light/mainship,
@@ -9395,6 +9453,10 @@
 	dir = 4
 	},
 /area/mainship/command/bridge)
+"fEL" = (
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/living/numbertwobunks)
 "fEO" = (
 /obj/machinery/door/airlock/mainship/marine/general/smart{
 	dir = 2
@@ -9582,12 +9644,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fWN" = (
-/obj/machinery/door/airlock/mainship/command/FCDRoffice{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "fWU" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating/icefloor/warnplate,
@@ -9902,14 +9958,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "gtX" = (
-/obj/structure/sink{
+/obj/machinery/marine_selector/clothes/leader,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/structure/mirror{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/pilotbunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "gwq" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -10063,9 +10117,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"gGw" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/numbertwobunks)
 "gHw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
@@ -10137,6 +10188,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"gOt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/numbertwobunks)
 "gPy" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -10184,6 +10245,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"gQH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/prison/arrow/clean,
+/area/mainship/hallways/hangar)
 "gRu" = (
 /obj/machinery/landinglight/cas{
 	dir = 4
@@ -10226,13 +10293,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
-"gWC" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "gXv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -10355,6 +10415,14 @@
 	dir = 1
 	},
 /area/mainship/living/numbertwobunks)
+"hgs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/blue/corner{
+	dir = 8
+	},
+/area/mainship/living/numbertwobunks)
 "hgY" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10419,11 +10487,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"hjO" = (
-/obj/effect/landmark/start/job/fieldcommander,
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "hjX" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/rad{
@@ -10498,16 +10561,19 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
+"hmM" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/mainship/cargo,
+/area/mainship/living/pilotbunks)
 "hnw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/lower_engineering)
-"hnY" = (
-/obj/machinery/marine_selector/clothes/synth,
-/turf/open/floor/mainship/cargo,
-/area/mainship/living/numbertwobunks)
 "hol" = (
 /obj/machinery/light/mainship,
 /obj/machinery/disposal,
@@ -10516,6 +10582,23 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
+"hor" = (
+/obj/machinery/cic_maptable,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"hoB" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/numbertwobunks)
 "hqs" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/mainship/orange/full,
@@ -10716,10 +10799,6 @@
 	dir = 1
 	},
 /area/mainship/living/port_emb)
-"hHj" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/mainship/cargo,
-/area/mainship/living/numbertwobunks)
 "hHM" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -10739,17 +10818,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
-"hIC" = (
-/obj/structure/displaycase/destroyed,
-/obj/item/toy/plush/rouny,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "hJa" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/air_alarm,
@@ -10771,18 +10839,11 @@
 	},
 /area/mainship/living/cryo_cells)
 "hKR" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/flashlight/combat,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest/lime,
-/obj/item/clothing/suit/storage/hazardvest/blue,
-/obj/item/tool/shovel/etool,
-/obj/item/storage/pouch/medkit/firstaid,
-/obj/item/tool/taperoll/engineering,
-/obj/effect/spawner/random/engineering/extinguisher/miniweighted,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/sandbags_empty/half,
-/turf/open/floor/mainship/cargo,
+/obj/item/toy/plush/rouny,
+/obj/structure/displaycase/destroyed,
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
 /area/mainship/living/numbertwobunks)
 "hNl" = (
 /obj/structure/bed/chair/comfy/black{
@@ -11147,22 +11208,6 @@
 /obj/docking_port/stationary/supply,
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
-"itC" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/turf/open/floor/carpet/side{
-	dir = 5
-	},
-/area/mainship/living/numbertwobunks)
-"itV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "iug" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -11345,6 +11390,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"iIn" = (
+/turf/open/floor/prison/arrow/clean{
+	dir = 1
+	},
+/area/mainship/living/numbertwobunks)
 "iJv" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/alpha)
@@ -11876,6 +11926,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
+"jEM" = (
+/obj/machinery/marine_selector/gear/commander,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "jER" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -12080,12 +12134,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
-"jYi" = (
-/obj/effect/ai_node,
-/turf/open/floor/carpet/side{
-	dir = 10
-	},
-/area/mainship/living/numbertwobunks)
 "jZv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12356,13 +12404,6 @@
 	dir = 6
 	},
 /area/mainship/squads/req)
-"kxg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "kxp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12461,6 +12502,19 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"kBP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "kBU" = (
 /obj/machinery/light/mainship/small{
 	dir = 4
@@ -12832,9 +12886,12 @@
 /turf/open/floor/mainship/silver,
 /area/mainship/command/cic)
 "llf" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/machinery/marine_selector/clothes/synth,
+/turf/open/floor/mainship/cargo,
+/area/mainship/living/pilotbunks)
 "llh" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
 /turf/open/floor/mainship/mono,
@@ -12990,17 +13047,6 @@
 "lvI" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"lwr" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "lxe" = (
 /turf/open/floor/mainship/orange{
 	dir = 5
@@ -13342,6 +13388,9 @@
 	dir = 8
 	},
 /area/mainship/hallways/bow_hallway)
+"lRd" = (
+/turf/open/floor/mainship/blue,
+/area/mainship/living/numbertwobunks)
 "lRg" = (
 /obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/orange{
@@ -13604,18 +13653,6 @@
 	},
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/surgery_hallway)
-"mqI" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "mra" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/green{
@@ -13703,10 +13740,6 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
-"myv" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "mzi" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -13730,6 +13763,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
+"mBc" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "mBt" = (
 /obj/machinery/computer/ordercomp,
 /turf/open/floor/mainship/green,
@@ -14006,6 +14048,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
+"mSr" = (
+/obj/machinery/cic_maptable/drawable/big,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "mTg" = (
 /obj/machinery/landinglight/cas{
 	dir = 1
@@ -14771,17 +14817,6 @@
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
 /area/mainship/hallways/hangar)
-"ofY" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/command/FCDRoffice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "ogn" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
@@ -14893,6 +14928,10 @@
 	dir = 10
 	},
 /area/mainship/command/bridge)
+"opL" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "orG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/personal{
 	name = "\improper Pilot's Bunks Airlock"
@@ -14954,6 +14993,10 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
+"oyG" = (
+/obj/machinery/computer/squad_manager,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "oyL" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15092,11 +15135,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "oHZ" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom{
-	dir = 2
-	},
+/obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/pilotbunks)
+/area/mainship/living/numbertwobunks)
 "oIq" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clothing/head/welding,
@@ -15813,6 +15854,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"pUx" = (
+/obj/effect/landmark/start/job/fieldcommander,
+/turf/open/floor/carpet/side{
+	dir = 4
+	},
+/area/mainship/living/numbertwobunks)
 "pUF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15832,14 +15879,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/bridgebunks)
-"pWE" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/living/numbertwobunks)
 "pWJ" = (
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -15868,10 +15907,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/repair_bay)
 "pXz" = (
-/obj/structure/toilet,
-/obj/structure/mirror,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/pilotbunks)
 "pXO" = (
 /turf/open/floor/mainship/silver/corner{
 	dir = 8
@@ -15975,16 +16012,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
-"qhh" = (
-/obj/machinery/keycard_auth{
-	pixel_y = -30
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/obj/item/plantable_flag,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "qhN" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -16025,17 +16052,6 @@
 /obj/machinery/line_nexter,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
-"qiO" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/carpet/side{
-	dir = 1
-	},
-/area/mainship/living/numbertwobunks)
 "qjs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/mainship{
@@ -16558,11 +16574,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
-"qYe" = (
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
 "qZy" = (
 /turf/open/floor/mainship/blue,
 /area/mainship/living/port_emb)
@@ -16609,17 +16620,12 @@
 	},
 /area/mainship/command/cic)
 "raA" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
-/obj/machinery/door/window{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/numbertwobunks)
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/pilotbunks)
 "rbv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16754,6 +16760,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
+"rok" = (
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "rpv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -16922,6 +16932,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/aft_hallway)
+"rGp" = (
+/obj/machinery/marine_selector/clothes/commander,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "rGG" = (
 /obj/structure/cable,
 /obj/machinery/firealarm{
@@ -16996,6 +17013,14 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/hallways/hangar)
+"rMW" = (
+/obj/machinery/light/mainship,
+/obj/item/plantable_flag,
+/obj/effect/ai_node,
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
+/area/mainship/living/numbertwobunks)
 "rNO" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/camera,
@@ -17426,12 +17451,19 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
+"stE" = (
+/turf/open/floor/prison/arrow/clean,
+/area/mainship/hallways/hangar)
 "stM" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/job/pilotofficer,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"stZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/personal,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "suc" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/book/manual/engineering_construction,
@@ -17453,6 +17485,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
+"svY" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/mainship/cargo,
+/area/mainship/living/pilotbunks)
 "swv" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
@@ -17574,16 +17610,6 @@
 /obj/item/toy/plush/moth,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_emb)
-"sMo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "sMD" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/reagent_containers/food/snacks/sandwiches/sandwich,
@@ -18251,6 +18277,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/silver/corner,
 /area/mainship/command/bridge)
+"tLv" = (
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "tLN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -18407,6 +18437,10 @@
 	dir = 9
 	},
 /area/mainship/hallways/repair_bay)
+"tYn" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/cargo,
+/area/mainship/living/pilotbunks)
 "tYy" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -18701,10 +18735,6 @@
 	dir = 10
 	},
 /area/space)
-"uym" = (
-/obj/machinery/door/airlock/command,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "uyz" = (
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
@@ -18870,9 +18900,6 @@
 	dir = 8
 	},
 /area/mainship/medical/operating_room_four)
-"uIz" = (
-/turf/open/floor/carpet/side,
-/area/mainship/living/numbertwobunks)
 "uJx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/purple/corner{
@@ -19017,14 +19044,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "uYg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -19168,9 +19195,8 @@
 	},
 /area/mainship/living/basketball)
 "vlF" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/pilotbunks)
 "vmj" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
@@ -19262,13 +19288,6 @@
 	dir = 1
 	},
 /area/mainship/medical/cmo_office)
-"vtz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "vtE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19727,6 +19746,7 @@
 "wif" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wks" = (
@@ -19764,10 +19784,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"wmE" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "wnT" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/mainship/sterile/dark,
@@ -19906,10 +19922,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
-"wCq" = (
-/obj/machinery/marine_selector/gear/commander,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "wDA" = (
 /obj/machinery/light{
 	dir = 4
@@ -20361,11 +20373,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
-"xwr" = (
-/turf/open/floor/carpet/side{
-	dir = 9
-	},
-/area/mainship/living/numbertwobunks)
 "xwJ" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -20428,10 +20435,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
-"xCC" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "xCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -20739,11 +20742,6 @@
 	dir = 5
 	},
 /area/mainship/medical/lower_medical)
-"yes" = (
-/obj/machinery/camera/autoname/mainship,
-/obj/machinery/vending/engivend,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "yeD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20828,27 +20826,12 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"yji" = (
-/obj/effect/ai_node,
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/marine_card,
-/obj/item/storage/box/ids,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "yjZ" = (
-/obj/structure/bed/chair/nometal{
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/carpet/side{
 	dir = 8
 	},
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "ykh" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -41379,14 +41362,14 @@ eLM
 kCI
 lOP
 bUE
-aVs
-aVs
-aVs
-aVs
-aVs
-aVs
-aVs
-aVs
+lzj
+lzj
+lzj
+lzj
+lzj
+lzj
+lzj
+lzj
 fZA
 aec
 aWr
@@ -41636,14 +41619,14 @@ blA
 vDT
 lOP
 lvI
-abR
-gjK
-mqI
-qhh
-abR
-hIC
-wCq
-abR
+lzj
+ugw
+srL
+nKK
+lzj
+cZJ
+gXv
+lzj
 adZ
 aeb
 aeb
@@ -41893,14 +41876,14 @@ blA
 vDT
 lOP
 uJT
-abR
-wmE
-yji
-vtz
-fWN
-hjO
-myv
-abR
+lzj
+xUW
+gyX
+fmE
+tJi
+uHQ
+mIu
+lzj
 wem
 aVk
 aaa
@@ -42150,14 +42133,14 @@ htp
 vDT
 lOP
 lvI
-abR
-xwJ
-sMo
-gWC
-abR
-xwr
-jYi
-abR
+lzj
+olA
+mZl
+tuC
+lzj
+lzj
+lzj
+lzj
 wem
 aVk
 aaa
@@ -42407,14 +42390,14 @@ hHM
 vDT
 tgH
 lvI
-abR
-abR
-ofY
-abR
-abR
-hgk
-uIz
-abR
+orG
+mVi
+tSg
+hvM
+lzj
+cZJ
+stM
+lzj
 fZA
 aVk
 aaa
@@ -42664,14 +42647,14 @@ hHM
 kST
 wAm
 ekU
-pWE
-bAh
-lwr
-xBW
-abR
-qiO
-uIz
-abR
+foR
+xJO
+ble
+wXn
+tJi
+uHQ
+mIu
+lzj
 sao
 aVk
 aaa
@@ -42921,14 +42904,14 @@ hHM
 vDT
 ikx
 paD
-bYm
-kxg
-itV
-bnr
-abR
-itC
-qYe
-abR
+lzj
+qqj
+cHr
+bXz
+lzj
+lzj
+lzj
+lzj
 fZA
 aVk
 aaa
@@ -43178,14 +43161,14 @@ hHM
 sim
 lOP
 vSJ
-abR
-abR
-uym
-abR
-abR
-abR
+lzj
+nOw
+mol
+dUv
+lzj
+tYn
 llf
-abR
+lzj
 qae
 aVk
 aaa
@@ -43435,14 +43418,14 @@ hHM
 vDT
 lOP
 ajg
-abR
-hHj
-ybO
-cyf
-abR
+qeE
+arK
+jnS
+ecE
+tJi
 coU
 vlF
-abR
+eQw
 wem
 aVk
 aaa
@@ -43692,14 +43675,14 @@ ppE
 vDT
 lOP
 iUK
-abR
-yes
-gGw
-xCC
-abR
+lzj
+lzj
+lzj
+lzj
+lzj
 pXz
-ybO
-abR
+aGj
+lzj
 wem
 aVk
 aaa
@@ -43950,13 +43933,13 @@ vDT
 qij
 anT
 abR
-hnY
+hgk
 yjZ
 hKR
-abR
-aop
+lzj
+pXz
 raA
-abR
+lzj
 fZA
 aVk
 aaa
@@ -44206,13 +44189,13 @@ blA
 vDT
 lOP
 xXY
+abR
+aBW
+pUx
+rMW
 lzj
-lzj
-lzj
-lzj
-lzj
-lzj
-lzj
+hmM
+svY
 lzj
 sao
 aVk
@@ -44463,13 +44446,13 @@ tzZ
 eaL
 bPG
 aWI
+abR
+abR
+abR
+ePZ
 lzj
-ugw
-srL
-nKK
 lzj
-cZJ
-gXv
+lzj
 lzj
 fZA
 aVk
@@ -44719,15 +44702,15 @@ mJs
 gfg
 brb
 lOP
-bUE
-lzj
-xUW
-gyX
-fmE
-tJi
-uHQ
-mIu
-lzj
+hor
+abR
+rok
+xBW
+lRd
+jEM
+rGp
+gjK
+abR
 wem
 aVk
 aaa
@@ -44975,16 +44958,16 @@ bgb
 pcr
 lvI
 bYN
-lOP
-uJT
-lzj
-olA
-mZl
-tuC
-lzj
-lzj
-lzj
-lzj
+kBP
+gQH
+bdA
+fgI
+cMJ
+hgs
+bHh
+gOt
+hoB
+abR
 wem
 aVk
 aaa
@@ -45233,15 +45216,15 @@ bSC
 aMR
 kCI
 lOP
-lvI
-orG
-mVi
-tSg
-hvM
-lzj
-cZJ
-stM
-lzj
+stE
+ybO
+ybO
+dJp
+ybO
+ybO
+aZQ
+eaA
+abR
 wem
 aVk
 aaa
@@ -45488,17 +45471,17 @@ xjj
 uns
 bqA
 lvI
-bGr
+lvI
 uYg
 cNr
-foR
-xJO
-ble
-wXn
-tJi
-uHQ
-mIu
-lzj
+abR
+opL
+iIn
+ybO
+mSr
+ybO
+tLv
+abR
 fZA
 aVk
 aaa
@@ -45747,15 +45730,15 @@ mJs
 gfg
 ygZ
 lOP
-lvI
-lzj
-qqj
-cHr
-bXz
-lzj
-lzj
-lzj
-lzj
+stE
+stZ
+ybO
+ybO
+ybO
+ybO
+ybO
+oyG
+abR
 sao
 aVk
 aaa
@@ -46004,16 +45987,16 @@ pcr
 lvI
 wif
 lOP
-uJT
-lzj
-nOw
-mol
-tuC
-lzj
+stE
+ybO
+ybO
+ybO
+eEv
+ybO
 fmN
-bFX
-lzj
-fZA
+ybO
+mBc
+jAD
 aVk
 aaa
 aaa
@@ -46261,16 +46244,16 @@ bSC
 aMR
 bPn
 lOP
-bUE
-qeE
-arK
-jnS
-ecE
+hor
+fEL
+rok
+clO
+xwJ
 oHZ
 gtX
-wXn
-eQw
-qae
+gjK
+abR
+wem
 aVk
 aaa
 aaa
@@ -46519,14 +46502,14 @@ gBG
 bGF
 bPG
 bbo
-lzj
-lzj
-lzj
-lzj
-lzj
-lzj
-lzj
-lzj
+abR
+abR
+abR
+abR
+abR
+abR
+abR
+abR
 wem
 aVk
 aaa
@@ -47289,7 +47272,7 @@ ceA
 blA
 esw
 lOP
-lvI
+bUE
 bRE
 bRE
 ehv

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -9498,7 +9498,6 @@
 	pixel_x = -7;
 	pixel_y = 2
 	},
-/obj/item/minimap_tablet,
 /turf/open/floor/mainship/silver{
 	dir = 4
 	},
@@ -11928,6 +11927,7 @@
 /area/mainship/hallways/port_umbilical)
 "jEM" = (
 /obj/machinery/marine_selector/gear/commander,
+/obj/item/minimap_tablet,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "jER" = (


### PR DESCRIPTION
## About The Pull Request

Merges FC and SL prep into one, complete with a drawable map table for group planning

Moves minimap tablet from CIC to the FC/SL preps on each ship to encourage use more

## Pillar of Spring:
(Note: Pictures outdated; minimap tablet is on the FC vendor in each of these photos)

![image](https://github.com/user-attachments/assets/9095da8c-d609-4778-81eb-bda657449871)

This also gives room for more spacious medic/engi/SG preps on Pillar of Spring specifically:
![image](https://github.com/user-attachments/assets/75c0e026-b42c-42c9-a1df-be9d78bf9198)

## Arachne: (fire alarm fixed)
![image](https://github.com/user-attachments/assets/6af38813-002e-42ab-a98c-5ab2f36d7baf)

## Sulaco:
![image](https://github.com/user-attachments/assets/5ce9636d-aacc-433b-a9a7-807550e4cc38)

## Theseus:
Theseus has SL prep split by squad. Because of this Theseus instead has a minimap briefing room outside the FC office:
![image](https://github.com/user-attachments/assets/15891aa8-20fd-415c-a45c-582589132936)
## Why It's Good For The Game

FCs and SLs need to work and plan together to ensure the marines' victory but the rooms they prepare in are often completely across the ship. This is bad for several reasons:
- FC/SLs can't plan during the first minutes of drop, which is the only time you get before engis/etc already have their gear setup.
- It's harder to plan over comms, it's easier in-person. It's even easier with a minimap table beside you.
- If you want to draft a plan on tacmap you previously had to walk all the way over to CIC and waste like 10 minutes waiting for everyone to arrive. Now you can hold a meeting from the comfort of prep, visually show your plan to the SLs, then draw it up!
- People tend to work together better if they've "met in person". Higher chance of meeting in person = higher cohesion = cooler gameplay.
- War room meetings are cool and I think we should make them easier to do
## Changelog
:cl:
add: Merged FC and SL prep rooms on Arachne, Sulaco and Pillar of Spring. Added a minimap table war room outside the FC's office on Theseus.
add: Expanded Pillar of Spring engineer, medic and smartgunner prep rooms.
/:cl:
