### PR TITLE
Stagger fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -618,7 +618,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define HUNTER_SNEAK_SLASH_ARMOR_PEN 20 //bonus AP
 #define HUNTER_SNEAK_ATTACK_RUN_DELAY 2 SECONDS
 #define HUNTER_PSYCHIC_TRACE_COOLDOWN 5 SECONDS //Cooldown of the Hunter's Psychic Trace, and duration of its arrow
-#define HUNTER_SILENCE_STAGGER_STACKS 1 //Silence imposes this many stagger stacks
+#define HUNTER_SILENCE_STAGGER_DURATION 1 SECONDS //Silence imposes this much stagger
 #define HUNTER_SILENCE_SENSORY_STACKS 7 //Silence imposes this many eyeblur and deafen stacks.
 #define HUNTER_SILENCE_MUTE_DURATION 10 SECONDS //Silence imposes this many seconds of the mute status effect.
 #define HUNTER_SILENCE_RANGE 5 //Range in tiles of the Hunter's Silence.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -645,7 +645,7 @@
 			silence_multiplier = HUNTER_SILENCE_MULTIPLIER
 		to_chat(target, span_danger("Your mind convulses at the touch of something ominous as the world seems to blur, your voice dies in your throat, and everything falls silent!") ) //Notify privately
 		target.playsound_local(target, 'sound/effects/ghost.ogg', 25, 0, 1)
-		target.adjust_stagger(HUNTER_SILENCE_STAGGER_STACKS * silence_multiplier)
+		target.adjust_stagger(HUNTER_SILENCE_STAGGER_DURATION * silence_multiplier)
 		target.adjust_blurriness(HUNTER_SILENCE_SENSORY_STACKS * silence_multiplier)
 		target.adjust_ear_damage(HUNTER_SILENCE_SENSORY_STACKS * silence_multiplier, HUNTER_SILENCE_SENSORY_STACKS * silence_multiplier)
 		target.apply_status_effect(/datum/status_effect/mute, HUNTER_SILENCE_MUTE_DURATION * silence_multiplier)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -456,7 +456,7 @@
 // *********** Punch
 // ***************************************
 #define WARRIOR_PUNCH_SLOWDOWN 3
-#define WARRIOR_PUNCH_STAGGER 3
+#define WARRIOR_PUNCH_STAGGER 3 SECONDS
 #define WARRIOR_PUNCH_EMPOWER_MULTIPLIER 1.5
 #define WARRIOR_PUNCH_GRAPPLED_DAMAGE_MULTIPLIER 1.5
 #define WARRIOR_PUNCH_GRAPPLED_DEBUFF_MULTIPLIER 1.5
@@ -628,7 +628,7 @@
 	playsound(src, sound_effect, 50, 1)
 	shake_camera(src, 1, 1)
 	add_slowdown(slowdown_stacks)
-	adjust_stagger(stagger_stacks SECONDS)
+	adjust_stagger(stagger_stacks)
 	adjust_blurriness(slowdown_stacks)
 	apply_damage(punch_damage, BRUTE, target_limb ? target_limb : 0, MELEE)
 	apply_damage(punch_damage, STAMINA, updating_health = TRUE)

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -23,8 +23,8 @@
 	var/list/datum/reagent/spit_reagents
 	///Amount of reagents transferred upon spit impact if any
 	var/reagent_transfer_amount
-	///Amount of stagger stacks imposed on impact if any
-	var/stagger_stacks
+	///Amount of stagger imposed on impact if any
+	var/stagger_duration
 	///Amount of slowdown stacks imposed on impact if any
 	var/slowdown_stacks
 	///These define the reagent transfer strength of the smoke caused by the spit, if any, and its aoe
@@ -45,7 +45,7 @@
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	damage = 40
-	stagger_stacks = 1.1 SECONDS
+	stagger_duration = 1.1 SECONDS
 	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
@@ -70,7 +70,7 @@
 	if(isnestedhost(carbon_victim))
 		return
 
-	carbon_victim.adjust_stagger(stagger_stacks)
+	carbon_victim.adjust_stagger(stagger_duration)
 	carbon_victim.add_slowdown(slowdown_stacks)
 
 	set_reagents()
@@ -139,7 +139,7 @@
 	damage = 20 //minor; this is mostly just to provide confirmation of a hit
 	max_range = 40
 	bullet_color = COLOR_PURPLE
-	stagger_stacks = 2
+	stagger_duration = 1 SECONDS
 	slowdown_stacks = 3
 
 
@@ -149,7 +149,7 @@
 		var/mob/living/carbon/target_carbon = target_mob
 		if(target_carbon.issamexenohive(proj.firer))
 			return
-		target_carbon.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
+		target_carbon.adjust_stagger(stagger_duration) //stagger briefly; useful for support
 		target_carbon.add_slowdown(slowdown_stacks) //slow em down
 
 
@@ -370,7 +370,7 @@
 	added_spit_delay = 1 SECONDS
 	spit_cost = 50
 	damage = 35
-	stagger_stacks = 2 SECONDS
+	stagger_duration = 2 SECONDS
 	slowdown_stacks = 3
 	ammo_behavior_flags = AMMO_XENO|AMMO_TARGET_TURF
 	bonus_projectiles_type = /datum/ammo/xeno/acid/airburst_bomblet/smokescreen
@@ -383,7 +383,7 @@
 		var/mob/living/carbon/target_carbon = target_mob
 		if(target_carbon.issamexenohive(proj.firer))
 			return
-		target_carbon.adjust_stagger(stagger_stacks)
+		target_carbon.adjust_stagger(stagger_duration)
 		target_carbon.add_slowdown(slowdown_stacks)
 
 /datum/ammo/xeno/acid/airburst_bomblet/smokescreen
@@ -401,7 +401,7 @@
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS
 	max_range = 16
 	shell_speed = 1.5
-	stagger_stacks = 2 SECONDS
+	stagger_duration = 2 SECONDS
 	slowdown_stacks = 3
 	///How long it knocks down the target
 	var/knockdown_duration = 2 SECONDS
@@ -416,5 +416,5 @@
 	var/mob/living/carbon/target_carbon = target_mob
 	if(target_carbon.issamexenohive(proj.firer))
 		return
-	staggerstun(target_mob, proj, max_range, 0, knockdown_duration, stagger_stacks, slowdown_stacks, knockback)
+	staggerstun(target_mob, proj, max_range, 0, knockdown_duration, stagger_duration, slowdown_stacks, knockback)
 	target_carbon.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)


### PR DESCRIPTION

## About The Pull Request
Fixes a few instances where stagger was still being treated as stacks instead of duration.

Hunter silence stagger is 1 second instead of 0.1 seconds.
Sticky spit is 1 second instead of 0.2 seconds.
Warrior punch stagger is defined in the define instead of the stagger proc for clarity (no change)
:cl:
fix: fixed hunter silence and sticky spit applying far less stagger than intended
/:cl:
