### PR TITLE
Removes the weird spaces at the beginnings of some messages

### DIFF
--- a/code/datums/elements/scalping.dm
+++ b/code/datums/elements/scalping.dm
@@ -18,7 +18,7 @@
 	M.visible_message(span_notice("[user] starts to tear into [M] with \the [source]") ,span_notice("You start hacking away at [M] with \the [source]"))
 	if(!do_after(user, 2 SECONDS, NONE, M))
 		return NONE
-	M.visible_message(span_danger("[user] brutally scalps [M]!"), span_danger(" You brutally scalp [M] 	with \the [source]!"))
+	M.visible_message(span_danger("[user] brutally scalps [M]!"), span_danger("You brutally scalp [M] 	with \the [source]!"))
 	var/obj/item/scalp/scalp = new(get_turf(M))
 	scalp.name = M.name + "'s " + initial(scalp.name)
 	return COMPONENT_ITEM_NO_ATTACK

--- a/code/datums/elements/scalping.dm
+++ b/code/datums/elements/scalping.dm
@@ -18,7 +18,7 @@
 	M.visible_message(span_notice("[user] starts to tear into [M] with \the [source]") ,span_notice("You start hacking away at [M] with \the [source]"))
 	if(!do_after(user, 2 SECONDS, NONE, M))
 		return NONE
-	M.visible_message(span_danger("[user] brutally scalps [M]!"), span_danger("You brutally scalp [M] 	with \the [source]!"))
+	M.visible_message(span_danger("[user] brutally scalps [M]!"), span_danger("You brutally scalp [M] with \the [source]!"))
 	var/obj/item/scalp/scalp = new(get_turf(M))
 	scalp.name = M.name + "'s " + initial(scalp.name)
 	return COMPONENT_ITEM_NO_ATTACK

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1383,10 +1383,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	set waitfor = 0
 	playsound(user, 'sound/effects/spin.ogg', 25, 1)
 	if(double)
-		user.visible_message("[user] deftly flicks and spins [src] and [double]!",span_notice(" You flick and spin [src] and [double]!"))
+		user.visible_message("[user] deftly flicks and spins [src] and [double]!",span_notice("You flick and spin [src] and [double]!"))
 		animation_wrist_flick(double, 1)
 	else
-		user.visible_message("[user] deftly flicks and spins [src]!",span_notice(" You flick and spin [src]!"))
+		user.visible_message("[user] deftly flicks and spins [src]!",span_notice("You flick and spin [src]!"))
 	animation_wrist_flick(src, direction)
 	sleep(0.3 SECONDS)
 	if(loc && user) playsound(user, 'sound/effects/thud.ogg', 25, 1)
@@ -1394,7 +1394,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 ///The fancy trick. Woah.
 /obj/item/proc/throw_catch_trick(mob/living/carbon/human/user)
 	set waitfor = 0
-	user.visible_message("[user] deftly flicks [src] and tosses it into the air!",span_notice(" You flick and toss [src] into the air!"))
+	user.visible_message("[user] deftly flicks [src] and tosses it into the air!",span_notice("You flick and toss [src] into the air!"))
 	var/img_layer = MOB_LAYER+0.1
 	var/image/trick = image(icon,user,icon_state,img_layer)
 	switch(pick(1,2))
@@ -1415,9 +1415,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return
 
 	if(user.get_inactive_held_item())
-		user.visible_message("[user] catches [src] with the same hand!",span_notice(" You catch [src] as it spins in to your hand!"))
+		user.visible_message("[user] catches [src] with the same hand!",span_notice("You catch [src] as it spins in to your hand!"))
 		return
-	user.visible_message("[user] catches [src] with his other hand!",span_notice(" You snatch [src] with your other hand! Awesome!"))
+	user.visible_message("[user] catches [src] with his other hand!",span_notice("You snatch [src] with your other hand! Awesome!"))
 	user.temporarilyRemoveItemFromInventory(src)
 	user.put_in_inactive_hand(src)
 	user.swap_hand()

--- a/code/game/objects/items/books/book.dm
+++ b/code/game/objects/items/books/book.dm
@@ -108,8 +108,8 @@
 
 /obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(user.zone_selected == "eyes")
-		user.visible_message(span_notice("You open up the book and show it to [M]. "), \
-			span_notice(" [user] opens up a book and shows it to [M]. "))
+		user.visible_message(span_notice("You open up the book and show it to [M]."), \
+			span_notice("[user] opens up a book and shows it to [M]."))
 		M << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book")
 
 

--- a/code/game/objects/items/circuitboards/machine.dm
+++ b/code/game/objects/items/circuitboards/machine.dm
@@ -94,7 +94,7 @@ to destroy them and players will be able to make replacements.
 	if(isscrewdriver(I))
 		machine_dir = turn(machine_dir, 90)
 		init_dirs = machine_dir
-		user.visible_message(span_notice("[user] adjusts the jumper on the [src]'s port configuration pins."), span_notice(" You adjust the jumper on the port configuration pins. Now set to [dir2text(machine_dir)]."))
+		user.visible_message(span_notice("[user] adjusts the jumper on the [src]'s port configuration pins."), span_notice("You adjust the jumper on the port configuration pins. Now set to [dir2text(machine_dir)]."))
 
 /obj/item/circuitboard/machine/unary_atmos/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/implants/implant_chem.dm
+++ b/code/game/objects/items/implants/implant_chem.dm
@@ -32,7 +32,7 @@
 	if(malfunction == MALFUNCTION_PERMANENT)
 		return FALSE
 	if(used)
-		to_chat(implant_owner, span_warning(" WARNING. Implant activation failed; Error code 345: Implant exhausted."))
+		to_chat(implant_owner, span_warning("WARNING. Implant activation failed; Error code 345: Implant exhausted."))
 		return FALSE
 	playsound(implant_owner, 'sound/machines/buzz-two.ogg', 60, 1)
 	reagents.trans_to(implant_owner, reagents.total_volume)

--- a/code/game/objects/items/implants/implant_cloak.dm
+++ b/code/game/objects/items/implants/implant_cloak.dm
@@ -43,7 +43,7 @@
 	apply_wibbly_filters(implant_owner)
 	playsound(implant_owner, 'sound/effects/seedling_chargeup.ogg', 100, TRUE)
 	if(!do_after(implant_owner, 3 SECONDS, IGNORE_HELD_ITEM, implant_owner))
-		to_chat(implant_owner, span_warning(" WARNING. Implant activation failed; Error code 423: Subject cancelled activation."))
+		to_chat(implant_owner, span_warning("WARNING. Implant activation failed; Error code 423: Subject cancelled activation."))
 		remove_wibbly_filters(implant_owner)
 		return
 	remove_wibbly_filters(implant_owner)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -41,7 +41,7 @@
 		if(WT.remove_fuel(0,user))
 			var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
 			new_item.add_to_stacks(usr)
-			visible_message(span_warning("[src] is shaped into metal by [user] with the weldingtool."), null, span_warning(" You hear welding."))
+			visible_message(span_warning("[src] is shaped into metal by [user] with the weldingtool."), null, span_warning("You hear welding."))
 			var/obj/item/stack/rods/R = src
 			var/replace = (user.get_inactive_held_item()==R)
 			R.use(4)

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -92,7 +92,7 @@
 		return
 
 	if(I.sharp)
-		user.visible_message(span_notice(" \the [user] starts cutting hair off \the [src]"), span_notice(" You start cutting the hair off \the [src]"), "You hear the sound of a knife rubbing against flesh")
+		user.visible_message(span_notice("\the [user] starts cutting hair off \the [src]"), span_notice("You start cutting the hair off \the [src]"), "You hear the sound of a knife rubbing against flesh")
 		if(!do_after(user,50, NONE, src, BUSY_ICON_HOSTILE))
 			return
 

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -90,22 +90,22 @@
 			return
 
 		open = !open
-		user.show_message(span_notice(" You [open ? "open" : "close"] the service panel."))
+		user.show_message(span_notice("You [open ? "open" : "close"] the service panel."))
 
 	else if(ismultitool(I) && open && !l_hacking)
-		user.show_message(span_warning(" Now attempting to reset internal memory, please hold."))
+		user.show_message(span_warning("Now attempting to reset internal memory, please hold."))
 		l_hacking = TRUE
 		if(!do_after(user, 100, NONE, src, BUSY_ICON_BUILD))
 			return
 
 		if(!prob(40))
-			user.show_message(span_warning(" Unable to reset internal memory."), 1)
+			user.show_message(span_warning("Unable to reset internal memory."), 1)
 			l_hacking = FALSE
 			return
 
 		l_setshort = TRUE
 		l_set = FALSE
-		user.show_message(span_warning(" Internal memory reset.  Please give it a few seconds to reinitialize."))
+		user.show_message(span_warning("Internal memory reset.  Please give it a few seconds to reinitialize."))
 		sleep(8 SECONDS)
 		l_setshort = FALSE
 		l_hacking = FALSE

--- a/code/game/objects/items/tools/policetape.dm
+++ b/code/game/objects/items/tools/policetape.dm
@@ -150,7 +150,7 @@
 	if(user.a_intent == INTENT_HELP && ((!can_puncture(W) && src.allowed(user))))
 		to_chat(user, "You can't break the [src] with that!")
 		return
-	user.visible_message(span_notice(" [user] breaks the [src]!"))
+	user.visible_message(span_notice("[user] breaks the [src]!"))
 
 	var/dir[2]
 	var/icon_dir = src.icon_state

--- a/code/game/objects/items/toys/toy_weapons.dm
+++ b/code/game/objects/items/toys/toy_weapons.dm
@@ -50,12 +50,12 @@
 	if (flag)
 		return
 	if (src.bullets < 1)
-		user.show_message(span_warning(" *click* *click*"), 2)
+		user.show_message(span_warning("*click* *click*"), 2)
 		playsound(user, 'sound/weapons/guns/fire/empty.ogg', 15, 1)
 		return
 	playsound(user, 'sound/weapons/guns/fire/gunshot.ogg', 15, 1)
 	src.bullets--
-	visible_message(span_danger("[user] fires a cap gun at [target]!"), null, span_warning(" You hear a gunshot"))
+	visible_message(span_danger("[user] fires a cap gun at [target]!"), null, span_warning("You hear a gunshot"))
 
 /obj/item/toy/gun_ammo
 	name = "ammo-caps"

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -90,7 +90,7 @@
 	if(!.)
 		return
 	if(src.reagents.total_volume >= 1)
-		src.visible_message(span_warning(" The [src] bursts!"),"You hear a pop and a splash.")
+		src.visible_message(span_warning("The [src] bursts!"),"You hear a pop and a splash.")
 		src.reagents.reaction(get_turf(hit_atom), TOUCH)
 		for(var/atom/A in get_turf(hit_atom))
 			src.reagents.reaction(A, TOUCH)
@@ -187,7 +187,7 @@
 	s.set_up(3, 1, src)
 	s.start()
 	new /obj/effect/decal/cleanable/ash(src.loc)
-	src.visible_message(span_warning(" The [src.name] explodes!"),span_warning(" You hear a snap!"))
+	src.visible_message(span_warning("The [src.name] explodes!"),span_warning("You hear a snap!"))
 	playsound(src, 'sound/effects/snap.ogg', 25, 1)
 	qdel(src)
 
@@ -204,7 +204,7 @@
 	s.set_up(2, 0, src)
 	s.start()
 	new /obj/effect/decal/cleanable/ash(src.loc)
-	visible_message(span_warning(" The [src.name] explodes!"),span_warning(" You hear a snap!"))
+	visible_message(span_warning("The [src.name] explodes!"),span_warning("You hear a snap!"))
 	playsound(src, 'sound/effects/snap.ogg', 25, 1)
 	qdel(src)
 
@@ -843,9 +843,9 @@
 				if(X.id == id)
 					X.score(side)
 					// no break, to update multiple scoreboards
-			visible_message(span_notice(" Swish! \the [I] lands in \the [src]."), 3)
+			visible_message(span_notice("Swish! \the [I] lands in \the [src]."), 3)
 		else
-			visible_message(span_warning(" \the [I] bounces off of \the [src]'s rim!"), 3)
+			visible_message(span_warning("\the [I] bounces off of \the [src]'s rim!"), 3)
 		return FALSE
 	else
 		return ..()

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -16,7 +16,7 @@
 		return
 
 	M.set_timed_status_effect(16 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
-	visible_message(span_danger("[M] has been beaten with \the [src] by [user]!"), null, span_warning(" You hear someone fall"), 2)
+	visible_message(span_danger("[M] has been beaten with \the [src] by [user]!"), null, span_warning("You hear someone fall"), 2)
 
 //Telescopic baton
 /obj/item/weapon/telebaton
@@ -33,7 +33,7 @@
 /obj/item/weapon/telebaton/attack_self(mob/user as mob)
 	on = !on
 	if(on)
-		user.visible_message(span_warning(" With a flick of their wrist, [user] extends their telescopic baton."),\
+		user.visible_message(span_warning("With a flick of their wrist, [user] extends their telescopic baton."),\
 		span_warning("You extend the baton."),\
 		"You hear an ominous click.")
 		icon_state = "telebaton_1"
@@ -42,7 +42,7 @@
 		force = 20
 		attack_verb = list("smacks", "strikes", "slaps")
 	else
-		user.visible_message(span_notice(" [user] collapses their telescopic baton."),\
+		user.visible_message(span_notice("[user] collapses their telescopic baton."),\
 		span_notice("You collapse the baton."),\
 		"You hear a click.")
 		icon_state = "telebaton_0"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -71,7 +71,7 @@
 	if(istype(H))
 		var/obj/item/card/id/I = H.wear_id
 		if(!istype(I) || !check_access(I))
-			H.visible_message(span_notice(" [src] beeeps as [H] picks it up"), span_danger("WARNING: Unauthorized user detected. Denying access..."))
+			H.visible_message(span_notice("[src] beeeps as [H] picks it up"), span_danger("WARNING: Unauthorized user detected. Denying access..."))
 			H.Paralyze(40 SECONDS)
 			H.visible_message(span_warning("[src] beeps and sends a shock through [H]'s body!"))
 			deductcharge(hitcost)

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -564,7 +564,7 @@
 							if(A)
 								for(A in occupant)
 									sleep(HEMOSTAT_REMOVE_MAX_DURATION*surgery_mod)
-									occupant.visible_message(span_warning(" [src] defty extracts a wriggling parasite from [occupant]'s ribcage!"))
+									occupant.visible_message(span_warning("[src] defty extracts a wriggling parasite from [occupant]'s ribcage!"))
 									var/mob/living/carbon/xenomorph/larva/L = locate() in occupant //the larva was fully grown, ready to burst.
 									if(L)
 										L.forceMove(get_turf(src))

--- a/code/game/objects/machinery/fire_alarm.dm
+++ b/code/game/objects/machinery/fire_alarm.dm
@@ -117,11 +117,11 @@ FIRE ALARM
 			if(ismultitool(I))
 				detecting = !detecting
 				if(detecting)
-					user.visible_message(span_warning(" [user] has reconnected [src]'s detecting unit!"), "You have reconnected [src]'s detecting unit.")
+					user.visible_message(span_warning("[user] has reconnected [src]'s detecting unit!"), "You have reconnected [src]'s detecting unit.")
 				else
-					user.visible_message(span_warning(" [user] has disconnected [src]'s detecting unit!"), "You have disconnected [src]'s detecting unit.")
+					user.visible_message(span_warning("[user] has disconnected [src]'s detecting unit!"), "You have disconnected [src]'s detecting unit.")
 			else if(iswirecutter(I))
-				user.visible_message(span_warning(" [user] has cut the wires inside \the [src]!"), "You have cut the wires inside \the [src].")
+				user.visible_message(span_warning("[user] has cut the wires inside \the [src]!"), "You have cut the wires inside \the [src].")
 				playsound(loc, 'sound/items/wirecutter.ogg', 25, 1)
 				buildstage = 1
 				update_icon()

--- a/code/game/objects/machinery/flasher.dm
+++ b/code/game/objects/machinery/flasher.dm
@@ -44,9 +44,9 @@
 /obj/machinery/flasher/wirecutter_act(mob/living/user, obj/item/W)
 	disable = !disable
 	if (disable)
-		user.visible_message(span_warning(" [user] has disconnected the [src]'s flashbulb!"), span_warning(" You disconnect the [src]'s flashbulb!"))
+		user.visible_message(span_warning("[user] has disconnected the [src]'s flashbulb!"), span_warning("You disconnect the [src]'s flashbulb!"))
 	if (!disable)
-		user.visible_message(span_warning(" [user] has connected the [src]'s flashbulb!"), span_warning(" You connect the [src]'s flashbulb!"))
+		user.visible_message(span_warning("[user] has connected the [src]'s flashbulb!"), span_warning("You connect the [src]'s flashbulb!"))
 
 /obj/machinery/flasher/attack_ai()
 	if (anchored)
@@ -114,7 +114,7 @@
 			user.show_message(span_warning("[src] is now secured."))
 			overlays += "[base_state]-s"
 		else
-			user.show_message(span_warning(" [src] can now be moved."))
+			user.show_message(span_warning("[src] can now be moved."))
 			overlays.Cut()
 
 /obj/machinery/flasher_button/attack_ai(mob/user as mob)

--- a/code/game/objects/machinery/igniter.dm
+++ b/code/game/objects/machinery/igniter.dm
@@ -71,10 +71,10 @@
 	else if(isscrewdriver(I))
 		disable = !disable
 		if(disable)
-			user.visible_message(span_warning(" [user] has disabled the [src]!"), span_warning(" You disable the connection to the [src]."))
+			user.visible_message(span_warning("[user] has disabled the [src]!"), span_warning("You disable the connection to the [src]."))
 			icon_state = "[base_state]-d"
 		else
-			user.visible_message(span_warning(" [user] has reconnected the [src]!"), span_warning(" You fix the connection to the [src]."))
+			user.visible_message(span_warning("[user] has reconnected the [src]!"), span_warning("You fix the connection to the [src]."))
 			if(powered())
 				icon_state = "[base_state]"
 			else

--- a/code/game/objects/machinery/kitchen/gibber.dm
+++ b/code/game/objects/machinery/kitchen/gibber.dm
@@ -105,10 +105,10 @@
 	if(operating)
 		return
 	if(!occupant)
-		visible_message(span_warning(" You hear a loud metallic grinding sound."))
+		visible_message(span_warning("You hear a loud metallic grinding sound."))
 		return
 	use_power(active_power_usage)
-	visible_message(span_warning(" You hear a loud squelchy grinding sound."))
+	visible_message(span_warning("You hear a loud squelchy grinding sound."))
 	playsound(loc, 'sound/machines/juicer.ogg', 50, TRUE)
 	operating = TRUE
 	update_icon()

--- a/code/game/objects/machinery/kitchen/microwave.dm
+++ b/code/game/objects/machinery/kitchen/microwave.dm
@@ -351,7 +351,7 @@
 
 /obj/machinery/microwave/proc/muck_finish()
 	playsound(src.loc, 'sound/machines/ding.ogg', 25, 1)
-	visible_message(span_warning(" The microwave gets covered in muck!"))
+	visible_message(span_warning("The microwave gets covered in muck!"))
 	dirty = 100 // Make it dirty so it can't be used util cleaned
 	DISABLE_BITFIELD(reagents.reagent_flags, OPENCONTAINER) //So you can't add condiments
 	icon_state = "mwbloody0" // Make it look dirty too
@@ -363,7 +363,7 @@
 	s.set_up(2, 1, src)
 	s.start()
 	icon_state = "mwb" // Make it look all busted up and shit
-	visible_message(span_warning(" The microwave breaks!")) //Let them know they're stupid
+	visible_message(span_warning("The microwave breaks!")) //Let them know they're stupid
 	broken = 2 // Make it broken so it can't be used util fixed
 	DISABLE_BITFIELD(reagents.reagent_flags, OPENCONTAINER) //So you can't add condiments
 	operating = 0 // Turn it off again aferwards

--- a/code/game/objects/machinery/kitchen/processor.dm
+++ b/code/game/objects/machinery/kitchen/processor.dm
@@ -104,7 +104,7 @@
 			stack_trace("[O] in processor doesn't have a suitable recipe.") //-rastaf0
 			continue
 		src.processing = 1
-		user.visible_message(span_notice(" [user] turns on [src]."), \
+		user.visible_message(span_notice("[user] turns on [src]."), \
 			"You turn on [src].", \
 			"You hear a food processor.")
 		playsound(src.loc, 'sound/machines/blender.ogg', 25, 1)
@@ -112,5 +112,5 @@
 		sleep(P.time)
 		P.process(src.loc, O)
 		src.processing = 0
-	src.visible_message(span_notice(" \the [src] finished processing."), \
+	src.visible_message(span_notice("\the [src] finished processing."), \
 		"You hear the food processor stopping/")

--- a/code/game/objects/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/objects/machinery/pipe/pipe_dispenser.dm
@@ -80,7 +80,7 @@
 				return
 
 			user.visible_message("[user] unfastens \the [src].", \
-				span_notice(" You have unfastened \the [src]. Now it can be pulled somewhere else."), \
+				span_notice("You have unfastened \the [src]. Now it can be pulled somewhere else."), \
 				"You hear ratchet.")
 			anchored = FALSE
 			machine_stat |= MAINT
@@ -95,7 +95,7 @@
 				return
 
 			user.visible_message("[user] fastens \the [src].", \
-				span_notice(" You have fastened \the [src]. Now it can dispense pipes."), \
+				span_notice("You have fastened \the [src]. Now it can dispense pipes."), \
 				"You hear ratchet.")
 			anchored = TRUE
 			machine_stat &= ~MAINT

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -469,11 +469,11 @@
 		return FALSE
 
 	if(tipped_level == 2)
-		user.visible_message(span_notice(" [user] begins to heave the vending machine back into place!"),span_notice(" You start heaving the vending machine back into place.."))
+		user.visible_message(span_notice("[user] begins to heave the vending machine back into place!"),span_notice("You start heaving the vending machine back into place.."))
 		if(!do_after(user, 80, IGNORE_HELD_ITEM, src, BUSY_ICON_FRIENDLY))
 			return FALSE
 
-		user.visible_message(span_notice(" [user] rights the [src]!"),span_notice(" You right the [src]!"))
+		user.visible_message(span_notice("[user] rights the [src]!"),span_notice("You right the [src]!"))
 		flip_back()
 		return TRUE
 
@@ -491,10 +491,10 @@
 		return
 	if(!iscarbon(user)) // AI can't heave remotely
 		return
-	user.visible_message(span_notice(" [user] begins to heave the vending machine back into place!"),span_notice(" You start heaving the vending machine back into place.."))
+	user.visible_message(span_notice("[user] begins to heave the vending machine back into place!"),span_notice("You start heaving the vending machine back into place.."))
 	if(!do_after(user, 80, IGNORE_HELD_ITEM, src, BUSY_ICON_FRIENDLY))
 		return FALSE
-	user.visible_message(span_notice(" [user] rights the [src]!"),span_notice(" You right the [src]!"))
+	user.visible_message(span_notice("[user] rights the [src]!"),span_notice("You right the [src]!"))
 	flip_back()
 	return TRUE
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -22,7 +22,7 @@
 			occupied = 1
 			meat = 5
 			meattype = 1
-			visible_message(span_warning(" [user] has forced [M] onto the spike, killing [M.p_them()] instantly!"))
+			visible_message(span_warning("[user] has forced [M] onto the spike, killing [M.p_them()] instantly!"))
 			M.death(TRUE)
 			G.grabbed_thing = null
 			qdel(G)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -194,9 +194,9 @@
 		return
 
 	if(length(contents) <= 1) //1 because the tray is inside.
-		visible_message(span_warning(" You hear a hollow crackle."))
+		visible_message(span_warning("You hear a hollow crackle."))
 	else
-		visible_message(span_warning(" You hear a roar as the crematorium activates."))
+		visible_message(span_warning("You hear a roar as the crematorium activates."))
 
 		cremating = 1
 

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -93,7 +93,7 @@
 	if(user != loc)
 		return
 	if(modded)
-		. += span_warning(" Fuel faucet is wrenched open, leaking the fuel!")
+		. += span_warning("Fuel faucet is wrenched open, leaking the fuel!")
 	if(rig)
 		. += span_notice("There is some kind of device rigged to the tank.")
 

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -34,7 +34,7 @@
 	if(user)
 		origin.loc = get_turf(user)
 		user.temporarilyRemoveItemFromInventory(src)
-		user.visible_message(span_notice(" [user] puts [src] down."), span_notice(" You put [src] down."))
+		user.visible_message(span_notice("[user] puts [src] down."), span_notice("You put [src] down."))
 		qdel(src)
 
 /obj/item/stool/attack_self(mob/user as mob)
@@ -43,7 +43,7 @@
 
 /obj/item/stool/attack(mob/M as mob, mob/user as mob)
 	if (prob(25) && istype(M,/mob/living))
-		user.visible_message(span_warning(" [user] breaks [src] over [M]'s back!"))
+		user.visible_message(span_warning("[user] breaks [src] over [M]'s back!"))
 		user.temporarilyRemoveItemFromInventory(src)
 		var/obj/item/stack/sheet/metal/m = new/obj/item/stack/sheet/metal
 		m.loc = get_turf(src)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -361,7 +361,7 @@
 	var/obj/item/reagent_containers/RG = I
 	if(istype(RG) && RG.is_open_container() && RG.reagents.total_volume < RG.reagents.maximum_volume)
 		RG.reagents.add_reagent(/datum/reagent/water, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-		user.visible_message(span_notice(" [user] fills \the [RG] using \the [src]."),span_notice(" You fill \the [RG] using \the [src]."))
+		user.visible_message(span_notice("[user] fills \the [RG] using \the [src]."),span_notice("You fill \the [RG] using \the [src]."))
 		return
 
 	else if(istype(I, /obj/item/weapon/baton))
@@ -400,8 +400,8 @@
 
 	I.wash()
 	user.visible_message( \
-		span_notice(" [user] washes \a [I] using \the [src]."), \
-		span_notice(" You wash \a [I] using \the [src]."))
+		span_notice("[user] washes \a [I] using \the [src]."), \
+		span_notice("You wash \a [I] using \the [src]."))
 
 
 /obj/structure/sink/kitchen

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -231,7 +231,7 @@
 			return
 
 		playsound(loc, 'sound/items/wirecutter.ogg', 25, 1)
-		user.visible_message(span_warning(" [user] cuts the fingertips off of the [src]."),span_warning(" You cut the fingertips off of the [src]."))
+		user.visible_message(span_warning("[user] cuts the fingertips off of the [src]."),span_warning("You cut the fingertips off of the [src]."))
 
 		clipped = TRUE
 		name = "mangled [name]"

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -174,7 +174,7 @@
 		to_chat(user, "Waving around a badge before swiping an ID would be pretty pointless.")
 		return
 	if(isliving(user))
-		user.visible_message(span_warning(" [user] displays [user.p_their()] TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."),span_warning(" You display your TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."))
+		user.visible_message(span_warning("[user] displays [user.p_their()] TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."),span_warning("You display your TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."))
 
 /obj/item/clothing/tie/holobadge/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -196,7 +196,7 @@
 
 /obj/item/clothing/tie/holobadge/attack(mob/living/carbon/human/M, mob/living/user)
 	if(isliving(user))
-		user.visible_message(span_warning(" [user] invades [M]'s personal space, thrusting [src] into [M.p_their()] face insistently."),span_warning(" You invade [M]'s personal space, thrusting [src] into [M.p_their()] face insistently. You are the law."))
+		user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into [M.p_their()] face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into [M.p_their()] face insistently. You are the law."))
 
 /obj/item/storage/box/holobadge
 	name = "holobadge box"

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -24,7 +24,7 @@
 
 /obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
 	if(ismob(target) && target.reagents && reagents.total_volume)
-		user.visible_message(span_warning(" \The [target] has been smothered with \the [src] by \the [user]!"), span_warning(" You smother \the [target] with \the [src]!"), "You hear some struggling and muffled cries of surprise")
+		user.visible_message(span_warning("\The [target] has been smothered with \the [src] by \the [user]!"), span_warning("You smother \the [target] with \the [src]!"), "You hear some struggling and muffled cries of surprise")
 		src.reagents.reaction(target, TOUCH)
 		addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, clear_reagents)), 5)
 		return

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -47,7 +47,7 @@
 		return
 
 	var/dat
-	user.visible_message(span_notice(" [user] runs the scanner over [target]."))
+	user.visible_message(span_notice("[user] runs the scanner over [target]."))
 
 	dat += "<h2>General Data</h2>"
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -442,7 +442,7 @@
 	pestlevel = 0
 	sampled = 0
 	update_icon()
-	visible_message(span_notice(" [src] has been overtaken by [seed.display_name]."))
+	visible_message(span_notice("[src] has been overtaken by [seed.display_name]."))
 
 
 /obj/machinery/hydroponics/proc/mutate(severity)
@@ -494,7 +494,7 @@
 	weedlevel = 0
 
 	update_icon()
-	visible_message(span_warning(" The <span class='notice'> [previous_plant] <span class='warning'> has suddenly mutated into <span class='notice'> [seed.display_name]!"))
+	visible_message(span_warning("The <span class='notice'> [previous_plant] <span class='warning'> has suddenly mutated into <span class='notice'> [seed.display_name]!"))
 
 
 /obj/machinery/hydroponics/attackby(obj/item/I, mob/user, params)
@@ -588,7 +588,7 @@
 			to_chat(user, span_warning("This plot is completely devoid of weeds. It doesn't need uprooting."))
 			return
 
-		user.visible_message(span_warning(" [user] starts uprooting the weeds."), span_warning(" You remove the weeds from the [src]."))
+		user.visible_message(span_warning("[user] starts uprooting the weeds."), span_warning("You remove the weeds from the [src]."))
 		weedlevel = 0
 		update_icon()
 
@@ -632,17 +632,17 @@
 
 	else
 		if(seed && !dead)
-			to_chat(usr, "[src] has [span_notice(" [seed.display_name] \black planted.")]")
+			to_chat(usr, "[src] has [span_notice("[seed.display_name] \black planted.")]")
 			if(health <= (seed.endurance / 2))
-				to_chat(usr, "The plant looks [span_warning(" unhealthy.")]")
+				to_chat(usr, "The plant looks [span_warning("unhealthy.")]")
 		else
 			to_chat(usr, "[src] is empty.")
 		to_chat(usr, "Water: [round(waterlevel,0.1)]/100")
 		to_chat(usr, "Nutrient: [round(nutrilevel,0.1)]/10")
 		if(weedlevel >= 5)
-			to_chat(usr, "[src] is [span_warning(" filled with weeds!")]")
+			to_chat(usr, "[src] is [span_warning("filled with weeds!")]")
 		if(pestlevel >= 5)
-			to_chat(usr, "[src] is [span_warning(" filled with tiny worms!")]")
+			to_chat(usr, "[src] is [span_warning("filled with tiny worms!")]")
 
 
 /obj/machinery/hydroponics/verb/close_lid()

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -289,7 +289,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 	if(!degree || immutable > 0) return
 
-	source_turf.visible_message(span_notice(" \The [display_name] quivers!"))
+	source_turf.visible_message(span_notice("\The [display_name] quivers!"))
 
 	//This looks like shit, but it's a lot easier to read/change this way.
 	var/total_mutations = rand(1,1+degree)
@@ -298,7 +298,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 			if(0) //Plant cancer!
 				lifespan = max(0,lifespan-rand(1,5))
 				endurance = max(0,endurance-rand(10,20))
-				source_turf.visible_message(span_warning(" \The [display_name] withers rapidly!"))
+				source_turf.visible_message(span_warning("\The [display_name] withers rapidly!"))
 			if(1)
 				nutrient_consumption = max(0,  min(5,   nutrient_consumption + rand(-(degree*0.1),(degree*0.1))))
 				water_consumption = max(0,  min(50,  water_consumption    + rand(-degree,degree)))
@@ -317,7 +317,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 				if(prob(degree*5))
 					carnivorous = max(0,  min(2,   carnivorous          + rand(-degree,degree)))
 					if(carnivorous)
-						source_turf.visible_message(span_notice(" \The [display_name] shudders hungrily."))
+						source_turf.visible_message(span_notice("\The [display_name] shudders hungrily."))
 			if(6)
 				weed_tolerance = max(0,  min(10,  weed_tolerance       + (rand(-2,2)   * degree)))
 				if(prob(degree*5))          parasite = !parasite
@@ -331,7 +331,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 				potency = max(0,  min(200, potency              + (rand(-20,20) * degree)))
 				if(prob(degree*5))
 					spread = max(0,  min(2,   spread               + rand(-1,1)))
-					source_turf.visible_message(span_notice(" \The [display_name] spasms visibly, shifting in the tray."))
+					source_turf.visible_message(span_notice("\The [display_name] spasms visibly, shifting in the tray."))
 			if(9)
 				maturation = max(0,  min(30,  maturation      + (rand(-1,1)   * degree)))
 				if(prob(degree*5))
@@ -340,22 +340,22 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 				if(prob(degree*2))
 					biolum = !biolum
 					if(biolum)
-						source_turf.visible_message(span_notice(" \The [display_name] begins to glow!"))
+						source_turf.visible_message(span_notice("\The [display_name] begins to glow!"))
 						if(prob(degree*2))
 							biolum_colour = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
-							source_turf.visible_message(span_notice(" \The [display_name]'s glow <font color='[biolum_colour]'>changes colour</font>!"))
+							source_turf.visible_message(span_notice("\The [display_name]'s glow <font color='[biolum_colour]'>changes colour</font>!"))
 					else
-						source_turf.visible_message(span_notice(" \The [display_name]'s glow dims..."))
+						source_turf.visible_message(span_notice("\The [display_name]'s glow dims..."))
 			if(11)
 				if(prob(degree*2))
 					flowers = !flowers
 					if(flowers)
-						source_turf.visible_message(span_notice(" \The [display_name] sprouts a bevy of flowers!"))
+						source_turf.visible_message(span_notice("\The [display_name] sprouts a bevy of flowers!"))
 						if(prob(degree*2))
 							flower_colour = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
-						source_turf.visible_message(span_notice(" \The [display_name]'s flowers <font=[flower_colour]>changes colour</font>!"))
+						source_turf.visible_message(span_notice("\The [display_name]'s flowers <font=[flower_colour]>changes colour</font>!"))
 					else
-						source_turf.visible_message(span_notice(" \The [display_name]'s flowers wither and fall off."))
+						source_turf.visible_message(span_notice("\The [display_name]'s flowers wither and fall off."))
 
 
 //Mutates a specific trait/set of traits.
@@ -583,7 +583,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 			//Handle spawning in living, mobile products (like dionaea).
 			if(istype(product,/mob/living))
-				product.visible_message(span_notice(" The pod disgorges [product]!"))
+				product.visible_message(span_notice("The pod disgorges [product]!"))
 
 			// Make sure the product is inheriting the correct seed type reference.
 			else if(istype(product,/obj/item/reagent_containers/food/snacks/grown))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -33,9 +33,9 @@
 	playsound(loc, SFX_SPARKS, 25, TRUE)
 	if (shock_damage > 10)
 		src.visible_message(
-			span_warning(" [src] was shocked by the [source]!"), \
+			span_warning("[src] was shocked by the [source]!"), \
 			span_danger("You feel a powerful shock course through your body!"), \
-			span_warning(" You hear a heavy electrical crack.") \
+			span_warning("You hear a heavy electrical crack.") \
 		)
 		if(isxeno(src))
 			if(mob_size != MOB_SIZE_BIG)
@@ -44,9 +44,9 @@
 			Paralyze(8 SECONDS)
 	else
 		src.visible_message(
-			span_warning(" [src] was mildly shocked by the [source]."), \
-			span_warning(" You feel a mild shock course through your body."), \
-			span_warning(" You hear a light zapping.") \
+			span_warning("[src] was mildly shocked by the [source]."), \
+			span_warning("You feel a mild shock course through your body."), \
+			span_warning("You hear a light zapping.") \
 		)
 
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -699,7 +699,7 @@
 
 
 /mob/living/carbon/human/proc/play_xylophone()
-	visible_message(span_warning(" [src] begins playing his ribcage like a xylophone. It's quite spooky."),span_notice(" You begin to play a spooky refrain on your ribcage."),span_warning(" You hear a spooky xylophone melody."))
+	visible_message(span_warning("[src] begins playing his ribcage like a xylophone. It's quite spooky."),span_notice("You begin to play a spooky refrain on your ribcage."),span_warning("You hear a spooky xylophone melody."))
 	var/song = pick('sound/effects/xylophone1.ogg','sound/effects/xylophone2.ogg','sound/effects/xylophone3.ogg')
 	playsound(loc, song, 25, 1)
 
@@ -739,7 +739,7 @@
 	if(handle_pulse())
 		to_chat(usr, span_notice("[self ? "You have a" : "[src] has a"] pulse! Counting..."))
 	else
-		to_chat(usr, span_warning(" [src] has no pulse!"))
+		to_chat(usr, span_warning("[src] has no pulse!"))
 		return
 
 	to_chat(usr, "You must[self ? "" : " both"] remain still until counting is finished.")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -74,14 +74,14 @@
 				var/suff = min(getOxyLoss(), 5) //Pre-merge level, less healing, more prevention of dieing.
 				adjustOxyLoss(-suff)
 				updatehealth()
-				visible_message(span_warning(" [human_user] performs CPR on [src]!"),
+				visible_message(span_warning("[human_user] performs CPR on [src]!"),
 					span_boldnotice("You feel a breath of fresh air enter your lungs. It feels good."),
 					vision_distance = 3)
 				to_chat(human_user, span_warning("Repeat at least every 7 seconds."))
 			else if(!HAS_TRAIT(src, TRAIT_UNDEFIBBABLE) && !TIMER_COOLDOWN_CHECK(src, COOLDOWN_CPR))
 				TIMER_COOLDOWN_START(src, COOLDOWN_CPR, 7 SECONDS)
 				dead_ticks -= 5
-				visible_message(span_warning(" [human_user] performs CPR on [src]!"), vision_distance = 3)
+				visible_message(span_warning("[human_user] performs CPR on [src]!"), vision_distance = 3)
 				to_chat(human_user, span_warning("The patient gains a little more time. Repeat every 7 seconds."))
 			else
 				to_chat(human_user, span_warning("You fail to aid [src]."))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -257,7 +257,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		zone = get_zone_with_miss_chance(zone, src)
 
 		if(!zone)
-			visible_message(span_notice(" \The [thrown_item] misses [src] narrowly!"), null, null, 5)
+			visible_message(span_notice("\The [thrown_item] misses [src] narrowly!"), null, null, 5)
 			if(living_thrower)
 				log_combat(living_thrower, src, "thrown at", thrown_item, "(FAILED: missed)")
 			return FALSE
@@ -299,7 +299,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			hit_report += "(embedded in [affecting.display_name])"
 
 	if(AM.throw_source && speed >= 15)
-		visible_message(span_warning(" [src] staggers under the impact!"),span_warning(" You stagger under the impact!"), null, null, 5)
+		visible_message(span_warning("[src] staggers under the impact!"),span_warning("You stagger under the impact!"), null, null, 5)
 		throw_at(get_edge_target_turf(src, get_dir(AM.throw_source, src)), 1, speed * 0.5)
 		hit_report += "(thrown away)"
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -887,7 +887,7 @@ to_chat will check for valid clients itself already so no need to double check f
 /datum/hive_status/proc/set_all_xeno_trackers(atom/target)
 	for(var/mob/living/carbon/xenomorph/X AS in get_all_xenos())
 		X.set_tracked(target)
-		to_chat(X, span_notice(" Now tracking [target.name]"))
+		to_chat(X, span_notice("Now tracking [target.name]"))
 
 // ***************************************
 // *********** Normal Xenos

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -97,7 +97,7 @@
 			else
 				if(X.nicknumber != xeno_name)
 					continue
-			to_chat(usr,span_notice(" You will now track [X.name]"))
+			to_chat(usr,span_notice("You will now track [X.name]"))
 			set_tracked(X)
 			break
 
@@ -106,7 +106,7 @@
 		for(var/obj/structure/xeno/silo/resin_silo AS in GLOB.xeno_resin_silos_by_hive[hivenumber])
 			if(num2text(resin_silo.number_silo) == silo_number)
 				set_tracked(resin_silo)
-				to_chat(usr,span_notice(" You will now track [resin_silo.name]"))
+				to_chat(usr,span_notice("You will now track [resin_silo.name]"))
 				break
 
 	if(href_list["watch_xeno_name"])

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -72,7 +72,7 @@
 		O.stop_throw()
 		apply_damage(O.throwforce*(speed * 0.2), O.damtype, BODY_ZONE_CHEST, MELEE, is_sharp(O), has_edge(O), TRUE, O.penetration)
 
-	visible_message(span_warning(" [src] has been hit by [AM]."), null, null, 5)
+	visible_message(span_warning("[src] has been hit by [AM]."), null, null, 5)
 	if(ismob(AM.thrower))
 		var/mob/M = AM.thrower
 		if(M.client)
@@ -85,7 +85,7 @@
 		if(W.sharp && prob(W.embedding.embed_chance))
 			W.embed_into(src)
 	if(AM.throw_source)
-		visible_message(span_warning(" [src] staggers under the impact!"),span_warning(" You stagger under the impact!"), null, 5)
+		visible_message(span_warning("[src] staggers under the impact!"),span_warning("You stagger under the impact!"), null, 5)
 		src.throw_at(get_edge_target_turf(src, get_dir(AM.throw_source, src)), 1, speed * 0.5)
 
 /mob/living/turf_collision(turf/T, speed)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -103,7 +103,7 @@
 /obj/item/paper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_selected == "eyes")
 		user.visible_message(span_notice("You show the paper to [M]. "), \
-			span_notice(" [user] holds up a paper and shows it to [M]. "))
+			span_notice("[user] holds up a paper and shows it to [M]. "))
 		examine(M)
 		return
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -371,7 +371,7 @@
 /obj/machinery/power/smes/proc/ion_act()
 	if(is_ground_level(z))
 		if(prob(1)) //explosion
-			visible_message(span_warning("\The [src] is making strange noises!"), null, span_warning(" You hear sizzling electronics."))
+			visible_message(span_warning("\The [src] is making strange noises!"), null, span_warning("You hear sizzling electronics."))
 			sleep(10*pick(4,5,6,7,10,14))
 			var/datum/effect_system/smoke_spread/smoke = new(src)
 			smoke.set_up(1, loc)

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -258,7 +258,7 @@
 	var/left = leftright[1] - 1
 	var/right = leftright[2] + 1
 	if(!(left == (angle-1)) && !(right == (angle+1)))
-		to_chat(operator, span_warning(" [src] cannot be rotated so violently."))
+		to_chat(operator, span_warning("[src] cannot be rotated so violently."))
 		return FALSE
 	var/mob/living/carbon/human/user = operator
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -47,8 +47,8 @@
 		to_chat(user, span_warning("The injector is empty."))
 		return
 
-	to_chat(user, span_notice(" You inject [M] with the injector."))
-	to_chat(M, span_notice(" [user] injects you with the injector."))
+	to_chat(user, span_notice("You inject [M] with the injector."))
+	to_chat(M, span_notice("[user] injects you with the injector."))
 	playsound(loc, 'sound/items/hypospray.ogg', 50, 1)
 
 	reagents.reaction(M, INJECT)
@@ -57,14 +57,14 @@
 		M.reagents.add_reagent(reagent_ids[mode], t)
 		reagent_volumes[reagent_ids[mode]] -= t
 		// to_chat(user, span_notice("[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining."))
-		to_chat(user, span_notice(" [t] units of <span class='warning'> [reagent_ids[mode]] <span class='notice'> injected for a total of <span class='warning'> [round(M.reagents.get_reagent_amount(reagent_ids[mode]))]<span class='notice'>. [reagent_volumes[reagent_ids[mode]]] units remaining."))
+		to_chat(user, span_notice("[t] units of <span class='warning'> [reagent_ids[mode]] <span class='notice'> injected for a total of <span class='warning'> [round(M.reagents.get_reagent_amount(reagent_ids[mode]))]<span class='notice'>. [reagent_volumes[reagent_ids[mode]]] units remaining."))
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user)
 	var/selection = tgui_input_list(user, "Please select a reagent:", "Reagent", reagent_ids)
 	if(!selection)
 		return
 	var/datum/reagent/R = GLOB.chemical_reagents_list[selection]
-	to_chat(user, span_notice(" Synthesizer is now producing '[R.name]'."))
+	to_chat(user, span_notice("Synthesizer is now producing '[R.name]'."))
 	mode = reagent_ids.Find(selection)
 	playsound(src.loc, 'sound/effects/pop.ogg', 15, 0)
 

--- a/code/modules/reagents/reagent_containers/food/piecake.dm
+++ b/code/modules/reagents/reagent_containers/food/piecake.dm
@@ -26,7 +26,7 @@
 	if(!.)
 		return
 	new /obj/effect/decal/cleanable/pie_smudge(loc)
-	visible_message(span_warning(" [src.name] splats."),span_warning(" You hear a splat."))
+	visible_message(span_warning("[src.name] splats."),span_warning("You hear a splat."))
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/pastries/berryclafoutis

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -348,7 +348,7 @@
 		return
 	new/obj/effect/decal/cleanable/egg_smudge(src.loc)
 	src.reagents.reaction(hit_atom, TOUCH)
-	src.visible_message(span_warning(" [src.name] has been squashed."),span_warning(" You hear a smack."))
+	src.visible_message(span_warning("[src.name] has been squashed."),span_warning("You hear a smack."))
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/egg/blue

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -37,7 +37,7 @@
 
 	else if(affected.hidden)
 		user.visible_message(span_notice("[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool]."), \
-		span_notice(" You take something out of incision on [target]'s [affected.display_name]s with \the [tool]."))
+		span_notice("You take something out of incision on [target]'s [affected.display_name]s with \the [tool]."))
 		target.balloon_alert_to_viewers("Shrapnel found")
 		affected.hidden.loc = get_turf(target)
 		affected.hidden.update_icon()

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -95,7 +95,7 @@
 ///Plays effects and doafter effects for the drone
 /obj/vehicle/unmanned/droid/scout/proc/start_cloak(mob/user)
 	if(!do_after(user, 3 SECONDS, IGNORE_HELD_ITEM, src))
-		to_chat(user, span_warning(" WARNING. Cloak activation failed; Error code 423: Subject moved during activation."))
+		to_chat(user, span_warning("WARNING. Cloak activation failed; Error code 423: Subject moved during activation."))
 		remove_wibbly_filters(src)
 		return
 	remove_wibbly_filters(src)


### PR DESCRIPTION

## About The Pull Request
8 billion years ago, bravemole made a PR where he regex'd a bunch of span_whatevers but in so doing he managed to add some spaces to the beginnings of some of them. While a lot of these are practically depreciated content, it's still visible in some areas (like attempting to violently rotate an emplaced weapon). This PR goes and removes all of these occourences, minus a few that don't really count/I'm not sure count.

You know. Hopefully. This PR is a bit too large to test, but it shouldn't have any serious effects that can't be repaired with a single followup PR.
## Why It's Good For The Game
I HATE YOU BRAVEMOLE I HATE YOU HATE YOU
## Changelog
:cl:
fix: some messages will no longer have an unnecessary space before them.
/:cl:
