### PR TITLE
MultiZ Cables can't be destroyed

### DIFF
--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -5,6 +5,7 @@
 	icon_state = "cablerelay-on"
 	cable_layer = CABLE_LAYER_1|CABLE_LAYER_2|CABLE_LAYER_3
 	machinery_layer = null
+	resistance_flags = RESIST_ALL //deleting multi-z connectors causes problems, so we don't
 
 /obj/structure/cable/multilayer/multiz/get_cable_connections(powernetless_only)
 	. = ..()
@@ -18,3 +19,6 @@
 	. += span_notice("[locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_below(T)) ? "Detected" : "Undetected"] hub UP.")
 	. += span_notice("[locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_above(T)) ? "Detected" : "Undetected"] hub DOWN.")
 
+// no cutting the cable either
+/obj/structure/cable/multilayer/multiz/handlecable(obj/item/W, mob/user, params)
+	return


### PR DESCRIPTION

## About The Pull Request

Looks to have been a concern by grayson on the previous multiz attempt, so I'll just fix this now
## Changelog
:cl:
balance: MultiZ Cables can't be destroyed
/:cl:
