### PR TITLE
Nukes the premade sentries on prison station

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -35416,7 +35416,6 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/full,
-/obj/item/weapon/gun/sentry/big_sentry/premade,
 /turf/open/floor/prison/blackfloor,
 /area/prison/pirate)
 "ckG" = (
@@ -36481,10 +36480,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/pirate)
-"cnH" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
-/turf/open/floor/plating,
-/area/prison/pirate)
 "cnI" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 1
@@ -36880,10 +36875,6 @@
 /obj/structure/table/reinforced/flipped{
 	dir = 1
 	},
-/turf/open/floor/plating/platebot,
-/area/prison/pirate)
-"cpb" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
 /turf/open/floor/plating/platebot,
 /area/prison/pirate)
 "cpc" = (
@@ -71154,7 +71145,7 @@ lZe
 lZe
 lED
 lED
-cnH
+lZe
 lED
 lED
 lZe
@@ -71927,7 +71918,7 @@ lED
 lED
 hKD
 lED
-cpb
+lED
 lZe
 cqC
 cro


### PR DESCRIPTION

## About The Pull Request
see title
## Why It's Good For The Game
Yeah I'm not sure why these are still around
in the old days they just skill checked xenos who weren't patient enough to evo to t3 
nowadays this only makes xeno prep a bit more annoying as you have to kill these stupid things before doing real work here
## Changelog
:cl:
del: Removes the pre-spawned sentry turrets on prisonstation
/:cl:
