### PR TITLE
Xenos can no longer pull (roller)beds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -217,11 +217,10 @@
 	grabbed_mob.forceMove(loc)
 	return TRUE
 
-/obj/structure/bed/pull_response(mob/puller)
+/obj/structure/bed/can_be_pulled(user, force)
+	. = ..()
 	if(isxeno(puller))
-		puller.stop_pulling()
 		return FALSE
-	return ..()
 
 /obj/structure/bed/alien
 	icon_state = "abed"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -217,6 +217,12 @@
 	grabbed_mob.forceMove(loc)
 	return TRUE
 
+/obj/structure/bed/pull_response(mob/puller)
+	if(isxeno(puller))
+		puller.stop_pulling()
+		return FALSE
+	return ..()
+
 /obj/structure/bed/alien
 	icon_state = "abed"
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -218,9 +218,9 @@
 	return TRUE
 
 /obj/structure/bed/can_be_pulled(user, force)
-	. = ..()
-	if(isxeno(puller))
+	if(isxeno(user))
 		return FALSE
+	return ..()
 
 /obj/structure/bed/alien
 	icon_state = "abed"


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
This lets xenos bypass restrictions on dragging dead people. That's very wack.

## Changelog
:cl: Lewdcifer
balance: Xenos can no longer pull beds such as rollerbeds.
/:cl: