### PR TITLE
Downgrades the Acid Jaws' build check ceiling level (???)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -282,7 +282,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 			to_chat(buyer, span_xenowarning("You cannot build in a dense location!"))
 		return FALSE
 	var/area/buildzone = get_area(buyer)
-	if(buildzone.ceiling > CEILING_UNDERGROUND)
+	if(buildzone.ceiling >= CEILING_UNDERGROUND)
 		if(!silent)
 			to_chat(buyer, span_xenowarning("We need open space to allow this structure to bombard enemies!"))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/d2f2926b-7fe4-48e4-ac34-4ba6b21e9fac)
Some maps use CEILING_UNDERGROUND in caves instead of the other ones
## Why It's Good For The Game
Jaws aren't meant to be built underground
## Changelog
:cl:
fix: removes the ability to place jaws in caves on a few specific maps
/:cl:
