### PR TITLE
Remove hardcode groundside noparallax and split it out into a Z trait

### DIFF
--- a/_maps/bigred_v2.json
+++ b/_maps/bigred_v2.json
@@ -9,6 +9,7 @@
 	"armor": "desert",
 	"announce_text": "A second generation colony has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!",
 	"traits":[{
-		"weather_sandstorm": true
+		"weather_sandstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/bluesummers.json
+++ b/_maps/bluesummers.json
@@ -9,6 +9,7 @@
 	"armor": "desert",
 	"announce_text": "We have picked up a trace of a signal from the HMS Bluesummers, a seed ship sent to colonize a new sector that has been missing for some time. Our preliminary scans show that the ship has crashed and splintered across a desert planet. We have been ordered to search for survivors and investigate the cause of this disaster. TGMC, prepare to deploy!",
 	"traits":[{
-		"weather_sandstorm": true
+		"weather_sandstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/daedalusprison.json
+++ b/_maps/daedalusprison.json
@@ -15,6 +15,7 @@
 	"quickbuilds": 2300,
 	"announce_text": "Coming from an icy planet within our jump drive range, a penal colony has sent out an emergency frequency that our comms array received. TGMC, prepare to deploy!",
 	"traits":[{
-		"weather_snowstorm": true
+		"weather_snowstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/desertdam.json
+++ b/_maps/desertdam.json
@@ -8,5 +8,8 @@
     "map_item_type": "/obj/item/map/desert_dam",
     "armor": "desert",
 	"quickbuilds": 3300,
-	"announce_text": "We've lost contact with NT's extra-solar colony, \"Chigusa Dam\", on the planet \"Trivonus IV.\" Your ship has been dispatched to assist."
+	"announce_text": "We've lost contact with NT's extra-solar colony, \"Chigusa Dam\", on the planet \"Trivonus IV.\" Your ship has been dispatched to assist.",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/desparity.json
+++ b/_maps/desparity.json
@@ -8,6 +8,7 @@
     "armor": "jungle",
 	"announce_text": "An emergency broadcast has been picked up by our scanners, triangulated to a jungle outpost near LV624, known as Desparity. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
 	"traits":[{
-		"weather_rain": true
+		"weather_rain": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/gelida_iv.json
+++ b/_maps/gelida_iv.json
@@ -15,6 +15,7 @@
 	"quickbuilds": 1900,
 	"announce_text": "Our comms array has detected an automated emergency signal broadcasting over a frequency reserved for the highest level of emergencies. The message was traced to the northern reaches of the research colony Gelida IV. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",
 	"traits":[{
-		"weather_snowstorm": true
+		"weather_snowstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/ice_colony_v2.json
+++ b/_maps/ice_colony_v2.json
@@ -12,6 +12,7 @@
 	"quickbuilds": 2100,
 	"announce_text": "A garbled, unintelligible communications message was broadcasted over a general frequency, and picked up by our comms relay. The message appears to have come from a second generation settlement, located on an ice cold planet. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",
 	"traits":[{
-		"weather_snowstorm": true
+		"weather_snowstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/icy_caves.json
+++ b/_maps/icy_caves.json
@@ -12,6 +12,7 @@
 	"quickbuilds": 1200,
 	"announce_text": "A garbled, unintelligible communications message was broadcasted over a general frequency, and picked up by our comms relay. The message appears to have come from a mining outpost, located on an ice cold planet. The ship is moving into the sector with thrusters at max throttle. TGMC, get briefed and then move out!",
 	"traits":[{
-		"weather_snowstorm": true
+		"weather_snowstorm": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/kutjevo.json
+++ b/_maps/kutjevo.json
@@ -6,5 +6,8 @@
 		"basic": 1
 	},
 	"quickbuilds": 1800,
-	"announce_text": "An automated distress signal has been received from Nanotrasen colony Kutjevo Refinery, known for botanical research, export, and raw materials processing and refinement. The ###SHIPNAME### has been dispatched to investigate."
+	"announce_text": "An automated distress signal has been received from Nanotrasen colony Kutjevo Refinery, known for botanical research, export, and raw materials processing and refinement. The ###SHIPNAME### has been dispatched to investigate.",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/lavaoutpost.json
+++ b/_maps/lavaoutpost.json
@@ -6,5 +6,8 @@
 		"basic": 1
 	},
 	"quickbuilds": 1800,
-	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to LO145. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!"
+	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to LO145. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/lawanka.json
+++ b/_maps/lawanka.json
@@ -9,6 +9,7 @@
 	"quickbuilds": 1800,
 	"announce_text": "An AI from a Nanotrasen sponsored Research Colony has been sending a distress signal, nonstop. Nanotrasen has hired us to reclaim the Colony in any form. TGMC, prepare to deploy!",
 	"traits":[{
-		"weather_rain": true
+		"weather_rain": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/lv624.json
+++ b/_maps/lv624.json
@@ -9,6 +9,7 @@
 	"quickbuilds": 2000,
 	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a third generation colony, known as LV-624. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
 	"traits":[{
-		"weather_acidrain": true
+		"weather_acidrain": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/lv759.json
+++ b/_maps/lv759.json
@@ -9,6 +9,7 @@
 	"armor": "urban",
 	"announce_text": "A routine check of nearby second-generation colonies has identified an anomaly on designation Zeta-Echo-7b, otherwise known as LV759.  The colony beacon has been transmitting a constant, unchanging signal for 7 weeks. Attempts to establish communication via standard protocols have been unsuccessful. TGMC, gear up and get ready to respond!",
 	"traits":[{
-		"weather_rain": true
+		"weather_rain": true,
+		"No Parallax": true
 	}]
 }

--- a/_maps/magmoor_digsite_iv.json
+++ b/_maps/magmoor_digsite_iv.json
@@ -8,5 +8,8 @@
 		"set3": 1
 	},
 	"quickbuilds": 1800,
-    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a mining and archaeological site, known as Magmoor Digsite IV. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!"
+    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a mining and archaeological site, known as Magmoor Digsite IV. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/metnal.json
+++ b/_maps/metnal.json
@@ -11,6 +11,9 @@
 	},
 	"armor": "prison",
 	"quickbuilds": 2100,
-	"announce_text": "A scrambled automated distress signal has been picked up from the nearby Metnal Mining Operation, though attempts to establish communications with the outpost have been unsuccessful. The ship has jumped within range to investigate. TGMC, prepare to deploy!"
+	"announce_text": "A scrambled automated distress signal has been picked up from the nearby Metnal Mining Operation, though attempts to establish communications with the outpost have been unsuccessful. The ship has jumped within range to investigate. TGMC, prepare to deploy!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }
 

--- a/_maps/orion_outpost.json
+++ b/_maps/orion_outpost.json
@@ -7,5 +7,8 @@
 	},
     "armor": "urban",
 	"quickbuilds": 1000,
-	"announce_text": "The automatic emergency beacon has activated at the Orion Military Outpost on the moon of Trivonus IV, a xenomorph infestation is likely. TGMC, get prepared and ready for a fight!"
+	"announce_text": "The automatic emergency beacon has activated at the Orion Military Outpost on the moon of Trivonus IV, a xenomorph infestation is likely. TGMC, get prepared and ready for a fight!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/oscar_outpost.json
+++ b/_maps/oscar_outpost.json
@@ -2,5 +2,8 @@
     "map_name": "Oscar Outpost",
     "map_path": "map_files/oscar_outpost",
     "map_file": "oscar_outpost.dmm",
-    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to Batallion 167's Supreme Command Center. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!"
+    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to Batallion 167's Supreme Command Center. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/prison_station_fop.json
+++ b/_maps/prison_station_fop.json
@@ -7,5 +7,8 @@
 	},
     "armor": "prison",
 	"quickbuilds": 1200,
-	"announce_text": "A Nanotrasen maximum security prison has activated its distress signal. The ship is swiftly cruising through space, and nearing the vicinity of the prison station. TGMC, get moving!"
+	"announce_text": "A Nanotrasen maximum security prison has activated its distress signal. The ship is swiftly cruising through space, and nearing the vicinity of the prison station. TGMC, get moving!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/research_outpost.json
+++ b/_maps/research_outpost.json
@@ -6,5 +6,8 @@
 		"basic": 1
 	},
 	"quickbuilds": 1000,
-    "announce_text": "A research outpost has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!"
+    "announce_text": "A research outpost has had a beacon transmitting the same signal, nonstop. Attempts to hail the colony over comms have proved futile. Because the ship was at a nearby drydock, it has been dispatched to figure out what's wrong. TGMC, prepare to deploy!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/riptide.json
+++ b/_maps/riptide.json
@@ -11,5 +11,6 @@
 	"quickbuilds": 2500,
 	"announce_text": "We have received a faint distress signal originating from a sandy island with a dense jungle. The ship has jumped within range of what looks like a beach resort. TGMC, gear up, don't forget your sunscreen and get ready to respond!",
 	"traits":[{
+		"No Parallax": true
 	}]
 }

--- a/_maps/vapor_processing.json
+++ b/_maps/vapor_processing.json
@@ -5,5 +5,8 @@
 	"disk_sets": {
 		"basic": 1
 	},
-    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a Vapor Processing colony, known as LV-984. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!"
+    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a Vapor Processing colony, known as LV-984. Through use of bluespace drive tech, the ship has jumped within range of the colony. TGMC, gear up and get ready to respond!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/_maps/whiskey_outpost_v2.json
+++ b/_maps/whiskey_outpost_v2.json
@@ -2,5 +2,8 @@
     "map_name": "Whiskey Outpost",
     "map_path": "map_files/Whiskey_Outpost",
     "map_file": "Whiskey_Outpost_v2.dmm",
-    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to Batallion 140's Supreme Command Center. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!"
+    "announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to Batallion 140's Supreme Command Center. Through use of emergency bluespace drive tech, the ship has jumped within range of the outpost. Senior officers are present and will need to be evacuated in order to completely finish your mission. TGMC, gear up and get ready to respond!",
+	"traits":[{
+		"No Parallax": true
+	}]
 }

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -35,8 +35,8 @@ require only minor tweaks.
 #define ZTRAIT_RAIN "weather_rain"
 #define ZTRAIT_SANDSTORM "weather_sandstorm"
 
-// number - bombcap is multiplied by this before being applied to bombs
-#define ZTRAIT_BOMBCAP_MULTIPLIER "Bombcap Multiplier"
+///boolean - does this z disable parallax?
+#define ZTRAIT_NOPARALLAX "No Parallax"
 
 // number - default gravity if there's no gravity generators or area overrides present
 #define ZTRAIT_GRAVITY "Gravity"
@@ -63,12 +63,6 @@ require only minor tweaks.
 #define ZTRAITS_CENTCOM list(ZTRAIT_CENTCOM = TRUE)
 #define ZTRAITS_STATION list(ZTRAIT_LINKAGE = CROSSLINKED, ZTRAIT_STATION = TRUE)
 #define ZTRAITS_SPACE list(ZTRAIT_LINKAGE = CROSSLINKED, ZTRAIT_SPACE_RUINS = TRUE)
-#define ZTRAITS_LAVALAND list(\
-	ZTRAIT_MINING = TRUE, \
-	ZTRAIT_LAVA_RUINS = TRUE, \
-	ZTRAIT_BOMBCAP_MULTIPLIER = 2, \
-	ZTRAIT_BASETURF = /turf/open/lava/smooth/lava_land_surface)
-#define ZTRAITS_REEBE list(ZTRAIT_REEBE = TRUE, ZTRAIT_BOMBCAP_MULTIPLIER = 0.5)
 
 #define DL_NAME "name"
 #define DL_TRAITS "traits"

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -56,11 +56,13 @@
 /datum/hud/proc/apply_parallax_pref(mob/viewmob)
 	var/mob/screenmob = viewmob || mymob
 	var/client/C = screenmob.client
-/*	if(SSmapping.level_trait(screen_location?.z, ZTRAIT_NOPARALLAX))
+	var/turf/screen_location = get_turf(screenmob)
+
+	if(SSmapping.level_trait(screen_location?.z, ZTRAIT_NOPARALLAX))
 		for(var/atom/movable/screen/plane_master/white_space as anything in get_true_plane_masters(PLANE_SPACE))
 			white_space.hide_plane(screenmob)
 		return FALSE
-*/
+
 	for(var/atom/movable/screen/plane_master/white_space as anything in get_true_plane_masters(PLANE_SPACE))
 		white_space.unhide_plane(screenmob)
 
@@ -93,11 +95,12 @@
 	return TRUE
 
 /datum/hud/proc/update_parallax_pref(mob/viewmob)
-	if(is_ground_level(viewmob.z))
+	var/mob/screen_mob = viewmob || mymob
+	if(!screen_mob.client)
 		return
-	remove_parallax(viewmob)
-	create_parallax(viewmob)
-	update_parallax(viewmob)
+	remove_parallax(screen_mob)
+	create_parallax(screen_mob)
+	update_parallax(screen_mob)
 
 // This sets which way the current shuttle is moving (returns true if the shuttle has stopped moving so the caller can append their animation)
 /datum/hud/proc/set_parallax_movedir(new_parallax_movedir, skip_windups, mob/viewmob)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -880,14 +880,8 @@
 
 /mob/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents = TRUE)
 	. = ..()
-	if(!client || !hud_used)
-		return
-	if(old_turf?.z == new_turf?.z)
-		return
-	if(is_ground_level(new_turf.z))
-		hud_used.remove_parallax(src)
-		return
-	hud_used.create_parallax(src)
+	if(!same_z_layer)
+		relayer_fullscreens()
 
 /mob/proc/point_to_atom(atom/pointed_atom)
 	var/turf/tile = get_turf(pointed_atom)


### PR DESCRIPTION

## About The Pull Request

Since some ground maps are in space this makes it look pretty again 
![image](https://github.com/user-attachments/assets/54f7170c-20e2-4d4f-8d3e-11d59b7ed221)

## Changelog
:cl:
fix: Slumbridge,deltastation and other maps now have working parallax
/:cl:
