### PR TITLE
Adds a second Corporate Liaison slot to Nuclear War

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -14390,6 +14390,7 @@
 /area/mainship/squads/general)
 "lJZ" = (
 /obj/structure/bed/chair/sofa/left,
+/obj/effect/landmark/start/job/corporateliaison,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "lKr" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -7645,6 +7645,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
+/obj/effect/landmark/start/job/corporateliaison,
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "aQY" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -9376,6 +9376,7 @@
 /obj/machinery/door_control/mainship/corporate{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/corporateliaison,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "fCa" = (

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -16,7 +16,7 @@
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/medical/medicalofficer = 4,
 		/datum/job/terragov/medical/researcher = 2,
-		/datum/job/terragov/civilian/liaison = 1,
+		/datum/job/terragov/civilian/liaison = 2,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
 		/datum/job/terragov/command/assault_crewman = 0,


### PR DESCRIPTION

## About The Pull Request
Adds a second Corporate Liaison slot to Nuclear War and adds a second CL spawnpoint to the maps that didnt have two.
## Why It's Good For The Game
Liaison is our only pure roleplay job, which means on busy rounds they are stuck talking to themselves while everyone else is doing their jobs. Adding a second slot frees up more opportunity to have someone to roleplay with and create more memorable rounds where two people have a buddy cop dynamic while everyone else is fighting.

TLDR: Roleplay is more fun with a friend!
## Changelog
:cl:
add: Added a second Corporate Liaison slot to Nuclear War.
/:cl:
