### PR TITLE
Allows maintainers to view player panel

### DIFF
--- a/code/modules/admin/panels/player_panel.dm
+++ b/code/modules/admin/panels/player_panel.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(player_panel, R_BAN, "Player Panel", "View the player panel", ADMIN_CATEGORY_MAIN)
+ADMIN_VERB(player_panel, R_ADMIN, "Player Panel", "View the player panel", ADMIN_CATEGORY_MAIN)
 	var/dat = {"<html>
 
 		<head>
@@ -294,7 +294,7 @@ ADMIN_VERB(player_panel, R_BAN, "Player Panel", "View the player panel", ADMIN_C
 	browser.open()
 
 
-ADMIN_VERB(player_panel_extended, R_BAN, "Player Panel Extended", "View the extended player panel", ADMIN_CATEGORY_MAIN)
+ADMIN_VERB(player_panel_extended, R_ADMIN, "Player Panel Extended", "View the extended player panel", ADMIN_CATEGORY_MAIN)
 	var/ref = "[REF(user.holder)];[HrefToken()]"
 	var/dat = "<table border=0 cellspacing=5><B><tr><th>Key</th><th>Name</th><th>Type</th><th>PP</th><th>CID</th><th>IP</th><th>JMP</th><th>FLW</th><th>Notes</th></tr></B>"
 
@@ -341,7 +341,7 @@ ADMIN_VERB(player_panel_extended, R_BAN, "Player Panel Extended", "View the exte
 	browser.set_content(dat)
 	browser.open()
 
-ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_BAN, "Show Player Panel", mob/M in world)
+ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_ADMIN, "Show Player Panel", mob/M in world)
 	if(!istype(M))
 		return
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1412,6 +1412,8 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 
 
 	else if(href_list["showmessageckeylinkless"])
+		if(!check_rights(R_BAN))
+			return
 		var/target = href_list["showmessageckeylinkless"]
 		browse_messages(target_ckey = target, linkless = TRUE)
 


### PR DESCRIPTION

## About The Pull Request

![Discord_zS8w63YdwY](https://github.com/user-attachments/assets/56ba53b5-8338-4056-b5d8-e96c4cc66b4d)

Barnet said it's alright, and notes/kick/ban are locked behind R_BAN. 
## Why It's Good For The Game

Just makes life a little easier for maintainers, and the actual admin stuff is locked away behind a perm maints don't get anyways.
## Changelog
:cl:
admin: Maintainers now have access to player panel (minus notes, banning, kicking, etc)
/:cl:
