### PR TITLE
Deathmark fixes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_keybindings.dm
+++ b/code/__DEFINES/dcs/signals/signals_keybindings.dm
@@ -256,6 +256,7 @@
 #define COMSIG_XENOABILITY_ENDURE "xenoability_endure"
 #define COMSIG_XENOABILITY_RAGE "xenoability_rage"
 #define COMSIG_XENOABILITY_VAMPIRISM "xenoability_vampirism"
+#define COMSIG_XENOABILITY_DEATHMARK "xenoability_deathmark"
 
 #define COMSIG_XENOABILITY_RUNNER_POUNCE "xenoability_runner_pounce"
 #define COMSIG_XENOABILITY_HUNTER_POUNCE "xenoability_hunter_pounce"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -812,6 +812,12 @@
 	description = "While active, will increase the ravagers healing for a while for every time it hits a new enemy. Effects stack."
 	keybind_signal = COMSIG_XENOABILITY_VAMPIRISM
 
+/datum/keybinding/xeno/ravager_deathmark
+	name = "deathmark"
+	full_name = "Ravager: Deathmark"
+	description = "Mark yourself for death, filling your bloodthirst, but failing to deal enough damage to living creatures while it is active instantly kills you."
+	keybind_signal = COMSIG_XENOABILITY_DEATHMARK
+
 /datum/keybinding/xeno/ravage
 	name = "ravage"
 	full_name = "Ravager: Ravage"

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -667,7 +667,12 @@
 /datum/action/ability/xeno_action/deathmark
 	name = "deathmark"
 	desc = "Mark yourself for death, filling your bloodthirst, but failing to deal enough damage to living creatures while it is active instantly kills you."
+	action_icon = 'icons/Xeno/actions/ravager.dmi'
+	action_icon_state = "deathmark"
 	cooldown_duration = DEATHMARK_DURATION*3
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DEATHMARK,
+	)
 	COOLDOWN_DECLARE(message_cooldown)
 	//tracker for damage dealt during deathmark
 	var/damage_dealt = 0


### PR DESCRIPTION

## About The Pull Request

Missing keybind and sprite got lost somewhere

## Changelog
:cl:
fix: Ravager: fixed deathmark not having a keybind
fix: Ravager: fixed deathmark not having a sprite set
/:cl:
