### PR TITLE
Prevents un-needed activation of auto-repair for robots if both damage values are 0.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/combat_robots.dm
+++ b/code/modules/mob/living/carbon/human/species_types/combat_robots.dm
@@ -96,6 +96,8 @@
 	if(!. || !ishuman(owner))
 		return
 	var/mob/living/carbon/human/howner = owner
+	if((howner.getBruteLoss() + howner.getFireLoss()) == 0)
+		return
 	howner.apply_status_effect(STATUS_EFFECT_REPAIR_MODE, 10 SECONDS)
 	howner.balloon_alert_to_viewers("Repairing")
 


### PR DESCRIPTION
## About The Pull Request

Self-repair for robots no longer activates if repairable damage is 0 (brute and burn).

## Why It's Good For The Game

No more un-needed / accidental activation of auto-repair for robots.

## Changelog

:cl: The_Man
fix: You can no longer activate robot self-repair if brute and burn damage is 0.
/:cl:
