### PR TITLE
add somolet in cryotube

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -198,7 +198,7 @@
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix
-	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/medicine/saline_glucose = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5)
+	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/medicine/saline_glucose = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5, /datum/reagent/medicine/research/somolent = 5)
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

what is somolet?

Heals both BRUTE and BURN but only when unconscious. The first 25 ticks heal increasing BRUTE and BURN equal to 0.4 multiplied by the current tick.
Afterwards, heals 10 of both BRUTE and BURN in addition to a small amount of CLONELOSS that scales with health, healing a default 0.2 CLONELOSS, with an additional 0.02 CLONELOSS healed for each point of health the user is missing, per tick.
After 25 ticks and while unconscious (which is required to heal), metabolism rate is increased from 0.2u to 0.8u. If the user is conscious, causes increasing STAM damage. 

## Why It's Good For The Game

let cryotube heal marines faster since that's its purpose. this is a very rare medicine to use, and in fact i've learned about this medicine today; a doc added this to the cryomix. if kuro says no, then best to close it

## Changelog

:cl:
balance: add somolet to cryotube
/:cl:
