### PR TITLE
Beam visual fix

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -79,7 +79,7 @@
  * Creates the beam effects and places them in a line from the origin to the target. Sets their rotation to make the beams face the target, too.
  */
 /datum/beam/proc/Draw()
-	var/Angle = round(Get_Angle(origin,target))
+	var/Angle = round(Get_Angle(origin,get_turf(target)))
 	var/matrix/rot_matrix = matrix()
 	var/turf/origin_turf = get_turf(origin)
 	rot_matrix.Turn(Angle)


### PR DESCRIPTION

## About The Pull Request
Fixes beams not visually hitting their targets in many cases.

Currently beams draw angle between the source and the target directly, which takes into account pixel_x and pixel_y. This makes beams look wonky against xenos since the beam shoots out to the left of them, due to them all having pixel shifts as they have large sprites.

I kept the source tracking since currently beams are sourced from things that DO want that pixel tracking (i.e. slow moving projectiles).


:cl:
fix: fixed a visual issue with beams
/:cl:
