### PR TITLE
Maw limit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -273,6 +273,11 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(!.)
 		return
 
+	if(locate(building_type) in GLOB.xeno_acid_jaws_by_hive[buyer.hivenumber])
+		if(!silent)
+			to_chat(buyer, span_xenowarning("We already have one!"))
+		return FALSE
+
 	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)
 		return FALSE
@@ -299,6 +304,11 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	. = ..()
 	if(!.)
 		return
+
+	if(locate(building_type) in GLOB.xeno_acid_jaws_by_hive[buyer.hivenumber])
+		if(!silent)
+			to_chat(buyer, span_xenowarning("We already have one!"))
+		return FALSE
 
 	var/turf/buildloc = get_turf(buyer)
 	if(!buildloc)


### PR DESCRIPTION

## About The Pull Request
Maw and Jaw structure is now limited to one per hive at a time (that's one each).
## Why It's Good For The Game
Spamming mass XOB on the marine ball is extremely bullshit.
## Changelog
:cl:
balance: Maw and Jaw structures now have a build limit of one each at any given time
/:cl:
