### PR TITLE
Adds a delay to tank firing after turning its turret

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -624,6 +624,8 @@
 		return FALSE
 	playsound(src, 'sound/effects/tankswivel.ogg', 80,1)
 	TIMER_COOLDOWN_START(src, COOLDOWN_TANK_SWIVEL, 3 SECONDS)
+	if(primary_weapon)
+		TIMER_COOLDOWN_START(src, COOLDOWN_MECHA_EQUIPMENT(primary_weapon.type), new_weapon_dir == REVERSE_DIR(turret_overlay.dir) ? 1 SECONDS : 0.5 SECONDS)
 	turret_overlay.setDir(new_weapon_dir)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
1 second delay if you do a full 180, 0.5 seconds if you turn 90 degrees.

Very short delay, maybe should be longer but we'll see.
## Why It's Good For The Game
Makes positioning matter a bit more, and adds some more counterplay where xenos can flank and punish an out of position tank slightly better.

Also probably less accidental FF gibs, although I would argue thats a downside.
## Changelog
:cl:
balance: Tank turret rotation adds a delay to firing
/:cl:
