### PR TITLE
Fix for engineers standard loadout

### DIFF
--- a/code/datums/outfits/quick_load_beginners.dm
+++ b/code/datums/outfits/quick_load_beginners.dm
@@ -377,7 +377,6 @@
 	l_hand = /obj/item/paper/tutorial/builder
 
 	backpack_contents = list(
-		/obj/item/stack/sheet/metal/small_stack = 1,
 		/obj/item/stack/sandbags_empty/full = 1,
 		/obj/item/tool/shovel/etool = 1,
 		/obj/item/storage/box/m94 = 1,
@@ -387,6 +386,8 @@
 
 	suit_contents = list(
 		/obj/item/stack/sheet/metal/large_stack = 3,
+		/obj/item/stack/sheet/metal/small_stack = 2,
+		/obj/item/stack/sheet/plasteel/large_stack = 1,
 	)
 
 


### PR DESCRIPTION


## About The Pull Request

Current loadout doesn't give plasteel as it used to, this causes you to lose out on equipment points since it'll use up all 75 while only giving you 52 points of gear.

The pr basically just gives the loadout back its plasteel with 50 in the engineer module and another 10 metal to help use 3 leftover points.

## Why It's Good For The Game

Its just a trap to pick this loadout since you lose 23 equipment points.

## Changelog

:cl:
Fix: Standard engi loadout now fully uses its points
