### PR TITLE
Makes lights auto-rotate to walls

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -81,7 +81,8 @@
 
 /obj/machinery/light/setDir(newdir)
 	. = ..()
-	update_offsets()
+	if(!autoplace)
+		update_offsets()
 
 /obj/machinery/light/update_overlays()
 	. = ..()
@@ -326,47 +327,46 @@
 				pixel_x = 0
 			if(EAST)
 				light_pixel_y = 0
+				light_pixel_x = -15
+				pixel_y = 0
+				pixel_x = 10
+			if(WEST)
+				light_pixel_y = 0
 				light_pixel_x = 15
 				pixel_y = 0
 				pixel_x = -10
-			if(WEST)
+		return
+	if(isclosedturf(get_turf(loc)))
+		return
+	for(var/direction in CARDINAL_DIRS)
+		if(!isclosedturf(get_step(loc, direction)))
+			continue
+		switch(direction)
+			if(NORTH)
+				light_pixel_y = 15
+				light_pixel_x = 0
+				pixel_y = 20
+				pixel_x = 0
+				dir = NORTH //rotate dirs so we visually face the direction of the wall
+			if(SOUTH)
+				light_pixel_y = -15
+				light_pixel_x = 0
+				pixel_y = 0
+				pixel_x = 0
+				dir = SOUTH
+			if(EAST)
 				light_pixel_y = 0
 				light_pixel_x = -15
 				pixel_y = 0
 				pixel_x = 10
+				dir = EAST
+			if(WEST)
+				light_pixel_y = 0
+				light_pixel_x = 15
+				pixel_y = 0
+				pixel_x = -10
+				dir = WEST
 		return
-	if(isclosedturf(get_turf(loc)))
-		return
-	for(var/i in CARDINAL_DIRS)
-		if(!isclosedturf(get_step(loc, i)))
-			continue
-		else
-			switch(i)
-				if(NORTH)
-					light_pixel_y = 15
-					light_pixel_x = 0
-					pixel_y = 20
-					pixel_x = 0
-					dir = NORTH //rotate dirs so we visually face the direction of the wall
-				if(SOUTH)
-					light_pixel_y = -15
-					light_pixel_x = 0
-					pixel_y = 0
-					pixel_x = 0
-					dir = SOUTH
-				if(EAST)
-					light_pixel_y = 0
-					light_pixel_x = 15
-					pixel_y = 0
-					pixel_x = -10
-					dir = EAST
-				if(WEST)
-					light_pixel_y = 0
-					light_pixel_x = -15
-					pixel_y = 0
-					pixel_x = 10
-					dir = WEST
-			return
 
 ///update the light state then icon
 /obj/machinery/light/proc/update(trigger = TRUE, toggle_on = TRUE)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -46,7 +46,7 @@
 	///looping sound for flickering lights
 	var/datum/looping_sound/flickeringambient/lightambient
 	///do we automatically snap to walls?
-	var/autoplace = true
+	var/autoplace = TRUE
 
 // create a new lighting fixture
 /obj/machinery/light/Initialize(mapload, ...)
@@ -311,7 +311,7 @@
 
 
 //automatically adjust place and offset to make sure sign isn't floating in the middle of nowhere
-/obj/structure/sign/proc/place_lights()
+/obj/machinery/light/proc/place_lights()
 	if(isclosedturf(get_step(loc, dir)))
 		switch(dir)
 			if(NORTH)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -337,7 +337,7 @@
 		return
 	if(isclosedturf(get_turf(loc)))
 		return
-	for(var/i in CARDINAL_ALL_DIRS)
+	for(var/i in CARDINAL_DIRS)
 		if(!isclosedturf(get_step(loc, i)))
 			continue
 		else
@@ -347,21 +347,25 @@
 					light_pixel_x = 0
 					pixel_y = 20
 					pixel_x = 0
+					dir = NORTH //rotate dirs so we visually face the direction of the wall
 				if(SOUTH)
 					light_pixel_y = -15
 					light_pixel_x = 0
 					pixel_y = 0
 					pixel_x = 0
+					dir = SOUTH
 				if(EAST)
 					light_pixel_y = 0
 					light_pixel_x = 15
 					pixel_y = 0
 					pixel_x = -10
+					dir = EAST
 				if(WEST)
 					light_pixel_y = 0
 					light_pixel_x = -15
 					pixel_y = 0
 					pixel_x = 10
+					dir = WEST
 			return
 
 ///update the light state then icon

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -45,6 +45,8 @@
 	var/flicker_time_lower_min = 0.2 SECONDS
 	///looping sound for flickering lights
 	var/datum/looping_sound/flickeringambient/lightambient
+	///do we automatically snap to walls?
+	var/autoplace = true
 
 // create a new lighting fixture
 /obj/machinery/light/Initialize(mapload, ...)
@@ -60,7 +62,10 @@
 			if(prob(5))
 				broken(TRUE)
 
-	update_offsets()
+	if(autoplace)
+		place_lights()
+	else
+		update_offsets()
 	update(FALSE)
 
 	return INITIALIZE_HINT_LATELOAD
@@ -303,6 +308,61 @@
 			light_pixel_x = -15
 			pixel_y = 0
 			pixel_x = 10
+
+
+//automatically adjust place and offset to make sure sign isn't floating in the middle of nowhere
+/obj/structure/sign/proc/place_lights()
+	if(isclosedturf(get_step(loc, dir)))
+		switch(dir)
+			if(NORTH)
+				light_pixel_y = 15
+				light_pixel_x = 0
+				pixel_y = 20
+				pixel_x = 0
+			if(SOUTH)
+				light_pixel_y = -15
+				light_pixel_x = 0
+				pixel_y = 0
+				pixel_x = 0
+			if(EAST)
+				light_pixel_y = 0
+				light_pixel_x = 15
+				pixel_y = 0
+				pixel_x = -10
+			if(WEST)
+				light_pixel_y = 0
+				light_pixel_x = -15
+				pixel_y = 0
+				pixel_x = 10
+		return
+	if(isclosedturf(get_turf(loc)))
+		return
+	for(var/i in CARDINAL_ALL_DIRS)
+		if(!isclosedturf(get_step(loc, i)))
+			continue
+		else
+			switch(i)
+				if(NORTH)
+					light_pixel_y = 15
+					light_pixel_x = 0
+					pixel_y = 20
+					pixel_x = 0
+				if(SOUTH)
+					light_pixel_y = -15
+					light_pixel_x = 0
+					pixel_y = 0
+					pixel_x = 0
+				if(EAST)
+					light_pixel_y = 0
+					light_pixel_x = 15
+					pixel_y = 0
+					pixel_x = -10
+				if(WEST)
+					light_pixel_y = 0
+					light_pixel_x = -15
+					pixel_y = 0
+					pixel_x = 10
+			return
 
 ///update the light state then icon
 /obj/machinery/light/proc/update(trigger = TRUE, toggle_on = TRUE)


### PR DESCRIPTION

## About The Pull Request

I did something similar to posters when porting Hybrisa, this PR makes lights automatically rotate to be against a wall if their rotation would leave them hanging out in the middle of space.

As long as your fixture is properly rotated this PR shouldn't affect you.

Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/17188

## Why It's Good For The Game

Mapper quality of life good, should entirely eliminate mapping errors involving improperly rotated lights, unless they're out in the middle of nowhere with no walls around.

## Changelog
:cl:
add: Added a system to auto-rotate light fixtures to avoid mapping errors.
/:cl:
