### PR TITLE
Fixes map errors on Pillar of Spring + map table adjustment

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -374,12 +374,6 @@
 	dir = 10
 	},
 /area/mainship/hallways/hangar/droppod)
-"apL" = (
-/obj/machinery/cic_maptable/drawable/big{
-	pixel_x = 0
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "apO" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/wood,
@@ -25029,6 +25023,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8
 	},
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "uCc" = (
@@ -40752,9 +40749,9 @@ miz
 aOG
 alG
 lqg
-apL
+lqg
 uBW
-apL
+lqg
 qtC
 oTv
 aOG

--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -4677,10 +4677,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
-"dXo" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/floor,
-/area/space)
 "dXZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/floor,
@@ -4803,10 +4799,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"eeE" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/mainship/floor,
-/area/space)
 "eff" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -8273,12 +8265,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"gTw" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/space)
 "gTZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10894,14 +10880,6 @@
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
-"iVk" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/space)
 "iVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -13795,10 +13773,6 @@
 	dir = 1
 	},
 /area/mainship/engineering/engineering_workshop)
-"lnT" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/floor,
-/area/space)
 "loy" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -16695,13 +16669,6 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
-"nCG" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/space)
 "nCM" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
@@ -18784,10 +18751,6 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"pjb" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/space/basic,
-/area/space)
 "pje" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/disposalpipe/segment{
@@ -19857,11 +19820,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/hallways/starboard_ert)
-"qfF" = (
-/obj/machinery/vending/uniform_supply,
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
-/area/space)
 "qfK" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clipboard{
@@ -20624,13 +20582,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"qOC" = (
-/obj/machinery/marine_selector/gear/commander,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/space)
 "qOG" = (
 /obj/effect/turf_decal/warning_stripes,
 /obj/vehicle/ridden/powerloader,
@@ -25339,10 +25290,6 @@
 	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
-"uOG" = (
-/obj/machinery/vending/weapon,
-/turf/open/space/basic,
-/area/space)
 "uOM" = (
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/black{
@@ -27013,10 +26960,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"wdM" = (
-/obj/machinery/marine_selector/gear/leader,
-/turf/open/space/basic,
-/area/space)
 "wer" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flipped{
@@ -28133,12 +28076,6 @@
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"xaW" = (
-/obj/machinery/marine_selector/gear/leader,
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
-/area/space)
 "xaX" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/structure/disposalpipe/segment{
@@ -42032,9 +41969,9 @@ meP
 meP
 jzy
 meP
-xaW
-iVk
-gTw
+meP
+meP
+meP
 meP
 kPR
 vkb
@@ -42337,11 +42274,11 @@ meP
 meP
 meP
 jzy
-pjb
 meP
-wdM
-pjb
-uOG
+meP
+meP
+meP
+meP
 meP
 bwF
 vkb
@@ -42542,7 +42479,7 @@ meP
 meP
 jzy
 meP
-nCG
+meP
 meP
 meP
 meP
@@ -42642,7 +42579,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -42744,7 +42681,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -42846,7 +42783,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -42948,7 +42885,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43050,7 +42987,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43152,7 +43089,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43254,7 +43191,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43356,7 +43293,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43458,7 +43395,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43560,7 +43497,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43662,7 +43599,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43764,7 +43701,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -43866,7 +43803,7 @@ meP
 meP
 meP
 meP
-meP
+jzy
 meP
 meP
 meP
@@ -44171,7 +44108,7 @@ meP
 (144,1,1) = {"
 meP
 meP
-dXo
+meP
 jzy
 meP
 meP
@@ -44273,7 +44210,7 @@ meP
 (145,1,1) = {"
 meP
 meP
-eeE
+meP
 jzy
 jzy
 jzy
@@ -44375,7 +44312,7 @@ meP
 (146,1,1) = {"
 meP
 meP
-qOC
+meP
 meP
 meP
 meP
@@ -44477,12 +44414,12 @@ meP
 (147,1,1) = {"
 meP
 meP
-lnT
-qfF
 meP
 meP
 meP
-eeE
+meP
+meP
+meP
 meP
 meP
 meP
@@ -44584,7 +44521,7 @@ meP
 meP
 meP
 meP
-qOC
+meP
 meP
 meP
 meP

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6197,12 +6197,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/hull/lower_hull)
-"hIw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "hIF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7750,12 +7744,6 @@
 /obj/structure/benchpress,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"jRq" = (
-/obj/machinery/cic_maptable/drawable/big{
-	pixel_x = 0
-	},
-/turf/closed/wall/mainship,
-/area/crew_quarters/toilet)
 "jRQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -14908,14 +14896,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/crew_quarters/toilet)
-"sAR" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship/small{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "sBh" = (
 /obj/item/reagent_containers/jerrycan,
 /obj/item/reagent_containers/jerrycan,
@@ -15284,6 +15264,11 @@
 /area/mainship/living/grunt_rnr)
 "tdE" = (
 /obj/machinery/vending/nanomed,
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
+"tdQ" = (
+/obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -18498,7 +18483,6 @@
 /turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "xbv" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -55004,7 +54988,7 @@ pqQ
 xLu
 fAJ
 fAJ
-jRq
+fAJ
 fAJ
 kVD
 cTx
@@ -58878,7 +58862,7 @@ fmP
 nhn
 nbh
 eeX
-tis
+tdQ
 cPg
 rHh
 hcr
@@ -60949,21 +60933,21 @@ wPV
 qFT
 sYv
 xbv
-sAR
-hUz
-rCA
-hIw
-hUz
-fAo
-hUz
-hUz
-anW
-cbS
-hUz
-hUz
-hUz
-hUz
-rCA
+mDY
+wPV
+sYv
+qFT
+wPV
+hME
+wPV
+wPV
+hME
+wPV
+wPV
+wPV
+wPV
+wPV
+sYv
 lew
 sYv
 fgk

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1501,7 +1501,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "bNh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3787,7 +3789,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/dinnerware,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "eHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5857,7 +5861,9 @@
 /area/mainship/command/cic)
 "hfu" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "hgl" = (
 /obj/vehicle/ridden/motorbike,
@@ -6996,7 +7002,9 @@
 /area/mainship/living/tankerbunks)
 "iIf" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "iII" = (
 /obj/structure/bed/chair/comfy{
@@ -8790,12 +8798,6 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
-"lfH" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -10884,7 +10886,9 @@
 /area/mainship/medical/upper_medical)
 "nwt" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "nwy" = (
 /obj/item/weapon/telebaton,
@@ -11661,6 +11665,12 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"oBe" = (
+/obj/machinery/cic_maptable/drawable/big{
+	pixel_x = 0
+	},
+/turf/closed/wall/mainship,
+/area/crew_quarters/toilet)
 "oCo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
@@ -47016,7 +47026,7 @@ nzB
 kDx
 kDx
 kDx
-lfH
+kDx
 kDx
 plN
 aql
@@ -54992,7 +55002,7 @@ pqQ
 xLu
 fAJ
 fAJ
-fAJ
+oBe
 fAJ
 kVD
 cTx
@@ -59128,7 +59138,7 @@ hfu
 eHh
 bNe
 iIf
-cPg
+lkH
 bFc
 ini
 lPY

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6018,9 +6018,6 @@
 /turf/open/floor/mainship/mono,
 /area/crew_quarters/toilet)
 "hoR" = (
-/obj/machinery/cic_maptable/drawable/big{
-	pixel_x = 0
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -55780,8 +55777,8 @@ rUF
 xWS
 mRy
 hoR
-cPg
 vDF
+cPg
 fHj
 rUF
 diF

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -992,6 +992,13 @@
 	dir = 8
 	},
 /area/space)
+"bhR" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "biq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/air_alarm{
@@ -1189,10 +1196,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/mainship/hull/lower_hull)
+/area/mainship/shipboard/firing_range)
 "bxv" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/upper_medical)
+"bxw" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "bxQ" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -1922,6 +1936,11 @@
 /obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship_hull,
 /area/space)
+"cpO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "cqy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -6810,7 +6829,7 @@
 /area/mainship/medical/lower_medical)
 "iwe" = (
 /turf/open/floor/plating,
-/area/mainship/hull/lower_hull)
+/area/mainship/shipboard/firing_range)
 "iwj" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
@@ -60896,17 +60915,17 @@ nWT
 nWT
 esN
 unX
-qeW
-rKn
-rKn
-rKn
+nJG
+nJG
+nJG
+nJG
 iwe
 bvM
-rKn
-rKn
-rKn
-rKn
-rCA
+nJG
+nJG
+nJG
+nJG
+bhR
 wHk
 wPV
 mDY
@@ -61153,17 +61172,17 @@ nWT
 nWT
 esN
 ssm
-hUz
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
+rCA
+cpO
+cpO
+cpO
+cpO
+cpO
+cpO
+cpO
+cpO
+cpO
+bxw
 esN
 esN
 esN
@@ -61408,19 +61427,19 @@ nWT
 nWT
 nWT
 nWT
-brL
-brL
-brL
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
 nWT
 nWT
 nWT


### PR DESCRIPTION

## About The Pull Request

See title
## Why It's Good For The Game

Fixes good

Removing map tables was requested because they made the room cramped
## Changelog
:cl:
fix: Fixed stray windows and tiles on Pillar of Spring
del: SL prep rooms now have 1 map table instead of 2 for space
/:cl:
