### PR TITLE
Adds Soda Dispenser to Valhalla.

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1666,6 +1666,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side,
 /area/centcom/valhalla)
+"cfr" = (
+/obj/machinery/chem_dispenser/soda{
+	dir = 8;
+	pixel_x = -17;
+	pixel_y = -1
+	},
+/turf/closed/mineral/smooth/indestructible,
+/area/centcom/valhalla)
 "cfQ" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -24657,7 +24665,7 @@ aqy
 gzY
 lEp
 lEp
-lEp
+cfr
 lEp
 box
 box


### PR DESCRIPTION
## About The Pull Request

Valhalla lacking a soda dispenser and that's bad.

## Why It's Good For The Game

Given how Valhalla is a place for testing and its missing one big tool for testing chem. I decided to add a wall soda dispenser to Valhalla's chem room. 
![Screenshot (984)](https://github.com/user-attachments/assets/5d5b5bcd-01bb-44ff-9d83-8be582dbff13)

## Changelog
:cl:
add: Adds soda dispenser to Valhalla.
/:cl:
