### PR TITLE
APC changes

### DIFF
--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -7,7 +7,7 @@
 	interior = /datum/interior/armored/transport
 	armored_flags = ARMORED_HAS_HEADLIGHTS|ARMORED_PURCHASABLE_TRANSPORT
 	permitted_weapons = list(/obj/item/armored_weapon/secondary_weapon, /obj/item/armored_weapon/secondary_flamer, /obj/item/armored_weapon/tow, /obj/item/armored_weapon/microrocket_pod)
-	permitted_mods = list(/obj/item/tank_module/overdrive, /obj/item/tank_module/ability/zoom, /obj/item/tank_module/interior/medical, /obj/item/tank_module/interior/clone_bay)
+	permitted_mods = list(/obj/item/tank_module/interior/medical, /obj/item/tank_module/interior/clone_bay)
 	required_entry_skill = SKILL_LARGE_VEHICLE_DEFAULT
 	minimap_icon_state = "apc"
 	turret_icon = null

--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -18,7 +18,7 @@
 	max_occupants = 20 //Clown car? Clown car.
 	enter_delay = 0.5 SECONDS
 	ram_damage = 25
-	move_delay = 0.5 SECONDS
+	move_delay = 0.35 SECONDS
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,
 		/obj/structure/largecrate,

--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -17,7 +17,7 @@
 	soft_armor = list(MELEE = 40, BULLET = 100 , LASER = 90, ENERGY = 60, BOMB = 60, BIO = 60, FIRE = 40, ACID = 40)
 	max_occupants = 20 //Clown car? Clown car.
 	enter_delay = 0.5 SECONDS
-	ram_damage = 25
+	ram_damage = 20
 	move_delay = 0.35 SECONDS
 	easy_load_list = list(
 		/obj/item/ammo_magazine/tank,


### PR DESCRIPTION
## About The Pull Request

Tittle, move delay from 0.5 seconds to 0.35 seconds

Also removes overdrive and zoom from the list of modules it can equip (it doesnt have a sprite it wasnt meant to use them tivi)

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/4a1838b1-9fe1-4b3c-9c0a-8894451a78aa)


## Changelog

:cl:
balance: Buffs APC move speed
removal: APC can no longer use tank modules (Overdrive, zoom)
/:cl:
