### PR TITLE
Fix untoggleable glasses turning themselves off on init

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -40,7 +40,7 @@
 
 /obj/item/clothing/glasses/Initialize(mapload)
 	. = ..()
-	if(active)	//For glasses that spawn active
+	if(active && toggleable)	//For glasses that spawn active
 		active = FALSE
 		activate()
 


### PR DESCRIPTION

## About The Pull Request

Another "no idea how this worked before"

Fixes spatial agent sunglasses

## Changelog
:cl:
fix: Fixed untoggleable glasses turning themselves off on load with no way to turn them on
/:cl:
