### PR TITLE
Traverse line proc

### DIFF
--- a/code/__HELPERS/math.dm
+++ b/code/__HELPERS/math.dm
@@ -48,25 +48,25 @@
  * Uses the ultra-fast [Bresenham Line-Drawing Algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
  */
 /proc/get_traversal_line(atom/starting_atom, atom/ending_atom)
-	var/current_x_step = starting_atom.x
+	var/current_x_step = starting_atom.x //start at x and y, then add 1 or -1 to these to get every turf from starting_atom to ending_atom
 	var/current_y_step = starting_atom.y
 
-	var/list/line = list(get_turf(starting_atom))
+	var/list/line = list(get_turf(starting_atom)) //get_turf(atom) is faster than locate(x, y, z)
 
-	var/x_distance = ending_atom.x - current_x_step
+	var/x_distance = ending_atom.x - current_x_step //x distance
 	var/y_distance = ending_atom.y - current_y_step
 
-	var/abs_x_distance = abs(x_distance)
+	var/abs_x_distance = abs(x_distance) //Absolute value of x distance
 	var/abs_y_distance = abs(y_distance)
 
-	var/x_distance_sign = SIGN(x_distance)
+	var/x_distance_sign = SIGN(x_distance) //Sign of x distance (+ or -)
 	var/y_distance_sign = SIGN(y_distance)
 
-	var/x = abs_x_distance >> 1
-	var/y = abs_y_distance >> 1
+	var/x = abs_x_distance >> 1 //Counters for steps taken, setting to distance/2
+	var/y = abs_y_distance >> 1 //Bit-shifting makes me l33t.  It also makes get_line() unnessecarrily fast.
 
 	if(abs_x_distance >= abs_y_distance)
-		for(var/distance_counter in 0 to (abs_x_distance - 1))
+		for(var/distance_counter in 0 to (abs_x_distance - 1)) //It'll take abs_x_distance steps to get there
 			x += abs_y_distance
 			current_x_step += x_distance_sign
 

--- a/code/__HELPERS/math.dm
+++ b/code/__HELPERS/math.dm
@@ -42,6 +42,54 @@
 			line += locate(current_x_step, current_y_step, starting_atom.z)
 	return line
 
+/**
+ * Get a list of turfs in a line from `starting_atom` to `ending_atom`.
+ * Unlike get_line, this only takes cardinal steps, useful for checking movement or LOS
+ * Uses the ultra-fast [Bresenham Line-Drawing Algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
+ */
+/proc/get_traversal_line(atom/starting_atom, atom/ending_atom)
+	var/current_x_step = starting_atom.x
+	var/current_y_step = starting_atom.y
+
+	var/list/line = list(get_turf(starting_atom))
+
+	var/x_distance = ending_atom.x - current_x_step
+	var/y_distance = ending_atom.y - current_y_step
+
+	var/abs_x_distance = abs(x_distance)
+	var/abs_y_distance = abs(y_distance)
+
+	var/x_distance_sign = SIGN(x_distance)
+	var/y_distance_sign = SIGN(y_distance)
+
+	var/x = abs_x_distance >> 1
+	var/y = abs_y_distance >> 1
+
+	if(abs_x_distance >= abs_y_distance)
+		for(var/distance_counter in 0 to (abs_x_distance - 1))
+			x += abs_y_distance
+			current_x_step += x_distance_sign
+
+			line += locate(current_x_step, current_y_step, starting_atom.z)
+
+			if(x >= abs_x_distance)
+				x -= abs_x_distance
+				current_y_step += y_distance_sign
+				line += locate(current_x_step, current_y_step, starting_atom.z)
+	else
+		for(var/distance_counter in 0 to (abs_y_distance - 1))
+			y += abs_x_distance
+			current_y_step += y_distance_sign
+
+			line += locate(current_x_step, current_y_step, starting_atom.z)
+
+			if(y >= abs_y_distance)
+				y -= abs_y_distance
+				current_x_step += x_distance_sign
+				line += locate(current_x_step, current_y_step, starting_atom.z)
+
+	return line
+
 ///Returns if a turf can be seen from another turf.
 /proc/can_see_through(turf/from_turf, turf/to_turf)
 	if(IS_OPAQUE_TURF(to_turf))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1203,7 +1203,7 @@ GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
  * Returns the last turf in the list it can successfully path to
 */
 /proc/check_path(atom/start, atom/end, pass_flags_checked = NONE)
-	var/list/path_to_target = get_line(start, end)
+	var/list/path_to_target = get_line(start, end) //we don't use traversal because link blocked checks both diags as needed
 	var/line_count = 1
 	while(line_count < length(path_to_target))
 		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], pass_flags_checked))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -833,62 +833,6 @@ GLOBAL_LIST_INIT(wallitems, typecacheof(list(
 		text2num(semver_regex.group[3]),
 	)
 
-//Reasonably Optimized Bresenham's Line Drawing
-/proc/getline(atom/start, atom/end)
-	var/x = start.x
-	var/y = start.y
-	var/z = start.z
-
-	//horizontal and vertical lines special case
-	if(y == end.y)
-		return x <= end.x ? block(locate(x,y,z), locate(end.x,y,z)) : reverseRange(block(locate(end.x,y,z), locate(x,y,z)))
-	if(x == end.x)
-		return y <= end.y ? block(locate(x,y,z), locate(x,end.y,z)) : reverseRange(block(locate(x,end.y,z), locate(x,y,z)))
-
-	//let's compute these only once
-	var/abs_dx = abs(end.x - x)
-	var/abs_dy = abs(end.y - y)
-	var/sign_dx = SIGN(end.x - x)
-	var/sign_dy = SIGN(end.y - y)
-
-	var/list/turfs = list(locate(x,y,z))
-
-	//diagonal special case
-	if(abs_dx == abs_dy)
-		for(var/j = 1 to abs_dx)
-			x += sign_dx
-			y += sign_dy
-			turfs += locate(x,y,z)
-		return turfs
-
-	/*x_error and y_error represents how far we are from the ideal line.
-	Initialized so that we will check these errors against 0, instead of 0.5 * abs_(dx/dy)*/
-
-	//We multiply every check by the line slope denominator so that we only handles integers
-	if(abs_dx > abs_dy)
-		var/y_error = -(abs_dx >> 1)
-		var/steps = abs_dx
-		while(steps--)
-			y_error += abs_dy
-			if(y_error > 0)
-				y_error -= abs_dx
-				y += sign_dy
-			x += sign_dx
-			turfs += locate(x,y,z)
-	else
-		var/x_error = -(abs_dy >> 1)
-		var/steps = abs_dy
-		while(steps--)
-			x_error += abs_dx
-			if(x_error > 0)
-				x_error -= abs_dy
-				x += sign_dx
-			y += sign_dy
-			turfs += locate(x,y,z)
-
-	. = turfs
-
-
 // Makes a call in the context of a different usr
 // Use sparingly
 /world/proc/PushUsr(mob/M, datum/callback/CB, ...)
@@ -1259,7 +1203,7 @@ GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
  * Returns the last turf in the list it can successfully path to
 */
 /proc/check_path(atom/start, atom/end, pass_flags_checked = NONE)
-	var/list/path_to_target = getline(start, end)
+	var/list/path_to_target = get_line(start, end)
 	var/line_count = 1
 	while(line_count < length(path_to_target))
 		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], pass_flags_checked))

--- a/code/datums/fire_support/gun_run.dm
+++ b/code/datums/fire_support/gun_run.dm
@@ -55,7 +55,7 @@
 	var/turf/start_turf = locate(clamp(target_turf.x + rand(-3, 3), 1, world.maxx), clamp(target_turf.y - 6, 1, world.maxy), target_turf.z)
 	var/turf/end_turf = locate(clamp(target_turf.x + rand(-3, 3), 1, world.maxx), clamp(target_turf.y + 6, 1, world.maxy), target_turf.z)
 
-	var/list/strafelist = get_line(start_turf, end_turf)
+	var/list/strafelist = get_traversal_line(start_turf, end_turf)
 	strafe_turfs(strafelist)
 
 ///lases each turf in the line one by one

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -349,7 +349,7 @@
 	for(var/i=0 to laze_radius)
 		beginning = get_step(beginning, revdir)
 		end = get_step(end, attackdir)
-	return get_line(beginning, end)
+	return get_traversal_line(beginning, end)
 
 /obj/structure/ship_ammo/cas/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
 	var/list/turf/lazertargets = get_turfs_to_impact(impact, attackdir)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -349,7 +349,7 @@
 	for(var/i=0 to laze_radius)
 		beginning = get_step(beginning, revdir)
 		end = get_step(end, attackdir)
-	return getline(beginning, end)
+	return get_line(beginning, end)
 
 /obj/structure/ship_ammo/cas/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
 	var/list/turf/lazertargets = get_turfs_to_impact(impact, attackdir)

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -336,21 +336,10 @@
 /datum/action/ability/activable/xeno/landslide/proc/get_affected_turfs(turf/origin_turf, direction, range)
 	if(!origin_turf || !direction || !range)
 		return
-	var/list/turf/turfs_list = list(origin_turf)
-	var/list/turf/turfs_to_check = list()
-	for(var/turf/turf_to_check AS in get_line(origin_turf, get_ranged_target_turf(origin_turf, direction, range)))
-		if(turf_to_check in turfs_list)
-			continue
-		turfs_to_check += turf_to_check
-	for(var/turf/turf_to_check AS in turfs_to_check)
-		for(var/turf/adjacent_turf AS in get_adjacent_open_turfs(turf_to_check))
-			if((adjacent_turf in turfs_to_check) || (adjacent_turf in turfs_list))
-				continue
-			turfs_to_check += adjacent_turf
-	for(var/turf/turf_to_check AS in turfs_to_check)
-		if(LinkBlocked(origin_turf, turf_to_check) || !line_of_sight(origin_turf, turf_to_check, range))
-			continue
-		turfs_list += turf_to_check
+	var/turf/end_turf = check_path(origin_turf, get_ranged_target_turf(origin_turf, direction, range), pass_flags_checked = NONE)
+	var/list/turf/turfs_list = get_traversal_line(origin_turf, end_turf)
+	for(var/turf/turf_to_check AS in turfs_list)
+		turfs_list |= get_adjacent_open_turfs(turf_to_check)
 	return turfs_list
 
 /**

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		add_cooldown(1 SECONDS)
 		return
 	xeno_owner.face_atom(targetted_turf)
-	turf_line = getline(get_step(xeno_owner, get_cardinal_dir(xeno_owner, targetted_turf)), check_path(xeno_owner, targetted_turf, PASS_THROW))
+	turf_line = get_line(get_step(xeno_owner, get_cardinal_dir(xeno_owner, targetted_turf)), check_path(xeno_owner, targetted_turf, PASS_THROW))
 	LAZYINITLIST(telegraphed_atoms)
 	for(var/turf/turf_from_line AS in turf_line)
 		telegraphed_atoms += new /obj/effect/xeno/abduct_warning(turf_from_line)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		add_cooldown(1 SECONDS)
 		return
 	xeno_owner.face_atom(targetted_turf)
-	turf_line = get_line(get_step(xeno_owner, get_cardinal_dir(xeno_owner, targetted_turf)), check_path(xeno_owner, targetted_turf, PASS_THROW))
+	turf_line = get_traversal_line(get_step(xeno_owner, get_cardinal_dir(xeno_owner, targetted_turf)), check_path(xeno_owner, targetted_turf, PASS_THROW))
 	LAZYINITLIST(telegraphed_atoms)
 	for(var/turf/turf_from_line AS in turf_line)
 		telegraphed_atoms += new /obj/effect/xeno/abduct_warning(turf_from_line)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -24,7 +24,7 @@
 	succeed_activate()
 
 	playsound(xeno_owner.loc, 'sound/effects/refill.ogg', 50, 1)
-	var/turflist = get_traversal_line(xeno_owner, target)
+	var/turflist = get_line(xeno_owner, target) //todo: use get_traversal_line and change spray_turfs to use get_dist_euclidean for range
 	spray_turfs(turflist)
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -24,7 +24,7 @@
 	succeed_activate()
 
 	playsound(xeno_owner.loc, 'sound/effects/refill.ogg', 50, 1)
-	var/turflist = get_line(xeno_owner, target)
+	var/turflist = get_traversal_line(xeno_owner, target)
 	spray_turfs(turflist)
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -24,7 +24,7 @@
 	succeed_activate()
 
 	playsound(xeno_owner.loc, 'sound/effects/refill.ogg', 50, 1)
-	var/turflist = getline(xeno_owner, target)
+	var/turflist = get_line(xeno_owner, target)
 	spray_turfs(turflist)
 	add_cooldown()
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -354,7 +354,7 @@
 
 /mob/living/simple_animal/hostile/proc/CheckFriendlyFire(atom/A)
 	if(check_friendly_fire)
-		for(var/turf/T in get_line(src,A)) // Not 100% reliable but this is faster than simulating actual trajectory
+		for(var/turf/T in get_traversal_line(src,A)) // Not 100% reliable but this is faster than simulating actual trajectory
 			for(var/mob/living/L in T)
 				if(L == src || L == A)
 					continue

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -354,7 +354,7 @@
 
 /mob/living/simple_animal/hostile/proc/CheckFriendlyFire(atom/A)
 	if(check_friendly_fire)
-		for(var/turf/T in getline(src,A)) // Not 100% reliable but this is faster than simulating actual trajectory
+		for(var/turf/T in get_line(src,A)) // Not 100% reliable but this is faster than simulating actual trajectory
 			for(var/mob/living/L in T)
 				if(L == src || L == A)
 					continue

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -168,7 +168,7 @@
 	var/current_target = get_turf(target)
 	switch(burn_type)
 		if(FLAMER_STREAM_STRAIGHT)
-			var/path_to_target = get_line(start_location, current_target)
+			var/path_to_target = get_traversal_line(start_location, current_target)
 			path_to_target -= start_location
 			recursive_flame_straight(1, old_turfs, path_to_target, range, current_target, flame_max_wall_pen)
 		if(FLAMER_STREAM_CONE)

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -168,7 +168,7 @@
 	var/current_target = get_turf(target)
 	switch(burn_type)
 		if(FLAMER_STREAM_STRAIGHT)
-			var/path_to_target = getline(start_location, current_target)
+			var/path_to_target = get_line(start_location, current_target)
 			path_to_target -= start_location
 			recursive_flame_straight(1, old_turfs, path_to_target, range, current_target, flame_max_wall_pen)
 		if(FLAMER_STREAM_CONE)

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -168,7 +168,7 @@
 	var/current_target = get_turf(target)
 	switch(burn_type)
 		if(FLAMER_STREAM_STRAIGHT)
-			var/path_to_target = get_traversal_line(start_location, current_target)
+			var/path_to_target = get_line(start_location, current_target) //todo: use get_traversal_line and change recursive_flame_straight to use get_dist_euclidean for range
 			path_to_target -= start_location
 			recursive_flame_straight(1, old_turfs, path_to_target, range, current_target, flame_max_wall_pen)
 		if(FLAMER_STREAM_CONE)

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -463,7 +463,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	if(target.loc == loc)
 		return TRUE
 	var/turf/starting_turf = get_turf(src)
-	var/list/turf/path = getline(starting_turf, target)
+	var/list/turf/path = get_line(starting_turf, target)
 	var/turf/target_turf = path[length(path)-1]
 	path -= starting_turf
 	if(!length(path))

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -459,11 +459,11 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	update_minimap_icon()
 
 ///Checks the path to the target for obstructions. Returns TRUE if the path is clear, FALSE if not.
-/obj/machinery/deployable/mounted/sentry/proc/check_target_path(atom/target)
+/obj/machinery/deployable/mounted/sentry/proc/check_target_path(atom/target) //todo: this whole proc is giga stinky and can probably just use line_of_sight and check_path
 	if(target.loc == loc)
 		return TRUE
 	var/turf/starting_turf = get_turf(src)
-	var/list/turf/path = get_line(starting_turf, target)
+	var/list/turf/path = get_traversal_line(starting_turf, target)
 	var/turf/target_turf = path[length(path)-1]
 	path -= starting_turf
 	if(!length(path))

--- a/code/modules/vehicles/armored/som_armored_weapons.dm
+++ b/code/modules/vehicles/armored/som_armored_weapons.dm
@@ -21,7 +21,7 @@
 
 /obj/item/armored_weapon/volkite_carronade/do_fire(turf/source_turf, ammo_override)
 	var/turf/target_turf = get_turf_in_angle(Get_Angle(source_turf, get_turf(current_target)), source_turf, beam_range)
-	var/list/turf/beam_turfs = get_line(source_turf, target_turf)
+	var/list/turf/beam_turfs = get_traversal_line(source_turf, target_turf)
 	var/list/turf/impacted_turfs = list()
 	var/list/light_effects = list()
 	var/list/stop_beam_turfs

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -169,7 +169,7 @@
 		buffer_distance = get_dist(nearby_hostile, src)
 		if (distance <= buffer_distance) //If we already found a target that's closer
 			continue
-		path = getline(src, nearby_hostile)
+		path = get_line(src, nearby_hostile)
 		path -= get_turf(src)
 		if(!length(path)) //Can't shoot if it's on the same turf
 			continue

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -158,7 +158,6 @@
 /obj/structure/xeno/xeno_turret/proc/get_target()
 	var/distance = range + 0.5 //we add 0.5 so if a potential target is at range, it is accepted by the system
 	var/buffer_distance
-	var/list/turf/path = list()
 	for (var/atom/nearby_hostile AS in potential_hostiles)
 		if(isliving(nearby_hostile))
 			var/mob/living/nearby_living_hostile = nearby_hostile
@@ -167,30 +166,12 @@
 		if(HAS_TRAIT(nearby_hostile, TRAIT_TURRET_HIDDEN))
 			continue
 		buffer_distance = get_dist(nearby_hostile, src)
-		if (distance <= buffer_distance) //If we already found a target that's closer
+		if(distance <= buffer_distance) //If we already found a target that's closer
 			continue
-		path = get_line(src, nearby_hostile)
-		path -= get_turf(src)
-		if(!length(path)) //Can't shoot if it's on the same turf
+
+		if(check_path(src, nearby_hostile, PASS_PROJECTILE) != get_turf(nearby_hostile)) //xeno turret seems to not care about actual sight, for whatever reason
 			continue
-		var/blocked = FALSE
-		for(var/turf/T AS in path)
-			if(IS_OPAQUE_TURF(T) || T.density && !(T.allow_pass_flags & PASS_PROJECTILE))
-				blocked = TRUE
-				break //LoF Broken; stop checking; we can't proceed further.
-
-			for(var/obj/machinery/MA in T)
-				if(MA.opacity || MA.density && !(MA.allow_pass_flags & PASS_PROJECTILE))
-					blocked = TRUE
-					break //LoF Broken; stop checking; we can't proceed further.
-
-			for(var/obj/structure/S in T)
-				if(S.opacity || S.density && !(S.allow_pass_flags & PASS_PROJECTILE))
-					blocked = TRUE
-					break //LoF Broken; stop checking; we can't proceed further.
-		if(!blocked)
-			distance = buffer_distance
-			. = nearby_hostile
+		. = nearby_hostile
 
 ///Return TRUE if a possible target is near
 /obj/structure/xeno/xeno_turret/proc/scan()


### PR DESCRIPTION
## About The Pull Request
Adds get_traversal_line and implements it in a few relevant situations.

Also removed the duplicate getline and replaced with get_line.
## Why It's Good For The Game
Bresenham line uses diagonal steps, which is problematic with how it's used in many situations, as any sort of movement/sight ultimately uses cardinal directions (even when going diagonally).

The new proc fills in those diagonal gaps so this can be used more accurately in many cases.
## Changelog
:cl:
code: Adds get_traversal_line, like get_line but filled in cardinal steps when going diagonal
/:cl:
