### PR TITLE
Tank and apc door now are full opaque

### DIFF
--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -79,6 +79,7 @@
 	name = "exit hatch"
 	icon = 'icons/obj/armored/3x3/tank_interior.dmi'
 	icon_state = "tank_interior_7"
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	resistance_flags = RESIST_ALL
 	///owner of this object, assigned during interior linkage
 	var/obj/vehicle/sealed/armored/owner


### PR DESCRIPTION

## About The Pull Request

See CL


## Changelog
:cl:
qol: The entire tile of tank doors now registers as part of the door for being clicked from the inside to make getting out easier
/:cl:
