### PR TITLE
Prevents king from being evolved on crash.

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -23,7 +23,7 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
-	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
+	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind, /datum/xeno_caste/king)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE


### PR DESCRIPTION

## About The Pull Request

Removed king from crash.

## Why It's Good For The Game

Without marines having access to requisitions on crash, the king loses one of its significant disadvantages.
Marines do not have access to supports like OB, vehicles, air support, tadpole ect on crash, all high player count things so its probably best if xenos cant have high player count things too.

## Changelog


:cl:
balance: King can no longer be evolved on crash.
/:cl:
