### PR TITLE
Remove old hacks for on_changed_z_level not being callled by moved

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -15,20 +15,5 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	return
 
 /mob/dead/forceMove(atom/destination)
-	var/turf/old_turf = get_turf(src)
-	var/turf/new_turf = get_turf(destination)
-	if (old_turf?.z != new_turf?.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(old_turf) == GET_TURF_PLANE_OFFSET(new_turf))
-		on_changed_z_level(old_turf, new_turf, same_z_layer) // todo these call seems redundant
-	var/oldloc = loc
-	loc = destination
-	Moved(oldloc, NONE, TRUE)
-
-/mob/dead/abstract_move(atom/destination)
-	var/turf/old_turf = get_turf(src)
-	var/turf/new_turf = get_turf(destination)
-	if (old_turf?.z != new_turf?.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(old_turf) == GET_TURF_PLANE_OFFSET(new_turf))
-		on_changed_z_level(old_turf, new_turf, same_z_layer) // todo these call seems redundant
-	return ..()
+	return abstract_move(destination)
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -86,14 +86,6 @@
 		ai.master_multicam.refresh_view()
 	update_parallax_contents()
 
-/mob/camera/aiEye/abstract_move(atom/new_loc)
-	var/turf/old_turf = get_turf(src)
-	var/turf/new_turf = get_turf(new_loc)
-	if(old_turf?.z != new_turf?.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(old_turf) == GET_TURF_PLANE_OFFSET(new_turf))
-		on_changed_z_level(old_turf, new_turf, same_z_layer) // todo these call seems redundant
-	return ..()
-
 
 /mob/camera/aiEye/Move(atom/newloc, direction, glide_size_override)
 	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -897,11 +897,6 @@
 	clear_important_client_contents()
 	canon_client = null
 
-/mob/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents = TRUE)
-	. = ..()
-	if(!same_z_layer)
-		relayer_fullscreens()
-
 /mob/proc/point_to_atom(atom/pointed_atom)
 	var/turf/tile = get_turf(pointed_atom)
 	if(!tile)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -107,12 +107,6 @@ All ShuttleMove procs go here
 
 // Called on atoms after everything has been moved
 /atom/movable/proc/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
-
-	var/turf/newT = get_turf(src)
-	if (newT.z != oldT.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(oldT) == GET_TURF_PLANE_OFFSET(newT))
-		on_changed_z_level(oldT, newT, same_z_layer)
-
 	if(light)
 		update_light()
 	if(rotation)


### PR DESCRIPTION
and a dupe relay fulllscreen call
## About The Pull Request

Yet another refactor exposing shitcode

## Changelog
:cl:
fix: fixed zlevel changes being called multiple times in some cases
/:cl:
