### PR TITLE
Adds extra sentries to valhalla

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1513,7 +1513,7 @@
 			/obj/item/ammo_magazine/sniper/incendiary = -1,
 			/obj/item/ammo_magazine/sniper/flak = -1,
 		),
-		"Mounted" = list(
+		"Emplaced" = list(
 			/obj/item/weapon/gun/standard_atgun = -1,
 			/obj/item/ammo_magazine/standard_atgun = -1,
 			/obj/item/ammo_magazine/standard_atgun/apcr = -1,
@@ -1536,6 +1536,18 @@
 			/obj/item/ammo_magazine/heavy_isg/sabot = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/heavy_laser/deployable = -1,
 			/obj/item/cell/lasgun/heavy_laser = -1,
+			/obj/item/storage/box/crate/minisentry = -1,
+			/obj/item/ammo_magazine/minisentry = -1,
+			/obj/item/storage/box/crate/sentry_shotgun = -1,
+			/obj/item/ammo_magazine/sentry/shotgun = -1,
+			/obj/item/storage/box/crate/sentry_sniper = -1,
+			/obj/item/ammo_magazine/sentry/sniper = -1,
+			/obj/item/storage/box/crate/sentry_flamer = -1,
+			/obj/item/ammo_magazine/sentry/flamer = -1,
+			/obj/item/storage/box/crate/sentry_laser = -1,
+			/obj/item/ammo_magazine/sentry/laser = -1,
+			/obj/item/attachable/buildasentry = -1,
+
 		),
 		"Equipment" = list(
 			/obj/item/clothing/glasses/hud/xenohud = -1,


### PR DESCRIPTION
## About The Pull Request
Adds the new req sentries (shotgun, sniper, flamer, laser) to the valhalla vendor, along with the minisentry and BAS (technically already acquirable, but having to go engie for it was kinda stinky)

Also renames the "Mounted" section of the valhalla req vendor to the "Emplaced" section to fit the sentries in
## Why It's Good For The Game
## Changelog
:cl:
add: Adds the shotgun, sniper, flamer, and laser sentries to the valhalla req vendor
add: Adds the minisentry and build-a-sentry to the valhalla req vendor
spellcheck: Renames the valhalla req vendor's "Mounted" tab to the "Emplaced" tab
/:cl:
