### PR TITLE
NPC wrangling

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -110,6 +110,11 @@
 		return
 	return ..()
 
+/datum/ai_behavior/human/ai_do_move()
+	if(mob_parent.pulledby?.faction == mob_parent.faction)
+		return //lets players wrangle NPC's
+	return ..()
+
 /datum/ai_behavior/human/register_action_signals(action_type)
 	switch(action_type)
 		if(MOVING_TO_ATOM)


### PR DESCRIPTION

## About The Pull Request
If you grab a friendly human NPC, they will stop moving.
## Why It's Good For The Game
Lets you wrangle NPC's better, hold them still for equipping/healing/feeding etc.
## Changelog
:cl:
qol: Grabbed friendly human NPC's will not move
/:cl:
