### PR TITLE
Adds Marine Rank to ID Card

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -121,7 +121,7 @@
 		name = "[(!newname)	? "identification card"	: "[newname]'s ID Card"][(!newjob) ? "" : " ([newjob])"]"
 		return
 
-	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
+	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment], "][(!paygrade) ? ")" : "[paygrade])"]"
 	if(isliving(loc))
 		var/mob/living/L = loc
 		L.name = L.get_visible_name()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -121,7 +121,7 @@
 		name = "[(!newname)	? "identification card"	: "[newname]'s ID Card"][(!newjob) ? "" : " ([newjob])"]"
 		return
 
-	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment], "][(!paygrade) ? ")" : "[paygrade])"]"
+	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"][(!paygrade) ? "" : " ([get_paygrades(paygrade, TRUE, gender)])"]"
 	if(isliving(loc))
 		var/mob/living/L = loc
 		L.name = L.get_visible_name()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -121,7 +121,7 @@
 		name = "[(!newname)	? "identification card"	: "[newname]'s ID Card"][(!newjob) ? "" : " ([newjob])"]"
 		return
 
-	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"][(!paygrade) ? "" : " ([get_paygrades(paygrade, TRUE, gender)])"]"
+	name = "[(!paygrade) ? "" : "[get_paygrades(paygrade, TRUE, gender)]. "][(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
 	if(isliving(loc))
 		var/mob/living/L = loc
 		L.name = L.get_visible_name()


### PR DESCRIPTION
## About The Pull Request

Adds Marine's Rank to their ID card, prefixed.

This has been made using VSCode this time, no suffering in DM.

![image](https://github.com/user-attachments/assets/9bbb64ab-38f2-4fc6-b4e8-41e675780689)
![image](https://github.com/user-attachments/assets/53b31c06-9e2d-4485-a9b4-a748dbda077d)

Kuro didn't seem to have a problem with xenos being able to read rank when asked.
I have made an additional commit that'll make xenos not be able to see ID cards if desired to prevent targeting.

## Why It's Good For The Game
Information Good.

Marines/Mentors can tell, at an examine, what rank a Marine is, and infer if they may need help or not. Rather than having to wait for them to say something.

## Changelog
:cl:
add: Marine's Rank is now prefixed to their ID card
/:cl:
