### PR TITLE
Fixes dchat runechat only showing for the owner

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -159,7 +159,7 @@
 
 /// Displays a message in deadchat, sent by source. Source is not linkified, message is, to avoid stuff like character names to be linkified.
 /// Automatically gives the class deadsay to the whole message (message + source)
-/proc/deadchat_broadcast(message, source = null, mob/follow_target = null, turf/turf_target = null, speaker_key = null, message_type = DEADCHAT_REGULAR)
+/proc/deadchat_broadcast(message, source = null, mob/follow_target = null, turf/turf_target = null, speaker_key = null, message_type = DEADCHAT_REGULAR, runechat_msg, runechat_source)
 	message = span_deadsay("[source][span_linkify("[message]")]")
 	for(var/mob/M in GLOB.player_list)
 		if(!M.client)
@@ -210,3 +210,6 @@
 			to_chat(M, rendered_message, avoid_highlighting = speaker_key == M.key)
 		else
 			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
+
+		if(runechat_source && runechat_msg)
+			M.create_chat_message(runechat_source, /datum/language/common, runechat_msg)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -95,8 +95,7 @@
 	if(client?.holder?.fakekey)
 		displayed_key = null
 
-	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key)
-	create_chat_message(src, /datum/language/common, message)
+	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key, runechat_msg = message, runechat_source=src)
 
 /mob/living/proc/get_message_mode(message)
 	var/key = message[1]


### PR DESCRIPTION

## About The Pull Request
Title

## Changelog
:cl:
fix: Fixed dchat runechat only showing for the owner
/:cl:
