### PR TITLE
Buffs to Sentinel/Retrogade Sentinel stats across the board

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -11,7 +11,7 @@
 	gib_flick = "gibbed-a-small"
 
 	// *** Melee Attacks *** //
-	melee_damage = 16
+	melee_damage = 18
 
 	// *** Speed *** //
 	speed = -0.9
@@ -21,7 +21,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 370
 
 	// *** Evolution *** //
 	evolution_threshold = 100
@@ -33,7 +33,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 25, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 0, BIO = 25, FIRE = 26, ACID = 25)
+	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 10, BIO = 30, FIRE = 30, ACID = 30)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.0 SECONDS


### PR DESCRIPTION
## About The Pull Request

Buffs sentinel across the board

## Why It's Good For The Game

So it turns out that in my original xeno buff pr I had planned to buff sentinel, but actually completely forgot to add the sentinel buffs. The caste has been performing below its T1 counterparts so this should bring it up to par.

Tldr: I forgor to buff it, teehee
## Changelog

:cl:
balance: General buffs to sentinel and retrograde damage and survivability
/:cl:
