### PR TITLE
OB sound fix

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -166,20 +166,23 @@
 	update_icon()
 
 /// Handles the playing of the Orbital Bombardment incoming sound and other visual and auditory effects of the cannon, usually a spiraling whistle noise but can be overridden.
-/obj/structure/orbital_cannon/proc/handle_ob_firing_effects(target, ob_sound = 'sound/effects/OB_incoming.ogg')
+/obj/structure/orbital_cannon/proc/handle_ob_firing_effects(turf/target, ob_sound = 'sound/effects/OB_incoming.ogg')
 	flick("OBC_firing",src)
-	for(var/mob/living/current_mob AS in GLOB.mob_living_list)
-		if(!current_mob || !is_mainship_level(current_mob.z))
-			continue
-		if(get_dist(src, current_mob) > 20)
-			current_mob.playsound_local(current_mob, 'sound/effects/obalarm.ogg', 25)
-		shake_camera(current_mob, 0.7 SECONDS)
-		to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as her orbital cannon opens fire."))
 	playsound(loc, 'sound/effects/obfire.ogg', 100, FALSE, 20, 4)
-	for(var/mob/mob AS in cheap_get_living_near(target, WARHEAD_FALLING_SOUND_RANGE))
-		mob.playsound_local(target, ob_sound, falloff = 2)
-
 	new /obj/effect/temp_visual/ob_impact(target, tray.warhead)
+
+	for(var/mob/living/current_mob AS in GLOB.mob_living_list)
+		if(current_mob.z == z)
+			if(get_dist(src, current_mob) > 20)
+				current_mob.playsound_local(current_mob, 'sound/effects/obalarm.ogg', 25)
+			shake_camera(current_mob, 0.7 SECONDS)
+			to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as her orbital cannon opens fire."))
+			continue
+		if(current_mob.z != target.z)
+			continue
+		if(get_dist(current_mob, target) > WARHEAD_FALLING_SOUND_RANGE)
+			continue
+		current_mob.playsound_local(target, ob_sound, falloff = 2)
 
 /obj/structure/orbital_cannon/proc/fire_ob_cannon(turf/T, mob/user)
 	set waitfor = FALSE

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -176,8 +176,8 @@
 		shake_camera(current_mob, 0.7 SECONDS)
 		to_chat(current_mob, span_warning("The deck of the [SSmapping.configs[SHIP_MAP].map_name] shudders as her orbital cannon opens fire."))
 	playsound(loc, 'sound/effects/obfire.ogg', 100, FALSE, 20, 4)
-	for(var/mob/M AS in hearers(WARHEAD_FALLING_SOUND_RANGE, target))
-		M.playsound_local(target, ob_sound, falloff = 2)
+	for(var/mob/mob AS in cheap_get_living_near(target, WARHEAD_FALLING_SOUND_RANGE))
+		mob.playsound_local(target, ob_sound, falloff = 2)
 
 	new /obj/effect/temp_visual/ob_impact(target, tray.warhead)
 


### PR DESCRIPTION
## About The Pull Request
The OB landing sound now actually plays to all mobs in the specified radius.

Generally just improves this proc to not be shitty.
## Why It's Good For The Game
Currently, it uses hearers() which is blocked by all opaque atoms (like walls).
## Changelog
:cl:
fix: fixed mobs not hearing the OB sound some times
/:cl:
