### PR TITLE
LTAAP fires at 0.05, damage adjusted accordingly.

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -44,11 +44,11 @@
 
 /datum/ammo/bullet/minigun/ltaap
 	name = "chaingun bullet"
-	damage = 15
-	penetration = 20
-	sundering = 1
+	damage = 8
+	penetration = 30
+	sundering = 0.5
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_BETTER_COVER_RNG|AMMO_IFF
-	damage_falloff = 1
+	damage_falloff = 0.1
 	accurate_range = 7
 	accuracy = 10
 	barricade_clear_distance = 4

--- a/code/modules/vehicles/armored/ammo_magazine.dm
+++ b/code/modules/vehicles/armored/ammo_magazine.dm
@@ -41,7 +41,7 @@
 	icon_state = "ltaap"
 	w_class = WEIGHT_CLASS_GIGANTIC
 	default_ammo = /datum/ammo/bullet/minigun/ltaap
-	max_rounds = 150
+	max_rounds = 999
 	loading_sound = 'sound/weapons/guns/interact/working_the_bolt.ogg'
 
 /obj/item/ammo_magazine/tank/ltaap_chaingun/hv

--- a/code/modules/vehicles/armored/ammo_magazine.dm
+++ b/code/modules/vehicles/armored/ammo_magazine.dm
@@ -41,7 +41,7 @@
 	icon_state = "ltaap"
 	w_class = WEIGHT_CLASS_GIGANTIC
 	default_ammo = /datum/ammo/bullet/minigun/ltaap
-	max_rounds = 999
+	max_rounds = 500
 	loading_sound = 'sound/weapons/guns/interact/working_the_bolt.ogg'
 
 /obj/item/ammo_magazine/tank/ltaap_chaingun/hv

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -333,7 +333,7 @@
 	accepted_ammo = list(/obj/item/ammo_magazine/tank/ltaap_chaingun, /obj/item/ammo_magazine/tank/ltaap_chaingun/hv)
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 	variance = 5
-	projectile_delay = 0.1 SECONDS
+	projectile_delay = 0.05 SECONDS
 	rearm_time = 5 SECONDS
 	hud_state_empty = "rifle_empty"
 


### PR DESCRIPTION
## About The Pull Request
LTAAP now fires at 0.05 (20 rounds a second) rather than .1 (10)
LTAAP now does 8/30 and has .1 falloff. Halved the sunder to accommodate the fire rate.
Mags increased from 150 to 500.
## Why It's Good For The Game
Makes LTAAP feel like a true minigun. ~~Stress tests shoddy PCs~~
## Changelog
:cl:
balance: LTAAP fires at double the RPM. Has 500 rounds per drum. Damage adjusted accordingly.
/:cl:
