### PR TITLE
Allows fireman carried people to be laid on surgery tables

### DIFF
--- a/code/datums/elements/riding.dm
+++ b/code/datums/elements/riding.dm
@@ -128,7 +128,7 @@
 	return ..()
 
 /obj/item/riding_offhand/on_thrown(mob/living/carbon/user, atom/target)
-	if(rider == user)
+	if(is_rider(user))
 		return //Piggyback user.
 	user.unbuckle_mob(rider)
 	var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
@@ -136,3 +136,6 @@
 	if(start_T && end_T)
 		log_combat(user, src, "thrown", addition = "from tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)] with the target tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]")
 	return rider
+
+/obj/item/riding_offhand/proc/is_rider(mob/living/user)
+	return (rider == user)

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -239,7 +239,7 @@
 	. = ..()
 	if(!istype(carried_person))
 		return
-	if(carried_person.is_rider())
+	if(carried_person.is_rider(user))
 		return
 	user.unbuckle_mob(carried_person.rider)
 	take_victim(carried_person.rider, user)

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -234,3 +234,13 @@
 		return 0
 
 	return 1
+
+/obj/machinery/optable/attackby(obj/item/riding_offhand/carried_person, mob/user, params)
+	. = ..()
+	if(!istype(carried_person))
+		return
+	if(carried_person.is_rider())
+		return
+	user.unbuckle_mob(carried_person.rider)
+	take_victim(carried_person.rider, user)
+	qdel(carried_person)

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -195,6 +195,17 @@
 		user.transferItemToLoc(I, src)
 		anes_tank = I
 		to_chat(user, span_notice("You connect \the [anes_tank] to \the [src]."))
+	
+	if(istype(I, /obj/item/riding_offhand))
+		var/obj/item/riding_offhand/carry_obj = I
+		if(carry_obj.is_rider(user))
+			return
+		if(victim)
+			balloon_alert(user, "already has patient!")
+			return
+		if(!take_victim(carry_obj.rider, user))
+			return
+		qdel(carry_obj)
 
 /obj/machinery/optable/grab_interact(obj/item/grab/grab, mob/user, base_damage = BASE_OBJ_SLAM_DAMAGE, is_sharp = FALSE)
 	. = ..()
@@ -234,13 +245,3 @@
 		return 0
 
 	return 1
-
-/obj/machinery/optable/attackby(obj/item/riding_offhand/carried_person, mob/user, params)
-	. = ..()
-	if(!istype(carried_person))
-		return
-	if(carried_person.is_rider(user))
-		return
-	user.unbuckle_mob(carried_person.rider)
-	take_victim(carried_person.rider, user)
-	qdel(carried_person)


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
Yes.
## Changelog
:cl:
add: Fireman carried people can be laid on top of surgery tables directly instead of having to drop to grab them again and click on the table.
/:cl:
