### PR TITLE
Campaign: Esword secondary fix

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/secondaries.dm
@@ -76,9 +76,13 @@
 	jobs_supported = list(SOM_SQUAD_MARINE, SOM_SQUAD_ENGINEER, SOM_SQUAD_VETERAN, SOM_SQUAD_LEADER)
 	item_typepath = /obj/item/weapon/energy/sword/som
 	loadout_item_flags = NONE
+	item_whitelist = null
+	req_desc = null
 
 /datum/loadout_item/secondary/esword/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout, datum/outfit_holder/holder)
-	wearer.equip_to_slot_or_del(new item_typepath(wearer), SLOT_IN_BELT)
+	wearer.equip_to_slot_or_del(new item_typepath(wearer), SLOT_BELT)
+	if(!isstorageobj(wearer.back))
+		return
 	default_load(wearer, loadout, holder)
 
 //kits


### PR DESCRIPTION

## About The Pull Request
Fixes #16875

Specifically, the sword actually spawns, and backpack is no longer a prereq (if you do have a backpack it gives you extra shit though, but this means you can have blink drive and dual sword if you want).

:cl:
fix: Campaign: Fixed the esword secondary not spawning, and requiring a backpack
/:cl:
