### PR TITLE
LTB Canister Ricochet and Rework

### DIFF
--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -257,11 +257,11 @@
 /datum/ammo/bullet/tx54_spread/tank_cannister/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister
 	bonus_projectiles_scatter = 0
-	damage = 40
+	damage = 35
 
 /datum/ammo/bullet/tx54_spread/tank_cannister/ricochet/one
 	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister/ricochet
-	damage = 50
+	damage = 40
 
 /datum/ammo/bullet/tx54_spread/tank_cannister/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, max_range = 4, stagger = 2 SECONDS, slowdown = 0.2)

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -239,20 +239,32 @@
 	damage_falloff = 0.5
 	max_range = 3
 	projectile_greyscale_colors = "#4f0303"
-	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister
-	bonus_projectiles_scatter = 6
+	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister/ricochet/one
+	bonus_projectiles_scatter = 4
 	bonus_projectile_quantity = 12
 
 /datum/ammo/bullet/tx54_spread/tank_cannister
 	name = "cannister shot"
 	icon_state = "flechette"
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_MOB
-	max_range = 7
-	damage = 50
+	max_range = 12
+	damage = 30
 	penetration = 15
 	sundering = 2
 	damage_falloff = 1
 	shrapnel_chance = 15
 
+/datum/ammo/bullet/tx54_spread/tank_cannister/ricochet
+	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister
+	bonus_projectiles_scatter = 0
+	damage = 40
+
+/datum/ammo/bullet/tx54_spread/tank_cannister/ricochet/one
+	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/tank_cannister/ricochet
+	damage = 50
+
 /datum/ammo/bullet/tx54_spread/tank_cannister/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, max_range = 4, stagger = 2 SECONDS, slowdown = 0.2)
+
+/datum/ammo/bullet/tx54_spread/tank_cannister/ricochet/on_hit_turf(turf/target_turf, obj/projectile/proj)
+	reflect(target_turf, proj, 5)


### PR DESCRIPTION
## About The Pull Request
1. Canister Submunitions now ricochet off walls 2 times
2. Reduces scatter of Canister submunitions (Was 6, now 4)
3. Increases range of Canister submunitions (Was 7, now 12)

Damage values very likely need adjusting.

https://github.com/user-attachments/assets/ace97af8-e925-4b99-8706-150bfc2ca271

## Why It's Good For The Game
Canister is mostly considered worthless alongside HE and APFSDS counterparts, it's almost never taken by higher-playtime tankers. This gives it an area-denial effect allowing the tank to reach, slightly, around corners and into mazes.

The range is increased, this does mean projectiles can reach offscreen, but its necessary for ricochet, and LTB rounds can travel very far anyway, guarantee there's no sniping shenaniganry here you cant pull off with LTB HE.

The scatter was reduced to allow for more strategic placement of shots vs. old near-90 degree spread.

## Changelog
:cl:
balance: LTB Canister now ricochets off walls (2 times), has reduced scatter (Was 6, now 4), and increased range (Was 7, now 12)
/:cl:
