### PR TITLE
Removes Shoulder Fire from the game

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -245,7 +245,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 40
+	damage = 35
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_heavy"

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -245,7 +245,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 35
+	damage = 40
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_heavy"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -468,7 +468,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.2
+	damage_falloff_mult = 0.6
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -568,7 +568,7 @@
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	damage_falloff_mult = 0.2
+	damage_falloff_mult = 0.7
 	aim_slowdown = 0
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_pistol_mode/standard,
@@ -659,7 +659,7 @@
 	autoburst_delay = 0.35 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.65
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.7
 	movement_acc_penalty_mult = 4
 	mode_list = list(
 		"Auto burst standard" = /datum/lasrifle/energy_carbine_mode/auto_burst,
@@ -788,6 +788,7 @@
 	scatter = -4
 	scatter_unwielded = 10
 	fire_delay = 0.8 SECONDS
+	damage_falloff_mult = 0.5
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.5
 	movement_acc_penalty_mult = 6
@@ -890,7 +891,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.3
+	damage_falloff_mult = 0.6
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -446,7 +446,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
@@ -468,7 +467,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.6
+	damage_falloff_mult = 0.5
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -865,7 +864,6 @@
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/weapon/gun/flamer/mini_flamer,
@@ -891,7 +889,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.6
+	damage_falloff_mult = 0.5
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -446,6 +446,7 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
@@ -467,7 +468,7 @@
 	scatter_unwielded = 10
 	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.55
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.2
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_rifle_mode/standard,
 		"Overcharge" = /datum/lasrifle/energy_rifle_mode/overcharge,
@@ -567,7 +568,7 @@
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	damage_falloff_mult = 0.7
+	damage_falloff_mult = 0.5
 	aim_slowdown = 0
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_pistol_mode/standard,
@@ -787,7 +788,6 @@
 	scatter = -4
 	scatter_unwielded = 10
 	fire_delay = 0.8 SECONDS
-	damage_falloff_mult = 0.5
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.5
 	movement_acc_penalty_mult = 6
@@ -864,6 +864,7 @@
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/weapon/gun/flamer/mini_flamer,
@@ -889,7 +890,7 @@
 	accuracy_mult_unwielded = 0.3
 	scatter_unwielded = 30
 	movement_acc_penalty_mult = 6
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.3
 	windup_sound = 'sound/weapons/guns/fire/laser_charge_up.ogg'
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_mg_mode/standard,

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -829,7 +829,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return ..()
 
 /mob/living/carbon/human/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if((wear_id?.iff_signal & proj.iff_signal) || (proj?.firer?.faction == faction && proj.original_target != src && Adjacent(proj.firer)))
+	if((wear_id?.iff_signal & proj.iff_signal))
 		proj.damage -= proj.damage*proj.damage_marine_falloff
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Tittle

## Why It's Good For The Game

Allows too much meme potential with stacking weapons, and although said weapons are fine otherwise, if shoulder fire remains in the game they'd have to be nerfed because of it

## Changelog

:cl:
balance: Shoulder fire has been removed from the game
/:cl:
