### PR TITLE
Overwatch fix

### DIFF
--- a/code/game/objects/machinery/overwatch/military.dm
+++ b/code/game/objects/machinery/overwatch/military.dm
@@ -174,6 +174,8 @@
 	switch(href_list["operation"])
 		if("logout_main")
 			selected_target = null
+		if("back")
+			current_squad = null
 		if("use_cam")
 			selected_target = locate(href_list["selected_target"])
 		if("message")


### PR DESCRIPTION

## About The Pull Request
Fixes the main overwatch console getting stuck assigned to one squad after using squad monitor.
## Why It's Good For The Game
Getting stuck to one squad means you can only use lases from that squad.
## Changelog
:cl:
fix: fixed the main overwatch console getting stuck to one squad
/:cl:
