### PR TITLE
Fixes death timers for T4 strains

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -726,7 +726,7 @@
 
 	if(dead_xeno == living_xeno_ruler)
 		on_ruler_death(dead_xeno)
-	var/datum/xeno_caste/base_caste = GLOB.xeno_caste_datums[dead_xeno.caste_base_type][XENO_UPGRADE_BASETYPE]
+	var/datum/xeno_caste/base_caste = GLOB.xeno_caste_datums[get_parent_caste_type(dead_xeno.xeno_caste)][XENO_UPGRADE_BASETYPE]
 	if(base_caste.death_evolution_delay <= 0)
 		return
 	if(!caste_death_timers[base_caste])

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -232,9 +232,9 @@
 
 ///returns the parent caste type for the given caste (e.g. bloodthirster would return base rav)
 /proc/get_parent_caste_type(datum/xeno_caste/root_type)
-    while(initial(root_type.parent_type) != /datum/xeno_caste)
-        root_type = root_type::parent_type
-    return root_type
+	while(initial(root_type.parent_type) != /datum/xeno_caste)
+		root_type = root_type::parent_type
+	return root_type
 
 /// basetype = list(strain1, strain2)
 GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -230,6 +230,12 @@
 		current_type = current_type::parent_type
 	return current_type
 
+///returns the parent caste type for the given caste (e.g. bloodthirster would return base rav)
+/proc/get_parent_caste_type(datum/xeno_caste/root_type)
+    while(initial(root_type.parent_type) != /datum/xeno_caste)
+        root_type = root_type::parent_type
+    return root_type
+
 /// basetype = list(strain1, strain2)
 GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 /proc/init_glob_strain_list()


### PR DESCRIPTION
## About The Pull Request
Per title. Should fix issues where T4 strains do not correctly set a death timer, allowing these to be bypassed. To provide an example, if King has a strain called Conqueror, and Conqueror died, a death timer would be set for the Conqueror but not for the King, which meant that people could immediately evolve to King again. This is fixed by this PR.

## Why It's Good For The Game
bug fix good

## Changelog
:cl: Lewdcifer
fix: Fixes death timers for T4 strains.
/:cl: