### PR TITLE
Fixes glasses/goggles being able to be toggled

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -67,6 +67,8 @@
 
 ///Toggle the functions of the glasses
 /obj/item/clothing/glasses/proc/activate(mob/user)
+	if(!toggleable)
+		return
 	active = !active
 
 	if(active && activation_sound)
@@ -244,6 +246,7 @@
 	eye_protection = 2
 	activation_sound = null
 	deactivation_sound = null
+	toggleable = TRUE
 
 /obj/item/clothing/glasses/welding/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -15,6 +15,7 @@
 	worn_icon_state = "glasses"
 	darkness_view = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	toggleable = TRUE
 
 
 /obj/item/clothing/glasses/night/tx8
@@ -55,6 +56,8 @@
 	darkness_view = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	item_flags = DELONDROP
+	toggleable = FALSE
+	active = TRUE
 
 /obj/item/clothing/glasses/night/sectoid/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Glasses/Goggles can no longer be toggled. Huds and night vision should be unaffected
Fixes #17050

## Why It's Good For The Game

No more mysterious hud visor appearing when you activate your ballistic goggles

## Changelog
:cl:
fix: Glasses/Goggles can no longer be toggled in hand creating an empty hud visor sprite
/:cl:
