### PR TITLE
Readds siloless collapse, now only happens with no silos and decorrupted gens

### DIFF
--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -86329,7 +86329,7 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/spaceport/cuppajoes)
 "pjO" = (
-/obj/machinery/power/geothermal,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/electical_systems/substation2)
 "pjQ" = (
@@ -94882,8 +94882,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/northeast)
 "qKo" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/electical_systems/substation2)
 "qKr" = (

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -24420,11 +24420,7 @@
 "bzC" = (
 /obj/effect/turf_decal/warning_stripes,
 /obj/structure/cable,
-/obj/machinery/power/geothermal{
-	desc = "A thermoelectric generator fueled by searing hot uranium!";
-	fail_rate = 5;
-	name = "thermoelectric generator"
-	},
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "bzD" = (

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -59047,8 +59047,8 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
 "wTo" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/interior/east_engineering)
 "wTu" = (

--- a/_maps/map_files/kutjevo/kutjevo.dmm
+++ b/_maps/map_files/kutjevo/kutjevo.dmm
@@ -1052,8 +1052,8 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/kutjevo/exterior/complex_border/botany_medical_cave)
 "bkn" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
 "bks" = (
@@ -9469,8 +9469,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
 "ksj" = (

--- a/_maps/map_files/lavaoutpost/LavaOutpost.dmm
+++ b/_maps/map_files/lavaoutpost/LavaOutpost.dmm
@@ -163,8 +163,8 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/north)
 "bM" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/one)
 "bP" = (
@@ -2852,17 +2852,17 @@
 /turf/open/floor/plating,
 /area/lavaland/cave/central)
 "Ew" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/three)
 "Ey" = (
 /turf/open/floor/tile/white,
 /area/lavaland/security)
 "Ez" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/three)
 "EB" = (
@@ -3035,9 +3035,9 @@
 /turf/closed/wall,
 /area/lavaland/cave/west)
 "Gg" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/one)
 "Gh" = (
@@ -3895,8 +3895,8 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/central)
 "Qc" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/two)
 "Qi" = (
@@ -3904,11 +3904,11 @@
 /turf/open/liquid/lava/autosmoothing,
 /area/lavaland/lava)
 "Qm" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/two)
 "Qt" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -1033,7 +1033,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "RD" = (
-/obj/machinery/power/geothermal/bigred,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering/east)
 "RW" = (

--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -33,6 +33,8 @@
 
 #define COMSIG_GLOB_SHIP_SELF_DESTRUCT_ACTIVATED "!ship_self_destruct_activated"
 
+#define COMSIG_GLOB_SILOLESS_COLLAPSE "!siloless_collapse"
+
 /// from /obj/machinery/setAnchored(): (machine, anchoredstate)
 #define COMSIG_GLOB_MACHINERY_ANCHORED_CHANGE "!machinery_anchored_change"
 /// called after a successful var edit somewhere in the world: (list/args)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -531,6 +531,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define XENO_ACID_WELL_MAX_CHARGES 5 //Maximum number of charges for the acid well
 
 #define HIVE_CAN_HIJACK (1<<0)
+#define HIVE_CAN_COLLAPSE_FROM_SILO (1<<1)
 
 #define XENO_PULL_CHARGE_TIME 2 SECONDS
 #define XENO_SLOWDOWN_REGEN 0.4

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -95,6 +95,7 @@
 
 //Nuclear war mode collapse duration
 #define NUCLEAR_WAR_ORPHAN_HIVEMIND 5 MINUTES
+#define NUCLEAR_WAR_SILO_COLLAPSE 5 MINUTES
 
 #define SHUTTLE_HIJACK_LOCK 30 MINUTES
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -358,15 +358,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 /datum/game_mode/proc/get_hivemind_collapse_countdown()
 	return
 
-/datum/game_mode/proc/siloless_hive_collapse()
-	return
-
-/datum/game_mode/proc/update_silo_death_timer(datum/hive_status/silo_owner)
-	return
-
-/datum/game_mode/proc/get_siloless_collapse_countdown()
-	return
-
 ///Provides the amount of time left before the game ends, used for the stat panel
 /datum/game_mode/proc/game_end_countdown()
 	return

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -358,6 +358,15 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 /datum/game_mode/proc/get_hivemind_collapse_countdown()
 	return
 
+/datum/game_mode/proc/siloless_hive_collapse()
+	return
+
+/datum/game_mode/proc/update_silo_death_timer(datum/hive_status/silo_owner)
+	return
+
+/datum/game_mode/proc/get_siloless_collapse_countdown()
+	return
+
 ///Provides the amount of time left before the game ends, used for the stat panel
 /datum/game_mode/proc/game_end_countdown()
 	return

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -64,7 +64,6 @@
 	if(round_stage == INFESTATION_MARINE_CRASHING)
 		round_finished = MODE_INFESTATION_M_MINOR
 		return
-	round_finished = MODE_INFESTATION_M_MAJOR
 
 /datum/game_mode/infestation/nuclear_war/get_hivemind_collapse_countdown()
 	var/eta = timeleft(orphan_hive_timer) MILLISECONDS
@@ -75,6 +74,11 @@
 		return
 
 	//handle potential stopping
+	if(round_stage != INFESTATION_MARINE_DEPLOYMENT)
+		if(siloless_hive_timer)
+			deltimer(siloless_hive_timer)
+			siloless_hive_timer = null
+		return
 	if(length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]))
 		if(siloless_hive_timer)
 			deltimer(siloless_hive_timer)

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -36,6 +36,7 @@
 		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
+	//Timer for xenos collapsing when they have no silo or corrupted generators.
 	var/siloless_hive_timer
 
 /datum/game_mode/infestation/nuclear_war/post_setup()
@@ -69,7 +70,8 @@
 	var/eta = timeleft(orphan_hive_timer) MILLISECONDS
 	return !isnull(eta) ? round(eta) : 0
 
-/datum/game_mode/infestation/nuclear_war/update_silo_death_timer(datum/hive_status/silo_owner)
+//This starts and stops the siloless collapse timer
+/datum/game_mode/infestation/nuclear_war/proc/update_silo_death_timer(datum/hive_status/silo_owner)
 	if(!(silo_owner.hive_flags & HIVE_CAN_COLLAPSE_FROM_SILO))
 		return
 
@@ -98,7 +100,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SILOLESS_COLLAPSE)
 
 ///called by [/proc/update_silo_death_timer] after [NUCLEAR_WAR_SILO_COLLAPSE] elapses to end the round
-/datum/game_mode/infestation/nuclear_war/siloless_hive_collapse()
+/datum/game_mode/infestation/nuclear_war/proc/siloless_hive_collapse()
 	if(!(round_type_flags & MODE_INFESTATION))
 		return
 	if(round_finished)
@@ -107,7 +109,8 @@
 		return
 	round_finished = MODE_INFESTATION_M_MAJOR
 
-/datum/game_mode/infestation/nuclear_war/get_siloless_collapse_countdown()
+//Gets the siloless collapse timer in miliseconds for the hud timer.
+/datum/game_mode/infestation/nuclear_war/proc/get_siloless_collapse_countdown()
 	var/eta = timeleft(siloless_hive_timer) MILLISECONDS
 	return !isnull(eta) ? round(eta) : 0
 

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -37,7 +37,6 @@
 		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
 	var/siloless_hive_timer
-	deploy_time_lock = 15 SECONDS
 
 /datum/game_mode/infestation/nuclear_war/post_setup()
 	. = ..()
@@ -90,7 +89,7 @@
 	if(siloless_hive_timer)
 		return
 
-	silo_owner.xeno_message("We don't have any silos or corrupted generators! The hive will collapse if nothing is done", "xenoannounce", 6, TRUE)
+	silo_owner.xeno_message("We don't have any silos or corrupted generators! The hive will collapse if nothing is done.", "xenoannounce", 6, TRUE)
 	siloless_hive_timer = addtimer(CALLBACK(src, PROC_REF(siloless_hive_collapse)), NUCLEAR_WAR_SILO_COLLAPSE, TIMER_STOPPABLE)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SILOLESS_COLLAPSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -924,7 +924,7 @@ to_chat will check for valid clients itself already so no need to double check f
 		return
 	if(!(SSticker.mode?.round_type_flags & MODE_XENO_RULER))
 		return
-	if(SSmonitor.gamestate == SHUTTERS_CLOSED) //don't trigger orphan hivemind if the shutters are closed
+	if(SSmonitor.gamestate != SHIPSIDE) //orphan hivemind will only happen during shipside.
 		return
 	var/datum/game_mode/infestation/D = SSticker.mode
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -96,8 +96,10 @@
 
 	var/hivemind_countdown = SSticker.mode?.get_hivemind_collapse_countdown()
 	.["hive_orphan_collapse"] = !isnull(hivemind_countdown) ? hivemind_countdown : 0
-	var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
-	var/siloless_countdown = mode.get_siloless_collapse_countdown()
+	var/siloless_countdown
+	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+		var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+		siloless_countdown = mode.get_siloless_collapse_countdown()
 	.["hive_silo_collapse"] = !isnull(siloless_countdown) ? siloless_countdown : 0
 	// Show all the death timers in milliseconds
 	.["hive_death_timers"] = list()
@@ -900,6 +902,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	hive_flags = HIVE_CAN_HIJACK|HIVE_CAN_COLLAPSE_FROM_SILO
 	/// Timer ID for the orphan hive timer
 	var/atom/movable/screen/text/screen_timer/orphan_hud_timer
+	/// Timer ID for the siloless collapse hud timer
 	var/atom/movable/screen/text/screen_timer/siloless_hud_timer
 
 /datum/hive_status/normal/New()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -96,7 +96,8 @@
 
 	var/hivemind_countdown = SSticker.mode?.get_hivemind_collapse_countdown()
 	.["hive_orphan_collapse"] = !isnull(hivemind_countdown) ? hivemind_countdown : 0
-	var/siloless_countdown = SSticker.mode?.get_siloless_collapse_countdown()
+	var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+	var/siloless_countdown = mode.get_siloless_collapse_countdown()
 	.["hive_silo_collapse"] = !isnull(siloless_countdown) ? siloless_countdown : 0
 	// Show all the death timers in milliseconds
 	.["hive_death_timers"] = list()
@@ -942,6 +943,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 	orphan_hud_timer = new(null, null, get_all_xenos(), D.orphan_hive_timer, "Orphan Hivemind Collapse: ${timer}", 150, -80)
 
+//This creates the hud timer for siloless collapse.
 /datum/hive_status/normal/proc/setup_siloless_hud_timer()
 	SIGNAL_HANDLER
 	var/datum/game_mode/infestation/nuclear_war/D = SSticker.mode
@@ -1069,7 +1071,9 @@ to_chat will check for valid clients itself already so no need to double check f
 
 
 /datum/hive_status/normal/on_shuttle_hijack(obj/docking_port/mobile/marine_dropship/hijacked_ship)
-	SSticker.mode.update_silo_death_timer(src)
+	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+		var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+		mode.update_silo_death_timer(src)
 	GLOB.xeno_enter_allowed = FALSE
 	xeno_message("Our Ruler has commanded the metal bird to depart for the metal hive in the sky! Run and board it to avoid a cruel death!")
 	RegisterSignal(hijacked_ship, COMSIG_SHUTTLE_SETMODE, PROC_REF(on_hijack_depart))

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -96,6 +96,8 @@
 
 	var/hivemind_countdown = SSticker.mode?.get_hivemind_collapse_countdown()
 	.["hive_orphan_collapse"] = !isnull(hivemind_countdown) ? hivemind_countdown : 0
+	var/siloless_countdown = SSticker.mode?.get_siloless_collapse_countdown()
+	.["hive_silo_collapse"] = !isnull(siloless_countdown) ? siloless_countdown : 0
 	// Show all the death timers in milliseconds
 	.["hive_death_timers"] = list()
 	// The key for caste_death_timer is the mob's type
@@ -199,6 +201,7 @@
 
 	.["hive_name"] = name
 	.["hive_orphan_max"] = NUCLEAR_WAR_ORPHAN_HIVEMIND MILLISECONDS
+	.["hive_silo_collapse_max"] = NUCLEAR_WAR_SILO_COLLAPSE MILLISECONDS
 
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	.["hive_larva_threshold"] = xeno_job.job_points_needed
@@ -893,17 +896,28 @@ to_chat will check for valid clients itself already so no need to double check f
 // *********** Normal Xenos
 // ***************************************
 /datum/hive_status/normal // subtype for easier typechecking and overrides
-	hive_flags = HIVE_CAN_HIJACK
+	hive_flags = HIVE_CAN_HIJACK|HIVE_CAN_COLLAPSE_FROM_SILO
 	/// Timer ID for the orphan hive timer
 	var/atom/movable/screen/text/screen_timer/orphan_hud_timer
+	var/atom/movable/screen/text/screen_timer/siloless_hud_timer
+
+/datum/hive_status/normal/New()
+	. = ..()
+	RegisterSignals(SSdcs, list(COMSIG_GLOB_SILOLESS_COLLAPSE), PROC_REF(setup_siloless_hud_timer))
+
+/datum/hive_status/normal/Destroy(force, ...)
+	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_SILOLESS_COLLAPSE)
 
 /datum/hive_status/normal/add_xeno(mob/living/carbon/xenomorph/X)
 	. = ..()
 	orphan_hud_timer?.apply_to(X)
+	siloless_hud_timer?.apply_to(X)
 
 /datum/hive_status/normal/remove_xeno(mob/living/carbon/xenomorph/X)
 	. = ..()
 	orphan_hud_timer?.remove_from(X)
+	siloless_hud_timer?.remove_from(X)
 
 /datum/hive_status/normal/handle_ruler_timer()
 	if(!isinfestationgamemode(SSticker.mode)) //Check just need for unit test
@@ -927,6 +941,11 @@ to_chat will check for valid clients itself already so no need to double check f
 	D.orphan_hive_timer = addtimer(CALLBACK(D, TYPE_PROC_REF(/datum/game_mode, orphan_hivemind_collapse)), NUCLEAR_WAR_ORPHAN_HIVEMIND, TIMER_STOPPABLE)
 
 	orphan_hud_timer = new(null, null, get_all_xenos(), D.orphan_hive_timer, "Orphan Hivemind Collapse: ${timer}", 150, -80)
+
+/datum/hive_status/normal/proc/setup_siloless_hud_timer()
+	SIGNAL_HANDLER
+	var/datum/game_mode/infestation/nuclear_war/D = SSticker.mode
+	siloless_hud_timer = new(null, null, get_all_xenos() , D.siloless_hive_timer, "Siloless Collapse: ${timer}")
 
 /datum/hive_status/normal/burrow_larva(mob/living/carbon/xenomorph/larva/L)
 	if(!is_ground_level(L.z))
@@ -1050,6 +1069,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 
 /datum/hive_status/normal/on_shuttle_hijack(obj/docking_port/mobile/marine_dropship/hijacked_ship)
+	SSticker.mode.update_silo_death_timer(src)
 	GLOB.xeno_enter_allowed = FALSE
 	xeno_message("Our Ruler has commanded the metal bird to depart for the metal hive in the sky! Run and board it to avoid a cruel death!")
 	RegisterSignal(hijacked_ship, COMSIG_SHUTTLE_SETMODE, PROC_REF(on_hijack_depart))

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -352,6 +352,8 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	is_on = FALSE
 	if(is_ground_level(z))
 		GLOB.corrupted_generators += 1
+	if(SSticker.mode)
+		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
 	power_gen_percent = 0
 	cur_tick = 0
 	icon_state = "off"

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -46,7 +46,9 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 		GLOB.generators_on_ground -= 1
 	if(corrupted && is_ground_level(z))
 		GLOB.corrupted_generators -= 1
-		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
+	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+		var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+		mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 	return ..()
 
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
@@ -264,7 +266,9 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 		cut_overlay(GLOB.welding_sparks)
 		if(is_ground_level(z))
 			GLOB.corrupted_generators -= 1
-			SSticker.mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
+		if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+			var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+			mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 		corrupted = 0
 		stop_processing()
 		update_icon()
@@ -352,8 +356,9 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	is_on = FALSE
 	if(is_ground_level(z))
 		GLOB.corrupted_generators += 1
-	if(SSticker.mode)
-		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
+	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+		var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+		mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 	power_gen_percent = 0
 	cur_tick = 0
 	icon_state = "off"

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -4,6 +4,7 @@
 #define GEOTHERMAL_HEAVY_DAMAGE 3
 
 GLOBAL_VAR_INIT(generators_on_ground, 0)
+GLOBAL_VAR_INIT(corrupted_generators, 0)
 
 /obj/machinery/power/geothermal
 	name = "\improper G-11 geothermal generator"
@@ -43,6 +44,9 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 /obj/machinery/power/geothermal/Destroy() //just in case
 	if(is_ground_level(z))
 		GLOB.generators_on_ground -= 1
+	if(corrupted && is_ground_level(z))
+		GLOB.corrupted_generators -= 1
+		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 	return ..()
 
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
@@ -258,6 +262,9 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 		user.visible_message(span_notice("[user] burns [src]'s resin off."),
 		span_notice("You burn [src]'s resin off."))
 		cut_overlay(GLOB.welding_sparks)
+		if(is_ground_level(z))
+			GLOB.corrupted_generators -= 1
+			SSticker.mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 		corrupted = 0
 		stop_processing()
 		update_icon()
@@ -343,6 +350,8 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 /obj/machinery/power/geothermal/proc/corrupt(hivenumber)
 	corrupted = hivenumber
 	is_on = FALSE
+	if(is_ground_level(z))
+		GLOB.corrupted_generators += 1
 	power_gen_percent = 0
 	cur_tick = 0
 	icon_state = "off"

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -41,7 +41,9 @@
 		RegisterSignals(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), PROC_REF(is_burrowed_larva_host))
 		if(length(GLOB.xeno_resin_silos_by_hive[hivenumber]) == 1)
 			GLOB.hive_datums[hivenumber].give_larva_to_next_in_queue()
-		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
+	if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+		var/datum/game_mode/infestation/nuclear_war/mode = SSticker.mode
+		mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
 	var/turf/tunnel_turf = get_step(src, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/xeno/tunnel/newt = new(tunnel_turf, hivenumber)
@@ -57,7 +59,8 @@
 	if(GLOB.hive_datums[hivenumber])
 		UnregisterSignal(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
 		GLOB.hive_datums[hivenumber].xeno_message("A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", "xenoannounce", 5, FALSE, loc, 'sound/voice/alien/help2.ogg',FALSE , null, /atom/movable/screen/arrow/silo_damaged_arrow)
-		INVOKE_NEXT_TICK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode, update_silo_death_timer), GLOB.hive_datums[hivenumber]) // checks all silos next tick after this one is gone
+		if(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN)
+			INVOKE_NEXT_TICK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode/infestation/nuclear_war, update_silo_death_timer), GLOB.hive_datums[hivenumber]) // checks all silos next tick after this one is gone
 		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 		playsound(loc,'sound/effects/alien/egg_burst.ogg', 75)
 	return ..()

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -41,6 +41,7 @@
 		RegisterSignals(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), PROC_REF(is_burrowed_larva_host))
 		if(length(GLOB.xeno_resin_silos_by_hive[hivenumber]) == 1)
 			GLOB.hive_datums[hivenumber].give_larva_to_next_in_queue()
+		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
 	var/turf/tunnel_turf = get_step(src, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/xeno/tunnel/newt = new(tunnel_turf, hivenumber)
@@ -56,6 +57,7 @@
 	if(GLOB.hive_datums[hivenumber])
 		UnregisterSignal(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
 		GLOB.hive_datums[hivenumber].xeno_message("A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", "xenoannounce", 5, FALSE, loc, 'sound/voice/alien/help2.ogg',FALSE , null, /atom/movable/screen/arrow/silo_damaged_arrow)
+		INVOKE_NEXT_TICK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode, update_silo_death_timer), GLOB.hive_datums[hivenumber]) // checks all silos next tick after this one is gone
 		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 		playsound(loc,'sound/effects/alien/egg_burst.ogg', 75)
 	return ..()

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -27,6 +27,8 @@ type InputPack = {
   hive_tactical_psy_points: number;
   hive_orphan_collapse: number;
   hive_orphan_max: number;
+  hive_silo_collapse: number;
+  hive_silo_collapse_max: number;
   hive_minion_count: number;
   hive_primos: PrimoUpgrades[];
   hive_death_timers: DeathTimer[];
@@ -215,6 +217,8 @@ const GeneralInfo = (_props: any) => {
     hive_orphan_collapse,
     hive_death_timers,
     hive_orphan_max,
+    hive_silo_collapse,
+    hive_silo_collapse_max,
   } = data;
 
   return (
@@ -272,6 +276,14 @@ const GeneralInfo = (_props: any) => {
             max={hive_orphan_max}
             tooltip="Hive must evolve a ruler!"
             left_side="Orphan Hivemind:"
+          />
+        </Flex.Item>
+        <Flex.Item>
+          <XenoCountdownBar
+            time={hive_silo_collapse}
+            max={hive_silo_collapse_max}
+            tooltip="Hive must build a silo or recorrupt generators!"
+            left_side="Siloless Collapse:"
           />
         </Flex.Item>
       </Flex>


### PR DESCRIPTION
## About The Pull Request
Orphan hive collapse will no longer happen during groundside, only shipside.

Xenos will now begin a 5 minute siloless collapse if they have no silos **AND** no corrupted generators.

Placing a new silo or recorrupting a generator will stop the timer and allow them to keep fighting.
Removed the stray generators on maps that had those, now all generators should be in the same general area.

TLDR: To major marines will need to kill silo and decorrupt generators.
## Why It's Good For The Game
Delayliens are annoying and this places much clearer goals for winning on both teams rather than searching for a mystery shrike.

The general flow of the round (when it is time for silo rush) will now go as follows:
Marines ATTACK silo while xenos DEFEND
Silo dies, marines retreat to go clean generators.
Last, marines DEFEND generators while xenos ATTACK to reclaim gens or can alternatively just make a new silo.
## Changelog
:cl:
add: Xenos will now collapse after 5 minutes if they have no silos and no corrupted generators.
remove: Orphan collapse will now only happen while shipside.
remove: Removed a few generators that were far from the main cluster on certain maps.
/:cl:
