### PR TITLE
Vali gets 1/2 greenblood per hit and loses greenblood passively

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -72,6 +72,10 @@
 	var/movement_boost = 0
 	///How much time left on vali heal till necrosis occurs
 	var/vali_necro_timer
+	///When you last gained greenblood from attacking. Used to trigger greenblood decaying.
+	var/last_attack_time = 0
+	///How much time until greenblood decaying occurs
+	var/greenblood_decay_timer
 
 	/**
 	 * This list contains the vali stat increases that correspond to each reagent
@@ -185,6 +189,9 @@
 
 /datum/component/chem_booster/process()
 	if(!boost_on)
+		greenblood_decay_timer = world.time - last_attack_time
+		if(greenblood_decay_timer < 5 SECONDS)
+			return
 		if(resource_storage_current >= resource_decay_amount)
 			update_resource(-resource_decay_amount)
 		return
@@ -385,6 +392,7 @@
 	if(resource_storage_current >= resource_storage_max)
 		return
 	update_resource(round(10*connected_weapon.attack_speed/11))
+	last_attack_time = world.time
 
 ///Adds or removes resource from the suit. Signal gets sent at every 25% of stored resource
 /datum/component/chem_booster/proc/update_resource(amount)

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -378,7 +378,7 @@
 		return
 	if(resource_storage_current >= resource_storage_max)
 		return
-	update_resource(round(5*connected_weapon.attack_speed/11))
+	update_resource(round(10*connected_weapon.attack_speed/11))
 
 ///Adds or removes resource from the suit. Signal gets sent at every 25% of stored resource
 /datum/component/chem_booster/proc/update_resource(amount)

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -378,7 +378,7 @@
 		return
 	if(resource_storage_current >= resource_storage_max)
 		return
-	update_resource(round(20*connected_weapon.attack_speed/11))
+	update_resource(round(5*connected_weapon.attack_speed/11))
 
 ///Adds or removes resource from the suit. Signal gets sent at every 25% of stored resource
 /datum/component/chem_booster/proc/update_resource(amount)


### PR DESCRIPTION
## About The Pull Request
Vali now gets half the amount of greenblood per attack, and it passively loses 2 greenblood per tick starting 5 seconds after your last attack. This does not drain while healing is on.
## Why It's Good For The Game
Vali healing is too free and you can very easily stab something a few times then use a gun for the rest of the time.
see #16819 for my full thoughts
## Changelog
:cl:
balance: Vali now gets half the greenblood per hit.
balance: Vali now loses 2 greenblood per tick passively while the healing is off, starting 5 seconds after your last attack.
/:cl:
