### PR TITLE
Fixes timestamps

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -49,7 +49,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 
 
 /proc/gameTimestamp(format = "hh:mm:ss", wtime = world.time)
-	return time2text(wtime - GLOB.timezoneOffset, format)
+	return time2text(wtime, format)
 
 
 /proc/stationTimestamp(format = "hh:mm:ss", wtime = world.time)


### PR DESCRIPTION

## About The Pull Request

Fixes timestamps showing incorrectly due to timezone no longer being set to incorrect UTC

high prio since these are also used in admin logging
## Why It's Good For The Game
## Changelog
:cl:
fix: Fixes round time timestamps
/:cl:
