### PR TITLE
Tank gib godemode check

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -88,7 +88,8 @@
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
-		target_mob.gib()
+		if(!(target_mob.status_flags & GODMODE))
+			target_mob.gib()
 	else
 		staggerstun(target_mob, proj, src.max_range, knockback = 1, hard_size_threshold = 3)
 	drop_nade(target_turf)
@@ -531,7 +532,7 @@
 
 /datum/ammo/bullet/tank_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	proj.proj_max_range -= 2
-	if(ishuman(target_mob) && prob(35))
+	if(ishuman(target_mob) && !(target_mob.status_flags & GODMODE) && prob(35))
 		target_mob.gib()
 
 /datum/ammo/bullet/tank_apfds/on_hit_obj(obj/target_object, obj/projectile/proj)
@@ -645,7 +646,8 @@
 
 /datum/ammo/rocket/coilgun/high/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(ishuman(target_mob) && prob(50)) //it only has AMMO_PASS_THROUGH_MOB so it can keep going if it gibs a mob
-		target_mob.gib()
+		if(!(target_mob.status_flags & GODMODE))
+			target_mob.gib()
 		proj.proj_max_range -= 5
 		return
 	proj.proj_max_range = 0


### PR DESCRIPTION

## About The Pull Request
Tank gibs now check for godmode before gibbing.
## Why It's Good For The Game
Funny gibs while in godmode from armourlock/petrify/hvh spawn protection is funny but probs bad.
## Changelog
:cl:
fix: Tank gibs now check for godmode
/:cl:
