### PR TITLE
Nerfs VP78 (Pistol Seasonal) to be only slight better than VP70 (Default)

### DIFF
--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -96,11 +96,10 @@
 /datum/ammo/bullet/pistol/squash
 	name = "squash-head pistol bullet"
 	hud_state = "pistol_squash"
-	accuracy = 5
-	damage = 32
+	damage = 24
 	penetration = 10
 	shrapnel_chance = 25
-	sundering = 2
+	sundering = 0.75
 
 /datum/ammo/bullet/pistol/mankey
 	name = "live monkey"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -573,6 +573,7 @@
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 3
+	aim_slowdown = 0.2
 
 /obj/item/weapon/gun/pistol/vp78/pmc
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/gyro, /obj/item/attachable/compensator)


### PR DESCRIPTION
## About The Pull Request
Nerfs VP78 from the pistol seasonal:
- 32 damage -> 24 damage (+4 above VP70)
- 2 sunder -> 0.75 sunder (+0.25 above VP70)
- 0 aimmode slowdown -> 0.2 aimmode slowdown (same as VP70)
- 5 accuracy -> 0 accuracy (same as VP70)

## Why It's Good For The Game
Most, if not all, pistols from the pistol season are straight upgrades and even go further than that into overpowered tier. Given that you can aimmode with a pistol, any consistently strong pistols can and will bring back issues regarding aim mode in death balls.

## Changelog
:cl:
balance: VP78, the pistol seasonal, is now only slightly better than VP70, the pistol always available, rather than immensely better.
/:cl:
