### PR TITLE
NPC buckle improvements

### DIFF
--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	light_range = 1
 	light_power = 0.5
 	light_color = LIGHT_COLOR_EMISSIVE_GREEN
+	faction = FACTION_TERRAGOV
 	//todo make these just use a turf?
 	///X target coordinate
 	var/target_x = 1
@@ -76,6 +77,9 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	for(var/atom/movable/ejectee AS in buckled_mobs) // dump them out, just in case no mobs get deleted
 		ejectee.forceMove(loc)
 	return ..()
+
+/obj/structure/droppod/ai_should_stay_buckled(mob/living/carbon/npc)
+	return TRUE
 
 ///Disables launching
 /obj/structure/droppod/proc/disable_launching()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -376,6 +376,9 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	if(LAZYLEN(buckled_mobs) || buckled_bodybag)
 		. += image("icon_state"="stretcher_box","layer"=LYING_MOB_LAYER + 0.1)
 
+/obj/structure/bed/medevac_stretcher/ai_should_stay_buckled(mob/living/carbon/npc)
+	return TRUE
+
 /obj/structure/bed/medevac_stretcher/attack_hand_alternate(mob/living/user)
 	activate_medevac_teleport(user)
 

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -205,6 +205,10 @@
 	open(TRUE)
 	return AI_OBSTACLE_RESOLVED
 
+///Whether an NPC mob should stay buckled to this atom or not
+/atom/movable/proc/ai_should_stay_buckled(mob/living/carbon/npc)
+	return FALSE
+
 //test stuff
 /mob/living/proc/add_test_ai()
 	AddComponent(/datum/component/ai_controller, /datum/ai_behavior/human)

--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -101,7 +101,7 @@
 			food.ai_use(human_parent, human_parent)
 			break
 
-	if(mob_parent.buckled && !istype(mob_parent.buckled, /obj/structure/droppod)) //unbuckling from your pod midflight is not ideal
+	if(mob_parent.buckled && !mob_parent.buckled.ai_should_stay_buckled(mob_parent))
 		mob_parent.buckled.unbuckle_mob(mob_parent)
 
 	for(var/datum/action/action in ability_list)

--- a/code/modules/vehicles/__vehicle.dm
+++ b/code/modules/vehicles/__vehicle.dm
@@ -69,6 +69,9 @@
 		if(0 to 25)
 			. += span_warning("It's falling apart!")
 
+/obj/vehicle/ai_should_stay_buckled(mob/living/carbon/npc)
+	return !is_driver(npc) //NPC's can't operate vehicles so we generally only want them buckled as a passenger
+
 /obj/vehicle/proc/is_key(obj/item/I)
 	return istype(I, key_type)
 


### PR DESCRIPTION

## About The Pull Request
NPC's will stay buckled to medivacs, and vehicles when not the driver (i.e. back of a hoverbike, in a sidecar, etc).

Also made drop pods actually in the TGMC faction so marine NPC's won't smash them to bits.
## Why It's Good For The Game
Smarter AI.
## Changelog
:cl:
qol: NPC's will stay buckled to medivac's and vehicles when not the driver
qol: NPC's will no longer smash drop pods as obstacles
/:cl:
