### PR TITLE
NPC Undefibbable check

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/healing.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/healing.dm
@@ -6,6 +6,8 @@
 	var/list/healing_chat = list("Healing you.", "Healing you, hold still.", "Stop moving!", "Fixing you up.", "Healing.", "Treating wounds.", "I'll have you patched up in no time.", "Quit your complaining, it's just a fleshwound.", "Cover me!", "Give me some room!")
 	///Chat lines for trying to heal
 	var/list/self_heal_chat = list("Healing, cover me!", "Healing over here.", "Where's the damn medic?", "Medic!", "Treating wounds.", "It's just a flesh wound.", "Need a little help here!", "Cover me!.")
+	///Chat lines for someone being perma
+	var/list/unrevivable_chat = list("We lost them!", "I lost them!", "Damn it, they're gone!", "Perma!", "No longer revivable.", "I can't help this one.", "I'm sorry.")
 
 /datum/ai_behavior/human/late_initialize()
 	if(human_ai_state_flags & HUMAN_AI_ANY_HEALING)
@@ -149,6 +151,10 @@
 		return
 
 	do_unset_target(patient, FALSE)
+	if(HAS_TRAIT(patient, TRAIT_UNDEFIBBABLE))
+		remove_from_heal_list(patient)
+		try_speak(pick(unrevivable_chat))
+		return
 
 	try_speak(pick(healing_chat))
 


### PR DESCRIPTION

## About The Pull Request
NPC medics will no longer try to revive people that are unrevivable.

:cl:
fix: NPC's will no longer try to revive undefibbable patients
/:cl:
