### PR TITLE
Regular webbing storage fix and adds comments to storage.dm

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -292,19 +292,19 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(!isnull(can_hold_list) && !isnull(storage_type_limits_list)) //Making sure can_hold_list also includes the things that bypass our w_class
 		can_hold_list += storage_type_limits_list
 
-	if(!isnull(can_hold_list))
+	if(!isnull(can_hold_list)) //Limits what can be held to what is in this list
 		var/unique_key = can_hold_list.Join("-")
 		if(!GLOB.cached_storage_typecaches[unique_key])
 			GLOB.cached_storage_typecaches[unique_key] = typecacheof(can_hold_list)
 		can_hold = GLOB.cached_storage_typecaches[unique_key]
 
-	if(!isnull(cant_hold_list))
+	if(!isnull(cant_hold_list)) //Sets what cannot be held, regardless of if it is on the other lists
 		var/unique_key = cant_hold_list.Join("-")
 		if(!GLOB.cached_storage_typecaches[unique_key])
 			GLOB.cached_storage_typecaches[unique_key] = typecacheof(cant_hold_list)
 		cant_hold = GLOB.cached_storage_typecaches[unique_key]
 
-	if(!isnull(storage_type_limits_list))
+	if(!isnull(storage_type_limits_list)) //Permits items to bypass w_class
 		var/unique_key = storage_type_limits_list.Join("-")
 		if(!GLOB.cached_storage_typecaches[unique_key])
 			GLOB.cached_storage_typecaches[unique_key] = typecacheof(storage_type_limits_list)

--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -81,13 +81,6 @@
 /datum/storage/internal/webbing/New(atom/parent)
 	. = ..()
 	set_holdable(
-		can_hold_list = list(
-			/obj/item/stack/razorwire,
-			/obj/item/stack/sheet,
-			/obj/item/stack/sandbags,
-			/obj/item/stack/snow,
-			/obj/item/cell/lasgun/plasma,
-		),
 		cant_hold_list = list(
 			/obj/item/cell/lasgun/volkite/powerpack
 		),
@@ -95,6 +88,7 @@
 			/obj/item/ammo_magazine/rifle,
 			/obj/item/ammo_magazine/smg,
 			/obj/item/ammo_magazine/sniper,
+			/obj/item/ammo_magazine/packet,
 			/obj/item/cell/lasgun,
 		)
 	)

--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -82,13 +82,16 @@
 	. = ..()
 	set_holdable(
 		cant_hold_list = list(
-			/obj/item/cell/lasgun/volkite/powerpack
+			/obj/item/cell/lasgun/volkite/powerpack,
+			/obj/item/stack/razorwire,
+			/obj/item/stack/sheet,
+			/obj/item/stack/sandbags,
+			/obj/item/stack/snow,
 		),
 		storage_type_limits_list = list(
 			/obj/item/ammo_magazine/rifle,
 			/obj/item/ammo_magazine/smg,
 			/obj/item/ammo_magazine/sniper,
-			/obj/item/ammo_magazine/packet,
 			/obj/item/cell/lasgun,
 		)
 	)


### PR DESCRIPTION
## About The Pull Request
Lumi edit: Fixes webbing fitting things it shouldn't.
~~Lets all small items into regular (3 slot) webbing.~~
## Why It's Good For The Game
bug fix
~~Lets you use regular webbing more generally, instead of just a magazine pouch on your uniform. Not giving it the G8 general purpose belt treatment and make it one slot as it doesn't make sense given the sprite. Maybe if it was a drop pouch.~~

~~Adds comments to Storage.dm, because i feel that it may not be clear enough. As it played a role in webbing being able to hold TE powerpacks.~~

~~Might need to add Sheets, razorwire, sandbags, and snow to the cant hold list, as it seems a bit odd to me that you can store 120 metal in the vest. I don't think that was an intended change, but i can't find anyone talking about it, it just sorta popped in somewhere.~~
## Changelog
:cl:
fix: Regular webbing can no longer hold things it wasn't supposed to
/:cl:
