### PR TITLE
Laser sentry range fix

### DIFF
--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -443,7 +443,7 @@
 	icon = 'icons/obj/machines/deployable/sentry/laser.dmi'
 	fire_sound = 'sound/weapons/guns/fire/laser.ogg'
 
-	turret_range = 10
+	turret_range = 8
 	deploy_time = 5 SECONDS
 	max_shells = 500
 	fire_delay = 0.2 SECONDS


### PR DESCRIPTION

## About The Pull Request
Fixes #17088
Laser sentry can no longer offscreen xenos with its hitscan zero scatter memery
## Why It's Good For The Game
I assume(?) that it wasn't intended for this to have offscreen range.
## Changelog
:cl:
fix: Laser sentry no longer has offscreen range
/:cl:
