### PR TITLE
Combat robot corpsman beginner loadouts now spawn with medevac beacons

### DIFF
--- a/code/datums/outfits/quick_load_robots.dm
+++ b/code/datums/outfits/quick_load_robots.dm
@@ -435,7 +435,6 @@
 	suit_store = /obj/item/weapon/gun/shotgun/pump/lever/repeater/beginner
 	l_hand = /obj/item/paper/tutorial/lifesaver
 
-
 	backpack_contents = list(
 		/obj/item/storage/box/m94 = 2,
 		/obj/item/ammo_magazine/packet/p4570 = 4,

--- a/code/datums/outfits/quick_load_robots.dm
+++ b/code/datums/outfits/quick_load_robots.dm
@@ -415,6 +415,7 @@
 //---- Squad Corpsman loadouts
 /datum/outfit/quick/beginner_robot/corpsman
 	jobtype = "Squad Corpsman"
+	r_hand = /obj/item/medevac_beacon
 
 /datum/outfit/quick/beginner_robot/corpsman/lifesaver
 	name = "Lifesaver"
@@ -432,6 +433,8 @@
 	back = /obj/item/storage/backpack/marine/corpsman
 	belt = /obj/item/storage/belt/lifesaver/beginner
 	suit_store = /obj/item/weapon/gun/shotgun/pump/lever/repeater/beginner
+	l_hand = /obj/item/paper/tutorial/lifesaver
+
 
 	backpack_contents = list(
 		/obj/item/storage/box/m94 = 2,
@@ -482,6 +485,7 @@
 	back = /obj/item/storage/backpack/marine/corpsman
 	belt = /obj/item/storage/belt/hypospraybelt/beginner
 	suit_store = /obj/item/weapon/gun/shotgun/pump/t35/beginner
+	l_hand = /obj/item/paper/tutorial/hypobelt
 
 	backpack_contents = list(
 		/obj/item/storage/box/m94 = 1,

--- a/code/modules/paperwork/beginner_tutorials.dm
+++ b/code/modules/paperwork/beginner_tutorials.dm
@@ -656,14 +656,12 @@
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are defibrillators. By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) \
+	Your gloves are defibrillators (unless you're a robot, in which case you have no gloves). By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) \
 	you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough. \
 	Drag your gloves to your backpack to recharge them. This even works on robots! \
 	Make sure your intent is help while doing this or you might just punch them right after they revive, taking them out again.<BR>
 	<BR>
 	While holding your repeater, use Z to wield your weapon with both hands, increasing accuracy and stability and reducing recoil. \
-	In the top left of your screen are several weapon-specific buttons. \
-	The "Take Aim" button toggles aim mode, a feature that slows your rate of fire in exchange for allowing you to shoot through allied marines.<BR>
 	<BR>
 	As your rifle is bolt-action, it needs to be racked after every shot. Do this by pressing your Unique Action key, which defaults to the spacebar.<BR>
 	<BR>
@@ -709,7 +707,7 @@
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are medical analyzers, which you can use on a patient by left clicking them. \
+	Your gloves are medical analyzers (unless you're a robot, in which case you have no gloves), which you can use on a patient by left clicking them. \
 	Before you do ANYTHING to a patient, use your medical analyzer on them. \
 	Not analyzing is the number one cause of overdoses. \
 	Right-click with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>

--- a/code/modules/paperwork/beginner_tutorials.dm
+++ b/code/modules/paperwork/beginner_tutorials.dm
@@ -656,7 +656,7 @@
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are defibrillators (unless you're a robot, in which case you have no gloves). By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) \
+	Your gloves are defibrillators (unless you're a robot, in which case you can't wear gloves). By clicking on any dead target with their exosuit removed (drag their sprite onto your sprite to remove it) \
 	you will attempt to bring them back to life, healing them somewhat and then resuscitating them if they're healed enough. \
 	Drag your gloves to your backpack to recharge them. This even works on robots! \
 	Make sure your intent is help while doing this or you might just punch them right after they revive, taking them out again.<BR>
@@ -707,7 +707,7 @@
 	<BR>
 	<b>TIPS</b><BR>
 	<BR>
-	Your gloves are medical analyzers (unless you're a robot, in which case you have no gloves), which you can use on a patient by left clicking them. \
+	Your gloves are medical analyzers (unless you're a robot, in which case you can't wear gloves), which you can use on a patient by left clicking them. \
 	Before you do ANYTHING to a patient, use your medical analyzer on them. \
 	Not analyzing is the number one cause of overdoses. \
 	Right-click with the analyzer instead shows them their own health scan, useful for getting their attention or informing them that they're fully healed.<BR>


### PR DESCRIPTION

## About The Pull Request
Combat robots that make the grave mistake of using the beginner loadouts will find themselves without the medevac beacon and text tutorial, the horror. This PR adds the medevac beacon to more accurately reflect the human corpsman beginner loadout.
## Why It's Good For The Game
poor combat robot didn't know where his beacon was and it made me sad.
## Changelog
:cl:
fix: Combat robot corpsman beginner loadouts now spawn with medevac beacons like their human counterparts.
/:cl:
