### PR TITLE
Campaign mech nerfs

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1951,7 +1951,6 @@
 			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/heavy_cannon = -1,
 			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/minigun = -1,
 			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/grenadelauncher = -1,
-			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/flamethrower = -1,
 			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/rpg = -1,
 			/obj/item/mecha_parts/mecha_equipment/laser_sword = -1,
 			/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser_spear = -1,
@@ -1969,7 +1968,6 @@
 			/obj/item/mecha_ammo/vendable/rpg = -1,
 			/obj/item/mecha_ammo/vendable/minigun = -1,
 			/obj/item/mecha_ammo/vendable/grenade = -1,
-			/obj/item/mecha_ammo/vendable/flamer = -1,
 		),
 		"Equipment" = list(
 			/obj/item/mecha_parts/mecha_equipment/armor/booster = -1,

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale.dm
@@ -310,8 +310,8 @@
 /obj/vehicle/sealed/mecha/combat/greyscale/recon/noskill // hvh type
 	mecha_flags = ADDING_ACCESS_POSSIBLE|CANSTRAFE|IS_ENCLOSED|HAS_HEADLIGHTS
 	pivot_step = FALSE
-	max_integrity = 1020
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 75, FIRE = 100, ACID = 0)
+	max_integrity = 300
+	soft_armor = list(MELEE = 25, BULLET = 70, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 75, FIRE = 100, ACID = 30)
 	facing_modifiers = list(VEHICLE_FRONT_ARMOUR = 0.5, VEHICLE_SIDE_ARMOUR = 1, VEHICLE_BACK_ARMOUR = 1.5)
 
 /obj/vehicle/sealed/mecha/combat/greyscale/assault
@@ -327,8 +327,8 @@
 /obj/vehicle/sealed/mecha/combat/greyscale/assault/noskill // hvh type
 	mecha_flags = ADDING_ACCESS_POSSIBLE|CANSTRAFE|IS_ENCLOSED|HAS_HEADLIGHTS
 	pivot_step = FALSE
-	max_integrity = 1390
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 75, FIRE = 100, ACID = 0)
+	max_integrity = 450
+	soft_armor = list(MELEE = 35, BULLET = 70, LASER = 60, ENERGY = 60, BOMB = 60, BIO = 75, FIRE = 100, ACID = 30)
 	facing_modifiers = list(VEHICLE_FRONT_ARMOUR = 0.5, VEHICLE_SIDE_ARMOUR = 1, VEHICLE_BACK_ARMOUR = 1.5)
 
 /obj/vehicle/sealed/mecha/combat/greyscale/vanguard
@@ -344,8 +344,8 @@
 /obj/vehicle/sealed/mecha/combat/greyscale/vanguard/noskill // hvh type
 	mecha_flags = ADDING_ACCESS_POSSIBLE|CANSTRAFE|IS_ENCLOSED|HAS_HEADLIGHTS
 	pivot_step = FALSE
-	max_integrity = 1760
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 75, FIRE = 100, ACID = 0)
+	max_integrity = 700
+	soft_armor = list(MELEE = 45, BULLET = 70, LASER = 60, ENERGY = 60, BOMB = 70, BIO = 75, FIRE = 100, ACID = 30)
 	facing_modifiers = list(VEHICLE_FRONT_ARMOUR = 0.5, VEHICLE_SIDE_ARMOUR = 1, VEHICLE_BACK_ARMOUR = 1.5)
 
 /obj/item/repairpack


### PR DESCRIPTION
## About The Pull Request
Nerfs mech EHP by over 50%.
Removes access to the flamer because it just fucking murderfucks everything in sight.

For reference, the single use AT rocket will now insta kill a recon mech, even from the front.
## Why It's Good For The Game
Current mech rework has completely and utterly fucked mech balance. This doesn't fix it, and frankly I can't until mech changes are done, but this should make them less cringe.
## Changelog
:cl:
balance: Significantly nerfed mechs in campaign
/:cl:
