### PR TITLE
Increases Melter's Health & Armor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -87,6 +87,12 @@
 	speed = -1.2
 	caste_flags = CASTE_ACID_BLOOD|CASTE_EVOLUTION_ALLOWED
 
+	// +50 health
+	max_health = 350
+
+	// +5 armor across the board
+	soft_armor = list(MELEE = 35, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 5, BIO = 10, FIRE = 25, ACID = 10)
+
 	// Loses pounce and evasion for acid-themed abilities.
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,


### PR DESCRIPTION
## About The Pull Request
Increases the Melter strain's health by 50 and all of their armor by 5.

## Why It's Good For The Game
Ever since gas got nerfed to be see-through, Melter became terrible since that was suppose to be the replacement of Evasion. To make up for this terribleness, they get some survivability.

## Changelog
:cl:
balance: Melter, a strain of Runner, now has +50 more health and +5 armor across the board.
/:cl: