### PR TITLE
Removes lie from drone castedatum

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -2,7 +2,7 @@
 	caste_name = "Drone"
 	display_name = "Drone"
 	upgrade_name = ""
-	caste_desc = "A builder of hives. Only drones may evolve into Shrikes."
+	caste_desc = "A builder of hives."
 	base_strain_type = /mob/living/carbon/xenomorph/drone
 	caste_type_path = /mob/living/carbon/xenomorph/drone
 


### PR DESCRIPTION

## About The Pull Request
this is fake news, anyone can evolve into shrikes
## Why It's Good For The Game
LIAR
## Changelog
:cl:
spellcheck: You will no longer believe the lie that only drones can evolve into Shrikes
/:cl:
