### PR TITLE
Restricts vali healing from firing guns

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -268,12 +268,14 @@
 		wearer.balloon_alert(wearer, "Halting green blood injection")
 		COOLDOWN_START(src, chemboost_activation_cooldown, 10 SECONDS)
 		setup_bonus_effects()
+		REMOVE_TRAIT(wearer, VALI_TRAIT, VALI_TRAIT)
 		return
 
 	processing_start = world.time
 	START_PROCESSING(SSobj, src)
 	RegisterSignal(wearer, COMSIG_MOB_DEATH, PROC_REF(on_off))
 	playsound(get_turf(wearer), 'sound/effects/bubbles.ogg', 30, 1)
+	ADD_TRAIT(wearer, VALI_TRAIT, VALI_TRAIT)
 	to_chat(wearer, span_notice("Commensing green blood injection.<b>[(automatic_meds_use && meds_beaker.reagents.total_volume) ? " Adding additional reagents." : ""]</b>"))
 	if(automatic_meds_use)
 		to_chat(wearer, get_meds_beaker_contents())

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1709,6 +1709,9 @@
 	if(!(gun_features_flags & GUN_ALLOW_SYNTHETIC) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user))
 		to_chat(user, span_warning("Your program does not allow you to use this firearm."))
 		return FALSE
+	if(HAS_TRAIT(user, VALI_TRAIT))
+		to_chat(user, span_warning("Your fingers fail you, HIT THEM!"))
+		return FALSE
 	if(HAS_TRAIT(src, TRAIT_GUN_SAFETY))
 		to_chat(user, span_warning("The safety is on!"))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

One method to limit gun vali, if vali heal is active, prevents you from shooting.
## Why It's Good For The Game

Gun vali is cringe, and lame.
## Changelog
:cl:
balance: Vali heal prevents firing guns
/:cl:
