### PR TITLE
Directional attacking now includes adjacent tiles

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -544,6 +544,7 @@
 #define COMSIG_MOB_CLICK_ALT_RIGHT "mob_click_alt_right"		//from base of mob/AltRightClick(): (atom/A)
 	#define COMSIG_MOB_CLICK_CANCELED (1<<0)
 	#define COMSIG_MOB_CLICK_HANDLED (1<<1)
+#define COMSIG_MOB_ATTACK_UNARMED "mob_attack_unarmed"			//from base of mob/UnarmedAttack(): (atom/A, params)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 ///from base of /mob/verb/examinate(): (atom/target)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -266,8 +266,7 @@
  * params is passed on here as the third arg
  */
 /mob/proc/UnarmedAttack(atom/A, has_proximity, params)
-	if(ismob(A))
-		changeNext_move(CLICK_CD_MELEE)
+	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_UNARMED, A, params)
 
 
 /*

--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -39,6 +39,7 @@
 
 
 /mob/living/carbon/human/UnarmedAttack(atom/A, proximity, list/modifiers)
+	. = ..()
 	if(lying_angle) //No attacks while laying down
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -2,6 +2,7 @@
 	Animals & All Unspecified
 */
 /mob/living/UnarmedAttack(atom/A, has_proximity, modifiers)
+	. = ..()
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	A.attack_animal(src)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -5,7 +5,6 @@
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
-	A.attack_animal(src)
 
 
 /atom/proc/attack_animal(mob/user as mob)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -21,7 +21,6 @@
 
 
 /mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, has_proximity, modifiers)
-	. = ..()
 	if(lying_angle)
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/xenomorph/UnarmedAttack(atom/A, has_proximity, modifiers)
+	. = ..()
 	if(lying_angle)
 		return FALSE
 	if(isclosedturf(get_turf(src)) && !iswallturf(A))	//If we are on a closed turf (e.g. in a wall) we can't attack anything, except walls (or well, resin walls really) so we can't make ourselves be stuck.
@@ -20,6 +21,7 @@
 
 
 /mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, has_proximity, modifiers)
+	. = ..()
 	if(lying_angle)
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))

--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -40,7 +40,7 @@
 	SIGNAL_HANDLER
 	if(!can_attack(source, clicked_atom))
 		return
-	if(ismob(clicked_atom))
+	if(ismob(clicked_atom) || !isturf(clicked_atom))
 		return
 	var/mob/target_mob = locate() in get_turf(clicked_atom)
 	if(!target_mob || source.faction == target_mob.faction)
@@ -50,8 +50,12 @@
 
 /// Checks if an attack is possible on a given atom.
 /datum/element/directional_attack/proc/can_attack(mob/source, atom/clicked_atom)
-	if(!(source?.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
+	if(!source)
 		return FALSE
 	if(QDELETED(clicked_atom))
+		return FALSE
+	if(!(source.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
+		return FALSE
+	if(source.a_intent != INTENT_HARM)
 		return FALSE
 	return TRUE

--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -38,7 +38,7 @@
 /// Inversely to the above proc, this one handles clicks on tiles that are adjacent to the source mob. If there is an eligible mob in the tile, it will attack them.
 /datum/element/directional_attack/proc/on_unarmed_attack(mob/source, atom/clicked_atom, click_params)
 	SIGNAL_HANDLER
-	if(!can_attack(source, clicked_atom))
+	if(!can_attack(source, clicked_atom) || source.a_intent != INTENT_HARM)
 		return
 	if(ismob(clicked_atom) || !isturf(clicked_atom))
 		return
@@ -50,12 +50,8 @@
 
 /// Checks if an attack is possible on a given atom.
 /datum/element/directional_attack/proc/can_attack(mob/source, atom/clicked_atom)
-	if(!source)
-		return FALSE
 	if(QDELETED(clicked_atom))
 		return FALSE
-	if(!(source.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
-		return FALSE
-	if(source.a_intent != INTENT_HARM)
+	if(!(source?.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
 		return FALSE
 	return TRUE

--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -6,16 +6,17 @@
 	. = ..()
 	if(!ismob(target))
 		return ELEMENT_INCOMPATIBLE
-
 	RegisterSignal(target, COMSIG_MOB_ATTACK_RANGED, PROC_REF(on_ranged_attack))
+	RegisterSignal(target, COMSIG_MOB_ATTACK_UNARMED, PROC_REF(on_unarmed_attack))
 
 /datum/element/directional_attack/Detach(datum/source, ...)
 	. = ..()
-	UnregisterSignal(source, COMSIG_MOB_ATTACK_RANGED)
+	UnregisterSignal(source, list(COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_UNARMED))
 
 /**
- * This proc handles clicks on tiles that aren't adjacent to the source mob
- * In addition to clicking the distant tile, it checks the tile in the direction and clicks the mob in the tile if there is one
+ * This proc handles clicks on tiles that are NOT adjacent to the source mob.
+ * In addition to clicking the distant tile, it checks the tile in the direction and clicks the mob in the tile if there an eligible one.
+ *
  * Arguments:
  * * source - The mob clicking
  * * clicked_atom - The atom being clicked (should be a distant one)
@@ -23,21 +24,34 @@
  */
 /datum/element/directional_attack/proc/on_ranged_attack(mob/source, atom/clicked_atom, click_params)
 	SIGNAL_HANDLER
-
-	if(!(source?.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
+	if(!can_attack(source, clicked_atom))
 		return
-
-	if(QDELETED(clicked_atom))
-		return
-
 	var/turf/turf_to_check = get_step(source, angle_to_dir(Get_Angle(source, clicked_atom)))
 	if(!turf_to_check || !source.Adjacent(turf_to_check))
 		return
-
-	var/mob/living/target_mob = locate() in turf_to_check
+	var/mob/target_mob = locate() in turf_to_check
 	if(!target_mob || source.faction == target_mob.faction)
 		return
-
-	//This is here to undo the +1 the click on the distant turf adds so we can click the mob near us
-	source.next_click = world.time - 1
+	source.next_click = world.time - 1 //This is here to undo the +1 the click on the distant turf adds so we can click the mob near us.
 	INVOKE_ASYNC(source, TYPE_PROC_REF(/mob, ClickOn), target_mob, turf_to_check, click_params)
+
+/// Inversely to the above proc, this one handles clicks on tiles that are adjacent to the source mob. If there is an eligible mob in the tile, it will attack them.
+/datum/element/directional_attack/proc/on_unarmed_attack(mob/source, atom/clicked_atom, click_params)
+	SIGNAL_HANDLER
+	if(!can_attack(source, clicked_atom))
+		return
+	if(ismob(clicked_atom))
+		return
+	var/mob/target_mob = locate() in get_turf(clicked_atom)
+	if(!target_mob || source.faction == target_mob.faction)
+		return
+	source.next_click = world.time - 1
+	INVOKE_ASYNC(source, TYPE_PROC_REF(/mob, UnarmedAttack), target_mob, TRUE, click_params)
+
+/// Checks if an attack is possible on a given atom.
+/datum/element/directional_attack/proc/can_attack(mob/source, atom/clicked_atom)
+	if(!(source?.client?.prefs?.toggles_gameplay & DIRECTIONAL_ATTACKS))
+		return FALSE
+	if(QDELETED(clicked_atom))
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -194,6 +194,11 @@
 			return TRUE
 
 
+/mob/living/simple_animal/UnarmedAttack(atom/A, has_proximity, modifiers)
+	. = ..()
+	A.attack_animal(src)
+
+
 /mob/living/simple_animal/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
## About The Pull Request
- Directional attacks will now include adjacent tiles. In order for this condition to work, the user must be on **harm intent**, and be targeting the specific tile.
- Adds a new signal, `COMSIG_MOB_ATTACK_UNARMED`, called by the `UnarmedAttack` proc.
- Some of `UnarmedAttack`'s child procs now call parent. Exceptions are made for xeno larvae, the hivemind, A.I., and simple animals.

## Why It's Good For The Game
Makes targeting easier for players, and less of a sprite hunt.

## Changelog
:cl: Lewdcifer
add: Directional attacking now affects adjacent tiles.
/:cl:
