### PR TITLE
Primordial Behemoths Eat Away Destructible Rock Walls

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -28,7 +28,15 @@
 	open_turf_type = /turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor
 	minimap_color = MINIMAP_BLACK
 	resistance_flags = UNACIDABLE
-	var/times_munched = 0
+	/// How many remaining times does a primordial behemoth need to attack this for it to delete itself?
+	var/behemoth_munches_left = 20
+
+/turf/closed/mineral/examine(mob/user)
+	. = ..()
+	if(isxenobehemoth(user))
+		var/mob/living/carbon/xenomorph/behemoth/behemoth_user = user
+		if(behemoth_user.upgrade == XENO_UPGRADE_PRIMO && !CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) && behemoth_munches_left != initial(behemoth_munches_left))
+			. += "You can munch this [behemoth_munches_left] more times before it is gone."
 
 /turf/closed/mineral/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_ROCK, -10, 5, 1)
@@ -69,12 +77,11 @@
 			"The stone. The rock. The boulder. Its name matters not when we consume it.",
 			"Delicious, delectable, simply exquisite. Just a few more minerals and it'd be perfect...")), null, 5)
 		var/mob/living/carbon/xenomorph/behemoth/behemoth_attacker = xeno_attacker
-		if(behemoth_attacker.upgrade == XENO_UPGRADE_PRIMO && !CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) && !behemoth_attacker.do_actions)
-			if(do_after(behemoth_attacker, 8 SECONDS, NONE, src, BUSY_ICON_GENERIC))
-				playsound(behemoth_attacker, 'sound/items/eatfood.ogg', 15, 1)
-				times_munched++
-				if(times_munched >= 5)
-					ChangeTurf(open_turf_type)
+		if(behemoth_attacker.upgrade == XENO_UPGRADE_PRIMO && !CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
+			behemoth_munches_left--
+			if(!behemoth_munches_left)
+				ChangeTurf(open_turf_type)
+				return
 
 /turf/closed/plasmacutter_act(mob/living/user, obj/item/I)
 	if(!isplasmacutter(I) || user.do_actions)

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -28,6 +28,7 @@
 	open_turf_type = /turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor
 	minimap_color = MINIMAP_BLACK
 	resistance_flags = UNACIDABLE
+	var/times_munched = 0
 
 /turf/closed/mineral/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_ROCK, -10, 5, 1)
@@ -67,6 +68,13 @@
 			"One bite, two bites... why not just finish the whole rock?",
 			"The stone. The rock. The boulder. Its name matters not when we consume it.",
 			"Delicious, delectable, simply exquisite. Just a few more minerals and it'd be perfect...")), null, 5)
+		var/mob/living/carbon/xenomorph/behemoth/behemoth_attacker = xeno_attacker
+		if(behemoth_attacker.upgrade == XENO_UPGRADE_PRIMO && !CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) && !behemoth_attacker.do_actions)
+			if(do_after(behemoth_attacker, 8 SECONDS, NONE, src, BUSY_ICON_GENERIC))
+				playsound(behemoth_attacker, 'sound/items/eatfood.ogg', 15, 1)
+				times_munched++
+				if(times_munched >= 5)
+					ChangeTurf(open_turf_type)
 
 /turf/closed/plasmacutter_act(mob/living/user, obj/item/I)
 	if(!isplasmacutter(I) || user.do_actions)


### PR DESCRIPTION
## About The Pull Request
Primordial Behemoths can eat and delete destructible rock walls after eating it 20 times.

## Why It's Good For The Game
There is a lot of soul right here. Also, it seems a bit unfair that xenos have no counterplay whatsoever to rock walls if marines can use plasma cutters to abuse the fact that xenos can't do anything about it except xope. With this, marines can have the excuse of telling xenos to get good and give some love to our favorite rock-munching caste. :)

## Changelog
:cl:
add: Primordial Behemoths can break destructible rock walls if they eat it enough times.
/:cl:
