### PR TITLE
[Beeg] Updates attack_verbs for simple present tense

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -126,7 +126,7 @@
 
 /mob/living/attacked_by(obj/item/attacking_item, mob/living/user, def_zone)
 
-	var/message_verb = "attacked"
+	var/message_verb = "attacks"
 	if(LAZYLEN(attacking_item.attack_verb))
 		message_verb = pick(attacking_item.attack_verb)
 	var/message_hit_area
@@ -354,7 +354,7 @@
  * def_zone: targetted area that will be attacked
  */
 /mob/living/proc/attacked_by_alternate(obj/item/I, mob/living/user, def_zone)
-	var/message_verb = "attacked"
+	var/message_verb = "attacks"
 	if(LAZYLEN(I.attack_verb))
 		message_verb = pick(I.attack_verb)
 	var/message_hit_area

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -26,7 +26,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 	var/attack_speed = 11
 	///Byond tick delay between right click alternate attacks
 	var/attack_speed_alternate = 11
-	///Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	///Used in attackby() to say how something was attacked "[x] [z.attack_verb] [y] with their [z]!" Should be in simple present tense!
 	var/list/attack_verb
 
 	///whether this item cuts

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -7,4 +7,4 @@
 		slot_r_hand_str = 'icons/mob/inhands/equipment/engineering_right.dmi',
 	)
 	icon_state = "blueprints"
-	attack_verb = list("attacked", "bapped", "hit")
+	attack_verb = list("attacks", "baps", "hits")

--- a/code/game/objects/items/books/book.dm
+++ b/code/game/objects/items/books/book.dm
@@ -8,7 +8,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
-	attack_verb = list("bashed", "whacked", "educated")
+	attack_verb = list("bashes", "whacks", "educates")
 	var/dat			 // Actual page content
 	var/due_date = 0 // Game time in 1/10th seconds
 	var/author		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -17,7 +17,7 @@
 	)
 	worn_icon_state = "table_parts"
 	atom_flags = CONDUCT
-	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb = list("slams", "bashes", "batters", "bludgeons", "thrashes", "whacks")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
 	/// How much of `deconstruct_type` will be spawned on wrench?

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -8,7 +8,7 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("called", "rang")
+	attack_verb = list("calls", "rings")
 	hitsound = 'sound/weapons/ring.ogg'
 
 /obj/item/clock
@@ -68,7 +68,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("bludgeoned", "whacked", "disciplined")
+	attack_verb = list("bludgeons", "whacks", "disciplines")
 
 /obj/item/staff/broom
 	name = "broom"
@@ -82,7 +82,7 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "skub"
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("skubbed")
+	attack_verb = list("skubs")
 
 /obj/item/ectoplasm
 	name = "ectoplasm"

--- a/code/game/objects/items/plantable_flags.dm
+++ b/code/game/objects/items/plantable_flags.dm
@@ -23,7 +23,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 55
 	attack_speed = 15
-	attack_verb = list("stabbed", "thrust", "smashed", "thumped", "bashed", "attacked", "clubbed", "speared", "jabbed", "torn", "gored")
+	attack_verb = list("stabs", "thrusts", "smashes", "thumps", "bashes", "attacks", "clubs", "spears", "jabs", "tears", "gores")
 	sharp = IS_SHARP_ITEM_BIG
 	throw_speed = 1
 	throw_range = 2

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -15,7 +15,7 @@
 		slot_r_hand_str = 'icons/mob/inhands/items/civilian_right.dmi',
 	)
 	worn_icon_state = "shard-glass"
-	attack_verb = list("stabbed", "slashed", "sliced", "cut")
+	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/source_sheet_type = /obj/item/stack/sheet/glass/glass
 	var/shardsize
 

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -10,7 +10,7 @@
 	throwforce = 5
 	throw_speed = 5
 	throw_range = 20
-	attack_verb = list("hit", "whacked", "sliced")
+	attack_verb = list("hits", "whacks", "slices")
 	max_amount = 20
 	merge_type = /obj/item/stack/barbed_wire
 
@@ -57,7 +57,7 @@
 	force = 15
 	throwforce = 10
 	throw_range = 5
-	attack_verb = list("hit", "whacked", "sliced")
+	attack_verb = list("hits", "whacks", "slices")
 	singular_name = "bundle"
 	max_amount = 10
 	merge_type = /obj/item/stack/razorwire

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -10,7 +10,7 @@
 	throw_speed = 5
 	throw_range = 20
 	max_amount = 60
-	attack_verb = list("hit", "bludgeoned", "whacked")
+	attack_verb = list("hits", "bludgeons", "whacks")
 
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -16,7 +16,7 @@
 	throw_speed = 5
 	throw_range = 20
 	max_amount = 50
-	attack_verb = list("hit", "bludgeoned", "whacked")
+	attack_verb = list("hits", "bludgeons", "whacks")
 	number_of_extra_variants = 3
 
 
@@ -79,7 +79,7 @@
 	throw_speed = 5
 	throw_range = 20
 	max_amount = 25
-	attack_verb = list("hit", "bludgeoned", "whacked")
+	attack_verb = list("hits", "bludgeons", "whacks")
 	merge_type = /obj/item/stack/sandbags
 
 

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -11,7 +11,7 @@
 	max_amount = 50
 	throw_speed = 3
 	throw_range = 3
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")
+	attack_verb = list("bashes", "batters", "bludgeons", "thrashes", "smashes")
 	var/perunit = 3750
 	var/sheettype = null //this is used for girders in the creation of walls/false walls
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -71,7 +71,7 @@
 	icon_state = "tile_e"
 	force = 3
 	throwforce = 5
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")
+	attack_verb = list("bashes", "batters", "bludgeons", "thrashes", "smashes")
 	turf_type = /turf/open/floor/light
 	var/on = 1
 	var/state = LIGHT_TILE_OK

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -8,7 +8,7 @@
 	worn_icon_state = "utility"
 	item_state_worn = TRUE
 	equip_slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined")
+	attack_verb = list("whips", "lashes", "disciplines")
 	w_class = WEIGHT_CLASS_BULKY
 	storage_type = /datum/storage/belt
 

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -327,7 +327,7 @@
 	desc = "A large, vibrantly colored katana scabbard used to carry a japanese sword. It can be strapped to the back, waist or armor. Because of the sturdy wood casing of the scabbard, it makes an okay defensive weapon in a pinch."
 	icon_state = "katana_holster"
 	force = 12
-	attack_verb = list("bludgeoned", "struck", "cracked")
+	attack_verb = list("bludgeons", "strikes", "cracks")
 	equip_slot_flags = ITEM_SLOT_BELT|ITEM_SLOT_BACK
 	holsterable_allowed = list(/obj/item/weapon/sword/katana)
 

--- a/code/game/objects/items/storage/kitchen_tray.dm
+++ b/code/game/objects/items/storage/kitchen_tray.dm
@@ -17,7 +17,7 @@
 	atom_flags = CONDUCT
 	hitsound = 'sound/items/trayhit1.ogg'
 	storage_type = /datum/storage/kitchen_tray
-	attack_verb = list("attacked", "slammed", "slapped")
+	attack_verb = list("attacks", "slams", "slaps")
 	/// Shield bash cooldown. based on world.time
 	var/cooldown = 0
 
@@ -30,7 +30,7 @@
 	. = ..()
 	if(!length(contents))
 		return
-	
+
 	for(var/obj/item/thing in src)
 		var/image/item_image = image("icon" = thing.icon, "icon_state" = thing.icon_state, "layer" = layer+0.01)
 		item_image.pixel_x = rand(-10, 10)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -13,7 +13,7 @@
 	throw_speed = 1
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("robusted")
+	attack_verb = list("robusts")
 
 
 /obj/item/storage/toolbox/emergency

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -12,7 +12,7 @@
 	throw_speed = 5
 	throw_range = 10
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
+	attack_verb = list("mops", "bashes", "bludgeons", "whacks")
 	var/mopping = 0
 	var/mopcount = 0
 
@@ -60,7 +60,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("warned", "cautioned", "smashed")
+	attack_verb = list("warns", "cautions", "smashes")
 
 /obj/item/clothing/head/warning_cone
 	name = "warning cone"
@@ -73,7 +73,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("warned", "cautioned", "smashed")
+	attack_verb = list("warns", "cautions", "smashes")
 	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 15, BIO = 10, FIRE = 20, ACID = 20)
 
 

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -15,7 +15,7 @@
 	throw_speed = 2
 	throw_range = 10
 	force = 10
-	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	attack_verb = list("slams", "whacks", "bashes", "thunks", "batters", "bludgeos", "thrashes")
 	var/max_water = 50
 	var/last_use = 1
 	var/safety = 1

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -107,7 +107,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/burnt = FALSE
 	var/smoketime = 5
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("burnt", "singed")
+	attack_verb = list("burns", "singes")
 
 /obj/item/tool/match/process()
 	smoketime--
@@ -285,7 +285,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	turn_light(null, TRUE)
 	heat = 1000
 	name = "lit [name]"
-	attack_verb = list("burnt", "singed")
+	attack_verb = list("burns", "singes")
 	damtype = BURN
 	if(reagents.get_reagent_amount(/datum/reagent/toxin/phoron)) // the phoron explodes when exposed to fire
 		var/datum/effect_system/reagents_explosion/e = new()
@@ -567,7 +567,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throwforce = 4
 	atom_flags = CONDUCT
 	equip_slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("burnt", "singed")
+	attack_verb = list("burns", "singes")
 
 /obj/item/tool/lighter/zippo
 	name = "\improper Zippo lighter"

--- a/code/game/objects/items/tools/hydro_tools.dm
+++ b/code/game/objects/items/tools/hydro_tools.dm
@@ -88,7 +88,7 @@
 	force = 5
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("slashed", "sliced", "cut", "clawed")
+	attack_verb = list("slashes", "slices", "cuts", "claws")
 
 //Hatchets and things to kill kudzu
 /obj/item/tool/hatchet
@@ -104,7 +104,7 @@
 	throw_range = 4
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
-	attack_verb = list("chopped", "torn", "cut")
+	attack_verb = list("chops", "tears", "cuts")
 
 /obj/item/tool/hatchet/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 25, 1)
@@ -122,7 +122,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	atom_flags = CONDUCT
 	equip_slot_flags = ITEM_SLOT_BACK
-	attack_verb = list("chopped", "sliced", "cut", "reaped")
+	attack_verb = list("chops", "slices", "cuts", "reaps")
 
 /obj/item/tool/scythe/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/tools/kitchen_tools.dm
+++ b/code/game/objects/items/tools/kitchen_tools.dm
@@ -27,7 +27,7 @@
 	throw_speed = 3
 	throw_range = 5
 	atom_flags = CONDUCT
-	attack_verb = list("attacked", "stabbed", "poked")
+	attack_verb = list("attacks", "stabs", "pokes")
 	sharp = 0
 	/// Is there something on this utensil?
 	var/image/loaded
@@ -89,13 +89,13 @@
 	name = "spoon"
 	desc = "It's a spoon. You can see your own upside-down face in the reflection."
 	icon_state = "spoon"
-	attack_verb = list("attacked", "poked")
+	attack_verb = list("attacks", "pokes")
 
 /obj/item/tool/kitchen/utensil/pspoon
 	name = "plastic spoon"
 	desc = "It's a plastic spoon. How dull."
 	icon_state = "pspoon"
-	attack_verb = list("attacked", "poked")
+	attack_verb = list("attacks", "pokes")
 
 /*
 * Knives
@@ -141,7 +141,7 @@
 	throwforce = 6
 	throw_speed = 3
 	throw_range = 6
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 
 /obj/item/tool/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick(span_danger("[user] is slitting [user.p_their()] wrists with the [name]! It looks like [user.p_theyre()] trying to commit suicide."), \
@@ -168,7 +168,7 @@
 	throwforce = 25
 	throw_speed = 3
 	throw_range = 6
-	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("cleaves", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	sharp = IS_SHARP_ITEM_ACCURATE
 	edge = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -186,4 +186,4 @@
 	throw_speed = 2
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb = list("bashes", "batters", "bludgeons", "thrashes", "whacks")

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -8,7 +8,7 @@
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/ratchet.ogg'
-	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
+	attack_verb = list("bashes", "batters", "bludgeons", "whacks")
 	tool_behaviour = TOOL_WRENCH
 
 
@@ -23,7 +23,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
-	attack_verb = list("stabbed")
+	attack_verb = list("stabs")
 	tool_behaviour = TOOL_SCREWDRIVER
 	/// If the item should be assigned a random color
 	var/random_color = TRUE
@@ -71,7 +71,7 @@
 	throw_speed = 2
 	throw_range = 9
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("pinched", "nipped")
+	attack_verb = list("pinches", "nips")
 	sharp = IS_SHARP_ITEM_SIMPLE
 	edge = 1
 	tool_behaviour = TOOL_WIRECUTTER
@@ -338,7 +338,7 @@
 	throwforce = 7
 	worn_icon_state = "crowbar"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	attack_verb = list("attacks", "bashes", "batters", "bludgeons", "whacks")
 	pry_capable = IS_PRY_CAPABLE_CROWBAR
 	tool_behaviour = TOOL_CROWBAR
 	usesound = 'sound/items/crowbar.ogg'

--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -14,7 +14,7 @@
 	worn_icon_state = "pickaxe"
 	w_class = WEIGHT_CLASS_BULKY
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
-	attack_verb = list("hit", "pierced", "sliced", "attacked")
+	attack_verb = list("hits", "pierces", "slices", "attacks")
 	var/drill_sound = 'sound/weapons/genhit.ogg'
 	var/drill_verb = "picking"
 	sharp = IS_SHARP_ITEM_SIMPLE
@@ -91,7 +91,7 @@
 	damtype = BURN
 	digspeed = 20 //Can slice though normal walls, all girders, or be used in reinforced wall deconstruction
 	drill_verb = "cutting"
-	attack_verb = list("dissolves", "disintegrates", "liquefies", "subliminates", "vaporizes")
+	attack_verb = list("dissolves", "disintegrates", "liquefies", "subliminates", "vaporizes") //See PC did the verbs correctly the first time around.
 	heat = 3800
 	light_system = MOVABLE_LIGHT
 	light_range = 2

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -177,7 +177,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 7
 	throw_range = 15
-	attack_verb = list("stamped")
+	attack_verb = list("stamps")
 
 /obj/item/tool/stamp/qm
 	name = "Quartermaster's Stamp"

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -11,7 +11,7 @@
 	force = 8
 	throwforce = 4
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
+	attack_verb = list("bashes", "bludgeons", "thrashes", "whacks")
 	var/dirt_overlay = "shovel_overlay"
 	var/folded = FALSE
 	var/dirt_type = NO_DIRT // 0 for no dirt, 1 for brown dirt, 2 for snow, 3 for big red, 4 for basalt(lava-land).

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -20,7 +20,7 @@
 	icon_state = "hemostat"
 	atom_flags = CONDUCT
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "pinched")
+	attack_verb = list("attacks", "pinches")
 
 /obj/item/tool/surgery/cautery
 	name = "cautery"
@@ -28,7 +28,7 @@
 	icon_state = "cautery"
 	atom_flags = CONDUCT
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("burnt")
+	attack_verb = list("burns")
 
 /obj/item/tool/surgery/surgicaldrill
 	name = "surgical drill"
@@ -38,10 +38,10 @@
 	atom_flags = CONDUCT
 	force = 15
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("drilled")
+	attack_verb = list("drills")
 
 /obj/item/tool/surgery/surgicaldrill/suicide_act(mob/user)
-	user.visible_message(span_danger("[user] is pressing the [name] to [user.p_their()] [pick("temple","chest")] and activating it! It looks like [user.p_theyre()] trying to commit suicide."))
+	user.visible_message(span_danger("[user] presses the [name] to [user.p_their()] [pick("temple","chest")] and activates it! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return (BRUTELOSS)
 
 /obj/item/tool/surgery/scalpel
@@ -56,7 +56,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 
 /obj/item/tool/surgery/scalpel/suicide_act(mob/user)
 	user.visible_message(pick(span_danger("[user] is slitting [user.p_their()] wrists with the [name]! It looks like [user.p_theyre()] trying to commit suicide."), \
@@ -94,7 +94,7 @@
 	throwforce = 9
 	throw_speed = 3
 	throw_range = 5
-	attack_verb = list("attacked", "slashed", "sawed", "cut")
+	attack_verb = list("attacks", "slashes", "saws", "cuts")
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
 
@@ -122,7 +122,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "hit", "bludgeoned")
+	attack_verb = list("attacks", "hits", "bludgeons")
 
 /obj/item/tool/surgery/suture
 	name = "surgical suture"
@@ -130,7 +130,7 @@
 	force = 3
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("needled", "sewed", "stabbed")
+	attack_verb = list("needles", "sews", "stabs")
 
 /obj/item/tool/surgery/surgical_membrane
 	name = "surgical membrane"

--- a/code/game/objects/items/toys/toy_weapons.dm
+++ b/code/game/objects/items/toys/toy_weapons.dm
@@ -17,7 +17,7 @@
 	equip_slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 
-	attack_verb = list("struck", "pistol whipped", "hit", "bashed")
+	attack_verb = list("strikes", "pistol whips", "hits", "bashes")
 	var/bullets = 7
 
 /obj/item/toy/gun/examine(mob/user)
@@ -83,7 +83,7 @@
 	icon_state = "foamcrossbow"
 	worn_icon_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb = list("attacks", "strikes", "hits")
 	var/bullets = 5
 
 /obj/item/toy/crossbow/examine(mob/user)
@@ -191,7 +191,7 @@
 	icon = 'icons/obj/items/weapons/energy.dmi'
 	icon_state = "sword"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb = list("attacks", "strikes", "hits")
 
 /obj/item/toy/sword/attack_self(mob/user as mob)
 	src.active = !( src.active )
@@ -224,6 +224,6 @@
 	force = 5
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
+	attack_verb = list("attacks", "slashes", "stabs", "slices")
 
 

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -152,7 +152,7 @@
 	icon = 'icons/obj/items/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("attacked", "coloured")
+	attack_verb = list("attacks", "colours")
 	var/colour = "#FF0000" //RGB
 	var/shadeColour = "#220000" //RGB
 	var/uses = 30 //0 for unlimited uses
@@ -390,7 +390,7 @@
 	icon_state = "d66"
 	w_class = WEIGHT_CLASS_TINY
 	var/sides = 6
-	attack_verb = list("diced")
+	attack_verb = list("dices")
 
 /obj/item/toy/dice/Initialize(mapload)
 	. = ..()
@@ -426,7 +426,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 15
-	attack_verb = list("HONKED")
+	attack_verb = list("HONKS")
 
 
 /obj/item/toy/bikehorn/Initialize(mapload)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -190,7 +190,7 @@
 	icon_state = "crushed_solocup"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("bludgeoned", "whacked", "slapped")
+	attack_verb = list("bludgeons", "whacks", "slaps")
 
 /obj/item/trash/trashbag
 	name = "trash bag"

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -40,7 +40,7 @@
 		worn_icon_state = "telebaton_1"
 		w_class = WEIGHT_CLASS_NORMAL
 		force = 20
-		attack_verb = list("smacked", "struck", "slapped")
+		attack_verb = list("smacks", "strikes", "slaps")
 	else
 		user.visible_message(span_notice(" [user] collapses their telescopic baton."),\
 		span_notice("You collapse the baton."),\
@@ -49,7 +49,7 @@
 		worn_icon_state = "telebaton_0"
 		w_class = WEIGHT_CLASS_SMALL
 		force = 3//not so robust now
-		attack_verb = list("hit", "punched")
+		attack_verb = list("hits", "punches")
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/items/weapons/knives.dmi'
 	icon_state = "shiv"
 	desc = "A makeshift glass shiv."
-	attack_verb = list("shanked", "shived")
+	attack_verb = list("shanks", "shivs")
 	hitsound = 'sound/weapons/slash.ogg'
 
 /obj/item/tool/kitchen/knife/shiv/plasma
@@ -33,7 +33,7 @@
 	throw_range = 6
 	attack_speed = 8
 	hitsound = 'sound/weapons/slash.ogg'
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 
 /obj/item/weapon/combat_knife/attackby(obj/item/I, mob/user)
 	if(!istype(I,/obj/item/stack/cable_coil))
@@ -86,7 +86,7 @@
 	throw_range = 6
 	attack_speed = 8
 	hitsound = 'sound/weapons/slash.ogg'
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "hooked")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts", "hooks")
 
 //Try to do a fancy trick with your cool knife
 /obj/item/weapon/karambit/attack_self(mob/user)
@@ -126,7 +126,7 @@
 	throw_speed = 5
 	throw_range = 7
 	hitsound = 'sound/weapons/slash.ogg'
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	equip_slot_flags = ITEM_SLOT_POCKET
 	max_amount = 5
 	amount = 5

--- a/code/game/objects/items/weapons/energy.dm
+++ b/code/game/objects/items/weapons/energy.dm
@@ -17,7 +17,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	atom_flags = CONDUCT|NOBLOODY
-	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
+	attack_verb = list("attacks", "chops", "cleaves", "tears", "cuts")
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
 
@@ -50,7 +50,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	atom_flags = NOBLOODY
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
 	equip_slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -8,7 +8,7 @@
 	force = 10
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
+	attack_verb = list("flogs", "whips", "lashes", "disciplines")
 
 /obj/item/weapon/chainofcommand/suicide_act(mob/user)
 	user.visible_message(span_danger("[user] is strangling [p_them()]self with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide."))
@@ -23,7 +23,7 @@
 	force = 5
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
+	attack_verb = list("bludgeons", "whacks", "disciplines", "thrashes")
 
 /obj/item/weapon/broken_bottle
 	name = "Broken Bottle"
@@ -35,7 +35,7 @@
 	throw_speed = 3
 	throw_range = 5
 	worn_icon_state = "broken_beer"
-	attack_verb = list("stabbed", "slashed", "attacked")
+	attack_verb = list("stabs", "slashes", "attacks")
 	sharp = IS_SHARP_ITEM_SIMPLE
 	edge = 0
 	var/icon/broken_outline = icon('icons/obj/items/drinks.dmi', "broken")
@@ -51,7 +51,7 @@
 	worn_icon_state = "powerfist"
 	equip_slot_flags = ITEM_SLOT_BELT
 	force = 10
-	attack_verb = list("smashed", "rammed", "power-fisted")
+	attack_verb = list("smashes", "rams", "power-fists")
 	var/obj/item/cell/cell
 	///the higher the power level the harder it hits
 	var/setting = 1
@@ -172,7 +172,7 @@
 	icon_state = "brick"
 	force = 30
 	throwforce = 40
-	attack_verb = list("smacked", "whacked", "bonked", "bricked", "thwacked", "socked", "donked")
+	attack_verb = list("smacks", "whacks", "bonks", "bricks", "thwacks", "socks", "donks")
 	hitsound = 'sound/weapons/heavyhit.ogg'
 
 /obj/item/stack/throwing_knife/stone
@@ -184,7 +184,7 @@
 	max_amount = 12
 	amount = 12
 	throw_delay = 0.3 SECONDS
-	attack_verb = list("smacked", "whacked", "bonked", "pelted", "thwacked", "cracked")
+	attack_verb = list("smacks", "whacks", "bonks", "pelts", "thwacks", "cracks")
 	hitsound = 'sound/weapons/heavyhit.ogg'
 	singular_name = "stone"
 	atom_flags = DIRLOCK

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -49,7 +49,7 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("shoved", "bashed")
+	attack_verb = list("shoves", "bashes")
 	soft_armor = list(MELEE = 40, BULLET = 20, LASER = 0, ENERGY = 70, BOMB = 0, BIO = 100, FIRE = 0, ACID = 0)
 	hard_armor = list(MELEE = 5, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hit_sound = 'sound/effects/grillehit.ogg'
@@ -191,7 +191,7 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("shoved", "bashed")
+	attack_verb = list("shoves", "bashes")
 	var/on_force = 10
 
 /obj/item/weapon/shield/energy/Initialize(mapload)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -10,7 +10,7 @@
 	edge = 0
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("beaten")
+	attack_verb = list("beats")
 	req_one_access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_ARMORY, ACCESS_MARINE_CAPTAIN, ACCESS_NT_CORPORATE, ACCESS_NT_PMC_GREEN)
 	var/stunforce = 10
 	var/agonyforce = 80
@@ -199,7 +199,7 @@
 	stunforce = 0
 	agonyforce = 60	//same force as a stunbaton, but uses way more charge.
 	hitcost = 2500
-	attack_verb = list("poked")
+	attack_verb = list("pokes")
 	equip_slot_flags = NONE
 	has_user_lock = FALSE
 

--- a/code/game/objects/items/weapons/swords.dm
+++ b/code/game/objects/items/weapons/swords.dm
@@ -11,7 +11,7 @@
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	///Special attack action granted to users with the right trait
 	var/datum/action/ability/activable/weapon_skill/sword_lunge/special_attack

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -168,7 +168,7 @@
 	atom_flags = CONDUCT
 	item_flags = TWOHANDED
 	force_wielded = 75
-	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
+	attack_verb = list("attacks", "chops", "cleaves", "tears", "cuts")
 
 /obj/item/weapon/twohanded/fireaxe/wield(mob/user)
 	. = ..()
@@ -308,7 +308,7 @@
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
 	atom_flags = NOBLOODY
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
 
@@ -331,7 +331,7 @@
 	edge = 1
 	sharp = IS_SHARP_ITEM_SIMPLE
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "stabbed", "jabbed", "torn", "gored")
+	attack_verb = list("attacks", "stabs", "jabs", "tears", "gores")
 	///Based on what direction the tip of the spear is pointed at in the sprite; maybe someone makes a spear that points northwest
 	var/current_angle = 45
 
@@ -419,7 +419,7 @@
 	edge = 1
 	sharp = IS_SHARP_ITEM_BIG
 	atom_flags = CONDUCT
-	attack_verb = list("sliced", "slashed", "jabbed", "torn", "gored")
+	attack_verb = list("slices", "slashes", "jabs", "tears", "gores")
 	resistance_flags = UNACIDABLE
 	attack_speed = 12 //Default is 7.
 
@@ -447,7 +447,7 @@
 	edge = 1
 	sharp = IS_SHARP_ITEM_BIG
 	atom_flags = CONDUCT | TWOHANDED
-	attack_verb = list("smashed", "hammered")
+	attack_verb = list("smashes", "hammers")
 	attack_speed = 20
 	///amount of fuel stored inside
 	var/max_fuel = 50
@@ -596,7 +596,7 @@
 	force_wielded = 85
 	penetration = 10
 	attack_speed = 20
-	attack_verb = list("attacked", "walloped", "smashed", "shattered", "bashed")
+	attack_verb = list("attacks", "wallops", "smashes", "shatters", "bashes")
 
 /obj/item/weapon/twohanded/sledgehammer/wield(mob/user)
 	. = ..()
@@ -622,7 +622,7 @@
 	icon_state = "chainsaw_off"
 	worn_icon_state = "chainsaw"
 	atom_flags = TWOHANDED
-	attack_verb = list("gored", "torn", "ripped", "shred", "slashed", "cut")
+	attack_verb = list("gores", "tears", "rips", "shreds", "slashes", "cuts")
 	force = 20
 	force_wielded = 75
 	throwforce = 30

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 7
 	throw_range = 15
-	attack_verb = list("banned")
+	attack_verb = list("bans")
 
 /obj/item/weapon/banhammer/attack(mob/M as mob, mob/user as mob)
 	to_chat(M, "<font color='red'><b> You have been banned FOR NO REISIN by [user]<b></font>")
@@ -43,7 +43,7 @@
 	force = 20
 	throwforce = 15
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("jabbed","stabbed","ripped")
+	attack_verb = list("jabs","stabs","rips")
 
 /obj/item/weapon/baseballbat
 	name = "\improper wooden baseball bat"
@@ -57,7 +57,7 @@
 	throw_speed = 3
 	throw_range = 7
 	throwforce = 7
-	attack_verb = list("smashed", "beaten", "slammed", "struck", "smashed", "battered", "cracked")
+	attack_verb = list("smashes", "beats", "slams", "strikes", "smashes", "batters", "cracks")
 	hitsound = 'sound/weapons/genhit3.ogg'
 
 /obj/item/weapon/baseballbat/metal
@@ -82,7 +82,7 @@
 	throw_speed = 3
 	throw_range = 4
 	throwforce = 7
-	attack_verb = list("patted", "tapped")
+	attack_verb = list("pats", "taps")
 	attack_speed = 4
 
 /obj/item/weapon/butterfly/attack_self(mob/user)
@@ -97,7 +97,7 @@
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		icon_state += "_open"
 		w_class = WEIGHT_CLASS_NORMAL
-		attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+		attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 		return
 	to_chat(user, span_notice("The [src] can now be concealed."))
 	force = initial(force)
@@ -123,7 +123,7 @@
 	force = 8
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
+	attack_verb = list("hits", "bludgeons", "whacks", "bonks")
 
 /obj/item/weapon/wirerod/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/machinery/newscaster.dm
+++ b/code/game/objects/machinery/newscaster.dm
@@ -16,4 +16,4 @@
 	)
 	icon_state = "newspaper"
 	w_class = WEIGHT_CLASS_TINY	//Let's make it fit in trashbags!
-	attack_verb = list("bapped")
+	attack_verb = list("baps")

--- a/code/game/objects/metnal_objects.dm
+++ b/code/game/objects/metnal_objects.dm
@@ -45,7 +45,7 @@
 	throwforce = 10
 	sharp = IS_SHARP_ITEM_BIG
 	edge = 1
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 // rocks

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -199,7 +199,7 @@
 	blood_sprite_state = "bloodyhands"
 	armor_protection_flags = HANDS
 	equip_slot_flags = ITEM_SLOT_GLOVES
-	attack_verb = list("challenged")
+	attack_verb = list("challenges")
 
 
 /obj/item/clothing/gloves/update_greyscale(list/colors, update)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -169,11 +169,11 @@
 
 /obj/item/weapon/heldglove/boxing/hook
 	icon_state = "boxing_p"
-	attack_verb = list("punched")
+	attack_verb = list("punches")
 
 /obj/item/weapon/heldglove/boxing/jab
 	icon_state = "boxing_j"
-	attack_verb = list("jabbed")
+	attack_verb = list("jabs")
 
 
 /obj/item/clothing/gloves/heldgloves/boxing/green

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -44,7 +44,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 3
 	throw_range = 3
-	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
+	attack_verb = list("bashes", "batters", "bludgeons", "whacks")
 
 
 /obj/item/grown/log/attackby(obj/item/I, mob/user, params)
@@ -90,7 +90,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 1
 	throw_range = 3
-	attack_verb = list("stung")
+	attack_verb = list("stings")
 	hitsound = ""
 
 	var/potency_divisior = 5

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -9,7 +9,7 @@
 	throwforce = 1
 	throw_speed = 3
 	throw_range = 5
-	attack_verb = list("attacked", "slapped", "whacked")
+	attack_verb = list("attacks", "slapped", "whacked")
 	organ_type = /datum/internal_organ/brain
 	organ_tag = "brain"
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -362,7 +362,7 @@
 //Species unarmed attacks
 /datum/unarmed_attack
 	///Empty hand hurt intent verb
-	var/attack_verb = list("attack")
+	var/attack_verb = list("attacks")
 	///Extra empty hand attack damage
 	var/damage = 0
 	///Sound that plays when you land a punch
@@ -391,7 +391,7 @@
 	return FALSE
 
 /datum/unarmed_attack/bite
-	attack_verb = list("bite") // 'x has biteed y', needs work
+	attack_verb = list("bites")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
 	damage = 5
@@ -404,15 +404,15 @@
 	return TRUE
 
 /datum/unarmed_attack/punch
-	attack_verb = list("punch")
+	attack_verb = list("punches")
 	damage = 3
 
 /datum/unarmed_attack/punch/strong
-	attack_verb = list("punch","bust","jab")
+	attack_verb = list("punches","busts","jabs")
 	damage = 10
 
 /datum/unarmed_attack/claws
-	attack_verb = list("scratch", "claw")
+	attack_verb = list("scratches", "claws")
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	damage = 5
@@ -420,12 +420,12 @@
 	edge = 1
 
 /datum/unarmed_attack/claws/strong
-	attack_verb = list("slash")
+	attack_verb = list("slashes")
 	damage = 10
 	shredding = 1
 
 /datum/unarmed_attack/bite/strong
-	attack_verb = list("maul")
+	attack_verb = list("mauls")
 	damage = 15
 	shredding = 1
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -113,12 +113,12 @@
 			if(!human_user.melee_damage || !target_zone)
 				human_user.do_attack_animation(src)
 				playsound(loc, attack.miss_sound, 25, TRUE)
-				visible_message(span_danger("[human_user] tried to [attack_verb] [src]!"), null, null, 5)
-				log_combat(human_user, src, "[attack_verb]ed", "(missed)")
+				visible_message(span_danger("[human_user] [attack_verb] at [src], but misses!"), null, null, 5)
+				log_combat(human_user, src, "[attack_verb]", "(missed)")
 				if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 					var/turf/T = get_turf(src)
-					log_ffattack("[key_name(human_user)] missed a [attack_verb] against [key_name(src)] in [AREACOORD(T)].")
-					msg_admin_ff("[ADMIN_TPMONTY(human_user)] missed a [attack_verb] against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
+					log_ffattack("[key_name(human_user)] missed a punch against [key_name(src)] in [AREACOORD(T)].")
+					msg_admin_ff("[ADMIN_TPMONTY(human_user)] missed a punch against [ADMIN_TPMONTY(src)] in [ADMIN_VERBOSEJMP(T)].")
 				return FALSE
 
 			human_user.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
@@ -129,7 +129,7 @@
 
 			playsound(loc, attack.attack_sound, 25, TRUE)
 
-			visible_message(span_danger("[human_user] [attack_verb]ed [src]!"), null, null, 5)
+			visible_message(span_danger("[human_user] [attack_verb] [src]!"), null, null, 5)
 			var/list/hit_report = list()
 			if(damage >= 4 && prob(25))
 				visible_message(span_danger("[human_user] has weakened [src]!"), null, null, 5)
@@ -141,7 +141,7 @@
 
 			hit_report += "(RAW DMG: [damage])"
 
-			log_combat(human_user, src, "[attack_verb]ed", "[hit_report.Join(" ")]")
+			log_combat(human_user, src, "[attack_verb]", "[hit_report.Join(" ")]")
 			if(!human_user.mind?.bypass_ff && !mind?.bypass_ff && human_user.faction == faction)
 				var/turf/T = get_turf(src)
 				human_user.ff_check(damage, src)
@@ -167,8 +167,8 @@
 						chance = !hand ? 40 : 20
 
 					if(prob(chance))
-						visible_message("<span class='danger'>[src]'s [W] goes off during struggle!", null, null, 5)
-						log_combat(human_user, src, "disarmed", "making their [W] go off")
+						visible_message("<span class='danger'>[src]'s [W.name] goes off during struggle!", null, null, 5)
+						log_combat(human_user, src, "disarmed", "making their [W.name] go off")
 						var/list/turfs = list()
 						for(var/turf/T in view())
 							turfs += T
@@ -180,25 +180,25 @@
 			if (randn <= 25)
 				apply_effect(3 SECONDS, WEAKEN)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
-				visible_message(span_danger("[human_user] has pushed [src]!"), null, null, 5)
+				visible_message(span_danger("[human_user] pushes [src] over!"), null, null, 5)
 				log_combat(human_user, src, "pushed")
 				return
 
 			if(randn <= 60)
 				//BubbleWrap: Disarming breaks a pull
 				if(pulling)
-					visible_message(span_danger("[human_user] has broken [src]'s grip on [pulling]!"), null, null, 5)
+					visible_message(span_danger("[human_user] breaks [src]'s grip on [pulling]!"), null, null, 5)
 					stop_pulling()
 				else
 					drop_held_item()
-					visible_message(span_danger("[human_user] has disarmed [src]!"), null, null, 5)
+					visible_message(span_danger("[human_user] disarms [src]!"), null, null, 5)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				log_combat(user, src, "disarmed")
 				return
 
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
-			visible_message(span_danger("[human_user] attempted to disarm [src]!"), null, null, 5)
+			visible_message(span_danger("[human_user] attempts to disarm [src]!"), null, null, 5)
 			log_combat(human_user, src, "missed a disarm")
 
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -99,12 +99,12 @@ Contains most of the procs that are called when a mob is attacked by something
 	else
 		target_zone = def_zone ? check_zone(def_zone) : get_zone_with_miss_chance(user.zone_selected, src)
 
-	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacked"
+	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacks"
 
 	if(!target_zone)
 		user.do_attack_animation(src)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE)
-		visible_message(span_danger("[user] tried to hit [src] with [I]!"), null, null, 5)
+		visible_message(span_danger("[user] tries to hit [src] with [user.p_their()] [I]!"), null, null, 5)
 		log_combat(user, src, "[attack_verb]", "(missed)")
 		if(!user.mind?.bypass_ff && !mind?.bypass_ff && user.faction == faction)
 			var/turf/T = get_turf(src)
@@ -131,7 +131,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/armor_verb
 	switch(percentage_penetration)
 		if(-INFINITY to 0)
-			visible_message(span_danger("[src] has been [attack_verb] in the [hit_area] with [I.name] by [user], but the attack is deflected by [p_their()] armor!"),\
+			visible_message(span_danger("[user] [attack_verb] [src] in the [hit_area] with [user.p_their()] [I.name], but the attack is deflected by [p_their()] armor!"),\
 			null, null, COMBAT_MESSAGE_RANGE, visible_message_flags = COMBAT_MESSAGE)
 			user.do_attack_animation(src, used_item = I)
 			log_combat(user, src, "attacked", I, "(FAILED: armor blocked) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(I.damtype)])")
@@ -143,7 +143,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		if(51 to 75)
 			armor_verb = " [p_their(TRUE)] armor has softened the hit!"
 
-	visible_message(span_danger("[src] has been [attack_verb] in the [hit_area] with [I.name] by [user]![armor_verb]"),\
+	visible_message(span_danger("[user] [attack_verb] [src] in the [hit_area] with [user.p_their()] [I.name]![armor_verb]"),\
 	null, null, 5, visible_message_flags = COMBAT_MESSAGE)
 
 	var/weapon_sharp = is_sharp(I)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -32,7 +32,7 @@
 	force = 20
 	sharp = IS_SHARP_ITEM_BIG
 	edge = TRUE
-	attack_verb = list("clawed", "slashed", "torn", "ripped", "diced", "cut", "bit")
+	attack_verb = list("claws", "slashes", "tears", "rips", "dices", "cuts", "bites")
 	item_flags = CAN_BUMP_ATTACK|DELONDROP
 	attack_speed = 8 //Same as unarmed delay
 	pry_capable = IS_PRY_CAPABLE_FORCE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -18,7 +18,7 @@
 	throw_speed = 1
 	equip_slot_flags = ITEM_SLOT_HEAD
 	armor_protection_flags = HEAD
-	attack_verb = list("bapped")
+	attack_verb = list("baps")
 
 	var/info		//What's actually written on the paper.
 	var/info_links	//A different version of the paper which includes html links at fields and EOF

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -12,7 +12,7 @@
 	throw_range = 2
 	throw_speed = 1
 	layer = MOB_LAYER
-	attack_verb = list("bapped")
+	attack_verb = list("baps")
 	var/amount = 0 //Amount of items clipped to the paper
 	var/page = 1
 	var/screen = 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -399,7 +399,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	throw_range = 5
 	atom_flags = CONDUCT
 	equip_slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
+	attack_verb = list("whips", "lashes", "disciplines", "flogs")
 	singular_name = "cable piece"
 	usesound = 'sound/items/deconstruct.ogg'
 	var/obj/structure/cable/target_type = /obj/structure/cable

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -189,7 +189,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	throw_range = 5
 	atom_flags = CONDUCT
 	equip_slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
+	attack_verb = list("whips", "lashes", "disciplines", "flogs")
 	singular_name = "pipe cleaner piece"
 	usesound = 'sound/items/deconstruct.ogg'
 

--- a/code/modules/projectiles/gun_attachables/muzzle.dm
+++ b/code/modules/projectiles/gun_attachables/muzzle.dm
@@ -36,7 +36,7 @@
 	throwforce = 10
 	attach_delay = 10 //Bayonets attach/detach quickly.
 	detach_delay = 10
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	melee_mod = 25
 	slot = ATTACHMENT_SLOT_MUZZLE
 	pixel_shift_x = 14 //Below the muzzle.
@@ -73,7 +73,7 @@
 	attack_speed = 8
 	attach_delay = 10 //Bayonets attach/detach quickly.
 	detach_delay = 10
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	melee_mod = 25
 	slot = ATTACHMENT_SLOT_MUZZLE
 	pixel_shift_x = 14 //Below the muzzle.

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -180,11 +180,11 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/proc/update_force_list()
 	switch(force)
 		if(-50 to 15)
-			attack_verb = list("struck", "hit", "bashed") //Unlikely to ever be -50, but just to be safe.
+			attack_verb = list("strikes", "hits", "bashes") //Unlikely to ever be -50, but just to be safe.
 		if(16 to 35)
-			attack_verb = list("smashed", "struck", "whacked", "beaten", "cracked")
+			attack_verb = list("smashes", "strikes", "whacks", "beats", "cracks")
 		else
-			attack_verb = list("slashed", "stabbed", "speared", "torn", "punctured", "pierced", "gored") //Greater than 35
+			attack_verb = list("slashes", "stabs", "spears", "tears", "punctures", "pierces", "gores") //Greater than 35
 
 
 /proc/get_active_firearm(mob/user)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -432,7 +432,7 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	bitesize = 2
 	tastes = list("dirt" = 1)
-	attack_verb = list("touched")
+	attack_verb = list("touches")
 
 /obj/item/reagent_containers/food/snacks/tofu
 	name = "Tofu"


### PR DESCRIPTION
## About The Pull Request
Generally, the attack verbs for most items are in **simple past tense**, which is what is displayed by the game when you attack something e.g. "Steve Bald was bashed by John Unga with the fire extinguisher.". However, chat messages like emotes are usually written in the **simple present tense**, e.g. "John Unga claps.", "John Unga cleans Steve Bald's leg and seals its wounds with bioglue.". This trend shows up where people who are used to the simple present tense of attack verbs add items like the plasma cutter or plushies with attack verbs in the simple present tesnse, meaning that they don't fit in with the current attack text e.g. "Steve Bald was subliminates by John Unga with the plasma cutter".

This PR moves over all attack verbs to the simple present tense, and rewrites the displayed text to support it.
 -> **TM FIRST I CAN'T TEST VIEWER ATTACK MESSAGES LOCALLY!!!** <-
## Why It's Good For The Game
This makes attack verbs more consistent with the ways emotes and actions are already written in the game, and makes you not look stupid when you add in new items.
It also looks nicer.
## Changelog
:cl:
spellcheck: updates attack verbs to use the simple present tense like emotes instead of the simple past tense.
/:cl:
