### PR TITLE
Behemoth no longer has heavy footstep sounds.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/behemoth.dm
@@ -14,7 +14,6 @@
 	mob_size = MOB_SIZE_BIG
 	max_buckled_mobs = 2
 	pixel_x = -28.5
-	footstep_type = FOOTSTEP_XENO_HEAVY
 
 
 // ***************************************


### PR DESCRIPTION

## About The Pull Request
Title. Literally.
## Why It's Good For The Game
This caste is kinda always going to be trash with the heavy footstep sounds. I think the kit is still way too overloaded but this is a good step at getting it in a better state.
## Changelog
:cl:
balance: Behemoth no longer has heavy footstep sounds.
sounddel: Behemoth no longer has heavy footstep sounds.
/:cl:
