### PR TITLE
Dragon Grab Bugfix & Dragon Player Panel

### DIFF
--- a/code/modules/admin/panels/player_panel.dm
+++ b/code/modules/admin/panels/player_panel.dm
@@ -482,6 +482,7 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_ADMIN, "Show Player Panel", mo
 		<a href='byond://?src=[ref];transform=shrike;mob=[REF(M)]'>Shrike</a> |
 		<a href='byond://?src=[ref];transform=hivemind;mob=[REF(M)]'>Hivemind</a> |
 		<a href='byond://?src=[ref];transform=king;mob=[REF(M)]'>King</a> |
+		<a href='byond://?src=[ref];transform=dragon;mob=[REF(M)]'>Dragon</a> |
 		<br>
 	"}
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -442,6 +442,8 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 				newmob = M.change_mob_type(/mob/living/carbon/xenomorph/queen, location, null, delmob)
 			if("king")
 				newmob = M.change_mob_type(/mob/living/carbon/xenomorph/king, location, null, delmob)
+			if("dragon")
+				newmob = M.change_mob_type(/mob/living/carbon/xenomorph/dragon, location, null, delmob)
 			if("wraith")
 				newmob = M.change_mob_type(/mob/living/carbon/xenomorph/wraith, location, null, delmob)
 			if("puppeteer")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug that occurs when a marine is failed to be grabbed after thrown from Dragon's Grab which causes the marine to gain the immobilize trait without removing it.

Adds Dragon as one of the possible Transformations in the Player Panel.

## Why It's Good For The Game
Bugfix, plus an admin wants this thing in the Player Panel.

## Changelog
:cl:
fix: Dragon's Grab no longer permanently immobilizes marines that were failed to be grabbed.
admin: Player Panel now has Dragon as one of the Transformations.
/:cl:
