### PR TITLE
Reduces the range of all flamers

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -59,7 +59,7 @@
 	light_power = 0.1
 	light_color = LIGHT_COLOR_ORANGE
 	///Max range of the flamer in tiles.
-	var/flame_max_range = 6
+	var/flame_max_range = 3
 	///Max resin wall penetration in tiles.
 	var/flame_max_wall_pen = 3
 	///After how many total resin walls the flame wont proceed further


### PR DESCRIPTION
## About The Pull Request
Per title. Range is reduced from 6 to 3.

## Why It's Good For The Game
Flamers, as they are at this moment, are very oppressive, and their continued presence makes the game very boring to play, not just for xenos, but for marines, too, unless they cave in and invest into a Surt module. This aims to reduce the amount of ammo that flamers can have, and is meant to be one of various options presented across several PRs, so that Kuro may pick and choose whatever he deems better.

## Changelog
:cl: Lewdcifer
balance: Reduced the range of all flamers from 6 to 3.
/:cl: