### PR TITLE
Default climb delay change

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -1,7 +1,7 @@
 /obj/structure
 	icon = 'icons/obj/structures/structures.dmi'
 	var/climbable = FALSE
-	var/climb_delay = 50
+	var/climb_delay = 1 SECONDS
 	var/barrier_flags = NONE
 	var/broken = FALSE //similar to machinery's stat BROKEN
 	obj_flags = CAN_BE_HIT

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -9,7 +9,7 @@
 	obj_flags = CAN_BE_HIT | IGNORE_DENSITY | BLOCKS_CONSTRUCTION_DIR
 	resistance_flags = XENO_DAMAGEABLE
 	allow_pass_flags = PASS_DEFENSIVE_STRUCTURE|PASSABLE|PASS_WALKOVER
-	climb_delay = 20 //Leaping a barricade is universally much faster than clumsily climbing on a table or rack
+	climb_delay = 2 SECONDS
 	interaction_flags = INTERACT_CHECK_INCAPACITATED
 	max_integrity = 100
 	barrier_flags = HANDLE_BARRIER_CHANCE

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -10,7 +10,6 @@
 	interaction_flags = INTERACT_CHECK_INCAPACITATED
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
 	climbable = TRUE
-	climb_delay = 10
 	resistance_flags = XENO_DAMAGEABLE
 
 /obj/structure/platform/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Default climb delay for structures changed to 1 second from 5(!!) seconds.
## Why It's Good For The Game
Having to take 5 seconds to climb onto a table is insane.
Robro buff.
## Changelog
:cl:
balance: Default climb delay for structures (such as tables) changed to 1 second from 5 seconds
/:cl:
