### PR TITLE
Hive status GUI is now wider

### DIFF
--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -110,7 +110,7 @@ export const HiveStatus = (_props: any) => {
     <Window
       theme="xeno"
       title={hive_name + ' Hive Status'}
-      width={1000}
+      width={1200}
       height={800}
     >
       <Window.Content scrollable>


### PR DESCRIPTION
## About The Pull Request
Makes the hive status wider so that it fits all the T3 castes on the screen when you initially open it instead of it being cut off.
Before:
![image](https://github.com/user-attachments/assets/9002734a-1a64-4c0e-ae4c-5911bf0c88fd)

After:
![image](https://github.com/user-attachments/assets/95e7a193-2f0b-4188-ae12-7510f39c0dfb)

## Why It's Good For The Game
@ivanmixo wanted this.
![image](https://github.com/user-attachments/assets/819823b2-1150-4778-bc6b-03956ae7c656)

## Changelog
:cl:
fix: Hive status GUI's width is now longer to fit all castes rather than cutting them off.
/:cl:
