### PR TITLE
Renames the RR's factory refills to be in line with the single shell purchase options

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2253,32 +2253,32 @@ FACTORY
 	cost = 400
 
 /datum/supply_packs/factory/standard_recoilless_refill
-	name = "Recoilless standard missile assembly refill"
+	name = "RL-160 RR HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/normal_rr_missile_refill)
 	cost = 300
 
 /datum/supply_packs/factory/light_recoilless_refill
-	name = "Recoilless light missile assembly refill"
+	name = "RL-160 RR LE shell assembly refill"
 	contains = list(/obj/item/factory_refill/light_rr_missile_refill)
 	cost = 300
 
 /datum/supply_packs/factory/heat_recoilless_refill
-	name = "Recoilless heat missile assembly refill"
+	name = "RL-160 RR HEAT shell assembly refill"
 	contains = list(/obj/item/factory_refill/heat_rr_missile_refill)
 	cost = 300
 
 /datum/supply_packs/factory/smoke_recoilless_refill
-	name = "Recoilless smoke missile assembly refill"
+	name = "RL-160 RR smoke shell assembly refill"
 	contains = list(/obj/item/factory_refill/smoke_rr_missile_refill)
 	cost = 300
 
 /datum/supply_packs/factory/cloak_recoilless_refill
-	name = "Recoilless cloak missile assembly refill"
+	name = "RL-160 RR cloak shell assembly refill"
 	contains = list(/obj/item/factory_refill/cloak_rr_missile_refill)
 	cost = 300
 
 /datum/supply_packs/factory/tfoot_recoilless_refill
-	name = "Recoilless tfoot missile assembly refill"
+	name = "RL-160 RR tanglefoot shell assembly refill"
 	contains = list(/obj/item/factory_refill/tfoot_rr_missile_refill)
 	cost = 300
 


### PR DESCRIPTION

## About The Pull Request
see title
## Why It's Good For The Game
what goddamn federal agent calls it the, "Recoilless standard missile"
## Changelog
:cl:
spellcheck: Recoilless Rifle shell factory refills are now named similarly to their single-shell counterparts.
/:cl:
