### PR TITLE
Starting weeds are now majority sticky.

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -68,8 +68,8 @@ GLOBAL_LIST_INIT(weed_type_list, typecacheof(list(
 
 //List of weeds with probability of spawning
 GLOBAL_LIST_INIT(weed_prob_list, list(
-	/obj/alien/weeds/node = 80,
-	/obj/alien/weeds/node/sticky = 5,
+	/obj/alien/weeds/node = 5,
+	/obj/alien/weeds/node/sticky = 85,
 	/obj/alien/weeds/node/resting = 10,
 ))
 


### PR DESCRIPTION
## About The Pull Request

//List of weeds with probability of spawning
GLOBAL_LIST_INIT(weed_prob_list, list(
	/obj/alien/weeds/node = 80,
	/obj/alien/weeds/node/sticky = 5,
	/obj/alien/weeds/node/resting = 10,
))

=>

GLOBAL_LIST_INIT(weed_prob_list, list(
	/obj/alien/weeds/node = 5,
	/obj/alien/weeds/node/sticky = 85,
	/obj/alien/weeds/node/resting = 10,
))

## Why It's Good For The Game

Reduction of mindless xenomorph preparation.

In order to ensure sticky weeds dominate xenos are forced to replace every normal weed node in an area by individually standing on top of each one and planting a sticky weed sac. I believe this is currently the worst part of xeno side preparations.

This will have balance impacts, however I strongly believe they will be minimal relative to the improvements to the enjoyment of xeno preparations. If this is too overpowered, I'd suggest instead reducing the amount to which maps start weeded so xenos are not forced to replace existing weeds.

I believe this will pull up the preparation 'floor' of xenos as it allows higher quality maze to be made with fewer hivelords without effecting the 'ceiling' as much. Ideally this may even reduce the number of 'slop rounds' where xenos get rolled instantly because their maze sucked because nobody bothered to do the most annoying part.

I strongly believe improving xenomorph prep is worth the side effects. The balance implications should really come secondary. Xenos shouldn't be forced to mindlessly replace roundstart weed sacs whatsoever. Changes to other areas things such as how much of each map starts weeded can be adjusted itself.

## Changelog

:cl:
qol: Starting alien weed nodes have a much higher chance to be sticky weed nodes rather than regular weed nodes.
/:cl:
