### PR TITLE
Fixes laser sentry IFF

### DIFF
--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -456,6 +456,7 @@
 	allowed_ammo_types = list(/obj/item/ammo_magazine/sentry/laser)
 
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
+	gun_features_flags = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_ENERGY
 
 	attachable_allowed = list(/obj/item/attachable/scope/unremovable/hsg_102)
 	starting_attachment_types = list(


### PR DESCRIPTION

## About The Pull Request
Corrects laser sentry gun flags.
No longer has IFF, and properly counts ammo via shots remaining.

## Changelog
:cl:
fix: The laser sentry no longer has IFF when it shouldn't have
/:cl:
