### PR TITLE
Drones can now use (slightly) more abilities while mounted

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -620,7 +620,7 @@
 	action_icon_state = "emit_pheromones"
 	ability_cost = 30
 	desc = "Opens your pheromone options."
-	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_NOTTURF|ABILITY_USE_BUSY|ABILITY_USE_BUCKLED
+	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_NOTTURF|ABILITY_USE_BUSY|ABILITY_USE_LYING|ABILITY_USE_BUCKLED
 
 /datum/action/ability/xeno_action/pheromones/proc/apply_pheros(phero_choice)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -620,7 +620,7 @@
 	action_icon_state = "emit_pheromones"
 	ability_cost = 30
 	desc = "Opens your pheromone options."
-	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_NOTTURF|ABILITY_USE_BUSY|ABILITY_USE_LYING
+	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_NOTTURF|ABILITY_USE_BUSY|ABILITY_USE_BUCKLED
 
 /datum/action/ability/xeno_action/pheromones/proc/apply_pheros(phero_choice)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -145,6 +145,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ENHANCEMENT,
 	)
+	use_state_flags = ABILITY_USE_BUCKLED
 	/// References Essence Link and its vars.
 	var/datum/action/ability/activable/xeno/essence_link/essence_link_action //todo: All this link stuff is handled in a stinky way
 	/// Used to determine whether Enhancement is already active or not. Also allows access to its vars.
@@ -153,7 +154,6 @@
 	var/damage_multiplier = 1.15
 	/// Speed bonus given by this ability.
 	var/speed_addition = -0.4
-	use_state_flags = ABILITY_USE_BUCKLED
 
 /datum/action/ability/xeno_action/enhancement/New(Target)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -153,6 +153,7 @@
 	var/damage_multiplier = 1.15
 	/// Speed bonus given by this ability.
 	var/speed_addition = -0.4
+	use_state_flags = ABILITY_USE_BUCKLED
 
 /datum/action/ability/xeno_action/enhancement/New(Target)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -281,7 +281,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_JELLY,
 	)
-	use_state_flags = ABILITY_USE_LYING
+	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_BUCKLED
 
 /datum/action/ability/xeno_action/create_jelly/can_use_action(silent = FALSE, override_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
quick aside I noticed while working on my gorger strain (coming 2032)
Right now, drones have a single usable ability while riding honse:
![image](https://github.com/user-attachments/assets/9a2a74f8-9db5-4798-b3ac-8689932bfc8d)

which is kinda goofy. 

This pr allows drones to switch their pheros, print a resin glob, and use their primo Empower while on a rideable xeno.
Healing, building, planting weeds, etc. can still only be done while not mounted.

technically they should still be able to Heal while mounted but I'm uncomfortable with the balance ramifications of spamming heal on a mounted crusher. so I won't be doing that
## Why It's Good For The Game
Pheros and the glob are strategic decisions that could conceivably be done from horseback
Enhancement is literally Useless if you're pocketing a rideable rn, since they'll run out of your sight immediately and snap it. This lets you exchange healing/building/etc. for enhancing during the push

Makes the xog rider slightly more Real(it's still more optimal to just pocket a different t3 though)
## Changelog
:cl:
balance: drones can now print a resin glob, change their pheros, and use their primo ability while mounted
/:cl:
