### PR TITLE
Kills one handed combat shotgun

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -83,7 +83,6 @@
 	icon_state = "t39"
 	worn_icon_state = "t39"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_sh39.ogg'
-	gun_features_flags = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
 	default_ammo_type = /datum/ammo/bullet/shotgun/buckshot
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,


### PR DESCRIPTION

## About The Pull Request
SH-39 can no longer be one handed.
## Why It's Good For The Game
Kills (or makes harder) gross slow stacking of slugs + vali slowdown.

Combat shotty is rather good when one handed, which means no slowdown, and more recently can be offhand fired with vali sword for gross slow stacking.

There's really no other reason why you'd one hand a combat shotty, considering shields were removed and akimbo is unreliable. Unless you have been delimbed I guess.
## Changelog
:cl:
balance: SH-39 can no longer be one handed, again
/:cl:
