### PR TITLE
Removes VP78 as a pistol seasonal

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -263,8 +263,6 @@ SUBSYSTEM_DEF(persistence)
 	item_list = list(
 		/obj/item/weapon/gun/pistol/g22 = -1,
 		/obj/item/ammo_magazine/pistol/g22 = -1,
-		/obj/item/weapon/gun/pistol/vp78 = -1,
-		/obj/item/ammo_magazine/pistol/vp78 = -1,
 		/obj/item/weapon/gun/pistol/heavy = -1,
 		/obj/item/ammo_magazine/pistol/heavy = -1,
 		/obj/item/weapon/gun/pistol/highpower = -1,

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -259,7 +259,7 @@ SUBSYSTEM_DEF(persistence)
 
 /datum/season_datum/weapons/guns/pistol_seasonal_two
 	name = "G22 and high-power gats"
-	description = "Four pistols for the pistol mains."
+	description = "Three pistols for the pistol mains."
 	item_list = list(
 		/obj/item/weapon/gun/pistol/g22 = -1,
 		/obj/item/ammo_magazine/pistol/g22 = -1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes VP78 as a pistol seasonal.
Alternative to #17041.

## Why It's Good For The Game
It has more damage, more sunder, more accuracy, and it has no slowdown while using aimmode. Ignoring the fact that it is a consistently high damage weapon that you can attach a pistol lace and shoot freely with as one of the remaining guns with aimmode, it is a straight upgrade from the VP70 which comes available to all marines.

## Changelog
:cl:
del: Removes VP78 from the pistol seasonal.
/:cl:
