### PR TITLE
Big red modular fix

### DIFF
--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -3,7 +3,7 @@
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "aC" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -33,7 +33,7 @@
 /obj/effect/spawner/random/weaponry/ammo,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/blue/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "bc" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -42,7 +42,7 @@
 /obj/structure/window_frame/mainship/white,
 /obj/item/shard,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "bg" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/icefloor,
@@ -65,7 +65,7 @@
 /obj/item/ammo_casing,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "by" = (
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
@@ -78,12 +78,12 @@
 "bO" = (
 /obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "bQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/orange/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "bW" = (
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -97,11 +97,11 @@
 /obj/effect/landmark/corpsespawner/marine/engineer,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/tcomms,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "bX" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "cj" = (
 /turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/c)
@@ -110,17 +110,17 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "cu" = (
 /obj/structure/prop/brokenvendor/surplusarmor,
 /turf/open/floor/mainship,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "cv" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/spawner/random/weaponry/ammo,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "cI" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -133,7 +133,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "cV" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/tile/whiteyellow/full,
@@ -143,7 +143,7 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "dK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -165,14 +165,14 @@
 "ea" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ek" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "eq" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -184,21 +184,21 @@
 	},
 /obj/item/shard,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "eN" = (
 /obj/structure/window_frame/mainship/white,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "fs" = (
 /obj/item/stack/sheet/plasteel,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "fG" = (
 /obj/structure/window_frame/mainship,
 /obj/item/shard,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "fY" = (
 /obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
@@ -223,22 +223,22 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "gR" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "gW" = (
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ha" = (
 /obj/item/stack/sheet/plasteel,
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "hh" = (
 /obj/machinery/air_alarm{
 	dir = 4
@@ -263,7 +263,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "hw" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/weaponry/gun,
@@ -273,37 +273,37 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mainship/orange/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "hT" = (
 /obj/structure/prop/brokenvendor/brokenuniformvendor/specialist,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "iB" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "iG" = (
 /obj/structure/cable,
 /turf/open/floor/mainship,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "iS" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ju" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /obj/item/shard,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "jD" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "jK" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -313,14 +313,14 @@
 	},
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/mainship/red,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "jO" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
 	},
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "jX" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/e)
@@ -341,7 +341,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "kK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/paperbin,
@@ -363,7 +363,7 @@
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "lp" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -372,7 +372,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -388,13 +388,13 @@
 "md" = (
 /obj/structure/prop/brokenvendor/surplusclothes,
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "mh" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 1
 	},
 /turf/open/floor/mainship/red,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "mp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -405,7 +405,7 @@
 "mq" = (
 /obj/structure/prop/brokenvendor/brokenmarinemedvendor,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "mv" = (
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
@@ -422,21 +422,21 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "nc" = (
 /obj/effect/spawner/random/weaponry/ammo,
 /turf/open/floor/mainship,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ng" = (
 /obj/machinery/computer/autodoc_console,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "nC" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "nX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -450,11 +450,11 @@
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ow" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "oF" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -492,7 +492,7 @@
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "pX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -502,7 +502,7 @@
 /obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "qr" = (
 /obj/machinery/door_control{
 	dir = 4;
@@ -519,7 +519,7 @@
 /obj/item/storage/surgical_tray,
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "qI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -541,7 +541,7 @@
 "qP" = (
 /obj/machinery/cryopod,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "rm" = (
 /obj/structure/cable,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -562,7 +562,7 @@
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "sa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -581,13 +581,13 @@
 /turf/open/floor/mainship/blue{
 	dir = 10
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "si" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "sx" = (
 /obj/machinery/door/window/right{
 	dir = 1
@@ -597,28 +597,28 @@
 	},
 /obj/effect/spawner/random/weaponry/ammo,
 /turf/open/floor/mainship/red,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "sB" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
 "sP" = (
 /obj/machinery/fuelcell_recycler,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "tl" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "tz" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/camera_advanced/overwatch,
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "tE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
@@ -628,7 +628,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "tM" = (
 /obj/structure/closet/jcloset,
 /obj/item/clothing/head/beret/jan,
@@ -643,7 +643,7 @@
 "tP" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/icefloor,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "tR" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -661,11 +661,11 @@
 "uh" = (
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "uk" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "uu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/lighter/random,
@@ -697,7 +697,7 @@
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "uZ" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
@@ -705,21 +705,21 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "vw" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4
 	},
 /obj/structure/prop/brokenvendor/brokenweaponsrack,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "vy" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "vG" = (
 /obj/machinery/light{
 	dir = 4
@@ -737,7 +737,7 @@
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "vO" = (
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 4
@@ -746,11 +746,11 @@
 "vS" = (
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "vX" = (
 /obj/structure/prop/brokenvendor/brokenuniformvendor,
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "wf" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 6
@@ -765,7 +765,7 @@
 "wl" = (
 /obj/structure/prop/mainship/mission_planning_system,
 /turf/open/floor/mainship/blue,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "wp" = (
 /obj/machinery/light{
 	dir = 4
@@ -785,12 +785,12 @@
 "wM" = (
 /obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "xe" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "xf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
@@ -801,7 +801,7 @@
 	},
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "xU" = (
 /obj/item/lightreplacer,
 /obj/item/clothing/glasses/welding,
@@ -813,11 +813,11 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "yh" = (
 /obj/structure/prop/brokenvendor/brokennanomedvendor,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "yn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -837,7 +837,7 @@
 /turf/open/floor/mainship/blue{
 	dir = 5
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "yB" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/tile/whiteyellow/full,
@@ -861,18 +861,18 @@
 /obj/machinery/vending/nanomed,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/blue,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "zb" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ze" = (
 /obj/machinery/power/monitor{
 	name = "Core Power Monitoring"
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "zg" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 1
@@ -880,7 +880,7 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "zi" = (
 /obj/machinery/door/poddoor/mainship/open,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -889,13 +889,13 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "zG" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "zO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -904,11 +904,11 @@
 /obj/structure/bed/chair/dropship/passenger,
 /obj/item/ammo_casing,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ai" = (
 /obj/machinery/computer/body_scanconsole,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Am" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
@@ -919,13 +919,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "AQ" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "AR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -938,7 +938,7 @@
 /obj/item/storage/belt/lifesaver/full,
 /obj/item/healthanalyzer,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ba" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -947,7 +947,7 @@
 /turf/open/floor/mainship/blue{
 	dir = 6
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Bc" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -957,18 +957,18 @@
 	},
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Be" = (
 /obj/item/fuel_cell/full,
 /obj/item/fuel_cell/random,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/shard,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Bn" = (
 /obj/structure/window/framed/mainship/canterbury,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Bv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -1001,14 +1001,14 @@
 /obj/structure/table/mainship,
 /obj/item/facepaint/black,
 /turf/open/floor/mainship/orange/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Cu" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/tool/weldpack,
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
 /obj/effect/spawner/random/weaponry/ammo,
 /turf/open/floor/mainship/orange/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Dc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -1045,7 +1045,7 @@
 "ET" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "EY" = (
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
@@ -1072,7 +1072,7 @@
 	},
 /obj/structure/prop/brokenvendor/brokenspecialistvendor/leader,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Fu" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -1090,18 +1090,18 @@
 "Fz" = (
 /obj/structure/prop/computer/cryopod,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "FC" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "FF" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "FJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -1110,18 +1110,18 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "FT" = (
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "FV" = (
 /turf/closed/wall/mainship/white,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Gf" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Gt" = (
 /obj/structure/table,
 /turf/open/floor,
@@ -1139,11 +1139,11 @@
 /obj/item/stack/barbed_wire/small_stack,
 /obj/effect/spawner/random/weaponry/gun/machineguns,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Id" = (
 /obj/item/ammo_casing,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ij" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -1160,7 +1160,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "IE" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1170,7 +1170,7 @@
 "Ja" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /turf/open/floor/podhatch/floor,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Jk" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -1184,7 +1184,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/red,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "JB" = (
 /obj/machinery/optable,
 /obj/item/radio/intercom{
@@ -1195,16 +1195,16 @@
 	},
 /obj/effect/landmark/corpsespawner/marine/corpsman,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "JC" = (
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "JK" = (
 /obj/machinery/prop/autolathe,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "JT" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
@@ -1212,7 +1212,7 @@
 /obj/effect/spawner/random/weaponry/ammo,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "JW" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
@@ -1229,27 +1229,27 @@
 /obj/machinery/vending/nanomed,
 /obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Kz" = (
 /obj/machinery/door/poddoor/mainship/open,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Lx" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
 /obj/item/ammo_casing,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "LE" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "LM" = (
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Mn" = (
 /obj/item/clothing/shoes/galoshes,
 /turf/open/floor/tile/whiteyellow/full,
@@ -1259,7 +1259,7 @@
 /obj/structure/window_frame/mainship,
 /obj/item/shard,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ME" = (
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/plating/icefloor,
@@ -1274,32 +1274,32 @@
 /obj/item/storage/bag/trash,
 /obj/item/storage/bag/trash,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "MP" = (
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "MU" = (
 /obj/structure/bed/chair/dropship/pilot{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Nj" = (
 /obj/structure/prop/brokenvendor/engivend,
 /turf/open/floor/mainship/orange/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Nk" = (
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Nw" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/air_alarm{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Nz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tracks/wheels/bloody{
@@ -1325,7 +1325,7 @@
 "Ow" = (
 /obj/structure/prop/brokenvendor/brokenspecialistvendor/corpsman,
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "OS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1339,7 +1339,7 @@
 /obj/item/shard,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "PN" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Office Complex"
@@ -1370,7 +1370,7 @@
 	},
 /obj/structure/prop/brokenvendor/brokenweaponsrack,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "PV" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marine_network,
@@ -1378,17 +1378,17 @@
 /turf/open/floor/mainship/blue{
 	dir = 9
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Qd" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /turf/open/floor/podhatch/floor,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Qr" = (
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Qt" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -1399,14 +1399,14 @@
 /obj/item/ammo_casing,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Qy" = (
 /obj/item/shard,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "QF" = (
 /turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/se)
@@ -1418,12 +1418,12 @@
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "QM" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ra" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper,
@@ -1432,7 +1432,7 @@
 "Rb" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Rd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1449,14 +1449,14 @@
 "Sj" = (
 /obj/structure/window_frame/mainship,
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Sv" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4
 	},
 /obj/structure/prop/brokenvendor/brokenuniformvendor/specialist,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "SA" = (
 /obj/item/pizzabox/meat{
 	pixel_y = 8
@@ -1468,11 +1468,11 @@
 /obj/item/tool/shovel/etool,
 /obj/effect/spawner/random/engineering/extinguisher/regularweighted,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "SE" = (
 /obj/structure/prop/brokenvendor/brokenuniformvendor/specialist,
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "SK" = (
 /obj/structure/cable,
 /obj/item/ammo_casing,
@@ -1481,7 +1481,7 @@
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "SY" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/landmark/weed_node,
@@ -1490,7 +1490,7 @@
 "Tm" = (
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Tx" = (
 /turf/closed/wall,
 /area/bigredv2/outside/office_complex)
@@ -1508,7 +1508,7 @@
 /obj/machinery/power/fusion_engine/random,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "TS" = (
 /obj/machinery/light{
 	dir = 4
@@ -1524,14 +1524,14 @@
 /area/bigredv2/outside/e)
 "Uz" = (
 /turf/closed/wall/mainship,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "US" = (
 /obj/structure/table/mainship,
 /obj/machinery/faxmachine/cic,
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "UW" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/corpsespawner/security,
@@ -1540,7 +1540,7 @@
 "Vc" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "VH" = (
 /obj/machinery/light{
 	dir = 8
@@ -1556,14 +1556,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "We" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/prop/brokenvendor/brokenspecialistvendor/sg,
 /turf/open/floor/mainship/red/full,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Wm" = (
 /turf/open/floor,
 /area/bigredv2/outside/c)
@@ -1571,7 +1571,7 @@
 /obj/item/stack/sheet/metal,
 /obj/item/shard,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ws" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning,
@@ -1588,7 +1588,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "WJ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1632,7 +1632,7 @@
 /obj/effect/spawner/random/weaponry/gun,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "XJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -1644,7 +1644,7 @@
 "XM" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Yc" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -1663,7 +1663,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Yo" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -1676,11 +1676,11 @@
 /area/bigredv2/outside/office_complex)
 "Yr" = (
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ys" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/podhatch/floor,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "YR" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -1689,18 +1689,18 @@
 	},
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Zd" = (
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Ze" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "Zl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1711,7 +1711,7 @@
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ZA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -1727,20 +1727,20 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ZD" = (
 /obj/machinery/door/poddoor/mainship/open,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ZJ" = (
 /obj/machinery/autodoc,
 /turf/open/floor/mainship/sterile,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 "ZW" = (
 /obj/effect/spawner/random/machinery/machine_frame,
 /turf/open/floor/mainship/cargo,
-/area/bigredv2/outside/office_complex)
+/area/bigredv2/outside/office_complex/crashed_ship)
 
 (1,1,1) = {"
 qL

--- a/code/game/area/bigred.dm
+++ b/code/game/area/bigred.dm
@@ -234,6 +234,9 @@
 	ceiling = CEILING_METAL
 	outside = FALSE
 
+/area/bigredv2/outside/office_complex/crashed_ship
+	name = "Derelict Canterbury"
+
 /area/bigredv2/outside/space_port
 	name = "Space Port"
 	icon_state = "green"


### PR DESCRIPTION

## About The Pull Request
Gives the crashed canterbury modular its own area

Previous pr added a duplicate APC, now the areas are split like they shouldve been.
## Why It's Good For The Game
Fix so big red passes checks
## Changelog
:cl:
fix: Crashed canterbury on big red now uses its own area.
/:cl:
