### PR TITLE
Puts the KLTD smart goggles back in the smartgunner equipment rack

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -177,6 +177,7 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 
 //A way to give them everything at once that still works with loadouts would be nice, but barring that make sure that your point calculation is set up so they don't get more than what they're supposed to
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
+	/obj/effect/vendor_bundle/smartgunner = list(CAT_ESS, "KLTD Smart Goggles", 0, "white"),
 	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Smart Machine Gun", 29, "sg-machinegun"), //If a smartgunner buys a SG-29, then they will have 16 points to purchase 4 SG-29 drums
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_SGSUP, "SG-29 Ammo Drum", 4, "sg-machinegun"),
 	/obj/item/weapon/gun/minigun/smart_minigun = list(CAT_SGSUP, "SG-85 Smart Handheld Gatling Gun", 27, "sg-minigun"), //If a smartgunner buys a SG-85, then they should be able to buy only 1 powerpack and 2 ammo bins

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -716,9 +716,6 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 	),
 	SQUAD_SMARTGUNNER = list(
 		/obj/item/clothing/glasses/night/m56_goggles = 1,
-		/obj/item/storage/holster/belt/pistol/smart_pistol = 1,
-		/obj/item/weapon/gun/pistol/smart_pistol = 1,
-		/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = 2,
 	),
 	SQUAD_LEADER = list(
 		/obj/item/explosive/plastique = 1,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -621,7 +621,6 @@
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
-		/obj/item/clothing/glasses/night/m56_goggles,
 	)
 
 /obj/effect/vendor_bundle/basic_jaeger_smartgunner
@@ -630,7 +629,6 @@
 		/obj/item/clothing/shoes/marine/full,
 		/obj/item/clothing/gloves/marine,
 		/obj/item/storage/box/MRE,
-		/obj/item/clothing/glasses/night/m56_goggles,
 		/obj/item/facepaint/green,
 	)
 
@@ -727,6 +725,11 @@
 		/obj/item/cell/high,
 		/obj/item/lightreplacer,
 		/obj/item/circuitboard/apc,
+	)
+
+/obj/effect/vendor_bundle/smartgunner
+	gear_to_spawn = list(
+		/obj/item/clothing/glasses/night/m56_goggles,
 	)
 
 /obj/effect/vendor_bundle/leader
@@ -932,7 +935,6 @@
 		/obj/item/clothing/under/marine/robotic,
 		/obj/item/tool/weldingtool,
 		/obj/item/stack/cable_coil,
-		/obj/item/clothing/glasses/night/m56_goggles,
 	)
 
 /obj/effect/vendor_bundle/robot/light_armor


### PR DESCRIPTION
## About The Pull Request

Pretty much the title

## Why It's Good For The Game

I don't think such an important role specific item should be hidden in an obscure location

## Changelog

:cl:
qol: KLTD smart goggles are located in the smartgunner equipment rack again
/:cl:
