### PR TITLE
Nerfs laser sentry range by 1 tile

### DIFF
--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -443,7 +443,7 @@
 	icon = 'icons/obj/machines/deployable/sentry/laser.dmi'
 	fire_sound = 'sound/weapons/guns/fire/laser.ogg'
 
-	turret_range = 8
+	turret_range = 7
 	deploy_time = 5 SECONDS
 	max_shells = 500
 	fire_delay = 0.2 SECONDS


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
Laser sentry with 8 tile range is capable of off-screen shooting if approached from the north/south
For other turrets this is perfectly fine, as you can dodge the bullets and they're subjected to accuracy rng, but the laser turret is not, making it just about impossible to push from those directions
The laser turret is also just about a direct upgrade over the standard turret, so this should maybe make it slightly less of an obvious pick over it, though really a laser turret is just ass design
## Changelog
:cl:
balance: nerf laser turret range by 1 tile (8 -> 7)
/:cl:
