### PR TITLE
Fire Immunity = Pyrogen Melting Stacks Immunity

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -588,6 +588,11 @@
 	layer = ABOVE_MOB_LAYER
 	vis_flags = VIS_INHERIT_DIR | VIS_INHERIT_ID | VIS_INHERIT_PLANE
 
+/datum/status_effect/stacking/melting_fire/can_have_status()
+	if(owner.soft_armor?.getRating(FIRE) >= 100)
+		return FALSE
+	return ..()
+
 /datum/status_effect/stacking/melting_fire/on_creation(mob/living/new_owner, stacks_to_apply)
 	if(new_owner.status_flags & GODMODE || new_owner.stat == DEAD)
 		qdel(src)

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -208,8 +208,6 @@
 /datum/status_effect/stacking/proc/on_threshold_drop()
 
 /datum/status_effect/stacking/proc/can_have_status()
-	if(owner.soft_armor?.getRating(FIRE) >= 100)
-		return FALSE
 	return owner.stat != DEAD
 
 /datum/status_effect/stacking/proc/can_gain_stacks()

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -208,6 +208,8 @@
 /datum/status_effect/stacking/proc/on_threshold_drop()
 
 /datum/status_effect/stacking/proc/can_have_status()
+	if(owner.soft_armor?.getRating(FIRE) >= 100)
+		return FALSE
 	return owner.stat != DEAD
 
 /datum/status_effect/stacking/proc/can_gain_stacks()


### PR DESCRIPTION
## About The Pull Request
Having 100+ soft fire armor grants you immunity to Pyrogen's melting stacks status effect.

## Why It's Good For The Game
Bugfix. Walking on a Pyrogen's fire tiles while immune doesn't give you melting stacks. But for some reason, anything that isn't fire tiles does?

## Changelog
:cl:
fix: Having 100+ fire armor (aka fire immunity) correctly prevents you from getting any melting stacks (from Pyrogen).
/:cl:
