### PR TITLE
Dragon Movement Speed Nerfs / Dragon Breath Armor Reduction

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -408,9 +408,9 @@
 	return TRUE
 
 /datum/action/ability/activable/xeno/backhand/dragon_breath/handle_regular_ability(atom/target, list/turf/affected_turfs)
-	xeno_owner.add_movespeed_modifier(MOVESPEED_ID_DRAGON_BREATH, TRUE, 0, NONE, TRUE, 1.6)
+	xeno_owner.add_movespeed_modifier(MOVESPEED_ID_DRAGON_BREATH, TRUE, 0, NONE, TRUE, 2)
 	xeno_owner.move_resist = MOVE_FORCE_OVERPOWERING
-	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(15)
+	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(10)
 	ADD_TRAIT(xeno_owner, TRAIT_HANDS_BLOCKED, DRAGON_ABILITY_TRAIT)
 	RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	starting_direction = get_cardinal_dir(xeno_owner, target)
@@ -485,7 +485,7 @@
 /datum/action/ability/activable/xeno/backhand/dragon_breath/proc/end_ability()
 	xeno_owner.remove_movespeed_modifier(MOVESPEED_ID_DRAGON_BREATH)
 	xeno_owner.move_resist = initial(xeno_owner.move_resist)
-	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(-15)
+	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(-10)
 	REMOVE_TRAIT(xeno_owner, TRAIT_HANDS_BLOCKED, DRAGON_ABILITY_TRAIT)
 	UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
 	starting_direction = null

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
@@ -14,7 +14,7 @@
 	melee_damage = 30
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 1000


### PR DESCRIPTION
## About The Pull Request
Dragon movement decreased from -0.5 to -0.1.
Dragon is now even slower while using Dragon Breath.
Dragon's armor gain while using Dragon Breath is decreased from 15 to 10.

## Why It's Good For The Game
Apparently, it is too fast according to Kuro (and others).

## Changelog
:cl:
balance: Dragon is now slower on average and even slower while using their ability, Dragon Breath.
balance: Dragon's armor gain while using Dragon Breath has been decreased from 15 to 10.
/:cl:
