### PR TITLE
Carrier ability pronoun correction + term standardization

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Use/Throw Facehugger"
 	action_icon_state = "throw_hugger"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Click on a non tile and non mob to bring a facehugger into your hand. Click at a target or tile to throw a facehugger."
+	desc = "Throw a facehugger at something. Using this ability on a facehugger already on the ground will recycle it to your storage."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_THROW_HUGGER,
 	)
@@ -96,13 +96,13 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /mob/living/carbon/xenomorph/proc/store_hugger(obj/item/clothing/mask/facehugger/F, message = TRUE, forced = FALSE) //todo: wrap this into ability
 	if(huggers < xeno_caste.huggers_max)
 		if(F.stat == DEAD && !forced)
-			to_chat(src, span_notice("This young one has already expired, we cannot salvage it."))
+			to_chat(src, span_notice("This facehugger has already expired, we cannot salvage it."))
 			return
 		F.kill_hugger()
 		huggers++
 		if(message)
 			playsound(src, 'sound/voice/alien/drool2.ogg', 50, 0, 1)
-			to_chat(src, span_notice("We salvage this young one's biomass to produce another. Now sheltering: [huggers] / [xeno_caste.huggers_max]."))
+			to_chat(src, span_notice("We salvage this facehugger's biomass to produce another. Now sheltering: [huggers] / [xeno_caste.huggers_max]."))
 	else if(message)
 		to_chat(src, span_warning("We can't carry any more facehuggers!"))
 
@@ -113,7 +113,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Place trap"
 	action_icon_state = "place_trap"
 	action_icon = 'icons/Xeno/actions/construction.dmi'
-	desc = "Place a hole on weeds that can be filled with a hugger or acid. Activates when a marine steps on it."
+	desc = "Place a hole on weeds that can be filled with a hugger or with acid. Activates when a marine steps on it."
 	ability_cost = 400
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_TRAP,
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	use_state_flags = ABILITY_USE_LYING
 
 /datum/action/ability/xeno_action/spawn_hugger/on_cooldown_finish()
-	to_chat(owner, span_xenodanger("We can now spawn another young one."))
+	to_chat(owner, span_xenodanger("We can now spawn another facehugger."))
 	owner.playsound_local(owner, 'sound/effects/alien/new_larva.ogg', 25, 0, 1)
 	return ..()
 
@@ -174,12 +174,12 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		return FALSE
 	if(xeno_owner.huggers >= xeno_owner.xeno_caste.huggers_max)
 		if(!silent)
-			to_chat(xeno_owner, span_xenowarning("We can't host any more young ones!"))
+			to_chat(xeno_owner, span_xenowarning("We can't host any more facehugger!"))
 		return FALSE
 
 /datum/action/ability/xeno_action/spawn_hugger/action_activate()
 	xeno_owner.huggers++
-	to_chat(xeno_owner, span_xenowarning("We spawn a young one via the miracle of asexual internal reproduction, adding it to our stores. Now sheltering: [xeno_owner.huggers] / [xeno_owner.xeno_caste.huggers_max]."))
+	to_chat(xeno_owner, span_xenowarning("We spawn a facehugger via the miracle of asexual internal reproduction, adding it to our stores. Now sheltering: [xeno_owner.huggers] / [xeno_owner.xeno_caste.huggers_max]."))
 	playsound(xeno_owner, 'sound/voice/alien/drool2.ogg', 50, 0, 1)
 	succeed_activate()
 	add_cooldown()
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Drop All Facehuggers"
 	action_icon_state = "carrier_panic"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Drop all stored huggers in a fit of panic. Uses all remaining plasma!"
+	desc = "Drop all stored facehuggers in a fit of panic. Uses all remaining plasma!"
 	ability_cost = 10
 	cooldown_duration = 50 SECONDS
 	keybinding_signals = list(
@@ -225,7 +225,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		return FALSE
 	if(xeno_owner.huggers < 1)
 		if(!silent)
-			to_chat(xeno_owner, span_xenowarning("We do not have any young ones to drop!"))
+			to_chat(xeno_owner, span_xenowarning("We do not have any facehuggers to drop!"))
 		return FALSE
 
 /datum/action/ability/xeno_action/carrier_panic/action_activate()
@@ -274,7 +274,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		xeno_owner.selected_hugger_type = GLOB.hugger_type_list[i+1]
 
 	var/atom/A = xeno_owner.selected_hugger_type
-	to_chat(xeno_owner, span_notice("We will now spawn <b>[initial(A.name)]\s</b> when using the Spawn Hugger ability."))
+	to_chat(xeno_owner, span_notice("We will now spawn <b>[initial(A.name)]\s</b> when using the Spawn Facehugger ability."))
 	xeno_owner.balloon_alert(xeno_owner,"[initial(A.name)]")
 	update_button_icon()
 	succeed_activate()
@@ -288,7 +288,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		if(initial(hugger_type.name) == hugger_choice)
 			xeno_owner.selected_hugger_type = hugger_type
 			break
-	to_chat(xeno_owner, span_notice("We will now spawn <b>[hugger_choice]\s</b> when using the spawn hugger ability."))
+	to_chat(xeno_owner, span_notice("We will now spawn <b>[hugger_choice]\s</b> when using the Spawn Facehugger ability."))
 	xeno_owner.balloon_alert(xeno_owner, "[hugger_choice]")
 	update_button_icon()
 	return succeed_activate()
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Build Hugger Turret"
 	action_icon_state = "hugger_turret"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Construct a turret that will launch huggers at enemy marines. The type of hugger launched will be the type selected when the turret is built."
+	desc = "Construct a turret that will launch facehuggers at enemy marines. The type of facehugger currently when the turret is built will determine the type of facehugger that is fired."
 	ability_cost = 800
 	cooldown_duration = 5 MINUTES
 	keybinding_signals = list(
@@ -350,7 +350,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Call of Younger"
 	action_icon_state = "call_younger"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Appeals to the larva inside the Marine. The Marine loses their balance, and larva's growth progress accelerates."
+	desc = "Appeals to the larva inside the Marine. The Marine loses their balance, and the larva's growth progress accelerates."
 	ability_cost = 150
 	cooldown_duration = 20 SECONDS
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Choose Hugger Type"
 	action_icon_state = "facehugger"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Selects which hugger type you will build with the Spawn Hugger ability."
+	desc = "Selects which hugger type you will build with the Use/Throw Facehugger ability."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CHOOSE_HUGGER,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_SWITCH_HUGGER,
@@ -294,10 +294,10 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	return succeed_activate()
 
 /datum/action/ability/xeno_action/build_hugger_turret
-	name = "build hugger turret"
+	name = "Build Hugger Turret"
 	action_icon_state = "hugger_turret"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Build a hugger turret"
+	desc = "Construct a turret that will launch huggers at enemy marines. The type of hugger launched will be the type selected when the turret is built."
 	ability_cost = 800
 	cooldown_duration = 5 MINUTES
 	keybinding_signals = list(
@@ -350,7 +350,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	name = "Call of Younger"
 	action_icon_state = "call_younger"
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
-	desc = "Appeals to the larva inside the Marine. The Marine loses his balance, and larva's progress accelerates."
+	desc = "Appeals to the larva inside the Marine. The Marine loses their balance, and larva's growth progress accelerates."
 	ability_cost = 150
 	cooldown_duration = 20 SECONDS
 	keybinding_signals = list(
@@ -372,12 +372,12 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 
 	if(!(locate(/obj/item/alien_embryo) in target))
 		if(!silent)
-			target.balloon_alert(owner, "He's not infected")
+			target.balloon_alert(owner, "Not infected")
 		return FALSE
 
 	if(target.stat == DEAD)
 		if(!silent)
-			target.balloon_alert(owner, "He's dead")
+			target.balloon_alert(owner, "Dead")
 		return FALSE
 
 	if(!line_of_sight(owner, target, 9))
@@ -404,7 +404,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	victim.emote("scream")
 	owner.visible_message(span_xenowarning("\the [owner] emits an unusual roar!"), \
 	span_xenowarning("We called out to the younger one inside [victim]!"))
-	victim.visible_message(span_xenowarning("\The [victim] loses his balance, falling to the side!"), \
+	victim.visible_message(span_xenowarning("\The [victim] loses [victim.p_their()] balance, falling to the side!"), \
 	span_xenowarning("You feel like something inside you is tearing out!"))
 
 	victim.apply_effects(2 SECONDS, 1 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Call of Younger now respects the target's pronouns instead of just using "his" for all cases
Ability descriptions will now use "facehugger" instead of just "hugger" or "young one"
Corrects description for the Use/Throw Facehugger ability (The ability will always throw the facehugger, and you cannot just bring it into your hand)
Also notes the ability to use Use/Throw Facehugger directly on a facehugger to recycle it
Capitalizes hugger turret name and gives it an actual description (Seriously people)
## Why It's Good For The Game
## Changelog
:cl:
spellcheck: Carrier: Call of Younger will now respect the target's pronouns
spellcheck: Carrier: Adds proper ability description to the Build Hugger Turret ability, capitalizes ability name
spellcheck: Carrier: Abilities will now exclusively use the term "facehugger" instead of "hugger" or "young one"
/:cl:
