### PR TITLE
Mech explosion fix

### DIFF
--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
@@ -58,9 +58,11 @@
 		limb.attach(src, key)
 
 /obj/vehicle/sealed/mecha/combat/greyscale/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	. = ..()
-	var/obj/effect/temp_visual/explosion/explosion = new /obj/effect/temp_visual/explosion(loc, 4, LIGHT_COLOR_LAVA, FALSE, TRUE)
-	explosion.pixel_x = 16
+	playsound(get_turf(src), SFX_EXPLOSION_MED, 100, TRUE) //destroy sound is normally very quiet
+	new /obj/effect/temp_visual/explosion(loc, 4, LIGHT_COLOR_LAVA, FALSE, TRUE)
+	for(var/mob/living/nearby_mob AS in cheap_get_living_near(src, 5))
+		shake_camera(nearby_mob, 4, 1)
+	return ..()
 
 /obj/vehicle/sealed/mecha/combat/greyscale/Destroy()
 	for(var/key in limbs)


### PR DESCRIPTION

## About The Pull Request
Mechs once again (visually) explode on destruction.
Also added some minor screenshake and sound effect like I did for tank.
## Why It's Good For The Game
Tivi stinky
## Changelog
:cl:
fix: fixed mech destruction effects
/:cl:
