### PR TITLE
Dragon Passflags

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -231,7 +231,7 @@
 	animate(xeno_owner, pixel_x = 0, pixel_y = 0, time = 0)
 	xeno_owner.status_flags = GODMODE|INCORPOREAL
 	xeno_owner.resistance_flags = RESIST_ALL
-	xeno_owner.pass_flags = PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE
+	xeno_owner.add_pass_flags(PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE, DRAGON_ABILITY_TRAIT)
 	xeno_owner.density = FALSE
 	ADD_TRAIT(xeno_owner, TRAIT_SILENT_FOOTSTEPS, XENO_TRAIT)
 	xeno_owner.gain_plasma(xeno_owner.xeno_caste.plasma_max)
@@ -262,7 +262,7 @@
 	performing_landing_animation = FALSE
 	xeno_owner.status_flags = initial(xeno_owner.status_flags)
 	xeno_owner.resistance_flags = initial(xeno_owner.resistance_flags)
-	xeno_owner.pass_flags = initial(xeno_owner.pass_flags)
+	xeno_owner.remove_pass_flags(PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE, DRAGON_ABILITY_TRAIT)
 	xeno_owner.density = TRUE
 	REMOVE_TRAIT(xeno_owner, TRAIT_SILENT_FOOTSTEPS, XENO_TRAIT)
 	xeno_owner.update_icons(TRUE)
@@ -657,7 +657,7 @@
 
 	RegisterSignal(grabbed_human, COMSIG_MOVABLE_POST_THROW, PROC_REF(throw_completion))
 	ADD_TRAIT(grabbed_human, TRAIT_IMMOBILE, DRAGON_ABILITY_TRAIT)
-	grabbed_human.pass_flags |= (PASS_MOB|PASS_XENO)
+	grabbed_human.add_pass_flags(PASS_MOB|PASS_XENO, DRAGON_ABILITY_TRAIT)
 	grabbed_human.throw_at(get_step(xeno_owner, xeno_owner.dir), 5, 5, xeno_owner)
 
 /// Removes signal and pass_flags from the thrown human and tries to grab them (via async).
@@ -665,7 +665,7 @@
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/thrown_human = source
 	UnregisterSignal(thrown_human, COMSIG_MOVABLE_POST_THROW)
-	thrown_human.pass_flags &= ~(PASS_MOB|PASS_XENO)
+	thrown_human.remove_pass_flags(PASS_MOB|PASS_XENO, DRAGON_ABILITY_TRAIT)
 	INVOKE_ASYNC(src, PROC_REF(try_grabbing), thrown_human)
 
 /// Try to grab the thrown human.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -92,10 +92,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/fire_burst_damage = 10
 	///Base fire stacks added on hit if the projectile has AMMO_INCENDIARY
 	var/incendiary_strength = 10
-	/// The projectile's alpha value on creation.
-	var/projectile_alpha = 255
-	/// What to multiply the sprite's size by.
-	var/projectile_size = 1
 
 /datum/ammo/proc/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	return


### PR DESCRIPTION

## About The Pull Request
Fixes Dragon's passflags to use the new managed passflag procs.
Removes unused variables left over from Dragon PR.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
code: Dragon's abilities use the managed passflag system.
/:cl:
