### PR TITLE
Revert "Laser pouch can no longer be used as a magazine for Lasguns or Tesla guns."

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -280,7 +280,7 @@
 	damage_falloff_mult = 0.25
 	fire_delay = 2
 	default_ammo_type = /obj/item/cell/lasgun/lasrifle
-	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle, /obj/item/cell/lasgun/lasrifle/recharger)
+	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle, /obj/item/cell/lasgun/lasrifle/recharger, /obj/item/cell/lasgun/volkite/powerpack/marine)
 	/// A list of available modes this gun can switch to
 	var/list/datum/lasrifle/mode_list = list()
 	/// The index of the current mode selected, used for non radial mode switches
@@ -379,7 +379,7 @@
 	equip_slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	default_ammo_type = /obj/item/cell/lasgun/lasrifle
-	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle, /obj/item/cell/lasgun/lasrifle/recharger)
+	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle, /obj/item/cell/lasgun/lasrifle/recharger, /obj/item/cell/lasgun/volkite/powerpack/marine)
 	gun_features_flags = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_SHOWS_AMMO_REMAINING
 	muzzle_flash_color = COLOR_TESLA_BLUE
 	ammo_level_icon = "tesla"


### PR DESCRIPTION
## About The Pull Request
this reverts https://github.com/tgstation/TerraGov-Marine-Corps/pull/14695 because of a couple reasons. 
## Why It's Good For The Game
1st, because it's fun. 
2nd, because it gives laser pouches an actual reason to exist, especially with backpack batteries, laser pouches are hilariously useless as they exist right now. every time I've been ingame and talked to people about it, the response has been overwhelmingly negative about the change, and we're not entirely sure why it was made in the first place. 
the whole knockdown = gun disconnected thing was a solid balancing mechanic, and this gives more realistic usability to more energy hungry lasermodes. 

3rd. remove or move them to req if this isn't enough, because they have no reason to exist as they do
4th, because I said I would
## Changelog

:cl:
revert: laser pouches being next to worthless
/:cl:
