### PR TITLE
More AI hazard detection

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -50,6 +50,7 @@
 
 /obj/effect/xenomorph/spray/Initialize(mapload, duration = 10 SECONDS, damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE, mob/living/_xeno_owner) //Self-deletes
 	. = ..()
+	notify_ai_hazard()
 	START_PROCESSING(SSprocessing, src)
 	QDEL_IN(src, duration + rand(0, 2 SECONDS))
 	acid_damage = damage

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -64,10 +64,6 @@
 	icon_state = "laser_target3"
 	layer = ABOVE_FLY_LAYER
 
-/obj/effect/overlay/blinking_laser/Initialize(mapload)
-	. = ..()
-	notify_ai_hazard()
-
 //CAS:
 
 //Minirockets
@@ -136,6 +132,7 @@
 
 /obj/effect/overlay/blinking_laser/marine/Initialize(mapload)
 	. = ..()
+	notify_ai_hazard()
 	prepare_huds()
 	var/datum/atom_hud/squad/squad_hud = GLOB.huds[DATA_HUD_SQUAD_TERRAGOV]
 	squad_hud.add_to_hud(src)
@@ -158,7 +155,6 @@
 /obj/effect/overlay/blinking_laser/marine/lines/Initialize(mapload)
 	. = ..()
 	dir = pick(CARDINAL_DIRS) //Randomises type, for variation
-
 
 //Drop pod.
 /obj/effect/overlay/blinking_laser/marine/pod_warning

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -64,6 +64,10 @@
 	icon_state = "laser_target3"
 	layer = ABOVE_FLY_LAYER
 
+/obj/effect/overlay/blinking_laser/Initialize(mapload)
+	. = ..()
+	notify_ai_hazard()
+
 //CAS:
 
 //Minirockets

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -115,7 +115,7 @@
 
 ///Returns the radius around this considered a hazard
 /atom/proc/get_ai_hazard_radius(mob/living/victim)
-	return null //null means no danger, vs 0 means stay off the hazard's turf
+	return 0 //null means no danger, vs 0 means stay off the hazard's turf
 
 /obj/item/explosive/grenade/get_ai_hazard_radius(mob/living/victim)
 	if(!dangerous)
@@ -130,6 +130,9 @@
 	if((victim.get_soft_armor(BIO) >= 100))
 		return null
 	return smokeradius
+
+/obj/item/explosive/grenade/globadier/get_ai_hazard_radius(mob/living/victim)
+	return 1
 
 /obj/fire/get_ai_hazard_radius(mob/living/victim)
 	if((victim.get_soft_armor(FIRE) >= 100))

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -65,6 +65,7 @@
 
 /obj/effect/temp_visual/behemoth/warning/Initialize(mapload, warning_duration)
 	. = ..()
+	notify_ai_hazard()
 	if(warning_duration)
 		duration = warning_duration
 	animate(src, time = duration - 0.5 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -723,6 +723,10 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	icon = 'icons/Xeno/Effects.dmi'
 	icon_state = "abduct_hook"
 
+/obj/effect/xeno/abduct_warning/Initialize(mapload)
+	. = ..()
+	notify_ai_hazard()
+
 // ***************************************
 // *********** Dislocate
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -510,6 +510,7 @@
 	. = ..()
 	particle_holder = new(src, channel_particle)
 	particle_holder.pixel_y = 0
+	notify_ai_hazard()
 
 /obj/effect/xeno/crush_orb
 	icon = 'icons/xeno/2x2building.dmi'

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -13,4 +13,5 @@
 
 /obj/effect/abstract/ripple/Initialize(mapload, time_left)
 	. = ..()
+	notify_ai_hazard()
 	animate(src, alpha=150, time=time_left)


### PR DESCRIPTION

## About The Pull Request
Adds more hazard detection for NPCs.

They will now avoid:

1. Landing shuttles (RIP Adelina)
2. Incoming CAS
3. The various types of acid spray
4. Warlock psycrush
5. Prae abduct

This in addition to already avoding nades and fire.

Let me know if there are any other obvious things they should try to avoid.
## Why It's Good For The Game
Smarter AI.
## Changelog
:cl:
add: Added more things for NPC's to avoid as hazards
/:cl:
