### PR TITLE
decapitalizes full faction announcement titles for consistency

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -88,7 +88,7 @@
 	else
 		alert_receivers = GLOB.alive_human_list_faction[human_owner.faction] + GLOB.ai_list + GLOB.observer_list
 		sound_alert = 'sound/misc/notice2.ogg'
-		announcement_title = "[uppertext(human_owner.job.title)]'s Announcement"
+		announcement_title = "[human_owner.job.title]'s Announcement"
 
 	for(var/mob/mob_receiver in alert_receivers)
 		mob_receiver.playsound_local(mob_receiver, sound_alert, 35, channel = CHANNEL_ANNOUNCEMENTS)

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -88,7 +88,7 @@
 	else
 		alert_receivers = GLOB.alive_human_list_faction[human_owner.faction] + GLOB.ai_list + GLOB.observer_list
 		sound_alert = 'sound/misc/notice2.ogg'
-		announcement_title = "[uppertext(human_owner.job.title)]'S ANNOUNCEMENT"
+		announcement_title = "[uppertext(human_owner.job.title)]'s Announcement"
 
 	for(var/mob/mob_receiver in alert_receivers)
 		mob_receiver.playsound_local(mob_receiver, sound_alert, 35, channel = CHANNEL_ANNOUNCEMENTS)

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -92,7 +92,7 @@
 
 	for(var/mob/mob_receiver in alert_receivers)
 		mob_receiver.playsound_local(mob_receiver, sound_alert, 35, channel = CHANNEL_ANNOUNCEMENTS)
-		mob_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[announcement_title]:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, override_color)
+		mob_receiver.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[uppertext(announcement_title)]:</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, override_color)
 		to_chat(mob_receiver, assemble_alert(
 			title = announcement_title,
 			subtitle = "Sent by [human_owner.get_paygrade(0) ? human_owner.get_paygrade(0) : human_owner.job.title] [human_owner.real_name]",


### PR DESCRIPTION
## About The Pull Request
Decapitalizes full faction announcement titles done by the FC/CMO/Captain/etc using send orders (in chat only - the title is still loud in maptext)
![image](https://github.com/user-attachments/assets/5d71d536-c694-46c3-92ac-d8ecbd6410b2)
![image](https://github.com/user-attachments/assets/a257b2a6-03f6-4807-ad03-821ca78156cb)
## Why It's Good For The Game
It's kinda jarring and just seems to be some kind of oversight on Lumi's part. Also, more consistency: this doesn't seem to happen with squad leader announcements
## Changelog
:cl:
fix: Full faction announcements (done by the FC, CMO, etc...) will no longer have fully capitalized titles in chat. (on-map titles are still capitalized)
/:cl:
