### PR TITLE
Spear fix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -242,7 +242,7 @@
 			return FALSE //here.Adjacent(there)
 		if(2 to INFINITY)
 			var/obj/dummy = new(get_turf(here))
-			dummy.allow_pass_flags |= PASS_LOW_STRUCTURE
+			dummy.pass_flags |= PASS_LOW_STRUCTURE
 			dummy.invisibility = INVISIBILITY_ABSTRACT
 			for(var/i in 1 to reach) //Limit it to that many tries
 				var/turf/T = get_step(dummy, get_dir(dummy, there))


### PR DESCRIPTION

## About The Pull Request
Fixes ranged melee weapons not being able to attack over certain objects like expected (i.e. tables and other jumpable objects).
## Why It's Good For The Game
Funny feature I broke 2 years ago.
## Changelog
:cl:
fix: fixed spears and other ranged melee items not being able to attack over some objects as intended
/:cl:
