### PR TITLE
Block Movement keybind now lets you rotate binoculars and scopes again

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -19,4 +19,4 @@
 /mob/living/keybind_face_direction(direction)
 	if(stat > CONSCIOUS)
 		return
-	return ..()
+	facedir(direction)


### PR DESCRIPTION

## About The Pull Request
Restores old functionality to binoculars and similar.
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: Block Movement keybind now lets you rotate scopes and binoculars like before.
/:cl:
