### PR TITLE
Increases command message length to 200 characters from 120 and 100

### DIFF
--- a/code/game/objects/machinery/overwatch/_overwatch.dm
+++ b/code/game/objects/machinery/overwatch/_overwatch.dm
@@ -21,7 +21,7 @@
 
 /// The maximum length we should use for sending messages with stuff like `message_member`,
 /// `message_squad` etc.
-#define MAX_COMMAND_MESSAGE_LENGTH 100
+#define MAX_COMMAND_MESSAGE_LENGTH 200
 
 ///Overwatch is on monitor mode
 #define OVERWATCH_ON_MONITOR (1<<0)

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -1,4 +1,4 @@
-#define MAX_COMMAND_MESSAGE_LEN 120
+#define MAX_COMMAND_MESSAGE_LEN 200
 
 /atom/movable/screen/text/screen_text/command_order
 	maptext_height = 64


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. Would do more but the screen popup cannot handle more than this without a smaller font
## Why It's Good For The Game
120 is woefully not enough for some more complex commands, this should make it a good deal easier
## Changelog
:cl:
spellcheck: Increases command message length to 200 characters from 120 and 100
/:cl:
