### PR TITLE
Add ping topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -77,3 +77,14 @@
 	.["hard_popcap"] = CONFIG_GET(number/hard_popcap) || 0
 	.["extreme_popcap"] = CONFIG_GET(number/extreme_popcap) || 0
 	.["popcap"] = max(CONFIG_GET(number/soft_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/extreme_popcap)) //generalized field for this concept for use across ss13 codebases
+
+
+/datum/world_topic/ping
+	keyword = "ping"
+	log = FALSE
+
+
+/datum/world_topic/ping/Run(list/input)
+	. = 0
+	for (var/client/C in GLOB.clients)
+		++.


### PR DESCRIPTION
## About The Pull Request

Adds a ping topic. This will help with haproxy health checks since it's cheaper than polling status

(PS I haven't compiled or tested this but it should be fine probably, if you test it for me I will love you forever)