### PR TITLE
droid and turret faction checks

### DIFF
--- a/code/__HELPERS/ai.dm
+++ b/code/__HELPERS/ai.dm
@@ -113,6 +113,8 @@
 				continue
 			if((GLOB.faction_to_iff[attacker_faction] == nearby_turret.iff_signal))
 				continue
+			if(nearby_turret.faction == attacker_faction)
+				continue
 			if(get_dist(source, nearby_turret) >= shorter_distance)
 				continue
 			if(need_los && !line_of_sight(source, nearby_turret))
@@ -132,6 +134,8 @@
 	if(target_flags & TARGET_UNMANNED_VEHICLE)
 		for(var/atom/nearby_unmanned AS in GLOB.unmanned_vehicles)
 			if(source.z != nearby_unmanned.z)
+				continue
+			if(nearby_unmanned.faction == attacker_faction)
 				continue
 			if(get_dist(source, nearby_unmanned) >= shorter_distance)
 				continue

--- a/code/__HELPERS/ai.dm
+++ b/code/__HELPERS/ai.dm
@@ -132,7 +132,7 @@
 			nearest_target = nearby_vehicle
 			shorter_distance = get_dist(source, nearby_vehicle)
 	if(target_flags & TARGET_UNMANNED_VEHICLE)
-		for(var/atom/nearby_unmanned AS in GLOB.unmanned_vehicles)
+		for(var/obj/vehicle/unmanned/nearby_unmanned AS in GLOB.unmanned_vehicles)
 			if(source.z != nearby_unmanned.z)
 				continue
 			if(nearby_unmanned.faction == attacker_faction)


### PR DESCRIPTION

## About The Pull Request
Makes AI actually check for the faction of droids/turrets.
## Why It's Good For The Game
No more killing the AI ripley.
## Changelog
:cl:
fix: NPC's actually check turret and droid faction when looking for targets
/:cl:
