### PR TITLE
Admins can now allow a mob to hear dchat

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -177,7 +177,7 @@
 			override = TRUE
 		if(SSticker.current_state == GAME_STATE_FINISHED)
 			override = TRUE
-		if(M.deadchat_override = TRUE)
+		if(M.deadchat_override == TRUE)
 			override = TRUE
 		if(isnewplayer(M) && !override)
 			continue

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -177,6 +177,8 @@
 			override = TRUE
 		if(SSticker.current_state == GAME_STATE_FINISHED)
 			override = TRUE
+		if(M.deadchat_override = TRUE)
+			override = TRUE
 		if(isnewplayer(M) && !override)
 			continue
 		if(M.stat != DEAD && !override)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -33,6 +33,8 @@
 	var/track_blood = 0
 	var/feet_blood_color
 	var/datum/skills/skills
+	/// Allows a mob to hear dchat regardless of other factors.
+	var/deadchat_override = FALSE
 
 
 	//Movement


### PR DESCRIPTION
## About The Pull Request
Allows admins to allow a mob to hear dchat by setting deadcht_override to TRUE on the mob. 
## Why It's Good For The Game
An admin was asking about this in a round and wasn't able to do this without breaking things, so i figured it'd be useful for them to have. 
## Changelog
:cl: Cheese
add: Admins can now allow a mob to hear dchat by overriding the mobs deadchat_override variable to true.
/:cl:
