### PR TITLE
Buffs defiler plasma economy

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -277,7 +277,7 @@
 	action_icon_state = "inject_egg"
 	action_icon = 'icons/Xeno/actions/defiler.dmi'
 	desc = "Inject an egg with toxins, killing the larva, but filling it full with gas ready to explode."
-	ability_cost = 100
+	ability_cost = 70
 	cooldown_duration = 5 SECONDS
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY
 	keybinding_signals = list(
@@ -410,7 +410,7 @@
 	action_icon = 'icons/Xeno/actions/defiler.dmi'
 	desc = "For a short duration the next 3 slashes made will inject a small amount of selected toxin."
 	cooldown_duration = 6 SECONDS
-	ability_cost = 100
+	ability_cost = 70
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REAGENT_SLASH,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -17,7 +17,7 @@
 	speed = -1
 
 	// *** Plasma *** //
-	plasma_max = 575
+	plasma_max = 650
 	plasma_gain = 35
 
 	// *** Health *** //


### PR DESCRIPTION
## About The Pull Request
Defiler max plasma 575 > 650
Defiler reagant slash cost 100 > 70
Defiler inject egg cost 100 >70

## Why It's Good For The Game
Defiler is generally okay, but with the addition of sizzler we now have an instant smokescreen ability on a ranged caste which cannot be sold for req points. This undermines a lot of the core reasons you'd play defiler and risk a fragile t3 corpse for gas coverage. Additionally, the removal of nanite/med stacking and general buffs to melee castes have made defilers less relevant for countering defensively stacked marines. Aimmode removal has helped defiler survivability, but it still faces more hard counters than the average t3 caste (AG/tanglefoot, combat robots, vehicles, mimir, stuns/staggers, and plasma draining effects). 

In light of all of that, I think it's reasonable to improve defiler's tight plasma economy and soften up one of these counters. As it stands, the caste can often fail to complete combos due to plasma limitations, especially if marines are employing any plasma drain equipment (such as the new Tesla turrets). Making this more forgiving should make one of our coolest castes a little more inviting.

Open to switching up numbers just spitballing

## Changelog
:cl:
balance: increased defiler max plasma from 575 > 650
balance: reduced defiler reagant slash cost from 100 > 70
balance: reduced defiler inject neurotoxin cost from 100 > 70
/:cl:
