### PR TITLE
Human bump attacks respect friendly human factions

### DIFF
--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -89,6 +89,9 @@
 	var/mob/living/living_target = target
 	if(bumper.faction == living_target.faction)
 		return //FF
+	var/mob/living/carbon/human/human_target = target
+	if(bumper.wear_id.iff_signal == human_target.wear_id.iff_signal)
+		return //FF
 	if(isxeno(target))
 		var/mob/living/carbon/xenomorph/xeno = target
 		if(bumper.wear_id && CHECK_BITFIELD(xeno.xeno_iff_check(), bumper.wear_id.iff_signal))


### PR DESCRIPTION

## About The Pull Request

Stops friendly melee marines and ERTs from hitting each other accidentally in passing.
## Why It's Good For The Game

Lessens the blood on my hands while near friendly factions.

Don't think it works for SOM/ICC/CLF as they use different IFF tags from each other.
## Changelog
:cl:
fix: human bump attacks respects human IFF
/:cl:
