### PR TITLE
buffs the microwave debuff's damage

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -770,7 +770,7 @@
 // *********** Microwave
 // ***************************************
 ///amount of damage done per tick by the microwave status effect
-#define MICROWAVE_STATUS_DAMAGE_MULT 4
+#define MICROWAVE_STATUS_DAMAGE_MULT 5
 ///duration of the microwave effect. Refreshed on application
 #define MICROWAVE_STATUS_DURATION 5 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Buffs the microwave damage from 4 per stack per tick to 5 per stack per tick.
## Why It's Good For The Game

As it stands, the microwave option on the laser rifle isn't very good. Other DOTs tend to have some sort of other effect or debuff associated with them past just the damage, but the microwave is just damage and nothing else. The microwave DOT does ignore armor, but the damage is so low (both on the DOT and actual projectile, which has a slow firerate as well) that this doesn't seem to matter much in practice.

Currently at max (5) stacks the debuff will do 4 damage per stack over 5 seconds, a total of 100 damage overall. This change will up that to 125 total. This isn't a major buff, but hopefully it will make the microwave a little more viable.
## Changelog
:cl:

balance: The microwave debuff now does 5 (up from 4) damage per stack.

/:cl:
