### PR TITLE
Seamless Blood Decals

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -48,6 +48,11 @@
 /obj/effect/decal/cleanable/blood/update_icon_state()
 	. = ..()
 	color = basecolor
+	pixel_x = rand(-16, 16)
+	pixel_y = rand(-16, 16)
+	var/matrix/rotate = matrix()
+	rotate.Turn(rand(0, 359))
+	transform = rotate
 
 /obj/effect/decal/cleanable/blood/proc/on_cross(datum/source, mob/living/carbon/human/perp, oldloc, oldlocs)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/284248c8-ab47-4c36-90ab-2973c06692a6)

basically just adds some randomization to blood decals so they look less repetitive
## Why It's Good For The Game
looks cool
## Changelog
:cl:
add: more seamless looking blood decals
/:cl:
