### PR TITLE
Revert "Allows Marines to shoot through mech using IFF"

### DIFF
--- a/code/modules/vehicles/mecha/combat/combat.dm
+++ b/code/modules/vehicles/mecha/combat/combat.dm
@@ -13,10 +13,3 @@
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = I
 			gun.projectiles_cache = gun.projectiles_cache_max
-
-/obj/vehicle/sealed/mecha/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	for(var/mob/living/carbon/human/crew AS in occupants)
-		if(crew.wear_id?.iff_signal & proj.iff_signal)
-			return FALSE
-	return ..()
-


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#16094

This is no longer desired behaviour with the rework
## Changelog
:cl:
balance: mech no longer be shot over by marines
/:cl:
