### PR TITLE
Removes a disk candidate site from Research Outpost

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -5813,10 +5813,6 @@
 	dir = 8
 	},
 /area/outpost/hallway/central)
-"Bm" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/tile/dark/red2,
-/area/outpost/brig/wardens_office)
 "Bn" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 4
@@ -25215,7 +25211,7 @@ Qo
 lp
 zg
 Tp
-Bm
+FG
 yY
 tz
 tx


### PR DESCRIPTION

## About The Pull Request
This disk is in the same building as the nuke.
## Why It's Good For The Game
Probably should not let marines take a disk on the nuke site
## Changelog
:cl:
balance: The nuke room on Research Outpost may no longer also have a disk.
/:cl:
