### PR TITLE
Tank driver periscope fix

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -72,8 +72,6 @@
 	var/list/easy_load_list
 	///Wether we are strafing
 	var/strafe = FALSE
-	///modifier to view range when manning a control chair
-	var/vis_range_mod = 0
 
 /obj/vehicle/sealed/armored/Initialize(mapload)
 	easy_load_list = typecacheof(easy_load_list)

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -22,7 +22,7 @@
 	max_occupants = 4
 	move_delay = 0.75 SECONDS
 	glide_size = 2.5
-	vis_range_mod = 2
+
 	ram_damage = 100
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,
@@ -173,7 +173,6 @@
 	armored_flags = ARMORED_HAS_PRIMARY_WEAPON|ARMORED_HAS_SECONDARY_WEAPON|ARMORED_HAS_UNDERLAY|ARMORED_HAS_HEADLIGHTS|ARMORED_WRECKABLE
 	move_delay = 0.6 SECONDS
 	glide_size = 2.5
-	vis_range_mod = 4
 	faction = FACTION_TERRAGOV
 	ram_damage = 130
 

--- a/code/modules/vehicles/armored/armored_actions.dm
+++ b/code/modules/vehicles/armored/armored_actions.dm
@@ -121,10 +121,10 @@
 	chassis.log_message("Toggled zoom mode.", LOG_MECHA)
 	to_chat(owner, "<font color='[chassis.zoom_mode?"blue":"red"]'>Zoom mode [chassis.zoom_mode?"en":"dis"]abled.</font>")
 	if(chassis.zoom_mode)
-		owner.client.view_size.set_view_radius_to(4.5)
+		owner.client.view_size.add(3)
 		SEND_SOUND(owner, sound('sound/mecha/imag_enh.ogg', volume=50))
 	else
-		owner.client.view_size.set_view_radius_to("[chassis.vis_range_mod]x[chassis.vis_range_mod]")
+		owner.client.view_size.add(-3)
 	update_button_icon()
 
 /datum/action/vehicle/sealed/armored/zoom/remove_action(mob/M)

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -36,8 +36,6 @@
 	var/obj/vehicle/sealed/armored/owner
 	///The skill required to man this chair
 	var/skill_req = SKILL_LARGE_VEHICLE_VETERAN
-	///tile range we increase vision by
-	var/vis_range_mod = 1
 
 /obj/structure/bed/chair/vehicle_crew/Destroy()
 	owner = null
@@ -59,17 +57,18 @@
 		return FALSE
 	return ..()
 
+/obj/structure/bed/chair/vehicle_crew/proc/get_vis_range_mod()
+	return 1
+
 /obj/structure/bed/chair/vehicle_crew/post_buckle_mob(mob/buckling_mob)
 	. = ..()
 	buckling_mob.reset_perspective(owner)
-	if(vis_range_mod)
-		buckling_mob.client.view_size.add(vis_range_mod)
+	buckling_mob.client.view_size.add(get_vis_range_mod())
 
 /obj/structure/bed/chair/vehicle_crew/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
 	buckled_mob.reset_perspective()
-	if(vis_range_mod)
-		buckled_mob.client.view_size.reset_to_default()
+	buckled_mob.client.view_size.reset_to_default()
 
 /obj/structure/bed/chair/vehicle_crew/relaymove(mob/living/user, direct)
 	return owner.relaymove(arglist(args))
@@ -77,7 +76,9 @@
 /obj/structure/bed/chair/vehicle_crew/driver
 	name = "driver seat"
 	buckling_x = 12
-	vis_range_mod = 4
+
+/obj/structure/bed/chair/vehicle_crew/driver/get_vis_range_mod()
+	return 4
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_buckle_mob(mob/buckling_mob)
 	. = ..()
@@ -94,6 +95,9 @@
 
 /obj/structure/bed/chair/vehicle_crew/gunner
 	name = "gunner seat"
+
+/obj/structure/bed/chair/vehicle_crew/gunner/get_vis_range_mod()
+	return (SSticker.mode.round_type_flags & MODE_HUMAN_ONLY) ? 4 : 1
 
 /obj/structure/bed/chair/vehicle_crew/gunner/post_buckle_mob(mob/buckling_mob)
 	. = ..()
@@ -122,7 +126,6 @@
 	pixel_y = 3
 	buckling_x = 0
 	buckling_y = 10
-	vis_range_mod = 4
 
 /obj/structure/bed/chair/vehicle_crew/driver/som/handle_layer()
 	return
@@ -134,7 +137,6 @@
 	pixel_y = 1
 	buckling_x = 0
 	buckling_y = 9
-	vis_range_mod = 4
 
 /obj/structure/bed/chair/vehicle_crew/gunner/som/handle_layer()
 	return

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -36,6 +36,8 @@
 	var/obj/vehicle/sealed/armored/owner
 	///The skill required to man this chair
 	var/skill_req = SKILL_LARGE_VEHICLE_VETERAN
+	///tile range we increase vision by
+	var/vis_range_mod = 1
 
 /obj/structure/bed/chair/vehicle_crew/Destroy()
 	owner = null
@@ -60,13 +62,13 @@
 /obj/structure/bed/chair/vehicle_crew/post_buckle_mob(mob/buckling_mob)
 	. = ..()
 	buckling_mob.reset_perspective(owner)
-	if(owner.vis_range_mod)
-		buckling_mob.client.view_size.set_view_radius_to("[owner.vis_range_mod]x[owner.vis_range_mod]")
+	if(vis_range_mod)
+		buckling_mob.client.view_size.add(vis_range_mod)
 
 /obj/structure/bed/chair/vehicle_crew/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
 	buckled_mob.reset_perspective()
-	if(owner.vis_range_mod)
+	if(vis_range_mod)
 		buckled_mob.client.view_size.reset_to_default()
 
 /obj/structure/bed/chair/vehicle_crew/relaymove(mob/living/user, direct)
@@ -75,20 +77,19 @@
 /obj/structure/bed/chair/vehicle_crew/driver
 	name = "driver seat"
 	buckling_x = 12
+	vis_range_mod = 4
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_buckle_mob(mob/buckling_mob)
 	. = ..()
 	buckling_mob.reset_perspective(owner)
 	ADD_TRAIT(buckling_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	buckling_mob.update_sight()
-	buckling_mob.client.view_size.set_view_radius_to(4.5)
 	owner.add_control_flags(buckling_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
 	REMOVE_TRAIT(buckled_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	buckled_mob.update_sight()
-	buckled_mob.client.view_size.reset_to_default()
 	owner.remove_control_flags(buckled_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/gunner
@@ -121,6 +122,7 @@
 	pixel_y = 3
 	buckling_x = 0
 	buckling_y = 10
+	vis_range_mod = 4
 
 /obj/structure/bed/chair/vehicle_crew/driver/som/handle_layer()
 	return
@@ -132,6 +134,7 @@
 	pixel_y = 1
 	buckling_x = 0
 	buckling_y = 9
+	vis_range_mod = 4
 
 /obj/structure/bed/chair/vehicle_crew/gunner/som/handle_layer()
 	return

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -97,7 +97,7 @@
 	name = "gunner seat"
 
 /obj/structure/bed/chair/vehicle_crew/gunner/get_vis_range_mod()
-	return (SSticker.mode.round_type_flags & MODE_HUMAN_ONLY) ? 4 : 1
+	return (SSticker.mode?.round_type_flags & MODE_HUMAN_ONLY) ? 4 : 1
 
 /obj/structure/bed/chair/vehicle_crew/gunner/post_buckle_mob(mob/buckling_mob)
 	. = ..()

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -78,10 +78,17 @@
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_buckle_mob(mob/buckling_mob)
 	. = ..()
+	buckling_mob.reset_perspective(owner)
+	ADD_TRAIT(buckling_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
+	buckling_mob.update_sight()
+	buckling_mob.client.view_size.set_view_radius_to(4.5)
 	owner.add_control_flags(buckling_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
+	REMOVE_TRAIT(buckled_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
+	buckled_mob.update_sight()
+	buckled_mob.client.view_size.reset_to_default()
 	owner.remove_control_flags(buckled_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/gunner

--- a/code/modules/vehicles/armored/interiors/periscope.dm
+++ b/code/modules/vehicles/armored/interiors/periscope.dm
@@ -32,7 +32,7 @@
 ///signal handler for canceling the looking
 /obj/structure/periscope/proc/stop_looking(mob/source)
 	SIGNAL_HANDLER
-	unset_interaction(source)
+	source.unset_interaction()
 
 /obj/structure/periscope/on_unset_interaction(mob/user)
 	. = ..()

--- a/code/modules/vehicles/armored/interiors/periscope.dm
+++ b/code/modules/vehicles/armored/interiors/periscope.dm
@@ -16,22 +16,31 @@
 /obj/structure/periscope/link_interior(datum/interior/link)
 	owner = link.container
 
-/obj/structure/periscope/attack_hand(mob/living/user)
+/obj/structure/periscope/can_interact(mob/user)
+	. = ..()
+	if(user.client?.eye != user) // e.g someone looking outside already
+		return FALSE
+
+/obj/structure/periscope/interact(mob/user)
 	. = ..()
 	user.reset_perspective(owner)
 	ADD_TRAIT(user, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	user.update_sight()
-	user.client.view_size.set_view_radius_to(4.5)
+	user.client.view_size.set_view_radius_to(5.5)
 	RegisterSignals(user, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DO_RESIST, COMSIG_MOB_LOGOUT), PROC_REF(stop_looking))
 
 ///signal handler for canceling the looking
 /obj/structure/periscope/proc/stop_looking(mob/source)
 	SIGNAL_HANDLER
-	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DO_RESIST, COMSIG_MOB_LOGOUT))
-	source.reset_perspective()
-	REMOVE_TRAIT(source, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
-	source.client.view_size.reset_to_default()
-	source.update_sight()
+	unset_interaction(source)
+
+/obj/structure/periscope/on_unset_interaction(mob/user)
+	. = ..()
+	UnregisterSignal(user, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DO_RESIST, COMSIG_MOB_LOGOUT))
+	user.reset_perspective()
+	REMOVE_TRAIT(user, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
+	user.client?.view_size.reset_to_default()
+	user.update_sight()
 
 /obj/structure/periscope/apc
 	name = "apc periscope"

--- a/code/modules/vehicles/armored/som_tank.dm
+++ b/code/modules/vehicles/armored/som_tank.dm
@@ -32,7 +32,6 @@
 	)
 	engine_sound = SFX_HOVER_TANK
 	engine_sound_length = 1.2 SECONDS
-	vis_range_mod = 4
 	faction = FACTION_SOM
 
 /obj/vehicle/sealed/armored/multitile/som_tank/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Fixes exploit where you can use periscope while driving
Since driving is way more interesting with the improved vision and your loader is often already too busy to do callouts, gave it periscope vision
Increased periscope vision by 1 tile to compensate i guess

Also improved the code for periscope while i was there

## Changelog
:cl:
balance: the tank driver now gets the old periscopes tier of zoom and nightvision
balance: the tank periscope has 1 extra range now
fix: fixed periscope being usable while driving the tank
/:cl:
