### PR TITLE
Minor clean-up of xeno vars

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -10,7 +10,7 @@
 #define ATTACK_EFFECT_MECHTOXIN "mech_toxin"
 #define ATTACK_EFFECT_BOOP "boop" //Honk
 #define ATTACK_EFFECT_GRAB "grab"
-#define ATTACK_EFFECT_REDSLASH pick("redslash","redslash2")
+#define ATTACK_EFFECT_REDSLASH list("redslash","redslash2")
 #define ATTACK_EFFECT_REDSTAB "redstab"
 #define ATTACK_EFFECT_DRAIN_STING "drain_sting"
 #define ATTACK_EFFECT_YELLOWPUNCH "yellowpunch"

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -105,7 +105,8 @@
 		span_danger("We lunge at [src]!"), null, 5)
 		return FALSE
 
-	X.do_attack_animation(src, X.attack_effect)
+	var/attack_effect = islist(X.attack_effect) ? pick(X.attack_effect) : X.attack_effect
+	X.do_attack_animation(src, attack_effect)
 
 	//The normal attack proceeds
 	playsound(loc, X.attack_sound, 25, 1)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -93,7 +93,6 @@
 			span_danger("Our slash is blocked by [src]'s shield!"), null, COMBAT_MESSAGE_RANGE)
 		return FALSE
 
-	var/attack_sound = SFX_ALIEN_CLAW_FLESH
 	var/attack_message1 = span_danger("\The [X] slashes [src]!")
 	var/attack_message2 = span_danger("We slash [src]!")
 	var/log = "slashed"
@@ -106,10 +105,10 @@
 		span_danger("We lunge at [src]!"), null, 5)
 		return FALSE
 
-	X.do_attack_animation(src, ATTACK_EFFECT_REDSLASH)
+	X.do_attack_animation(src, X.attack_effect)
 
 	//The normal attack proceeds
-	playsound(loc, attack_sound, 25, 1)
+	playsound(loc, X.attack_sound, 25, 1)
 	X.visible_message("[attack_message1]", \
 	"[attack_message2]")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -4,9 +4,6 @@
 	desc = "A primordial creature, evolved to smash the hardiest of defences and hunt the hardiest of prey."
 	icon = 'icons/Xeno/castes/king.dmi'
 	icon_state = "King Walking"
-	attacktext = "bites"
-	attack_sound = null
-	friendly = "nuzzles"
 	health = 500
 	maxHealth = 500
 	plasma_stored = 300

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -4,9 +4,6 @@
 	desc = "A huge, looming alien creature. The biggest and the baddest."
 	icon = 'icons/Xeno/castes/queen.dmi'
 	icon_state = "Queen Walking"
-	attacktext = "bites"
-	attack_sound = null
-	friendly = "nuzzles"
 	health = 300
 	maxHealth = 300
 	plasma_stored = 300

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
@@ -5,10 +5,6 @@
 	icon = 'icons/Xeno/castes/shrike.dmi'
 	icon_state = "Shrike Walking"
 	bubble_icon = "alienroyal"
-	attacktext = "bites"
-	attack_sound = null
-	friendly = "nuzzles"
-	wall_smash = FALSE
 	health = 240
 	maxHealth = 240
 	plasma_stored = 300

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
@@ -5,10 +5,6 @@
 	icon = 'icons/Xeno/castes/warlock.dmi'
 	icon_state = "Warlock Walking"
 	bubble_icon = "alienroyal"
-	attacktext = "slashes"
-	attack_sound = null
-	friendly = "nuzzles"
-	wall_smash = FALSE
 	health = 320
 	maxHealth = 320
 	plasma_stored = 1400

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -72,8 +72,6 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_AGILITY,
 	)
 	action_type = ACTION_TOGGLE
-	/// Whether the ability is active or not.
-	var/ability_active = FALSE
 
 /datum/action/ability/xeno_action/toggle_agility/New(Target)
 	. = ..()
@@ -82,11 +80,11 @@
 /datum/action/ability/xeno_action/toggle_agility/action_activate()
 	GLOB.round_statistics.warrior_agility_toggles++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "warrior_agility_toggles")
-	ability_active = !ability_active
-	set_toggle(ability_active ? TRUE : FALSE)
+	toggled = !toggled
+	set_toggle(toggled)
 	xeno_owner.update_icons()
 	add_cooldown()
-	if(!ability_active)
+	if(!toggled)
 		xeno_owner.remove_movespeed_modifier(MOVESPEED_ID_WARRIOR_AGILITY)
 		xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(WARRIOR_AGILITY_ARMOR_MODIFIER)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -101,7 +101,7 @@
 
 /datum/action/ability/activable/xeno/warrior/use_ability(atom/A)
 	var/datum/action/ability/xeno_action/toggle_agility/agility_action = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/toggle_agility]
-	if(agility_action?.ability_active)
+	if(agility_action?.toggled)
 		agility_action.action_activate()
 
 /// Adds an outline around the ability button to represent Empower.

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -19,7 +19,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/warrior/handle_special_state()
 	var/datum/action/ability/xeno_action/toggle_agility/agility_action = actions_by_path[/datum/action/ability/xeno_action/toggle_agility]
-	if(agility_action?.ability_active)
+	if(agility_action?.toggled)
 		icon_state = "[xeno_caste.caste_name][(xeno_flags & XENO_ROUNY) ? " rouny" : ""] Agility"
 		return TRUE
 	return FALSE
@@ -27,5 +27,5 @@
 /mob/living/carbon/xenomorph/warrior/handle_special_wound_states(severity)
 	. = ..()
 	var/datum/action/ability/xeno_action/toggle_agility/agility_action = actions_by_path[/datum/action/ability/xeno_action/toggle_agility]
-	if(agility_action?.ability_active)
+	if(agility_action?.toggled)
 		return "wounded_agility_[severity]"

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -265,7 +265,7 @@
 		balloon_alert(src, "We must be at full plasma to evolve")
 		return FALSE
 
-	if (agility || fortify || crest_defense || status_flags & INCORPOREAL)
+	if (fortify || crest_defense || status_flags & INCORPOREAL)
 		balloon_alert(src, "We cannot evolve while in this stance")
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -268,8 +268,7 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	speak_emote = list("hisses")
 	melee_damage = 5 //Arbitrary damage value
 	attacktext = "claws"
-	attack_sound = null
-	friendly = "nuzzles"
+	attack_sound = SFX_ALIEN_CLAW_FLESH
 	wall_smash = FALSE
 	health = 5
 	maxHealth = 5
@@ -372,16 +371,15 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	///Multiplicative melee damage modifier; referenced by attack_alien.dm, most notably attack_alien_harm
 	var/xeno_melee_damage_modifier = 1
 
+	/// Visual effect that appears when doing a normal attack.
+	var/attack_effect = ATTACK_EFFECT_REDSLASH
+
 	//Charge vars
 	///Will the mob charge when moving ? You need the charge verb to change this
 	var/is_charging = CHARGE_OFF
 
 	// Gorger vars
 	var/overheal = 0
-
-	// Warrior vars
-	///0 - upright, 1 - all fours
-	var/agility = 0
 
 	// Defender vars
 	var/fortify = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -42,9 +42,6 @@
 
 	//Attack
 	melee_damage = 0
-	attacktext = "attacks"
-	attack_sound = null
-	friendly = "nuzzles" //If the mob does no damage with it's attack
 	var/obj_damage = 0 //how much damage this simple animal does to objects, if any
 	var/attacked_sound = SFX_PUNCH //Played when someone punches the creature
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value


### PR DESCRIPTION
## About The Pull Request
Combed through some vars and decided to get rid of unnecessary stuff, make actual use of the `attack_sound` var, and implement an `attack_effect` var as setup for future xeno castes (such as Conqueror).

## Why It's Good For The Game
Squeaky clean code (just ignore the absolute mess that is mob code).

## Changelog
:cl: Lewdcifer
code: Minor clean-up of xeno vars. Gets rid of unnecessary overrides, uses the attack_sound var, and implements an attack_effect var as setup for future content.
/:cl:
