### PR TITLE
Reworks breach/demolition modes for detpack

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -21,6 +21,7 @@
 	var/atom/plant_target = null //which atom the detpack is planted on
 	var/target_drag_delay = null //store this for restoration later
 	var/boom = FALSE //confirms whether we actually detted.
+	var/boom_direction //which direction we were planted in; determines which way breach detpacks blast through walls
 	var/detonation_pending
 	var/sound_timer
 	var/datum/radio_frequency/radio_connection
@@ -292,6 +293,7 @@
 		var/location
 		location = target
 		forceMove(location)
+		boom_direction = get_dir(user, location)
 
 		log_game("[key_name(user)] planted [src.name] on [target.name] at [AREACOORD(target.loc)] with [timer] second fuse.")
 		message_admins("[ADMIN_TPMONTY(user)] planted [src.name] on [target.name] at [ADMIN_VERBOSEJMP(target.loc)] with [timer] second fuse.")
@@ -366,11 +368,11 @@
 	plant_target.ex_act(EXPLODE_DEVASTATE)
 	plant_target = null
 	if(det_mode == TRUE) //If we're on demolition mode, big boom.
-		explosion(det_location, 3, 5, 6, 0, 6)
+		explosion(det_location, 0, 7, 9, 0, 7)
 	else //if we're not, focused boom.
-		explosion(det_location, 2, 2, 3, 0, 3, throw_range = FALSE)
-	qdel(src)
-
+		if(iswallturf(det_location)) //Breach the other side of the wall if planted on one
+			det_location = get_step(det_location, boom_direction)
+		explosion(det_location, 3, 4, 4, 0, 4)
 
 /obj/item/detpack/attack(mob/M as mob, mob/user as mob, def_zone)
 	return


### PR DESCRIPTION

## About The Pull Request

Old Demolition mode is the new Breach mode (3, 4, 4  explosion)
Demolition is a wider explosion that has no deva, meaning it can't destroy walls (0, 7, 9)

Detpacks set to 'breach mode' now explode on the **opposite side of the wall to where you placed them**. (see below)

![image](https://github.com/user-attachments/assets/8360884d-c4bf-4f4b-81a0-f2ad912fa5c7)
## Why It's Good For The Game

Detpacks are in a really weird spot right now. Demolition is purely better than breach, in every way possible. They're intended to be used for traps, but because both explosions are so focused, they can't be used for it. I'm guessing the intention was that breach deals less friendly damage, but with how expensive detpacks are (and also the changes I'm making below) it's just.. kinda useless.

Breach changes:
Because of how explosion code works, _placing a detpack on a wall is less effective than placing it on the floor_. (Placing it on a wall produces 1 deva; on the floor produces 3 deva).
This is unintuitive and stupid. Since detpacks serve as (kind of) a breaching charge, they should breach through the wall, not behind it!
## Changelog
:cl:
balance: Demolition detpack explosion: 3, 5, 6 -> 0, 7, 9
balance: Breach detpack explosion: 2, 2, 3 -> 3, 4, 4
balance: Breach charge will now explode on the opposite side of a wall, if it is planted on a wall
/:cl:
