### PR TITLE
Gives supply beacons the supply ordering interface

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -4,7 +4,21 @@
 	icon = 'icons/obj/items/beacon.dmi'
 	icon_state = "motion_0"
 	w_class = WEIGHT_CLASS_SMALL
+	///Var for the window pop-up
+	var/datum/supply_ui/requests/supply_interface
 
 /obj/item/supply_beacon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/beacon, TRUE, 60, "motion_2")
+
+/obj/item/supply_beacon/examine(mob/user)
+	. = ..()
+	. += span_notice("Right-Click with empty hand when anchored to open requisitions interface.")
+
+/obj/item/supply_beacon/attack_hand_alternate(mob/living/user)
+	if(!allowed(user) || !anchored)
+		return ..()
+	if(!supply_interface)
+		supply_interface = new(src)
+
+	return supply_interface.interact(user)


### PR DESCRIPTION
## About The Pull Request
This PR gives the supply beacons the ordering interface, accessible via right click only when its anchored. This gives them the same functionality that radiopacks do, but doesn't exactly render them as radiopack replacements since you still need to actually go to the beacon to order things from it.
## Why It's Good For The Game
The RO's attention span may possibly be one of the most important resources for marines, second only to their precious requisition points. By minimizing the conversational back-and-forths on req radio ("what sentry did you want again? who needed the zx? we don't have the points..."), this PR aims to reduce both marine and RO frustration, as well as free up the RO to perform other tasks like reqtorio or vendor supply drops.

By allowing marines to just put in an order for what they need themselves, they only need to pester the RO to approve their order and coordinate what beacon to send it to. This also has the added benefit of having your name on the box: RO knows who to bother for the order, and people are less likely to steal your shit if it has your name on it. Win win.
## Changelog
:cl:
add: You can now right click supply beacons to access the supply interface.
/:cl:
