### PR TITLE
Mentors can no longer use the dsay verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -407,7 +407,7 @@ ADMIN_VERB(msay, R_ADMIN|R_MENTOR, "msay", "Speak in the private mentor channel"
 	var/msg = input(src, null, "dsay \"text\"") as text|null
 	SSadmin_verbs.dynamic_invoke_verb(src, /datum/admin_verb/dsay, msg)
 
-ADMIN_VERB(dsay, R_ADMIN|R_MENTOR, "dsay", "Speak as an admin in deadchat.", ADMIN_CATEGORY_MAIN, msg as text)
+ADMIN_VERB(dsay, R_ADMIN, "dsay", "Speak as an admin in deadchat.", ADMIN_CATEGORY_MAIN, msg as text)
 	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
 
 	if(!msg)


### PR DESCRIPTION

## About The Pull Request
They can't see dchat when alive and if they're dead they can just use the normal say verb like normal people.
## Why It's Good For The Game
I don't see the point of them being able to use dsay if they can't even see what they wrote if they're not dead.
## Changelog
:cl:
admin: Mentors can no longer use the dsay verb
/:cl:
