### PR TITLE
Prevent people joining valhalla before round has started

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -720,7 +720,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	set name = "Join Valhalla"
 	set category = "Ghost"
 
-	if(SSticker.mode)
+	if(!SSticker.mode)
 		to_chat(user, span_warning("Please wait for the round to begin first."))
 		return
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -721,7 +721,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	set category = "Ghost"
 
 	if(!SSticker.mode)
-		to_chat(user, span_warning("Please wait for the round to begin first."))
+		to_chat(usr, span_warning("Please wait for the round to begin first."))
 		return
 
 	if(is_banned_from(ckey, ROLE_VALHALLA))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -720,6 +720,10 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	set name = "Join Valhalla"
 	set category = "Ghost"
 
+	if(SSticker.mode)
+		to_chat(user, span_warning("Please wait for the round to begin first."))
+		return
+
 	if(is_banned_from(ckey, ROLE_VALHALLA))
 		to_chat(usr, span_notice("You are banned from Valhalla!"))
 		return


### PR DESCRIPTION

## About The Pull Request
This is causing runtimes because SSticker doesn't have a mode, when a lot of hive code relies on the mode.

Sidenote I have no idea under what changelog tag to put this under so uhh
## Why It's Good For The Game
runtime bad
## Changelog
:cl:
code: You can no longer join valhalla before the round has started
/:cl:
