### PR TITLE
disposable nerf

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -320,8 +320,8 @@
 /datum/ammo/rocket/oneuse
 	name = "explosive rocket"
 	damage = 100
-	penetration = 100
-	sundering = 100
+	penetration = 50
+	sundering = 25
 	max_range = 30
 
 /datum/ammo/rocket/som


### PR DESCRIPTION

## About The Pull Request
Disposable AP down from 100 to 50.
Sunder down from 100 to 25.
## Why It's Good For The Game
Disposable was doing more damage than HE sadar, which is wew as fuck when they're easily spammable.
Also 100 sunder is in general, fucking horrible.
## Changelog
:cl:
balance: Disposable AP and sunder reduced from 100 and 100, to 50 and 25
/:cl:
