### PR TITLE
Missing soundin no longer runtimes

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -49,14 +49,14 @@
 A good representation is: 'byond applies a volume reduction to the sound every X tiles', where X is falloff.
  */
 /proc/playsound(atom/source, soundin, vol, vary, sound_range, falloff, is_global, frequency, channel = 0, ambient_sound = FALSE)
+	if(!soundin)
+		return
+
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
 	if(islist(soundin))
 		CRASH("playsound(): soundin attempted to pass a list! Consider using pick()")
-
-	if(!soundin)
-		CRASH("playsound(): no soundin passed")
 
 	if(vol < SOUND_AUDIBLE_VOLUME_MIN) // never let sound go below SOUND_AUDIBLE_VOLUME_MIN or bad things will happen
 		CRASH("playsound(): volume below SOUND_AUDIBLE_VOLUME_MIN. [vol] < [SOUND_AUDIBLE_VOLUME_MIN]")


### PR DESCRIPTION

## About The Pull Request
Made this check a return instead of a crash.

A pretty huge chunk of the calls to this proc are using various sound vars with the assumption that many of them will be null.
So it seems better to simply return since its intended, rather than crashing 5 million times.

:cl:
code: playsound() early returns instead of runtimes when there is no soundin
/:cl:
