### PR TITLE
Brings back aim mode to the Martini-Henry

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -551,6 +551,7 @@
 
 	gun_features_flags = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
 	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 19, "under_y" = 14, "stock_x" = 15, "stock_y" = 12)
+	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_slowdown = 0.35
 	aim_time = 0.5 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

This just brings back the aim mode to the Martini-Henry after it was removed in the aim mode removal PR.

## Why It's Good For The Game

The lack of aim mode makes this gun kind of inconsistent with the other precision rifles. It also still has the other aim mode stats in the code despite not having aim mode which seems to imply this wasn't really meant to no longer have aim mode.

## Changelog

:cl:
balance: The Martini-Henry can use aim mode again
/:cl:
