### PR TITLE
Add public address config option

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -7,6 +7,8 @@ Basics, the most important.
 
 /datum/config_entry/string/server // If you set this location, it sends you there instead of trying to reconnect.
 
+/datum/config_entry/string/public_address
+
 /datum/config_entry/string/title //The title of the main window
 
 /datum/config_entry/string/hostedby // Sets the hosted by name on unix platforms.

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -57,6 +57,10 @@
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
 
+	var/public_address = CONFIG_SET(string/public_address)
+	if(public_address)
+		.["public_address"] = public_address
+
 	var/list/adm = get_admin_counts()
 	var/list/presentmins = adm["present"]
 	var/list/afkmins = adm["afk"]

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -57,7 +57,7 @@
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
 
-	var/public_address = CONFIG_SET(string/public_address)
+	var/public_address = CONFIG_GET(string/public_address)
 	if(public_address)
 		.["public_address"] = public_address
 

--- a/code/modules/admin/verbs/chat_commands.dm
+++ b/code/modules/admin/verbs/chat_commands.dm
@@ -11,7 +11,7 @@
 	if(rtod - last_tgs_check < TGS_STATUS_THROTTLE)
 		return
 	last_tgs_check = rtod
-	var/server = CONFIG_GET(string/server)
+	var/server = CONFIG_GET(string/public_address) || CONFIG_GET(string/server)
 	return "Round ID: [GLOB.round_id] | Round Time: [gameTimestamp("hh:mm")] | Players: [length(GLOB.clients)] | Ground Map: [length(SSmapping.configs) ? SSmapping.configs[GROUND_MAP].map_name : "Loading..."] | Ship Map: [length(SSmapping.configs) ? SSmapping.configs[SHIP_MAP].map_name : "Loading..."] | Mode: [GLOB.master_mode] | Round Status: [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] | Link: [server ? server : "<byond://[world.internet_address]:[world.port]>"]"
 
 


### PR DESCRIPTION
mirror of https://github.com/tgstation/tgstation/pull/89421 and https://github.com/tgstation/tgstation/pull/89447
used by the server-info-fetcher, https://github.com/tgstation-operations/server-info-fetcher/pull/2

:cl:
config: Add PUBLIC_ADDRESS as a config option, serves to show the public IP for players to connect to.
/:cl:
