### PR TITLE
Various Detpack QoL

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -89,6 +89,7 @@
 		balloon_alert(user, "Frequency copied over")
 
 /obj/item/detpack/unique_action(mob/user, special_treatment)
+	. = ..()
 	on = !on
 	update_icon()
 

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -21,7 +21,6 @@
 	var/atom/plant_target = null //which atom the detpack is planted on
 	var/target_drag_delay = null //store this for restoration later
 	var/boom = FALSE //confirms whether we actually detted.
-	var/boom_direction //which direction we were planted in; determines which way breach detpacks blast through walls
 	var/detonation_pending
 	var/sound_timer
 	var/datum/radio_frequency/radio_connection
@@ -296,7 +295,6 @@
 		var/location
 		location = target
 		forceMove(location)
-		boom_direction = get_dir(user, location)
 
 		log_game("[key_name(user)] planted [src.name] on [target.name] at [AREACOORD(target.loc)] with [timer] second fuse.")
 		message_admins("[ADMIN_TPMONTY(user)] planted [src.name] on [target.name] at [ADMIN_VERBOSEJMP(target.loc)] with [timer] second fuse.")
@@ -370,11 +368,9 @@
 	plant_target.ex_act(EXPLODE_DEVASTATE)
 	plant_target = null
 	if(det_mode == TRUE) //If we're on demolition mode, big boom.
-		explosion(det_location, 0, 7, 9, 0, 7)
+		explosion(det_location, 3, 5, 6, 0, 6)
 	else //if we're not, focused boom.
-		if(iswallturf(det_location)) //Breach the other side of the wall if planted on one
-			det_location = get_step(det_location, boom_direction)
-		explosion(det_location, 3, 4, 4, 0, 4)
+		explosion(det_location, 2, 2, 3, 0, 3, throw_range = FALSE)
 	qdel(src)
 
 

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -1,6 +1,6 @@
 /obj/item/detpack
 	name = "detonation pack"
-	desc = "Programmable remotely triggered 'smart' explosive controlled via a signaler, used for demolitions and impromptu booby traps. Can be set to breach or demolition detonation patterns. Unique action to arm. Click on it with a signaller to copy over the signal code."
+	desc = "Programmable remotely triggered 'smart' explosive controlled via a signaler, used for demolitions and impromptu booby traps. Can be set to breach or demolition detonation patterns. Unique action to arm. Click on it with a signaler to copy over the signal code."
 	gender = PLURAL
 	icon = 'icons/obj/det.dmi'
 	icon_state = "detpack_off"

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -87,7 +87,7 @@
 		var/obj/item/assembly/signaler/signaler = I
 		code = signaler.code
 		set_frequency(signaler.frequency)
-		balloon_alert(user, "Frequency copied over".")
+		balloon_alert(user, "Frequency copied over")
 
 /obj/item/detpack/unique_action(mob/user, special_treatment)
 	on = !on

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -1,6 +1,6 @@
 /obj/item/detpack
 	name = "detonation pack"
-	desc = "Programmable remotely triggered 'smart' explosive controlled via a signaler, used for demolitions and impromptu booby traps. Can be set to breach or demolition detonation patterns."
+	desc = "Programmable remotely triggered 'smart' explosive controlled via a signaler, used for demolitions and impromptu booby traps. Can be set to breach or demolition detonation patterns. Unique action to arm. Click on it with a signaller to copy over the signal code."
 	gender = PLURAL
 	icon = 'icons/obj/det.dmi'
 	icon_state = "detpack_off"
@@ -46,7 +46,6 @@
 	if(armed)
 		. += "<b>It is armed!</b>"
 
-
 /obj/item/detpack/Destroy()
 	if(sound_timer)
 		deltimer(sound_timer)
@@ -87,16 +86,20 @@
 		var/obj/item/assembly/signaler/signaler = I
 		code = signaler.code
 		set_frequency(signaler.frequency)
-		to_chat(user, "You transfer the frequency and code of [signaler] to [src].")
+		balloon_alert(user, "Frequency copied over".")
+
+/obj/item/detpack/unique_action(mob/user, special_treatment)
+	on = !on
+	update_icon()
 
 /obj/item/detpack/attack_hand(mob/living/user)
 	if(armed)
-		to_chat(user, "<font color='warning'>Active anchor bolts are holding it in place! Disarm [src] first to remove it!</font>")
+		balloon_alert(user, "Disarm it first!")
 		return
 	if(plant_target)
 		user.visible_message(span_notice("[user] begins unsecuring [src] from [plant_target]."),
 		span_notice("You begin unsecuring [src] from [plant_target]."))
-		if(!do_after(user, 30, NONE, src, BUSY_ICON_BUILD))
+		if(!do_after(user, 3 SECONDS, NONE, src, BUSY_ICON_BUILD))
 			return
 		user.visible_message(span_notice("[user] unsecures [src] from [plant_target]."),
 		span_notice("You unsecure [src] from [plant_target]."))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -1,6 +1,6 @@
 /obj/item/assembly/signaler
 	name = "remote signaling device"
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another."
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Use to activate, alt-click to open the menu."
 	icon_state = "signaller"
 	worn_icon_state = "signaler"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
@@ -86,13 +86,19 @@ Code:
 			code = new_code
 
 	if(href_list["send"])
-		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-			to_chat(usr, span_warning("[src] is still recharging..."))
-			return
-		TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
-		INVOKE_ASYNC(src, PROC_REF(signal))
+		INVOKE_ASYNC(src, PROC_REF(try_send_signal))
 
 	updateUsrDialog()
+
+/obj/item/assembly/signaler/unique_action(mob/user, special_treatment)
+	try_send_signal()
+
+/obj/item/assembly/signaler/proc/try_send_signal()
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
+		balloon_alert(usr, "Recharging"))
+		return
+	TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
+	signal()
 
 /obj/item/assembly/signaler/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -1,6 +1,6 @@
 /obj/item/assembly/signaler
 	name = "remote signaling device"
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Use to activate, alt-click to open the menu."
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Unique action to activate, use to open the menu."
 	icon_state = "signaller"
 	worn_icon_state = "signaler"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -91,6 +91,7 @@ Code:
 	updateUsrDialog()
 
 /obj/item/assembly/signaler/unique_action(mob/user, special_treatment)
+	. = ..()
 	try_send_signal()
 
 /obj/item/assembly/signaler/proc/try_send_signal()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -95,7 +95,7 @@ Code:
 
 /obj/item/assembly/signaler/proc/try_send_signal()
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-		balloon_alert(usr, "Recharging"))
+		balloon_alert(usr, "Recharging")
 		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 	signal()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For detpacks:
Unique action now turns the detpack on/off.
Added guidance to linking signaler/detpack codes to its description.
Some detpack messages converted to balloon alerts.

For signalers:
Unique action now sends a signal.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Detpacks should be able to be operated without a menu. It's way more intuitive.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
add: Unique action for signalers now sends the signal
add: Unique action for detpacks now turns them on/off
qol: Balloon alerts added to some detpack messages
/:cl:
