### PR TITLE
Reduces the amount of fuel on the M-22 welding kit and the flamer backpack

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -464,7 +464,7 @@
 	equip_slot_flags = ITEM_SLOT_BACK
 	icon_state = "marine_flamerpack"
 	w_class = WEIGHT_CLASS_BULKY
-	max_fuel = 500 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.
+	max_fuel = 300 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.
 
 /obj/item/tool/handheld_charger
 	name = "handheld charger"

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -98,8 +98,8 @@
 	icon_state = "flamethrower_tank"
 	equip_slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	max_rounds = 500
-	current_rounds = 500
+	max_rounds = 300
+	current_rounds = 300
 	reload_delay = 1 SECONDS
 	caliber = CALIBER_FUEL_THICK
 	magazine_flags = MAGAZINE_WORN


### PR DESCRIPTION
## About The Pull Request
Per title. Both contained 500 units, now reduced to 300.

## Why It's Good For The Game
Flamers, as they are at this moment, are very oppressive, and their continued presence makes the game very boring to play, not just for xenos, but for marines, too, unless they cave in and invest into a Surt module. This aims to reduce the amount of ammo that flamers can have, and is meant to be one of various options presented across several PRs, so that Kuro may pick and choose whatever he deems better.

## Changelog
:cl: Lewdcifer
balance: Reduces the amount of fuel on the M-22 welding kit and the flamer backpack from 500 to 300.
/:cl: