### PR TITLE
Tank faction setting

### DIFF
--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -36,7 +36,7 @@
 	var/obj/vehicle/sealed/armored/owner
 	///The skill required to man this chair
 	var/skill_req = SKILL_LARGE_VEHICLE_VETERAN
-
+	///Control flags given to the mob on buckle
 	var/control_flags = NONE
 
 /obj/structure/bed/chair/vehicle_crew/Destroy()

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -37,6 +37,8 @@
 	///The skill required to man this chair
 	var/skill_req = SKILL_LARGE_VEHICLE_VETERAN
 
+	var/control_flags = NONE
+
 /obj/structure/bed/chair/vehicle_crew/Destroy()
 	owner = null
 	return ..()
@@ -64,11 +66,17 @@
 	. = ..()
 	buckling_mob.reset_perspective(owner)
 	buckling_mob.client.view_size.add(get_vis_range_mod())
+	if(control_flags)
+		owner.add_control_flags(buckling_mob, control_flags)
+	if(control_flags & VEHICLE_CONTROL_DRIVE) //set by last driver, not unset
+		owner.faction = buckling_mob.faction
 
 /obj/structure/bed/chair/vehicle_crew/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
 	buckled_mob.reset_perspective()
 	buckled_mob.client.view_size.reset_to_default()
+	if(control_flags)
+		owner.remove_control_flags(buckled_mob, control_flags)
 
 /obj/structure/bed/chair/vehicle_crew/relaymove(mob/living/user, direct)
 	return owner.relaymove(arglist(args))
@@ -76,48 +84,32 @@
 /obj/structure/bed/chair/vehicle_crew/driver
 	name = "driver seat"
 	buckling_x = 12
+	control_flags = VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS
 
 /obj/structure/bed/chair/vehicle_crew/driver/get_vis_range_mod()
 	return 4
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_buckle_mob(mob/buckling_mob)
 	. = ..()
-	buckling_mob.reset_perspective(owner)
 	ADD_TRAIT(buckling_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	buckling_mob.update_sight()
-	owner.add_control_flags(buckling_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/driver/post_unbuckle_mob(mob/buckled_mob)
 	. = ..()
 	REMOVE_TRAIT(buckled_mob, TRAIT_SEE_IN_DARK, VEHICLE_TRAIT)
 	buckled_mob.update_sight()
-	owner.remove_control_flags(buckled_mob, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 
 /obj/structure/bed/chair/vehicle_crew/gunner
 	name = "gunner seat"
+	control_flags = VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT
 
 /obj/structure/bed/chair/vehicle_crew/gunner/get_vis_range_mod()
 	return (SSticker.mode?.round_type_flags & MODE_HUMAN_ONLY) ? 4 : 1
 
-/obj/structure/bed/chair/vehicle_crew/gunner/post_buckle_mob(mob/buckling_mob)
-	. = ..()
-	owner.add_control_flags(buckling_mob, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
-
-/obj/structure/bed/chair/vehicle_crew/gunner/post_unbuckle_mob(mob/buckled_mob)
-	. = ..()
-	owner.remove_control_flags(buckled_mob, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
-
 /obj/structure/bed/chair/vehicle_crew/driver_gunner
 	name = "apc commander seat"
 	skill_req = SKILL_LARGE_VEHICLE_EXPERIENCED
-
-/obj/structure/bed/chair/vehicle_crew/driver_gunner/post_buckle_mob(mob/buckling_mob)
-	. = ..()
-	owner.add_control_flags(buckling_mob, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT|VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
-
-/obj/structure/bed/chair/vehicle_crew/driver_gunner/post_unbuckle_mob(mob/buckled_mob)
-	. = ..()
-	owner.remove_control_flags(buckled_mob, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT|VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
+	control_flags = VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT|VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS
 
 /obj/structure/bed/chair/vehicle_crew/driver/som
 	icon = 'icons/obj/armored/3x4/som_interior_small_props.dmi'


### PR DESCRIPTION

## About The Pull Request
Armoured vehicles now have their faction set by the driver (not unset when you get up), same as mech.
## Why It's Good For The Game
Don't have AI and other stuff target friendly vehicles.
## Changelog
:cl:
fix: Armoured vehicles now have their faction set by the driver
/:cl:
