### PR TITLE
Fix outfits missing their holster contents

### DIFF
--- a/code/datums/outfits/quick_load_outfits.dm
+++ b/code/datums/outfits/quick_load_outfits.dm
@@ -294,6 +294,10 @@
 		/obj/item/stack/barbed_wire/half_stack = 1,
 	)
 
+	belt_contents = list(
+		/obj/item/weapon/gun/smg/m25/holstered = 1,
+	)
+
 
 /datum/outfit/quick/tgmc/marine/standard_lasermg
 	name = "Laser Machinegunner"
@@ -329,6 +333,10 @@
 		/obj/item/storage/box/MRE = 1,
 		/obj/item/ammo_magazine/smg/m25/extended = 3,
 		/obj/item/ammo_magazine/packet/p10x20mm = 1,
+	)
+
+	belt_contents = list(
+		/obj/item/weapon/gun/smg/m25 = 1,
 	)
 
 
@@ -1188,6 +1196,11 @@
 		/obj/item/explosive/grenade/som = 1,
 	)
 
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
+	)
+
 
 /datum/outfit/quick/som/marine/breacher
 	name = "V-21 Breacher"
@@ -1238,6 +1251,11 @@
 		/obj/item/explosive/grenade/incendiary/som = 1,
 	)
 
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
+	)
+
 
 /datum/outfit/quick/som/marine/machine_gunner
 	name = "V-41 Machinegunner"
@@ -1264,6 +1282,11 @@
 		/obj/item/stack/sandbags_empty/half = 1,
 		/obj/item/stack/sandbags/large_stack = 1,
 		/obj/item/stack/barbed_wire/half_stack = 1,
+	)
+
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
 	)
 
 
@@ -1872,6 +1895,12 @@
 		/obj/item/tool/extinguisher/mini = 1,
 		/obj/item/storage/box/MRE/som = 1,
 	)
+
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
+	)
+
 
 //Base SOM leader outfit
 /datum/outfit/quick/som/squad_leader

--- a/code/datums/outfits/som_ert.dm
+++ b/code/datums/outfits/som_ert.dm
@@ -143,6 +143,8 @@
 		/obj/item/reagent_containers/hypospray/advanced/combat_advanced = 1,
 	)
 
+	belt_contents = null
+
 /datum/outfit/job/som/ert/medic/standard_assaultrifle
 	suit_store = /obj/item/weapon/gun/rifle/som/mag_harness
 

--- a/code/datums/outfits/som_ert.dm
+++ b/code/datums/outfits/som_ert.dm
@@ -143,7 +143,6 @@
 		/obj/item/reagent_containers/hypospray/advanced/combat_advanced = 1,
 	)
 
-	belt_contents = null
 
 /datum/outfit/job/som/ert/medic/standard_assaultrifle
 	suit_store = /obj/item/weapon/gun/rifle/som/mag_harness
@@ -674,11 +673,6 @@
 
 	r_pocket_contents = list(
 		/obj/item/cell/lasgun/volkite = 3,
-	)
-
-	belt_contents = list(
-		/obj/item/weapon/gun/pistol/som/burst = 1,
-		/obj/item/ammo_magazine/pistol/som/extended = 6,
 	)
 
 

--- a/code/datums/outfits/som_ert.dm
+++ b/code/datums/outfits/som_ert.dm
@@ -383,6 +383,11 @@
 		/obj/item/tool/crowbar/red = 1,
 	)
 
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
+	)
+
 
 /datum/outfit/job/som/ert/veteran/shotgunner
 	belt = /obj/item/storage/belt/shotgun/som/flechette
@@ -550,6 +555,11 @@
 		/obj/item/reagent_containers/hypospray/autoinjector/dylovene = 1,
 	)
 
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
+	)
+
 
 /datum/outfit/job/som/ert/veteran/breacher_rpg
 	head = /obj/item/clothing/head/modular/som/lorica
@@ -662,6 +672,11 @@
 
 	r_pocket_contents = list(
 		/obj/item/cell/lasgun/volkite = 3,
+	)
+
+	belt_contents = list(
+		/obj/item/weapon/gun/pistol/som/burst = 1,
+		/obj/item/ammo_magazine/pistol/som/extended = 6,
 	)
 
 


### PR DESCRIPTION
## About The Pull Request

Yep, was missing `SUIT_IN_HOLSTER` in my list of slots to check in my script
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/16987
## Why It's Good For The Game

Outfits having stuff they're supposed to good
## Changelog
:cl:
fix: Some SOM and marine hvh outfits' holster contents are once again filled
/:cl:
