### PR TITLE
Fixes xeno dragging crit humans doing brute damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -165,7 +165,7 @@
 /mob/living/carbon/human/adjustOxyLoss(amount, forced = FALSE)
 	if(species.species_flags & NO_BREATHE && !forced)
 		oxyloss = 0
-		return FALSE
+		return
 	return ..()
 
 /mob/living/carbon/human/setOxyLoss(amount, forced = FALSE)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -165,7 +165,7 @@
 /mob/living/carbon/human/adjustOxyLoss(amount, forced = FALSE)
 	if(species.species_flags & NO_BREATHE && !forced)
 		oxyloss = 0
-		return
+		return FALSE
 	return ..()
 
 /mob/living/carbon/human/setOxyLoss(amount, forced = FALSE)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -44,6 +44,7 @@
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	oxyloss = clamp(oxyloss + amount, 0, maxHealth * 2)
+	return TRUE
 
 /mob/living/proc/setOxyLoss(amount)
 	if(status_flags & GODMODE)


### PR DESCRIPTION
## About The Pull Request
When an xenomorph drags a crit human (or any species that doesn't have NO_BREATHE), they now correctly deal only oxygen damage instead of brute damage and oxygen damage at the same time.

Before this, dragging a crit human would deal 3 brute damage and 3 oxygen damage per tile dragged.
After this, dragging a crit human would deal 3 oxygen damage per tile dragged (as intended).

Species who do not breathe, like combat robots, are unaffected by this as they do not have to deal with oxygen damage.
## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Humans (or any breathing species) who are critdragged by xenomorphs now correctly take only oxygen damage instead of brute damage and oxygen damage at the same time. 
/:cl:
