### PR TITLE
Crew monitor fix

### DIFF
--- a/code/game/objects/machinery/computer/crew.dm
+++ b/code/game/objects/machinery/computer/crew.dm
@@ -12,13 +12,22 @@
 	active_power_usage = 500
 //	circuit = /obj/item/circuitboard/computer/crew
 	interaction_flags = INTERACT_MACHINE_TGUI
+	///List of tracked jumpsuits
 	var/list/tracked = list()
+	///Crewmembers groundside
 	var/list/crewmembers_planetside = list()
+	///Crewmembers shipside
 	var/list/crewmembers_on_ship = list()
+	///Crewmembers in transit z-level
 	var/list/crewmembers_in_transit = list()
+	///Which z-level we display
 	var/displayed_z_level = DISPLAY_ON_SHIP
+	///The sorting proc used for current settings
 	var/cmp_proc = /proc/cmp_list_asc
+	///How the list will be sorted
 	var/sortkey = "name"
+	///The faction of humans we can see
+	var/faction = FACTION_TERRAGOV
 
 /obj/machinery/computer/crew/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -113,11 +122,13 @@
 	updateUsrDialog()
 
 /obj/machinery/computer/crew/proc/scan()
-	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
-		var/obj/item/clothing/under/C = H.w_uniform
+	for(var/mob/living/carbon/human/human in GLOB.human_mob_list)
+		if(human.faction != faction)
+			continue
+		var/obj/item/clothing/under/C = human.w_uniform
 		if(!istype(C))
 			continue
-		if(C.has_sensor && H.mind)
+		if(C.has_sensor && human.mind)
 			add_to_tracked(C)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixes #5751
Fixes crew monitor console displaying ALL humans.
It now just checks players with a matching faction. i.e. no more detecting hostile erts etc.

Also means we can make SOM versions etc in the future.

Some autodoc as well. Theres other ass code in crew monitor, but I don't want to touch it in this PR.
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: Crew monitors no longer track all humans
/:cl:
