### PR TITLE
Reopens "Nanites only heal brute/burn if they can fix at least 3 damage"

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -1369,13 +1369,13 @@
 				L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 				L.adjustToxLoss(-0.15 * effect_str)
 
-			if(volume > 5 && (L.getBruteLoss(organic_only = TRUE) >= (3 * effect_str))) // only heal if we can derive the full value from it. slows down IB causing super blood loss from limb damage ticks we can't ignore (because we purge bicaridine)
+			if(volume > 5 && (L.getBruteLoss(organic_only = TRUE) >= 3)) // so we don't waste nanites healing miniscule damage
 				L.heal_overall_damage(3 * effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))
 					to_chat(L, span_notice("Your cuts and bruises begin to scab over rapidly!"))
 
-			if(volume > 5 && (L.getFireLoss(organic_only = TRUE) >= (3 * effect_str))) // as above, only heal if we get full value healing. slows down chip mitigated fire damage from super-killing fire-resistant users with nanite regen blood loss
+			if(volume > 5 && (L.getFireLoss(organic_only = TRUE) >= 3)) // same but for burn
 				L.heal_overall_damage(0, 3 * effect_str)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -1369,13 +1369,13 @@
 				L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 				L.adjustToxLoss(-0.15 * effect_str)
 
-			if(volume > 5 && L.getBruteLoss(organic_only = TRUE))
+			if(volume > 5 && (L.getBruteLoss(organic_only = TRUE) >= (3 * effect_str))) // only heal if we can derive the full value from it. slows down IB causing super blood loss from limb damage ticks we can't ignore (because we purge bicaridine)
 				L.heal_overall_damage(3 * effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))
 					to_chat(L, span_notice("Your cuts and bruises begin to scab over rapidly!"))
 
-			if(volume > 5 && L.getFireLoss(organic_only = TRUE))
+			if(volume > 5 && (L.getFireLoss(organic_only = TRUE) >= (3 * effect_str))) // as above, only heal if we get full value healing. slows down chip mitigated fire damage from super-killing fire-resistant users with nanite regen blood loss
 				L.heal_overall_damage(0, 3 * effect_str)
 				holder.remove_reagent(/datum/reagent/medicalnanites, 0.5)
 				if(prob(10))


### PR DESCRIPTION

## About The Pull Request

See #16170 (ty @Ephemeralis)

tl;dr: nanites will only heal & consume nanites when a user meets a minimum threshold of 3 damage, instead of nanites being spent on 0.25 chip damage
## Why It's Good For The Game

![IMG_1605](https://github.com/user-attachments/assets/9724b9dc-e7dd-4238-af11-5aa79cb6a552)

Nanites aren't very good right now, and barely anybody takes them. The large amount of DOTs and chip damage in the game (melting fire, sentinel spit, IB 0.25 brute ticks) that you'll suffer through the average round basically ensure you'll need to chug down a comically large amount of food to keep your nutrition and blood up.

At the present moment, they're just strictly worse than the 'sidegrade' to BKTT they're meant to be. Having them handle chip damage better will make them at least usable (you'll still be punished horribly for taking a lot of damage).
## Changelog
🆑
balance: Nanites now only spend themselves to heal brute or burn damage if they can cover at least 3 damage of either type, making instances of trickle/chip damage from things like IB much less immediately dangerous to your blood level.
/:cl:
