### PR TITLE
You can no longer see ghost runetext when you can't see the ghost

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -159,7 +159,7 @@
 
 /// Displays a message in deadchat, sent by source. Source is not linkified, message is, to avoid stuff like character names to be linkified.
 /// Automatically gives the class deadsay to the whole message (message + source)
-/proc/deadchat_broadcast(message, source = null, mob/follow_target = null, turf/turf_target = null, speaker_key = null, message_type = DEADCHAT_REGULAR, runechat_msg, runechat_source)
+/proc/deadchat_broadcast(message, source = null, mob/follow_target = null, turf/turf_target = null, speaker_key = null, message_type = DEADCHAT_REGULAR, runechat_msg, atom/runechat_source)
 	message = span_deadsay("[source][span_linkify("[message]")]")
 	for(var/mob/M in GLOB.player_list)
 		if(!M.client)
@@ -211,5 +211,5 @@
 		else
 			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
 
-		if(runechat_source && runechat_msg)
+		if(runechat_source && runechat_msg && (runechat_source.z == M.z) && (M.see_invisible >= runechat_source.invisibility))
 			M.create_chat_message(runechat_source, /datum/language/common, runechat_msg)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

Also doesn't generate the runetext if they're off zlevel, since dchat is across the entire game and its pointless overhead.

Not tested because I'm too lazy to check with 2 clients.
## Why It's Good For The Game
Seeing a bunch of invisible ghosts talking as admin or observer with ghost vision off is aylmao
## Changelog
:cl:
fix: Ghost runetext is no longer visible if the ghost itself is not
/:cl:
