### PR TITLE
Adds 5 more intel computers to big red + fixes an apc

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -5075,6 +5075,7 @@
 /area/bigredv2/outside/virology)
 "aXv" = (
 /obj/machinery/light,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
 "aXw" = (
@@ -13585,6 +13586,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"pqQ" = (
+/obj/structure/cable,
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "prH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -41773,7 +41779,7 @@ hya
 rHD
 jGk
 bEs
-sEu
+pqQ
 jJZ
 rHD
 tQE

--- a/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
@@ -106,6 +106,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"fG" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "fI" = (
 /obj/machinery/light{
 	dir = 8
@@ -1655,7 +1659,7 @@ Kn
 hr
 Zx
 pu
-Zs
+fG
 Um
 Zs
 Zs

--- a/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
@@ -431,6 +431,10 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"wY" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "xf" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 8
@@ -1557,7 +1561,7 @@ Sv
 pX
 Wi
 Ao
-ib
+wY
 At
 ib
 ib

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -770,6 +770,10 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
+"Gt" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "GE" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1678,7 +1682,7 @@ HK
 KP
 ho
 UM
-nV
+Gt
 Yk
 nV
 nV

--- a/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
@@ -68,6 +68,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"dE" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
+/area/bigredv2/outside/engineering/east)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -1553,7 +1557,7 @@ TA
 pY
 ug
 Oo
-GK
+dE
 Pw
 GK
 GK

--- a/_maps/modularmaps/big_red/bigredetavar1.dmm
+++ b/_maps/modularmaps/big_red/bigredetavar1.dmm
@@ -717,6 +717,10 @@
 "Fo" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/northeast/garbledradio)
+"FP" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "FY" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor,
@@ -1170,7 +1174,7 @@ Zt
 zS
 Zl
 xa
-gk
+FP
 Zc
 gk
 xa

--- a/_maps/modularmaps/big_red/bigredetavar2.dmm
+++ b/_maps/modularmaps/big_red/bigredetavar2.dmm
@@ -872,8 +872,7 @@
 /turf/open/floor/freezer,
 /area/bigredv2/outside/general_offices)
 "Su" = (
-/obj/structure/rack,
-/obj/item/mass_spectrometer/adv,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/engine/atmosdark,
 /area/bigredv2/outside/general_offices)
 "Sw" = (
@@ -931,6 +930,7 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 50
 	},
+/obj/item/mass_spectrometer/adv,
 /turf/open/floor/engine/atmosdark,
 /area/bigredv2/outside/general_offices)
 "UY" = (

--- a/_maps/modularmaps/big_red/bigredetavar3.dmm
+++ b/_maps/modularmaps/big_red/bigredetavar3.dmm
@@ -795,6 +795,11 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/bigredv2/outside/general_offices)
+"LY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/general_offices)
 "Mk" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -1300,7 +1305,7 @@ op
 Wf
 lq
 fJ
-fJ
+LY
 Eb
 ck
 IS

--- a/_maps/modularmaps/big_red/bigredetavar4.dmm
+++ b/_maps/modularmaps/big_red/bigredetavar4.dmm
@@ -315,8 +315,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/ne)
 "rZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/engineering/tool,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "sa" = (

--- a/_maps/modularmaps/big_red/bigredetavar5.dmm
+++ b/_maps/modularmaps/big_red/bigredetavar5.dmm
@@ -45,7 +45,8 @@
 	dir = 8;
 	on = 1
 	},
-/obj/effect/ai_node,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/general_offices)
 "ch" = (
@@ -82,8 +83,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "cW" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/general_offices)
 "dl" = (
@@ -503,6 +503,13 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
+/area/bigredv2/outside/general_offices)
+"uZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
 /area/bigredv2/outside/general_offices)
 "vi" = (
 /obj/structure/cable,
@@ -1288,7 +1295,7 @@ IP
 XG
 Iz
 xA
-UM
+uZ
 xA
 bk
 XG

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -522,6 +522,20 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
+"xE" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/tool/pen/blue{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor,
+/area/bigredv2/outside/office_complex)
 "xJ" = (
 /obj/item/mass_spectrometer,
 /obj/effect/landmark/weed_node,
@@ -652,6 +666,10 @@
 /obj/item/tool/lighter/random,
 /obj/effect/ai_node,
 /turf/open/floor/tile/whiteyellow/full,
+/area/bigredv2/outside/office_complex)
+"Dq" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "Dt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1551,9 +1569,9 @@ hl
 Bd
 If
 ov
-Fg
-cx
+Dq
 ic
+As
 ov
 Hm
 Hm
@@ -1576,7 +1594,7 @@ ov
 ov
 ov
 ov
-As
+xE
 JL
 As
 kW

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -9,6 +9,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "aT" = (
@@ -184,10 +185,6 @@
 /obj/item/shard,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/outside/office_complex)
-"eK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/icefloor,
-/area/bigredv2/outside/office_complex)
 "eN" = (
 /obj/structure/window_frame/mainship/white,
 /turf/open/floor/plating,
@@ -206,6 +203,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/c)
+"gq" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
+/area/bigredv2/outside/office_complex)
 "gJ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -529,6 +533,7 @@
 "qN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -536,6 +541,14 @@
 "qP" = (
 /obj/machinery/cryopod,
 /turf/open/floor/mainship/mono,
+/area/bigredv2/outside/office_complex)
+"rm" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupecorner,
+/area/bigredv2/outside/office_complex)
+"rr" = (
+/obj/structure/cable,
+/turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "rt" = (
 /turf/open/floor/marking/asteroidwarning{
@@ -549,6 +562,11 @@
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
+/area/bigredv2/outside/office_complex)
+"sa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "sd" = (
 /obj/machinery/firealarm{
@@ -667,6 +685,10 @@
 	name = "\improper Office Complex Shutters"
 	},
 /turf/open/floor/plating,
+/area/bigredv2/outside/office_complex)
+"uK" = (
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "uL" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -799,6 +821,7 @@
 "yn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
 "ys" = (
@@ -1015,6 +1038,8 @@
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
+/obj/machinery/power/apc,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "ET" = (
@@ -1030,6 +1055,14 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
 /area/bigredv2/outside/c)
+"Fe" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1;
+	name = "\improper Private Office"
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/office_complex)
 "Fp" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/se)
@@ -1232,10 +1265,7 @@
 /turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "MJ" = (
-/obj/structure/table,
-/obj/machinery/computer/pod/old{
-	name = "Personal Computer"
-	},
+/obj/machinery/computer/intel_computer,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "MN" = (
@@ -1565,6 +1595,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/prop1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "WY" = (
@@ -1607,6 +1638,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
 "XM" = (
@@ -2126,7 +2158,7 @@ RN
 Tx
 wF
 pA
-wF
+uK
 Tx
 Tx
 Tx
@@ -2172,17 +2204,17 @@ Tx
 Tx
 aT
 mv
-Am
-Cj
-Xu
+sa
+Fe
+gq
 aC
 yn
-eK
+OS
 yn
 yn
 XJ
-Hj
-mv
+rm
+rr
 Fp
 "}
 (20,1,1) = {"
@@ -2196,7 +2228,7 @@ Jk
 Fu
 Tx
 EA
-mv
+rr
 WJ
 Tx
 dP

--- a/_maps/modularmaps/big_red/bigredofficevar3.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar3.dmm
@@ -677,8 +677,7 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
 "Fr" = (
-/obj/structure/table,
-/obj/machinery/computer3/laptop/secure_data,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/office_complex)
 "FM" = (


### PR DESCRIPTION

## About The Pull Request
title, and the canterbury crashed onto office modular had no office apc.
## Why It's Good For The Game
Intel are a great objective for pulling marines away from the standard paths, more will help with this.
## Changelog
:cl:
add: Added 5 new intel computers to Big Red.
fix: Fixed an APC on a modular in Big Red.
/:cl:
