### PR TITLE
Playsound will now scream under certain conditions

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -15,6 +15,16 @@
 
 #define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
+/// This is the lowest volume that can be used by playsound otherwise it gets ignored
+/// Most sounds around 10 volume can barely be heard. Almost all sounds at 5 volume or below are inaudible
+/// This is to prevent sound being spammed at really low volumes due to distance calculations
+/// Recommend setting this to anywhere from 10-3 (or 0 to disable any sound minimum volume restrictions)
+/// Ex. For a 70 volume sound, 17 tile range, 3 exponent, 2 falloff_distance:
+/// Setting SOUND_AUDIBLE_VOLUME_MIN to 0 for the above will result in 17x17 radius (289 turfs)
+/// Setting SOUND_AUDIBLE_VOLUME_MIN to 5 for the above will result in 14x14 radius (196 turfs)
+/// Setting SOUND_AUDIBLE_VOLUME_MIN to 10 for the above will result in 11x11 radius (121 turfs)
+#define SOUND_AUDIBLE_VOLUME_MIN 3
+
 ///Default range of a sound.
 #define SOUND_RANGE 17
 #define MEDIUM_RANGE_SOUND_EXTRARANGE -5

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -20,9 +20,11 @@
 	var/storage_type = /datum/storage
 
 /obj/item/storage/Initialize(mapload, ...)
-	. = ..()
+	..()
 	create_storage(storage_type)
+	return INITIALIZE_HINT_LATELOAD
 
+/obj/item/storage/LateInitialize()
 	PopulateContents()
 
 ///Use this to fill your storage with items. USE THIS INSTEAD OF NEW/INIT

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -49,9 +49,21 @@
 A good representation is: 'byond applies a volume reduction to the sound every X tiles', where X is falloff.
  */
 /proc/playsound(atom/source, soundin, vol, vary, sound_range, falloff, is_global, frequency, channel = 0, ambient_sound = FALSE)
+	if(isarea(source))
+		CRASH("playsound(): source is an area")
+
+	if(islist(soundin))
+		CRASH("playsound(): soundin attempted to pass a list! Consider using pick()")
+
+	if(!soundin)
+		CRASH("playsound(): no soundin passed")
+
+	if(vol < SOUND_AUDIBLE_VOLUME_MIN) // never let sound go below SOUND_AUDIBLE_VOLUME_MIN or bad things will happen
+		CRASH("playsound(): volume below SOUND_AUDIBLE_VOLUME_MIN. [vol] < [SOUND_AUDIBLE_VOLUME_MIN]")
+
 	var/turf/turf_source = get_turf(source)
 
-	if (!turf_source || !soundin || !vol)
+	if (!turf_source)
 		return
 
 	//allocate a channel if necessary now so its the same for everyone

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -21,6 +21,7 @@ The Grenade Launchers
 		slot_l_hand_str = 'icons/mob/inhands/guns/special_left_1.dmi',
 		slot_r_hand_str = 'icons/mob/inhands/guns/special_right_1.dmi',
 	)
+	reload_sound = 'sound/weapons/guns/interact/ks23_insert.ogg'
 	fire_sound = 'sound/weapons/guns/fire/grenadelauncher.ogg'
 	fire_rattle = 'sound/weapons/guns/fire/grenadelauncher.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/m92_cocked.ogg'


### PR DESCRIPTION

## About The Pull Request

No vol, no sound, played on an area

atomization in prep for playsound refactor.

you should NOT be doing any of these it just wastes cpu time

## Changelog
:cl:
code: passing invalid playsound() arguments will now cause a runtime
/:cl:
