### PR TITLE
Fix several DB issues

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -17,7 +17,7 @@ Fixed admin rank table flags being capped at 16 in the DB instead of 24 (byond m
 Fixed staminaloss in dead table being unsigned
 
 ```sql
-ALTER TABLE 'admin_ranks'
+ALTER TABLE `admin_ranks`
 	MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
 	MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
 	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -2,17 +2,31 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 2.0; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (2, 2);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (2, 3);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (2, 2);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (2, 3);
 
 In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
+Version 2.3, 04 February 2025, by TiviPlus
+Fixed admin rank table flags being capped at 16 in the DB instead of 24 (byond max)
+Fixed staminaloss in dead table being unsigned
+
+```sql
+ALTER TABLE 'admin_ranks'
+	MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
+	MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
+	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;
+
+ALTER TABLE `death`
+	MODIFY COLUMN 'staminaloss' smallint(5) signed NOT NULL;
+```
+----------------------------------------------------
 Version 2.2, 04 April 2024, by TiviPlus
 Added `tutorial_completions` to mark what ckeys have completed contextual tutorials.
 
-```
+```sql
 CREATE TABLE `tutorial_completions` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `ckey` VARCHAR(32) NOT NULL,
@@ -24,9 +38,9 @@ CREATE TABLE `tutorial_completions` (
 
 Version 2.1, 2 February 2021, by TiviPlus - adds playtime tracking to notes
 Modified table `messages`, adding column `playtime` to show the user's playtime when the note was created
-
+```sql
 ALTER TABLE `messages` ADD `playtime` INT(11) NULL DEFAULT(NULL) AFTER `severity`
-
+```
 ----------------------------------------------------
 
 Version 2.0 13 November 2020, by TiviPlus - Fixed various stickyban ban queries and update with /tg/station style datumized poll handling:
@@ -38,6 +52,7 @@ Added procedure `set_poll_deleted` that's called when deleting a poll to set del
 
 Created missing stickyban tables `stickyban_matched_cid` and `stickyban_matched_ip`, added columm `last_matched` to `stickyban_matched_ckey` and added column `deleted_ckey` to `messages` . These missing was causing queries to fail.
 
+```sql
 ALTER TABLE `stickyban_matched_ckey`
 	ADD COLUMN `last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `first_matched`;
 
@@ -92,7 +107,7 @@ UPDATE `poll_textreply` SET deleted = 1 WHERE pollid = poll_id;
 END
 $$
 DELIMITER ;
-
+```
 ----------------------------------------------------
 
 Version 1.0, 28 February 2018, by LaKiller8 - initial release, inspired by /tg/station schema

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -2,10 +2,13 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 2.0; The query to update the schema revision table is:
 
+```sql
 INSERT INTO `schema_revision` (`major`, `minor`) VALUES (2, 3);
 or
+```
+```sql
 INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (2, 3);
-
+```
 In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -23,7 +23,7 @@ ALTER TABLE `admin_ranks`
 	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;
 
 ALTER TABLE `death`
-	MODIFY COLUMN 'staminaloss' smallint(5) signed NOT NULL;
+	MODIFY COLUMN `staminaloss` smallint(5) signed NOT NULL;
 ```
 ----------------------------------------------------
 Version 2.2, 04 April 2024, by TiviPlus

--- a/SQL/tgmc-schema.sql
+++ b/SQL/tgmc-schema.sql
@@ -36,9 +36,9 @@ CREATE TABLE IF NOT EXISTS `admin_log` (
 -- Dumping structure for table feedback.admin_ranks
 CREATE TABLE IF NOT EXISTS `admin_ranks` (
   `rank` varchar(32) NOT NULL,
-  `flags` smallint(5) unsigned NOT NULL,
-  `exclude_flags` smallint(5) unsigned NOT NULL,
-  `can_edit_flags` smallint(5) unsigned NOT NULL,
+  `flags` mediumint(5) unsigned NOT NULL,
+  `exclude_flags` mediumint(5) unsigned NOT NULL,
+  `can_edit_flags` mediumint(5) unsigned NOT NULL,
   PRIMARY KEY (`rank`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS `death` (
   `oxyloss` smallint(5) unsigned NOT NULL,
   `toxloss` smallint(5) unsigned NOT NULL,
   `cloneloss` smallint(5) unsigned NOT NULL,
-  `staminaloss` smallint(5) unsigned NOT NULL,
+  `staminaloss` smallint(5) NOT NULL,
   `last_words` varchar(255) DEFAULT NULL,
   `suicide` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)

--- a/code/__DEFINES/_subsystems.dm
+++ b/code/__DEFINES/_subsystems.dm
@@ -1,7 +1,7 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 2
-#define DB_MINOR_VERSION 2
+#define DB_MINOR_VERSION 3
 
 //Timing subsystem
 //Don't run if there is an identical unique timer active

--- a/code/datums/jobs/job/special_forces.dm
+++ b/code/datums/jobs/job/special_forces.dm
@@ -7,29 +7,29 @@
 
 //Special forces Standard
 /datum/job/special_forces/standard
-	title = "Special Response Force Standard"
+	title = "Special Force Standard"
 	outfit = /datum/outfit/job/special_forces/standard
 
 
 //Special Force breacher
 /datum/job/special_forces/breacher
-	title = "Special Response Force Breacher"
+	title = "Special Force Breacher"
 	outfit = /datum/outfit/job/special_forces/breacher
 
 
 /datum/job/special_forces/drone_operator
-	title = "Special Response Force Drone Operator"
+	title = "Special Force Drone Operator"
 	outfit = /datum/outfit/job/special_forces/drone_operator
 
 
 //Special forces Medic
 /datum/job/special_forces/medic
-	title = "Special Response Force Medic"
+	title = "Special Force Medic"
 	outfit = /datum/outfit/job/special_forces/medic
 	skills_type = /datum/skills/combat_medic/special_forces
 
 //Special forces Leader
 /datum/job/special_forces/leader
-	title = "Special Response Force Leader"
+	title = "Special Force Leader"
 	skills_type = /datum/skills/sl/pmc/special_forces
 	outfit = /datum/outfit/job/special_forces/leader

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -110,7 +110,7 @@ Good luck, but do not expect to survive."})
 
 //Atmospherics Technician
 /datum/job/survivor/atmos
-	title = "Atmospherics Technician Survivor"
+	title = "Atmos Technician Survivor"
 	skills_type = /datum/skills/civilian/survivor/atmos
 	outfit = /datum/outfit/job/survivor/atmos
 


### PR DESCRIPTION
## About The Pull Request

See https://github.com/tgstation/tgstation/pull/89348 (admin ranks are 2 bytes wide when they should be 3 wide like the max in byond)
Staminaloss can be negative which meant many deaths werent saving
Fixed certain job names exceeding the character limit of job roles (lmao)

```sql
ALTER TABLE `admin_ranks`
	MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
	MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;

ALTER TABLE `death`
	MODIFY COLUMN `staminaloss` smallint(5) signed NOT NULL;
```
## Changelog
:cl:
server: Fixed certain things not saving in the DB
/:cl:
