### PR TITLE
Adds Vertical Grip to MG-27 and MG-60.

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -434,6 +434,7 @@
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/flashlight/under,
+		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -976,6 +976,7 @@
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight/under,
+		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/foldable/bipod,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,


### PR DESCRIPTION
## About The Pull Request
Adds Vertical grip to MG-27 MMG and MG-60 MMG.
## Why It's Good For The Game
GPMG got removed VGRIP cause of Aim Mode gameplay. That's gone now so I think its fine to return VGRIP to this for now. The wield penalty is pretty insane with VGRIP so the tradeoff is very, very steep.

MMG has vertical grip now. Since I'm roleplaying my best Tiviplus impression. I'm not elaborating any more.

## Changelog
:cl:
balance: MMG and GPMG have vgrip now.
/:cl:
