### PR TITLE
Only actual hive leader can jack or capture alamo

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -493,6 +493,9 @@
 	var/datum/game_mode/infestation/infestation_mode = SSticker.mode //Minor QOL, any xeno can check the console after a leader hijacks
 	if(!(xeno_attacker.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT) && (infestation_mode.round_stage != INFESTATION_MARINE_CRASHING))
 		return
+	if(xeno_attacker.hive.living_xeno_ruler != xeno_attacker) //If we aren't the actual hive leader, prevent us from controling alamo
+		to_chat(xeno_attacker, span_xenowarning("We must be the hive leader!"))
+		return
 	#ifndef TESTING
 	if(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK > world.time)
 		to_chat(xeno_attacker, span_xenowarning("It's too early to do this!"))

--- a/code/modules/tgui/states/alamo.dm
+++ b/code/modules/tgui/states/alamo.dm
@@ -3,7 +3,7 @@
  *
  * Humans need to have access and be adjacent to use it.
  * Silicons and other lifeforms get their default ui_state pass.
- * Xenomorphs need to be intelligent
+ * Xenomorphs need to be intelligent & hive lead
  */
 
 GLOBAL_DATUM_INIT(alamo_state, /datum/ui_state/alamo_state, new)
@@ -28,8 +28,10 @@ GLOBAL_DATUM_INIT(alamo_state, /datum/ui_state/alamo_state, new)
 
 /mob/living/carbon/xenomorph/alamo_can_use_topic(src_object)
 	var/datum/game_mode/infestation/infestation_mode = SSticker.mode
-	if(infestation_mode.round_stage == INFESTATION_MARINE_CRASHING) //Minor QOL, any xeno can check the console after a leader hijacks
+	if(infestation_mode.round_stage == INFESTATION_MARINE_CRASHING) //Minor QOL, any xeno can check the console after the hive lead hijacks
 		return GLOB.xeno_state.can_use_topic(src_object, src)
 	if(!(xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
+		return default_can_use_topic(src_object)
+	if(hive.living_xeno_ruler != src)
 		return default_can_use_topic(src_object)
 	return GLOB.xeno_state.can_use_topic(src_object, src)


### PR DESCRIPTION
## About The Pull Request
Makes it so only the actual hive leader (the one at the top of the list in hive status, oldest alive T4, the xeno who "rises to lead the hive") can jack or capture alamo, rather than any T4
## Why It's Good For The Game
This has been admin policy for the longest time, just makes it easier codewise. 
## Changelog
:cl: Cheese
add: Only the actual hive leader can jack or capture alamo now, rather than every T4. (The xeno at the top of the list in hive status is hive leader)
/:cl:
