### PR TITLE
Replaces plat miner in south of ice colony for a phoron one.

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -20867,7 +20867,7 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/east)
 "gOB" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "gOC" = (


### PR DESCRIPTION
## About The Pull Request
Title
![imagen](https://github.com/user-attachments/assets/cae046c4-5893-4db4-8fd5-77b5aee11a57)
That one
## Why It's Good For The Game
This miner can be caded extremely easily, tad can park less than a screen away and it's besides a disk, so it's always easy to defend.
This shouldn't be a plat miner.

## Changelog
:cl:
balance: Replaces plat miner on south ice colony with a phoron one
/:cl:
