### PR TITLE
Fire and liquid turf jump/throw interaction fixes

### DIFF
--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -637,15 +637,15 @@
 
 ///Clean up all throw vars
 /atom/movable/proc/stop_throw(flying = FALSE, original_layer)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
-	if(loc)
-		SEND_SIGNAL(loc, COMSIG_TURF_THROW_ENDED_HERE, src)
 	set_throwing(FALSE)
 	if(flying)
 		set_flying(FALSE, original_layer)
 	thrower = null
 	thrown_speed = 0
 	throw_source = null
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
+	if(loc)
+		SEND_SIGNAL(loc, COMSIG_TURF_THROW_ENDED_HERE, src)
 
 /atom/movable/proc/handle_buckled_mob_movement(newloc, direct, glide_size_override)
 	for(var/m in buckled_mobs)

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -1200,11 +1200,15 @@
 
 ///Toggles AM between throwing states
 /atom/movable/proc/set_throwing(new_throwing)
+	if(throwing == new_throwing)
+		return
 	throwing = new_throwing
 	if(throwing)
 		pass_flags |= PASS_THROW
+		add_nosubmerge_trait(THROW_TRAIT)
 	else
 		pass_flags &= ~PASS_THROW
+		REMOVE_TRAIT(src, TRAIT_NOSUBMERGE, THROW_TRAIT)
 
 ///Toggles AM between flying states
 /atom/movable/proc/set_flying(flying, new_layer)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -198,12 +198,12 @@
 /mob/living/fire_act(burn_level)
 	if(!burn_level)
 		return
-	if(status_flags & (INCORPOREAL|GODMODE)) //Ignore incorporeal/invul targets
+	if(status_flags & (INCORPOREAL|GODMODE))
+		return FALSE
+	if(pass_flags & PASS_FIRE)
 		return FALSE
 	if(soft_armor.getRating(FIRE) >= 100)
 		to_chat(src, span_warning("You are untouched by the flames."))
-		return FALSE
-	if(pass_flags & PASS_FIRE) //Pass fire allow to cross fire without being affected.
 		return FALSE
 
 	take_overall_damage(rand(10, burn_level), BURN, FIRE, updating_health = TRUE, max_limbs = 4)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -33,6 +33,7 @@
 
 	var/static/list/connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_cross),
+		COMSIG_TURF_JUMP_ENDED_HERE = PROC_REF(on_jump_landing),
 	)
 	AddElement(/datum/element/connect_loc, connections)
 	AddComponent(/datum/component/submerge_modifier, 10)
@@ -125,6 +126,11 @@
 /obj/fire/proc/on_cross(datum/source, atom/movable/crosser, oldloc, oldlocs)
 	SIGNAL_HANDLER
 	affect_atom(crosser)
+
+///Effects applied to anything that jumps onto the fire
+/obj/fire/proc/on_jump_landing(datum/source, mob/living/jumper)
+	SIGNAL_HANDLER
+	affect_atom(jumper)
 
 ///Applies effects to an atom
 /obj/fire/proc/affect_atom(atom/affected)


### PR DESCRIPTION
## About The Pull Request
Maybe TM this first. I checked through the stop_throw signal related procs and it should all be fine, but its possible I missed some weird interaction.

Throwing items across lava will no longer burn them.
Thrown things will no longer visually submerge mid throw
Jumping (or being thrown into) fire or liquid turfs (water/lava) will now instantly proc the relevant effects.

Generally a small refactor/cleanup for liquid turf procs, to make the code a bit cleaner and reusable.

## Why It's Good For The Game
Bug fixes.
## Changelog
:cl:
fix: fixed items being burnt by lava while mid throw
fix: fixed things visually submerging mid throw
fix: fixed mobs not being immediately ignited when landing in fire/lava
/:cl:
