### PR TITLE
Critical rock change

### DIFF
--- a/code/game/objects/structures/rocks.dm
+++ b/code/game/objects/structures/rocks.dm
@@ -240,6 +240,19 @@
 	bound_height = 64
 	bound_width = 64
 	icon_variants = 4
+	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
+
+/obj/structure/rock/variable/jungle_large/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override),
+		COMSIG_TURF_CHECK_COVERED = TYPE_PROC_REF(/atom/movable, turf_cover_check),
+	)
+	AddElement(/datum/element/connect_loc, connections)
+
+/obj/structure/rock/variable/jungle_large/footstep_override(atom/movable/source, list/footstep_overrides)
+	footstep_overrides[FOOTSTEP_CONCRETE] = layer
 
 //drought rocks
 /obj/structure/rock/variable/drought


### PR DESCRIPTION

## About The Pull Request
The 4 tile grassy rock pile thing can now be jumped on/walked around on.

There's definitely other stuff that needs this but uh, someone's gotta remind me.
## Why It's Good For The Game
Walk on the pebble.
Don't get stuck on the pebble.
Be dry on the pebble.
## Changelog
:cl:
qol: Large grassy rock piles can be jumped onto and walked upon
/:cl:
