### PR TITLE
Tesla Turret can no longer be toggled on or off by ghosts

### DIFF
--- a/code/game/objects/machinery/tesla_turret.dm
+++ b/code/game/objects/machinery/tesla_turret.dm
@@ -137,6 +137,8 @@
 
 /obj/machinery/deployable/tesla_turret/interact(mob/user)
 	. = ..()
+	if(user.stat == DEAD)
+		return
 	if(!battery)
 		balloon_alert(user, "no battery")
 		return


### PR DESCRIPTION
## About The Pull Request
bugfix
## Why It's Good For The Game
#1 bug hater
## Changelog
:cl: Cheese
fix: Tesla Turrets can longer be turned on or off by ghosts
/:cl:
