### PR TITLE
Adds "Toggle Health Scan" verb to spectators

### DIFF
--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -68,10 +68,9 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	START_PROCESSING(SSobj, src)
 
 /obj/item/healthanalyzer/ui_state(mob/user)
-	if(isobserver(user))
-		return GLOB.observer_state
-	else
+	if(!isobserver(user))
 		return GLOB.not_incapacitated_state
+	return GLOB.observer_state
 
 /obj/item/healthanalyzer/process()
 	if(get_turf(src) != get_turf(current_user) || get_dist(get_turf(current_user), get_turf(patient)) > track_distance || patient == current_user)

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -68,10 +68,10 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	START_PROCESSING(SSobj, src)
 
 /obj/item/healthanalyzer/ui_state(mob/user)
-    if(isobserver(user))
-        return GLOB.always_state
-    else
-        return GLOB.not_incapacitated_state
+	if(isobserver(user))
+		return GLOB.always_state
+	else
+		return GLOB.not_incapacitated_state
 
 /obj/item/healthanalyzer/process()
 	if(get_turf(src) != get_turf(current_user) || get_dist(get_turf(current_user), get_turf(patient)) > track_distance || patient == current_user)

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 
 /obj/item/healthanalyzer/ui_state(mob/user)
 	if(isobserver(user))
-		return GLOB.always_state
+		return GLOB.observer_state
 	else
 		return GLOB.not_incapacitated_state
 

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -68,7 +68,10 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	START_PROCESSING(SSobj, src)
 
 /obj/item/healthanalyzer/ui_state(mob/user)
-	return GLOB.not_incapacitated_state
+    if(isobserver(user))
+        return GLOB.always_state
+    else
+        return GLOB.not_incapacitated_state
 
 /obj/item/healthanalyzer/process()
 	if(get_turf(src) != get_turf(current_user) || get_dist(get_turf(current_user), get_turf(patient)) > track_distance || patient == current_user)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -35,6 +35,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/lastsetting = null	//Stores the last setting that ghost_others was set to, for a little more efficiency when we update ghost images. Null means no update is necessary
 
 	var/inquisitive_ghost = FALSE
+	/// Stores variable set in toggle_health_scan.
 	var/health_scan = FALSE
 	var/obj/item/healthanalyzer/integrated/health_analyzer
 	///A weakref to the original corpse of the observer
@@ -116,6 +117,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	QDEL_NULL(orbit_menu)
 	GLOB.observer_list -= src //"wait isnt this done in logout?" Yes it is but because this is clients thats unreliable so we do it again here
 	SSmobs.dead_players_by_zlevel[z] -= src
+
+	QDEL_NULL(health_analyzer)
 
 	return ..()
 
@@ -872,17 +875,20 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	else
 		to_chat(src, span_notice("You will no longer examine things you click on."))
 
+/// Toggle for whether you health-scan living beings on click as observer.
 /mob/dead/observer/verb/toggle_health_scan()
 	set category = "Ghost"
 	set name = "Toggle Health Scan"
 	set desc = "Toggles whether you health-scan living beings on click"
 
 	if(health_scan)
-		to_chat(src, "<span class='notice'>Health scan disabled.</span>")
+		to_chat(src, span_notice("Health scan disabled."))
 		health_scan = FALSE
+		QDEL_NULL(health_analyzer)
 	else
-		to_chat(src, "<span class='notice'>Health scan enabled.</span>")
+		to_chat(src, span_notice("Health scan enabled."))
 		health_scan = TRUE
+		health_analyzer = new()
 
 /mob/dead/observer/verb/join_valhalla()
 	set name = "Join Valhalla"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -37,6 +37,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/inquisitive_ghost = FALSE
 	/// Stores variable set in toggle_health_scan.
 	var/health_scan = FALSE
+	/// Creates health_analyzer to scan with on toggle_health_scan toggle.
 	var/obj/item/healthanalyzer/integrated/health_analyzer
 	///A weakref to the original corpse of the observer
 	var/datum/weakref/can_reenter_corpse

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -35,6 +35,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/lastsetting = null	//Stores the last setting that ghost_others was set to, for a little more efficiency when we update ghost images. Null means no update is necessary
 
 	var/inquisitive_ghost = FALSE
+	var/health_scan = FALSE
+	var/obj/item/healthanalyzer/integrated/health_analyzer
 	///A weakref to the original corpse of the observer
 	var/datum/weakref/can_reenter_corpse
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -869,6 +871,18 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		to_chat(src, span_notice("You will now examine everything you click on."))
 	else
 		to_chat(src, span_notice("You will no longer examine things you click on."))
+
+/mob/dead/observer/verb/toggle_health_scan()
+	set category = "Ghost"
+	set name = "Toggle Health Scan"
+	set desc = "Toggles whether you health-scan living beings on click"
+
+	if(health_scan)
+		to_chat(src, "<span class='notice'>Health scan disabled.</span>")
+		health_scan = FALSE
+	else
+		to_chat(src, "<span class='notice'>Health scan enabled.</span>")
+		health_scan = TRUE
 
 /mob/dead/observer/verb/join_valhalla()
 	set name = "Join Valhalla"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -400,9 +400,3 @@
 	SHOULD_CALL_PARENT(TRUE)
 	SIGNAL_HANDLER
 	return NONE
-
-/mob/living/carbon/attack_ghost(mob/dead/observer/user)
-	if(!user.health_scan)
-		return FALSE
-	user.health_analyzer.analyze_vitals(src, user)
-	return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -400,3 +400,11 @@
 	SHOULD_CALL_PARENT(TRUE)
 	SIGNAL_HANDLER
 	return NONE
+
+/mob/living/carbon/attack_ghost(mob/dead/observer/user)
+	if(!user.health_scan)
+		return FALSE
+	if(isnull(user.health_analyzer))
+		user.health_analyzer = new()
+	user.health_analyzer.analyze_vitals(src, user)
+	return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -404,7 +404,5 @@
 /mob/living/carbon/attack_ghost(mob/dead/observer/user)
 	if(!user.health_scan)
 		return FALSE
-	if(isnull(user.health_analyzer))
-		user.health_analyzer = new()
 	user.health_analyzer.analyze_vitals(src, user)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1126,3 +1126,9 @@
 	if(!do_after(src, get_up_time, IGNORE_LOC_CHANGE|IGNORE_HELD_ITEM, src))
 		return
 	return ..()
+
+/mob/living/carbon/human/attack_ghost(mob/dead/observer/user)
+	if(!user.health_scan)
+		return FALSE
+	user.health_analyzer.analyze_vitals(src, user)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Added "Toggle Health Scan" verb to spectators. Upon enabling will display health scanner UI window to the user.

## Why It's Good For The Game

Useful functionality for spectators and admins.

## Changelog

:cl: The_Man
add: Added new verb "Toggle Health Scan" for spectators.
qol: If "Toggle Health Scan" is enabled, spectators will health scan on click.
/:cl: