### PR TITLE
Acid cost affected by dissolvability, cast delay buffed against flares

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -51,9 +51,9 @@
 #define TRAP_ACID_STRONG "strong acid"
 
 //Xeno acid strength defines
-#define WEAK_ACID_STRENGTH 0.016
-#define REGULAR_ACID_STRENGTH 0.04
-#define STRONG_ACID_STRENGTH 0.1
+#define WEAK_ACID_STRENGTH 0.04
+#define REGULAR_ACID_STRENGTH 0.1
+#define STRONG_ACID_STRENGTH 0.25
 
 #define PUPPET_RECALL "recall puppet"
 #define PUPPET_SEEK_CLOSEST "seeking closest and attack order" //not xeno-usable

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -51,9 +51,9 @@
 #define TRAP_ACID_STRONG "strong acid"
 
 //Xeno acid strength defines
-#define WEAK_ACID_STRENGTH 0.04
-#define REGULAR_ACID_STRENGTH 0.1
-#define STRONG_ACID_STRENGTH 0.25
+#define WEAK_ACID_STRENGTH 0.016
+#define REGULAR_ACID_STRENGTH 0.04
+#define STRONG_ACID_STRENGTH 0.1
 
 #define PUPPET_RECALL "recall puppet"
 #define PUPPET_SEEK_CLOSEST "seeking closest and attack order" //not xeno-usable

--- a/code/game/objects/items/explosives/grenades/flares.dm
+++ b/code/game/objects/items/explosives/grenades/flares.dm
@@ -19,7 +19,7 @@
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2
 
-/obj/item/explosive/grenade/flare/proc/get_acid_delay()
+/obj/item/explosive/grenade/flare/get_acid_delay()
 	return 0.5 SECONDS
 
 /obj/item/explosive/grenade/flare/Initialize(mapload)

--- a/code/game/objects/items/explosives/grenades/flares.dm
+++ b/code/game/objects/items/explosives/grenades/flares.dm
@@ -19,6 +19,9 @@
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2
 
+/obj/item/explosive/grenade/flare/proc/get_acid_delay()
+	return 0.5 SECONDS
+
 /obj/item/explosive/grenade/flare/Initialize(mapload)
 	. = ..()
 	fuel = rand(lower_fuel_limit, upper_fuel_limit) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -826,7 +826,7 @@
 		return fail_activate()
 
 	new current_acid_type(get_turf(A), A, A.dissolvability(current_acid_type::acid_strength))
-	succeed_activate(ability_cost / A.dissolvability(current_acid_type::acid_strength))
+	succeed_activate(ability_cost - (ability_cost * A.dissolvability(current_acid_type::acid_strength) - 1))
 
 	if(!isturf(A))
 		log_combat(X, A, "spat on", addition="with corrosive acid")

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -826,7 +826,7 @@
 		return fail_activate()
 
 	new current_acid_type(get_turf(A), A, A.dissolvability(current_acid_type::acid_strength))
-	succeed_activate(ability_cost - (ability_cost * A.dissolvability(current_acid_type::acid_strength) - 1))
+	succeed_activate(ability_cost * A.dissolvability(current_acid_type::acid_strength) > 0 ? ability_cost / A.dissolvability(current_acid_type::acid_strength) : ability_cost)
 
 	if(!isturf(A))
 		log_combat(X, A, "spat on", addition="with corrosive acid")

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -826,7 +826,7 @@
 		return fail_activate()
 
 	new current_acid_type(get_turf(A), A, A.dissolvability(current_acid_type::acid_strength))
-	succeed_activate()
+	succeed_activate(ability_cost / A.dissolvability(current_acid_type::acid_strength))
 
 	if(!isturf(A))
 		log_combat(X, A, "spat on", addition="with corrosive acid")


### PR DESCRIPTION
## About The Pull Request

Dynamic plasma cost is cool; 2x faster casting matches the plasma cost reduction on flares which cost 50% plasma when scaling by dissolvability. So you can now melt 2 flares for the price of the former 1 in time and plasma. Oh and your walls will be 2x more expensive.

## Why It's Good For The Game

It's dynamic I guess

## Changelog
:cl:
balance: 2x faster acid casting on flares, plasma cost affected by dissolvability (0.5x flares, 2x walls)
/:cl: