### PR TITLE
Adds assault crewman to Valhalla jobs

### DIFF
--- a/code/datums/jobs/job/fallen.dm
+++ b/code/datums/jobs/job/fallen.dm
@@ -73,6 +73,13 @@
 	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_MECH, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
 	outfit = /datum/outfit/job/command/mech_pilot/fallen
 
+/datum/job/fallen/marine/assault_crewman
+	title = ROLE_FALLEN(ASSAULT_CREWMAN)
+	skills_type = /datum/skills/assault_crewman
+	access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_ARMORED, ACCESS_CIVILIAN_PUBLIC)
+	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_ARMORED, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
+	outfit = /datum/outfit/job/command/assault_crewman
+
 /datum/job/fallen/marine/fieldcommander
 	title = ROLE_FALLEN(FIELD_COMMANDER)
 	skills_type = /datum/skills/fo

--- a/code/datums/jobs/job/fallen.dm
+++ b/code/datums/jobs/job/fallen.dm
@@ -78,7 +78,7 @@
 	skills_type = /datum/skills/assault_crewman
 	access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_ARMORED, ACCESS_CIVILIAN_PUBLIC)
 	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_ARMORED, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
-	outfit = /datum/outfit/job/command/assault_crewman
+	outfit = /datum/outfit/job/command/assault_crewman/fallen
 
 /datum/job/fallen/marine/fieldcommander
 	title = ROLE_FALLEN(FIELD_COMMANDER)

--- a/code/datums/outfits/shipside.dm
+++ b/code/datums/outfits/shipside.dm
@@ -167,7 +167,7 @@
 	gloves = /obj/item/clothing/gloves/marine
 	l_pocket = /obj/item/pamphlet/tank_loader
 
-/datum/outfit/job/command/mech_pilot/fallen
+/datum/outfit/job/command/assault_crewman/fallen
 	ears = null
 
 /datum/outfit/job/command/transport_crewman

--- a/code/datums/outfits/shipside.dm
+++ b/code/datums/outfits/shipside.dm
@@ -167,6 +167,9 @@
 	gloves = /obj/item/clothing/gloves/marine
 	l_pocket = /obj/item/pamphlet/tank_loader
 
+/datum/outfit/job/command/mech_pilot/fallen
+	ears = null
+
 /datum/outfit/job/command/transport_crewman
 	name = TRANSPORT_CREWMAN
 	jobtype = /datum/job/terragov/command/transport_crewman


### PR DESCRIPTION

## About The Pull Request
Adds the assault crewman to Valhalla so you can actually use the APCs and tanks.
## Why It's Good For The Game
Since #16941, there wasn't a way to use the tanks in Valhalla since MP was fulfilling this role.
Now you can just be the AC.
## Changelog
:cl:
add: Added assault crewman to Valhalla, allowing you to test tanks and APCs again.
/:cl:
