### PR TITLE
Cuts carrier "Spawn Facehugger" ability cooldown in half

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	action_icon = 'icons/Xeno/actions/carrier.dmi'
 	desc = "Spawn a facehugger that is stored on your body."
 	ability_cost = 200
-	cooldown_duration = 10 SECONDS
+	cooldown_duration = 5 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SPAWN_HUGGER,
 	)


### PR DESCRIPTION
## About The Pull Request
``cooldown_duration = 10 SECONDS`` -> ``cooldown_duration = 5 SECONDS`` in ``abilities_carrier.dm`` on line 154 for ``/datum/action/ability/xeno_action/spawn_hugger``

Made with 50% imded energy but that's just because i'm at my most code-active when i've experienced it in-game.

Not tested in-game on a local branch for the simple reason that a single digit change like this doesn't tend to break stuff.
## Why It's Good For The Game
Currently it takes about one minute and 20 seconds for a carrier to fill up all their facehugger slots, and you're usually spending that time on resting weeds waiting to have a chance at being of some use again unless you're being a stinker and doing resin holes instead. 

Given how easily marines swat away facehuggers, both in one-on-one encounters where they can shoot it once or otherwise just click on them in melee or in groups where a single SG or anyone else that saw it can just shoot/melee it similarly, alongside the fact that the effects for a fair amount of the huggers can be almost instantly mitigated or solved (larval huggers in particular is a big offender of this) I think it would be nice if carrier could throw more of these at marines more often to improve their presence on the field and the effect they can have on marines.

## Changelog

:cl: VonDiech/Citruses
balance: The spawn-facehugger ability for carrier has had its cooldown cut from 10 seconds to 5 seconds.
/:cl:
