### PR TITLE
Blocks admin keybinding usage by people without holders

### DIFF
--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -2,6 +2,13 @@
 	category = CATEGORY_ADMIN
 	weight = WEIGHT_ADMIN
 
+/datum/keybinding/admin/down(client/user)
+	. = ..()
+	if(.)
+		return
+
+	if(isnull(user.holder)) //blocking non admins triggering warning messages
+		return TRUE
 
 /datum/keybinding/admin/admin_say
 	hotkey_keys = list("F3")


### PR DESCRIPTION

## About The Pull Request

Pressing F7 would trigger a warning marked as a runtime when a non admin pressed the bind.

Mentors are handled separately in the admin verb proc itself
## Why It's Good For The Game

Runtime log less clogged
## Changelog
:cl:
admin: Blocks admin keybinding usage by people who aren't admins/mentors
/:cl:
