### PR TITLE
NPC item storage

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -420,6 +420,21 @@
 	COOLDOWN_START(src, ai_retreat_cooldown, 8 SECONDS)
 	change_action(MOVING_TO_SAFETY, next_target, list(INFINITY)) //fallback
 
+///Tries to store an item
+/datum/ai_behavior/human/proc/try_store_item(obj/item/item)
+	if(!mob_parent.equip_to_appropriate_slot(item))
+		return FALSE
+	mob_parent.update_inv_l_hand(FALSE)
+	mob_parent.update_inv_r_hand(FALSE)
+	return TRUE
+
+///Tries to store any items in hand
+/datum/ai_behavior/human/proc/store_hands()
+	if(mob_parent.l_hand)
+		try_store_item(mob_parent.l_hand)
+	if(mob_parent.r_hand)
+		try_store_item(mob_parent.r_hand)
+
 ///Reacts to a heard message
 /datum/ai_behavior/human/proc/recieve_message(atom/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 	SIGNAL_HANDLER

--- a/code/modules/ai/ai_behaviors/human_mobs/weapon_module.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/weapon_module.dm
@@ -90,6 +90,8 @@
 
 ///Tries to equip weaponry, and updates behavior appropriately
 /datum/ai_behavior/human/proc/do_equip_weaponry()
+	store_hands()
+
 	var/obj/item/weapon/primary
 	var/obj/item/weapon/secondary
 


### PR DESCRIPTION

## About The Pull Request
Added some procs for NPC's to store held items.

Specifically when equipping weapons, they will now try store whatever is in their hands first.
This means if they have a pistol/knife out and try equip a rifle, they'll store the smaller weapon instead of just dropping it on the floor like a dweeb.
## Why It's Good For The Game
Better inventory management, paves way to actual equip items in use later.
## Changelog
:cl:
add: NPC's store equipped weapons when equipping new ones
/:cl:
