### PR TITLE
NPC death checks for chems

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -199,6 +199,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
 ///Checks if an NPC should use give this to someone
 /datum/reagent/proc/ai_should_use(mob/living/target, inject_vol)
+	if(target.stat == DEAD)
+		return FALSE
 	if(overdose_threshold < inject_vol + target.reagents.get_reagent_amount(type))
 		return FALSE
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
NPC's won't give chems to corpses anymore.
This means they should actually work down the priority list to bandages and such.
## Why It's Good For The Game
He's dead, Jim.
## Changelog
:cl:
fix: NPC's will no longer give chems to corpses
/:cl:
