### PR TITLE
Ports tg Block Movement keybind

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_keybindings.dm
+++ b/code/__DEFINES/dcs/signals/signals_keybindings.dm
@@ -24,10 +24,6 @@
 #define COMSIG_KB_LIVING_RESIST_DOWN "keybinding_living_resist_down"
 #define COMSIG_KB_LIVING_JUMP_DOWN "keybind_living_jump_down"
 #define COMSIG_KB_LIVING_JUMP_UP "keybind_living_jump_up"
-#define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"
-#define COMSIG_KB_MOB_FACEEAST_DOWN "keybinding_mob_faceeast_down"
-#define COMSIG_KB_MOB_FACESOUTH_DOWN "keybinding_mob_facesouth_down"
-#define COMSIG_KB_MOB_FACEWEST_DOWN "keybinding_mob_facewest_down"
 #define COMSIG_KB_MOB_STOPPULLING_DOWN "keybinding_mob_stoppulling_down"
 #define COMSIG_KB_MOB_CYCLEINTENTRIGHT_DOWN "keybinding_mob_cycleintentright_down"
 #define COMSIG_KB_MOB_CYCLEINTENTLEFT_DOWN "keybinding_mob_cycleintentleft_down"
@@ -47,6 +43,7 @@
 #define COMSIG_KB_MOVEMENT_SOUTH_DOWN "keybinding_movement_south_down"
 #define COMSIG_KB_MOVEMENT_WEST_DOWN "keybinding_movement_west_down"
 #define COMSIG_KB_MOVEMENT_EAST_DOWN "keybinding_movement_east_down"
+#define COMSIG_KB_MOB_BLOCKMOVEMENT_DOWN "keybinding_mob_blockmovement_down"
 
 //Admin
 #define COMSIG_KB_ADMIN_ASAY_DOWN "keybinding_admin_asay_down"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -2,69 +2,6 @@
 	category = CATEGORY_MOB
 	weight = WEIGHT_MOB
 
-
-/datum/keybinding/mob/face_north
-	hotkey_keys = list("CtrlW", "CtrlNorth")
-	name = "face_north"
-	full_name = "Face North"
-	description = ""
-	keybind_signal = COMSIG_KB_MOB_FACENORTH_DOWN
-
-/datum/keybinding/mob/face_north/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/M = user.mob
-	M.northface()
-	return TRUE
-
-
-/datum/keybinding/mob/face_east
-	hotkey_keys = list("CtrlD", "CtrlEast")
-	name = "face_east"
-	full_name = "Face East"
-	description = ""
-	keybind_signal = COMSIG_KB_MOB_FACEEAST_DOWN
-
-/datum/keybinding/mob/face_east/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/M = user.mob
-	M.eastface()
-	return TRUE
-
-
-/datum/keybinding/mob/face_south
-	hotkey_keys = list("CtrlS", "CtrlSouth")
-	name = "face_south"
-	full_name = "Face South"
-	description = ""
-	keybind_signal = COMSIG_KB_MOB_FACESOUTH_DOWN
-
-/datum/keybinding/mob/face_south/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/M = user.mob
-	M.southface()
-	return TRUE
-
-/datum/keybinding/mob/face_west
-	hotkey_keys = list("CtrlA", "CtrlWest")
-	name = "face_west"
-	full_name = "Face West"
-	description = ""
-	keybind_signal = COMSIG_KB_MOB_FACEWEST_DOWN
-
-/datum/keybinding/mob/face_west/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/M = user.mob
-	M.westface()
-	return TRUE
-
 /datum/keybinding/mob/stop_pulling
 	hotkey_keys = list("Delete")
 	name = "stop_pulling"
@@ -341,3 +278,22 @@
 	if(!target || !user.mob.Adjacent(target))	//In case the target moved away while selecting them
 		return
 	user.mob.interaction_emote(target)
+
+/datum/keybinding/mob/prevent_movement
+	hotkey_keys = list("")
+	name = "block_movement"
+	full_name = "Block movement"
+	description = "Prevents you from moving"
+	keybind_signal = COMSIG_KB_MOB_BLOCKMOVEMENT_DOWN
+
+/datum/keybinding/mob/prevent_movement/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.movement_locked = TRUE
+
+/datum/keybinding/mob/prevent_movement/up(client/user)
+	. = ..()
+	if(.)
+		return
+	user.movement_locked = FALSE

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -1384,3 +1384,11 @@ GLOBAL_LIST_EMPTY(submerge_filter_timer_list)
 	SIGNAL_HANDLER
 	UnregisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NOSUBMERGE))
 	set_submerge_level(loc, duration = 0.1)
+
+/**
+* A wrapper for setDir that should only be able to fail by living mobs.
+*
+* Called from [/atom/movable/proc/keyLoop], this exists to be overwritten by living mobs with a check to see if we're actually alive enough to change directions
+*/
+/atom/movable/proc/keybind_face_direction(direction)
+	setDir(direction)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -95,6 +95,8 @@
 	var/keysend_tripped = FALSE
 	///custom movement keys for this client
 	var/list/movement_keys = list()
+	///Are we locking our movement input?
+	var/movement_locked = FALSE
 
 	var/list/parallax_layers
 	var/list/parallax_layers_cached

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -6,8 +6,6 @@
 	// But the move of one mob might poke the client of another, so we do this
 	if(!user)
 		return FALSE
-	if(user.keys_held["Ctrl"])
-		return
 	var/movement_dir = user.intended_direction | user.next_move_dir_add
 	// If we're not movin anywhere, we aren't movin anywhere
 	// Safe because nothing adds to movement_dir after this moment
@@ -23,7 +21,16 @@
 		movement_dir &= ~(NORTH|SOUTH)
 	if((movement_dir & EAST) && (movement_dir & WEST))
 		movement_dir &= ~(EAST|WEST)
-	user.Move(get_step(src, movement_dir), movement_dir)
+
+	//turn without moving while using the movement lock key.
+	if(user.movement_locked)
+		keybind_face_direction(movement_dir)
+	// Null check cause of the signal above
+	else if(user)
+		user.Move(get_step(src, movement_dir), movement_dir)
+		return !!movement_dir //true if there was actually any player input
+
+	return FALSE
 
 /client/proc/calculate_move_dir()
 	var/movement_dir = NONE

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -45,7 +45,7 @@
 	var/movement = movement_keys[_key]
 	if(movement)
 		calculate_move_dir()
-		if(!keys_held["Ctrl"] && !(next_move_dir_sub & movement))
+		if(!movement_locked && !(next_move_dir_sub & movement))
 			next_move_dir_add |= movement
 
 	// Client-level keybindings are ones anyone should be able to do at any time
@@ -90,7 +90,7 @@
 	var/movement = movement_keys[_key]
 	if(movement)
 		calculate_move_dir()
-		if(!keys_held["Ctrl"] && !(next_move_dir_add & movement))
+		if(!movement_locked && !(next_move_dir_add & movement))
 			next_move_dir_sub |= movement
 
 	// We don't do full key for release, because for mod keys you

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -15,3 +15,8 @@
 
 /mob/living/set_submerge_level(turf/new_loc, turf/old_loc, submerge_icon = 'icons/turf/alpha_64.dmi', submerge_icon_state = "liquid_alpha", duration = cached_multiplicative_slowdown + next_move_slowdown)
 	return ..()
+
+/mob/living/keybind_face_direction(direction)
+	if(stat > CONSCIOUS)
+		return
+	return ..()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -190,15 +190,6 @@
 	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
 		ai.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
-/mob/camera/aiEye/proc/register_facedir_signals(mob/user)
-	RegisterSignal(user, COMSIG_KB_MOB_FACENORTH_DOWN, VERB_REF(northface))
-	RegisterSignal(user, COMSIG_KB_MOB_FACEEAST_DOWN, VERB_REF(eastface))
-	RegisterSignal(user, COMSIG_KB_MOB_FACESOUTH_DOWN, VERB_REF(southface))
-	RegisterSignal(user, COMSIG_KB_MOB_FACEWEST_DOWN, VERB_REF(westface))
-
-/mob/camera/aiEye/proc/unregister_facedir_signals(mob/user)
-	UnregisterSignal(user, list(COMSIG_KB_MOB_FACENORTH_DOWN, COMSIG_KB_MOB_FACEEAST_DOWN, COMSIG_KB_MOB_FACESOUTH_DOWN, COMSIG_KB_MOB_FACEWEST_DOWN))
-
 /mob/camera/aiEye/playsound_local(turf/turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, sound/sound_to_use, distance_multiplier)
 	if((istype(parent_cameranet) && !parent_cameranet.checkTurfVis(get_turf(src))) || !ai)
 		return

--- a/code/modules/remote_fob/computer.dm
+++ b/code/modules/remote_fob/computer.dm
@@ -60,7 +60,6 @@
 	screen_overlay = "fob_transfer_emissive"
 	user.lighting_alpha = 120
 	eyeobj.name = "Remote Construction Drone"
-	eyeobj.register_facedir_signals(user)
 	if(eyeobj.eye_initialized)
 		eyeobj.setLoc(get_turf(spawn_spot))
 
@@ -172,7 +171,6 @@
 	screen_overlay = "fob_emissive"
 	eyeobj.invisibility = INVISIBILITY_ABSTRACT
 	eyeobj.eye_initialized = FALSE
-	eyeobj.unregister_facedir_signals(user)
 	UnregisterSignal(user, COMSIG_MOB_CLICKON)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
Ports the Block Movement keybind which replaces our current face north/south/west/east keybinds and means that grabbing things with ctrl no longer needs to bolt you in place
## Why It's Good For The Game
The grab keybind (ctrl) being on the same unchangable stop movement button (ctrl) was painful and caused many xeno deaths. No more shall we suffer!
## Changelog
:cl:
qol: Block Movement is now on a keybind that you can use to face directions without moving.
/:cl:
