### PR TITLE
Fixes a storage runtime

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -522,12 +522,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 ///Returns a list of lookers, basically any mob that can see our contents
 /datum/storage/proc/can_see_content()
 	var/list/lookers = list()
-	for(var/i in content_watchers)
-		var/mob/content_watcher_mob = i
-		if(content_watcher_mob.s_active == src && content_watcher_mob.client)
-			lookers |= content_watcher_mob
-		else
+	for(var/mob/content_watcher_mob AS in content_watchers)
+		if(!ismob(content_watcher_mob) || !content_watcher_mob.client || content_watcher_mob.s_active != src)
 			content_watchers -= content_watcher_mob
+			continue
+		lookers |= content_watcher_mob
 	return lookers
 
 ///Opens our storage, closes the storage if we are s_active


### PR DESCRIPTION

## About The Pull Request
This should be a safer, less runtime prone way of doing this. First we make sure it's actually a mob that exists, then if it has a client and then if the mobs active storage is src. Had some runtime happening where it'd complain about `null.s_active`
## Why It's Good For The Game
runtime bad
## Changelog
:cl:
fix: fixed a storage runtime
/:cl:
