### PR TITLE
Kills cringe marine weapon damage

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -31,7 +31,7 @@
 	icon_state = "stun"
 	hud_state = "taser"
 	hud_state_empty = "battery_empty"
-	damage = 10
+	damage = 0
 	penetration = 100
 	damage_type = STAMINA
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_SKIPS_ALIENS
@@ -49,7 +49,7 @@
 	hud_state_empty = "battery_empty"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_SPECIAL_PROCESS
 	shell_speed = 0.1
-	damage = 20
+	damage = 0
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
 
@@ -59,7 +59,7 @@
 /datum/ammo/energy/tesla/focused
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_SPECIAL_PROCESS|AMMO_IFF
 	shell_speed = 0.1
-	damage = 10
+	damage = 0
 	penetration = 10
 	bullet_color = COLOR_TESLA_BLUE
 
@@ -82,7 +82,7 @@
 	hud_state_empty = "electrothermal_empty"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_SPECIAL_PROCESS|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 0.2
-	damage = 150
+	damage = 0
 	penetration = 50
 	max_range = 20
 	bullet_color = COLOR_PALE_GREEN_GRAY
@@ -120,7 +120,7 @@
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN
 	hud_state = "laser_overcharge"
 	armor_type = LASER
-	damage = 40
+	damage = 0
 	penetration = 5
 	max_range = 7
 	hitscan_effect_icon = "beam_heavy"
@@ -133,7 +133,7 @@
 	ammo_behavior_flags = AMMO_ENERGY
 	shell_speed = 4
 	accurate_range = 15
-	damage = 20
+	damage = 0
 	penetration = 10
 	max_range = 30
 	accuracy_var_low = 3
@@ -147,7 +147,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 40
+	damage = 0
 	max_range = 40
 	penetration = 50
 	sundering = 5
@@ -156,7 +156,7 @@
 	name = "microwave heat bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_heat"
-	damage = 12 //requires mod with -0.15 multiplier should math out to 10
+	damage = 0 //requires mod with -0.15 multiplier should math out to 10
 	penetration = 100 // It's a laser that burns the skin! The fire stacks go threw anyway.
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY
 	sundering = 1
@@ -172,7 +172,7 @@
 	accuracy_var_high = 9
 	accurate_range = 5
 	max_range = 5
-	damage = 42
+	damage = 0
 	damage_falloff = 10
 	penetration = 0
 	sundering = 5
@@ -185,7 +185,7 @@
 	accuracy_var_high = 9
 	accurate_range = 5
 	max_range = 5
-	damage = 35
+	damage = 0
 	damage_falloff = 10
 	penetration = 0
 
@@ -193,7 +193,7 @@
 	name = "disabler bolt"
 	icon_state = "disablershot"
 	hud_state = "laser_disabler"
-	damage = 45
+	damage = 0
 	penetration = 0
 	damage_type = STAMINA
 	bullet_color = COLOR_DISABLER_BLUE
@@ -205,7 +205,7 @@
 	name = "pulse bolt"
 	icon_state = "pulse2"
 	hud_state = "pulse"
-	damage = 45 // this is gotta hurt...
+	damage = 0 // this is gotta hurt...
 	max_range = 40
 	penetration = 100
 	sundering = 100
@@ -215,7 +215,7 @@
 	name = "practice laser bolt"
 	icon_state = "disablershot"
 	hud_state = "laser_disabler"
-	damage = 45
+	damage = 0
 	penetration = 0
 	damage_type = STAMINA
 	ammo_behavior_flags = AMMO_ENERGY
@@ -231,7 +231,7 @@
 
 /datum/ammo/energy/lasgun/marine
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN
-	damage = 20
+	damage = 0
 	penetration = 10
 	sundering = 1.5
 	max_range = 30
@@ -245,7 +245,7 @@
 	name = "overcharged laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
-	damage = 40
+	damage = 0
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_heavy"
@@ -254,7 +254,7 @@
 	name = "weakening laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_efficiency"
-	damage = 30
+	damage = 0
 	penetration = 10
 	sundering = 0
 	damage_type = STAMINA
@@ -275,7 +275,7 @@
 	name = "microwave laser bolt"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_xray"
-	damage = 20
+	damage = 0
 	penetration = 20
 	sundering = 2
 	hitscan_effect_icon = "beam_grass"
@@ -306,7 +306,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 8
-	damage = 35
+	damage = 0
 	damage_falloff = 8
 	penetration = 20
 	sundering = 1
@@ -320,7 +320,7 @@
 	name = "impact laser blast"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_impact"
-	damage = 35
+	damage = 0
 	penetration = 10
 	sundering = 0
 	hitscan_effect_icon = "pu_laser"
@@ -334,7 +334,7 @@
 	name = "crippling laser blast"
 	icon_state = "overchargedlaser"
 	hud_state = "laser_disabler"
-	damage = 20
+	damage = 0
 	penetration = 10
 	sundering = 0
 	hitscan_effect_icon = "blue_beam"
@@ -345,19 +345,19 @@
 
 /datum/ammo/energy/lasgun/marine/autolaser
 	name = "machine laser bolt"
-	damage = 18
+	damage = 0
 	penetration = 15
 	sundering = 1
 
 /datum/ammo/energy/lasgun/marine/autolaser/burst
 	name = "burst machine laser bolt"
 	hud_state = "laser_efficiency"
-	damage = 12
+	damage = 0
 
 /datum/ammo/energy/lasgun/marine/autolaser/charge
 	name = "charged machine laser bolt"
 	hud_state = "laser_overcharge"
-	damage = 50
+	damage = 0
 	penetration = 30
 	sundering = 3
 	hitscan_effect_icon = "beam_heavy"
@@ -371,7 +371,7 @@
 /datum/ammo/energy/lasgun/marine/autolaser/melting
 	name = "melting machine laser bolt"
 	hud_state = "laser_melting"
-	damage = 15
+	damage = 0
 	penetration = 20
 	sundering = 0
 	hitscan_effect_icon = "beam_solar"
@@ -394,7 +394,7 @@
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"
 	hud_state = "laser_sniper"
-	damage = 60
+	damage = 0
 	penetration = 30
 	accurate_range_min = 5
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_SNIPER
@@ -407,7 +407,7 @@
 	name = "sniper heat bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_heat"
-	damage = 40
+	damage = 0
 	penetration = 10
 	accurate_range_min = 5
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_HITSCAN|AMMO_SNIPER
@@ -419,7 +419,7 @@
 	name = "sniper shattering bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_impact"
-	damage = 40
+	damage = 0
 	penetration = 30
 	accurate_range_min = 5
 	sundering = 10
@@ -443,7 +443,7 @@
 	name = "sniper laser bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_disabler"
-	damage = 100
+	damage = 0
 	penetration = 30
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_SNIPER
 	sundering = 1
@@ -452,19 +452,19 @@
 	bullet_color = COLOR_DISABLER_BLUE
 
 /datum/ammo/energy/lasgun/marine/ricochet/one
-	damage = 80
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet
 
 /datum/ammo/energy/lasgun/marine/ricochet/two
-	damage = 65
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/one
 
 /datum/ammo/energy/lasgun/marine/ricochet/three
-	damage = 50
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/two
 
 /datum/ammo/energy/lasgun/marine/ricochet/four
-	damage = 40
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/lasgun/marine/ricochet/three
 
 /datum/ammo/energy/lasgun/marine/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
@@ -476,7 +476,7 @@
 /datum/ammo/energy/lasgun/marine/pistol
 	name = "pistol laser bolt"
 	hud_state = "laser_efficiency"
-	damage = 20
+	damage = 0
 	penetration = 5
 	sundering = 1
 	hitscan_effect_icon = "beam_particle"
@@ -486,7 +486,7 @@
 	name = "disabler bolt"
 	icon_state = "disablershot"
 	hud_state = "laser_disabler"
-	damage = 70
+	damage = 0
 	penetration = 0
 	damage_type = STAMINA
 	hitscan_effect_icon = "beam_stun"
@@ -496,7 +496,7 @@
 	name = "microwave heat bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_heat"
-	damage = 20
+	damage = 0
 	shell_speed = 2.5
 	penetration = 10
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_HITSCAN
@@ -512,7 +512,7 @@
 	hud_state = "laser_heat"
 	icon_state = "u_laser"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_HITSCAN
-	damage = 25
+	damage = 0
 	penetration = 5
 	sundering = 1
 	max_range = 15
@@ -523,7 +523,7 @@
 	hud_state = "laser_xray"
 	icon_state = "xray"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 25
+	damage = 0
 	penetration = 100
 	max_range = 10
 	hitscan_effect_icon = "xray_beam"
@@ -531,7 +531,7 @@
 /datum/ammo/energy/lasgun/marine/heavy_laser
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER|AMMO_ENERGY|AMMO_HITSCAN|AMMO_INCENDIARY
 	hud_state = "laser_overcharge"
-	damage = 60
+	damage = 0
 	penetration = 10
 	sundering = 1
 	max_range = 30
@@ -559,7 +559,7 @@
 	name = "laser sentry bolt"
 	icon_state = "laser"
 	hud_state = "laser"
-	damage = 35
+	damage = 0
 	penetration = 15
 	sundering = 2
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN
@@ -577,7 +577,7 @@
 	shell_speed = 3
 
 /datum/ammo/energy/plasma/rifle_standard
-	damage = 25
+	damage = 0
 	penetration = 20
 	sundering = 0.75
 
@@ -585,7 +585,7 @@
 	icon_state = "plasma_big"
 	hud_state = "plasma_blast"
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_PASS_THROUGH_MOB
-	damage = 40
+	damage = 0
 	penetration = 30
 	sundering = 2
 	damage_falloff = 0.5
@@ -601,7 +601,7 @@
 	name = "plasma blast"
 	icon_state = "plasma_ball_small"
 	hud_state = "plasma_blast"
-	damage = 30
+	damage = 0
 	penetration = 10
 	sundering = 2
 	damage_falloff = 0.5
@@ -624,7 +624,7 @@
 	drop_nade(target_mob.loc)
 
 /datum/ammo/energy/plasma/blast/melting
-	damage = 40
+	damage = 0
 	sundering = 3
 	damage_falloff = 0.5
 	accurate_range = 7
@@ -641,7 +641,7 @@
 			living_victim.apply_status_effect(STATUS_EFFECT_MELTING, melting_stacks)
 
 /datum/ammo/energy/plasma/blast/shatter
-	damage = 40
+	damage = 0
 	sundering = 3
 	damage_falloff = 0.5
 	accurate_range = 9
@@ -654,7 +654,7 @@
 
 /datum/ammo/energy/plasma/blast/incendiary
 	name = "plasma glob"
-	damage = 30
+	damage = 0
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY
 	shell_speed = 2
 	icon_state = "plasma_big"
@@ -672,7 +672,7 @@
 	name = "plasma heavy glob"
 	icon_state = "plasma_ball_big"
 	hud_state = "plasma_sphere"
-	damage = 60
+	damage = 0
 	penetration = 40
 	sundering = 10
 
@@ -717,7 +717,7 @@
 
 /datum/ammo/energy/plasma/smg_standard
 	icon_state = "plasma_ball_small"
-	damage = 14
+	damage = 0
 	penetration = 10
 	sundering = 0.5
 	damage_falloff = 1.5
@@ -726,19 +726,19 @@
 	reflect(target_turf, proj, 5)
 
 /datum/ammo/energy/plasma/smg_standard/one
-	damage = 16
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard
 
 /datum/ammo/energy/plasma/smg_standard/two
-	damage = 18
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/one
 
 /datum/ammo/energy/plasma/smg_standard/three
-	damage = 20
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/two
 
 /datum/ammo/energy/plasma/smg_standard/four
-	damage = 22
+	damage = 0
 	bonus_projectiles_type = /datum/ammo/energy/plasma/smg_standard/three
 
 // Plasma //
@@ -749,7 +749,7 @@
 	armor_type = LASER
 	shell_speed = 4
 	accurate_range = 15
-	damage = 40
+	damage = 0
 	penetration = 15
 	max_range = 30
 	accuracy_var_low = 3
@@ -760,7 +760,7 @@
 	icon_state = "overchargedlaser"
 	hud_state = "electrothermal"
 	hud_state_empty = "electrothermal_empty"
-	damage = 40
+	damage = 0
 	max_range = 14
 	penetration = 5
 	shell_speed = 1.5
@@ -770,7 +770,7 @@
 	///Fire burn time
 	var/heat = 12
 	///Fire damage
-	var/burn_damage = 9
+	var/burn_damage = 0
 	///Fire color
 	var/fire_color = "green"
 
@@ -810,7 +810,7 @@
 	max_range = 40
 	accurate_range = 10
 	accuracy = 25
-	damage = 850
+	damage = 0
 	penetration = 120
 	sundering = 30
 	damage_falloff = 5

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -12,7 +12,7 @@
 	hud_state = "minigun"
 	hud_state_empty = "smartgun_empty"
 	accurate_range = 12
-	damage = 40 //Reduced damage due to vastly increased mobility
+	damage = 0 //Reduced damage due to vastly increased mobility
 	penetration = 40 //Reduced penetration due to vastly increased mobility
 	accuracy = 5
 	barricade_clear_distance = 2
@@ -26,7 +26,7 @@
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	accurate_range = 5
-	damage = 25
+	damage = 0
 	penetration = 15
 	shrapnel_chance = 25
 	sundering = 2.5
@@ -36,7 +36,7 @@
 	hud_state = "minigun"
 	hud_state_empty = "smartgun_empty"
 	accurate_range = 6
-	damage = 16
+	damage = 0
 	penetration = 15
 	shrapnel_chance = 15
 	sundering = 1.5
@@ -44,7 +44,7 @@
 
 /datum/ammo/bullet/minigun/ltaap
 	name = "chaingun bullet"
-	damage = 15
+	damage = 0
 	penetration = 20
 	sundering = 1
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_IFF
@@ -54,7 +54,7 @@
 	barricade_clear_distance = 4
 
 /datum/ammo/bullet/minigun/ltaap/hv
-	damage = 35
+	damage = 0
 	penetration = 30
 	ammo_behavior_flags = AMMO_BALLISTIC
 	hud_state = "hivelo_impact"
@@ -68,7 +68,7 @@
 	accurate_range_min = 6
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 30
+	damage = 0
 	penetration = 50
 	sundering = 1
 	max_range = 35
@@ -93,7 +93,7 @@
 	name = "autocannon smart-detonating bullet"
 	hud_state = "sniper_flak"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_TARGET_TURF
-	damage = 50
+	damage = 0
 	penetration = 30
 	sundering = 5
 	max_range = 30
@@ -113,7 +113,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 4
 	max_range = 14
-	damage = 150
+	damage = 0
 	penetration = 100
 	sundering = 20
 	bullet_color = COLOR_PULSE_BLUE
@@ -130,7 +130,7 @@
 	hud_state = "railgun_hvap"
 	shell_speed = 5
 	max_range = 21
-	damage = 100
+	damage = 0
 	penetration = 30
 	sundering = 50
 
@@ -141,7 +141,7 @@
 	name = "smart armor piercing railgun slug"
 	hud_state = "railgun_smart"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE|AMMO_IFF
-	damage = 100
+	damage = 0
 	penetration = 20
 	sundering = 20
 
@@ -155,7 +155,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOVABLE|AMMO_UNWIELDY
 	shell_speed = 4
 	max_range = 14
-	damage = 150
+	damage = 0
 	penetration = 100
 	sundering = 0
 	bullet_color = COLOR_PULSE_BLUE
@@ -173,7 +173,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 5
 	max_range = 31
-	damage = 70
+	damage = 0
 	penetration = 35
 	sundering = 5
 	bullet_color = COLOR_PULSE_BLUE
@@ -190,7 +190,7 @@
 	hud_state = "alloy_spike"
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 40
+	damage = 0
 	penetration = 40
 	sundering = 3.5
 
@@ -199,7 +199,7 @@
 	hud_state = "alloy_spike"
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 25
+	damage = 0
 	penetration = 30
 	sundering = 0.5
 	max_range = 21

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -15,7 +15,7 @@
 	accuracy_var_low = 15
 	accuracy_var_high = 5
 	max_range = 6
-	damage = 30
+	damage = 0
 	penetration = 20
 	sundering = 3
 	damage_falloff = 0
@@ -23,7 +23,7 @@
 /datum/ammo/bullet/atgun_spread/incendiary
 	name = "incendiary flechette"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB|AMMO_INCENDIARY|AMMO_LEAVE_TURF
-	damage = 20
+	damage = 0
 	penetration = 10
 	sundering = 1.5
 
@@ -52,7 +52,7 @@
 	accurate_range = 15
 	damage_type = STAMINA
 	armor_type = BIO
-	damage = 70
+	damage = 0
 	penetration = 0
 	shrapnel_chance = 0
 	///percentage of xenos total plasma to drain when hit by a pepperball
@@ -68,7 +68,7 @@
 			X.use_plasma(plasma_drain)
 
 /datum/ammo/bullet/pepperball/pepperball_mini
-	damage = 40
+	damage = 0
 	drain_multiplier = 0.03
 	plasma_drain = 15
 
@@ -83,7 +83,7 @@
 	accuracy = 20
 	accurate_range = 15
 	max_range = 15
-	damage = 40
+	damage = 0
 	penetration = 50
 	shrapnel_chance = 75
 
@@ -96,7 +96,7 @@
 	ammo_behavior_flags = AMMO_INCENDIARY|AMMO_FLAME|AMMO_TARGET_TURF
 	armor_type = FIRE
 	max_range = 7
-	damage = 31
+	damage = 0
 	damage_falloff = 0
 	incendiary_strength = 30 //Firestacks cap at 20, but that's after armor.
 	bullet_color = LIGHT_COLOR_FIRE
@@ -145,7 +145,7 @@
 	icon_state = "spray_flamer"
 	max_range = 7
 	shell_speed = 0.3
-	damage = 6
+	damage = 0
 	burntime = 0.3 SECONDS
 
 /datum/ammo/flamethrower/sentry // is also a spray
@@ -153,7 +153,7 @@
 	icon_state = "spray_flamer"
 	max_range = 7
 	shell_speed = 0.3
-	damage = 6
+	damage = 0
 	burntime = 0.3 SECONDS
 
 /datum/ammo/water
@@ -191,7 +191,7 @@
 
 /datum/ammo/rocket/toy
 	name = "\improper toy rocket"
-	damage = 1
+	damage = 0
 
 /datum/ammo/rocket/toy/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	to_chat(target_mob, "<font size=6 color=red>NO BUGS</font>")
@@ -212,7 +212,7 @@
 	var/nade_type = /obj/item/explosive/grenade
 	icon_state = "grenade"
 	armor_type = BOMB
-	damage = 15
+	damage = 0
 	accuracy = 15
 	max_range = 10
 

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -72,7 +72,7 @@
 	smoke.set_up(6, T, 7)
 	smoke.start()
 	flame_radius(4, T)
-	flame_radius(1, T, burn_intensity = 75, burn_duration = 45, burn_damage = 15, fire_stacks = 75)
+	flame_radius(1, T, burn_intensity = 75, burn_duration = 45, burn_damage = 0, fire_stacks = 75)
 
 /datum/ammo/mortar/smoke/howi/plasmaloss
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss

--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -9,7 +9,7 @@
 	hud_state = "pistol"
 	hud_state_empty = "pistol_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 20
+	damage = 0
 	penetration = 5
 	accurate_range = 5
 	sundering = 1
@@ -17,14 +17,14 @@
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"
 	hud_state = "pistol_light"
-	damage = 15
+	damage = 0
 	penetration = 5
 	sundering = 0.5
 
 /datum/ammo/bullet/pistol/tiny/ap
 	name = "light pistol bullet"
 	hud_state = "pistol_lightap"
-	damage = 22.5
+	damage = 0
 	penetration = 15 //So it can actually hurt something.
 	sundering = 0.5
 	damage_falloff = 1.5
@@ -33,7 +33,7 @@
 /datum/ammo/bullet/pistol/tranq
 	name = "tranq bullet"
 	hud_state = "pistol_tranq"
-	damage = 25
+	damage = 0
 	damage_type = STAMINA
 
 /datum/ammo/bullet/pistol/tranq/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -54,7 +54,7 @@
 /datum/ammo/bullet/pistol/ap
 	name = "armor-piercing pistol bullet"
 	hud_state = "pistol_ap"
-	damage = 20
+	damage = 0
 	penetration = 12.5
 	shrapnel_chance = 15
 	sundering = 0.5
@@ -62,7 +62,7 @@
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"
 	hud_state = "pistol_heavy"
-	damage = 30
+	damage = 0
 	penetration = 5
 	shrapnel_chance = 25
 	sundering = 2.15
@@ -70,7 +70,7 @@
 /datum/ammo/bullet/pistol/superheavy
 	name = "high impact pistol bullet"
 	hud_state = "pistol_superheavy"
-	damage = 45
+	damage = 0
 	penetration = 15
 	sundering = 3
 	damage_falloff = 0.75
@@ -91,13 +91,13 @@
 	damage_type = BURN
 	shrapnel_chance = 0
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
-	damage = 20
+	damage = 0
 
 /datum/ammo/bullet/pistol/squash
 	name = "squash-head pistol bullet"
 	hud_state = "pistol_squash"
 	accuracy = 5
-	damage = 32
+	damage = 0
 	penetration = 10
 	shrapnel_chance = 25
 	sundering = 2
@@ -111,7 +111,7 @@
 	damage_type = BURN
 	ammo_behavior_flags = AMMO_INCENDIARY
 	shell_speed = 2
-	damage = 15
+	damage = 0
 
 
 /datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/target_mob, obj/projectile/proj)

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -10,7 +10,7 @@
 	hud_state_empty = "revolver_empty"
 	handful_amount = 7
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 45
+	damage = 0
 	penetration = 10
 	sundering = 3
 
@@ -19,7 +19,7 @@
 
 /datum/ammo/bullet/revolver/tp44
 	name = "standard revolver bullet"
-	damage = 40
+	damage = 0
 	penetration = 15
 	sundering = 1
 
@@ -29,7 +29,7 @@
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
 	hud_state = "revolver_small"
-	damage = 30
+	damage = 0
 
 /datum/ammo/bullet/revolver/small/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, slowdown = 0.5)
@@ -41,7 +41,7 @@
 	damage_falloff = 0
 	accuracy = 15
 	accurate_range = 15
-	damage = 30
+	damage = 0
 	penetration = 10
 
 /datum/ammo/bullet/revolver/judge
@@ -51,13 +51,13 @@
 	damage_falloff = 0
 	accuracy = 15
 	accurate_range = 15
-	damage = 70
+	damage = 0
 	penetration = 10
 
 /datum/ammo/bullet/revolver/heavy
 	name = "heavy revolver bullet"
 	hud_state = "revolver_heavy"
-	damage = 50
+	damage = 0
 	penetration = 5
 	accuracy = -10
 
@@ -69,7 +69,7 @@
 /datum/ammo/bullet/revolver/t76
 	name = "magnum bullet"
 	handful_amount = 5
-	damage = 100
+	damage = 0
 	penetration = 40
 	sundering = 0.5
 
@@ -80,7 +80,7 @@
 	name = "high-impact revolver bullet"
 	hud_state = "revolver_impact"
 	handful_amount = 6
-	damage = 50
+	damage = 0
 	penetration = 20
 	sundering = 3
 

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -10,35 +10,35 @@
 	hud_state_empty = "rifle_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 12
-	damage = 25
+	damage = 0
 	penetration = 5
 	sundering = 0.5
 
 /datum/ammo/bullet/rifle/ap
 	name = "armor-piercing rifle bullet"
 	hud_state = "rifle_ap"
-	damage = 20
+	damage = 0
 	penetration = 25
 	sundering = 3
 
 /datum/ammo/bullet/rifle/hv
 	name = "high-velocity rifle bullet"
 	hud_state = "hivelo"
-	damage = 20
+	damage = 0
 	penetration = 20
 	sundering = 0.5
 
 /datum/ammo/bullet/rifle/heavy
 	name = "heavy rifle bullet"
 	hud_state = "rifle_heavy"
-	damage = 30
+	damage = 0
 	penetration = 10
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater
 	name = "heavy impact rifle bullet"
 	hud_state = "sniper"
-	damage = 70
+	damage = 0
 	penetration = 20
 	sundering = 1.25
 
@@ -56,14 +56,14 @@
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 25
+	damage = 0
 	penetration = 10
 	sundering = 0.75
 
 /datum/ammo/bullet/rifle/som_machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 28
+	damage = 0
 	penetration = 12.5
 	sundering = 1
 
@@ -77,7 +77,7 @@
 	damage_falloff = 0.5
 	accurate_range = 18
 	max_range = 30
-	damage = 60
+	damage = 0
 	penetration = 20
 	sundering = 2
 
@@ -87,7 +87,7 @@
 /datum/ammo/bullet/rifle/som_big/incendiary
 	name = "heavy incendiary bullet"
 	hud_state = "hivelo_fire"
-	damage = 40
+	damage = 0
 	penetration = 10
 	sundering = 1
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
@@ -99,7 +99,7 @@
 /datum/ammo/bullet/rifle/som_big/anti_armour
 	name = "heavy AT bullet"
 	hud_state = "hivelo_impact"
-	damage = 40
+	damage = 0
 	penetration = 45
 	sundering = 8
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOVABLE
@@ -124,7 +124,7 @@
 	damage_falloff = 0
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 15
-	damage = 40
+	damage = 0
 	penetration = 30
 	sundering = 5
 	bullet_color = COLOR_SOFT_RED
@@ -133,7 +133,7 @@
 	name = "high velocity incendiary bullet"
 	hud_state = "hivelo_fire"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_PASS_THROUGH_MOB
-	damage = 25
+	damage = 0
 	penetration = 20
 	sundering = 2.5
 	bullet_color = LIGHT_COLOR_FIRE
@@ -141,7 +141,7 @@
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
-	damage = 30
+	damage = 0
 	penetration = 20
 	sundering = 6.5
 
@@ -152,7 +152,7 @@
 	name = "crude heavy rifle bullet"
 	hud_state = "rifle_crude"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 30
+	damage = 0
 	penetration = 15
 	sundering = 1.75
 
@@ -164,14 +164,14 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 25
 	max_range = 40
-	damage = 65
+	damage = 0
 	penetration = 17.5
 	sundering = 2
 
 /datum/ammo/bullet/rifle/garand
 	name = "heavy marksman bullet"
 	hud_state = "sniper"
-	damage = 75
+	damage = 0
 	penetration = 25
 	sundering = 1.25
 
@@ -181,12 +181,12 @@
 	hud_state_empty = "hivelo_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	penetration = 15
-	damage = 32.5
+	damage = 0
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/icc_confrontationrifle
 	name = "armor-piercing heavy rifle bullet"
 	hud_state = "rifle_ap"
-	damage = 50
+	damage = 0
 	penetration = 40
 	sundering = 3.5

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -18,7 +18,7 @@
 	accuracy = 40
 	accurate_range = 20
 	max_range = 14
-	damage = 200
+	damage = 0
 	penetration = 100
 	sundering = 100
 	bullet_color = LIGHT_COLOR_FIRE
@@ -47,12 +47,12 @@
 	hud_state = "rocket_he"
 	accurate_range = 20
 	max_range = 14
-	damage = 200
+	damage = 0
 	penetration = 75
 	sundering = 50
 
 /datum/ammo/rocket/he/unguided
-	damage = 100
+	damage = 0
 	ammo_behavior_flags = AMMO_SNIPER // We want this one to specifically go over onscreen range.
 
 /datum/ammo/rocket/he/unguided/drop_nade(turf/T)
@@ -62,7 +62,7 @@
 	name = "kinetic penetrator"
 	icon_state = "rocket_ap"
 	hud_state = "rocket_ap"
-	damage = 340
+	damage = 0
 	accurate_range = 15
 	penetration = 200
 	sundering = 0
@@ -77,7 +77,7 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 200
+	damage = 0
 	hud_state = "bigshell_he"
 	sundering = 20
 	barricade_clear_distance = 4
@@ -103,7 +103,7 @@
 	hud_state = "bigshell_he"
 	hud_state_empty = "shell_empty"
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_TARGET_TURF
-	damage = 100
+	damage = 0
 	penetration = 200
 	max_range = 30
 	shell_speed = 0.75
@@ -122,7 +122,7 @@
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 275
+	damage = 0
 	penetration = 75
 	shell_speed = 7
 	accurate_range = 24
@@ -147,7 +147,7 @@
 	damage_type = BURN
 	accuracy_var_low = 7
 	accurate_range = 15
-	damage = 200
+	damage = 0
 	penetration = 75
 	max_range = 20
 	sundering = 100
@@ -164,7 +164,7 @@
 	name = "thermobaric rocket"
 	hud_state = "rocket_thermobaric"
 	ammo_behavior_flags = AMMO_SNIPER
-	damage = 40
+	damage = 0
 	penetration = 25
 	max_range = 30
 	sundering = 2
@@ -195,13 +195,13 @@
 	name = "super thermobaric rocket"
 	hud_state = "rocket_thermobaric"
 	ammo_behavior_flags = AMMO_SNIPER
-	damage = 200
+	damage = 0
 	penetration = 75
 	max_range = 30
 	sundering = 100
 
 /datum/ammo/rocket/wp/unguided
-	damage = 100
+	damage = 0
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_INCENDIARY
 	effect_radius = 5
 
@@ -216,7 +216,7 @@
 	shell_speed = 2
 	accurate_range = 20
 	max_range = 30
-	damage = 100
+	damage = 0
 	penetration = 50
 	sundering = 50
 
@@ -228,7 +228,7 @@
 	icon_state = "recoilless_rifle_heat"
 	hud_state = "shell_heat"
 	ammo_behavior_flags = AMMO_SNIPER
-	damage = 200
+	damage = 0
 	penetration = 100
 	sundering = 0
 
@@ -256,7 +256,7 @@
 	ammo_behavior_flags = AMMO_SNIPER //We want this to specifically go farther than onscreen range.
 	accurate_range = 15
 	max_range = 20
-	damage = 75
+	damage = 0
 	penetration = 50
 	sundering = 25
 
@@ -270,7 +270,7 @@
 	ammo_behavior_flags = AMMO_SNIPER
 	accurate_range = 21
 	max_range = 21
-	damage = 10
+	damage = 0
 	penetration = 0
 	sundering = 0
 	/// Smoke type created when projectile detonates.
@@ -310,7 +310,7 @@
 	ammo_behavior_flags = AMMO_SNIPER //We want this to specifically go farther than onscreen range.
 	accurate_range = 15
 	max_range = 20
-	damage = 75
+	damage = 0
 	penetration = 15
 	sundering = 25
 
@@ -319,7 +319,7 @@
 
 /datum/ammo/rocket/oneuse
 	name = "explosive rocket"
-	damage = 100
+	damage = 0
 	penetration = 50
 	sundering = 25
 	max_range = 30
@@ -331,7 +331,7 @@
 	ammo_behavior_flags = AMMO_SNIPER
 	accurate_range = 15
 	max_range = 20
-	damage = 80
+	damage = 0
 	penetration = 20
 	sundering = 20
 
@@ -344,7 +344,7 @@
 	hud_state = "rpg_le"
 	ammo_behavior_flags = AMMO_SNIPER
 	accurate_range = 15
-	damage = 60
+	damage = 0
 	penetration = 10
 
 /datum/ammo/rocket/som/light/drop_nade(turf/T)
@@ -354,7 +354,7 @@
 	name = "thermobaric RPG"
 	icon_state = "rpg_thermobaric"
 	hud_state = "rpg_thermobaric"
-	damage = 30
+	damage = 0
 
 /datum/ammo/rocket/som/thermobaric/drop_nade(turf/T)
 	explosion(T, 0, 4, 5, 0, 4, 4)
@@ -363,7 +363,7 @@
 	name = "HEAT RPG"
 	icon_state = "rpg_heat"
 	hud_state = "rpg_heat"
-	damage = 200
+	damage = 0
 	penetration = 100
 	sundering = 0
 	accuracy = -10 //Not designed for anti human use
@@ -382,7 +382,7 @@
 	name = "irrad RPG"
 	icon_state = "rpg_rad"
 	hud_state = "rpg_rad"
-	damage = 50
+	damage = 0
 	penetration = 10
 	///Base strength of the rad effects
 	var/rad_strength = 20
@@ -420,7 +420,7 @@
 	hud_state_empty = "shell_empty"
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER|AMMO_PASS_THROUGH_TURF
 	shell_speed = 2
-	damage = 90
+	damage = 0
 	penetration = 30
 	sundering = 25
 	max_range = 30
@@ -437,7 +437,7 @@
 	hud_state = "shell_apcr"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 4
-	damage = 200
+	damage = 0
 	penetration = 70
 	sundering = 25
 
@@ -460,7 +460,7 @@
 	name = "low velocity high explosive shell"
 	hud_state = "shell_he"
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER
-	damage = 50
+	damage = 0
 	penetration = 50
 	sundering = 35
 
@@ -475,7 +475,7 @@
 	hud_state = "shell_le"
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER
 	shell_speed = 3
-	damage = 30
+	damage = 0
 	penetration = 30
 	sundering = 5
 	bonus_projectiles_type = /datum/ammo/bullet/atgun_spread
@@ -519,7 +519,7 @@
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 300
+	damage = 0
 	penetration = 75
 	shell_speed = 4
 	accurate_range = 24
@@ -573,7 +573,7 @@
 /datum/ammo/rocket/homing/microrocket /// this is basically a tgmc version of the above
 	name = "homing HE microrocket"
 	shell_speed = 0.3
-	damage = 75
+	damage = 0
 	penetration = 40
 	sundering = 10
 	turn_rate = 10
@@ -587,7 +587,7 @@
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER|AMMO_SPECIAL_PROCESS|AMMO_IFF
 	shell_speed = 0.3
 	turn_rate = 10
-	damage = 60
+	damage = 0
 	penetration = 30
 	sundering = 10
 	max_range = 30
@@ -607,7 +607,7 @@
 	accuracy = 10
 	accurate_range = 20
 	max_range = 40
-	damage = 300
+	damage = 0
 	penetration = 50
 	sundering = 10
 	bullet_color = LIGHT_COLOR_TUNGSTEN
@@ -621,7 +621,7 @@
 
 /datum/ammo/rocket/coilgun/low
 	shell_speed = 2
-	damage = 150
+	damage = 0
 	penetration = 40
 	sundering = 5
 
@@ -631,7 +631,7 @@
 /datum/ammo/rocket/coilgun/high
 	damage_falloff = 0
 	shell_speed = 4
-	damage = 450
+	damage = 0
 	penetration = 70
 	sundering = 20
 	ammo_behavior_flags = AMMO_SNIPER|AMMO_PASS_THROUGH_MOB
@@ -654,7 +654,7 @@
 	hud_state = "shell_heat"
 	ammo_behavior_flags = AMMO_SNIPER
 	shell_speed = 1
-	damage = 180
+	damage = 0
 	penetration = 100
 	sundering = 0
 
@@ -663,7 +663,7 @@
 
 /datum/ammo/rocket/icc_lowvel_high_explosive
 	name = "Low Velocity HE shell"
-	damage = 50
+	damage = 0
 	penetration = 100
 	sundering = 10
 	ammo_behavior_flags = AMMO_SNIPER // We want this to specifically go over onscreen range.

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -17,7 +17,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 3
 	max_range = 15
-	damage = 100
+	damage = 0
 	penetration = 20
 	sundering = 7.5
 
@@ -31,7 +31,7 @@
 	icon_state = "beanbag"
 	hud_state = "shotgun_beanbag"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 15
+	damage = 0
 	max_range = 15
 	shrapnel_chance = 0
 	accuracy = 5
@@ -46,7 +46,7 @@
 	damage_type = BRUTE
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
 	max_range = 15
-	damage = 70
+	damage = 0
 	penetration = 15
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
@@ -66,14 +66,14 @@
 	accuracy_var_low = 8
 	accuracy_var_high = 8
 	max_range = 15
-	damage = 50
+	damage = 0
 	damage_falloff = 0.5
 	penetration = 15
 	sundering = 7
 
 /datum/ammo/bullet/shotgun/flechette/flechette_spread
 	name = "additional flechette"
-	damage = 40
+	damage = 0
 	sundering = 5
 
 /datum/ammo/bullet/shotgun/buckshot
@@ -88,7 +88,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 40
+	damage = 0
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -104,7 +104,7 @@
 	accurate_range = 3
 	max_range = 10
 	shrapnel_chance = 15
-	damage = 30
+	damage = 0
 	damage_falloff = 3
 
 /datum/ammo/bullet/hefa_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -117,7 +117,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 40
+	damage = 0
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/frag
@@ -131,7 +131,7 @@
 	accuracy_var_low = 8
 	accuracy_var_high = 8
 	max_range = 15
-	damage = 10
+	damage = 0
 	damage_falloff = 0.5
 	penetration = 0
 
@@ -152,7 +152,7 @@
 
 /datum/ammo/bullet/shotgun/frag/frag_spread
 	name = "additional frag shell"
-	damage = 5
+	damage = 0
 
 /datum/ammo/bullet/shotgun/sx16_buckshot
 	name = "shotgun buckshot shell" //16 gauge is between 12 and 410 bore.
@@ -165,7 +165,7 @@
 	accuracy_var_low = 10
 	accuracy_var_high = 10
 	max_range = 10
-	damage = 25
+	damage = 0
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/sx16_buckshot/spread
@@ -183,7 +183,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 50
+	damage = 0
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -196,7 +196,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 4
 	max_range = 15
-	damage = 125
+	damage = 0
 	penetration = 50
 	sundering = 15
 
@@ -210,7 +210,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 50
+	damage = 0
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/sx16_flechette
@@ -224,7 +224,7 @@
 	accuracy_var_low = 7
 	accuracy_var_high = 7
 	max_range = 15
-	damage = 15
+	damage = 0
 	damage_falloff = 0.5
 	penetration = 15
 
@@ -237,7 +237,7 @@
 	hud_state = "shotgun_slug"
 	shell_speed = 3
 	max_range = 15
-	damage = 40
+	damage = 0
 	penetration = 20
 
 /datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -253,7 +253,7 @@
 	bonus_projectiles_amount = 4
 	bonus_projectiles_scatter = 2
 	max_range = 15
-	damage = 17
+	damage = 0
 	damage_falloff = 0.25
 	penetration = 15
 	sundering = 1.5
@@ -268,7 +268,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 3
 	max_range = 15
-	damage = 60
+	damage = 0
 	penetration = 30
 	sundering = 3.5
 
@@ -286,12 +286,12 @@
 	accuracy_var_low = 10
 	accuracy_var_high = 10
 	max_range = 10
-	damage = 50
+	damage = 0
 	damage_falloff = 1
 
 /datum/ammo/bullet/shotgun/mbx900_buckshot/spread
 	name = "additional buckshot"
-	damage = 40
+	damage = 0
 
 /datum/ammo/bullet/shotgun/mbx900_sabot
 	name = "light shotgun sabot shell"
@@ -301,7 +301,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 5
 	max_range = 30
-	damage = 50
+	damage = 0
 	penetration = 40
 	sundering = 3
 
@@ -312,7 +312,7 @@
 	hud_state = "shotgun_tracker"
 	shell_speed = 4
 	max_range = 30
-	damage = 5
+	damage = 0
 	penetration = 100
 
 /datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -325,7 +325,7 @@
 	hud_state = "shotgun_tracker"
 	shell_speed = 4
 	max_range = 30
-	damage = 5
+	damage = 0
 	penetration = 100
 
 /datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/target_mob, obj/projectile/proj)

--- a/code/modules/projectiles/ammo_types/smartgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smartgun_ammo.dm
@@ -11,7 +11,7 @@
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 12
-	damage = 20
+	damage = 0
 	penetration = 15
 	sundering = 2
 
@@ -22,7 +22,7 @@
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 12
-	damage = 10
+	damage = 0
 	penetration = 25
 	sundering = 1
 	damage_falloff = 0.1
@@ -33,7 +33,7 @@
 	hud_state = "smartgun"
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 40
+	damage = 0
 	max_range = 40
 	penetration = 30
 	sundering = 5
@@ -49,7 +49,7 @@
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_IFF
 	accurate_range = 12
-	damage = 30
+	damage = 0
 	penetration = 10
 	sundering = 1
 
@@ -59,7 +59,7 @@
 	hud_state = "spotrifle"
 	hud_state_empty = "smartgun_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 50
+	damage = 0
 	max_range = 40
 	penetration = 25
 	sundering = 5
@@ -68,7 +68,7 @@
 /datum/ammo/bullet/spottingrifle/highimpact
 	name = "smart high-impact spotting bullet"
 	hud_state = "spotrifle_impact"
-	damage = 10
+	damage = 0
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -77,7 +77,7 @@
 /datum/ammo/bullet/spottingrifle/heavyrubber
 	name = "smart heavy-rubber spotting bullet"
 	hud_state = "spotrifle_rubber"
-	damage = 10
+	damage = 0
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/heavyrubber/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -86,7 +86,7 @@
 /datum/ammo/bullet/spottingrifle/plasmaloss
 	name = "smart tanglefoot spotting bullet"
 	hud_state = "spotrifle_plasmaloss"
-	damage = 10
+	damage = 0
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/plasmaloss/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -97,7 +97,7 @@
 /datum/ammo/bullet/spottingrifle/tungsten
 	name = "smart tungsten spotting bullet"
 	hud_state = "spotrifle_tungsten"
-	damage = 10
+	damage = 0
 	sundering = 0.5
 
 /datum/ammo/bullet/spottingrifle/tungsten/on_hit_mob(mob/target_mob, obj/projectile/proj)
@@ -106,7 +106,7 @@
 /datum/ammo/bullet/spottingrifle/flak
 	name = "smart flak spotting bullet"
 	hud_state = "spotrifle_flak"
-	damage = 60
+	damage = 0
 	sundering = 0.5
 	airburst_multiplier = 0.5
 
@@ -118,5 +118,5 @@
 	hud_state = "spotrifle_incend"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
 	damage_type = BURN
-	damage = 10
+	damage = 0
 	sundering = 0.5

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -11,7 +11,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 7
 	accuracy_var_high = 7
-	damage = 20
+	damage = 0
 	accurate_range = 4
 	damage_falloff = 1
 	sundering = 0.5
@@ -20,7 +20,7 @@
 /datum/ammo/bullet/smg/ap
 	name = "armor-piercing submachinegun bullet"
 	hud_state = "smg_ap"
-	damage = 15
+	damage = 0
 	penetration = 30
 	sundering = 3
 
@@ -32,7 +32,7 @@
 	name = "hollow-point submachinegun bullet"
 	hud_state = "pistol_squash"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 35
+	damage = 0
 	penetration = 0
 	damage_falloff = 3
 	shrapnel_chance = 45
@@ -41,7 +41,7 @@
 	name = "squash-head submachinegun bullet"
 	hud_state = "pistol_squash"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 15
+	damage = 0
 	penetration = 15
 	armor_type = BOMB
 	sundering = 1
@@ -63,13 +63,13 @@
 	name = "incendiary submachinegun bullet"
 	hud_state = "smg_fire"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
-	damage = 18
+	damage = 0
 	penetration = 0
 
 /datum/ammo/bullet/smg/rad
 	name = "radioactive submachinegun bullet"
 	hud_state = "smg_rad"
-	damage = 15
+	damage = 0
 	penetration = 15
 	sundering = 1
 
@@ -83,6 +83,6 @@
 
 /datum/ammo/bullet/smg/heavy
 	name = "heavy submachinegun bullet"
-	damage = 27.5
+	damage = 0
 	penetration = 10
 	sundering = 1

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -14,7 +14,7 @@
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
-	damage = 90
+	damage = 0
 	penetration = 50
 	sundering = 15
 
@@ -26,14 +26,14 @@
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SNIPER
 	accuracy_var_high = 7
 	max_range = 20
-	damage = 70
+	damage = 0
 	penetration = 30
 	sundering = 5
 
 /datum/ammo/bullet/sniper/flak
 	name = "flak sniper bullet"
 	hud_state = "sniper_flak"
-	damage = 90
+	damage = 0
 	penetration = 0
 	sundering = 30
 	airburst_multiplier = 0.5
@@ -46,7 +46,7 @@
 	handful_icon_state = "crude_sniper"
 	hud_state = "sniper_crude"
 	handful_amount = 5
-	damage = 75
+	damage = 0
 	penetration = 35
 	sundering = 15
 
@@ -56,7 +56,7 @@
 	hud_state = "sniper_crude"
 	handful_amount = 5
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 120
+	damage = 0
 	penetration = 20
 	accurate_range_min = 0
 	///shatter effection duration when hitting mobs
@@ -74,7 +74,7 @@
 	hud_state = "sniper_supersonic"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy = 20
-	damage = 100
+	damage = 0
 	penetration = 60
 	sundering = 50
 
@@ -82,7 +82,7 @@
 	name = "high caliber rifle bullet"
 	hud_state = "sniper_heavy"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER
-	damage = 80
+	damage = 0
 	penetration = 30
 	sundering = 7.5
 	damage_falloff = 0.25
@@ -91,7 +91,7 @@
 	name = "high caliber flak rifle bullet"
 	hud_state = "sniper_heavy_flak"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER
-	damage = 40
+	damage = 0
 	penetration = 10
 	sundering = 10
 	damage_falloff = 0.25
@@ -104,7 +104,7 @@
 	name = "low velocity high caliber rifle bullet"
 	hud_state = "sniper_auto"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER
-	damage = 50
+	damage = 0
 	penetration = 30
 	sundering = 2
 	damage_falloff = 0.25
@@ -116,6 +116,6 @@
 	hud_state = "sniper_fire"
 	accurate_range_min = 4
 	shell_speed = 5
-	damage = 120
+	damage = 0
 	penetration = 60
 	sundering = 20

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -11,7 +11,7 @@
 	hud_state_empty = "rifle_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 10
-	damage = 25
+	damage = 0
 	penetration = 20
 	damage_falloff = 0.25
 
@@ -21,11 +21,11 @@
 /datum/ammo/bullet/turret/gauss
 	name = "heavy gauss turret slug"
 	hud_state = "rifle_heavy"
-	damage = 60
+	damage = 0
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 20
+	damage = 0
 	penetration = 20
 	ammo_behavior_flags = AMMO_BALLISTIC
 
@@ -34,7 +34,7 @@
 	name = "antimaterial bullet"
 	bullet_color = COLOR_SOFT_RED
 	accurate_range = 21
-	damage = 80
+	damage = 0
 	penetration = 50
 	sundering = 5
 
@@ -46,7 +46,7 @@
 	bonus_projectiles_amount = 6
 	bonus_projectiles_scatter = 5
 	max_range = 10
-	damage = 20
+	damage = 0
 	penetration = 40
 	damage_falloff = 1
 
@@ -56,7 +56,7 @@
 /datum/ammo/bullet/turret/spread
 	name = "additional buckshot"
 	max_range = 10
-	damage = 20
+	damage = 0
 	penetration = 40
 	damage_falloff = 1
 
@@ -68,7 +68,7 @@
 	damage_type = BURN
 	ammo_behavior_flags = AMMO_INCENDIARY|AMMO_FLAME
 	armor_type = FIRE
-	damage = 30
+	damage = 0
 	max_range = 7
 	bullet_color = LIGHT_COLOR_FIRE
 

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -19,7 +19,7 @@
 	shell_speed = 2
 	accurate_range = 12
 	max_range = 15
-	damage = 12			//impact damage from a grenade to the dome
+	damage = 0			//impact damage from a grenade to the dome
 	penetration = 0
 	sundering = 0
 	shrapnel_chance = 0
@@ -134,7 +134,7 @@
 	accuracy_var_high = 5
 	max_range = 4
 	shell_speed = 3
-	damage = 20
+	damage = 0
 	penetration = 20
 	sundering = 1.5
 	damage_falloff = 0
@@ -145,7 +145,7 @@
 /datum/ammo/bullet/tx54_spread/incendiary
 	name = "incendiary flechette"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB|AMMO_INCENDIARY|AMMO_LEAVE_TURF
-	damage = 15
+	damage = 0
 	penetration = 10
 	sundering = 1.5
 
@@ -164,7 +164,7 @@
 	name = "chemical bomblet"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB|AMMO_LEAVE_TURF
 	max_range = 3
-	damage = 5
+	damage = 0
 	penetration = 0
 	sundering = 0
 	shrapnel_chance = 0
@@ -201,7 +201,7 @@
 	name = "chemical bomblet"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB|AMMO_LEAVE_TURF
 	max_range = 4
-	damage = 5
+	damage = 0
 	penetration = 0
 	sundering = 0
 	///The foam type loaded in this ammo
@@ -233,7 +233,7 @@
 /datum/ammo/tx54/tank_cannister
 	name = "cannister"
 	icon_state = "cannister_shot"
-	damage = 30
+	damage = 0
 	penetration = 0
 	ammo_behavior_flags = AMMO_SNIPER
 	damage_falloff = 0.5
@@ -248,7 +248,7 @@
 	icon_state = "flechette"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB
 	max_range = 7
-	damage = 50
+	damage = 0
 	penetration = 15
 	sundering = 2
 	damage_falloff = 1


### PR DESCRIPTION

## About The Pull Request
This pull request removes damage-dealing capabilities from all marine firearms, including rifles, shotguns, and sidearms. This change is designed to fundamentally reshape combat by forcing marines to engage with the game’s mechanics in new, creative ways.
## Why It's Good For The Game

Promotes Teamwork and Tactical Innovation
- Marines will no longer rely on "spray and pray" tactics. Instead, squads must coordinate with explosives, fortifications, melee weapons, and environmental traps. This fosters deeper strategic play and rewards clever use of the game’s sandbox mechanics.

Reduces Xeno Frustration
- New xeno players often face instant deletion by concentrated marine fire. Removing guns levels the playing field, allowing xenos to engage more dynamically and giving both sides longer, more suspenseful encounters.

Emphasizes Horror Survival Themes
- A marine with no easy ranged options embodies the "helplessness vs. overwhelming threat" trope central to the genre. This amplifies tension and forces marines to think like prey, not an unstoppable death squad.

Shifts Meta from DPS to Utility
- Flares, welding tools, and deployables will finally shine. This change encourages loadout diversity and gives niche items purpose beyond "shoot xeno slightly faster."

Experimental Shakeup
- Stagnation kills games. This radical experiment will generate valuable data on player adaptability and emergent strategies, sparking community discussion and iterative balancing.
## Changelog
:cl:
balance: Removes all damage from marine weapons
/:cl:
