### PR TITLE
Better explosion logging & directional explosions

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -93,10 +93,56 @@ SUBSYSTEM_DEF(explosions)
 // 5 explosion power is a (0, 1, 3) explosion.
 // 1 explosion power is a (0, 0, 1) explosion.
 
-/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE)
-	return SSexplosions.explode(epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range, throw_range, adminlog, silent, smoke, color, tiny)
+/**
+ * Makes a given atom explode.
+ *
+ * Arguments:
+ * - [origin][/atom]: The atom that's exploding.
+ * - devastation_range: The range at which the effects of the explosion are at their strongest.
+ * - heavy_impact_range: The range at which the effects of the explosion are relatively severe.
+ * - light_impact_range: The range at which the effects of the explosion are relatively weak.
+ * - light_impact_range: The range at which the effects of the explosion are very weak.
+ * - flash_range: The range at which the explosion flashes people.
+ * - flame_range: range to make flame objs in
+ * - throw_range: range the explosion throws people away
+ * - adminlog: Whether to log the explosion/report it to the administration.
+ * - silent: Whether to generate/execute sound effects.
+ * - smoke: Whether to generate a smoke cloud provided the explosion is powerful enough to warrant it.
+ * - color: light color that happens with the explosion
+ * - tiny: whether to try use the tiny explosion sprite for this
+ * - protect_epicenter: Whether to leave the epicenter turf unaffected by the explosion
+ * - explosion_cause: [Optional] The atom that caused the explosion, when different to the origin. Used for logging.
+ * - explosion_direction: The angle in which the explosion is pointed (for directional explosions.)
+ * - explosion_arc: The angle of the arc covered by a directional explosion (if 360 the explosion is non-directional.)
+ */
+/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360)
+	return SSexplosions.explode(arglist(args))
 
-/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range, throw_range, adminlog, silent, smoke, color, tiny)
+/**
+ * Makes a given atom explode.
+ *
+ * Arguments:
+ * - [origin][/atom]: The atom that's exploding.
+ * - devastation_range: The range at which the effects of the explosion are at their strongest.
+ * - heavy_impact_range: The range at which the effects of the explosion are relatively severe.
+ * - light_impact_range: The range at which the effects of the explosion are relatively weak.
+ * - light_impact_range: The range at which the effects of the explosion are very weak.
+ * - flash_range: The range at which the explosion flashes people.
+ * - flame_range: range to make flame objs in
+ * - throw_range: range the explosion throws people away
+ * - adminlog: Whether to log the explosion/report it to the administration.
+ * - silent: Whether to generate/execute sound effects.
+ * - smoke: Whether to generate a smoke cloud provided the explosion is powerful enough to warrant it.
+ * - color: light color that happens with the explosion
+ * - tiny: whether to try use the tiny explosion sprite for this
+ * - protect_epicenter: Whether to leave the epicenter turf unaffected by the explosion
+ * - explosion_cause: [Optional] The atom that caused the explosion, when different to the origin. Used for logging.
+ * - explosion_direction: The angle in which the explosion is pointed (for directional explosions.)
+ * - explosion_arc: The angle of the arc covered by a directional explosion (if 360 the explosion is non-directional.)
+ */
+/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360)
+	explosion_cause = explosion_cause ? explosion_cause : epicenter
+
 	epicenter = get_turf(epicenter)
 	if(!epicenter)
 		return
@@ -110,10 +156,30 @@ SUBSYSTEM_DEF(explosions)
 	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flame_range, throw_range)
 	var/started_at = REALTIMEOFDAY
 
+	// Now begins a bit of a logic train to find out whodunnit.
+	var/who_did_it = "N/A"
+	var/who_did_it_game_log = "N/A"
+
+	// Projectiles have special handling. They rely on a firer var and not fingerprints. Check special cases for firer being
+	// mecha, mob or an object such as the gun itself. Handle each uniquely.
+	if(istype(explosion_cause, /obj/projectile)) // todo we mostly pass ammo datums cus drop explosion doesnt pass the projectiles-pls fix
+		var/obj/projectile/fired_projectile = explosion_cause
+		if(ismob(fired_projectile.firer))
+			who_did_it = "\[Projectile firer: [ADMIN_LOOKUPFLW(fired_projectile.firer)]\]"
+			who_did_it_game_log = "\[Projectile firer: [key_name(fired_projectile.firer)]\]"
+		else // no fuckin idea?? better just send the obj that did it
+			who_did_it = "\[Projectile firer: [fired_projectile.firer], ref:[text_ref(fired_projectile.firer)]\]"
+			who_did_it_game_log = "\[Projectile firer: [fired_projectile.firer], ref:[text_ref(fired_projectile.firer)]]\]"
+	// Otherwise if the explosion cause is an atom, try get the ref. could be fingerprints but alas our logging sucks
+	else if(istype(explosion_cause))
+		who_did_it = "\[Exploder: [explosion_cause], ref:[text_ref(explosion_cause)]\]"
+		who_did_it_game_log = "\[Exploder: [explosion_cause], ref:[text_ref(explosion_cause)]]\]"
+
 	if(adminlog)
-		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)]")
-		if(is_mainship_level(epicenter.z))
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)]")
+		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Possible cause: [explosion_cause]. Last fingerprints: [who_did_it].")
+		var/datum/game_mode/infestation/xenomode = SSticker.mode
+		if(istype(xenomode) && (xenomode.round_stage != INFESTATION_MARINE_CRASHING) && is_mainship_level(epicenter.z))
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)], Possible cause: [explosion_cause]. Last fingerprints: [who_did_it_game_log]")
 
 	if(max_range >= 6 || heavy_impact_range)
 		new /obj/effect/temp_visual/shockwave(epicenter, max_range)
@@ -197,18 +263,7 @@ SUBSYSTEM_DEF(explosions)
 		for(var/mob/living/carbon/carbon_viewers in viewers(flash_range, epicenter))
 			carbon_viewers.flash_act()
 
-	var/list/turfs_in_range = block(
-		locate(
-			max(epicenter.x - max_range, 1),
-			max(epicenter.y - max_range, 1),
-			epicenter.z
-			),
-		locate(
-			min(epicenter.x + max_range, world.maxx),
-			min(epicenter.y + max_range, world.maxy),
-			epicenter.z
-			)
-		)
+	var/list/turfs_in_range = prepare_explosion_turfs(max_range, epicenter, protect_epicenter, explosion_direction, explosion_arc)
 
 	var/throw_strength //used here for epicenter and also later for every other turf
 	if(devastation_range > 0)
@@ -227,10 +282,12 @@ SUBSYSTEM_DEF(explosions)
 		if(flame_range > 0) //this proc shouldn't be used for flames only, but here we are
 			if(usr)
 				to_chat(usr, span_narsiesmall("Please don't use explosions for flames-only, use flame_radius()"))
+			stack_trace("Please don't use explosions for flames-only, use flame_radius()")
 			flameturf += turfs_in_range
 		if(throw_range > 0) //admemes, what have you done
 			if(usr)
 				to_chat(usr, span_narsie("Stop using explosions for memes!"))
+			stack_trace("Please don't use explosions for throws")
 			for(var/t in turfs_in_range)
 				var/turf/throw_turf = t
 				throwTurf[throw_turf] += list(epicenter)
@@ -348,6 +405,87 @@ This way we'll be able to draw the explosion's expansion path without having to 
 	weakTurf -= T
 	flameturf -= T
 	throwTurf -= T
+
+/// Returns a list of turfs in X range from the epicenter
+/// Returns in a unique order, spiraling outwards
+/// This is done to ensure our progressive cache of blast resistance is always valid
+/// This is quite fast
+/proc/prepare_explosion_turfs(range, turf/epicenter, protect_epicenter, explosion_direction, explosion_arc)
+	var/list/outlist = list()
+	var/list/candidates = list()
+	// Add in the center if it's not protected
+	if(!protect_epicenter)
+		outlist += epicenter
+
+	var/our_x = epicenter.x
+	var/our_y = epicenter.y
+	var/our_z = epicenter.z
+
+	var/max_x = world.maxx
+	var/max_y = world.maxy
+
+	// Work out the angles to explode between
+	var/first_angle_limit = WRAP(explosion_direction - explosion_arc * 0.5, 0, 360)
+	var/second_angle_limit = WRAP(explosion_direction + explosion_arc * 0.5, 0, 360)
+
+	// Get everything in the right order
+	var/lower_angle_limit
+	var/upper_angle_limit
+	var/do_directional
+	var/reverse_angle
+
+	// Work out which case we're in
+	if(first_angle_limit == second_angle_limit) // CASE A: FULL CIRCLE
+		do_directional = FALSE
+	else if(first_angle_limit < second_angle_limit) // CASE B: When the arc does not cross 0 degrees
+		lower_angle_limit = first_angle_limit
+		upper_angle_limit = second_angle_limit
+		do_directional = TRUE
+		reverse_angle = FALSE
+	else if (first_angle_limit > second_angle_limit) // CASE C: When the arc crosses 0 degrees
+		lower_angle_limit = second_angle_limit
+		upper_angle_limit = first_angle_limit
+		do_directional = TRUE
+		reverse_angle = TRUE
+
+	for(var/i in 1 to range)
+		var/lowest_x = our_x - i
+		var/lowest_y = our_y - i
+		var/highest_x = our_x + i
+		var/highest_y = our_y + i
+		// top left to one before top right
+		if(highest_y <= max_y)
+			candidates += block(
+				lowest_x, highest_y, our_z,
+				highest_x - 1, highest_y, our_z
+			)
+		// top right to one before bottom right
+		if(highest_x <= max_x)
+			candidates += block(
+				highest_x, highest_y, our_z,
+				highest_x, lowest_y + 1, our_z
+			)
+		// bottom right to one before bottom left
+		if(lowest_y >= 1)
+			candidates += block(
+				highest_x, lowest_y, our_z,
+				lowest_x + 1, lowest_y, our_z
+			)
+		// bottom left to one before top left
+		if(lowest_x >= 1)
+			candidates += block(
+				lowest_x, lowest_y, our_z,
+				lowest_x, highest_y - 1, our_z
+			)
+
+	if(!do_directional)
+		outlist += candidates
+	else
+		for(var/turf/candidate as anything in candidates)
+			var/angle = Get_Angle(epicenter, candidate)
+			if(ISINRANGE(angle, lower_angle_limit, upper_angle_limit) ^ reverse_angle)
+				outlist += candidate
+	return outlist
 
 /datum/controller/subsystem/explosions/fire(resumed = FALSE)
 	if(!(length(weakTurf) || length(lowTurf) || length(medTurf) || length(highTurf) || length(flameturf) || length(throwTurf) || length(weakMovAtom) ||length(lowMovAtom) || length(medMovAtom) || length(highMovAtom)))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -220,7 +220,7 @@ SUBSYSTEM_DEF(ticker)
 		var/turf/epi = bomb.loc
 		qdel(bomb)
 		if(epi)
-			explosion(epi, 0, 256, 512, 0, silent = TRUE)
+			explosion(epi, 0, 256, 512, 0, silent = TRUE, explosion_cause="station_explosion_detonation")
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING

--- a/code/datums/components/remote_control.dm
+++ b/code/datums/components/remote_control.dm
@@ -104,7 +104,7 @@
 
 ///Called when a explosive vehicle clicks and tries to explde itself
 /datum/component/remote_control/proc/uv_handle_click_explosive(mob/user, atom/target, params)
-	explosion(get_turf(controlled), 1, 2, 3, 4)
+	explosion(get_turf(controlled), 1, 2, 3, 4, explosion_cause=user)
 	remote_control_off()
 	return TRUE
 

--- a/code/datums/fire_support/gun_run.dm
+++ b/code/datums/fire_support/gun_run.dm
@@ -117,6 +117,6 @@
 	playsound(strafelist[1], 'sound/weapons/guns/fire/volkite_4.ogg', 60, FALSE, 25, falloff = 3)
 	strafed = strafelist[1]
 	strafelist -= strafed
-	explosion(strafed, light_impact_range = 2, flame_range = 2, throw_range = 0)
+	explosion(strafed, light_impact_range = 2, flame_range = 2, throw_range = 0, explosion_cause=name)
 	if(length(strafelist))
 		addtimer(CALLBACK(src, PROC_REF(strafe_turfs), strafelist), 0.2 SECONDS)

--- a/code/datums/fire_support/missile.dm
+++ b/code/datums/fire_support/missile.dm
@@ -11,7 +11,7 @@
 	start_sound = null
 
 /datum/fire_support/cruise_missile/select_target(turf/target_turf)
-	explosion(target_turf, 4, 5, 6)
+	explosion(target_turf, 4, 5, 6, explosion_cause="cruise missile")
 
 /datum/fire_support/cruise_missile/unlimited
 	fire_support_type = FIRESUPPORT_TYPE_CRUISE_MISSILE_UNLIMITED
@@ -56,4 +56,4 @@
 		strength = victim.modify_by_armor(strength, BIO, 25)
 		victim.apply_radiation(strength, sound_level)
 
-	explosion(target_turf, 0, 1, 0, 4)
+	explosion(target_turf, 0, 1, 0, 4, explosion_cause=name)

--- a/code/datums/fire_support/mortar.dm
+++ b/code/datums/fire_support/mortar.dm
@@ -15,7 +15,7 @@
 	start_sound = 'sound/weapons/guns/misc/mortar_long_whistle.ogg'
 
 /datum/fire_support/mortar/do_impact(turf/target_turf)
-	explosion(target_turf, 0, 2, 3, 5, 2)
+	explosion(target_turf, 0, 2, 3, 5, 2, explosion_cause="mortar fire support")
 
 /datum/fire_support/mortar/som
 	fire_support_type = FIRESUPPORT_TYPE_HE_MORTAR_SOM
@@ -31,7 +31,7 @@
 	initiate_screen_message = "Coordinates confirmed, incendiary inbound!"
 
 /datum/fire_support/mortar/incendiary/do_impact(turf/target_turf)
-	explosion(target_turf, weak_impact_range = 4, flame_range = 5, throw_range = 0)
+	explosion(target_turf, weak_impact_range = 4, flame_range = 5, throw_range = 0, explosion_cause="incen mortar fire support")
 	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35)
 
 /datum/fire_support/mortar/incendiary/som

--- a/code/datums/fire_support/rockets.dm
+++ b/code/datums/fire_support/rockets.dm
@@ -9,7 +9,7 @@
 	initiate_screen_message = "Rockets hot, incoming!"
 
 /datum/fire_support/rockets/do_impact(turf/target_turf)
-	explosion(target_turf, 0, 2, 4, 6, 2)
+	explosion(target_turf, 0, 2, 4, 6, 2, explosion_cause=name)
 
 /datum/fire_support/rockets/unlimited
 	fire_support_type = FIRESUPPORT_TYPE_ROCKETS_UNLIMITED
@@ -29,4 +29,4 @@
 	uses = 2
 
 /datum/fire_support/incendiary_rockets/do_impact(turf/target_turf)
-	explosion(target_turf, weak_impact_range = 4, flame_range = 4, throw_range = 2)
+	explosion(target_turf, weak_impact_range = 4, flame_range = 4, throw_range = 2, explosion_cause=name)

--- a/code/datums/gamemodes/campaign/missions/raiding_base.dm
+++ b/code/datums/gamemodes/campaign/missions/raiding_base.dm
@@ -216,7 +216,7 @@
 	ob_called = TRUE
 	resume_mission_timer(src, TRUE)
 	//We handle this here instead of the beacon structure because it could be destroyed before this triggers
-	explosion(location, 45, flame_range = 20)
+	explosion(location, 45, flame_range = 20, explosion_cause="beacon explosion")
 	if(QDELETED(beacon))
 		return
 	qdel(beacon)

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -65,7 +65,7 @@
 		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
 		appendage.droplimb()
-	explosion(target, 2, 2, 6, 7, 5, 5)
+	explosion(target, 2, 2, 6, 7, 5, 5, explosion_cause=activator)
 	qdel(src)
 
 /obj/item/clothing/suit/storage/marine/boomvest/attack_hand_alternate(mob/living/user)
@@ -114,7 +114,7 @@
 		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
 		appendage.droplimb()
-	explosion(target, 15, 0, 0, 0, 15, 15)
+	explosion(target, 15, 0, 0, 0, 15, 15, explosion_cause=activator)
 	qdel(src)
 
 /obj/item/clothing/suit/storage/marine/boomvest/fast

--- a/code/game/objects/items/explosives/grenades/bullet_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/bullet_grenade.dm
@@ -65,5 +65,5 @@
 	ammo_type = /datum/ammo/bullet/hefa_buckshot
 
 /obj/item/explosive/grenade/bullet/hefa/prime()
-	explosion(loc, light_impact_range = 2, heavy_impact_range = 1)
+	explosion(loc, light_impact_range = 2, heavy_impact_range = 1, explosion_cause=src)
 	return ..()

--- a/code/game/objects/items/explosives/grenades/explosive_grenades.dm
+++ b/code/game/objects/items/explosives/grenades/explosive_grenades.dm
@@ -81,7 +81,7 @@
 	if(!.)
 		return
 	if(launched && active && !istype(hit_atom, /turf/open)) //Only contact det if active, we actually hit something, and we're fired from a grenade launcher.
-		explosion(loc, light_impact_range = 1, flash_range = 2)
+		explosion(loc, light_impact_range = 1, flash_range = 2, explosion_cause="thrown by someone")
 		qdel(src)
 
 /obj/item/explosive/grenade/creampie

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -97,7 +97,7 @@
 	notify_ai_hazard()
 	return TRUE
 
-///Detonation effects
+///Detonation effects TODO MAKE THIS PASS THE USER TO EXPLOSION FOR LOGGING
 /obj/item/explosive/grenade/proc/prime()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/idiot = loc
@@ -114,7 +114,7 @@
 			idiot.emote("scream")
 			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[idiot.ckey]
 			personal_statistics.grenade_hand_delimbs ++
-	explosion(loc, light_impact_range = src.light_impact_range, weak_impact_range = src.weak_impact_range)
+	explosion(loc, light_impact_range = src.light_impact_range, weak_impact_range = src.weak_impact_range, explosion_cause=src)
 	qdel(src)
 
 ///Adjusts det time, used for grenade launchers

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -188,7 +188,7 @@ Stepping directly on the mine will also blow it up
 	if(triggered)
 		return
 	triggered = TRUE
-	explosion(tripwire ? tripwire.loc : loc, light_impact_range = 3)
+	explosion(tripwire ? tripwire.loc : loc, light_impact_range = 3, explosion_cause=src)
 	QDEL_NULL(tripwire)
 	qdel(src)
 
@@ -252,7 +252,7 @@ Stepping directly on the mine will also blow it up
 	if(triggered)
 		return
 	triggered = TRUE
-	explosion(tripwire ? tripwire.loc : loc, 2, 0, 0, 4)
+	explosion(tripwire ? tripwire.loc : loc, 2, 0, 0, 4, explosion_cause=src)
 	QDEL_NULL(tripwire)
 	qdel(src)
 

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -157,7 +157,7 @@
 		explosion(plant_target, flash_range = 1) //todo: place as abuse of explosion
 		qdel(src)
 		return
-	explosion(plant_target, 0, 0, 1, 0, 0, 0, 1, 0, 1)
+	explosion(plant_target, 0, 0, 1, 0, 0, 0, 1, 0, 1, explosion_cause=src)
 	playsound(plant_target, SFX_EXPLOSION_SMALL, 100, FALSE, 25)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	smoke.set_up(smokeradius, plant_target, 2)

--- a/code/game/objects/items/power_cells.dm
+++ b/code/game/objects/items/power_cells.dm
@@ -222,13 +222,12 @@
 
 ///Explodes, scaling with cell charge
 /obj/item/cell/proc/explode()
-	var/turf/epicenter = get_turf(src)
 
 	var/heavy_impact_range = clamp(round(sqrt(charge) * 0.01), 0, 3)
 	var/light_impact_range = clamp(round(sqrt(charge) * 0.15), 0, 4)
 	var/flash_range = clamp(round(sqrt(charge) * 0.05), -1, 4)
 
-	explosion(epicenter, 0, heavy_impact_range, light_impact_range, 0, flash_range)
+	explosion(src, 0, heavy_impact_range, light_impact_range, 0, flash_range)
 
 	QDEL_IN(src, 1)
 

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -369,11 +369,11 @@
 	plant_target.ex_act(EXPLODE_DEVASTATE)
 	plant_target = null
 	if(det_mode == TRUE) //If we're on demolition mode, big boom.
-		explosion(det_location, 0, 7, 9, 0, 7)
+		explosion(det_location, 0, 7, 9, 0, 7, explosion_cause=src) // TODO PASS THE USER HERE
 	else //if we're not, focused boom.
 		if(iswallturf(det_location)) //Breach the other side of the wall if planted on one
 			det_location = get_step(det_location, boom_direction)
-		explosion(det_location, 3, 4, 4, 0, 4)
+		explosion(det_location, 3, 4, 4, 0, 4, explosion_cause=src) // TODO PASS THE USER HERE
 	qdel(src)
 
 /obj/item/detpack/attack(mob/M as mob, mob/user as mob, def_zone)

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -377,7 +377,7 @@
 		if(T.welding)
 			balloon_alert(user, "That was stupid")
 			log_bomber(user, "triggered a weldpack explosion", src)
-			explosion(src, light_impact_range = 3)
+			explosion(src, light_impact_range = 3, explosion_cause=user)
 			qdel(src)
 		if(T.get_fuel() == T.max_fuel || !reagents.total_volume)
 			return ..()

--- a/code/game/objects/machinery/bots/roomba.dm
+++ b/code/game/objects/machinery/bots/roomba.dm
@@ -88,9 +88,9 @@
 		return
 	tgui_alert(user, "Are you really sure to want to try your luck with the devilish roomba?", "The roomba roulette", list("Yes", "Yes!", "Yes?"))
 	if(prob(50))
-		explosion(user, 1, throw_range = "[user] lost at the roomba roulette")
-		return
-	explosion(src, 1, throw_range = "[user] won at the roomba roulette")
+		explosion(user, 1, throw_range = "[user] lost at the roomba roulette", explosion_cause=user)
+		return // TODO WHO THE FUCK IS PASSING A STRING AS AN ARG DUDE
+	explosion(src, 1, throw_range = "[user] won at the roomba roulette", explosion_cause=user)
 	qdel(src)
 
 /obj/machinery/bot/roomba/attackby(obj/item/I, mob/living/user, def_zone)

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 ///Do the stuff when it "hits the ground"
 /obj/structure/droppod/proc/dodrop(turf/targetturf, mob/user)
 	deadchat_broadcast(" has landed at [get_area(targetturf)]!", src, user ? user : null, targetturf)
-	explosion(targetturf, light_impact_range = 2)
+	explosion(targetturf, light_impact_range = 2, explosion_cause=user)
 	playsound(targetturf, 'sound/effects/droppod_impact.ogg', 100)
 	QDEL_NULL(reserved_area)
 	addtimer(CALLBACK(src, PROC_REF(completedrop), user), 7) //dramatic effect
@@ -539,7 +539,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 
 /obj/structure/droppod/nonmob/mech_pod/dodrop(turf/targetturf, mob/user)
 	deadchat_broadcast(" has landed at [get_area(targetturf)]!", src, stored_object ? stored_object : null)
-	explosion(targetturf, 1, 2) //A mech just dropped onto your head from orbit
+	explosion(targetturf, 1, 2, explosion_cause=user) //A mech just dropped onto your head from orbit
 	playsound(targetturf, 'sound/effects/droppod_impact.ogg', 100)
 	QDEL_NULL(reserved_area)
 	addtimer(CALLBACK(src, PROC_REF(completedrop), user), 7) //dramatic effect

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -301,7 +301,7 @@
 
 /obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, color = COLOR_CYAN)//no messaging admin, that'd spam them.
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, color = COLOR_CYAN, explosion_cause="railgun")//no messaging admin, that'd spam them.
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last railgun has fired and impacted the ground.
 
@@ -394,7 +394,7 @@
 
 /obj/structure/ship_ammo/cas/rocket/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
 	qdel(src)
 
 //ATGMs, defined by 3 second travel time and tight explosion sizes.
@@ -440,7 +440,7 @@
 
 /obj/structure/ship_ammo/cas/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
 	flame_radius(fire_range, impact, 30, 60) //cooking for a long time
 	var/datum/effect_system/smoke_spread/phosphorus/warcrime = new
 	warcrime.set_up(fire_range + 1, impact, 7)
@@ -467,7 +467,7 @@
 
 /obj/structure/ship_ammo/cas/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range) //more spread out, with flames
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range, explosion_cause=src) //more spread out, with flames
 	qdel(src)
 
 //The fatty is well.. Fat.
@@ -486,7 +486,7 @@
 
 /obj/structure/ship_ammo/cas/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range) //first explosion is small to trick xenos into thinking its a minirocket.
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src) //first explosion is small to trick xenos into thinking its a minirocket.
 	addtimer(CALLBACK(src, PROC_REF(delayed_detonation), impact), 3 SECONDS)
 
 /**
@@ -502,7 +502,7 @@
 		var/list/coords = impact_coords[i]
 		var/turf/detonation_target = locate(impact.x+coords[1],impact.y+coords[2],impact.z)
 		detonation_target.ceiling_debris_check(2)
-		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)
+		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, explosion_cause=src)
 	qdel(src)
 
 // This is the "Default" heavy rocket.
@@ -557,7 +557,7 @@
 
 /obj/structure/ship_ammo/cas/minirocket/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)//no messaging admin, that'd spam them.
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
@@ -614,7 +614,7 @@
 
 /obj/structure/ship_ammo/cas/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0, explosion_cause=src)
 	var/datum/effect_system/smoke_spread/plasmaloss/S = new
 	S.set_up(9, impact, 9)// Between grenade and mortar
 	S.start()
@@ -665,7 +665,7 @@
 
 /obj/structure/ship_ammo/cas/bomb/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE)//no messaging admin, that'd spam them.
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
 
 // Four hundos have no real gimmick beyond being a bigger payload.
 /obj/structure/ship_ammo/cas/bomb/fourhundred
@@ -720,7 +720,7 @@
 
 /obj/structure/ship_ammo/cas/bomblet/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, heavy_explosion_range, light_explosion_range, adminlog = FALSE)//no messaging admin, that'd spam them.
+	explosion(impact, heavy_explosion_range, light_explosion_range, explosion_cause=src)
 
 /obj/structure/ship_ammo/cas/bomblet/medium
 	name = "\improper AOE-75lb 'Poppies' stack"

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -344,7 +344,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 
 
 /obj/structure/ob_ammo/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	explosion(loc, light_impact_range = 2, flash_range = 3, flame_range = 2)
+	explosion(loc, light_impact_range = 2, flash_range = 3, flame_range = 2, explosion_cause=blame_mob)
 	return ..()
 
 
@@ -363,7 +363,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 
 /obj/structure/ob_ammo/warhead/explosive/warhead_impact(turf/target, inaccuracy_amt = 0)
 	. = ..()
-	explosion(target, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 0, 15 - inaccuracy_amt)
+	explosion(target, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 0, 15 - inaccuracy_amt, explosion_cause=src)
 
 
 
@@ -394,7 +394,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	var/total_amt = max(25 - inaccuracy_amt, 20)
 	for(var/i = 1 to total_amt)
 		var/turf/U = pick_n_take(turf_list)
-		explosion(U, 2, 4, 6, 0, 6, throw_range = 0, adminlog = FALSE) //rocket barrage
+		explosion(U, 2, 4, 6, 0, 6, throw_range = 0, explosion_cause=src)
 		sleep(0.1 SECONDS)
 
 /obj/structure/ob_ammo/warhead/plasmaloss

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -188,11 +188,11 @@
 		return
 	exploding = TRUE
 	if (reagents.total_volume > 500)
-		explosion(loc, light_impact_range = 4, flame_range = 4)
+		explosion(loc, light_impact_range = 4, flame_range = 4, explosion_cause="fueltank explosion")
 	else if (reagents.total_volume > 100)
-		explosion(loc, light_impact_range = 3, flame_range = 3)
+		explosion(loc, light_impact_range = 3, flame_range = 3, explosion_cause="fueltank explosion")
 	else
-		explosion(loc, light_impact_range = 2, flame_range = 2)
+		explosion(loc, light_impact_range = 2, flame_range = 2, explosion_cause="fueltank explosion")
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(burn_level)
@@ -238,13 +238,13 @@
 
 	if(reagents.total_volume > 500)
 		flame_radius(5, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 5)
+		explosion(loc, light_impact_range = 5, explosion_cause="xfueltank explosion")
 	else if(reagents.total_volume > 100)
 		flame_radius(4, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 4)
+		explosion(loc, light_impact_range = 4, explosion_cause="xfueltank explosion")
 	else
 		flame_radius(3, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 3)
+		explosion(loc, light_impact_range = 3, explosion_cause="xfueltank explosion")
 
 	qdel(src)
 

--- a/code/game/objects/structures/supplypod.dm
+++ b/code/game/objects/structures/supplypod.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(pod_styles, list(\
 
 	var/explosion_sum = B[1] + B[2] + B[3] + B[4]
 	if(explosion_sum != 0)
-		explosion(get_turf(src), B[1], B[2], B[3], 0, B[4])
+		explosion(get_turf(src), B[1], B[2], B[3], 0, B[4], explosion_cause=src)
 	else if(!effectQuiet)
 		playsound(src, "explosion", landingSound ? 15 : 80, 1)
 

--- a/code/game/objects/structures/vehicle_props.dm
+++ b/code/game/objects/structures/vehicle_props.dm
@@ -7,15 +7,15 @@
 	///used to determine the probability that a car will detonate upon being destroyed
 	var/explosion_probability = 1
 
-/obj/structure/prop/urban/vehicles/Destroy()
-	explode()
+/obj/structure/prop/urban/vehicles/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
+	explode(blame_mob)
 	return ..()
 
 ///spawns a bunch of debris and plays a sound when a vehicle is wrecked
-/obj/structure/prop/urban/vehicles/proc/explode()
+/obj/structure/prop/urban/vehicles/proc/explode(mob/blame_mob)
 	src.visible_message(span_danger("<B>[src] blows apart!</B>"), null, null, 1)
 	if(prob(explosion_probability))
-		explosion(loc, light_impact_range = 3, flame_range = 2)
+		explosion(loc, light_impact_range = 3, flame_range = 2, explosion_cause=blame_mob)
 	playsound(loc, 'sound/effects/car_crush.ogg', 25)
 	var/turf/Tsec = get_turf(src)
 	new /obj/item/stack/rods(Tsec)

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -434,11 +434,11 @@ ADMIN_VERB(drop_bomb, R_FUN, "Drop Bomb", "Cause an explosion of varying strengt
 			new /obj/effect/overlay/temp/blinking_laser (user.mob.loc)
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(delayed_detonate_bomb_napalm), get_turf(user.mob.loc)), 1 SECONDS)
 		if("Small Bomb")
-			explosion(user.mob.loc, 1, 2, 3, 0, 3)
+			explosion(user.mob.loc, 1, 2, 3, 0, 3, explosion_cause=key_name_admin(user))
 		if("Medium Bomb")
-			explosion(user.mob.loc, 2, 3, 4, 0, 4)
+			explosion(user.mob.loc, 2, 3, 4, 0, 4, explosion_cause=key_name_admin(user))
 		if("Big Bomb")
-			explosion(user.mob.loc, 3, 5, 7, 0, 5)
+			explosion(user.mob.loc, 3, 5, 7, 0, 5, explosion_cause=key_name_admin(user))
 		if("Maxcap")
 			explosion(user.mob.loc, GLOB.MAX_EX_DEVESTATION_RANGE, GLOB.MAX_EX_HEAVY_RANGE, GLOB.MAX_EX_LIGHT_RANGE, 0, GLOB.MAX_EX_FLASH_RANGE)
 		if("Custom Bomb")
@@ -458,7 +458,7 @@ ADMIN_VERB(drop_bomb, R_FUN, "Drop Bomb", "Cause an explosion of varying strengt
 			input_flame_range = clamp(input_flame_range, 0, world_max)
 			switch(tgui_alert(user, "Deploy payload?", "DIR: [input_devastation_range] | HIR: [input_heavy_impact_range] | LIR: [input_light_impact_range] | FshR: [input_flash_range] | FlmR: [input_flame_range] | ThR: [input_throw_range]", list("Launch!", "Cancel")))
 				if("Launch!")
-					explosion(user.mob.loc, input_devastation_range, input_heavy_impact_range, input_light_impact_range, 0, input_flash_range, input_flame_range, input_throw_range)
+					explosion(user.mob.loc, input_devastation_range, input_heavy_impact_range, input_light_impact_range, 0, input_flash_range, input_flame_range, input_throw_range, explosion_cause=key_name_admin(user))
 				else
 					return
 			choice = "[choice] ([input_devastation_range], [input_heavy_impact_range], [input_light_impact_range], 0, [input_flash_range], [input_flame_range])" //For better logging.
@@ -471,11 +471,11 @@ ADMIN_VERB(drop_bomb, R_FUN, "Drop Bomb", "Cause an explosion of varying strengt
 /proc/delayed_detonate_bomb(turf/impact, input_devastation_range, input_heavy_impact_range, input_light_impact_range, input_flash_range, input_flame_range, input_throw_range, ceiling_debris)
 	if(ceiling_debris)
 		impact.ceiling_debris_check(ceiling_debris)
-	explosion(impact, input_devastation_range, input_heavy_impact_range, input_light_impact_range, 0, input_flash_range, input_flame_range, input_throw_range)
+	explosion(impact, input_devastation_range, input_heavy_impact_range, input_light_impact_range, 0, input_flash_range, input_flame_range, input_throw_range, explosion_cause="delayed admin explosion")
 
 /proc/delayed_detonate_bomb_fatty(turf/impact)
 	impact.ceiling_debris_check(2)
-	explosion(impact, 2, 3, 4)
+	explosion(impact, 2, 3, 4, explosion_cause="delayed admin fatty")
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(delayed_detonate_bomb_fatty_final), impact), 3 SECONDS)
 
 /proc/delayed_detonate_bomb_fatty_final(turf/impact)
@@ -484,11 +484,11 @@ ADMIN_VERB(drop_bomb, R_FUN, "Drop Bomb", "Cause an explosion of varying strengt
 		var/list/coords = impact_coords[i]
 		var/turf/detonation_target = locate(impact.x+coords[1],impact.y+coords[2],impact.z)
 		detonation_target.ceiling_debris_check(2)
-		explosion(detonation_target, 2, 3, 4, adminlog = FALSE)
+		explosion(detonation_target, 2, 3, 4, adminlog = FALSE, explosion_cause="delayed admin decondary bombs")
 
 /proc/delayed_detonate_bomb_napalm(turf/impact)
 	impact.ceiling_debris_check(3)
-	explosion(impact, 2, 3, 4, 0, 6)
+	explosion(impact, 2, 3, 4, 0, 6, explosion_cause="delayed admin napalm")
 	flame_radius(5, impact, 30, 60)
 
 ADMIN_VERB(drop_dynex_bomb, R_FUN, "Drop DynEx Bomb", "Cause an explosion of varying strength at your location.", ADMIN_CATEGORY_FUN)

--- a/code/modules/admin/smites/bsa.dm
+++ b/code/modules/admin/smites/bsa.dm
@@ -10,7 +10,7 @@
 /datum/smite/bsa/effect(client/user, mob/living/target)
 	. = ..()
 
-	explosion(target.loc)
+	explosion(target.loc, explosion_cause=key_name_admin(user))
 
 	var/turf/open/floor/target_turf = get_turf(target)
 	if (istype(target_turf))

--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -28,6 +28,6 @@
 	var/left_click = pa.Find("left")
 
 	if(left_click)
-		explosion(object, devastation, heavy, light, 0, flash, throw_range = throw_input, adminlog = FALSE, silent = TRUE)
+		explosion(object, devastation, heavy, light, 0, flash, throw_range = throw_input, adminlog = FALSE, silent = TRUE, explosion_cause=key_name(c))
 		to_chat(c, span_notice("Success."))
 		log_admin("Build Mode: [key_name(c)] caused an explosion(dev=[devastation], hvy=[heavy], lgt=[light], flash=[flash]) at [AREACOORD(object)]")

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -195,7 +195,7 @@
 					empulse(src.loc, 3, 8, 1)
 			if (overcharge_percent >= 150)
 				if (prob(1))
-					explosion(loc, 1, 2, 4, 0, 5)
+					explosion(loc, 1, 2, 4, 0, 5, explosion_cause="overcharged smes")
 		if ((3.6e6+1) to INFINITY)
 			if (overcharge_percent >= 115)
 				if (prob(8))
@@ -207,7 +207,7 @@
 					empulse(src.loc, 4, 10, 1)
 			if (overcharge_percent >= 140)
 				if (prob(1))
-					explosion(loc, 2, 4, 6, 0, 8)
+					explosion(loc, 2, 4, 6, 0, 8, explosion_cause="overcharged smes")
 		else //how the hell was this proc called for negative charge
 			charge = 0
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -412,7 +412,7 @@
 	addtimer(CALLBACK(src, PROC_REF(delayed_explosion)), 0.5 SECONDS)
 
 /obj/machinery/light/proc/delayed_explosion()
-	explosion(loc, 0, 1, 3, 0, 2)
+	explosion(loc, 0, 1, 3, 0, 2, explosion_cause=src)
 	qdel(src)
 
 //types

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -191,7 +191,7 @@
 		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/power/port_gen/pacman/proc/overheat()
-	explosion(loc, 3, 6)
+	explosion(loc, 3, 6, explosion_cause=src)
 
 /obj/machinery/power/port_gen/pacman/attackby(obj/item/O, mob/user, params)
 	if(istype(O, sheet_path))
@@ -289,7 +289,7 @@
 	time_per_sheet = 85
 
 /obj/machinery/power/port_gen/pacman/super/overheat()
-	explosion(loc, 4)
+	explosion(loc, 4, explosion_cause=src)
 
 /obj/machinery/power/port_gen/pacman/mrs
 	name = "\improper M.R.S.P.A.C.M.A.N.-type portable generator"
@@ -301,7 +301,7 @@
 	time_per_sheet = 80
 
 /obj/machinery/power/port_gen/pacman/mrs/overheat()
-	explosion(loc, 4)
+	explosion(loc, 4, explosion_cause=src)
 
 /obj/machinery/power/port_gen/pacman/mobile_power
 	name = "\improper A.D.V.P.A.C.M.A.N.-type portable generator"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -376,7 +376,7 @@
 			var/datum/effect_system/smoke_spread/smoke = new(src)
 			smoke.set_up(1, loc)
 			smoke.start()
-			explosion(loc, light_impact_range = 2, flash_range = 3)
+			explosion(loc, light_impact_range = 2, flash_range = 3, explosion_cause=src)
 			qdel(src)
 			return
 		if(prob(15)) //Power drain

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -148,7 +148,7 @@
 						visible_message("Magnetic containment stabilised.")
 						return
 					visible_message("DANGER! Magnetic containment field failure in 3 ... 2 ... 1 ...")
-					explosion(loc, 2, 3, 5, 0, 8)
+					explosion(loc, 2, 3, 5, 0, 8, explosion_cause=src)
 					// Not sure if this is necessary, but just in case the SMES *somehow* survived..
 					qdel(src)
 

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -110,7 +110,7 @@
 	proj.proj_max_range -= 2
 
 /datum/ammo/energy/bfg/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 0)
+	explosion(T, 0, 0, 4, 0, 0, explosion_cause=src)
 
 /datum/ammo/energy/bfg/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
@@ -609,7 +609,7 @@
 	max_range = 12
 
 /datum/ammo/energy/plasma/blast/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE)
+	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE, explosion_cause=src)
 
 /datum/ammo/energy/plasma/blast/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
@@ -632,7 +632,7 @@
 	var/melting_stacks = 2
 
 /datum/ammo/energy/plasma/blast/melting/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 4, color = COLOR_DISABLER_BLUE)
+	explosion(T, weak_impact_range = 4, color = COLOR_DISABLER_BLUE, explosion_cause=src)
 	for(var/mob/living/living_victim in viewers(3, T)) //normally using viewers wouldn't work due to darkness and smoke both blocking vision. However explosions clear both temporarily so we avoid this issue.
 		var/datum/status_effect/stacking/melting/debuff = living_victim.has_status_effect(STATUS_EFFECT_MELTING)
 		if(debuff)
@@ -648,7 +648,7 @@
 	ammo_behavior_flags = AMMO_ENERGY
 
 /datum/ammo/energy/plasma/blast/shatter/drop_nade(turf/T)
-	explosion(T, light_impact_range = 2, weak_impact_range = 5, throw_range = 0, color = COLOR_DISABLER_BLUE)
+	explosion(T, light_impact_range = 2, weak_impact_range = 5, throw_range = 0, color = COLOR_DISABLER_BLUE, explosion_cause=src)
 	for(var/mob/living/living_victim in viewers(3, T))
 		living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, 5 SECONDS)
 

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -205,7 +205,7 @@
 	max_range = 21
 
 /datum/ammo/bullet/sarden/high_explosive/drop_nade(turf/T)
-	explosion(T, light_impact_range = 2, weak_impact_range = 4)
+	explosion(T, light_impact_range = 2, weak_impact_range = 4, explosion_cause=src)
 
 /datum/ammo/bullet/sarden/high_explosive/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/target_turf = get_turf(target_mob)

--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -34,7 +34,7 @@
 	max_range = 30
 
 /datum/ammo/rocket/mech/drop_nade(turf/T)
-	explosion(T, 0, 0, 5, 0, 5)
+	explosion(T, 0, 0, 5, 0, 5, explosion_cause=src)
 
 /*
 //================================================

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -18,13 +18,13 @@
 	bullet_color = COLOR_VERY_SOFT_YELLOW
 
 /datum/ammo/mortar/drop_nade(turf/T)
-	explosion(T, 1, 2, 5, 0, 3)
+	explosion(T, 1, 2, 5, 0, 3, explosion_cause=src)
 
 /datum/ammo/mortar/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(target_turf)
 
 /datum/ammo/mortar/incend/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 7, throw_range = 0)
+	explosion(T, 0, 2, 3, 0, 7, throw_range = 0, explosion_cause=src)
 	flame_radius(4, T)
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
@@ -34,7 +34,7 @@
 
 /datum/ammo/mortar/smoke/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 0, throw_range = 0)
+	explosion(T, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(10, T, 11)
 	smoke.start()
@@ -51,10 +51,10 @@
 	icon_state = "howi"
 
 /datum/ammo/mortar/howi/drop_nade(turf/T)
-	explosion(T, 1, 6, 7, 0, 12)
+	explosion(T, 1, 6, 7, 0, 12, explosion_cause=src)
 
 /datum/ammo/mortar/howi/incend/drop_nade(turf/T)
-	explosion(T, 0, 3, 0, 0, 0, 3, throw_range = 0)
+	explosion(T, 0, 3, 0, 0, 0, 3, throw_range = 0, explosion_cause=src)
 	flame_radius(5, T)
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
@@ -67,7 +67,7 @@
 
 /datum/ammo/mortar/smoke/howi/wp/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 0, throw_range = 0)
+	explosion(T, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(6, T, 7)
 	smoke.start()
@@ -79,7 +79,7 @@
 
 /datum/ammo/mortar/smoke/howi/plasmaloss/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 5, 0, 0, throw_range = 0)
+	explosion(T, 0, 0, 5, 0, 0, throw_range = 0, explosion_cause=src)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(10, T, 11)
 	smoke.start()
@@ -90,10 +90,10 @@
 	shell_speed = 1.5
 
 /datum/ammo/mortar/rocket/drop_nade(turf/T)
-	explosion(T, 1, 2, 5, 0, 3)
+	explosion(T, 1, 2, 5, 0, 3, explosion_cause=src)
 
 /datum/ammo/mortar/rocket/incend/drop_nade(turf/T)
-	explosion(T, 0, 3, 0, 0, 3, throw_range = 0)
+	explosion(T, 0, 3, 0, 0, 3, throw_range = 0, explosion_cause=src)
 	flame_radius(5, T)
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
@@ -107,7 +107,7 @@
 
 /datum/ammo/mortar/rocket/smoke/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 3, throw_range = 0)
+	explosion(T, 0, 0, 1, 0, 3, throw_range = 0, explosion_cause=src)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(10, T, 11)
 	smoke.start()
@@ -116,10 +116,10 @@
 	shell_speed = 2.5
 
 /datum/ammo/mortar/rocket/mlrs/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 2)
+	explosion(T, 0, 0, 4, 0, 2, explosion_cause=src)
 
 /datum/ammo/mortar/rocket/mlrs/incendiary/drop_nade(turf/T)
-	explosion(T, 0, 0, 2, 0, 2)
+	explosion(T, 0, 0, 2, 0, 2, explosion_cause=src)
 	flame_radius(3, T)
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
@@ -129,7 +129,7 @@
 
 /datum/ammo/mortar/rocket/smoke/mlrs/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 2, 0, 0, throw_range = 0)
+	explosion(T, 0, 0, 2, 0, 0, throw_range = 0, explosion_cause=src)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(5, T, 6)
 	smoke.start()

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -25,7 +25,7 @@
 	barricade_clear_distance = 2
 
 /datum/ammo/rocket/drop_nade(turf/T)
-	explosion(T, 0, 4, 6, 0, 2)
+	explosion(T, 0, 4, 6, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -56,7 +56,7 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG // We want this one to specifically go over onscreen range.
 
 /datum/ammo/rocket/he/unguided/drop_nade(turf/T)
-	explosion(T, 0, 7, 0, 0, 2, throw_range = 4)
+	explosion(T, 0, 7, 0, 0, 2, throw_range = 4, explosion_cause=src)
 
 /datum/ammo/rocket/ap
 	name = "kinetic penetrator"
@@ -68,7 +68,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/ap/drop_nade(turf/T)
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/ltb
 	name = "cannon round"
@@ -83,7 +83,7 @@
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3)
+	explosion(T, 0, 2, 5, 0, 3, explosion_cause=src)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -95,7 +95,7 @@
 	drop_nade(target_turf)
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
-	explosion(target_turf, 1, 4, 6, 0, 3)
+	explosion(target_turf, 1, 4, 6, 0, 3, explosion_cause=src)
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"
@@ -111,7 +111,7 @@
 	handful_amount = 1
 
 /datum/ammo/rocket/heavy_isg/drop_nade(turf/T)
-	explosion(T, 0, 7, 8, 12)
+	explosion(T, 0, 7, 8, 12, explosion_cause=src)
 
 /datum/ammo/rocket/heavy_isg/unguided
 	hud_state = "bigshell_he_unguided"
@@ -221,7 +221,7 @@
 	sundering = 50
 
 /datum/ammo/rocket/recoilless/drop_nade(turf/T)
-	explosion(T, 0, 3, 4, 0, 2)
+	explosion(T, 0, 3, 4, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/recoilless/heat
 	name = "HEAT shell"
@@ -233,7 +233,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/recoilless/heat/drop_nade(turf/T)
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/recoilless/heat/mech //for anti mech use in HvH
 	name = "HEAM shell"
@@ -247,7 +247,7 @@
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
 /datum/ammo/rocket/recoilless/heat/mech/drop_nade(turf/T)
-	explosion(T, 0, 1, 0, 0, 1)
+	explosion(T, 0, 1, 0, 0, 1, explosion_cause=src)
 
 /datum/ammo/rocket/recoilless/light
 	name = "light explosive shell"
@@ -261,7 +261,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/recoilless/light/drop_nade(turf/T)
-	explosion(T, 0, 1, 8, 0, 1)
+	explosion(T, 0, 1, 8, 0, 1, explosion_cause=src)
 
 /datum/ammo/rocket/recoilless/chemical
 	name = "low velocity chemical shell"
@@ -283,7 +283,7 @@
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(smokeradius, T, rand(5,9))
 	smoke.start()
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/recoilless/chemical/cloak
 	name = "low velocity chemical shell"
@@ -315,7 +315,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/recoilless/low_impact/drop_nade(turf/T)
-	explosion(T, 0, 1, 8, 0, 2)
+	explosion(T, 0, 1, 8, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/oneuse
 	name = "explosive rocket"
@@ -336,7 +336,7 @@
 	sundering = 20
 
 /datum/ammo/rocket/som/drop_nade(turf/T)
-	explosion(T, 0, 3, 6, 0, 2)
+	explosion(T, 0, 3, 6, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/som/light
 	name = "low impact RPG"
@@ -348,7 +348,7 @@
 	penetration = 10
 
 /datum/ammo/rocket/som/light/drop_nade(turf/T)
-	explosion(T, 0, 2, 7, 0, 2)
+	explosion(T, 0, 2, 7, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/som/thermobaric
 	name = "thermobaric RPG"
@@ -357,7 +357,7 @@
 	damage = 30
 
 /datum/ammo/rocket/som/thermobaric/drop_nade(turf/T)
-	explosion(T, 0, 4, 5, 0, 4, 4)
+	explosion(T, 0, 4, 5, 0, 4, 4, explosion_cause=src)
 
 /datum/ammo/rocket/som/heat //Anti tank, or mech
 	name = "HEAT RPG"
@@ -376,7 +376,7 @@
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
 /datum/ammo/rocket/som/heat/drop_nade(turf/T)
-	explosion(T, 0, 1, 0, 0, 1)
+	explosion(T, 0, 1, 0, 0, 1, explosion_cause=src)
 
 /datum/ammo/rocket/som/rad
 	name = "irrad RPG"
@@ -411,7 +411,7 @@
 		strength = victim.modify_by_armor(strength, BIO, 25)
 		victim.apply_radiation(strength, sound_level)
 
-	explosion(T, weak_impact_range = 4)
+	explosion(T, weak_impact_range = 4, explosion_cause=src)
 
 /datum/ammo/rocket/atgun_shell
 	name = "high explosive ballistic cap shell"
@@ -427,7 +427,7 @@
 	handful_amount = 1
 
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 2)
+	explosion(T, 0, 2, 3, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/atgun_shell/on_hit_turf(turf/target_turf, obj/projectile/proj) //no explosion every time it hits a turf
 	proj.proj_max_range -= 10
@@ -442,7 +442,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -465,7 +465,7 @@
 	sundering = 35
 
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
-	explosion(T, 0, 3, 5)
+	explosion(T, 0, 3, 5, explosion_cause=src)
 
 /datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
@@ -483,7 +483,7 @@
 	var/bonus_projectile_quantity = 10
 
 /datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/T)
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/det_turf = get_step_towards(target_mob, proj)
@@ -555,7 +555,7 @@
 	var/turn_rate = 5
 
 /datum/ammo/rocket/homing/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 4, 1)
+	explosion(T, 0, 2, 3, 4, 1, explosion_cause=src)
 
 /datum/ammo/rocket/homing/ammo_process(obj/projectile/proj, damage)
 	if(QDELETED(proj.original_target))
@@ -579,7 +579,7 @@
 	turn_rate = 10
 
 /datum/ammo/rocket/homing/microrocket/drop_nade(turf/T)
-	explosion(T, 0, 0, 0, 4, 1)
+	explosion(T, 0, 0, 0, 4, 1, explosion_cause=src)
 
 /datum/ammo/rocket/homing/tow
 	name = "TOW-III missile"
@@ -593,7 +593,7 @@
 	max_range = 30
 
 /datum/ammo/rocket/homing/tow/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 2)
+	explosion(T, 0, 0, 4, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/coilgun
 	name = "kinetic penetrator"
@@ -614,7 +614,7 @@
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/coilgun/drop_nade(turf/T)
-	explosion(T, 0, 3, 5, 0, 2)
+	explosion(T, 0, 3, 5, 0, 2, explosion_cause=src)
 
 /datum/ammo/rocket/coilgun/holder //only used for tankside effect checks
 	ammo_behavior_flags = AMMO_ENERGY
@@ -626,7 +626,7 @@
 	sundering = 5
 
 /datum/ammo/rocket/coilgun/low/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 4)
+	explosion(T, 0, 2, 3, 4, explosion_cause=src)
 
 /datum/ammo/rocket/coilgun/high
 	damage_falloff = 0
@@ -637,7 +637,7 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG|AMMO_PASS_THROUGH_MOB
 
 /datum/ammo/rocket/coilgun/high/drop_nade(turf/T)
-	explosion(T, 1, 4, 5, 6, 2)
+	explosion(T, 1, 4, 5, 6, 2, explosion_cause=src)
 
 /datum/ammo/rocket/coilgun/high/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(ishuman(target_mob) && prob(50)) //it only has AMMO_PASS_THROUGH_MOB so it can keep going if it gibs a mob
@@ -659,7 +659,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/icc_lowvel_heat/drop_nade(turf/T)
-	explosion(T, flash_range = 1)
+	explosion(T, flash_range = 1, explosion_cause=src)
 
 /datum/ammo/rocket/icc_lowvel_high_explosive
 	name = "Low Velocity HE shell"
@@ -670,4 +670,4 @@
 	shell_speed = 1
 
 /datum/ammo/rocket/icc_lowvel_high_explosive/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 2)
+	explosion(T, 0, 2, 3, 0, 2, explosion_cause=src)

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -136,7 +136,7 @@
 	penetration = 0
 
 /datum/ammo/bullet/shotgun/frag/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 2, tiny = TRUE)
+	explosion(T, weak_impact_range = 2, tiny = TRUE, explosion_cause=src)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(target_mob))

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -111,7 +111,7 @@
 	projectile_greyscale_colors = COLOR_AMMO_HIGH_EXPLOSIVE
 
 /datum/ammo/tx54/he/drop_nade(turf/T)
-	explosion(T, 0, 0, 1, 3, 1)
+	explosion(T, 0, 0, 1, 3, 1, explosion_cause=src)
 
 /datum/ammo/tx54/he/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	drop_nade(get_turf(target_mob))

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -219,7 +219,7 @@
 /obj/item/ammo_magazine/fire_act(burn_level)
 	if(!current_rounds)
 		return
-	explosion(loc, 0, 0, 0, 1, 1, throw_range = FALSE, tiny = TRUE)
+	explosion(loc, 0, 0, 0, 1, 1, throw_range = FALSE, tiny = TRUE, explosion_cause="ammo mag cookoff")
 	qdel(src)
 
 //Helper proc, to allow us to see a percentage of how full the magazine is.
@@ -498,7 +498,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/big_ammo_box/fire_act(burn_level)
 	if(!bullet_amount)
 		return
-	explosion(loc, 0, 0, 1, 0, 2, throw_range = FALSE) //blow it up.
+	explosion(loc, 0, 0, 1, 0, 2, throw_range = FALSE, explosion_cause="ammo box cookoff") //blow it up.
 	qdel(src)
 
 //Deployable shotgun ammo box

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 
 /obj/machinery/deployable/mounted/sentry/deconstruct(disassembled = TRUE, mob/living/blame_mob)
 	if(!disassembled)
-		explosion(loc, light_impact_range = 3)
+		explosion(loc, light_impact_range = 3, explosion_cause=blame_mob)
 	return ..()
 
 /obj/machinery/deployable/mounted/sentry/on_deconstruction()

--- a/code/modules/reagents/chemistry/recipes/other.dm
+++ b/code/modules/reagents/chemistry/recipes/other.dm
@@ -267,7 +267,7 @@
 	var/datum/effect_system/smoke_spread/bad/smoke = new
 	smoke.set_up((radius - 1), get_turf(holder.get_holder()), 2)
 	smoke.start()
-	explosion(get_turf(holder.get_holder()), light_impact_range = radius)
+	explosion(get_turf(holder.get_holder()), light_impact_range = radius, explosion_cause="gunpowder chem")
 
 
 /datum/chemical_reaction/explosive/anfo
@@ -278,5 +278,5 @@
 	var/radius = round(sqrt(created_volume* 0.25), 1) // should be a max of 2 tiles
 	if(radius > 2)
 		radius = 2 //enforced by a hardcap. Sorry!
-	explosion(get_turf(holder.get_holder()), heavy_impact_range = radius)
+	explosion(get_turf(holder.get_holder()), heavy_impact_range = radius, explosion_cause="anfo chem")
 

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -11,18 +11,6 @@
 	dheight = 15
 	hidden = TRUE  //To make them not block landings during distress
 
-// Big explosions
-
-/*	explosion(front, 3, 4, 7, 0)
-	explosion(rear, 3, 4, 7, 0)
-	explosion(left, 3, 4, 7, 0)
-	explosion(right, 3, 4, 7, 0)
-
-	explosion(front_right, 4, 6, 10, 0)
-	explosion(front_left, 4, 6, 10, 0)
-	explosion(rear_right, 4, 6, 10, 0)
-	explosion(rear_left, 3, 4, 7, 0)
-*/
 
 // -- Shuttles
 

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -188,7 +188,7 @@
 
 /obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
 	playsound(get_turf(src), SFX_EXPLOSION_LARGE, 100, TRUE) //destroy sound is normally very quiet
-	new /obj/effect/temp_visual/explosion(get_turf(src), 7, LIGHT_COLOR_LAVA, FALSE, TRUE, explosion_cause=blame_mob)
+	new /obj/effect/temp_visual/explosion(get_turf(src), 7, LIGHT_COLOR_LAVA, FALSE, TRUE)
 	for(var/mob/living/nearby_mob AS in occupants + cheap_get_living_near(src, 7))
 		shake_camera(nearby_mob, 4, 2)
 	if(istype(blame_mob) && blame_mob.ckey)

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -188,7 +188,7 @@
 
 /obj/vehicle/sealed/armored/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
 	playsound(get_turf(src), SFX_EXPLOSION_LARGE, 100, TRUE) //destroy sound is normally very quiet
-	new /obj/effect/temp_visual/explosion(get_turf(src), 7, LIGHT_COLOR_LAVA, FALSE, TRUE)
+	new /obj/effect/temp_visual/explosion(get_turf(src), 7, LIGHT_COLOR_LAVA, FALSE, TRUE, explosion_cause=blame_mob)
 	for(var/mob/living/nearby_mob AS in occupants + cheap_get_living_near(src, 7))
 		shake_camera(nearby_mob, 4, 2)
 	if(istype(blame_mob) && blame_mob.ckey)

--- a/code/modules/vehicles/armored/som_armored_weapons.dm
+++ b/code/modules/vehicles/armored/som_armored_weapons.dm
@@ -83,7 +83,7 @@
 		beam_turfs.Cut(beam_turfs.Find(impacted_turf))
 		stop_beam_turfs = RANGE_TURFS(1, impacted_turf)
 
-	explosion(target_turf, 0, 2, 5, 0, 3, 4, 4)
+	explosion(target_turf, 0, 2, 5, 0, 3, 4, 4, explosion_cause=current_firer)
 
 	QDEL_IN(source_turf.beam(target_turf, "volkite", beam_type = /obj/effect/ebeam/carronade), CARRONADE_BEAM_TIME)
 	QDEL_LIST_IN(light_effects, CARRONADE_BEAM_TIME)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -48,7 +48,7 @@
 	return TRUE
 
 /obj/vehicle/ridden/atv/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	explosion(src, devastation_range = -1, light_impact_range = 2, flame_range = 3, flash_range = 4)
+	explosion(src, devastation_range = -1, light_impact_range = 2, flame_range = 3, flash_range = 4, explosion_cause=blame_mob)
 	return ..()
 
 /obj/vehicle/ridden/atv/Destroy()

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -72,7 +72,7 @@
 	add_occupant(kidnapped, VEHICLE_CONTROL_KIDNAPPED)
 
 /obj/vehicle/sealed/car/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	explosion(src, heavy_impact_range = 1, light_impact_range = 2, flash_range = 3, adminlog = FALSE)
+	explosion(src, heavy_impact_range = 1, light_impact_range = 2, flash_range = 3, adminlog = FALSE, explosion_cause=blame_mob)
 	log_message("[src] exploded due to destruction", LOG_ATTACK)
 	return ..()
 

--- a/code/modules/vehicles/hover_bike.dm
+++ b/code/modules/vehicles/hover_bike.dm
@@ -72,7 +72,7 @@
 	return welder_repair_act(user, I, 15, 3 SECONDS, fuel_req = 1)
 
 /obj/vehicle/ridden/hover_bike/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	explosion(src, light_impact_range = 4, flame_range = (rand(33) ? 3 : 0))
+	explosion(src, light_impact_range = 4, flame_range = (rand(33) ? 3 : 0), explosion_cause=blame_mob)
 	return ..()
 
 /obj/vehicle/ridden/hover_bike/lava_act()

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -169,7 +169,7 @@
 	smoke.start()
 
 /obj/vehicle/ridden/motorbike/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	explosion(src, light_impact_range = 2, flash_range = 0)
+	explosion(src, light_impact_range = 2, flash_range = 0, explosion_cause=blame_mob)
 	return ..()
 
 /obj/vehicle/ridden/motorbike/Destroy()


### PR DESCRIPTION

## About The Pull Request
Added new args for 
protect_epicenter excludes the central turf from exploding
atom/explosion_cause string or atom that "caused" the explosion, used for improved logging. note isnt implemented to 100% usefulness but should help occasionally
explosion_direction = 0 angle to point explosion
explosion_arc = 360 angle to fire explosion in

this is sorta a tg port, but the only real 100% port thing is prepare_explosion_turfs
## Changelog
:cl:
code: added backend or directional explosions
admin: admin explosion logs will now try to provide an explosion cause or user to blame
/:cl:
