### PR TITLE
Facehuggers can no longer land on vehicles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -359,10 +359,10 @@
 
 /obj/item/clothing/mask/facehugger/throw_impact(atom/hit_atom, speed)
 	if(isopenturf(hit_atom))
-		var/valid_victim = FALSE
-		if(locate(/obj/vehicle/sealed) in hit_atom)
+		if((locate(/obj/hitbox) in hit_atom) && !leaping) // Kill the hugger if it's thrown on the hitbox of a vehicle
 			kill_hugger()
 			return
+		var/valid_victim = FALSE
 		for(var/mob/living/carbon/M in hit_atom)
 			if(!M.can_be_facehugged(src))
 				continue

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -360,6 +360,9 @@
 /obj/item/clothing/mask/facehugger/throw_impact(atom/hit_atom, speed)
 	if(isopenturf(hit_atom))
 		var/valid_victim = FALSE
+		if(locate(/obj/vehicle/sealed) in hit_atom)
+			kill_hugger()
+			return
 		for(var/mob/living/carbon/M in hit_atom)
 			if(!M.can_be_facehugged(src))
 				continue


### PR DESCRIPTION

## About The Pull Request

Huggers will now instantly die if they land on a vehicle.
## Why It's Good For The Game

there's currently a 'trick' carriers can do where if they throw a hugger onto a vehicle, marines can't shoot it because it isn't considered a desant. this feels a little slimy and maybe a little bit of an exploit. items can't be desants right now, so this is the next best thing.

(if this is considered too harsh we could throw the huggers off the vehicle instead of killing them)
## Changelog
:cl:
balance: Huggers now die if thrown onto a vehicle.
/:cl:
