### PR TITLE
Mech repair retargets itself to the chest now when a limb is repaired

### DIFF
--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	if(!(blame_mob.zone_selected in def_zones))
 		return
 	if(part_health <= 0)
-		return COMPONENT_NO_TAKE_DAMAGE // intentional, you're supposed to swap target yourself properly?
+		return
 	part_health = max(0, part_health-damage_amount)
 	if(part_health <= 0)
 		disable()


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/e4b6b423-c365-4041-9b76-c0dc46c3fe29)

## Changelog
:cl:
qol: Mech repair retargets itself to the chest now when a limb is repaired
/:cl:
