### PR TITLE
let medical rig hold tweezers and ESR-12

### DIFF
--- a/code/datums/storage/subtypes/belt.dm
+++ b/code/datums/storage/subtypes/belt.dm
@@ -88,6 +88,7 @@
 		/obj/item/bodybag,
 		/obj/item/defibrillator,
 		/obj/item/tweezers,
+		/obj/item/tweezers_advanced,
 		/obj/item/roller,
 		/obj/item/tool/research,
 		/obj/item/tool/soap,

--- a/code/datums/storage/subtypes/belt.dm
+++ b/code/datums/storage/subtypes/belt.dm
@@ -87,6 +87,7 @@
 		/obj/item/stack/medical,
 		/obj/item/bodybag,
 		/obj/item/defibrillator,
+		/obj/item/tweezers,
 		/obj/item/roller,
 		/obj/item/tool/research,
 		/obj/item/tool/soap,


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

For a medical rig that can hold defibs, cryobag, rollers, and hypospray, it's weird that for 4 years it cannot hold tweezers. Let medical rig continue its niche to hold different medical items compare to the lifesaver which hold more pills and stuff.

also ESR-12

## Changelog

:cl:
balance: medical rig can now hold tweezers and ESR-12
/:cl:
