### PR TITLE
Adds electrical insulation to Officer Gloves.

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -55,8 +55,9 @@
 
 /obj/item/clothing/gloves/marine/officer
 	name = "officer gloves"
-	desc = "Shiny and impressive. They look expensive."
+	desc = "Shiny and impressive while also insulating against electric shocks. They look expensive."
 	icon_state = "black"
+	siemens_coefficient = 0
 
 /obj/item/clothing/gloves/marine/officer/chief
 	name = "chief officer gloves"


### PR DESCRIPTION

## About The Pull Request

Adds electrical insulation to Officer Gloves.

## Why It's Good For The Game

Field Commanders are often responsible for repairing APC's which exposes them to electric shocks.
Field Commanders have engineering skill so should have gloves that allow them to use these skills.
I am malting after I as FC tried to repair the APC on the Canter during crash but got shocked (hardstunned) when mending the APC wires so we got nuked.

## Changelog

:cl:
balance: Officer/FC gloves are now insulated.
/:cl:
