### PR TITLE
Jumping mobs now make any mobs buckled to them jump

### DIFF
--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -55,20 +55,19 @@
 	UnregisterSignal(parent, list(COMSIG_KB_LIVING_JUMP_DOWN))
 	if(jump_flags & JUMP_CHARGEABLE)
 		RegisterSignal(parent, COMSIG_KB_LIVING_JUMP_DOWN, PROC_REF(charge_jump))
-		RegisterSignal(parent, COMSIG_KB_LIVING_JUMP_UP, PROC_REF(do_jump))
+		RegisterSignal(parent, COMSIG_KB_LIVING_JUMP_UP, PROC_REF(start_jump))
 	else
-		RegisterSignal(parent, COMSIG_KB_LIVING_JUMP_DOWN, PROC_REF(do_jump))
+		RegisterSignal(parent, COMSIG_KB_LIVING_JUMP_DOWN, PROC_REF(start_jump))
 
 ///Starts charging the jump
 /datum/component/jump/proc/charge_jump(mob/living/jumper)
 	jump_start_time = world.timeofday
 
-///Performs the jump
-/datum/component/jump/proc/do_jump(mob/living/jumper, buckled_check = TRUE)
+///handles pre-jump checks and setup of additional jump behavior.
+/datum/component/jump/proc/start_jump(mob/living/jumper)
 	SIGNAL_HANDLER
-	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
-		return
-	if(buckled_check && jumper.buckled)
+
+	if(jumper.buckled)
 		return
 	if(jumper.incapacitated())
 		return
@@ -78,6 +77,17 @@
 			to_chat(jumper, span_warning("Your leg servos do not allow you to jump!"))
 			return
 		to_chat(jumper, span_warning("Catch your breath!"))
+		return
+
+	do_jump(jumper)
+	//Forces all who ride to jump alongside the jumper.
+	for(var/mob/buckled_mob AS in jumper.buckled_mobs)
+		do_jump(buckled_mob, FALSE)
+
+///Performs the jump
+/datum/component/jump/proc/do_jump(mob/living/jumper, use_stamina = TRUE)
+
+	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
 		return
 
 	var/effective_jump_duration = jump_duration
@@ -98,11 +108,12 @@
 	var/original_pass_flags = jumper.pass_flags
 
 	SEND_SIGNAL(jumper, COMSIG_ELEMENT_JUMP_STARTED, effective_jump_height, effective_jump_duration)
-	jumper.adjustStaminaLoss(stamina_cost)
+	if(use_stamina)
+		jumper.adjustStaminaLoss(stamina_cost)
 	jumper.pass_flags |= effective_jumper_allow_pass_flags
 	ADD_TRAIT(jumper, TRAIT_SILENT_FOOTSTEPS, JUMP_COMPONENT)
 	jumper.add_nosubmerge_trait(JUMP_COMPONENT)
-	RegisterSignal(parent, COMSIG_MOB_THROW, PROC_REF(jump_throw))
+	RegisterSignal(jumper, COMSIG_MOB_THROW, PROC_REF(jump_throw))
 
 	jumper.add_filter(JUMP_COMPONENT, 2, drop_shadow_filter(color = COLOR_TRANSPARENT_SHADOW, size = 0.9))
 	var/shadow_filter = jumper.get_filter(JUMP_COMPONENT)
@@ -127,7 +138,7 @@
 	jumper.remove_traits(list(TRAIT_SILENT_FOOTSTEPS, TRAIT_NOSUBMERGE), JUMP_COMPONENT)
 	SEND_SIGNAL(jumper, COMSIG_ELEMENT_JUMP_ENDED, TRUE, 1.5, 2)
 	SEND_SIGNAL(jumper.loc, COMSIG_TURF_JUMP_ENDED_HERE, jumper)
-	UnregisterSignal(parent, COMSIG_MOB_THROW)
+	UnregisterSignal(jumper, COMSIG_MOB_THROW)
 
 ///Jump throw bonuses
 /datum/component/jump/proc/jump_throw(mob/living/thrower, target, thrown_thing, list/throw_modifiers)

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -67,6 +67,9 @@
 /datum/component/jump/proc/start_jump(mob/living/jumper)
 	SIGNAL_HANDLER
 
+	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
+		return
+
 	if(jumper.buckled)
 		return
 	if(jumper.incapacitated())
@@ -80,15 +83,13 @@
 		return
 
 	do_jump(jumper)
+	jumper.adjustStaminaLoss(stamina_cost)
 	//Forces all who ride to jump alongside the jumper.
 	for(var/mob/buckled_mob AS in jumper.buckled_mobs)
-		do_jump(buckled_mob, FALSE)
+		do_jump(buckled_mob)
 
 ///Performs the jump
-/datum/component/jump/proc/do_jump(mob/living/jumper, use_stamina = TRUE)
-
-	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
-		return
+/datum/component/jump/proc/do_jump(mob/living/jumper)
 
 	var/effective_jump_duration = jump_duration
 	var/effective_jump_height = jump_height
@@ -108,8 +109,6 @@
 	var/original_pass_flags = jumper.pass_flags
 
 	SEND_SIGNAL(jumper, COMSIG_ELEMENT_JUMP_STARTED, effective_jump_height, effective_jump_duration)
-	if(use_stamina)
-		jumper.adjustStaminaLoss(stamina_cost)
 	jumper.pass_flags |= effective_jumper_allow_pass_flags
 	ADD_TRAIT(jumper, TRAIT_SILENT_FOOTSTEPS, JUMP_COMPONENT)
 	jumper.add_nosubmerge_trait(JUMP_COMPONENT)

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -64,11 +64,11 @@
 	jump_start_time = world.timeofday
 
 ///Performs the jump
-/datum/component/jump/proc/do_jump(mob/living/jumper)
+/datum/component/jump/proc/do_jump(mob/living/jumper, buckled_check = TRUE)
 	SIGNAL_HANDLER
 	if(TIMER_COOLDOWN_CHECK(jumper, JUMP_COMPONENT_COOLDOWN))
 		return
-	if(jumper.buckled)
+	if(buckled_check && jumper.buckled)
 		return
 	if(jumper.incapacitated())
 		return

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -245,7 +245,6 @@
 /datum/component/riding/creature/crusher/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_LIVING_SET_LYING_ANGLE, PROC_REF(check_carrier_fall_over))
-	RegisterSignal(parent, COMSIG_ELEMENT_JUMP_STARTED, PROC_REF(make_rider_jump))
 
 /datum/component/riding/creature/crusher/log_riding(mob/living/living_parent, mob/living/rider)
 	if(!istype(living_parent) || !istype(rider))
@@ -277,15 +276,6 @@
 		. = riding_offsets["[mob_type]"]
 	else if(riding_offsets["[RIDING_OFFSET_ALL]"])
 		. = riding_offsets["[RIDING_OFFSET_ALL]"]
-
-/// If the crusher jumps, the rider(s) jumps alongside them
-/datum/component/riding/creature/crusher/proc/make_rider_jump()
-	SIGNAL_HANDLER
-
-	var/atom/movable/parentmovable = parent
-	for(var/mob/living/rider AS in parentmovable.buckled_mobs)
-		var/datum/component/jump/riderjump = rider.GetComponent(/datum/component/jump)
-		riderjump?.do_jump(rider, buckled_check = FALSE)
 
 // ***************************************
 // *********** Widow

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -245,6 +245,7 @@
 /datum/component/riding/creature/crusher/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_LIVING_SET_LYING_ANGLE, PROC_REF(check_carrier_fall_over))
+	RegisterSignal(parent, COMSIG_ELEMENT_JUMP_STARTED, PROC_REF(make_rider_jump))
 
 /datum/component/riding/creature/crusher/log_riding(mob/living/living_parent, mob/living/rider)
 	if(!istype(living_parent) || !istype(rider))
@@ -276,6 +277,15 @@
 		. = riding_offsets["[mob_type]"]
 	else if(riding_offsets["[RIDING_OFFSET_ALL]"])
 		. = riding_offsets["[RIDING_OFFSET_ALL]"]
+
+/// If the crusher jumps, the rider(s) jumps alongside them
+/datum/component/riding/creature/crusher/proc/make_rider_jump()
+	SIGNAL_HANDLER
+
+	var/atom/movable/parentmovable = parent
+	for(var/mob/living/rider AS in parentmovable.buckled_mobs)
+		var/datum/component/jump/riderjump = rider.GetComponent(/datum/component/jump)
+		riderjump?.do_jump(rider, buckled_check = FALSE)
 
 // ***************************************
 // *********** Widow


### PR DESCRIPTION
## About The Pull Request
Mobs buckled to a jumping mob are now compelled to jump at the same time as their carrier.
This looks much better and allows mobs with a rider to pull off much fancier maneuvers.

<s>Calling the component directly like this is total slop but this is how it's done everywhere else so </s>
Obliterated. Lumi helped me find a better solution, jump component now iterates through mobs buckled to the jumper and forces them to jump.

## Why It's Good For The Game
![but-heres-the-jumper-jumping-cat](https://github.com/user-attachments/assets/72bb9b94-1ac9-4019-b362-4f4ac09b6a30)
## Changelog
:cl:
qol: mobs buckled to a jumping mob now jump alongside them
/:cl:
