### PR TITLE
Dancer Debuff list expansion

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -417,11 +417,17 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		adjusted_mult += 0.25
 	if(living_target.IsSlowed())
 		adjusted_mult += 0.25
-	if(living_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
-		adjusted_mult += 0.25
 	if(living_target.IsConfused())
 		adjusted_mult += 0.25
 	if(living_target.IsImmobilized())
+		adjusted_mult += 0.25
+	if(living_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
+		adjusted_mult += 0.25
+	if(living_target.has_status_effect(STATUS_EFFECT_MELTING_FIRE))
+		adjusted_mult += 0.25
+	if(living_target.has_status_effect(STATUS_EFFECT_SHATTER))
+		adjusted_mult += 0.25
+	if(living_target.has_status_effect(STATUS_EFFECT_MELTING))
 		adjusted_mult += 0.25
 	//big bonus if target has a "helpless" debuff
 	if(living_target.IsParalyzed() || living_target.IsStun() || living_target.IsKnockdown())


### PR DESCRIPTION
## About The Pull Request
Adds more debuffs to the scaling of dancer damage
## Why It's Good For The Game
Dancer is supposed to scale off of debuffs that other xenos can apply and these debuffs were missing, notably pyrofire
## Changelog
:cl: Cheese
balance: Dancer debuff scaling now also respects Shatter, Pyrofire, and Melting debuffs. 
/:cl:
