### PR TITLE
Campaign map fixes

### DIFF
--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -7876,8 +7876,8 @@
 /area/campaign/jungle_outpost/ground/jungle/north)
 "NQ" = (
 /obj/structure/rack,
-/obj/item/weapon/gun/rifle/tx11,
-/obj/item/weapon/gun/rifle/tx11,
+/obj/item/weapon/gun/rifle/tx11/scopeless,
+/obj/item/weapon/gun/rifle/tx11/scopeless,
 /turf/open/floor/tile/red/redtaupe{
 	dir = 4
 	},

--- a/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
+++ b/_maps/map_files/Campaign maps/nt_base/nt_base.dmm
@@ -13469,7 +13469,7 @@
 /area/gelida/indoors/c_block/mining)
 "jVX" = (
 /obj/structure/table/mainship,
-/obj/item/weapon/gun/rifle/tx11,
+/obj/item/weapon/gun/rifle/tx11/scopeless,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -20248,7 +20248,7 @@
 /obj/item/ammo_magazine/rifle/tx11,
 /obj/item/ammo_magazine/rifle/tx11,
 /obj/item/ammo_magazine/rifle/tx11,
-/obj/item/weapon/gun/rifle/tx11{
+/obj/item/weapon/gun/rifle/tx11/scopeless{
 	pixel_y = -6
 	},
 /turf/open/floor/prison,
@@ -27253,7 +27253,7 @@
 /area/gelida/indoors/a_block/security)
 "tRN" = (
 /obj/structure/closet/crate/ammo,
-/obj/item/weapon/gun/rifle/tx11,
+/obj/item/weapon/gun/rifle/tx11/scopeless,
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "tRT" = (

--- a/_maps/map_files/Campaign maps/som_base/sombase.dmm
+++ b/_maps/map_files/Campaign maps/som_base/sombase.dmm
@@ -4432,7 +4432,7 @@
 /area/rocinante_base/surface/building/science/bio_lab)
 "gci" = (
 /obj/machinery/floor_warn_light,
-/turf/closed/shuttle/re_corner,
+/turf/closed/shuttle,
 /area/rocinante_base/surface/building/science/tele_lab)
 "gdi" = (
 /obj/machinery/vending/coffee,
@@ -12809,7 +12809,7 @@
 /turf/open/floor/plating/dmg1,
 /area/rocinante_base/surface/building/mining_construction)
 "sdN" = (
-/turf/closed/shuttle/re_corner,
+/turf/closed/shuttle,
 /area/rocinante_base/surface/building/science/tele_lab)
 "seF" = (
 /obj/structure/flora/ausbushes/grassybush,

--- a/_maps/map_files/Campaign maps/tgmc_raid_base/tgmc_raiding_base.dmm
+++ b/_maps/map_files/Campaign maps/tgmc_raid_base/tgmc_raiding_base.dmm
@@ -7484,10 +7484,6 @@
 /obj/structure/cargo_container/hd,
 /turf/open/floor/plating/ground/concrete,
 /area/campaign/tgmc_raiding/underground/cargo)
-"Ee" = (
-/obj/structure/closet/secure_closet/captain,
-/turf/open/floor/carpet/blue,
-/area/campaign/tgmc_raiding/underground/command/captain)
 "Ef" = (
 /obj/structure/flora/drought/tall_cactus,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -26484,7 +26480,7 @@ IH
 IH
 IH
 IH
-Ee
+ra
 ie
 CR
 rZ


### PR DESCRIPTION
## About The Pull Request
Fixes TGMC raiding base have a full mateba belt.

Swaps a few AR-11's with scopes on some maps with nonscoped versions.

Fixes SOM supply base having some space tiles (which was bizarre, as the turfs they DID have previously... never actually existed as it's own turf type).


:cl:
fix: Campaign: Fixed some map issues
/:cl:
