### PR TITLE
Vali module wearers deal 10% gun damage

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -167,7 +167,7 @@
 	wearer = null
 
 	REMOVE_TRAIT(user, VALI_TRAIT, VALI_TRAIT)
-	to_chat(user, span_danger("Your body relaxes as the module retracts itself from you"))
+	to_chat(user, span_danger("Your body relaxes as the module retracts itself from you."))
 
 ///Sets up actions and vars when the suit is equipped
 /datum/component/chem_booster/proc/equipped(datum/source, mob/equipper, slot)
@@ -182,7 +182,7 @@
 	wearer.overlays += resource_overlay
 	update_resource(0)
 	ADD_TRAIT(equipper, VALI_TRAIT, VALI_TRAIT)
-	to_chat(equipper, span_danger("Your skin crawls as needles and probes nestles themselves into your body"))
+	to_chat(equipper, span_danger("Your skin crawls as needles and probes nestles themselves into your body."))
 
 /datum/component/chem_booster/process()
 	if(resource_storage_current < resource_drain_amount)
@@ -359,7 +359,7 @@
 /datum/component/chem_booster/proc/manage_weapon_connection(obj/item/weapon_to_connect)
 	if(connected_weapon)
 		wearer.balloon_alert(wearer, "Disconnected [connected_weapon]")
-		REMOVE_TRAIT(connected_weapon, TRAIT_NODROP, TRAIT_NODROP)
+		REMOVE_TRAIT(connected_weapon, TRAIT_NODROP, VALI_TRAIT)
 		UnregisterSignal(connected_weapon, COMSIG_ITEM_ATTACK)
 		UnregisterSignal(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED))
 		connected_weapon = null
@@ -369,7 +369,7 @@
 		return FALSE
 
 	connected_weapon = weapon_to_connect
-	ADD_TRAIT(connected_weapon, TRAIT_NODROP, TRAIT_NODROP)
+	ADD_TRAIT(connected_weapon, TRAIT_NODROP, VALI_TRAIT)
 	RegisterSignal(connected_weapon, COMSIG_ITEM_ATTACK, PROC_REF(drain_resource))
 	RegisterSignals(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED), PROC_REF(vali_connect))
 	return TRUE

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -166,6 +166,9 @@
 	wearer.overlays -= resource_overlay
 	wearer = null
 
+	REMOVE_TRAIT(user, VALI_TRAIT, VALI_TRAIT)
+	to_chat(user, span_danger("Your body relaxes as the module retracts itself from you"))
+
 ///Sets up actions and vars when the suit is equipped
 /datum/component/chem_booster/proc/equipped(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
@@ -178,6 +181,8 @@
 
 	wearer.overlays += resource_overlay
 	update_resource(0)
+	ADD_TRAIT(equipper, VALI_TRAIT, VALI_TRAIT)
+	to_chat(equipper, span_danger("Your skin crawls as needles and probes nestles themselves into your body"))
 
 /datum/component/chem_booster/process()
 	if(resource_storage_current < resource_drain_amount)
@@ -354,7 +359,7 @@
 /datum/component/chem_booster/proc/manage_weapon_connection(obj/item/weapon_to_connect)
 	if(connected_weapon)
 		wearer.balloon_alert(wearer, "Disconnected [connected_weapon]")
-		REMOVE_TRAIT(connected_weapon, TRAIT_NODROP, VALI_TRAIT)
+		REMOVE_TRAIT(connected_weapon, TRAIT_NODROP, TRAIT_NODROP)
 		UnregisterSignal(connected_weapon, COMSIG_ITEM_ATTACK)
 		UnregisterSignal(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED))
 		connected_weapon = null
@@ -364,7 +369,7 @@
 		return FALSE
 
 	connected_weapon = weapon_to_connect
-	ADD_TRAIT(connected_weapon, TRAIT_NODROP, VALI_TRAIT)
+	ADD_TRAIT(connected_weapon, TRAIT_NODROP, TRAIT_NODROP)
 	RegisterSignal(connected_weapon, COMSIG_ITEM_ATTACK, PROC_REF(drain_resource))
 	RegisterSignals(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED), PROC_REF(vali_connect))
 	return TRUE

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -195,6 +195,8 @@
 	var/damage_mult = 1
 	///Same as above, for damage bleed (falloff)
 	var/damage_falloff_mult = 1
+	///Multiplier, bullet damage decreased for Vali users
+	var/vali_penalty = 0.1
 	///Screen shake when the weapon is fired while wielded.
 	var/recoil = 0
 	///Screen shake when the weapon is fired while unwielded.
@@ -1792,6 +1794,8 @@
 		var/mob/living/living_firer = firer
 		if(living_firer.IsStaggered())
 			projectile_to_fire.damage *= STAGGER_DAMAGE_MULTIPLIER
+		if(HAS_TRAIT(living_firer, VALI_TRAIT))
+			projectile_to_fire.damage *= vali_penalty
 
 ///Sets the projectile accuracy and scatter
 /obj/item/weapon/gun/proc/setup_bullet_accuracy()

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -195,8 +195,8 @@
 	var/damage_mult = 1
 	///Same as above, for damage bleed (falloff)
 	var/damage_falloff_mult = 1
-	///Multiplier, bullet damage decreased for Vali users
-	var/vali_penalty = 0.1
+	///Multiplies the projectile's damage for Vali users
+	var/damage_mult_vali = 0.1
 	///Screen shake when the weapon is fired while wielded.
 	var/recoil = 0
 	///Screen shake when the weapon is fired while unwielded.
@@ -1795,7 +1795,7 @@
 		if(living_firer.IsStaggered())
 			projectile_to_fire.damage *= STAGGER_DAMAGE_MULTIPLIER
 		if(HAS_TRAIT(living_firer, VALI_TRAIT))
-			projectile_to_fire.damage *= vali_penalty
+			projectile_to_fire.damage *= damage_mult_vali
 
 ///Sets the projectile accuracy and scatter
 /obj/item/weapon/gun/proc/setup_bullet_accuracy()


### PR DESCRIPTION

## About The Pull Request
Kills Gun Vali
Adds a bullet damage multiplier to those with the vali module equiped.
Adds a smidgeon of flavor text
## Why It's Good For The Game
Gun vali is an abomination to the fundamental understanding of the module. It also increases the complexity of balancing the vali module as a whole, this would neuter the gun aspect, keeping balance to the simplicity of how stupidly tanky a melee marine can be. This change will make it so that any bullet fired from the vali module wearer will be multiplied by X, at the time of righting X = 0.1, a tenth of the damage normally dealt, while i am open to the idea of going as high as 0.25, the point of this PR is to remove gun vali from any form of viability. You'd still get the stun/knockback/status effects such as shatter and igniting xenos from incidiary bullets, but the base damage will be all but removed.

Is this shitcode? I dunno, i'm not a coder. So probably?

I'm still working on a free health scan module so those that use vali for that purpose can still have that. My pea brain doesn't understand how modules and such work.

- [ ] Make health scanner module.
## Changelog
:cl:
balance: Vali wearer bullet damage penalty
/:cl:
