### PR TITLE
LZ shutter button will no longer open if alamo is groundside.

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -149,6 +149,14 @@
 		to_chat(user, span_notice("The containment shutters can't open yet!"))
 		return
 	#endif
+	var/obj/docking_port/mobile/marine_dropship/D
+	for(var/k in SSshuttle.dropships)
+		var/obj/docking_port/mobile/M = k
+		if(M.control_flags & SHUTTLE_MARINE_PRIMARY_DROPSHIP)
+			D = M
+	if(is_ground_level(D.z))
+		to_chat(user, span_notice("The containment shutters can't open with the dropship groundside!"))
+		return
 	if(!allowed(user))
 		to_chat(user, span_danger("Access Denied"))
 		flick("[initial(icon_state)]-denied", src)


### PR DESCRIPTION

## About The Pull Request
9/10 times opening shutters with alamo groundside is pure grief, this will prevent those situations.
## Why It's Good For The Game
Marines forced to not throw the round.
## Changelog
:cl:
add: LZ shutter button will no longer be usable if the alamo is groundside.
/:cl:
