### PR TITLE
Adds standard deck of cards to marine vendor/customization

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -221,6 +221,7 @@
 			/obj/item/compass = -1,
 			/obj/item/tool/hand_labeler = -1,
 			/obj/item/toy/deck/kotahi = -1,
+			/obj/item/toy/deck = -1,
 			/obj/item/deployable_floodlight = 5,
 		),
 	)

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -225,6 +225,12 @@ GLOBAL_LIST_INIT(gear_datums, populate_gear_list())
 	cost = 2
 	slot = SLOT_R_HAND
 
+/datum/gear/card_deck
+	display_name = "Deck of cards"
+	path = /obj/item/toy/deck
+	cost = 2
+	slot = SLOT_R_HAND
+
 /datum/gear/rosary
 	display_name = "Rosary"
 	path = /obj/item/rosary


### PR DESCRIPTION
## About The Pull Request

does what it says on the tin

tested card decks spawning from roundstart customization and marine vending with no issues

## Why It's Good For The Game

https://github.com/user-attachments/assets/fe4b0487-b520-4083-977f-0c7b98e1a96a

KOTAHI/Not Uno was added to vendor/customization two years back but I cant find any reason/explanation as to why conventional card decks weren't.

## Changelog

:cl:
add: Card decks are now available for Marines in Character Customization and Marine Armaments Vendors
/:cl:
