### PR TITLE
Armour module style touchups

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/head.dm
@@ -33,7 +33,7 @@
 	jobs_supported = list(SOM_FIELD_COMMANDER)
 
 /datum/loadout_item/helmet/som_surt
-	name = "Hades Helmet"
+	name = "'Hades' incendiary insulation system helmet"
 	desc = "A standard combat helmet with a Hades fireproof module."
 	req_desc = "Requires a suit with a Hades module."
 	item_typepath = /obj/item/clothing/head/modular/som/hades
@@ -41,7 +41,7 @@
 	item_whitelist = list(/obj/item/clothing/suit/modular/som/heavy/pyro = ITEM_SLOT_OCLOTHING)
 
 /datum/loadout_item/helmet/som_tyr
-	name = "Lorica Helmet"
+	name = "'Lorica' armor reinforcement system helmet"
 	desc = "A bulky helmet paired with the 'Lorica' armor module, designed for outstanding protection at the cost of significant weight and reduced flexibility. \
 	Substantial additional armor improves protection against all damage."
 	req_desc = "Requires a suit with a Lorica module."
@@ -75,8 +75,8 @@
 	loadout_item_flags = NONE
 
 /datum/loadout_item/helmet/som_mimir
-	name = "Biohazard helmet"
-	desc = "A standard combat helmet with a Mithridatius 'Mith' environmental protection module."
+	name = "'Mithridatius' hostile environment protection helmet"
+	desc = "A standard combat helmet with an integrated Mithridatius 'Mith' hostile environment protection module."
 	req_desc = "Requires a suit with a Mithridatius environmental protection module."
 	item_typepath = /obj/item/clothing/head/modular/som/bio
 	jobs_supported = list(SOM_SQUAD_VETERAN)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -24,7 +24,7 @@
  * Shoulder lamp strength module
  */
 /obj/item/armor_module/module/better_shoulder_lamp
-	name = "\improper Baldur Light Amplification System"
+	name = "\improper Baldur light amplification system"
 	desc = "Designed for mounting on modular armor. Substantially increases the power output of your modular armor's mounted flashlight. Be the light in the darkness."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_lamp"
@@ -38,7 +38,7 @@
  * Mini autodoc module
  */
 /obj/item/armor_module/module/valkyrie_autodoc
-	name = "\improper Valkyrie Automedical Armor System"
+	name = "\improper Valkyrie automedical system"
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	desc = "Designed for mounting on modular armor. This module has advanced medical systems that inject tricordrazine and tramadol based on the user's needs, as well as automatically securing the bones and body of the wearer, effectively splinting them until professional medical attention can be admistered. Will definitely impact mobility."
 	icon_state = "mod_autodoc"
@@ -61,7 +61,7 @@
 	return ..()
 
 /obj/item/armor_module/module/valkyrie_autodoc/som
-	name = "\improper Apollo Automedical Armor System"
+	name = "\improper Apollo automedical system"
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	desc = "Designed to be mounted on SOM combat armor, or internally inside Gorgon assault armor. This module has advanced medical systems that inject tricordrazine and tramadol based on the user's needs, as well as automatically securing the bones and body of the wearer, effectively splinting them until professional medical attention can be admistered. Will definitely impact mobility."
 	icon_state = "mod_autodoc_som"
@@ -72,9 +72,9 @@
  * Fire poof module
 */
 /obj/item/armor_module/module/fire_proof
-	name = "\improper Surt Pyrotechnical Insulation System"
+	name = "\improper Surt thermal insulation system"
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
-	desc = "Designed for mounting on modular armor. Providing a near immunity to being bathed in flames, and amazing flame retardant qualities, this is every pyromaniac's first stop to survival. Will impact mobility."
+	desc = "Designed for mounting on modular armor. It shields you from the effects of fire, and prevents you from being set alight by any means. Wearing this in combination with the corresponding helmet module will render you completely impervious to fire. Will definitely impact mobility."
 	icon_state = "mod_fire"
 	worn_icon_state = "mod_fire_a"
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 45, ACID = 0)
@@ -92,16 +92,9 @@
 	parent.armor_features_flags &= ~ARMOR_FIRE_RESISTANT
 	return ..()
 
-/obj/item/armor_module/module/fire_proof/som
-	name = "\improper Hades Incendiary Insulation System"
-	desc = "Designed for mounting on modular SOM armor. Provides excellent resistance to fire and prevents combustion. As it is not a sealed system, it does not completely protect the user from the heat of fire. Will impact mobility."
-	icon_state = "mod_fire_som"
-	worn_icon_state = "mod_fire_som_a"
-
 /obj/item/armor_module/module/fire_proof_helmet
-
-	name = "\improper Surt Pyrotechnical Insulation Helmet System"
-	desc = "Designed for mounting on a modular helmet. Providing a near immunity to being bathed in flames, and amazing flame retardant qualities, this is every pyromaniac's first stop to survival."
+	name = "\improper Surt thermal insulation system helmet module"
+	desc = "Designed for mounting on a modular helmet. It shields you from the effects of fire, and prevents you from being set alight by any means. Wearing this in combination with the corresponding helmet module will render you completely impervious to fire. Will definitely impact mobility."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_fire_head"
 	worn_icon_state = "mod_fire_head_a"
@@ -109,12 +102,19 @@
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "mod_fire_head_xn", /obj/item/clothing/head/modular/tdf = "")
 
+/obj/item/armor_module/module/fire_proof/som
+	name = "\improper Hades incendiary insulation system"
+	desc = "Designed for mounting on modular SOM armor. It provides near-immunity to the effects of fire, and prevents you from being set alight by any means. Wearing this in combination with the corresponding helmet module will render you completely impervious to fire. Will not actually provide any resistance against volkite weaponry. Will impact mobility."
+	icon_state = "mod_fire_som"
+	worn_icon_state = "mod_fire_som_a"
+
 /**
  * Extra armor module
 */
+
 /obj/item/armor_module/module/tyr_extra_armor
-	name = "\improper Mark 2 Tyr Armor Reinforcement"
-	desc = "Designed for mounting on modular armor. A substantial amount of additional armor plating designed to grant the user extra protection against threats, ranging from xeno slashes to friendly fire incidents. This newer version has improved protection. Will definitely impact mobility."
+	name = "\improper Tyr Mk.2 armor reinforcement system"
+	desc = "Designed for mounting on modular armor. A substantial amount of additional all-around armor plating designed to grant the user extra protection against any kind of threat. This newer version has improved protection, and will impact mobility less than its predecessor."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_armor"
 	worn_icon_state = "mod_armor_a"
@@ -133,25 +133,16 @@
 	return ..()
 
 /obj/item/armor_module/module/tyr_extra_armor/mark1
-	name = "\improper Mark 1 Tyr Armor Reinforcement"
-	desc = "Designed for mounting on modular armor. A substantial amount of additional armor plating designed to grant the user extra protection against threats, ranging from xeno slashes to friendly fire incidents. This older version has worse protection. Will greatly impact mobility."
+	name = "\improper Tyr Mk.1 armor reinforcement system"
+	desc = "Designed for mounting on modular armor. A decent amount of additional all-around armor plating designed to grant the user extra protection against any kind of threat. This older version has worse protection. Will greatly impact mobility."
 	icon_state = "mod_armor_lower"
 	worn_icon_state = "mod_armor_lower_a"
 	soft_armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, FIRE = 10, ACID = 10)
 	slowdown = 0.4
 
-/obj/item/armor_module/module/tyr_extra_armor/som
-	name = "\improper Lorica Armor Reinforcement"
-	desc = "Designed for mounting on modular SOM armor. A substantial amount of additional armor plating designed to grant the user extra protection against all forms of damage. Will definitely impact mobility."
-	icon = 'icons/mob/modular/modular_armor_modules.dmi'
-	icon_state = "lorica_armor"
-	worn_icon_state = "lorica_armor_a"
-	attachment_layer = null
-	soft_armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 15, BIO = 5, FIRE = 10, ACID = 5)
-
 /obj/item/armor_module/module/tyr_head
-	name = "\improper Tyr Helmet System"
-	desc = "Designed for mounting on a modular helmet. When attached, this system provides substantial resistance to most damaging hazards, ranging from xeno slashes to friendly fire incidents."
+	name = "\improper Tyr armor reinforcement system helmet module"
+	desc = "Designed for mounting on a modular helmet. A substantial amount of all-around armour plating designed to grant the user extra protection against any kind of threat."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "tyr_head"
 	worn_icon_state = "tyr_head_a"
@@ -159,9 +150,32 @@
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "tyr_head_xn", /obj/item/clothing/head/modular/tdf = "")
 
+/obj/item/armor_module/module/tyr_extra_armor/som
+	name = "\improper Lorica armor reinforcement system"
+	desc = "Designed for mounting on modular SOM armor. A substantial amount of additional armor plating designed to grant the user extra protection against all forms of damage. Will definitely impact mobility."
+	icon = 'icons/mob/modular/modular_armor_modules.dmi'
+	icon_state = "lorica_armor"
+	worn_icon_state = "lorica_armor_a"
+	attachment_layer = null
+	soft_armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 15, BIO = 5, FIRE = 10, ACID = 5)
+
+/*
+	Friendly fire module
+*/
+
+/obj/item/armor_module/module/ballistic_armor
+	name = "\improper Hod ballistic deflection system"
+	desc = "Designed for mounting on modular armor. Contains large amounts of ballistic armor plating, as well as energetically reflective and thermally dissipative material that grant it a high level of defense against bullets and lasers alike. Will impact mobility."
+	icon = 'icons/mob/modular/modular_armor_modules.dmi'
+	icon_state = "mod_ff"
+	worn_icon_state = "mod_ff_a"
+	soft_armor = list(MELEE = 0, BULLET = 40, LASER = 40, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	slowdown = 0.2
+	slot = ATTACHMENT_SLOT_MODULE
+
 /obj/item/armor_module/module/hod_head
-	name = "\improper Hod Helmet System"
-	desc = "Designed for mounting on a modular helmet. When attached, this system provides substantial resistance to most gunshot wounds by providing high internal padding within the helmet's structure."
+	name = "\improper Hod ballistic deflection system helmet module"
+	desc = "Designed for mounting on a modular helmet. Contains large amounts of ballistic armor plating, as well as energetically reflective and thermally dissipative material that grant it a high level of defense against bullets and lasers alike. Will impact mobility."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_ff_head"
 	worn_icon_state = "mod_ff_head_a"
@@ -172,8 +186,8 @@
  * Environment protection module
 */
 /obj/item/armor_module/module/mimir_environment_protection
-	name = "\improper Mark 2 Mimir Environmental Resistance System"
-	desc = "Designed for mounting on modular armor. This newer model provides great resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
+	name = "\improper Mimir Mk.2 environmental resistance system"
+	desc = "Designed for mounting on modular armor. This newer model provides great resistance to acid, as well as biological and radiological threats. Pairing this with a Mimir helmet module and a gas mask will make the user impervious to gas attacks. Will impact mobility."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_biohazard"
 	worn_icon_state = "mod_biohazard_a"
@@ -200,25 +214,9 @@
 	parent.gas_transfer_coefficient -= siemens_coefficient_mod
 	return ..()
 
-/obj/item/armor_module/module/mimir_environment_protection/mark1
-	name = "\improper Mark 1 Mimir Environmental Resistance System"
-	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
-	icon_state = "mod_biohazard"
-	worn_icon_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 15, FIRE = 0, ACID = 15)
-	slowdown = 0.2
-
-//SOM version
-/obj/item/armor_module/module/mimir_environment_protection/som
-	name = "\improper Mithridatius Hostile Environment System"
-	desc = "Designed for mounting on modular SOM armor. This module appears to be designed to protect the user from the effects of radiological attacks, although also provides improved resistance against other environmental threats such as acid and gas. Pairing this with a Mithridatius helmet module and mask will make the user impervious to gas clouds. Will impact mobility."
-	icon_state = "mithridatius"
-	worn_icon_state = "mithridatius_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 0, ACID = 20)
-
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet
-	name = "\improper Mark 2 Mimir Environmental Helmet System"
-	desc = "Designed for mounting on a modular helmet. This newer model provides great resistance to acid, biological, and even radiological attacks. Pairing this with a Mimir suit module and mask will provide the user with immunity from xenomorph cloud reagents entering bloodstream."
+	name = "\improper Mimir Mk.2 environmental resistance system helmet module"
+	desc = "Designed for mounting on a modular helmet. This newer model provides great resistance to acid, as well as biological and radiological threats. Pairing this with a Mimir suit module and a gas mask will make the user impervious to gas attacks."
 	icon_state = "mimir_head"
 	worn_icon_state = "mimir_head_a"
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 40, FIRE = 0, ACID = 30)
@@ -226,14 +224,33 @@
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "mimir_head_xn", /obj/item/clothing/head/modular/tdf = "")
 
+/obj/item/armor_module/module/mimir_environment_protection/mark1
+	name = "\improper Mimir Mk.1 environmental resistance system"
+	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, as well as biological, and radiological threats. Pairing this with a Mimir helmet module and mask will make the user highly resistant to gas attacks, but will not provide immunity. Will impact mobility."
+	icon_state = "mod_biohazard"
+	worn_icon_state = "mod_biohazard_a"
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 15, FIRE = 0, ACID = 15)
+	slowdown = 0.2
+
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
-	name = "\improper Mark 1 Mimir Environmental Helmet System"
-	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks. Pairing this with a Mimir suit module and mask will provide the user with immunity from xenomorph cloud reagents entering bloodstream."
+	name = "\improper Mimir Mk.1 environmental resistance system helmet module"
+	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid, as well as biological, and radiological threats. Pairing this with a Mimir helmet module and mask will make the user highly resistant to gas attacks, but will not provide immunity. Will impact mobility."
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 15, FIRE = 0, ACID = 15)
 
-//Explosive defense armor
+//SOM version
+/obj/item/armor_module/module/mimir_environment_protection/som
+	name = "\improper Mithridatius hostile environment protection system"
+	desc = "Designed for mounting on modular SOM armor. This module appears to be designed to protect the user from the effects of radiological attacks, although it also provides improved resistance against other environmental threats such as acids and gasses. Pairing this with a Mithridatius helmet module and mask will make the user impervious to gas clouds. Will impact mobility."
+	icon_state = "mithridatius"
+	worn_icon_state = "mithridatius_a"
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 0, ACID = 20)
+
+/*
+	Explosive defense armor
+*/
+
 /obj/item/armor_module/module/hlin_explosive_armor
-	name = "\improper Hlin Explosive Compensation Module"
+	name = "\improper Hlin explosive compensation system"
 	desc = "Designed for mounting on modular armor. Uses a complex set of armor plating and compensation to lessen the effect of explosions. Will impact mobility"
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_boomimmune"
@@ -242,18 +259,9 @@
 	slowdown = 0.2
 	slot = ATTACHMENT_SLOT_MODULE
 
-/**
- * Extra armor module
+/*
+	chemical enhancement module
 */
-/obj/item/armor_module/module/ballistic_armor
-	name = "\improper Hod Accident Prevention Plating"
-	desc = "Designed for mounting on modular armor. A substantial amount of additional reflective ballistic armor plating designed to reduce the impact of friendly fire incidents, will lessen the affects of bullets and lasers. Will impact mobility."
-	icon = 'icons/mob/modular/modular_armor_modules.dmi'
-	icon_state = "mod_ff"
-	worn_icon_state = "mod_ff_a"
-	soft_armor = list(MELEE = 0, BULLET = 40, LASER = 40, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	slowdown = 0.2
-	slot = ATTACHMENT_SLOT_MODULE
 
 /obj/item/armor_module/module/chemsystem
 	name = "\improper Vali chemical enhancement module"
@@ -290,9 +298,13 @@
 		return
 	icon_state = initial(icon_state)
 
+/*////////////////////////
+	energy shield module
+*/////////////////////////
+
 /obj/item/armor_module/module/eshield
-	name = "\improper Svalinn Energy Shield System"
-	desc = "A brand new innovation in armor systems, this module creates a shield around the user that is capable of negating all damage at the cost of increased vulnerability to melee, biological, and acid attacks. If it sustains too much it will deactivate, and leave the user vulnerable."
+	name = "\improper Svalinn energy shield system"
+	desc = "A brand new innovation in armor systems, this module creates a shield around the user that is capable of negating all damage at the cost of increased vulnerability to melee, biological, and acid attacks. If it sustains too much damage it will deactivate, and leave the user vulnerable until it recharges."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_eshield"
 	worn_icon_state = "mod_eshield_a"
@@ -465,7 +477,7 @@
 
 //original Martian design, donutsteel
 /obj/item/armor_module/module/eshield/som
-	name = "\improper Aegis Energy Dispersion Module"
+	name = "\improper Aegis energy dispersion system"
 	desc = "A sophisticated shielding unit, designed to disperse the energy of incoming impacts, rendering them harmless to the user. If it sustains too much it will deactivate, and leave the user vulnerable. It is unclear if this was a purely  SOM designed module, or whether it was reverse engineered from the TGMC's 'Svalinn' shield system which was developed around the same time."
 
 /obj/item/armor_module/module/eshield/som/overclocked
@@ -475,9 +487,13 @@
 	shield_color_mid = LIGHT_COLOR_RED_ORANGE
 	shield_color_full = LIGHT_COLOR_ELECTRIC_CYAN
 
+/*
+	Loki illusion projection
+*/
+
 /obj/item/armor_module/module/mirage
-	name = "\improper Loki Illusion Module"
-	desc = "Designed for mounting on modular armor. This module creates a holographic projection of the user, which can be used to distract enemies and draw their fire when the user is hit."
+	name = "\improper Loki illusion projection system"
+	desc = "Designed for mounting on modular armor. This module creates a holographic projection of the user while simultaneously rendering them invisible for a short duration, which can be used to distract enemies and draw their fire."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_illusion"
 	worn_icon_state = "mod_illusion_a"
@@ -509,7 +525,7 @@
 #define ARMORLOCK_GAS_TRANSFER_COEFF -1
 
 /obj/item/armor_module/module/armorlock
-	name = "\improper Thor Armorlock Module"
+	name = "\improper Thor armor lock system"
 	desc = "Designed for mounting on modular armor. This module seals gaps in the armor when activated, making the user unable to do any actions but increasing their armor."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_armorlock"
@@ -596,7 +612,7 @@
  *   Helmet Modules
 */
 /obj/item/armor_module/module/welding
-	name = "welding Helmet Module"
+	name = "\improper HM-3 welding visor helmet module"
 	desc = "Designed for mounting on a modular helmet. This module can be toggled on or off to function as welding protection for your delicate eyes."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "welding_head"
@@ -639,7 +655,7 @@
 	user.update_inv_head()
 
 /obj/item/armor_module/module/welding/som
-	name = "integrated welding Helmet Module"
+	name = "integrated welding visor helmet module"
 	desc = "Built in welding module for a SOM engineering helmet. This module can be toggled on or off to function as welding protection for your delicate eyes."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "welding_head_som"
@@ -647,7 +663,7 @@
 	attach_features_flags = ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
 
 /obj/item/armor_module/module/welding/superior
-	name = "superior welding Helmet Module"
+	name = "\improper HM-33 superior welding visor helmet module"
 	desc = "Designed for mounting on a modular helmet. This more expensive module can be toggled on or off to function as welding protection for your delicate eyes, strangely smells like potatoes."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "welding_head"
@@ -663,7 +679,7 @@
 	parent.AddComponent(/datum/component/clothing_tint, TINT_4, active)
 
 /obj/item/armor_module/module/binoculars
-	name = "binocular Helmet Module"
+	name = "\improper HM-6 binocular helmet module"
 	desc = "Designed for mounting on a modular helmet. Can be flipped down to view into the distance."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "binocular_head"
@@ -703,7 +719,7 @@
 	return COMSIG_MOB_CLICK_CANCELED
 
 /obj/item/armor_module/module/binoculars/artemis_mark_two // a little cheating with subtypes
-	name = "\improper Mark 2 Freyr Helmet Module"
+	name = "\improper Freyr Mk.2 visual assistance helmet system"
 	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, allowing them to see clearly even in the harshest of circumstances. This version is enhanced and allows the marine to peer through the visor, akin to binoculars."
 	icon_state = "artemis_head"
 	worn_icon_state = "artemis_head_mk2_a"
@@ -713,7 +729,7 @@
 	parent.AddComponent(/datum/component/blur_protection)
 
 /obj/item/armor_module/module/artemis
-	name = "\improper Mark 1 Freyr Helmet Module"
+	name = "\improper Freyr Mk.1 visual assistance helmet system"
 	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, allowing them to see clearly even in the harshest of circumstances."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "artemis_head"
@@ -731,8 +747,8 @@
 #define COMMS_SETUP 2
 
 /obj/item/armor_module/module/antenna
-	name = "antenna helmet module"
-	desc = "Designed for mounting on a modular Helmet. This module is able to shield against the interference of caves, allowing for normal messaging in shallow caves, and only minor interference when deep."
+	name = "\improper HM-9 antenna helmet module"
+	desc = "Designed for mounting on a modular helmet. This module is able to shield against the interference of caves, allowing for normal messaging in shallow caves, and only minor interference when deep."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "antenna_head"
 	worn_icon_state = "antenna_head_a"

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -57,7 +57,7 @@
 /** General storage */
 /obj/item/armor_module/storage/general
 	name = "general-purpose storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
 	icon_state = "mod_general_bag"
 	storage_type = /datum/storage/internal/general
 
@@ -69,7 +69,7 @@
 
 /obj/item/armor_module/storage/ammo_mag
 	name = "magazine storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Holds some magazines. Don’t expect to fit specialist munitions or LMG drums in, but you can get some good mileage. Looks like it might slow you down a bit."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Holds some magazines. Don’t expect to fit specialist munitions or LMG drums in, but you can get some good mileage. Looks like it might slow you down a bit."
 	icon_state = "mod_mag_bag"
 	storage_type = /datum/storage/internal/ammo_mag
 	slowdown = 0.1
@@ -94,7 +94,7 @@
 
 /obj/item/armor_module/storage/engineering
 	name = "engineering storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag"
 	storage_type = /datum/storage/internal/engineering
 
@@ -106,7 +106,7 @@
 
 /obj/item/armor_module/storage/medical
 	name = "medical storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
 	storage_type = /datum/storage/internal/medical
 
@@ -125,20 +125,20 @@
 
 /obj/item/armor_module/storage/injector
 	name = "injector Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of injectors."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Can hold a substantial variety of injectors."
 	icon_state = "mod_injector_bag"
 	storage_type = /datum/storage/internal/injector
 
 /obj/item/armor_module/storage/integrated
 	name = "IS Pattern Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Impedes movement somewhat, but holds about as much as a satchel could."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Impedes movement somewhat, but holds about as much as a satchel could."
 	icon_state = "mod_is_bag"
 	storage_type = /datum/storage/internal/integrated
 	slowdown = 0.2
 
 /obj/item/armor_module/storage/grenade
 	name = "Grenade Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a respectable amount of grenades."
+	desc = "Designed for mounting on the TGMC's modular armor systems. Can hold a respectable amount of grenades."
 	icon_state = "mod_grenade_harness"
 	storage_type = /datum/storage/internal/grenade
 

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -56,19 +56,19 @@
 
 /** General storage */
 /obj/item/armor_module/storage/general
-	name = "General Purpose Storage module"
+	name = "general-purpose storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
 	icon_state = "mod_general_bag"
 	storage_type = /datum/storage/internal/general
 
 /obj/item/armor_module/storage/general/som
-	name = "General Purpose Storage module"
+	name = "general-purpose storage module"
 	desc = "Designed for mounting on SOM combat armor. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like pistols or magazines."
 	icon_state = "mod_general_bag_som"
 	worn_icon_state = "mod_general_bag_som_a"
 
 /obj/item/armor_module/storage/ammo_mag
-	name = "Magazine Storage module"
+	name = "magazine storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Holds some magazines. Don’t expect to fit specialist munitions or LMG drums in, but you can get some good mileage. Looks like it might slow you down a bit."
 	icon_state = "mod_mag_bag"
 	storage_type = /datum/storage/internal/ammo_mag
@@ -93,19 +93,19 @@
 	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
 
 /obj/item/armor_module/storage/engineering
-	name = "Engineering Storage module"
+	name = "engineering storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag"
 	storage_type = /datum/storage/internal/engineering
 
 /obj/item/armor_module/storage/engineering/som
-	name = "Engineering Storage module"
+	name = "engineering storage module"
 	desc = "Designed for mounting on SOM combat armor. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag_som"
 	worn_icon_state = "mod_engineer_bag_som_a"
 
 /obj/item/armor_module/storage/medical
-	name = "Medical Storage module"
+	name = "medical storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
 	storage_type = /datum/storage/internal/medical
@@ -118,13 +118,13 @@
 	new /obj/item/storage/pill_bottle/tramadol(src)
 
 /obj/item/armor_module/storage/medical/som
-	name = "Medical Storage module"
+	name = "medical storage module"
 	desc = "Designed for mounting on SOM combat armor. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag_som"
 	worn_icon_state = "mod_medic_bag_som_a"
 
 /obj/item/armor_module/storage/injector
-	name = "Injector Storage module"
+	name = "injector Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of injectors."
 	icon_state = "mod_injector_bag"
 	storage_type = /datum/storage/internal/injector

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1150,14 +1150,14 @@ ARMOR
 	cost = 400
 
 /datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
-	name = "Valkyrie autodoc armor module"
+	name = "Valkyrie automedical system"
 	contains = list(
 		/obj/item/armor_module/module/valkyrie_autodoc,
 	)
 	cost = 120
 
 /datum/supply_packs/armor/modular/attachments/fire_proof
-	name = "Surt fireproof module set"
+	name = "Surt thermal insulation system set"
 	contains = list(
 		/obj/item/armor_module/module/fire_proof,
 		/obj/item/armor_module/module/fire_proof_helmet,
@@ -1165,14 +1165,14 @@ ARMOR
 	cost = 120
 
 /datum/supply_packs/armor/modular/attachments/tyr_extra_armor
-	name = "Tyr mark 2 armor module"
+	name = "Tyr Mk.2 armor reinforcement system"
 	contains = list(
 		/obj/item/armor_module/module/tyr_extra_armor,
 	)
 	cost = 120
 
 /datum/supply_packs/armor/modular/attachments/mimir_environment_protection
-	name = "Mimir mark 2 module set"
+	name = "Mimir Mk.2 environmental resistance system set"
 	contains = list(
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
@@ -1180,12 +1180,12 @@ ARMOR
 	cost = 150
 
 /datum/supply_packs/armor/modular/attachments/hlin_bombimmune
-	name = "Hlin explosive armor module"
+	name = "Hlin explosive compensation system"
 	contains = list(/obj/item/armor_module/module/hlin_explosive_armor)
 	cost = 120
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
-	name = "Freyr mark 2 helmet module"
+	name = "Freyr Mk.2 visual assistance helmet system"
 	contains = list(
 		/obj/item/armor_module/module/binoculars/artemis_mark_two,
 	)


### PR DESCRIPTION

## About The Pull Request
Updates some armour module descriptions to better reflect how they work and the level of protection they provide
changes the capitalization of their names
Moves the mark indicator a step forwards to ensure that the name is always at the start
changes how SOM armour module helmets are referred to in their purchase UI (??? I don't play sloppaign)
Updates req orders to reflect all of this
## Why It's Good For The Game
uh...
## Changelog
:cl:
spellcheck: Updates armour module stylization
/:cl:
