### PR TITLE
Removes Russian Red from ground maps

### DIFF
--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -38144,7 +38144,6 @@
 "jXd" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular,
-/obj/item/storage/pill_bottle/russian_red,
 /turf/open/floor/tile/blue/whiteblue,
 /area/desert_dam/building/medical/medsecure)
 "jXf" = (

--- a/_maps/map_files/riptide/riptide.dmm
+++ b/_maps/map_files/riptide/riptide.dmm
@@ -6048,7 +6048,6 @@
 /area/riptide/inside/chapel)
 "ejd" = (
 /obj/structure/table,
-/obj/item/storage/pill_bottle/packet/russian_red,
 /turf/open/floor/tile/blue,
 /area/riptide/inside/medical/offices)
 "eju" = (

--- a/_maps/modularmaps/corsatdome/corsatdomeicecolony.dmm
+++ b/_maps/modularmaps/corsatdome/corsatdomeicecolony.dmm
@@ -1971,7 +1971,6 @@
 /obj/effect/turf_decal/tile/corsatstraight/lightpurple{
 	dir = 1
 	},
-/obj/item/storage/pill_bottle/packet/russian_red,
 /turf/open/floor/grayscale/round/lightgray,
 /area/corsat/gamma/biodome/virology)
 "wU" = (


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

Kuro wants it, walance must be restored to TGMC.

## Changelog
:cl:
balance: Removed Russian Red from a few groundside maps.
/:cl:
