### PR TITLE
Experiment: Remove manifests from lobby access

### DIFF
--- a/code/_onclick/hud/screen_objects/menu_text_objects.dm
+++ b/code/_onclick/hud/screen_objects/menu_text_objects.dm
@@ -120,24 +120,6 @@
 	var/mob/new_player/player = hud.mymob
 	player.try_to_observe()
 
-/atom/movable/screen/text/lobby/clickable/manifest
-	maptext = "<span class='lobbytext'>VIEW MANIFEST</span>"
-	icon_state = "manifest"
-
-/atom/movable/screen/text/lobby/clickable/manifest/Click()
-	. = ..()
-	var/mob/new_player/player = hud.mymob
-	player.view_manifest()
-
-/atom/movable/screen/text/lobby/clickable/xenomanifest
-	maptext = "<span class='lobbytext'>VIEW HIVE LEADERS</span>"
-	icon_state = "manifest"
-
-/atom/movable/screen/text/lobby/clickable/xenomanifest/Click()
-	. = ..()
-	var/mob/new_player/player = hud.mymob
-	player.view_xeno_manifest()
-
 /atom/movable/screen/text/lobby/clickable/background
 	maptext = "<span class='lobbytext'>BACKGROUND</span>"
 	icon_state = "background"


### PR DESCRIPTION

## About The Pull Request

This has been discussed a few times so let's put the theory to the test and remove manifests from access in the lobby

## Why It's Good For The Game
One of the issues we have is static stacking where everybody goes x side because they recognize people

Example: I see lux queen and new FC, every usual player goes xeno
I see unknown shrike with no queen and tomboy fc so I go xeno

Repeat this for every usual (thus, much more likely to be competent) player joining
While yes this doesnt hold for everyone and I know some people coordinate in metacords or whatever the point of  this is to see if we can't lessen this effect by hiding manifests

This PR will NOT be merged but it may be used to base on future tweaks to the information available in the Lobby


