### PR TITLE
Adds new MAPPING_DIRECTIONAL_HELPERS from tg

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -122,8 +122,3 @@
 #define WORLD_VIEW "15x15"
 #define WORLD_VIEW_NUM 7
 #define VIEW_NUM_TO_STRING(v) "[1 + 2 * v]x[1 + 2 * v]"
-
-#define TEXT_NORTH "[NORTH]"
-#define TEXT_SOUTH "[SOUTH]"
-#define TEXT_EAST "[EAST]"
-#define TEXT_WEST "[WEST]"

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -1,0 +1,38 @@
+
+#define TEXT_NORTH "[NORTH]"
+#define TEXT_SOUTH "[SOUTH]"
+#define TEXT_EAST "[EAST]"
+#define TEXT_WEST "[WEST]"
+
+//dir macros
+///Returns true if the dir is diagonal, false otherwise
+#define ISDIAGONALDIR(d) (d&(d-1))
+///True if the dir is north or south, false therwise
+#define NSCOMPONENT(d)   (d&(NORTH|SOUTH))
+///True if the dir is east/west, false otherwise
+#define EWCOMPONENT(d)   (d&(EAST|WEST))
+///Flips the dir for north/south directions
+#define NSDIRFLIP(d)     (d^(NORTH|SOUTH))
+///Flips the dir for east/west directions
+#define EWDIRFLIP(d)     (d^(EAST|WEST))
+
+//Actually better performant than reverse_direction()
+#define REVERSE_DIR(dir) ( ((dir & 85) << 1) | ((dir & 170) >> 1) )
+
+/// Create directional subtypes for a path to simplify mapping.
+#define MAPPING_DIRECTIONAL_HELPERS(path, offset) ##path/directional/north {\
+	dir = NORTH; \
+	pixel_y = offset; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_y = -offset; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = offset; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = -offset; \
+}

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -44,11 +44,6 @@
 
 
 #define UP_OR_DOWN 16
-#define ISDIAGONALDIR(d) (d&(d-1))
-#define NSCOMPONENT(d) (d&(NORTH|SOUTH))
-#define EWCOMPONENT(d) (d&(EAST|WEST))
-#define NSDIRFLIP(d) (d^(NORTH|SOUTH))
-#define EWDIRFLIP(d) (d^(EAST|WEST))
 
 #define MACHINE_NOT_ELECTRIFIED 0
 #define MACHINE_ELECTRIFIED_PERMANENT -1

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -125,8 +125,5 @@ GLOBAL_VAR_INIT(global_unique_id, 1)
 #define LIGHT_BROKEN 2
 #define LIGHT_BURNED 3
 
-//Actually better performant than reverse_direction()
-#define REVERSE_DIR(dir) ( ((dir & 85) << 1) | ((dir & 170) >> 1) )
-
 // shorter way to write as anything
 #define AS as anything

--- a/code/game/objects/machinery/fire_alarm.dm
+++ b/code/game/objects/machinery/fire_alarm.dm
@@ -1,6 +1,3 @@
-
-
-
 /*
 FIRE ALARM
 */
@@ -28,6 +25,11 @@ FIRE ALARM
 	var/last_process = 0
 	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
+
+//whoever made these the sprites on these inverted I will find you, fix this shit and change the offset
+// todo: actually replace all of these in maps
+// also remove the 	switch(dir) when you do
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, (-32))
 
 /obj/machinery/firealarm/Initialize(mapload, direction, building)
 	. = ..()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -58,6 +58,7 @@ F// DM Environment file for baystation12.dme.
 #include "code\__DEFINES\coordinates.dm"
 #include "code\__DEFINES\crafting.dm"
 #include "code\__DEFINES\defibrillator.dm"
+#include "code\__DEFINES\directional.dm"
 #include "code\__DEFINES\DNA.dm"
 #include "code\__DEFINES\do_afters.dm"
 #include "code\__DEFINES\dropship_equipment.dm"


### PR DESCRIPTION
## About The Pull Request

Make sure grayson sees this before merge

We should be using this instead of switch() on init, since it makes these display properly in map editors, lets you pixel offset them, and means less copy paste

I was going to add the fire alarm one as an example but its kinda cursed so its a todo(tm) instead

Needs a lot of mapping changes so I leave it up to the mappers to fix all the uses where this macro should be used (apcs,platforms, etc etc)

## Changelog
:cl:
code: added MAPPING_DIRECTIONAL_HELPERS for mappers. please use this instead of dir and pixel varedits and initialize() switches
/:cl:
