### PR TITLE
XOB and xortar fire now alerts ghosts like marine OBs do

### DIFF
--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -350,6 +350,7 @@
 	var/datum/maw_ammo/ammo = new selected_type
 	var/turf/clicked_turf = locate(polled_coords[1], polled_coords[2], z)
 	addtimer(CALLBACK(src, PROC_REF(maw_impact_start), ammo, clicked_turf, xeno_shooter), ammo.impact_time-2 SECONDS)
+	notify_ghosts("<b>[xeno_shooter]</b> has just fired \the <b>[src]</b> !", source = clicked_turf, action = NOTIFY_JUMP)
 	//this is stinky but we need to call parent for acid jaw regardless so have to do the tracking, for both, here
 	switch(type)
 		if(/obj/structure/xeno/acid_maw)


### PR DESCRIPTION

## About The Pull Request
See title
## Why It's Good For The Game
Uerhh
## Changelog
:cl:
qol: Acid Maws and Acid Jaws now notify ghosts when fired, and their point of impact may be jumped to.
/:cl:
