### PR TITLE
Xenomorph Pop Requirements by Gamemode

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -45,7 +45,7 @@
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,
-		/datum/xeno_caste/carrier = 10,
+		/datum/xeno_caste/carrier = 8,
 		/datum/xeno_caste/hivelord = 8,
 	)
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -44,7 +44,6 @@
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,
-		/datum/xeno_caste/carrier = 8,
 		/datum/xeno_caste/hivelord = 8,
 	)
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -41,6 +41,12 @@
 	var/last_larva_check
 	bioscan_interval = 0
 
+	// Crash Xeno Player Requirements to Evolve, applied with loop in post_setup().
+	evo_requirements = list(
+		/datum/xeno_caste/king = 14,
+		/datum/xeno_caste/queen = 10,
+	)
+
 /datum/game_mode/infestation/crash/pre_setup()
 	. = ..()
 
@@ -111,6 +117,13 @@
 		else // Handles Shrike etc
 			var/mob/living/carbon/xenomorph/X = i
 			X.upgrade_stored = X.xeno_caste.upgrade_threshold
+
+
+
+	// Apply Evolution Xeno Population Locks:
+	//for(var/datum/xeno_caste/caste AS in evo_requirements)
+	//	GLOB.xeno_caste_datums[caste][XENO_UPGRADE_BASETYPE].evolve_min_xenos = evo_requirements[caste]
+
 
 
 /datum/game_mode/infestation/crash/announce()

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -41,7 +41,6 @@
 	var/last_larva_check
 	bioscan_interval = 0
 
-	// Crash Xeno Player Requirements to Evolve, applied with loop in post_setup().
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -119,9 +119,6 @@
 			X.upgrade_stored = X.xeno_caste.upgrade_threshold
 
 
-
-
-
 /datum/game_mode/infestation/crash/announce()
 	to_chat(world, span_round_header("The current map is - [SSmapping.configs[GROUND_MAP].map_name]!"))
 	priority_announce(

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -23,7 +23,7 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
-	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
+	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions
 	var/shuttle_landed = FALSE
@@ -45,6 +45,8 @@
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,
+		/datum/xeno_caste/carrier = 8,
+		/datum/xeno_caste/hivelord = 8,
 	)
 
 /datum/game_mode/infestation/crash/pre_setup()

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -45,7 +45,7 @@
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,
-		/datum/xeno_caste/carrier = 8,
+		/datum/xeno_caste/carrier = 10,
 		/datum/xeno_caste/hivelord = 8,
 	)
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -120,10 +120,6 @@
 
 
 
-	// Apply Evolution Xeno Population Locks:
-	//for(var/datum/xeno_caste/caste AS in evo_requirements)
-	//	GLOB.xeno_caste_datums[caste][XENO_UPGRADE_BASETYPE].evolve_min_xenos = evo_requirements[caste]
-
 
 
 /datum/game_mode/infestation/crash/announce()

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -13,9 +13,10 @@
 	var/bioscan_interval = 15 MINUTES
 	/// State of the nuke
 	var/planet_nuked = INFESTATION_NUKE_NONE
-
-	// Base Infestation HvX Xeno Player Requirements to Evolve, applied with loop in post_setup().
-	// Redefined in nuclear_war.dm and crash.dm
+	/**
+	 * Assoc list showing how many xenos are needed by caste.
+	 * [caste datum] = [amount of xenos needed]
+	 */
 	var/list/evo_requirements = list(
 		/datum/xeno_caste/king = 12,
 		/datum/xeno_caste/queen = 8,

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -14,6 +14,13 @@
 	/// State of the nuke
 	var/planet_nuked = INFESTATION_NUKE_NONE
 
+	// Base Infestation HvX Xeno Player Requirements to Evolve, applied with loop in post_setup().
+	// Redefined in nuclear_war.dm and crash.dm
+	var/list/evo_requirements = list(
+		/datum/xeno_caste/king = 12,
+		/datum/xeno_caste/queen = 8,
+	)
+
 /datum/game_mode/infestation/post_setup()
 	. = ..()
 	if(bioscan_interval)
@@ -32,6 +39,10 @@
 		new_tunnel.tunnel_desc = "["[get_area_name(new_tunnel)]"] (X: [new_tunnel.x], Y: [new_tunnel.y])"
 	for(var/i in GLOB.xeno_jelly_pod_turfs)
 		new /obj/structure/xeno/resin_jelly_pod(i, XENO_HIVE_NORMAL)
+
+	// Apply Evolution Xeno Population Locks:
+	for(var/datum/xeno_caste/caste AS in evo_requirements)
+		GLOB.xeno_caste_datums[caste][XENO_UPGRADE_BASETYPE].evolve_min_xenos = evo_requirements[caste]
 
 /datum/game_mode/infestation/process()
 	if(round_finished)

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -39,7 +39,7 @@
 
 	evo_requirements = list(
 		/datum/xeno_caste/king = 12,
-		/datum/xeno_caste/queen = 4,
+		/datum/xeno_caste/queen = 8,
 	)
 
 /datum/game_mode/infestation/nuclear_war/post_setup()

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -63,9 +63,7 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
 
-	// Apply Evolution Xeno Population Locks:
-	//for(var/datum/xeno_caste/caste in evo_requirements)
-	//	GLOB.xeno_caste_datums[caste][XENO_UPGRADE_BASETYPE].evolve_min_xenos = evo_requirements[caste]
+
 
 /datum/game_mode/infestation/nuclear_war/orphan_hivemind_collapse()
 	if(round_finished)

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -63,8 +63,6 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
 
-
-
 /datum/game_mode/infestation/nuclear_war/orphan_hivemind_collapse()
 	if(round_finished)
 		return

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -37,6 +37,12 @@
 		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
 
+	// Nuclear War Xeno Player Requirements to Evolve, applied with loop in post_setup().
+	evo_requirements = list(
+		/datum/xeno_caste/king = 12,
+		/datum/xeno_caste/queen = 4,
+	)
+
 /datum/game_mode/infestation/nuclear_war/post_setup()
 	. = ..()
 
@@ -56,6 +62,10 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_EXPLODED, PROC_REF(on_nuclear_explosion))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
+
+	// Apply Evolution Xeno Population Locks:
+	//for(var/datum/xeno_caste/caste in evo_requirements)
+	//	GLOB.xeno_caste_datums[caste][XENO_UPGRADE_BASETYPE].evolve_min_xenos = evo_requirements[caste]
 
 /datum/game_mode/infestation/nuclear_war/orphan_hivemind_collapse()
 	if(round_finished)

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -37,7 +37,6 @@
 		/datum/job/xenomorph = NUCLEAR_WAR_LARVA_POINTS_NEEDED,
 	)
 
-	// Nuclear War Xeno Player Requirements to Evolve, applied with loop in post_setup().
 	evo_requirements = list(
 		/datum/xeno_caste/king = 12,
 		/datum/xeno_caste/queen = 4,


### PR DESCRIPTION
## About The Pull Request

Enables changing the required xenos to evolve Queen, King, or anything else added to the list to values dependent on the current game mode.

## Why It's Good For The Game

Enables disentangling pop requirements for crash and nuclear war for better balancing.

## Changelog

:cl: Isy232, Ivanmixo
balance: Crash now requires 10 xenos for Queen and 14 for King and 8 for Hivelord.
balance: Nuclear War now requires 4 xenos for Queen and 12 (unchanged) for King.
code: Xeno evolution pop requirement can now depend on game mode.
/:cl:
