### PR TITLE
Nerf: Sizzler Caste firerate

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -110,7 +110,7 @@
 	caste_desc = "Gross! The large creature is venting a hot steam."
 
 		// *** Ranged Attack *** //
-	spit_delay = 1.5 SECONDS
+	spit_delay = 0.75 SECONDS
 	spit_types = list(/datum/ammo/xeno/acid/airburst)
 
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -110,7 +110,7 @@
 	caste_desc = "Gross! The large creature is venting a hot steam."
 
 		// *** Ranged Attack *** //
-	spit_delay = 0.5 SECONDS
+	spit_delay = 1.5 SECONDS
 	spit_types = list(/datum/ammo/xeno/acid/airburst)
 
 	actions = list(

--- a/html/changelogs/AutoChangeLog-pr-17012.yml
+++ b/html/changelogs/AutoChangeLog-pr-17012.yml
@@ -1,0 +1,4 @@
+author: "novaepee"
+delete-after: True
+changes:
+  - imageadd: "New Miner Sprites"


### PR DESCRIPTION
## About The Pull Request
As the title suggests, this nerfs the Sizzler Strain's firerate. From 0.5 to 0.75

<details>
<summary>Video Reference</summary>

I too, don't understand why my PC turned into Bandicam. This is the old firerate


https://github.com/user-attachments/assets/330a0668-667b-48f1-83d5-20633bdd2e49

This is the new firerate

https://github.com/user-attachments/assets/067bd299-efa3-4489-a9e1-083559efa6d9




</details>

## Why It's Good For The Game

The Sizzler Strain has an absurd firerate for a "shotgun" type of a xeno that spits burn damage out.


## Changelog


:cl:
balance: Sizzler strain
/:cl:
