### PR TITLE
V-35 handling nerfs

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2239,8 +2239,8 @@
 	unload_sound = 'sound/weapons/guns/interact/m4ra_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/m4ra_reload.ogg'
 	caliber = CALIBER_10x27_CASELESS
-	aim_slowdown = 0.75
-	wield_delay = 1 SECONDS
+	aim_slowdown = 0.8
+	wield_delay = 1.1 SECONDS
 	force = 20
 	max_shells = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/som_big
@@ -2278,9 +2278,9 @@
 
 	fire_delay = 0.65 SECONDS
 	accuracy_mult = 1.1
-	scatter = -2
+	scatter = -1
 	burst_amount = 1
-	movement_acc_penalty_mult = 6
+	movement_acc_penalty_mult = 7
 
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 0.2 SECONDS


### PR DESCRIPTION

## About The Pull Request
Some mild handling nerfs to the V-35.
Slightly increased wield slowdown and wield time, and worse scatter/acc on the move.
## Why It's Good For The Game
Makes the V-35 less good/reliable at blowing off limbs without simply nerfing the damage and making it useless.
## Changelog
:cl:
balance: Campaign: Small handling nerfs to the V-35
/:cl:
