### PR TITLE
Laser Rifle and MG lose rail scope

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -245,7 +245,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 40
+	damage = 35
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_heavy"

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -245,7 +245,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 35
+	damage = 40
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_heavy"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -468,7 +468,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.2
+	damage_falloff_mult = 0.6
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -568,7 +568,7 @@
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	damage_falloff_mult = 0.2
+	damage_falloff_mult = 0.7
 	aim_slowdown = 0
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_pistol_mode/standard,
@@ -659,7 +659,7 @@
 	autoburst_delay = 0.35 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.65
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.7
 	movement_acc_penalty_mult = 4
 	mode_list = list(
 		"Auto burst standard" = /datum/lasrifle/energy_carbine_mode/auto_burst,
@@ -788,6 +788,7 @@
 	scatter = -4
 	scatter_unwielded = 10
 	fire_delay = 0.8 SECONDS
+	damage_falloff_mult = 0.5
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.5
 	movement_acc_penalty_mult = 6
@@ -890,7 +891,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.3
+	damage_falloff_mult = 0.6
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -467,7 +467,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.2
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -567,7 +567,7 @@
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	damage_falloff_mult = 0.7
+	damage_falloff_mult = 0.2
 	aim_slowdown = 0
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_pistol_mode/standard,
@@ -658,7 +658,7 @@
 	autoburst_delay = 0.35 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.65
-	damage_falloff_mult = 0.7
+	damage_falloff_mult = 0.5
 	movement_acc_penalty_mult = 4
 	mode_list = list(
 		"Auto burst standard" = /datum/lasrifle/energy_carbine_mode/auto_burst,
@@ -787,7 +787,6 @@
 	scatter = -4
 	scatter_unwielded = 10
 	fire_delay = 0.8 SECONDS
-	damage_falloff_mult = 0.5
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.5
 	movement_acc_penalty_mult = 6
@@ -889,7 +888,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.3
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -446,7 +446,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
@@ -468,7 +467,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.6
+	damage_falloff_mult = 0.5
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -865,7 +864,6 @@
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/weapon/gun/flamer/mini_flamer,
@@ -891,7 +889,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.6
+	damage_falloff_mult = 0.5
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,


### PR DESCRIPTION
## About The Pull Request

Tittle

## Why It's Good For The Game

~~Laser guns were balanced with no aim mode in mind, so they had better stats overall + hitscan, however following the deletium of aim mode, they, despite not having aim mode, got shoulder fire as well, making them overtuned compared to ballistics.
This should put them in line as having better handling than ballistics but a bit higher falloff to make up for hitscan~~ 

Shoulder fire is gone so falloff changes are no longer needed

Rifle and MG lose rail scope, I don't think they should have this since hitscan is a thing

## Changelog

:cl:
balance: Laser Rifle and MG can no longer equip rail scope
/:cl:
