### PR TITLE
Makes the platforms on gelida non dense

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -139,9 +139,6 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "adr" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
@@ -326,12 +323,6 @@
 /obj/structure/table/reinforced/prison,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
-"all" = (
-/obj/structure/platform{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/gelida/landing_zone_2)
 "alr" = (
 /turf/open/floor/plating,
 /area/shuttle/drop2/gelida)
@@ -370,7 +361,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "amW" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/closed/wall/r_wall/unmeltable,
@@ -404,10 +395,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "aob" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -509,7 +500,7 @@
 /area/gelida/indoors/c_block/mining)
 "aqM" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -640,7 +631,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "auP" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -679,12 +670,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"avQ" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "awx" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/cleanmarked,
@@ -743,12 +728,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"ayZ" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "azo" = (
 /obj/machinery/light{
 	dir = 8
@@ -826,13 +805,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/cavestructuretwo)
-"aDi" = (
-/obj/machinery/floodlight/colony,
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_street)
 "aDk" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -931,12 +903,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"aHQ" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_forecon/UD6_Typhoon)
 "aHR" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/blue,
@@ -998,7 +964,7 @@
 /area/gelida/indoors/a_block/bridges/op_centre)
 "aKK" = (
 /obj/structure/cable,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -1269,12 +1235,6 @@
 	dir = 5
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
-"aSG" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "aSI" = (
 /obj/structure/prop/mainship/gelida/smallwire,
 /obj/structure/prop/mainship/gelida/smallwire{
@@ -1287,7 +1247,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "aSN" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/shuttle/dropship2/walltwo/alt,
@@ -1544,12 +1504,6 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
-"bbO" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "bbT" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 2
@@ -1576,7 +1530,7 @@
 /area/gelida/indoors/c_block/cargo)
 "bcK" = (
 /obj/effect/spawner/random/misc/structure/girder/highspawn,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1721,12 +1675,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
-"bfA" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/central_streets)
 "bfK" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison/whitepurple/full{
@@ -1774,12 +1722,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"bhm" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "bhn" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/reagent_containers/jerrycan{
@@ -1865,8 +1807,8 @@
 /area/gelida/cavestructuretwo)
 "bjt" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
-/obj/structure/platform{
+/obj/structure/platform/nondense,
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1897,7 +1839,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_street)
 "bkG" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -1942,9 +1884,6 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "blP" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2322,7 +2261,7 @@
 /area/gelida/indoors/a_block/fitness)
 "bAg" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -2352,7 +2291,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "bCj" = (
@@ -2384,12 +2323,6 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
-"bCC" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_street)
 "bCH" = (
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -2408,17 +2341,11 @@
 /turf/closed/wall/r_wall,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "bDq" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall/r_wall/unmeltable,
 /area/gelida/landing_zone_2)
-"bDR" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/liquid/water/river,
-/area/gelida/indoors/a_block/fitness)
 "bDW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
@@ -2454,7 +2381,7 @@
 /obj/item/shard,
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2584,7 +2511,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "bJC" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/closed/wall,
@@ -2616,7 +2543,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "bKO" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/c_block/cargo)
 "bLc" = (
@@ -2703,7 +2630,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkred/full,
@@ -2778,15 +2705,6 @@
 	dir = 5
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"bPK" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/stairs/corner_seamless{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "bPQ" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -3019,7 +2937,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "bZP" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3076,7 +2994,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "cbQ" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3098,7 +3016,7 @@
 /area/gelida/indoors/c_block/bridge)
 "cca" = (
 /obj/structure/closet/crate,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -3122,7 +3040,7 @@
 /area/gelida/indoors/a_block/hallway)
 "ccO" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3140,13 +3058,6 @@
 /obj/machinery/floodlight,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
-"cdT" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/effect/spawner/random/machinery/disposal,
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/garage)
 "cec" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -3164,20 +3075,14 @@
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/outdoors/colony_streets/south_west_street)
-"cex" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "ceI" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3245,7 +3150,7 @@
 /area/gelida/indoors/a_block/admin)
 "chg" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3289,11 +3194,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
-"ciW" = (
-/obj/structure/platform_decoration,
-/obj/machinery/light,
-/turf/open/floor/prison/darkpurple,
-/area/gelida/indoors/a_block/dorms)
 "cji" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3378,7 +3278,7 @@
 /area/gelida/caves/west_caves)
 "cmM" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3495,7 +3395,7 @@
 /area/gelida/powergen)
 "csP" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3670,7 +3570,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "cym" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/unmeltable,
@@ -3774,12 +3674,6 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
-"cCj" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/indoors/a_block/admin)
 "cCx" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -3949,15 +3843,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/casino)
-"cHg" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/mining)
 "cHh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -4000,7 +3885,7 @@
 /area/gelida/outdoors/colony_streets/south_street)
 "cIv" = (
 /obj/effect/landmark/weed_node,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreen/full,
@@ -4060,14 +3945,6 @@
 	dir = 8
 	},
 /area/gelida/outdoors/colony_streets/south_street)
-"cKK" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "cKR" = (
 /obj/vehicle/train/cargo/engine{
 	dir = 8
@@ -4078,9 +3955,6 @@
 /obj/machinery/door_control{
 	id = "A-Block-Dorm Shutters";
 	pixel_y = 26
-	},
-/obj/structure/stairs/seamless/platform{
-	dir = 1
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
@@ -4460,12 +4334,6 @@
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"cXD" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "cXJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -4528,7 +4396,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "cYV" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -4544,7 +4412,7 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "cZL" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -4614,13 +4482,6 @@
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"dbq" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/stairs/seamless/platform,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/cargo)
 "dbK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -4636,7 +4497,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "dci" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -4677,12 +4538,6 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
-"dds" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/north_street)
 "ddP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/w_rockies)
@@ -4747,7 +4602,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
 "dgz" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -4845,7 +4700,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "djI" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/closed/wall,
@@ -4986,23 +4841,6 @@
 	dir = 1
 	},
 /area/gelida/outdoors/colony_streets/north_street)
-"dqj" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/floor,
-/area/gelida/landing_zone_forecon/UD6_Tornado)
-"dqk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/gelida/indoors/b_block/bridge)
 "dqv" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -5074,9 +4912,6 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "dsJ" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
@@ -5209,9 +5044,6 @@
 /area/gelida/indoors/a_block/admin)
 "dxy" = (
 /obj/structure/stairs/corner_seamless,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "dxI" = (
@@ -5221,7 +5053,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "dxJ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -5257,12 +5089,6 @@
 "dzB" = (
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
-"dzD" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/liquid/water/river,
-/area/gelida/indoors/a_block/fitness)
 "dzJ" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -5346,7 +5172,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "dCy" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -5483,7 +5309,7 @@
 /area/gelida/indoors/a_block/dorms)
 "dGP" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5584,12 +5410,6 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/cavestructuretwo)
-"dKD" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "dKG" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
@@ -6048,15 +5868,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
-"dYO" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/machinery/floodlight/colony,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/east_central_street)
 "dZe" = (
 /obj/structure/closet/crate/miningcar{
 	name = "\improper materials storage bin";
@@ -6435,7 +6246,7 @@
 /area/gelida/indoors/b_block/bar)
 "enh" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -6466,19 +6277,12 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"eon" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "eow" = (
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
 "eoG" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/fitness)
 "eoI" = (
@@ -6520,9 +6324,6 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "epF" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
@@ -6557,7 +6358,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "eqR" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6573,13 +6374,10 @@
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "erZ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -6707,7 +6505,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
 "euw" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/fitness)
 "eux" = (
@@ -6724,12 +6522,6 @@
 	dir = 6
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
-"euX" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "eva" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/shuttle/dropship/floor,
@@ -6754,7 +6546,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/kitchen)
 "evs" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -6943,7 +6735,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "eCc" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "eCd" = (
@@ -7062,20 +6854,11 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/central_streets)
 "eFj" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"eFm" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "eFo" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/newspaper,
@@ -7191,7 +6974,7 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "eIA" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -7201,7 +6984,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "eIX" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -7325,13 +7108,6 @@
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
-"eMH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/stairs/seamless/platform,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/cargo)
 "eMI" = (
 /turf/open/floor/prison/blue/plate{
 	dir = 1
@@ -7406,9 +7182,6 @@
 "ePO" = (
 /obj/structure/stairs/corner_seamless{
 	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -7514,7 +7287,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/bridge)
 "eTs" = (
-/obj/structure/platform_decoration,
 /obj/effect/landmark/campaign_structure/phoron_crate,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
@@ -7541,7 +7313,7 @@
 /area/gelida/indoors/a_block/security)
 "eUq" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "eUv" = (
@@ -7550,7 +7322,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/central_streets)
 "eUC" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -7588,7 +7360,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_street)
 "eVq" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -7665,12 +7437,6 @@
 "eWY" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"eWZ" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "eXl" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 8
@@ -7721,12 +7487,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"eYt" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "eYA" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -7842,7 +7602,7 @@
 "fbs" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -7920,14 +7680,6 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/hallway)
-"ffD" = (
-/obj/structure/platform_decoration,
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Westlock"
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/dorms)
 "ffH" = (
 /obj/machinery/light{
 	dir = 8
@@ -8026,15 +7778,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"fix" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/stairs/corner_seamless{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "fiP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8083,7 +7826,7 @@
 /area/gelida/indoors/b_block/bridge)
 "flB" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
 "flF" = (
@@ -8194,7 +7937,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "fpy" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -8258,12 +8001,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/c_block/cargo)
-"frR" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "fsy" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -8283,9 +8020,6 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "fur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/c_block/cargo)
 "fuv" = (
@@ -8296,7 +8030,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "fuw" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -8316,7 +8050,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/b_block/hydro)
 "fvh" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -8329,7 +8063,7 @@
 /area/gelida/landing_zone_2)
 "fwd" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "fwg" = (
@@ -8351,12 +8085,6 @@
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/bridge)
-"fwH" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "fwL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -8398,7 +8126,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "fyu" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -8460,14 +8188,6 @@
 "fBW" = (
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/hallway)
-"fCe" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "fCp" = (
 /obj/effect/spawner/random/machinery/disposal,
 /turf/open/floor/prison/darkbrown/full,
@@ -8537,7 +8257,7 @@
 /area/gelida/indoors/a_block/medical)
 "fFL" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -8612,12 +8332,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/bridges/corpo)
-"fJd" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "fJx" = (
 /obj/item/tool/crowbar/red,
 /turf/open/floor/prison/whitepurple/full{
@@ -8663,7 +8377,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "fLi" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/kitchen)
 "fLo" = (
@@ -8679,12 +8393,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
-"fMz" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/gelida/indoors/a_block/garden)
 "fMQ" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -8742,7 +8450,7 @@
 /area/gelida/indoors/b_block/bridge)
 "fOW" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges)
 "fPi" = (
@@ -8779,7 +8487,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "fQG" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/shuttle/dropship2/wallthree/alt,
@@ -8820,9 +8528,6 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "fRP" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
@@ -8891,7 +8596,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "fVe" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -9107,7 +8812,7 @@
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "gbQ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -9137,9 +8842,6 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "gcv" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
@@ -9400,7 +9102,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "gme" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -9433,7 +9135,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -9542,11 +9244,6 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"gqE" = (
-/obj/structure/platform_decoration,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "gqI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -9651,7 +9348,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
 "gut" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/closed/wall,
@@ -9922,7 +9619,7 @@
 /area/gelida/cavestructuretwo)
 "gBs" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -10303,11 +10000,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/bridges/op_centre)
-"gNd" = (
-/obj/structure/platform_decoration,
-/obj/structure/stairs/corner_seamless,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "gNq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -10407,12 +10099,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
-"gPU" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/liquid/water/river,
-/area/gelida/indoors/a_block/fitness)
 "gQb" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen/corner{
@@ -10480,8 +10166,8 @@
 /area/gelida/landing_zone_forecon/landing_zone_4)
 "gSx" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
-/obj/structure/platform,
-/obj/structure/platform{
+/obj/structure/platform/nondense,
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -10767,7 +10453,7 @@
 /area/gelida/indoors/b_block/hydro)
 "hey" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -10786,9 +10472,6 @@
 	dir = 8;
 	pixel_x = 6;
 	pixel_y = 6
-	},
-/obj/structure/platform_decoration{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
@@ -10983,7 +10666,7 @@
 "hlu" = (
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/kitchen)
 "hlS" = (
@@ -11130,12 +10813,6 @@
 	},
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
-"hqY" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/cargo)
 "hrr" = (
 /turf/closed/shuttle/dropship2/engine_sidealt{
 	dir = 1
@@ -11196,7 +10873,7 @@
 /turf/open/floor/prison,
 /area/gelida/cavestructuretwo)
 "hsP" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -11236,10 +10913,10 @@
 /area/gelida/indoors/c_block/cargo)
 "htI" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/bridge)
 "htY" = (
@@ -11302,9 +10979,6 @@
 /area/gelida/indoors/b_block/bar)
 "hwu" = (
 /obj/structure/girder/displaced,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "hwJ" = (
@@ -11424,7 +11098,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -11617,9 +11291,6 @@
 "hGT" = (
 /obj/structure/stairs/seamless{
 	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 1
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
@@ -11831,7 +11502,7 @@
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -12020,14 +11691,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"hVw" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/east_central_street)
 "hVB" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/prison/whitepurple/full{
@@ -12064,14 +11727,6 @@
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
-"hXa" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/east_central_street)
 "hXh" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -12109,24 +11764,17 @@
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
-/obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
 	},
 /area/gelida/outdoors/colony_streets/south_west_street)
-"hYC" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/garage)
 "hYR" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/east,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "hYS" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -12320,7 +11968,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "ieD" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12362,12 +12010,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
-"igb" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/liquid/water/river,
-/area/gelida/indoors/a_block/fitness)
 "igB" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
@@ -12385,7 +12027,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "igJ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -12668,7 +12310,7 @@
 /area/gelida/landing_zone_1)
 "ioS" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12804,7 +12446,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
 "iux" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/closed/wall,
@@ -12843,7 +12485,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
 "iwh" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/c_block/garage)
 "iwn" = (
@@ -12995,7 +12637,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "iBo" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -13025,9 +12667,6 @@
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 7
-	},
-/obj/structure/platform_decoration{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
@@ -13127,7 +12766,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "iFj" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -13382,7 +13021,7 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "iOv" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/shuttle/dropship2/wallthree/alt,
@@ -13512,7 +13151,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkred/full,
@@ -13539,7 +13178,7 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/corpo)
 "iUo" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -13599,12 +13238,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/medical)
-"iXP" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/gelida/indoors/c_block/cargo)
 "iYg" = (
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
@@ -14010,7 +13643,7 @@
 /area/gelida/outdoors/colony_streets/south_east_street)
 "jlX" = (
 /obj/effect/spawner/gibspawner/xeno,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -14173,10 +13806,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"jry" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/prison/darkred/full,
-/area/gelida/indoors/a_block/kitchen)
 "jrU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -14271,7 +13900,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/cavestructuretwo)
 "jue" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -14280,7 +13909,7 @@
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -14604,7 +14233,7 @@
 "jJI" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -14724,7 +14353,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/powergen)
 "jMm" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -14754,7 +14383,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "jMU" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -14807,7 +14436,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "jOp" = (
 /obj/structure/closet/crate,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -14972,7 +14601,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
 "jRM" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -15118,7 +14747,7 @@
 "jVI" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/kitchen)
 "jVJ" = (
@@ -15262,12 +14891,6 @@
 "kci" = (
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
-"kcw" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "kcF" = (
 /obj/structure/dropship_piece/two/front{
 	dir = 1
@@ -15497,7 +15120,6 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "kjd" = (
-/obj/structure/platform_decoration,
 /obj/structure/stairs/corner_seamless,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -15717,18 +15339,9 @@
 /obj/item/storage/backpack/marine/engineerpack,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"krZ" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_street)
 "ksh" = (
 /obj/structure/stairs/corner_seamless{
 	dir = 1
-	},
-/obj/structure/platform_decoration{
-	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/south_east_street)
@@ -15820,12 +15433,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"kwz" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/cargo)
 "kwJ" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
@@ -15882,12 +15489,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_street)
-"kym" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "kyO" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/door_control{
@@ -15975,7 +15576,7 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
 "kCS" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -15985,7 +15586,7 @@
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/warning_stripes/stripedsquare/tile/border,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/black/full,
@@ -16078,12 +15679,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
-"kFi" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "kFl" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
@@ -16134,9 +15729,6 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "kHK" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
@@ -16144,7 +15736,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "kHL" = (
 /obj/effect/ai_node,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreen/full,
@@ -16281,7 +15873,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "kMe" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison,
@@ -16338,18 +15930,9 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"kNv" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "kNF" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -16378,12 +15961,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
-"kOy" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "kON" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
@@ -16406,15 +15983,11 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "kPS" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/kitchen)
-"kPU" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "kQh" = (
 /obj/vehicle/ridden/powerloader{
 	dir = 4
@@ -16539,12 +16112,6 @@
 /obj/item/shard,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
-"kVt" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "kVA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -16704,9 +16271,6 @@
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -16743,7 +16307,6 @@
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
 "lcm" = (
-/obj/structure/platform_decoration,
 /obj/item/reagent_containers/food/drinks/flask/marine,
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/blue/plate{
@@ -16864,9 +16427,6 @@
 /area/gelida/indoors/a_block/medical)
 "lgh" = (
 /obj/effect/spawner/gibspawner/xeno,
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkpurple,
 /area/gelida/indoors/a_block/dorms)
@@ -16988,7 +16548,7 @@
 "liP" = (
 /obj/structure/window/framed/colony,
 /obj/effect/spawner/random/misc/structure/curtain,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/garage)
 "liQ" = (
@@ -17006,7 +16566,6 @@
 /area/gelida/indoors/a_block/admin)
 "lkC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/platform_decoration,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
 "lkF" = (
@@ -17035,7 +16594,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "lkU" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -17043,7 +16602,7 @@
 "llH" = (
 /obj/structure/window/reinforced,
 /obj/structure/showcase/six,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/podhatch/floor,
@@ -17166,13 +16725,13 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "lpr" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
 /area/gelida/indoors/c_block/cargo)
 "lpZ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -17203,7 +16762,7 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "lqX" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -17336,14 +16895,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
-"lvE" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_street)
 "lvH" = (
 /obj/effect/spawner/random/engineering/ore_box,
 /obj/item/tool/weldpack{
@@ -17573,14 +17124,14 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_street)
 "lDR" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
 /area/gelida/landing_zone_forecon/landing_zone_4)
 "lDZ" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -17639,15 +17190,6 @@
 "lFD" = (
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
-"lFR" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "lGp" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_door,
@@ -17786,7 +17328,7 @@
 /area/gelida/outdoors/rock)
 "lKp" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -18057,7 +17599,7 @@
 	},
 /area/gelida/indoors/b_block/bridge)
 "lUa" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/closed/wall,
@@ -18129,14 +17671,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
-"lWQ" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "lXf" = (
 /turf/closed/shuttle/dropship2/finright{
 	dir = 1
@@ -18285,9 +17819,6 @@
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
@@ -18401,7 +17932,7 @@
 /area/gelida/indoors/b_block/bar)
 "mfl" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "mfz" = (
@@ -18654,20 +18185,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
-"mmH" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/mainship{
-	dir = 2;
-	id = "checkpoint2"
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/central_streets)
 "mmL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/sensor_tower,
@@ -18757,9 +18274,6 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "mpj" = (
 /obj/structure/stairs/corner_seamless,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
@@ -18884,7 +18398,7 @@
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "mtN" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -18959,13 +18473,6 @@
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
-"mxd" = (
-/obj/structure/platform_decoration,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "mxg" = (
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
@@ -19077,7 +18584,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "mAu" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -19088,7 +18595,7 @@
 	name = "????";
 	stat = 2
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -19232,15 +18739,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
-"mHT" = (
-/obj/effect/spawner/random/misc/structure/supplycrate,
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "mHV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/yellow/patch,
@@ -19272,7 +18770,7 @@
 /area/gelida/indoors/a_block/dorms)
 "mJc" = (
 /obj/machinery/floodlight,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 7
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -19320,21 +18818,21 @@
 /area/gelida/indoors/c_block/cargo)
 "mKL" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "mKS" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "mLe" = (
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -19370,7 +18868,7 @@
 /area/gelida/indoors/c_block/casino)
 "mLW" = (
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -19419,7 +18917,7 @@
 "mOp" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -19467,7 +18965,7 @@
 /area/gelida/indoors/c_block/mining)
 "mPv" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -19479,7 +18977,7 @@
 /area/gelida/caves/west_caves/garbledradio)
 "mPL" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -19495,7 +18993,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "mQg" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/closed/wall,
@@ -19654,12 +19152,6 @@
 "mVh" = (
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
-"mWb" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "mWd" = (
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/landing_zone_1)
@@ -19784,7 +19276,7 @@
 /turf/open/floor/tile/dark2,
 /area/gelida/outdoors/rock)
 "ncG" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/c_block/bridge)
 "ncQ" = (
@@ -19925,12 +19417,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
-"ngw" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/heatinggrate,
-/area/gelida/indoors/c_block/bridge)
 "ngP" = (
 /turf/closed/wall/r_wall,
 /area/gelida/landing_zone_2)
@@ -19959,10 +19445,6 @@
 	},
 /turf/open/shuttle/dropship/seven,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"nij" = (
-/obj/structure/stairs/seamless/platform,
-/turf/open/floor/prison,
-/area/gelida/indoors/c_block/cargo)
 "niz" = (
 /obj/structure/prop/mainship/gelida/lightstick{
 	pixel_x = -9;
@@ -20066,7 +19548,7 @@
 /area/gelida/powergen)
 "nkO" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/bridge)
 "nkZ" = (
@@ -20095,7 +19577,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -20155,7 +19637,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "noe" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -20254,12 +19736,6 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
-"nsE" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "nsF" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -20362,9 +19838,6 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "nwb" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/item/newspaper,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
@@ -20391,7 +19864,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "nws" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "nwC" = (
@@ -20520,12 +19993,6 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/landing_zone_2)
-"nCJ" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/central_streets)
 "nDe" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/kitchen,
@@ -20562,7 +20029,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/garage)
 "nDI" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/closed/wall,
@@ -20610,7 +20077,7 @@
 "nFy" = (
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -20668,12 +20135,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"nHb" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/floor,
-/area/gelida/landing_zone_forecon/UD6_Tornado)
 "nHg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20852,7 +20313,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "nMP" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -20876,7 +20337,7 @@
 /area/gelida/indoors/b_block/hydro)
 "nND" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -20946,7 +20407,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/outdoors/rock)
 "nOQ" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "nPI" = (
@@ -21019,7 +20480,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -21053,7 +20514,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "nSH" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -21127,7 +20588,7 @@
 /area/gelida/indoors/a_block/medical)
 "nVx" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -21139,7 +20600,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "nWs" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/kitchen)
 "nWw" = (
@@ -21218,7 +20679,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/east_caves)
 "nYN" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -21352,13 +20813,13 @@
 	dir = 1
 	},
 /obj/structure/rack/nometal,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "obW" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/closed/wall,
@@ -21395,9 +20856,6 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "oda" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -21520,12 +20978,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
-"ohb" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/east_central_street)
 "ohU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21603,7 +21055,7 @@
 /area/gelida/indoors/a_block/dorm_north)
 "olh" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -21613,7 +21065,7 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -21728,13 +21180,13 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/hallway)
 "orn" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_1)
 "orM" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/podhatch/floor,
 /area/gelida/indoors/a_block/corpo)
 "osq" = (
@@ -21827,9 +21279,6 @@
 /area/gelida/indoors/c_block/mining)
 "ovu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
@@ -21947,15 +21396,12 @@
 /area/gelida/indoors/b_block/hydro)
 "oAr" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "oAK" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
@@ -22100,9 +21546,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "oEx" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
 	},
@@ -22126,7 +21569,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
 "oER" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -22168,12 +21611,6 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/platebot,
 /area/gelida/indoors/c_block/cargo)
-"oFT" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "oGt" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -22192,7 +21629,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
 "oGJ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -22255,7 +21692,7 @@
 /area/gelida/indoors/a_block/admin)
 "oHY" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -22297,7 +21734,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "oJi" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -22480,12 +21917,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/admin)
-"oPL" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "oQi" = (
 /obj/effect/spawner/random/decal/blood,
 /turf/open/floor/plating,
@@ -22575,14 +22006,6 @@
 "oTb" = (
 /obj/machinery/landinglight/lz1,
 /turf/open/floor/prison/whitegreenfull2,
-/area/gelida/landing_zone_2)
-"oTs" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
 /area/gelida/landing_zone_2)
 "oTy" = (
 /obj/structure/table/reinforced,
@@ -22675,11 +22098,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"oVE" = (
-/obj/structure/stairs/seamless,
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "oVG" = (
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
@@ -22794,7 +22212,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkred/full,
@@ -22826,7 +22244,6 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "oZr" = (
-/obj/structure/platform_decoration,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
@@ -23022,14 +22439,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"pfs" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 8
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "pfY" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/spawner/random/decal/blood,
@@ -23137,7 +22546,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
 "pii" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -23148,14 +22557,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
-"pir" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "piD" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/plating/heatinggrate,
@@ -23217,7 +22618,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/fitness)
 "pjR" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/shuttle/dropship2/cornersalt{
@@ -23245,7 +22646,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "pkK" = (
 /obj/structure/girder/displaced,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "pkM" = (
@@ -23253,7 +22654,7 @@
 /turf/open/floor/prison/darkpurple,
 /area/gelida/indoors/a_block/dorms)
 "pkP" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -23291,7 +22692,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "pmX" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -23316,14 +22717,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_street)
-"pnQ" = (
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "poa" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison/plate,
@@ -23351,7 +22744,7 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
 "pqa" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -23431,12 +22824,6 @@
 /obj/item/weapon/cane,
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
-"psP" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/gelida/landing_zone_2)
 "ptl" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/mainship/stripesquare,
@@ -23550,7 +22937,7 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "pyk" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/bridges)
 "pyr" = (
@@ -23660,17 +23047,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"pAt" = (
-/obj/structure/stairs/seamless{
-	dir = 1
-	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison/blue/plate{
-	dir = 1
-	},
-/area/gelida/indoors/a_block/admin)
 "pAx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23809,7 +23185,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "pFW" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -23932,13 +23308,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
-"pJP" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "pJR" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/beakers,
@@ -23972,7 +23341,7 @@
 /area/gelida/indoors/c_block/garage)
 "pKf" = (
 /obj/effect/spawner/random/misc/structure/barrel,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -24004,7 +23373,7 @@
 /area/gelida/outdoors/colony_streets/windbreaker)
 "pLe" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -24212,17 +23581,6 @@
 /obj/item/tool/crowbar,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_street)
-"pSk" = (
-/obj/structure/stairs/seamless{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison/blue/plate{
-	dir = 1
-	},
-/area/gelida/indoors/a_block/admin)
 "pSH" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -24416,7 +23774,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "pZc" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "pZD" = (
@@ -24507,14 +23865,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
-"qbe" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "qbo" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -24642,7 +23994,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "qfy" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -24666,9 +24018,6 @@
 /area/gelida/indoors/a_block/bridges/op_centre)
 "qgs" = (
 /obj/structure/stairs/corner_seamless{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -24858,7 +24207,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "qna" = (
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -24866,7 +24215,7 @@
 "qnk" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -24903,7 +24252,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "qoP" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -24938,7 +24287,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "qqv" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/shuttle/dropship2/walltwo/alt,
@@ -24950,7 +24299,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "qrg" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -25014,12 +24363,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
-"quz" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/gelida/landing_zone_forecon/UD6_Typhoon)
 "quG" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -25213,7 +24556,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "qzY" = (
@@ -25232,16 +24575,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
-"qBP" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/dorms)
 "qCr" = (
 /obj/effect/acid_hole{
 	dir = 4
@@ -25328,7 +24661,7 @@
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "qFS" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -25388,7 +24721,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
 "qIf" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/prison/whitegreen/full,
@@ -25578,12 +24911,6 @@
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
-"qNv" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/central_streets)
 "qNz" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/weed_node,
@@ -25593,12 +24920,6 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/landing_zone_1)
-"qNT" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "qOf" = (
 /obj/structure/cargo_container/nt,
 /turf/open/floor/prison/darkbrown/full,
@@ -25609,12 +24930,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
-"qOh" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/gelida/indoors/a_block/garden)
 "qOn" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/black/full,
@@ -25627,10 +24942,6 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
-"qOv" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/cargo)
 "qOE" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/landing_zone_2)
@@ -25920,15 +25231,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "qYn" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 1;
-	pixel_y = 7
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
@@ -26053,7 +25357,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/darkred/full,
@@ -26267,7 +25571,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "rhx" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -26429,14 +25733,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"rlb" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison/blue/plate{
-	dir = 1
-	},
-/area/gelida/indoors/a_block/admin)
 "rli" = (
 /obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -26446,14 +25742,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
-"rll" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 4
-	},
-/area/gelida/landing_zone_2)
 "rln" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -26462,7 +25750,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorm_north)
 "rlx" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -26497,7 +25785,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "rmB" = (
-/obj/structure/platform_decoration,
 /obj/structure/stairs/corner_seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -26887,7 +26174,7 @@
 	dir = 4
 	},
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -27191,8 +26478,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "rMI" = (
-/obj/structure/platform,
-/obj/structure/platform{
+/obj/structure/platform/nondense,
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -27230,10 +26517,10 @@
 /area/gelida/indoors/a_block/corpo)
 "rNw" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -27366,7 +26653,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/hallway)
 "rRJ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -27549,14 +26836,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"rZQ" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "rZS" = (
 /obj/machinery/vending/cigarette/colony,
 /obj/machinery/light{
@@ -27600,7 +26879,7 @@
 	name = "Display synthetic"
 	},
 /obj/structure/window/reinforced,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/podhatch/floor,
 /area/gelida/indoors/a_block/corpo)
 "saI" = (
@@ -27665,12 +26944,6 @@
 "sdU" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_street)
-"sdZ" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/central_streets)
 "sek" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -27871,19 +27144,10 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
 "skG" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
 /turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_west_street)
-"skK" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 1
-	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "skP" = (
 /obj/structure/bed/chair/comfy{
@@ -27897,7 +27161,7 @@
 /area/gelida/indoors/a_block/dorms)
 "slv" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/medical)
 "sly" = (
@@ -27918,7 +27182,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "smj" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
 "smR" = (
@@ -28006,7 +27270,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkred/full,
@@ -28147,7 +27411,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/fitness)
 "stL" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -28317,7 +27581,7 @@
 /area/gelida/outdoors/colony_streets/south_street)
 "szK" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/corpo)
 "szN" = (
@@ -28396,18 +27660,12 @@
 	dir = 9
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
-"sCi" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/south_east_street)
 "sCz" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/caves/east_caves/garbledradio)
 "sCG" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -28559,13 +27817,13 @@
 /area/gelida/indoors/a_block/executive)
 "sHZ" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "sIb" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -28711,12 +27969,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/b_block/hydro)
-"sMv" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "sMC" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -28729,12 +27981,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/hallway)
-"sMO" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/gelida/indoors/a_block/garden)
 "sMS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -28771,7 +28017,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/kitchen)
 "sNT" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -28809,7 +28055,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/bridge)
 "sPN" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/b_block/bridge)
 "sPO" = (
@@ -28966,14 +28212,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/cavestructuretwo)
-"sUO" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_east_street)
 "sUT" = (
 /obj/machinery/light{
 	dir = 4
@@ -29091,7 +28329,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "sYN" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -29169,15 +28407,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
-"taZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/cargo)
 "tbe" = (
 /obj/machinery/light{
 	dir = 1
@@ -29211,7 +28440,7 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "tcn" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -29331,7 +28560,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "tgK" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/closed/wall,
 /area/gelida/indoors/a_block/corpo)
 "tgL" = (
@@ -29343,7 +28572,7 @@
 /area/gelida/indoors/c_block/garage)
 "thk" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -29426,10 +28655,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"tjQ" = (
-/obj/structure/platform_decoration,
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "tjU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -29509,7 +28734,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "tmu" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -29552,12 +28777,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
-"tnD" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_street)
 "tnJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -29597,12 +28816,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
-"tpW" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/garage)
 "tqc" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -29650,7 +28863,6 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "trd" = (
-/obj/structure/stairs/seamless/platform,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/bridge)
 "trn" = (
@@ -29663,7 +28875,7 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "trS" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -29886,7 +29098,7 @@
 	},
 /area/gelida/outdoors/colony_streets/south_street)
 "tBM" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -29935,7 +29147,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "tCL" = (
 /obj/structure/cable,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/closed/wall,
@@ -29982,12 +29194,6 @@
 	},
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
-"tFU" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "tGa" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/storage/backpack/marine/satchel{
@@ -30103,7 +29309,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "tKP" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -30373,13 +29579,6 @@
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
-"tVl" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/cargo)
 "tVH" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -30422,7 +29621,7 @@
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/black/full,
@@ -30441,12 +29640,6 @@
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
-"tXk" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "tXK" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/north,
 /obj/structure/cable,
@@ -30558,7 +29751,7 @@
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "ubR" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /obj/machinery/door/poddoor/mainship{
 	dir = 1
 	},
@@ -30616,7 +29809,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "udK" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -30776,7 +29969,7 @@
 /turf/closed/shuttle/dropship2/cornersalt,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "ujY" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -30813,9 +30006,6 @@
 /area/gelida/landing_zone_1)
 "ukV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
@@ -30836,12 +30026,6 @@
 /obj/item/toy/dice,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
-"uma" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/indoors/a_block/admin)
 "umk" = (
 /turf/closed/shuttle/dropship2/engineone{
 	dir = 8
@@ -30927,9 +30111,6 @@
 "uoU" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
-/obj/structure/platform_decoration{
-	dir = 5
-	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
 "upa" = (
@@ -30991,14 +30172,6 @@
 /obj/machinery/smartfridge/seeds,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/hydro)
-"usO" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/central_streets)
 "utz" = (
 /obj/structure/rack/nometal,
 /turf/open/floor/prison/darkbrown/full,
@@ -31064,7 +30237,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "uwf" = (
@@ -31211,7 +30384,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "uCf" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -31456,12 +30629,6 @@
 	},
 /turf/open/floor/plating,
 /area/gelida/powergen)
-"uIC" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "uJf" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/computer/PC{
@@ -31475,7 +30642,7 @@
 /area/gelida/indoors/a_block/bridges)
 "uJv" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -31542,13 +30709,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/east_caves)
-"uLZ" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/central_streets)
 "uMq" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -31632,7 +30792,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "uPm" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -31642,7 +30802,6 @@
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/hallway)
 "uPN" = (
-/obj/structure/platform_decoration,
 /obj/structure/stairs/corner_seamless,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -31731,7 +30890,7 @@
 "uSU" = (
 /obj/structure/window/reinforced,
 /obj/structure/showcase/six,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/podhatch/floor,
 /area/gelida/indoors/a_block/corpo)
 "uTf" = (
@@ -31767,15 +30926,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
-"uUq" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/stairs/corner_seamless{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "uUB" = (
 /turf/closed/wall/r_wall{
 	dir = 5
@@ -32028,7 +31178,6 @@
 /area/gelida/indoors/a_block/executive)
 "vcr" = (
 /obj/structure/stairs/corner_seamless,
-/obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "vcW" = (
@@ -32149,7 +31298,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "vgZ" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -32306,7 +31455,7 @@
 /area/gelida/indoors/c_block/casino)
 "vmp" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -32322,7 +31471,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -32351,15 +31500,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"voF" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/stairs/seamless/platform{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/cargo)
 "voT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -32391,13 +31531,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/security)
-"vqz" = (
-/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison/darkbrown/full,
-/area/gelida/indoors/c_block/cargo)
 "vqA" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -32463,12 +31596,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/hallway)
-"vsV" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "vsX" = (
 /obj/structure/stairs/corner_seamless{
 	dir = 1
@@ -32503,7 +31630,6 @@
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
-/obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "vtt" = (
@@ -32606,13 +31732,6 @@
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"vwB" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "vwV" = (
 /obj/structure/prop/mainship/gelida/barrier,
 /turf/open/floor/prison/darkred/full,
@@ -32658,7 +31777,6 @@
 /area/gelida/indoors/c_block/mining)
 "vxO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/platform_decoration,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/c_block/cargo)
 "vxP" = (
@@ -32687,7 +31805,7 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "vyH" = (
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkpurple,
 /area/gelida/indoors/a_block/dorms)
 "vyS" = (
@@ -32786,12 +31904,6 @@
 	dir = 8
 	},
 /area/gelida/indoors/a_block/kitchen)
-"vCo" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "vCy" = (
 /obj/machinery/light{
 	dir = 4
@@ -32859,12 +31971,6 @@
 "vEM" = (
 /turf/open/floor/prison,
 /area/gelida/landing_zone_forecon/landing_zone_4)
-"vFk" = (
-/obj/structure/platform_decoration{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_east_street)
 "vFl" = (
 /obj/machinery/light{
 	dir = 4
@@ -32964,7 +32070,7 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "vJl" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -33172,9 +32278,6 @@
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/prison/blue/plate{
@@ -33188,7 +32291,7 @@
 "vQP" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -33223,7 +32326,7 @@
 /area/gelida/indoors/c_block/casino)
 "vTp" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -33239,7 +32342,7 @@
 /obj/structure/prop/mainship/gelida/planterboxsoil{
 	dir = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 5
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -33378,8 +32481,8 @@
 /area/gelida/outdoors/colony_streets/south_east_street)
 "waf" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
-/obj/structure/platform{
+/obj/structure/platform/nondense,
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /obj/machinery/door/poddoor/mainship{
@@ -33497,12 +32600,6 @@
 "wdk" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"wdu" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/gelida/outdoors/colony_streets/north_west_street)
 "wdR" = (
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
@@ -33718,9 +32815,6 @@
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "woj" = (
@@ -33765,7 +32859,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -33797,7 +32891,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/outdoors/w_rockies)
 "wqy" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/closed/shuttle/dropship2/cornersalt,
@@ -33829,7 +32923,7 @@
 /area/gelida/indoors/a_block/bridges/dorms_fitness)
 "wrm" = (
 /obj/effect/spawner/random/misc/structure/curtain,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/garage)
 "wrn" = (
@@ -33927,14 +33021,6 @@
 "wtN" = (
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"wtT" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
-	dir = 4
-	},
-/area/gelida/outdoors/colony_streets/north_west_street)
 "wud" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/prison/cleanmarked,
@@ -34003,13 +33089,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/hallway)
-"wwL" = (
-/obj/structure/platform_decoration,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "wxi" = (
 /obj/structure/prop/mainship/gelida/smallwire{
 	dir = 4
@@ -34288,7 +33367,6 @@
 	},
 /area/gelida/landing_zone_2)
 "wHJ" = (
-/obj/structure/platform_decoration,
 /obj/structure/bed/roller,
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/blue/plate{
@@ -34302,7 +33380,7 @@
 /area/gelida/indoors/a_block/admin)
 "wIa" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "wId" = (
@@ -34345,12 +33423,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"wKr" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/c_block/cargo)
 "wKz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -34491,14 +33563,8 @@
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
-"wQe" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
-/area/gelida/outdoors/colony_streets/central_streets)
 "wQo" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -34574,7 +33640,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/corpo)
 "wSD" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/closed/wall,
@@ -34635,12 +33701,6 @@
 	dir = 9
 	},
 /area/gelida/outdoors/colony_streets/south_west_street)
-"wUJ" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/gelida/indoors/a_block/corpo)
 "wUK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -34753,7 +33813,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "xad" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -34795,12 +33855,6 @@
 /obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
-"xbV" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/outdoors/rock)
 "xcj" = (
 /turf/closed/wall,
 /area/gelida/indoors/c_block/bridge)
@@ -34815,7 +33869,7 @@
 /area/gelida/indoors/lone_buildings/chunk)
 "xdj" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform,
+/obj/structure/platform/nondense,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "xdp" = (
@@ -34826,9 +33880,6 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
 "xef" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
@@ -34869,16 +33920,7 @@
 /obj/effect/landmark/campaign_structure/phoron_crate,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
-"xic" = (
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/gelida/indoors/a_block/garden)
 "xie" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
@@ -34994,9 +34036,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "xmu" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
@@ -35050,14 +34089,6 @@
 /obj/item/clothing/head/collectable/tophat,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/cavestructuretwo)
-"xow" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison/green/full{
-	dir = 4
-	},
-/area/gelida/indoors/b_block/bridge)
 "xoV" = (
 /obj/structure/table/reinforced/prison,
 /obj/machinery/prop/computer/PC{
@@ -35158,7 +34189,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "xsN" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/closed/wall,
@@ -35210,10 +34241,6 @@
 /obj/structure/cargo_container/red,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_street)
-"xtY" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/heatinggrate,
-/area/gelida/indoors/c_block/bridge)
 "xtZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -35268,12 +34295,6 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
-"xwk" = (
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_2)
 "xwq" = (
 /obj/structure/cargo_container{
 	dir = 1
@@ -35335,7 +34356,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/stairs/seamless/platform,
 /turf/open/floor/prison{
 	dir = 4
 	},
@@ -35356,7 +34376,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "xzp" = (
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -35396,14 +34416,14 @@
 /area/gelida/indoors/a_block/dorms)
 "xBf" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/admin)
 "xBF" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -35424,13 +34444,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorms)
-"xBY" = (
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/landing_zone_1)
 "xCd" = (
 /obj/structure/table/wood/gambling,
 /obj/item/spacecash/c500{
@@ -35445,7 +34458,7 @@
 /area/gelida/indoors/c_block/cargo)
 "xCv" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -35684,7 +34697,7 @@
 /area/gelida/indoors/a_block/admin)
 "xIR" = (
 /obj/effect/spawner/random/misc/structure/chair_or_metal/west,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
@@ -35833,15 +34846,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"xMw" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/prison/green/full{
-	dir = 4
-	},
-/area/gelida/indoors/b_block/bridge)
 "xMA" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -35850,7 +34854,7 @@
 /obj/machinery/floodlight/colony{
 	pixel_y = 9
 	},
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 15
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -35877,7 +34881,6 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "xNN" = (
-/obj/structure/platform_decoration,
 /obj/structure/stairs/corner_seamless{
 	dir = 1
 	},
@@ -35903,15 +34906,12 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "xOn" = (
 /obj/structure/closet/crate,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_1)
 "xOE" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
@@ -35920,7 +34920,7 @@
 /area/gelida/landing_zone_2)
 "xOJ" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 6
 	},
 /turf/open/floor/prison/whitegreenfull2,
@@ -35998,7 +34998,7 @@
 /area/gelida/indoors/a_block/security)
 "xQz" = (
 /obj/structure/window_frame/colony/reinforced,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -36051,7 +35051,7 @@
 /area/gelida/outdoors/colony_streets/south_street)
 "xRE" = (
 /obj/machinery/floodlight/landing,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 9
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -36087,7 +35087,7 @@
 /area/gelida/indoors/a_block/fitness)
 "xTc" = (
 /obj/structure/window/framed/colony,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -36100,7 +35100,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "xTr" = (
 /obj/structure/cargo_container/horizontal,
-/obj/structure/platform{
+/obj/structure/platform/nondense{
 	dir = 10
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -36203,9 +35203,6 @@
 	},
 /area/gelida/indoors/b_block/hydro)
 "xVV" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /obj/structure/stairs/corner_seamless{
 	dir = 8
 	},
@@ -37687,7 +36684,7 @@ wOd
 wOd
 wOd
 wOd
-pJP
+lIC
 wOd
 wOd
 wOd
@@ -37905,11 +36902,11 @@ wOd
 wOd
 wOd
 wOd
-tFU
+wOd
 cZL
 lpZ
 tmu
-bbO
+wOd
 wOd
 wOd
 wOd
@@ -38125,7 +37122,7 @@ wOd
 wOd
 wOd
 wOd
-tFU
+wOd
 qrg
 lpZ
 pHY
@@ -38133,7 +37130,7 @@ gve
 pHY
 lpZ
 fyu
-bbO
+wOd
 wOd
 wOd
 wOd
@@ -38345,7 +37342,7 @@ npE
 npE
 npE
 wOd
-tFU
+wOd
 cZL
 lpZ
 pHY
@@ -38357,7 +37354,7 @@ epc
 pHY
 lpZ
 tmu
-bbO
+wOd
 wOd
 wOd
 npE
@@ -38566,7 +37563,7 @@ npE
 wOd
 wOd
 wOd
-tFU
+wOd
 cZL
 pHY
 gve
@@ -38580,7 +37577,7 @@ gve
 gve
 pHY
 tmu
-bbO
+wOd
 wOd
 wOd
 wOd
@@ -38786,7 +37783,7 @@ npE
 wOd
 wOd
 wOd
-tFU
+wOd
 cZL
 lpZ
 pHY
@@ -38804,7 +37801,7 @@ abc
 pHY
 lpZ
 tmu
-bbO
+wOd
 wOd
 wOd
 lIC
@@ -39006,7 +38003,7 @@ plT
 gXV
 wOd
 lIC
-tFU
+wOd
 cZL
 lpZ
 pHY
@@ -39028,7 +38025,7 @@ bwJ
 pHY
 lpZ
 tmu
-bbO
+wOd
 wOd
 wOd
 npE
@@ -39227,7 +38224,7 @@ npE
 wDw
 npE
 wOd
-tFU
+wOd
 cZL
 dTA
 fvt
@@ -39251,7 +38248,7 @@ fvt
 fvt
 dTA
 tmu
-bbO
+wOd
 wOd
 wOd
 npE
@@ -39550,11 +38547,11 @@ lQO
 lQO
 gxK
 ijV
-dqj
+lYx
 lYx
 lYx
 xPd
-fJd
+uew
 uew
 eQn
 eQn
@@ -39696,7 +38693,7 @@ xpG
 alr
 wLl
 pHY
-bPK
+xNN
 wOd
 npE
 wOd
@@ -39994,7 +38991,7 @@ lQO
 lQO
 hze
 ijV
-nHb
+lYx
 lYx
 lYx
 xPd
@@ -41446,7 +40443,7 @@ wOd
 wOd
 lIC
 wOd
-gNd
+uWz
 pHY
 urz
 xpG
@@ -41472,7 +40469,7 @@ xpG
 alr
 wLl
 pHY
-fix
+gPQ
 wOd
 npE
 wDw
@@ -41891,7 +40888,7 @@ wOd
 wOd
 mFF
 wOd
-sMv
+wOd
 nSH
 xAT
 vnD
@@ -41915,7 +40912,7 @@ vnD
 vnD
 xAT
 nMP
-xwk
+wOd
 wOd
 npE
 wDw
@@ -42114,7 +41111,7 @@ wOd
 mJV
 wOd
 wOd
-sMv
+wOd
 nSH
 mAu
 pHY
@@ -42136,7 +41133,7 @@ wIz
 pHY
 mAu
 nMP
-xwk
+wOd
 wOd
 wOd
 npE
@@ -42338,7 +41335,7 @@ wOd
 wOd
 wOd
 wOd
-sMv
+wOd
 nSH
 mAu
 pHY
@@ -42356,7 +41353,7 @@ wIz
 pHY
 mAu
 nMP
-xwk
+wOd
 wOd
 wOd
 wOd
@@ -42562,7 +41559,7 @@ wVl
 lIC
 wOd
 wOd
-sMv
+wOd
 nSH
 pHY
 gve
@@ -42576,7 +41573,7 @@ gve
 gve
 pHY
 nMP
-xwk
+wOd
 wOd
 wOd
 wOd
@@ -42785,7 +41782,7 @@ wOd
 lIC
 wOd
 wOd
-sMv
+wOd
 nSH
 mAu
 pHY
@@ -42797,7 +41794,7 @@ epc
 pHY
 mAu
 nMP
-xwk
+wOd
 wOd
 wOd
 wOd
@@ -43009,7 +42006,7 @@ wOd
 wOd
 wOd
 wOd
-sMv
+wOd
 nND
 mAu
 pHY
@@ -43017,7 +42014,7 @@ pHY
 pHY
 mAu
 xOJ
-xwk
+wOd
 wOd
 wOd
 lIC
@@ -43234,9 +42231,9 @@ wOd
 wOd
 wOd
 iUl
-oTs
 ydC
-rll
+ydC
+ydC
 geE
 wOd
 wOd
@@ -43591,8 +42588,8 @@ pCd
 yfp
 yfp
 yfp
-qBP
-ffD
+pAx
+dOS
 yfp
 yfp
 yfp
@@ -44019,9 +43016,9 @@ uew
 uew
 gwI
 sSY
-kcw
+sSY
 jXE
-pfs
+sSY
 wKm
 scR
 tzc
@@ -44051,7 +43048,7 @@ tix
 bZn
 oZr
 bZn
-mmH
+qkB
 bZn
 sqm
 gVv
@@ -44468,13 +43465,13 @@ vaA
 fZv
 yfp
 yfp
-kPU
+sir
 sSY
 sSY
 sSY
 sSY
 sSY
-vwB
+jUR
 uxt
 cpg
 rum
@@ -44485,12 +43482,12 @@ ghj
 ghj
 vPN
 eOG
-gqE
+vWZ
 bZn
 bZn
 bZn
 bZn
-aSG
+uhx
 yfp
 yfp
 qGg
@@ -44575,13 +43572,13 @@ npE
 wDw
 npE
 wOd
-tFU
+wOd
 udK
 oas
 eGw
 oas
-all
-psP
+oas
+wDw
 ndb
 ndb
 ndb
@@ -45124,7 +44121,7 @@ uew
 uew
 kTF
 vaE
-skK
+kTM
 yfp
 wot
 xlV
@@ -45166,7 +44163,7 @@ mQd
 ghj
 lLt
 yfp
-uLZ
+lvq
 gHP
 vaN
 gHP
@@ -45790,7 +44787,7 @@ uew
 uew
 fAj
 vaE
-rZQ
+kTM
 yfp
 oXD
 pqb
@@ -45832,7 +44829,7 @@ xBL
 sZV
 wcc
 yfp
-bfA
+hoS
 gVv
 uky
 vaN
@@ -46211,13 +45208,13 @@ sSY
 sSY
 sSY
 sSY
-mxd
+glO
 sSY
 sSY
 sSY
 glO
 sSY
-pfs
+sSY
 sSY
 sSY
 glO
@@ -46573,14 +45570,14 @@ oHe
 gEI
 gEI
 nvd
-uIC
+ndb
 amW
 fuw
 fuw
 fuw
 jue
-vCo
-xbV
+ndb
+ndb
 ndb
 ndb
 ndb
@@ -46671,11 +45668,11 @@ sir
 sSY
 sSY
 sSY
-pfs
+sSY
 sSY
 jXE
 sSY
-kcw
+sSY
 sSY
 sSY
 jTQ
@@ -48225,11 +47222,11 @@ sir
 sir
 sir
 rMw
-lWQ
+rMw
 rMw
 vUQ
 rMw
-wtT
+rMw
 cHi
 rMw
 sir
@@ -48255,7 +47252,7 @@ yfp
 fHC
 myO
 qGN
-ciW
+raW
 yfp
 yfp
 rcO
@@ -49311,7 +48308,7 @@ cgS
 eQn
 uew
 iiB
-skK
+kTM
 vPO
 cyK
 ams
@@ -49828,7 +48825,7 @@ hrB
 wPD
 wPD
 yfp
-wQe
+hoS
 vaN
 vaN
 vaN
@@ -50421,7 +49418,7 @@ bcB
 rai
 eue
 tzc
-rZQ
+kTM
 vPO
 glJ
 sKa
@@ -51115,7 +50112,7 @@ unI
 jDy
 vPO
 vPO
-eFm
+scv
 kZp
 vaE
 kTM
@@ -51531,7 +50528,7 @@ eue
 eue
 eue
 sWa
-skK
+kTM
 vPO
 ams
 sKa
@@ -51572,13 +50569,13 @@ nGw
 rbc
 yfp
 yfp
-wdu
+sir
 rMw
 rMw
 rMw
 sir
 rdf
-eYt
+nGK
 nGK
 nGK
 xsN
@@ -51588,13 +50585,13 @@ opk
 aVM
 pyk
 ruv
-qNv
+ruv
 ruv
 iES
 uhx
 rzM
 rzM
-oPL
+uhx
 yfp
 yfp
 gyo
@@ -52011,9 +51008,9 @@ uew
 uew
 crx
 dAm
-mHT
+dAm
 rMw
-lWQ
+rMw
 rMw
 muE
 uew
@@ -52041,9 +51038,9 @@ vaN
 rsp
 ndh
 rzM
-usO
+rzM
 ker
-fCe
+rzM
 rzM
 fda
 gVv
@@ -52213,11 +51210,11 @@ bqU
 sKa
 ams
 eoG
-bDR
 hDu
 hDu
 hDu
-gPU
+hDu
+hDu
 pqa
 xsO
 tyG
@@ -52641,7 +51638,7 @@ eQn
 uew
 uew
 vaE
-rZQ
+kTM
 vPO
 ams
 cuY
@@ -53087,12 +52084,12 @@ kZp
 vaE
 wAW
 rMw
-wtT
 rMw
 rMw
 rMw
 rMw
-cXD
+rMw
+sir
 ieD
 hCr
 ams
@@ -53430,7 +52427,7 @@ noN
 jTv
 jTv
 bdC
-xow
+piP
 lEm
 hNU
 piP
@@ -53545,11 +52542,11 @@ sKa
 cMf
 oIK
 euw
-igb
 hDu
 hDu
 hDu
-dzD
+hDu
+hDu
 bjt
 scv
 iiB
@@ -53981,7 +52978,7 @@ uew
 tzc
 tzc
 crx
-cXD
+sir
 xTc
 kgP
 rwW
@@ -54917,7 +53914,7 @@ lVd
 lxv
 aVM
 pyk
-nCJ
+ruv
 ruv
 jHl
 ycD
@@ -55146,7 +54143,7 @@ nFy
 qna
 tcn
 bJC
-sdZ
+uhx
 sqm
 vaN
 gZo
@@ -56285,9 +55282,9 @@ nIU
 nIU
 haY
 sOb
-taZ
+qbN
 nIU
-qOv
+nIU
 sOb
 qLx
 qLx
@@ -56422,7 +55419,7 @@ omJ
 txH
 lMj
 iLU
-wUJ
+iLU
 suP
 aOl
 oqy
@@ -56507,7 +55504,7 @@ nIU
 nIU
 nIU
 sOb
-eMH
+qbN
 jFW
 jFW
 lpr
@@ -56728,11 +55725,11 @@ nIU
 nIU
 nIU
 nIU
-hqY
+lTQ
 ovu
 qac
-iXP
-wKr
+qac
+lTQ
 nIU
 nIU
 qbN
@@ -56954,7 +55951,7 @@ lkC
 fur
 ikA
 vxO
-tVl
+lkC
 mlK
 qHd
 wsw
@@ -57173,7 +56170,7 @@ pdT
 lCf
 nIU
 sOb
-voF
+qbN
 ohZ
 ohZ
 lpr
@@ -57839,7 +56836,7 @@ rME
 xCd
 uFM
 sOb
-dbq
+qKt
 mec
 mec
 lpr
@@ -58314,7 +57311,7 @@ lqf
 noN
 jTv
 vJl
-dqk
+blP
 sdy
 chr
 blP
@@ -58477,7 +57474,7 @@ imb
 rXg
 iVD
 fLi
-sdZ
+uhx
 bZn
 bZn
 bZn
@@ -58536,7 +57533,7 @@ noN
 jTv
 jTv
 soJ
-xMw
+dFT
 lEm
 tYH
 piP
@@ -58775,7 +57772,7 @@ sdU
 nIN
 pPX
 vjI
-cHg
+hGT
 hGT
 mKd
 wqK
@@ -59318,7 +58315,7 @@ xCF
 dzL
 txH
 wSD
-bCC
+wtG
 vrL
 jlM
 ujh
@@ -59539,7 +58536,7 @@ dzL
 vJT
 iZq
 tgK
-bCC
+wtG
 vrL
 jlM
 jlM
@@ -59752,10 +58749,10 @@ ujh
 jlM
 jlM
 drE
-lvE
 srx
 srx
-krZ
+srx
+wtG
 lkU
 wAt
 pPq
@@ -60244,7 +59241,7 @@ uRd
 xqU
 eNj
 eNj
-jry
+rsL
 aEa
 gPK
 nDe
@@ -60416,18 +59413,18 @@ eZJ
 ujh
 jlM
 qxh
-dds
 mXF
 mXF
 mXF
 mXF
-tnD
+mXF
+wtG
 lkU
 dzL
 dKQ
 dzL
 tgK
-aDi
+mBa
 mXF
 mXF
 mXF
@@ -61144,7 +60141,7 @@ neN
 neN
 xff
 aEa
-cex
+tzW
 jIb
 eux
 jIb
@@ -61588,7 +60585,7 @@ uce
 neN
 bsh
 aEa
-mWb
+tzW
 jIb
 eux
 eux
@@ -61967,10 +60964,10 @@ ilb
 vby
 ueJ
 cfr
-avQ
+cfr
 cfr
 nGk
-kNv
+nGk
 nGk
 nGk
 nGk
@@ -62014,7 +61011,7 @@ iBw
 iBw
 iBw
 iBw
-qOh
+iBw
 rRJ
 awO
 xNL
@@ -62228,7 +61225,7 @@ ecp
 xjz
 awO
 eCc
-sMO
+iBw
 iBw
 iBw
 uJT
@@ -62469,10 +61466,10 @@ lTL
 loO
 rdG
 kpb
-hXa
+kpb
 kpb
 vcW
-hVw
+kpb
 kpb
 goK
 jIb
@@ -62723,12 +61720,12 @@ xvC
 tYd
 eTs
 wfV
-kwz
+etr
 vgQ
 hto
 etr
 jTx
-vqz
+uyq
 bKO
 nIU
 nIU
@@ -62851,7 +61848,7 @@ uYy
 ilb
 ilb
 ilb
-kFi
+hWs
 ihl
 vsY
 phJ
@@ -62894,7 +61891,6 @@ kxB
 hUv
 awO
 eCc
-fMz
 iBw
 iBw
 iBw
@@ -62902,7 +61898,8 @@ iBw
 iBw
 iBw
 iBw
-xic
+iBw
+iBw
 mtN
 lMI
 jQg
@@ -62945,7 +61942,7 @@ xvC
 xvC
 xvC
 dCy
-nij
+etr
 vPi
 rLY
 mec
@@ -63739,7 +62736,7 @@ uYy
 uYy
 ilb
 ilb
-cKK
+hWs
 ihl
 jWM
 xUH
@@ -64448,7 +63445,6 @@ kxB
 hUv
 awO
 eCc
-sMO
 iBw
 iBw
 iBw
@@ -64456,7 +63452,8 @@ iBw
 iBw
 iBw
 iBw
-qOh
+iBw
+iBw
 mtN
 qlD
 hUv
@@ -65114,7 +64111,7 @@ pup
 fOz
 awO
 eCc
-fMz
+iBw
 iBw
 lcj
 oef
@@ -65337,21 +64334,21 @@ dmn
 snA
 snA
 iux
-fMz
+iBw
 iBw
 iBw
 iBw
 cWj
 iBw
 iBw
-xic
+iBw
 rRJ
 awO
 sDt
 pup
 awO
 nOQ
-kOy
+lTL
 mjh
 mhj
 mhj
@@ -65771,7 +64768,7 @@ nGk
 uNW
 ilb
 ilb
-kFi
+hWs
 poj
 xGD
 wex
@@ -65959,7 +64956,7 @@ pKS
 ilb
 ilb
 vby
-kFi
+hWs
 ihl
 omo
 icj
@@ -66472,7 +65469,7 @@ nrk
 mhj
 mhj
 mhj
-cex
+tzW
 jIb
 eux
 eux
@@ -66847,7 +65844,7 @@ ilb
 ilb
 ilb
 ilb
-cKK
+hWs
 ihl
 sDc
 oZU
@@ -67360,7 +66357,7 @@ uUN
 xHX
 mhj
 mhj
-mWb
+tzW
 eux
 eux
 jZM
@@ -67547,7 +66544,7 @@ dtN
 tbN
 ilb
 ilb
-cKK
+hWs
 poj
 gBK
 yjN
@@ -67591,7 +66588,7 @@ jZM
 jZM
 jIb
 vJb
-ohb
+heL
 iBo
 jMm
 jMm
@@ -67603,7 +66600,7 @@ hjw
 jMm
 jMm
 mQg
-euX
+heL
 eEP
 xMn
 dxJ
@@ -67739,7 +66736,7 @@ ilb
 tyz
 hWs
 unA
-pnQ
+krt
 sMi
 sMi
 sMi
@@ -67961,10 +66958,10 @@ tyz
 tyz
 hWs
 unA
-vsV
+nGk
 krt
 krt
-qNT
+nGk
 unA
 maC
 ilb
@@ -68193,9 +67190,9 @@ ilb
 vby
 hWs
 ihl
-vsV
+nGk
 fuL
-qNT
+nGk
 ihl
 maC
 ilb
@@ -68470,7 +67467,7 @@ vCT
 xHX
 mhj
 mhj
-cex
+tzW
 jIb
 jIb
 eux
@@ -68879,7 +67876,7 @@ ilb
 ilb
 ilb
 ilb
-kFi
+hWs
 poj
 poj
 oBG
@@ -68939,10 +67936,10 @@ iwh
 heL
 heL
 lDZ
-ngw
+ltL
 lZD
 wEk
-xtY
+ltL
 ubR
 uet
 jio
@@ -69302,11 +68299,11 @@ ilb
 ilb
 vby
 ilb
-tXk
+ilb
 vmp
 tBM
 lKp
-eon
+bKq
 bKq
 bKq
 ilb
@@ -69336,7 +68333,7 @@ qBz
 ovz
 kSR
 aRp
-pSk
+jKd
 jKd
 jKd
 jKd
@@ -69358,7 +68355,7 @@ nrk
 mhj
 mhj
 mhj
-mWb
+tzW
 ayL
 jIb
 eux
@@ -69367,7 +68364,7 @@ jZM
 eux
 eux
 wGR
-eWZ
+heL
 nDI
 qfy
 qfy
@@ -69379,7 +68376,7 @@ xFA
 hjw
 qfy
 lUa
-nsE
+heL
 heL
 heL
 dxJ
@@ -69434,7 +68431,7 @@ wnq
 gCK
 dtV
 gCK
-oVE
+kDw
 jDt
 jDt
 jDt
@@ -69522,7 +68519,7 @@ ilb
 vby
 ilb
 ilb
-tXk
+ilb
 vgZ
 tBM
 qMR
@@ -69530,7 +68527,7 @@ vEM
 qMR
 tBM
 jRM
-eon
+bKq
 bKq
 raK
 ilb
@@ -69593,13 +68590,13 @@ gKW
 heL
 heL
 heL
-eWZ
+heL
 bAg
 sxT
 ijt
 dtS
 xdj
-nsE
+heL
 heL
 heL
 heL
@@ -69650,7 +68647,7 @@ xmm
 txG
 jDt
 jDt
-fwH
+jDt
 jOp
 gCK
 gCK
@@ -69658,7 +68655,7 @@ xyj
 jhS
 jhS
 hey
-xBY
+rJo
 rJo
 jDt
 jDt
@@ -69742,7 +68739,7 @@ daV
 ilb
 ilb
 ilb
-tXk
+ilb
 vgZ
 tBM
 qMR
@@ -69754,7 +68751,7 @@ asG
 qMR
 tBM
 jRM
-eon
+bKq
 bKq
 ilb
 ilb
@@ -69815,17 +68812,17 @@ heL
 heL
 heL
 heL
-ohb
+heL
 bAg
 sxT
 ijt
 sYL
 xdj
-euX
+heL
 heL
 rwy
 heL
-ohb
+heL
 dxJ
 xcj
 lAW
@@ -69870,7 +68867,7 @@ xmm
 xmm
 jDt
 jDt
-fwH
+jDt
 xRE
 thk
 jhS
@@ -69963,7 +68960,7 @@ jQr
 tmH
 ilb
 ilb
-tXk
+ilb
 vgZ
 qMR
 vEM
@@ -69977,7 +68974,7 @@ vEM
 vEM
 qMR
 jRM
-eon
+bKq
 bKq
 bKq
 ilb
@@ -70030,7 +69027,7 @@ eux
 vtd
 jIb
 hKm
-ohb
+heL
 iBo
 jMm
 jMm
@@ -70091,7 +69088,7 @@ xmm
 xmm
 pcI
 jDt
-fwH
+jDt
 orn
 qOf
 kfN
@@ -70105,7 +69102,7 @@ nkm
 eXl
 xAe
 xTr
-kym
+jDt
 jDt
 pcI
 jDt
@@ -70183,7 +69180,7 @@ ilb
 ilb
 ilb
 ilb
-tXk
+ilb
 vgZ
 tBM
 qMR
@@ -70201,7 +69198,7 @@ jMX
 qMR
 tBM
 jRM
-eon
+bKq
 bKq
 bKq
 vby
@@ -70223,7 +69220,7 @@ eYA
 ovz
 nYg
 lev
-uma
+yjN
 jHA
 kFl
 oIO
@@ -70269,14 +69266,14 @@ cRs
 ckG
 uYJ
 jyo
-cdT
+cWO
 hYS
-tpW
+dtS
 gMy
 rcp
-hYC
+dtS
 hjw
-sCi
+uet
 rxC
 rou
 rou
@@ -70311,7 +69308,7 @@ jDt
 xmm
 jDt
 jDt
-fwH
+jDt
 orn
 fpy
 gCK
@@ -70329,7 +69326,7 @@ mWd
 gCK
 mAF
 dci
-kym
+jDt
 jDt
 jDt
 jDt
@@ -70403,7 +69400,7 @@ tyz
 ilb
 ilb
 vby
-tXk
+ilb
 lDR
 aKK
 qMR
@@ -70425,7 +69422,7 @@ vnd
 qMR
 tBM
 jRM
-eon
+bKq
 bKq
 ilb
 tyz
@@ -70531,7 +69528,7 @@ eWY
 ngv
 jDt
 jDt
-fwH
+jDt
 orn
 fpy
 gCK
@@ -70553,7 +69550,7 @@ mWd
 gCK
 fpy
 dci
-kym
+jDt
 jDt
 jDt
 jDt
@@ -70624,7 +69621,7 @@ jIg
 tyz
 ilb
 juQ
-tXk
+ilb
 vnB
 aeG
 ozG
@@ -70648,7 +69645,7 @@ bcV
 bcV
 lAi
 omk
-eon
+bKq
 bKq
 tyz
 jIg
@@ -70665,8 +69662,8 @@ fhF
 gRj
 fNo
 ovz
-pAt
-cCj
+lev
+yjN
 cAR
 jHA
 mVh
@@ -70752,7 +69749,7 @@ eWY
 iAT
 ngv
 jDt
-fwH
+jDt
 fbs
 uXB
 lZJ
@@ -70776,7 +69773,7 @@ oLu
 oLu
 qxM
 dci
-kym
+jDt
 jDt
 jDt
 jDt
@@ -70922,10 +69919,10 @@ xad
 jnm
 ijt
 wIa
-oFT
+mrh
 iBR
 gSx
-oFT
+mrh
 hfL
 oGJ
 ijt
@@ -71221,7 +70218,7 @@ kqs
 ecy
 pUt
 gCK
-uUq
+vsX
 jDt
 txG
 txG
@@ -71361,7 +70358,7 @@ jIb
 eux
 nUn
 jZM
-dYO
+vZi
 hjw
 oQi
 mrh
@@ -71370,7 +70367,7 @@ mrh
 cpl
 oWN
 mrh
-dKD
+mrh
 dxy
 eRT
 qYn
@@ -71408,7 +70405,7 @@ eWY
 ndb
 ndb
 rIi
-tjQ
+ndb
 ndb
 ndb
 ndb
@@ -71629,7 +70626,7 @@ ndb
 ndb
 ndb
 ndb
-wwL
+rIi
 ndb
 rkR
 rkR
@@ -71753,7 +70750,7 @@ wMa
 wMa
 wMa
 uLr
-quz
+mXb
 avJ
 avJ
 avJ
@@ -71766,7 +70763,7 @@ tyz
 tyz
 ilb
 hWs
-vFk
+nGk
 eIX
 qcQ
 uWx
@@ -71998,7 +70995,7 @@ hNA
 wMj
 lcm
 lev
-rlb
+nYg
 nYg
 icZ
 kEG
@@ -72197,7 +71194,7 @@ eRE
 eRE
 eRE
 xvL
-aHQ
+mXb
 avJ
 avJ
 avJ
@@ -72211,7 +71208,7 @@ jIg
 ilb
 xxR
 roC
-vFk
+nGk
 eUC
 bcK
 pkP
@@ -72440,14 +71437,14 @@ dDD
 krt
 krt
 krt
-pir
+krt
 iPj
-sUO
 krt
 krt
 krt
 krt
-vsV
+krt
+nGk
 orh
 sML
 wsk
@@ -72961,7 +71958,7 @@ ndb
 ndb
 ndb
 ndb
-lFR
+rIi
 ndb
 rkR
 rkR
@@ -73184,7 +72181,7 @@ ndb
 ndb
 ndb
 rIi
-ayZ
+ndb
 ndb
 ndb
 ndb
@@ -73288,7 +72285,7 @@ oKU
 ghd
 xDv
 ilb
-qbe
+ilb
 gmJ
 rxI
 lBH
@@ -73312,7 +72309,7 @@ fZD
 fZD
 rxI
 woU
-frR
+ilb
 ilb
 tyz
 fcY
@@ -73416,7 +72413,7 @@ ndb
 ndb
 fBC
 jDt
-bhm
+jDt
 erZ
 jdO
 sgl
@@ -73440,7 +72437,7 @@ sgl
 sgl
 jdO
 eVq
-kVt
+jDt
 jDt
 jDt
 jDt
@@ -73511,7 +72508,7 @@ ilb
 ilb
 ilb
 vby
-qbe
+ilb
 gbQ
 auP
 qMR
@@ -73533,7 +72530,7 @@ asG
 qMR
 auP
 ujY
-frR
+ilb
 ilb
 vby
 tyz
@@ -73639,7 +72636,7 @@ fBC
 fBC
 fBC
 jDt
-bhm
+jDt
 erZ
 jMU
 gCK
@@ -73661,7 +72658,7 @@ sMe
 czo
 cca
 xOn
-kVt
+jDt
 jDt
 jDt
 jDt
@@ -73735,7 +72732,7 @@ ilb
 ilb
 ilb
 ilb
-qbe
+ilb
 gbQ
 auP
 qMR
@@ -73753,7 +72750,7 @@ pYo
 qMR
 auP
 ujY
-frR
+ilb
 ilb
 ilb
 ilb
@@ -73863,7 +72860,7 @@ txG
 jDt
 jDt
 jDt
-bhm
+jDt
 erZ
 jMU
 gCK
@@ -73881,7 +72878,7 @@ jmj
 ogh
 pKf
 xOn
-kVt
+jDt
 jDt
 jDt
 jDt
@@ -73959,7 +72956,7 @@ vby
 ilb
 vby
 ilb
-qbe
+ilb
 gbQ
 qMR
 vEM
@@ -73973,7 +72970,7 @@ vEM
 vEM
 qMR
 ujY
-frR
+ilb
 ilb
 ilb
 ilb
@@ -74087,7 +73084,7 @@ jDt
 jDt
 jDt
 jDt
-bhm
+jDt
 erZ
 gCK
 wsH
@@ -74101,7 +73098,7 @@ bHK
 bHK
 ogh
 vTp
-kVt
+jDt
 jDt
 jDt
 pcI
@@ -74182,7 +73179,7 @@ ilb
 ilb
 ilb
 ilb
-qbe
+ilb
 gbQ
 auP
 qMR
@@ -74194,7 +73191,7 @@ pYo
 qMR
 auP
 ujY
-frR
+ilb
 ilb
 vby
 ilb
@@ -74310,7 +73307,7 @@ txG
 txG
 jDt
 jDt
-bhm
+jDt
 erZ
 jMU
 gCK
@@ -74322,7 +73319,7 @@ mWd
 gCK
 jMU
 eVq
-kVt
+jDt
 jDt
 jDt
 jDt
@@ -74406,7 +73403,7 @@ ilb
 vby
 ilb
 ilb
-qbe
+ilb
 gbQ
 auP
 qMR
@@ -74414,7 +73411,7 @@ vEM
 qMR
 auP
 ujY
-frR
+ilb
 ilb
 ilb
 vby
@@ -74534,7 +73531,7 @@ txG
 txG
 jDt
 jDt
-bhm
+jDt
 nVx
 jMU
 gCK
@@ -74542,7 +73539,7 @@ eDu
 gCK
 jMU
 iFj
-kVt
+jDt
 jDt
 jDt
 jDt
@@ -74630,11 +73627,11 @@ ilb
 vby
 ilb
 ilb
-qbe
+ilb
 uJv
 auP
 enh
-frR
+ilb
 ilb
 ilb
 vby
@@ -74758,11 +73755,11 @@ txG
 txG
 jDt
 jDt
-bhm
+jDt
 erZ
 jMU
 eVq
-kVt
+jDt
 jDt
 jDt
 jDt


### PR DESCRIPTION
## About The Pull Request

Alternative to just killing them all
## Why It's Good For The Game
Mistiming the jump when you are on rush can get you killed, and even if it didn't, it's extremely annoying
They shouldn't block movement at all, they are decorations.
## Changelog
:cl:
qol: Makes the platforms on gelida non dense
/:cl:
