### PR TITLE
Falling down a zlevel will stun for 2 instead of 5 seconds per Z

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -886,7 +886,7 @@ below 100 is not dizzy
 		apply_damage(incoming_damage, BRUTE)
 
 	if(!skip_knockdown)
-		Knockdown(levels * 5 SECONDS)
+		Knockdown(levels * 2 SECONDS)
 	return .
 
 /**


### PR DESCRIPTION

## About The Pull Request

Noted by tye when testing the new map

## Changelog
:cl:
balance: Falling down a zlevel will stun for 2 instead of 5 seconds per Z
/:cl:
