### PR TITLE
Area by z dup fix

### DIFF
--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -141,7 +141,7 @@
 		return
 	if(!areas_in_z["[z]"])
 		areas_in_z["[z]"] = list()
-	areas_in_z["[z]"] += src
+	areas_in_z["[z]"] |= src
 
 
 


### PR DESCRIPTION

## About The Pull Request
Random bug I found while checking something else.
areas_in_z will no longer have dup entries due to modulars.

:cl:
code: Fixed modular mapping creating dup entries in areas_in_z 
/:cl:
