### PR TITLE
Change keybind names to the actual strains, rather than the parent caste

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -267,21 +267,21 @@
 
 /datum/keybinding/xeno/smokescreen_spit
 	name = "smokescreen_spit"
-	full_name = "Boiler - Sizzler: Smokescreen Spit"
+	full_name = "Sizzler: Smokescreen Spit"
 	description = "Empowers your next spit to create a smokescreen."
 	keybind_signal = COMSIG_XENOABILITY_SMOKESCREEN_SPIT
 	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/steam_rush
 	name = "steam_rush"
-	full_name = "Boiler - Sizzler: Steam Rush"
+	full_name = "Sizzler: Steam Rush"
 	description = "Speeds up and increases slash damage."
 	keybind_signal = COMSIG_XENOABILITY_STEAM_RUSH
 	hotkey_keys = list("Space")
 
 /datum/keybinding/xeno/high_pressure_spit
 	name = "high_pressure_spit"
-	full_name = "Boiler - Sizzler: High Pressure Spit"
+	full_name = "Sizzler: High Pressure Spit"
 	description = "Fires a high pressure glob of acid that shatters and massively knocksback the target."
 	keybind_signal = COMSIG_XENOABILITY_HIGH_PRESSURE_SPIT
 	hotkey_keys = list("E")
@@ -710,74 +710,74 @@
 
 /datum/keybinding/xeno/dodge
 	name = "Dodge"
-	full_name = "Praetorian: Dodge"
+	full_name = "Dancer: Dodge"
 	description = "Flood your body with adrenaline, gaining a speed boost upon activation and the ability to pass through mobs. Enemies automatically receive bump attacks when passed."
 	keybind_signal = COMSIG_XENOABILITY_DODGE
 
 /datum/keybinding/xeno/impale
 	name = "Impale"
-	full_name = "Praetorian: Impale"
+	full_name = "Dancer: Impale"
 	description = "Skewer an object next to you with your tail. The more debuffs on a living target, the greater the damage done. Penetrates the armor of marked targets."
 	keybind_signal = COMSIG_XENOABILITY_IMPALE
 
 /datum/keybinding/xeno/tail_trip
 	name = "Tail Trip"
-	full_name = "Praetorian: Tail Trip"
+	full_name = "Dancer: Tail Trip"
 	description = "Twirl your tail around low to the ground, knocking over and disorienting any adjacent marines. Marked enemies receive stronger debuffs and are briefly stunned."
 	keybind_signal = COMSIG_XENOABILITY_TAIL_TRIP
 
 /datum/keybinding/xeno/tail_hook
 	name = "Tail Hook"
-	full_name = "Praetorian: Tail Hook"
+	full_name = "Dancer: Tail Hook"
 	description = "Swing your tail high, sending the hooked edge gouging into any targets within 2 tiles. Hooked marines have their movement slowed and are dragged, spinning, towards you. Marked marines are slowed for longer and briefly knocked over."
 	keybind_signal = COMSIG_XENOABILITY_TAILHOOK
 
 /datum/keybinding/xeno/baton_pass
 	name = "Baton Pass"
-	full_name = "Praetorian: Baton Pass"
+	full_name = "Dancer: Baton Pass"
 	description = "Inject another xenomorph with your built-up adrenaline, increasing their movement speed considerably for 6 seconds. Puts dodge on cooldown when used. Less effect on quick xenos."
 	keybind_signal = COMSIG_XENOABILITY_BATONPASS
 
 /datum/keybinding/xeno/abduct
 	name = "Abduct"
-	full_name = "Praetorian: Abduct"
+	full_name = "Oppressor: Abduct"
 	description = "After a delay, grab marines from a 7 tiles away. Canceling early has consequences."
 	keybind_signal = COMSIG_XENOABILITY_ABDUCT
 
 /datum/keybinding/xeno/dislocate
 	name = "Dislocate"
-	full_name = "Praetorian: Dislocate"
+	full_name = "Oppressor: Dislocate"
 	description = "Punch a marine and knock them back by two tiles."
 	keybind_signal = COMSIG_XENOABILITY_DISLOCATE
 
 /datum/keybinding/xeno/item_throw
 	name = "Item Throw"
-	full_name = "Praetorian: Item Throw"
+	full_name = "Oppressor: Item Throw"
 	description = "Pick up an item and throw it. Damage and range varies based on item's size."
 	keybind_signal = COMSIG_XENOABILITY_ITEM_THROW
 
 /datum/keybinding/xeno/tail_lash
 	name = "Tail Lash"
-	full_name = "Praetorian: Tail Lash"
+	full_name = "Oppressor: Tail Lash"
 	description = "Knock back marines in a 2x3 radius where you're facing by two tiles."
 	keybind_signal = COMSIG_XENOABILITY_TAIL_LASH
 
 /datum/keybinding/xeno/tail_lash_select
 	name = "Tail Lash (Select)"
-	full_name = "Praetorian: Select Tail Lash"
+	full_name = "Oppressor: Select Tail Lash"
 	description = "Knock back marines in a 2x3 radius where you're facing by two tiles."
 	keybind_signal = COMSIG_XENOABILITY_TAIL_LASH_SELECT
 
 /datum/keybinding/xeno/advance_oppressor
 	name = "Advance (Oppressor)"
-	full_name = "Praetorian: Advance"
+	full_name = "Oppressor: Advance"
 	description = "Launch yourself with tremendous speed toward a location. Hitting a marine will cause them to be launched incredibly far."
 	keybind_signal = COMSIG_XENOABILITY_ADVANCE_OPPRESSOR
 
 /datum/keybinding/xeno/screech
 	name = "screech"
 	full_name = "Queen: Screech"
-	description = ""
+	description = "Screech, shortly stunning and deafening all nearby marines."
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 	hotkey_keys = list("E")
 
@@ -862,7 +862,7 @@
 
 /datum/keybinding/xeno/ravager_deathmark
 	name = "deathmark"
-	full_name = "Ravager: Deathmark"
+	full_name = "Bloodthirster: Deathmark"
 	description = "Mark yourself for death, filling your bloodthirst, but failing to deal enough damage to living creatures while it is active instantly kills you."
 	keybind_signal = COMSIG_XENOABILITY_DEATHMARK
 
@@ -976,35 +976,35 @@
 
 /datum/keybinding/xeno/toss_grenade
 	name = "toss_grenade"
-	full_name = "Spitter: Toss Grenade"
+	full_name = "Globadier: Toss Grenade"
 	description = "Toss a grenade at your target."
 	keybind_signal = COMSIG_XENOABILITY_TOSS_GRENADE
 	hotkey_keys = list("R")
 
 /datum/keybinding/xeno/pick_grenade
 	name = "pick_grenade"
-	full_name = "Spitter: Pick Grenade"
+	full_name = "Globadier: Pick Grenade"
 	description = "Pick which grenade to use with Toss Grenade."
 	keybind_signal = COMSIG_XENOABILITY_PICK_GRENADE
 	hotkey_keys = list("F")
 
 /datum/keybinding/xeno/acid_mine
 	name = "acid_mine"
-	full_name = "Spitter: Place Acid Mine"
+	full_name = "Globadier: Place Acid Mine"
 	description = "Place a Acid Mine at your location."
 	keybind_signal = COMSIG_XENOABILITY_ACID_MINE
 	hotkey_keys = list("G")
 
 /datum/keybinding/xeno/gas_mine
 	name = "gas_mine"
-	full_name = "Spitter: Gas Mine"
+	full_name = "Globadier: Gas Mine"
 	description = "Place a Gas Mine at your location."
 	keybind_signal = COMSIG_XENOABILITY_GAS_MINE
 	hotkey_keys = list("H")
 
 /datum/keybinding/xeno/acid_rocket
 	name = "acid_rocket"
-	full_name = "Spitter: Acid Rocket"
+	full_name = "Globadier: Acid Rocket"
 	description = "Fire a acid rocket at your target, after a short charge up."
 	keybind_signal = COMSIG_XENOABILITY_ACID_ROCKET
 	hotkey_keys = list("Y")


### PR DESCRIPTION
## About The Pull Request
wawaw
## Why It's Good For The Game
more clarity
lumi told me to
## Changelog
:cl: Cheese
qol: Strain keybinds now use the strain name, rather than the parent name, in the keybinding menu.
/:cl:
