### PR TITLE
[BOUNTY] Gorger drain abilities now steal Greenblood 

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -746,7 +746,8 @@
 
 #define COMSIG_XENOMORPH_LEAP_BUMP "xenomorph_leap_bump" //from /mob/living/carbon/xenomorph/bump
 
-#define COMSIG_XENO_GREENBLOOD_DRAIN "xeno_greenblood_drain"
+#define COMSIG_XENO_DRAIN_HIT "xeno_drain_hit"
+#define COMSIG_XENO_CARNAGE_HIT "xeno_carnage_hit"
 
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"

--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -746,6 +746,8 @@
 
 #define COMSIG_XENOMORPH_LEAP_BUMP "xenomorph_leap_bump" //from /mob/living/carbon/xenomorph/bump
 
+#define COMSIG_XENO_GREENBLOOD_DRAIN "xeno_greenblood_drain"
+
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -670,7 +670,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define GORGER_CARNAGE_MOVEMENT -0.5
 #define GORGER_FEAST_DURATION -1 // lasts indefinitely, self-cancelled when insufficient plasma left
 
-#define GORGER_GREENBLOOD_STEAL_FLAT 15 //This many units of greenblood are always stolen
+#define GORGER_GREENBLOOD_STEAL_FLAT 10 //This many units of greenblood are always stolen
 #define GORGER_GREENBLOOD_STEAL_PERCENTAGE 25 //bonus % of current greenblood taken from vali on drain
 #define GORGER_GREENBLOOD_CONVERSION 1.25 //Amount of blood(plasma) gained per unit of greenblood drained from target.
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -670,6 +670,10 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define GORGER_CARNAGE_MOVEMENT -0.5
 #define GORGER_FEAST_DURATION -1 // lasts indefinitely, self-cancelled when insufficient plasma left
 
+#define GORGER_GREENBLOOD_STEAL_FLAT 15 //This many units of greenblood are always stolen
+#define GORGER_GREENBLOOD_STEAL_PERCENTAGE 25 //bonus % of current greenblood taken from vali on drain
+#define GORGER_GREENBLOOD_CONVERSION 1.25 //Amount of blood(plasma) gained per unit of greenblood drained from target.
+
 //carrier defines
 #define CARRIER_HUGGER_THROW_SPEED 2
 #define CARRIER_HUGGER_THROW_DISTANCE 5

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -542,7 +542,7 @@
 	update_resource(-drain_value)
 
 	var/mob/living/carbon/xenomorph/xeno_drainer = drainer
-	xeno_drainer.gain_plasma(drain_value * GORGER_GREENBLOOD_BONUS)
+	xeno_drainer.gain_plasma(drain_value * GORGER_GREENBLOOD_CONVERSION)
 
 #undef EXTRACT
 #undef LOAD

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -528,7 +528,7 @@
 		KEYBINDING_NORMAL = COMSIG_KB_VALI_CONNECT,
 	)
 
-//handles xeno abilities mooching our greenblood. Signal is routed through the equipping mob.
+///handles xeno abilities mooching our greenblood. Signal is routed through the equipping mob.
 /datum/component/chem_booster/proc/steal_greenblood(owner, drain_plasma_gain, drainer)
 	SIGNAL_HANDLER
 

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -172,7 +172,7 @@
 	wearer.overlays -= resource_overlay
 	wearer = null
 
-	UnregisterSignal(wearer, COMSIG_XENO_GREENBLOOD_DRAIN)
+	UnregisterSignal(wearer, list(COMSIG_XENO_DRAIN_HIT, COMSIG_XENO_CARNAGE_HIT))
 
 ///Sets up actions and vars when the suit is equipped
 /datum/component/chem_booster/proc/equipped(datum/source, mob/equipper, slot)
@@ -187,7 +187,7 @@
 	wearer.overlays += resource_overlay
 	update_resource(0)
 
-	RegisterSignal(wearer, COMSIG_XENO_GREENBLOOD_DRAIN, PROC_REF(steal_greenblood))
+	RegisterSignals(wearer, list(COMSIG_XENO_DRAIN_HIT, COMSIG_XENO_CARNAGE_HIT), PROC_REF(steal_greenblood))
 
 /datum/component/chem_booster/process()
 	if(resource_storage_current < resource_drain_amount)

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -518,7 +518,7 @@
 
 		if(do_after(owner_xeno, KNOCKDOWN_DURATION, IGNORE_HELD_ITEM, target))
 			owner_xeno.gain_plasma(plasma_gain_on_hit)
-			SEND_SIGNAL(target, COMSIG_XENO_GREENBLOOD_DRAIN, owner_xeno.xeno_caste.drain_plasma_gain, owner_xeno);\
+			SEND_SIGNAL(target, COMSIG_XENO_GREENBLOOD_DRAIN, owner_xeno.xeno_caste.drain_plasma_gain, owner_xeno)
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		for(var/mob/living/carbon/xenomorph/target_xeno AS in cheap_get_xenos_near(owner_xeno, 4))
 			if(target_xeno == owner_xeno)

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -518,7 +518,7 @@
 
 		if(do_after(owner_xeno, KNOCKDOWN_DURATION, IGNORE_HELD_ITEM, target))
 			owner_xeno.gain_plasma(plasma_gain_on_hit)
-			SEND_SIGNAL(target, COMSIG_XENO_GREENBLOOD_DRAIN, owner_xeno.xeno_caste.drain_plasma_gain, owner_xeno)
+			SEND_SIGNAL(target, COMSIG_XENO_CARNAGE_HIT, owner_xeno.xeno_caste.drain_plasma_gain, owner_xeno)
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		for(var/mob/living/carbon/xenomorph/target_xeno AS in cheap_get_xenos_near(owner_xeno, 4))
 			if(target_xeno == owner_xeno)

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -518,7 +518,7 @@
 
 		if(do_after(owner_xeno, KNOCKDOWN_DURATION, IGNORE_HELD_ITEM, target))
 			owner_xeno.gain_plasma(plasma_gain_on_hit)
-
+			SEND_SIGNAL(target, COMSIG_XENO_GREENBLOOD_DRAIN, owner_xeno.xeno_caste.drain_plasma_gain, owner_xeno);\
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		for(var/mob/living/carbon/xenomorph/target_xeno AS in cheap_get_xenos_near(owner_xeno, 4))
 			if(target_xeno == owner_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -133,7 +133,7 @@
 	var/drain_healing = GORGER_DRAIN_HEAL;\
 	HEAL_XENO_DAMAGE(xeno_owner, drain_healing, TRUE);\
 	adjustOverheal(xeno_owner, drain_healing);\
-	SEND_SIGNAL(target_human, COMSIG_XENO_GREENBLOOD_DRAIN, xeno_owner.xeno_caste.drain_plasma_gain, xeno_owner);\
+	SEND_SIGNAL(target_human, COMSIG_XENO_DRAIN_HIT, xeno_owner.xeno_caste.drain_plasma_gain, xeno_owner);\
 	xeno_owner.gain_plasma(xeno_owner.xeno_caste.drain_plasma_gain)
 
 /datum/action/ability/activable/xeno/drain/use_ability(mob/living/carbon/human/target_human)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -133,6 +133,7 @@
 	var/drain_healing = GORGER_DRAIN_HEAL;\
 	HEAL_XENO_DAMAGE(xeno_owner, drain_healing, TRUE);\
 	adjustOverheal(xeno_owner, drain_healing);\
+	SEND_SIGNAL(target_human, COMSIG_XENO_GREENBLOOD_DRAIN, xeno_owner.xeno_caste.drain_plasma_gain, xeno_owner);\
 	xeno_owner.gain_plasma(xeno_owner.xeno_caste.drain_plasma_gain)
 
 /datum/action/ability/activable/xeno/drain/use_ability(mob/living/carbon/human/target_human)


### PR DESCRIPTION
## About The Pull Request
**Commissioned by Elsa**
Gorger now mooches 25% of a Vali's current greenblood, plus 10 units, on each drain attack.
This blood is directly converted into gorger blood ammo at 1.25 per each unit of greenblood.
Balance has been plugged into defines and may be subject to change. 

Vali users get a little message in chat letting them know their greenblood is being stolen. Let me know if it should be bigger.
## Why It's Good For The Game
Improves Gorger's status as a Vali Counterplay. 
Reduces the benefit of intentionally letting a gorger feed off you to farm max greenblood from them 

## Changelog
:cl: Sun-Soaked, Comissioned by Elsa
balance: Gorger's drain and carnage attacks now steal greenblood from the target, if they have a vali harness.
/:cl:
