### PR TITLE
Weak explosions no longer destroy weeds

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -88,7 +88,7 @@
 /obj/alien/weeds/ex_act(severity)
 	if(severity == EXPLODE_WEAK)
 		return
-	return = ..()
+	return ..()
 
 ///Check if we have a parent node, if not, qdel ourselve
 /obj/alien/weeds/proc/check_for_parent_node()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -85,6 +85,11 @@
 			if(W)
 				W.update_icon()
 
+/obj/alien/weeds/ex_act(severity)
+	if(severity == EXPLODE_WEAK)
+		return
+	return = ..()
+
 ///Check if we have a parent node, if not, qdel ourselve
 /obj/alien/weeds/proc/check_for_parent_node()
 	if(parent_node)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
Weak explosions from things like the autocannon are highly spammable, and AOE, spammable weed removal is actually a really strong ability, as it directly debuffs target xenos even further.
## Changelog
:cl:
balance: Weak explosions no longer damage weeds
/:cl:
