### PR TITLE
Better AI obstacle handling

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -69,6 +69,13 @@ GLOBAL_LIST_EMPTY(nodes_with_enemies)
 GLOBAL_LIST_EMPTY(nodes_with_construction)
 #define can_cross_lava_turf(turf_to_check) (!islava(turf_to_check) || locate(/obj/structure/catwalk) in turf_to_check) //todo: this needs work
 
+///Obstacle needs attacking
+#define AI_OBSTACLE_ATTACK "ai_obstacle_attack"
+///Obstacle can be jumped
+#define AI_OBSTACLE_JUMP "ai_obstacle_jump"
+///Obstacle has already been handled
+#define AI_OBSTACLE_RESOLVED "ai_obstacle_resolved"
+
 ///If the mob parent can heal itself and so should flee
 #define HUMAN_AI_SELF_HEAL (1<<0)
 ///Uses weapons

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -30,7 +30,7 @@
 	///is this barriade wired?
 	var/is_wired = FALSE
 
-/obj/structure/barricade/Initialize(mapload)
+/obj/structure/barricade/Initialize(mapload, mob/user)
 	. = ..()
 	update_icon()
 	var/static/list/connections = list(
@@ -38,6 +38,8 @@
 		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
 	)
 	AddElement(/datum/element/connect_loc, connections)
+	if(user)
+		faction = user.faction
 
 /obj/structure/barricade/handle_barrier_chance(mob/living/M)
 	return prob(max(30,(100.0*obj_integrity)/max_integrity))

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -350,8 +350,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		if((SEND_SIGNAL(mob_parent, COMSIG_STATE_MAINTAINED_DISTANCE) & COMSIG_MAINTAIN_POSITION))
 			return
 		if(!get_dir(mob_parent, atom_to_walk_to)) //We're right on top, move out of it
-			ai_complete_move(pick(CARDINAL_ALL_DIRS))
-			return
+			return CARDINAL_ALL_DIRS
 		if(prob(50)) //placeholder number, will probs be a var like sidestep prob, so they're not just constantly wiggling about
 			return
 		if(prob(sidestep_prob)) //shuffle about

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -136,6 +136,45 @@
 		return null
 	return 0
 
+//Obstacle handling
+///Handles the obstacle or tells AI behavior how to interact with it
+/obj/proc/ai_handle_obstacle(mob/living/user, move_dir) //do we need to/can we just check can_pass???
+	if((loc == user.loc) && !(atom_flags & ON_BORDER)) //dense things under us don't block
+		return
+	if((atom_flags & ON_BORDER) && (move_dir != (loc == user.loc ? dir : REVERSE_DIR(dir)))) //we only care about border objects actually blocking us
+		return
+	//todo:walkover stuff?
+	if(user.can_jump() && is_jumpable(user))
+		return AI_OBSTACLE_JUMP
+	if(faction == user.faction) //don't break our shit
+		return AI_OBSTACLE_RESOLVED //not sure if I need something new here
+	if(!(resistance_flags & INDESTRUCTIBLE) && (obj_flags & CAN_BE_HIT))
+		return AI_OBSTACLE_ATTACK
+
+/obj/structure/ai_handle_obstacle(mob/living/user, move_dir)
+	. = ..()
+	if(. == AI_OBSTACLE_JUMP)
+		return //jumping is always best
+	if(!climbable)
+		return
+	INVOKE_ASYNC(src, PROC_REF(do_climb), user)
+	return AI_OBSTACLE_RESOLVED
+
+/obj/structure/barricade/folding/ai_handle_obstacle(mob/living/user, move_dir)
+	toggle_open(null, user)
+	return AI_OBSTACLE_RESOLVED
+
+/obj/machinery/door/airlock/ai_handle_obstacle(mob/living/user, move_dir)
+	. = ..()
+	if(!.)
+		return
+	if(operating) //Airlock already doing something
+		return null
+	if(welded || locked) //It's welded or locked, can't force that open
+		return
+	open(TRUE)
+	return AI_OBSTACLE_RESOLVED
+
 //test stuff
 /mob/living/proc/add_test_ai()
 	AddComponent(/datum/component/ai_controller, /datum/ai_behavior/human)

--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -201,8 +201,7 @@
 
 /datum/ai_behavior/human/deal_with_obstacle(datum/source, direction)
 	var/turf/obstacle_turf = get_step(mob_parent, direction)
-	if(obstacle_turf.atom_flags & AI_BLOCKED)
-		return
+
 	for(var/mob/mob_blocker in obstacle_turf.contents)
 		if(!mob_blocker.density)
 			continue
@@ -249,6 +248,11 @@
 	if(should_jump)
 		SEND_SIGNAL(mob_parent, COMSIG_AI_JUMP)
 		INVOKE_ASYNC(src, PROC_REF(ai_complete_move), direction, FALSE)
+		return COMSIG_OBSTACLE_DEALT_WITH
+
+	//We do this last because there could be other stuff blocking us from even reaching the turf
+	if(istype(obstacle_turf, /turf/closed/wall/resin))
+		INVOKE_ASYNC(src, PROC_REF(melee_interact), null, obstacle_turf)
 		return COMSIG_OBSTACLE_DEALT_WITH
 
 /datum/ai_behavior/human/set_goal_node(datum/source, obj/effect/ai_node/new_goal_node)

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 //------------------------------------------------------------------
 //Setup and Deletion
 
-/obj/machinery/deployable/mounted/sentry/Initialize(mapload, _internal_item, deployer)
+/obj/machinery/deployable/mounted/sentry/Initialize(mapload, obj/item/_internal_item, mob/deployer)
 	. = ..()
 	var/obj/item/weapon/gun/gun = get_internal_item()
 
@@ -48,6 +48,8 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 		var/mob/living/carbon/human/_deployer = deployer
 		var/obj/item/card/id/id = _deployer.get_idcard(TRUE)
 		iff_signal = id?.iff_signal
+	if(deployer)
+		faction = deployer.faction
 
 	knockdown_threshold = gun?.knockdown_threshold ? gun.knockdown_threshold : initial(gun.knockdown_threshold)
 	range = CHECK_BITFIELD(gun.turret_flags, TURRET_RADIAL) ?  gun.turret_range - 2 : gun.turret_range
@@ -538,7 +540,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	name = "broken build-a-sentry"
 	desc = "You should not be seeing this unless a mapper, coder or admin screwed up."
 
-/obj/machinery/deployable/mounted/sentry/buildasentry/Initialize(mapload, _internal_item, deployer) //I know the istype spam is a bit much, but I don't think there is a better way.
+/obj/machinery/deployable/mounted/sentry/buildasentry/Initialize(mapload, obj/item/_internal_item, mob/deployer) //I know the istype spam is a bit much, but I don't think there is a better way.
 	. = ..()
 	var/obj/item/internal_sentry = get_internal_item()
 	if(internal_sentry)


### PR DESCRIPTION
## About The Pull Request
Improved the code, fixing various issues.
Notably for the players, NPC's will now:

1. Actually open cades when possible instead of nerd raging them to death
2.  Will not destroy obstacles that belong to their faction
3. Cades and sentries have their faction var set by their builder/deployer
4. Will more accurately figure out what obstacles to deal with
5. Will attack resin walls in their way

Now that obstacle handling is split out to a obj var, we can add more specific behavior as needed, without all the funny snowflake.

PR up for review, but there's probably a few more things I will add before merge.
## Why It's Good For The Game
Smarter AI
## Changelog
:cl:
add: NPC obstacle handling improved
qol: Barricades and sentries have their faction set by their deployer. NPC's will avoid destroying friendly obstacles
/:cl:
