### PR TITLE
Removes bad prison station disk, adds 2 new ones

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -37226,6 +37226,7 @@
 /turf/open/floor/prison,
 /area/prison/disposal)
 "cqm" = (
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/prison,
 /area/prison/disposal)
 "cqo" = (
@@ -40183,6 +40184,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
+"dNU" = (
+/obj/item/tool/kitchen/utensil/spoon,
+/turf/open/floor/plating/ground/dirt,
+/area/space)
 "dOO" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/bright_clean/two,
@@ -42336,9 +42341,8 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
 "jdI" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/prison,
-/area/prison/security/head)
+/turf/open/floor/plating,
+/area/prison/cellblock/protective)
 "jej" = (
 /obj/structure/toilet{
 	dir = 4
@@ -44736,6 +44740,12 @@
 /obj/item/reagent_containers/spray,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"oZF" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/prison/darkred{
+	dir = 4
+	},
+/area/prison/security/monitoring/medsec/south)
 "pbf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46437,6 +46447,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green/corner,
 /area/prison/cellblock/lowsec/se)
+"sJU" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/plating/ground/dirt,
+/area/space)
 "sKg" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -83527,7 +83541,7 @@ bju
 czl
 czB
 czN
-czN
+oZF
 cAa
 czU
 aab
@@ -93002,7 +93016,7 @@ cnh
 coc
 cav
 cpp
-cqh
+cpY
 cqh
 cqh
 cqh
@@ -93258,8 +93272,8 @@ cqS
 cni
 cod
 bYM
-cpp
-bWl
+jdI
+sJU
 bWl
 aab
 aab
@@ -93516,7 +93530,7 @@ cht
 cof
 coK
 cpp
-bWl
+dNU
 bWl
 aab
 adO
@@ -93773,7 +93787,7 @@ cmz
 chH
 cgI
 cpq
-cpq
+cjR
 cpq
 cpq
 cpq
@@ -96597,7 +96611,7 @@ cgI
 cgI
 cgI
 cgI
-cgI
+coi
 cgI
 cpx
 vrN
@@ -107890,7 +107904,7 @@ bSd
 bNm
 bNm
 bNm
-jdI
+bZz
 tkT
 psK
 bZx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![prisons](https://github.com/user-attachments/assets/9293c19d-83da-483a-9721-cbd0a441fb82)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The removed disk is in a completely unacceptable position, not even 20 tiles away from fob. Back in 2020 before marines had pc and tank, it was at least somewhat possible to hold them back, but with the addition of these tools it just isn't.

The two new disk locations are placed in areas which are literally never visited in normal games. In particular, I have never seen a single person enter the disposals room on this map in 5 years of playing on it.
p.s. I also added another entrance into the disposals room to make it a little harder to hold
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
remove: Prison Station security director disk remove(the one right next to lz2)
add: Prison Station receives 2 new disks, one in disposals(southeast) and one in a security checkpoint(dead south)
/:cl:
