### PR TITLE
Fixes detpack not deleting on explode

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -374,6 +374,7 @@
 		if(iswallturf(det_location)) //Breach the other side of the wall if planted on one
 			det_location = get_step(det_location, boom_direction)
 		explosion(det_location, 3, 4, 4, 0, 4)
+	qdel(src)
 
 /obj/item/detpack/attack(mob/M as mob, mob/user as mob, def_zone)
 	return


### PR DESCRIPTION

## About The Pull Request

Detpack used to rely on its explosion to delete itself
Now that the explosion doesn't always center on detpack, it can sometimes survive exploding, resulting in an immortal detpack

Qdels the detpack on explode because it shouldn't survive exploding
## Why It's Good For The Game

Fixes good
## Changelog
:cl:
fix: Fixes detpack not exploding
/:cl:
