### PR TITLE
Re-educates marines on safe dietary practices.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -65,7 +65,10 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) + ((reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) / reagents.total_volume) * bitesize * 18.75) //adds our next bite to our total nutrition in body and stomach
+		var/bite_nutrition = ((reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) / reagents.total_volume) * bitesize * 18.75)
+		if(reagents.total_volume < bitesize)
+			bite_nutrition = reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75
+		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) + bite_nutrition //adds our next bite to our total nutrition in body and stomach
 		if(M == user)								//If you're eating it yourself
 			var/mob/living/carbon/H = M
 			if(ishuman(H) && (H.species.species_flags & ROBOTIC_LIMBS))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -65,7 +65,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) + (reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) //adds our next bite to our total nutrition in body and stomach
+		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) + ((reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) / reagents.total_volume) * bitesize * 18.75) //adds our next bite to our total nutrition in body and stomach
 		if(M == user)								//If you're eating it yourself
 			var/mob/living/carbon/H = M
 			if(ishuman(H) && (H.species.species_flags & ROBOTIC_LIMBS))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -65,21 +65,21 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 25)
+		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 25) + (reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 25)
 		if(M == user)								//If you're eating it yourself
 			var/mob/living/carbon/H = M
 			if(ishuman(H) && (H.species.species_flags & ROBOTIC_LIMBS))
 				balloon_alert(user, "can't eat food")
 				return
-			if(fullness <= 50)
+			if(fullness <= NUTRITION_STARVING)
 				balloon_alert(user, "hungrily chews [src]")
-			if(fullness > 50 && fullness <= 150)
+			if(fullness > NUTRITION_STARVING && fullness <= NUTRITION_HUNGRY)
 				balloon_alert(user, "hungrily eats [src]")
-			if(fullness > 150 && fullness <= 350)
+			if(fullness > NUTRITION_HUNGRY && fullness <= NUTRITION_WELLFED)
 				balloon_alert(user, "takes bite of [src]")
-			if(fullness > 350 && fullness <= 550)
-				balloon_alert(user, "unwillingly chews [src]")
-			if(fullness > 550)
+			if(fullness > NUTRITION_WELLFED && fullness <= NUTRITION_OVERFED)
+				balloon_alert(user, "nibbles on [src]")
+			if(fullness > NUTRITION_OVERFED)
 				balloon_alert(user, "cannot eat more of [src]")
 				return FALSE
 		else
@@ -87,7 +87,7 @@
 			if(ishuman(H) && (H.species.species_flags & ROBOTIC_LIMBS))
 				balloon_alert(user, "can't eat food")
 				return
-			if(fullness <= 550)
+			if(fullness <= NUTRITION_OVERFED)
 				balloon_alert_to_viewers("tries to feed [M]")
 			else
 				balloon_alert_to_viewers("tries to feed [M] but can't")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -65,7 +65,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 25) + (reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 25)
+		var/fullness = C.nutrition + (C.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) + (reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 18.75) //adds our next bite to our total nutrition in body and stomach
 		if(M == user)								//If you're eating it yourself
 			var/mob/living/carbon/H = M
 			if(ishuman(H) && (H.species.species_flags & ROBOTIC_LIMBS))


### PR DESCRIPTION
## About The Pull Request
Fixes the eating messages using the wrong (10 year old) values.
Marines will be unable to eat if the next bite would make them fat.
## Why It's Good For The Game
Better to use our nice pretty nutrition defines instead of incorrect 10 year old numbers.
New players will no longer be fat and slow 24/7.
## Changelog
:cl:
add: Marines have been better trained about nutrition and will stop eating before they get fat.
fix: Eating messages use the correct nutrition values.
/:cl:
