### PR TITLE
Fixes tank runtimes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -412,8 +412,12 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 ///Helper function for updating last_equipped_slot when item is drawn from storage
 /obj/item/proc/set_last_equipped_slot_of_storage(datum/storage/storage_datum)
 	var/obj/item/storage_item = storage_datum.parent
+	if(!isitem(storage_item))
+		return
+
 	while(isitem(storage_item.loc)) // for stuff like armor modules we have to find topmost item
 		storage_item = storage_item.loc
+
 	if(storage_item)
 		last_equipped_slot = slot_to_in_storage_slot(storage_item.last_equipped_slot)
 
@@ -428,7 +432,6 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 ///called when this item is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
 /obj/item/proc/on_enter_storage(obj/item/storage/S as obj)
 	item_flags |= IN_STORAGE
-	return
 
 
 ///called when "found" in pockets and storage items. Returns 1 if the search should end.

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -263,6 +263,12 @@
 	if(ammo)
 		eject_ammo()
 	ammo = popleft(ammo_magazine)
+
+	if(!ammo)
+		for(var/mob/occupant AS in chassis.occupants)
+			occupant.hud_used.update_ammo_hud(src, list(hud_state_empty, hud_state_empty), 0)
+		return
+
 	for(var/mob/occupant AS in chassis.occupants)
 		occupant.hud_used.update_ammo_hud(src, list(ammo.default_ammo.hud_state, ammo.default_ammo.hud_state_empty), ammo.current_rounds)
 


### PR DESCRIPTION

## About The Pull Request
Fixes runtime that happens when taking items out of ammo rack
Fixes runtime when unloading the breech by hand, the ammo counter actually gets updated to reflect that now
## Why It's Good For The Game
Runtime bad
## Changelog
:cl:
fix: Fixed runtime when taking ammo out of tank ammo racks
fix: Ammo counter for tank should update correctly now when manually unloading breech
/:cl:
