### PR TITLE
Adds bloodthirster to global list of all xeno types

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -91,6 +91,8 @@ GLOBAL_LIST_INIT(all_xeno_types, list(
 	/mob/living/carbon/xenomorph/wraith/primordial,
 	/mob/living/carbon/xenomorph/ravager,
 	/mob/living/carbon/xenomorph/ravager/primordial,
+	/mob/living/carbon/xenomorph/ravager/bloodthirster,
+	/mob/living/carbon/xenomorph/ravager/bloodthirster/primordial,
 	/mob/living/carbon/xenomorph/praetorian,
 	/mob/living/carbon/xenomorph/praetorian/primordial,
 	/mob/living/carbon/xenomorph/praetorian/dancer,


### PR DESCRIPTION

## About The Pull Request
Tivi forgot to add this strain to The Big List
## Why It's Good For The Game
Bloodthirster now appears in valhalla spawnlist, among other places. Now please fix the balance tivi I beg y
## Changelog
:cl:
fix: Bloodthirster is now represented on the global list of all xeno types
/:cl:
