### PR TITLE
[BOUNTY] Xeno throws while in crit now apply oxyloss

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -393,10 +393,10 @@
 /mob/living/carbon/human/set_stat(new_stat) //registers/unregisters critdragging signals
 	. = ..()
 	if(new_stat == UNCONSCIOUS)
-		RegisterSignal(src, COMSIG_MOVABLE_PULL_MOVED, TYPE_PROC_REF(/mob/living/carbon/human, oncritdrag))
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/mob/living/carbon/human, on_crit_moved))
 		return
 	if(. == UNCONSCIOUS)
-		UnregisterSignal(src, COMSIG_MOVABLE_PULL_MOVED)
+		UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
 /// Handles when the player clicks on themself with the grab item
 /mob/living/carbon/proc/grabbed_self_attack(mob/living/user)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -40,13 +40,11 @@
 ///gives humans oxy when moved around in certain conditions. called on COMSIG_MOVABLE_MOVED
 /mob/living/carbon/human/proc/on_crit_moved(datum/source, atom/old_loc, movement_dir, forced = FALSE, list/old_locs)
 	SIGNAL_HANDLER
-	if(pulledby || throwing) // only catch the scenarios we're interested in: being pulled, or being thrown
-		if(pulledby && !isxeno(pulledby)) // if we're being pulled, only xenos should damage us
-			return
-		// no thrower check; getting thrown around while nearly dead is pretty risky, after all!
-		if(adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
-			return
-		INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS)
+	if(pulledby && !isxeno(pulledby)) // if we're being pulled, only xenos should damage us
+		return
+	if(!adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
+		INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS) // if we can't take oxy damage, take it as brute instead
+	updatehealth() // force a health update so we can't get dragged any further than we should be
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -40,12 +40,10 @@
 ///gives humans oxy when moved around in certain conditions. called on COMSIG_MOVABLE_MOVED
 /mob/living/carbon/human/proc/on_crit_moved(datum/source, atom/old_loc, movement_dir, forced = FALSE, list/old_locs)
 	SIGNAL_HANDLER
-	if(pulledby || throwing || buckled) // only catch the scenarios we're interested in: pulls, throws, and certain stuff we can be buckled to
+	if(pulledby || throwing) // only catch the scenarios we're interested in: pulls and throws
 		if(pulledby && !isxeno(pulledby)) // only care about xenos pulling us
 			return
 		if(throwing && !isxeno(thrower)) // same here, albeit for throwing
-			return
-		if(buckled && !isxeno(buckled.pulledby)) // some stuff like rollerbeds can be pulled by xenos; catch those too
 			return
 		if(!adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
 			INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS) // if we can't take oxy damage (for some reason), take it as brute instead

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -40,11 +40,16 @@
 ///gives humans oxy when moved around in certain conditions. called on COMSIG_MOVABLE_MOVED
 /mob/living/carbon/human/proc/on_crit_moved(datum/source, atom/old_loc, movement_dir, forced = FALSE, list/old_locs)
 	SIGNAL_HANDLER
-	if(pulledby && !isxeno(pulledby)) // if we're being pulled, only xenos should damage us
-		return
-	if(!adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
-		INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS) // if we can't take oxy damage, take it as brute instead
-	updatehealth() // force a health update so we can't get dragged any further than we should be
+	if(pulledby || throwing || buckled) // only catch the scenarios we're interested in: pulls, throws, and certain stuff we can be buckled to
+		if(pulledby && !isxeno(pulledby)) // only care about xenos pulling us
+			return
+		if(throwing && !isxeno(thrower)) // same here, albeit for throwing
+			return
+		if(buckled && !isxeno(buckled.pulledby)) // some stuff like rollerbeds can be pulled by xenos; catch those too
+			return
+		if(!adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
+			INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS) // if we can't take oxy damage (for some reason), take it as brute instead
+		updatehealth() // force a health update so we can't get dragged any further than we should be
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -37,11 +37,14 @@
 			else
 				hud_used.healths.icon_state = "health6"
 
-///gives humans oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
-/mob/living/carbon/human/proc/oncritdrag()
+///gives humans oxy when moved around in certain conditions. called on COMSIG_MOVABLE_MOVED
+/mob/living/carbon/human/proc/on_crit_moved(datum/source, atom/old_loc, movement_dir, forced = FALSE, list/old_locs)
 	SIGNAL_HANDLER
-	if(isxeno(pulledby))
-		if(adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) //take oxy damage per tile dragged
+	if(pulledby || throwing) // only catch the scenarios we're interested in: being pulled, or being thrown
+		if(pulledby && !isxeno(pulledby)) // if we're being pulled, only xenos should damage us
+			return
+		// no thrower check; getting thrown around while nearly dead is pretty risky, after all!
+		if(adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS)) // take oxy damage per tile moved
 			return
 		INVOKE_ASYNC(src, PROC_REF(adjustBruteLoss), HUMAN_CRITDRAG_OXYLOSS)
 


### PR DESCRIPTION
## About The Pull Request
Adjusts critdragging code to include throwing, besides normal pulling. This effectively makes xeno abilities that displace the target also inflict oxyloss, instead of limiting this functionality to pulls only. Furthermore, critdrag now also updates health, preventing humans from being dragged any further than they should be.

## Why It's Good For The Game
Prevents xenos from dragging people for insane distances and sending them to Brazil.

## Changelog
:cl: Lewdcifer
balance: Being thrown while in crit will now apply oxyloss and update health. This prevents xenos from dragging people for insane distances.
/:cl: