### PR TITLE
Crusher nerfs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 485
+	max_health = 450
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -36,7 +36,7 @@
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 50, ACID = 100)
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.7
+	sunder_multiplier = 0.9
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 445
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
@@ -36,7 +36,7 @@
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 50, ACID = 100)
 
 	// *** Sunder *** //
-	sunder_multiplier = 0.9
+	sunder_multiplier = 0.85
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"


### PR DESCRIPTION
## About The Pull Request

Nerfs crusher sunder multiplier and total health.

## Why It's Good For The Game

Following the removal of aim mode, crusher became a real bastard to play against, this should reign him in somewhat

## Changelog

:cl:
balance: Crusher sunder mult nerfed, Crusher total health nerfed
/:cl:
