### PR TITLE
Reduce engi vendor and req costs for genghis charges

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/cell/high = list(CAT_ENGSUP, "High capacity powercell", 1, "engi-tool"),
 		/obj/item/clothing/glasses/welding/superior = list(CAT_ENGSUP, "Superior welding goggles", 2, "engi-tool"),
 		/obj/item/armor_module/module/welding/superior = list(CAT_ENGSUP, "Superior welding module", 2, "engi-tool"),
-		/obj/item/explosive/plastique/genghis_charge = list(CAT_ENGSUP, "EX-62 Genghis incendiary charge", 15, "engi-explosive"),
+		/obj/item/explosive/plastique/genghis_charge = list(CAT_ENGSUP, "EX-62 Genghis incendiary charge", 5, "engi-explosive"),
 		/obj/item/detpack = list(CAT_ENGSUP, "Detonation pack", 5, "engi-explosive"),
 		/obj/item/explosive/plastique = list(CAT_ENGSUP, "Plastique explosive", 2, "engi-explosive"),
 		/obj/item/storage/box/explosive_mines/large = list(CAT_ENGSUP, "Large M20 mine box", 35, "engi-explosive"),

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1008,7 +1008,7 @@ EXPLOSIVES
 /datum/supply_packs/explosives/plastique_incendiary
 	name = "EX-62 Genghis incendiary charge"
 	contains = list(/obj/item/explosive/plastique/genghis_charge)
-	cost = 150
+	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/explosives/detpack


### PR DESCRIPTION

## About The Pull Request
Reduces the engi vendor cost for genghis charges down to 5 from 15 and the req cost down to 50 from 150.

## Why It's Good For The Game
For such a situational item that might never get used at all during an op to have such a high price compared to other items seems off to me, like a detpack costs 5 and 50 and can be used in more situations.

5 and 50 seems less extreme to me and less of a steep investment for something with such a specific niche of clearing large blobs of connected walls and pretty much nothing else. 
## Changelog
:cl:
balance: Reduced genghis charge cost in engi vendor from 15 to 5 and Req 150 to 50
/:cl:
