### PR TITLE
GAU Cas rebalance

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -259,13 +259,17 @@
 	for(var/i=1 to attack_width)
 		strafed = strafelist[1]
 		strafelist -= strafed
-		strafed.ex_act(EXPLODE_LIGHT)
 		new /obj/effect/temp_visual/heavyimpact(strafed)
 		for(var/atom/movable/AM AS in strafed)
 			if(QDELETED(AM))
 				continue
-			//This may seem a bit wacky as we're exploding the turf's content twice, but doing it another way would be even more wacky because of how hard it is to modify explosion damage without adding a whole other explosion type
-			AM.ex_act(EXPLODE_LIGHT)
+			if(!iscarbon(AM))
+				AM.ex_act(EXPLODE_LIGHT)
+				AM.take_damage(60)
+				continue
+			var/mob/living/carbon/victim = AM
+			victim.adjustBruteLoss(rand(80,140))
+
 
 	if(length(strafelist))
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 2)


### PR DESCRIPTION
## About The Pull Request
Changes damage (to mobs) to be anywhere from 80 - 140 brute damage, instead of being 20 - 180 bomb damage. Objects are still exploded twice, with two light explosions. 
## Why It's Good For The Game
Cas is unfun to fight against as a xeno, both because there is nothing they can do against it, and because of the RNG. GAU is a particularlly bad case of this, and being able to deal anywhere from 20 - 180 bomb damage, mutiple times, per tile, is very unfun, and poor for feedback. Sometimes you might just roll 20 damage twice, or you just 360 damage and are dead if not almost dead. This raises the minimum damage, so cas pilots aren't wondering why the xeno they just hit was barely effected, changes the damage to brute (why would a minigun be explosive damage), and lowers the minimum damage, to make it fairer on xenos.

All of the above issues become infinitely worse with how spammable GAU is, and with how big of a AOE it has, along with the fact that you can be hit multiple times by it.
## Changelog
:cl:
balance: GAU 30mm minigun now does brute damage to mobs, instead of bomb.
balance: GAU 30mm now deals between 80 - 140 damage to mobs, from 20 - 180 bomb damage.
/:cl:
