### PR TITLE
Adds mechs to valhalla vehicle spawner button

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -333,6 +333,9 @@
 		/obj/vehicle/sealed/armored/multitile/som_tank,
 		/obj/vehicle/sealed/armored/multitile/campaign,
 		/obj/vehicle/sealed/armored/multitile/icc_lvrt,
+		/obj/vehicle/sealed/mecha/combat/greyscale/recon,
+		/obj/vehicle/sealed/mecha/combat/greyscale/assault,
+		/obj/vehicle/sealed/mecha/combat/greyscale/vanguard,
 	)
 
 	var/selected_vehicle = tgui_input_list(user, "Which vehicle do you want to spawn?", "Vehicle spawn", spawnable_vehicles)


### PR DESCRIPTION

## About The Pull Request
Adds recon, assault, and vanguard mechs to the valhalla spawner button.
## Why It's Good For The Game
Useful for testing mech interactions as xeno
## Changelog
:cl:
add: Valhalla vehicle spawner buttons now include the three types of mechs.
/:cl:
