### PR TITLE
Certain HUDs will now appear over game world objects

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -27,6 +27,9 @@
 #define XENO_BLESSING_HUD "xeno_blessing_hud" //indicates what blessings the xeno has
 #define XENO_EVASION_HUD "xeno_extra_hud" // displays anything extra or additional such as runner's evasion duration
 
+/// huds that layer on a higher plane in an attempt to ALWAYS show
+#define HUDS_LAYERING_HIGH list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD, QUEEN_OVERWATCH_HUD, XENO_RANK_HUD, ARMOR_SUNDER_HUD, XENO_DEBUFF_HUD, XENO_FIRE_HUD, XENO_BLESSING_HUD, XENO_EVASION_HUD)
+
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud
 
 //by default everything in the hud_list of an atom is an image

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -260,7 +260,7 @@
 
 /atom/movable/screen/plane_master/point
 	name = "Point"
-	documentation = "I mean like, what do you want me to say? Points draw over pretty much everything else, so they get their own plane. Remember we layer render relays to draw planes in their proper order on render plates."
+	documentation = "I mean like, what do you want me to say? Points draw over pretty much everything else, so they get their own plane. We also draw HUD images to here for the same reason. Remember we layer render relays to draw planes in their proper order on render plates."
 	plane = POINT_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -866,7 +866,10 @@ directive is properly returned.
 	return TRUE
 
 /atom/proc/prepare_huds()
-	hud_list = new
+	for(var/key in hud_list)
+		var/image/removee = hud_list[key]
+		LAZYREMOVE(update_on_z, removee)
+	hud_list = list()
 	for(var/hud in hud_possible) //Providing huds.
 		var/hint = hud_possible[hud]
 		switch(hint)
@@ -875,6 +878,8 @@ directive is properly returned.
 			else
 				var/image/I = image('icons/mob/hud/human.dmi', src, "")
 				I.appearance_flags = RESET_COLOR|RESET_TRANSFORM|KEEP_APART
+				SET_PLANE_EXPLICIT(I, HIGH_GAME_PLANE, src)
+				LAZYADD(update_on_z, I)
 				hud_list[hud] = I
 
 /**

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -870,6 +870,7 @@ directive is properly returned.
 		var/image/removee = hud_list[key]
 		LAZYREMOVE(update_on_z, removee)
 	hud_list = list()
+	var/static/list/higher_hud_list = HUDS_LAYERING_HIGH
 	for(var/hud in hud_possible) //Providing huds.
 		var/hint = hud_possible[hud]
 		switch(hint)
@@ -878,8 +879,9 @@ directive is properly returned.
 			else
 				var/image/I = image('icons/mob/hud/human.dmi', src, "")
 				I.appearance_flags = RESET_COLOR|RESET_TRANSFORM|KEEP_APART
-				SET_PLANE_EXPLICIT(I, HIGH_GAME_PLANE, src)
-				LAZYADD(update_on_z, I)
+				if(hud in higher_hud_list)
+					SET_PLANE_EXPLICIT(I, POINT_PLANE, src)
+					LAZYADD(update_on_z, I)
 				hud_list[hud] = I
 
 /**


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/97bb506e-3648-46b0-8a57-c783678fa153)

## Changelog
:cl:
qol: Certain HUDs will now appear over game world objects. Most notably this means that xeno HUDS now layer over smoke
/:cl:
