### PR TITLE
Add stat tracking to acid maw and jaw

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -489,7 +489,10 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.points_from_xenos] requisitions points gained from xenomorph sales."
 	if(GLOB.round_statistics.runner_items_stolen)
 		parts += "[GLOB.round_statistics.runner_items_stolen] items stolen by runners."
-
+	if(GLOB.round_statistics.acid_maw_fires)
+		parts += "[GLOB.round_statistics.acid_maw_fires] Acid Maw uses."
+	if(GLOB.round_statistics.acid_jaw_fires)
+		parts += "[GLOB.round_statistics.acid_jaw_fires] Acid Jaw uses."
 	if(GLOB.round_statistics.sandevistan_uses)
 		var/sandevistan_text = "[GLOB.round_statistics.sandevistan_uses] number of times someone was boosted by a sandevistan"
 		if(GLOB.round_statistics.sandevistan_gibs)

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -99,6 +99,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/huggers_created = 0
 	var/impregnations = 0
 	var/items_snatched = 0
+	var/acid_maw_uses = 0
+	var/acid_jaw_uses = 0
 
 	//Close air support
 	var/cas_cannon_shots = 0
@@ -240,6 +242,10 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 		support_stats += "Repaired [apcs_repaired] APC\s."
 	if(items_snatched)
 		support_stats += "Snatched [items_snatched] item\s."
+	if(acid_maw_uses)
+		support_stats += "Fired the Acid Maw [acid_maw_uses] time\s"
+	if(acid_jaw_uses)
+		support_stats += "Fired the Acid Jaw [acid_jaw_uses] time\s"
 
 	if(generator_sabotages_performed)
 		support_stats += "Sabotaged [generator_sabotages_performed] generator\s."

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -103,3 +103,5 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/sandevistan_uses = 0
 	var/sandevistan_gibs = 0
 	var/runner_items_stolen = 0
+	var/acid_maw_fires = 0
+	var/acid_jaw_fires = 0

--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -271,6 +271,10 @@
 	var/datum/maw_ammo/ammo = new selected_type
 	var/turf/clicked_turf = locate(polled_coords[1], polled_coords[2], z)
 	addtimer(CALLBACK(src, PROC_REF(maw_impact_start), ammo, clicked_turf, xeno_attacker), ammo.impact_time-2 SECONDS)
+	GLOB.round_statistics.acid_maw_fires++
+	if(xeno_attacker.client)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[xeno_attacker.ckey]
+		personal_statistics.acid_maw_uses++
 	ammo.launch_animation(clicked_turf, src)
 	S_TIMER_COOLDOWN_START(src, COOLDOWN_MAW_GLOB, ammo.cooldown_time)
 
@@ -302,3 +306,10 @@
 		/datum/maw_ammo/hugger,
 		/datum/maw_ammo/xeno_fire,
 	)
+
+/obj/structure/xeno/acid_maw/acid_jaws/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount, damage_type, armor_type, effects, armor_penetration, isrightclick)
+	GLOB.round_statistics.acid_jaw_fires++
+	if(xeno_attacker.client)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[xeno_attacker.ckey]
+		personal_statistics.acid_jaw_uses++
+	. = ..()


### PR DESCRIPTION
## About The Pull Request
Adds stat tracking to acid maw and jaw uses
## Why It's Good For The Game
stats r cool
## Changelog

:cl: Cheese
add: Acid Maw and Jaw uses are now stattracked
/:cl:
