### PR TITLE
Adds *trick emote, allowing you to do_trick() (revolver trick) on items.

### DIFF
--- a/code/__DEFINES/emote.dm
+++ b/code/__DEFINES/emote.dm
@@ -7,3 +7,4 @@
 #define EMOTE_RESTRAINT_CHECK (1<<3) //Checks if the mob is restrained before performing the emote
 #define NO_KEYBIND (1<<4) //This emote has no keybind
 #define EMOTE_ARMS_CHECK (1<<5) //Checks if the mob has arms
+#define EMOTE_ACTIVE_ITEM (1<<6) //Checks if the mob is actively holding an item

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -193,3 +193,9 @@
 				return FALSE
 			user.balloon_alert(user, "You cannot [key] while restrained")
 			return FALSE
+
+		if(emote_flags & EMOTE_ACTIVE_ITEM)
+			if(user.get_active_held_item() != null)
+				return TRUE
+			user.balloon_alert(user, "You need to hold an item to trick it.")
+			return FALSE

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -197,5 +197,5 @@
 		if(emote_flags & EMOTE_ACTIVE_ITEM)
 			if(user.get_active_held_item() != null)
 				return TRUE
-			user.balloon_alert(user, "You need to hold an item to trick it.")
+			user.balloon_alert(user, "You need to hold an item to [key] it.")
 			return FALSE

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -195,7 +195,7 @@
 			return FALSE
 
 		if(emote_flags & EMOTE_ACTIVE_ITEM)
-			if(user.get_active_held_item() != null)
+			if(!isnull(user.get_active_held_item()))
 				return TRUE
 			user.balloon_alert(user, "You need to hold an item to [key] it.")
 			return FALSE

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -88,19 +88,6 @@
 	hitsound = 'sound/weapons/slash.ogg'
 	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts", "hooks")
 
-//Try to do a fancy trick with your cool knife
-/obj/item/weapon/karambit/attack_self(mob/user)
-	. = ..()
-	if(!user.dextrous)
-		to_chat(user, span_warning("You don't have the dexterity to do this."))
-		return
-	if(user.incapacitated() || !isturf(user.loc))
-		to_chat(user, span_warning("You can't do this right now."))
-		return
-	if(user.do_actions)
-		return
-	do_trick(user)
-
 /obj/item/weapon/karambit/fade
 	icon_state = "karambit_fade"
 	worn_icon_state = "karambit_fade"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -564,3 +564,15 @@
 		return
 	var/image/pain = image('icons/mob/talk.dmi', user, icon_state = "pain")
 	user.add_emote_overlay(pain)
+
+/datum/emote/living/carbon/human/trick
+	key = "trick"
+	key_third_person = "tricks"
+	emote_flags = EMOTE_ACTIVE_ITEM|EMOTE_RESTRAINT_CHECK
+
+/datum/emote/living/carbon/human/trick/run_emote(mob/user, params, type_override, intentional, prefix)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/I = user.get_active_held_item()
+	I.do_trick(usr)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -42,23 +42,6 @@
 	///Whether the chamber can be spun for Russian Roulette. If False the chamber can be spun.
 	var/catchworking = TRUE
 
-
-/obj/item/weapon/gun/revolver/verb/revolvertrick()
-	set category = "Weapons"
-	set name = "Do a revolver trick"
-	set desc = "Show off to all your friends!"
-	var/obj/item/weapon/gun/revolver/gun = get_active_firearm(usr)
-	if(!gun)
-		return
-	if(!istype(gun))
-		return
-	if(usr.do_actions)
-		return
-	if(zoom)
-		to_chat(usr, span_warning("You cannot conceviably do that while looking down \the [src]'s scope!"))
-		return
-	do_trick(usr)
-
 //-------------------------------------------------------
 //R-44 COMBAT REVOLVER
 


### PR DESCRIPTION

## About The Pull Request
Adds a new emote *trick, which you can bind to do a flip trick (like the revolver or karambit) on any item.
## Why It's Good For The Game
Tricking weapons is a mostly harmless cosmetic emote that's locked behind revolvers and karambits due to the influence of one cowboy-obsessed Russian gunslinger. And CS skins.
No more! Now you may trick items as you please, potentially providing endless entertainment to your comrades by juggling ammo boxes on your way groundside.
## Changelog
:cl:
add: Added *trick emote that lets you do tricks on weapons and items alike.
/:cl:
