### PR TITLE
Buffs standard SMGs overall

### DIFF
--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -44,8 +44,8 @@
 	damage = 15
 	penetration = 15
 	armor_type = BOMB
-	sundering = 0.5
-	damage_falloff = 1.7
+	sundering = 1
+	damage_falloff = 2.0
 	shrapnel_chance = 0
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 3 SECONDS
@@ -83,7 +83,7 @@
 
 /datum/ammo/bullet/smg/heavy
 	name = "heavy submachinegun bullet"
-	damage = 22.5
+	damage = 27.5
 	penetration = 10
 	sundering = 1
 

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -45,7 +45,7 @@
 	penetration = 15
 	armor_type = BOMB
 	sundering = 1
-	damage_falloff = 2.0
+	damage_falloff = 2
 	shrapnel_chance = 0
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 3 SECONDS
@@ -86,4 +86,3 @@
 	damage = 27.5
 	penetration = 10
 	sundering = 1
-

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -11,9 +11,9 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 7
 	accuracy_var_high = 7
-	damage = 15
+	damage = 17.5
 	accurate_range = 4
-	damage_falloff = 1.4
+	damage_falloff = 1
 	sundering = 0.5
 	penetration = 5
 
@@ -83,7 +83,7 @@
 
 /datum/ammo/bullet/smg/heavy
 	name = "heavy submachinegun bullet"
-	damage = 20
+	damage = 22.5
 	penetration = 10
 	sundering = 1
-	damage_falloff = 1.2
+

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -11,9 +11,9 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 7
 	accuracy_var_high = 7
-	damage = 20
+	damage = 15
 	accurate_range = 4
-	damage_falloff = 1
+	damage_falloff = 1.4
 	sundering = 0.5
 	penetration = 5
 
@@ -45,7 +45,7 @@
 	penetration = 15
 	armor_type = BOMB
 	sundering = 1
-	damage_falloff = 2
+	damage_falloff = 1.7
 	shrapnel_chance = 0
 	///shatter effection duration when hitting mobs
 	var/shatter_duration = 3 SECONDS
@@ -83,6 +83,7 @@
 
 /datum/ammo/bullet/smg/heavy
 	name = "heavy submachinegun bullet"
-	damage = 27.5
+	damage = 20
 	penetration = 10
 	sundering = 1
+	damage_falloff = 1.2

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -11,7 +11,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 7
 	accuracy_var_high = 7
-	damage = 17.5
+	damage = 20
 	accurate_range = 4
 	damage_falloff = 1
 	sundering = 0.5
@@ -44,7 +44,7 @@
 	damage = 15
 	penetration = 15
 	armor_type = BOMB
-	sundering = 1
+	sundering = 0.5
 	damage_falloff = 1.7
 	shrapnel_chance = 0
 	///shatter effection duration when hitting mobs

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -42,7 +42,7 @@
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_mp19.ogg'
 	caliber = CALIBER_10X20_CASELESS //codex
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
-	max_shells = 30 //codex
+	max_shells = 45 //codex
 	equip_slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	type_of_casings = null
 	default_ammo_type = /obj/item/ammo_magazine/smg/standard_machinepistol
@@ -72,7 +72,7 @@
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.9
 	recoil_unwielded = 0
-	fire_delay = 0.10 SECONDS
+	fire_delay = 0.15 SECONDS
 
 	scatter = 0
 	scatter_unwielded = 4
@@ -104,7 +104,7 @@
 	icon_state = "t90"
 	worn_icon_state = "t90"
 	caliber = CALIBER_10X20_CASELESS //codex
-	max_shells = 50 //codex
+	max_shells = 80 //codex
 	equip_slot_flags = ITEM_SLOT_BACK
 	wield_delay = 0.7 SECONDS
 	force = 20
@@ -134,7 +134,7 @@
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.9
 	scatter = 1
-	fire_delay = 0.10 SECONDS
+	fire_delay = 0.15 SECONDS
 	scatter_unwielded = 8
 	aim_slowdown = 0.2
 	burst_amount = 0
@@ -160,7 +160,7 @@
 	icon_state = "t45"
 	worn_icon_state = "t45"
 	caliber = CALIBER_41AE //codex
-	max_shells = 40 //codex
+	max_shells = 55 //codex
 	fire_sound = 'sound/weapons/guns/fire/skorpevo.ogg'
 	unload_sound = 'sound/weapons/guns/interact/mp5_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/mp5_reload.ogg'
@@ -198,7 +198,7 @@
 	aim_slowdown = 0.25
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.20 SECONDS
 	burst_delay =  0.2 SECONDS
 	burst_amount = 3
 	scatter = 2

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -198,7 +198,7 @@
 	aim_slowdown = 0.25
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
-	fire_delay = 0.20 SECONDS
+	fire_delay = 0.25 SECONDS
 	burst_delay =  0.2 SECONDS
 	burst_amount = 3
 	scatter = 2

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -72,7 +72,7 @@
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.9
 	recoil_unwielded = 0
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.10 SECONDS
 
 	scatter = 0
 	scatter_unwielded = 4
@@ -134,7 +134,7 @@
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.9
 	scatter = 1
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.10 SECONDS
 	scatter_unwielded = 8
 	aim_slowdown = 0.2
 	burst_amount = 0
@@ -198,7 +198,7 @@
 	aim_slowdown = 0.25
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.15 SECONDS
 	burst_delay =  0.2 SECONDS
 	burst_amount = 3
 	scatter = 2

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -205,8 +205,8 @@
 	caliber = CALIBER_10X20_CASELESS
 	default_ammo = /datum/ammo/bullet/smg
 	w_class = WEIGHT_CLASS_SMALL
-	current_rounds = 150
-	max_rounds = 150
+	current_rounds = 240
+	max_rounds = 240
 
 /obj/item/ammo_magazine/packet/p4570
 	name = "packet of .45-70"
@@ -236,8 +236,8 @@
 	icon_state = "41AE"
 	default_ammo = /datum/ammo/bullet/smg/heavy
 	w_class = WEIGHT_CLASS_SMALL
-	current_rounds = 160
-	max_rounds = 160
+	current_rounds = 165
+	max_rounds = 165
 
 /obj/item/ammo_magazine/packet/p41ae_squashhead
 	name = "packet of .41 AE squashhead"
@@ -246,5 +246,5 @@
 	icon_state = "41AE_squash"
 	default_ammo = /datum/ammo/bullet/smg/squash
 	w_class = WEIGHT_CLASS_SMALL
-	current_rounds = 160
-	max_rounds = 160
+	current_rounds = 165
+	max_rounds = 165

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -40,7 +40,7 @@
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t19"
 	icon_state_mini = "mag_smg"
-	max_rounds = 35
+	max_rounds = 45
 	w_class = WEIGHT_CLASS_SMALL
 
 //-------------------------------------------------------
@@ -51,7 +51,7 @@
 	desc = "A 10x20mm caseless submachine gun magazine."
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t90"
-	max_rounds = 60
+	max_rounds = 80
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state_mini = "mag_t90"
 
@@ -64,7 +64,7 @@
 	default_ammo = /datum/ammo/bullet/smg/heavy
 	caliber = CALIBER_41AE
 	icon_state = "t45"
-	max_rounds = 45
+	max_rounds = 55
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state_mini = "mag_heavy_smg"
 	bonus_overlay = "t45_mag"

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -40,7 +40,7 @@
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t19"
 	icon_state_mini = "mag_smg"
-	max_rounds = 30
+	max_rounds = 35
 	w_class = WEIGHT_CLASS_SMALL
 
 //-------------------------------------------------------
@@ -51,7 +51,7 @@
 	desc = "A 10x20mm caseless submachine gun magazine."
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t90"
-	max_rounds = 50
+	max_rounds = 60
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state_mini = "mag_t90"
 
@@ -64,7 +64,7 @@
 	default_ammo = /datum/ammo/bullet/smg/heavy
 	caliber = CALIBER_41AE
 	icon_state = "t45"
-	max_rounds = 40
+	max_rounds = 45
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state_mini = "mag_heavy_smg"
 	bonus_overlay = "t45_mag"


### PR DESCRIPTION
## About The Pull Request

Buffs the machine pistol, standard smg and heavy smg

## Why It's Good For The Game

These guns have fallen off pretty hard post xeno buffs. Although, in general, buffing things in response to other things is powercrepe and bad, I do think these three need it.

Overall, they have better ammo economy thanks to increased mag sizes.

Ammo packets have been adjusted according to the mag increases
## Changelog

:cl:
balance: The marine standard smg, heavy smg and machine pistol's mag sizes have been increased
balance: The ammo packets for the smgs have had their total bullet count increased
/:cl:
