### PR TITLE
Xenos can no longer pull resin cocoons

### DIFF
--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -125,9 +125,8 @@
 		return
 	icon_state = "xeno_cocoon_open"
 
-/obj/structure/cocoon/pull_response(mob/puller)
-	if(isxeno(puller))
-		puller.stop_pulling()
+/obj/structure/cocoon/can_be_pulled(user, force)
+	if(isxeno(user))
 		return FALSE
 	return ..()
 

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -125,6 +125,12 @@
 		return
 	icon_state = "xeno_cocoon_open"
 
+/obj/structure/cocoon/pull_response(mob/puller)
+	if(isxeno(puller))
+		puller.stop_pulling()
+		return FALSE
+	return ..()
+
 /obj/structure/cocoon/opened_cocoon
 	icon_state = "xeno_cocoon_open"
 	anchored = FALSE


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
This bypasses xeno restrictions on dragging dead people. That's very wack.

## Changelog
:cl: Lewdcifer
balance: Xenos can no longer pull resin cocoons.
/:cl: