### PR TITLE
fix admin VV "Set Species"

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -773,7 +773,13 @@
 		new_species = race
 	return ..()
 
+/// Turns our human into a selected species `new_species`
+/// new_species must be either a string or a species datum
 /mob/living/carbon/human/proc/set_species(new_species, default_colour)
+	// Here we'll convert the species into a string. It's a bandaid fix
+	if(istype(new_species, /datum/species))
+		var/datum/species/old_type = new_species
+		new_species = old_type.name
 
 	if(!new_species)
 		new_species = "Human"


### PR DESCRIPTION

## About The Pull Request
fix "Set Species"
the admin VV was passing a /datum/species to the proc when the proc only calls for a string.
I've just added a check to convert a datum into a string to ensure it works wether you pass a string or a datum
## Why It's Good For The Game
bugfix
## Changelog
:cl:
admin: fix VV "Set Species"
/:cl:
