### PR TITLE
Adresses `remove_from_storage` calling itself in most cases

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -866,6 +866,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			continue
 		M.client.screen -= item
 
+	if(!QDELETED(item))
+		UnregisterSignal(item, COMSIG_MOVABLE_MOVED)
+		item.on_exit_storage(src)
+		item.mouse_opacity = initial(item.mouse_opacity)
+
 	if(new_location)
 		if(ismob(new_location))
 			item.layer = ABOVE_HUD_LAYER
@@ -884,11 +889,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	for(var/i in can_see_content())
 		var/mob/M = i
 		show_to(M)
-
-	if(!QDELETED(item))
-		UnregisterSignal(item, COMSIG_MOVABLE_MOVED)
-		item.on_exit_storage(src)
-		item.mouse_opacity = initial(item.mouse_opacity)
 
 	for(var/limited_type in storage_type_limits_max)
 		if(istype(item, limited_type))


### PR DESCRIPTION
## About The Pull Request

The call stack here was a mess to navigate for such a specific fix.

`remove_from_storage` calls `forceMove` which sends `COMSIG_MOVABLE_MOVED` down the line which every item in storage has registered to call `remove_from_storage` so that gets called again. And eventually when they're all done and start returning back the line eventually it'll run into the MRE's override which deletes the MRE and by extension the storage datum, but since the `forceMove`'s call to `remove_from_storage` is still not finished it'll try to still access `parent`'s vars, which causes a runtime.

This could use a TM if you feel like it, I don't know if reordering this here will cause some weird behaviour.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: MREs no longer runtime when the last piece of food is removed from them
/:cl:
