### PR TITLE
Everyone except spatial agents can only spawn mechs once

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -77,6 +77,7 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 //Job/role helpers
 #define ismarinefaction(H) (H.faction == "TerraGov")
 #define isterragovjob(J) (istype(J, /datum/job/terragov))
+#define isspatialagentjob(J) (istype(J, /datum/job/spatial_agent))
 #define ismedicaljob(J) (istype(J, /datum/job/terragov/medical))
 #define isengineeringjob(J) (istype(J, /datum/job/terragov/engineering))
 #define ismarinejob(J) (istype(J, /datum/job/terragov/squad))

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -93,6 +93,7 @@
 #define ENDURE_TRAIT "endure" //Ravager Endure ability.
 #define RAGE_TRAIT "rage" //Ravager Rage ability.
 #define UNMANNED_VEHICLE "unmanned"
+#define MECH_VENDOR_TRAIT "mechvendor"
 #define STEALTH_TRAIT "stealth" //From hunter stealth
 #define REVIVE_TO_CRIT_TRAIT "revive_to_crit"
 #define GUN_TRAIT "gun" //Traits related to guns
@@ -143,7 +144,7 @@
 ///AM will not be submerged. Trait must ALWAYS be added via the add_nosubmerge_trait proc for correct behavior
 #define TRAIT_NOSUBMERGE "trait_nosubmerge"
 
-
+#define TRAIT_HAS_SPAWNED_MECH "has_spawned_mech"
 
 //added b grilling a food
 #define TRAIT_FOOD_GRILLED "food_grilled"

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
@@ -224,8 +224,6 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	if(.)
 		return
 
-	if(S_TIMER_COOLDOWN_TIMELEFT(src, COOLDOWN_MECHA))
-		return FALSE
 	var/selected_part = params["bodypart"]
 	if(selected_part && !(selected_part in selected_primary))
 		return FALSE // non valid body parts
@@ -281,6 +279,12 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 			selected_name = new_name
 
 		if("assemble")
+			var/mob/living/user = usr
+			if(HAS_TRAIT(user, TRAIT_HAS_SPAWNED_MECH))
+				tgui_alert(user, "You have already deployed a mech!")
+				return FALSE
+			if(S_TIMER_COOLDOWN_TIMELEFT(src, COOLDOWN_MECHA))
+				return FALSE
 			for(var/key in selected_primary)
 				if(isnull(selected_primary[key]))
 					return FALSE
@@ -291,7 +295,9 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 				return FALSE
 			addtimer(CALLBACK(src, PROC_REF(deploy_mech)), 1 SECONDS)
 			playsound(get_step(src, dir), 'sound/machines/elevator_move.ogg', 50, 0)
-			S_TIMER_COOLDOWN_START(src, COOLDOWN_MECHA, 5 MINUTES)
+			if(!isspatialagentjob(user.job))
+				S_TIMER_COOLDOWN_START(src, COOLDOWN_MECHA, 5 MINUTES)
+				ADD_TRAIT(usr, TRAIT_HAS_SPAWNED_MECH, MECH_VENDOR_TRAIT)
 			return TRUE
 
 		if("add_weapon")


### PR DESCRIPTION
Also fixes mechs being unable to spawn themselves more ammo if they had just spawned their mech
## About The Pull Request

Everyone except spatial agents can only spawn mechs once, spatial agents also ignore the cd
also fix the cd applying to things that are not spawning a new mech

## Why It's Good For The Game

kurocracy decree

## Changelog
:cl:
balance: Everyone except spatial agents can only spawn mechs once
fix: having just spawned a mech now does not prevent you from spawning ammo
/:cl:
