### PR TITLE
Some autocannon nerfs

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -190,9 +190,9 @@
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 30
-	penetration = 40
-	sundering = 2.5
+	damage = 40
+	penetration = 45
+	sundering = 4
 
 /datum/ammo/rocket/tank_autocannon_he
 	name = "autocannon high explosive"
@@ -202,14 +202,14 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	damage = 15
 	penetration = 20
-	sundering = 1.5
+	sundering = 0
 
 /datum/ammo/rocket/tank_autocannon_he/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 3, tiny = TRUE)
+	explosion(T, weak_impact_range = 2, tiny = TRUE)
 
-/datum/ammo/rocket/tank_autocannon_he/on_hit_mob(mob/target_mob, obj/projectile/proj) // This is so it doesn't knock back on hit.
-	var/target_turf = get_turf(target_mob) // skipping staggerstun on parent
-	drop_nade(target_turf)
+/datum/ammo/rocket/tank_autocannon_he/on_hit_mob(mob/target_mob, obj/projectile/proj)
+	//this specifically doesn't knockback. Don't change the explosion above weak.
+	drop_nade(get_turf(target_mob))
 
 // SARDEN
 

--- a/code/modules/vehicles/armored/ammo_magazine.dm
+++ b/code/modules/vehicles/armored/ammo_magazine.dm
@@ -57,7 +57,7 @@
 	desc = "A 100 round box for an autocannon. Loaded with Armor Piercing rounds."
 	caliber = CALIBER_30X17MM
 	icon_state = "tank_autocannon_ap"
-	max_rounds = 100
+	max_rounds = 50
 	default_ammo = /datum/ammo/bullet/tank_autocannon_ap
 	loading_sound = 'sound/vehicles/weapons/tank_autocannon_reload.ogg'
 

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -361,7 +361,7 @@
 	accepted_ammo = list(/obj/item/ammo_magazine/tank/autocannon, /obj/item/ammo_magazine/tank/autocannon/high_explosive)
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 	variance = 2
-	projectile_delay = 0.35 SECONDS
+	projectile_delay = 0.45 SECONDS
 	rearm_time = 9 SECONDS
 	hud_state_empty = "hivelo_empty"
 


### PR DESCRIPTION

## About The Pull Request
Nerfs autocannon fire rate from 0.35 to 0.45.
Reduced HE radius from 3 to 2.
Removed the sunder from HE direct hit.
Reduced magazine capacity from 100 to 50.

AP ammo buffed to 40 dam, 45 pen and 4 sunder (its still worse than HE in most situations though).
## Why It's Good For The Game
Autocannon tank, specifically HE ammo, is extremely shitty for xenos to play against.
Its very high DPS, large AOE spammable damage with constantly stacked slowdown, sunder, weed removal, and insane ammo economy.

This probably doesn't even rein it in enough, but its better than current state.
## Changelog
:cl:
balance: Nerfed tank autocannon and HE ammo, AP ammo slightly buffed
/:cl:
