### PR TITLE
Plasteel nonfolding cades are now upgradable

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -1158,9 +1158,6 @@
 	barricade_type = "new_plasteel"
 	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 50)
 
-/obj/structure/barricade/solid/plasteel/attempt_barricade_upgrade()
-	return //not upgradable
-
 /*----------------------*/
 // FOLDING METAL
 /*----------------------*/


### PR DESCRIPTION
## About The Pull Request
Allows solid / non folding plasteel cades to be upgraded, the same as normal metal cades
![image](https://github.com/user-attachments/assets/174cd7ef-a09b-4cb1-b0d2-6b2130bef454)
Ballistic, Acid, and concussive, in order.
## Why It's Good For The Game
They r kinda weak for their cost
## Changelog
:cl: Cheese
balance: Non-folding Plasteel cades can now be upgraded with metal, like metal cades. 
/:cl:
