### PR TITLE
Allows squad leaders to take a radiopack as a backpack option

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -541,6 +541,7 @@ GLOBAL_LIST_INIT(leader_clothes_listed_products, list(
 		/obj/item/storage/backpack/marine/satchel = list(CAT_BAK, "Satchel", 0, "black"),
 		/obj/item/storage/backpack/marine/standard = list(CAT_BAK, "Backpack", 0, "black"),
 		/obj/item/storage/holster/blade/machete/full = list(CAT_BAK, "Machete scabbard", 0, "black"),
+		/obj/item/storage/backpack/marine/radiopack = list(CAT_BAK, "Radio Pack", 0, "black"),
 		/obj/item/armor_module/storage/uniform/black_vest = list(CAT_WEB, "Tactical black vest", 0, "black"),
 		/obj/item/armor_module/storage/uniform/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),
 		/obj/item/armor_module/storage/uniform/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),


### PR DESCRIPTION

## About The Pull Request
see title
the ability to buy a radiopack for 15 SL vendor points is retained in case you want four for some reason
## Why It's Good For The Game
offers SLs a more approachable alternative to lugging around a supply beacon all game. 15 points is a pretty scary buyin cost for an item that is arguably only about as useful as a standard supply beacon with a bit of QOL functionality, nevermind the fact that this also forces you to wear a backpack...
## Changelog
:cl:

balance: Marine squad leaders may now take the radiopack as a backpack option
/:cl:
