### PR TITLE
Removes shoulder fire from the game

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -829,7 +829,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return ..()
 
 /mob/living/carbon/human/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if((wear_id?.iff_signal & proj.iff_signal) || (proj?.firer?.faction == faction && proj.original_target != src && Adjacent(proj.firer)))
+	if((wear_id?.iff_signal & proj.iff_signal))
 		proj.damage -= proj.damage*proj.damage_marine_falloff
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Tittle

## Why It's Good For The Game

Allows too much meme potential with stacking weapons, and although said weapons are fine otherwise, if shoulder fire remains in the game they'd have to be nerfed because of it

## Changelog

:cl:
balance: Shoulder fire has been removed from the game
/:cl:
