### PR TITLE
LTB Changes (Removes Gib, reduces damage, reload.)

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -77,22 +77,13 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 200
+	damage = 125
 	hud_state = "bigshell_he"
-	sundering = 20
+	sundering = 15
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, 0, 2, 5, 0, 3)
-
-/datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/target_turf = get_turf(target_mob)
-	if(!isxeno(target_mob))
-		if(!(target_mob.status_flags & GODMODE))
-			target_mob.gib()
-	else
-		staggerstun(target_mob, proj, max_range, knockback = 1, hard_size_threshold = 3)
-	drop_nade(target_turf)
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
 	explosion(target_turf, 1, 4, 6, 0, 3)
@@ -122,7 +113,7 @@
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 275
+	damage = 200
 	penetration = 75
 	shell_speed = 7
 	accurate_range = 24
@@ -532,8 +523,6 @@
 
 /datum/ammo/bullet/tank_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	proj.proj_max_range -= 2
-	if(ishuman(target_mob) && !(target_mob.status_flags & GODMODE) && prob(35))
-		target_mob.gib()
 
 /datum/ammo/bullet/tank_apfds/on_hit_obj(obj/target_object, obj/projectile/proj)
 	if(!isvehicle(target_object) && !ishitbox(target_object))

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -77,13 +77,13 @@
 	accurate_range = 15
 	max_range = 40
 	penetration = 50
-	damage = 125
+	damage = 150
 	hud_state = "bigshell_he"
 	sundering = 15
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3)
+	explosion(T, 0, 3, 5, 0, 3)
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
 	explosion(target_turf, 1, 4, 6, 0, 3)

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -39,7 +39,7 @@
 	///scatter of this weapon. in degrees and modified by arm this is attached to
 	var/variance = 0
 	/// since mech guns only get one firemode this is for all types of shots
-	var/projectile_delay = 5 SECONDS
+	var/projectile_delay = 3 SECONDS
 	/// time between shots in a burst
 	var/projectile_burst_delay = 2
 	///bullets per burst if firemode is set to burst
@@ -47,7 +47,7 @@
 	///fire mode to use for autofire
 	var/fire_mode = GUN_FIREMODE_SEMIAUTO
 	///how many seconds automatic, and manual, reloading takes
-	var/rearm_time = 3.5 SECONDS
+	var/rearm_time = 3 SECONDS
 	///ammo hud icon to display when no ammo is loaded
 	var/hud_state_empty = "shell_empty"
 

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -47,7 +47,7 @@
 	///fire mode to use for autofire
 	var/fire_mode = GUN_FIREMODE_SEMIAUTO
 	///how many seconds automatic, and manual, reloading takes
-	var/rearm_time = 4 SECONDS
+	var/rearm_time = 3.5 SECONDS
 	///ammo hud icon to display when no ammo is loaded
 	var/hud_state_empty = "shell_empty"
 


### PR DESCRIPTION
## About The Pull Request
LTB no longer gibs on direct hit.
APFSDS has had its damage reduced to 200 from 275
HE now does 150 damage on direct hit from 200, 15 sunder from 25.
Heavy explosion range to 3 from 2
LTB Rearm/Projectile damage reduced to 3.
## Why It's Good For The Game
LTB gibbing makes it obnoxious to balance around. It can randomly remove people from the game so clearly it has to be pretty strong. Removing it and putting it in line will allow us to actually give tank more guns than the two extremes of IFF Chaingun or LTB cannon.
## Changelog
:cl:
balance: LTB no longer gibs, deals less damage in general. Canister is unchanged. Reloads and shoots faster.
/:cl:
