### PR TITLE
Disables Wraith

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(all_xeno_types, list(
 	))
 
 GLOBAL_LIST_INIT(xeno_types_tier_one, list(/datum/xeno_caste/runner, /datum/xeno_caste/drone, /datum/xeno_caste/sentinel, /datum/xeno_caste/defender))
-GLOBAL_LIST_INIT(xeno_types_tier_two, list(/datum/xeno_caste/hunter, /datum/xeno_caste/warrior, /datum/xeno_caste/spitter, /datum/xeno_caste/hivelord, /datum/xeno_caste/carrier, /datum/xeno_caste/bull, /datum/xeno_caste/wraith, /datum/xeno_caste/puppeteer, /datum/xeno_caste/pyrogen))
+GLOBAL_LIST_INIT(xeno_types_tier_two, list(/datum/xeno_caste/hunter, /datum/xeno_caste/warrior, /datum/xeno_caste/spitter, /datum/xeno_caste/hivelord, /datum/xeno_caste/carrier, /datum/xeno_caste/bull, /datum/xeno_caste/puppeteer, /datum/xeno_caste/pyrogen))
 GLOBAL_LIST_INIT(xeno_types_tier_three, list(/datum/xeno_caste/gorger, /datum/xeno_caste/widow, /datum/xeno_caste/ravager, /datum/xeno_caste/praetorian, /datum/xeno_caste/boiler, /datum/xeno_caste/defiler, /datum/xeno_caste/crusher, /datum/xeno_caste/shrike, /datum/xeno_caste/behemoth, /datum/xeno_caste/warlock))
 GLOBAL_LIST_INIT(xeno_types_tier_four, list(/datum/xeno_caste/shrike, /datum/xeno_caste/queen, /datum/xeno_caste/king))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -16,7 +16,7 @@
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	spit_types = list(/datum/ammo/energy/xeno/psy_blast)
 
-	deevolves_to = /datum/xeno_caste/spitter
+	deevolves_to = /datum/xeno_caste/warrior
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
 	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 10, BIO = 35, FIRE = 35, ACID = 35)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -16,7 +16,7 @@
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	spit_types = list(/datum/ammo/energy/xeno/psy_blast)
 
-	deevolves_to = /datum/xeno_caste/wraith
+	deevolves_to = /datum/xeno_caste/spitter
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = null
 	soft_armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 10, BIO = 35, FIRE = 35, ACID = 35)


### PR DESCRIPTION
## About The Pull Request
You can no longer evolve to Wraith. It's off the T2 evo list.
## Why It's Good For The Game
Kuro doesn't like it. I agree. Abilities are very strong, and it being fragile would probably just make it CBT to play. It is sentenced to Hell until someone reworks it to not be cracked and, at the same time, not be frustrating to play.
## Changelog
:cl:
del: Wraith can no longer be picked. Forcefully devolved Warlocks will devolve to Warriors instead.
/:cl:
