### PR TITLE
Revert wraith health and speed changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -12,14 +12,14 @@
 	melee_damage = 24
 
 	// *** Speed *** //
-	speed = -1.1
+	speed = -1.25
 
 	// *** Plasma *** //
 	plasma_max = 400
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 340
+	max_health = 260
 
 	// *** Evolution *** //
 	evolution_threshold = 225


### PR DESCRIPTION

## About The Pull Request
Returns wraith to -1.25 speed and 260 health
## Why It's Good For The Game
Wraith has many abilities to protect itself and therefore should die if it fails to use those.
## Changelog
:cl:
balance: Wraith health reduced to 260, speed increased to -1.25
/:cl:
