### PR TITLE
Reduces the amount of xenos required for Queen and King

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -29,7 +29,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 12
+	evolve_min_xenos = 9
 	death_evolution_delay = 7 MINUTES
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -29,7 +29,7 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
-	evolve_min_xenos = 8
+	evolve_min_xenos = 7
 	maximum_active_caste = 1
 	death_evolution_delay = 5 MINUTES
 


### PR DESCRIPTION
## About The Pull Request
Per title. Queen now requires 7 instead of 8, and King now requires 9 instead of 12.

## Why It's Good For The Game
Bruh I wanna play King fr but this mf ass pop requirement depriving me from some good ol Conqueror fun. I ain't gon lie that shit got me tight af

## Changelog
:cl: Lewdcifer
balance: Amount of xenos required for Queen reduced from 8 to 7.
balance: Amount of xenos required for King reduced from 12 to 9.
/:cl: