### PR TITLE
Fixes mech damage overlays

### DIFF
--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -113,7 +113,7 @@
 /// Returns an overlay or list of overlays to use on the mech
 /datum/mech_limb/proc/get_overlays()
 	if(disabled && !has_destroyed_iconstate)
-		return null
+		return
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)
@@ -216,7 +216,7 @@
 
 /datum/mech_limb/head/get_overlays()
 	if(disabled && !has_destroyed_iconstate)
-		return null
+		return
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)
@@ -410,7 +410,7 @@
 
 /datum/mech_limb/arm/get_overlays()
 	if(disabled && !has_destroyed_iconstate)
-		return null
+		return
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -131,7 +131,7 @@
 			percent = owner.obj_integrity / owner.max_integrity
 		if(percent > 0.75)
 			return
-		var/dmg_percent = CEILING(percent, 0.25)*100
+		var/dmg_percent = max(CEILING(percent, 0.25)*100, 25)
 		. += iconstate2appearance(greyscale_type::icon_file, prefix+icon_state+"[dmg_percent]")
 
 ///intercepts damage intended for the mech and applies it to this limb when needed
@@ -232,8 +232,14 @@
 		emissive_appearance(visor_icon, prefix+visor_icon_state, owner)
 	)
 	if(has_damage_overlays)
-		var/percent = (part_health / initial(part_health))
-		var/dmg_percent = FLOOR(percent, 0.25)*100
+		var/percent
+		if(initial(part_health))
+			percent = (part_health / initial(part_health))
+		else
+			percent = owner.obj_integrity / owner.max_integrity
+		if(percent > 0.75)
+			return
+		var/dmg_percent = max(CEILING(percent, 0.25)*100, 25)
 		. += iconstate2appearance(greyscale_type::icon_file, prefix+icon_state+"[dmg_percent]")
 
 /datum/mech_limb/head/disable()
@@ -417,12 +423,16 @@
 	if(!owner.is_wreck && !owner.swapped_to_backweapons && (MECHA_R_BACK in owner.equip_by_category))
 		prefix += "fire"
 	. += iconstate2appearance(overlay_icon, prefix+icon_state)
-	if(has_damage_overlays && initial(part_health))
-		var/percent = (part_health / initial(part_health))
+	if(has_damage_overlays)
+		var/percent
+		if(initial(part_health))
+			percent = (part_health / initial(part_health))
+		else
+			percent = owner.obj_integrity / owner.max_integrity
 		if(percent > 0.75)
 			return
-		var/dmg_percent = CEILING(percent, 0.25)*100
-		. += iconstate2appearance(greyscale_type::icon_file, prefix+icon_state+"[dmg_percent]")
+		var/dmg_percent = max(CEILING(percent, 0.25)*100, 25)
+		. += iconstate2appearance(greyscale_type::icon_file, prefix+icon_state+"arm"+"[dmg_percent]")
 
 /datum/mech_limb/arm/recon
 	part_health = 100

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -112,13 +112,12 @@
 
 /// Returns an overlay or list of overlays to use on the mech
 /datum/mech_limb/proc/get_overlays()
+	if(disabled && !has_destroyed_iconstate)
+		return null
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)
 		prefix = "d_"
-	else if(disabled)
-		if(!has_destroyed_iconstate)
-			return null
 	else if (owner.leg_overload_mode && has_boosting_state)
 		prefix = "b_"
 
@@ -216,13 +215,12 @@
 	visor_icon = SSgreyscale.GetColoredIconByType(visor_config, visor_color)
 
 /datum/mech_limb/head/get_overlays()
+	if(disabled && !has_destroyed_iconstate)
+		return null
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)
 		prefix = "d_"
-	else if(disabled)
-		if(!has_damage_overlays)
-			return null
 	else if(owner.leg_overload_mode && has_boosting_state)
 		prefix = "b_"
 
@@ -411,13 +409,12 @@
 	return ..()
 
 /datum/mech_limb/arm/get_overlays()
+	if(disabled && !has_destroyed_iconstate)
+		return null
 	. = list()
 	var/prefix = ""
 	if(owner.is_wreck)
 		prefix = "d_"
-	else if(disabled)
-		if(!has_destroyed_iconstate)
-			return null
 	else if (owner.leg_overload_mode && has_boosting_state)
 		prefix = "b_"
 	if(!owner.is_wreck && !owner.swapped_to_backweapons && (MECHA_R_BACK in owner.equip_by_category))


### PR DESCRIPTION

## About The Pull Request


## Changelog
:cl:
fix: fixed mechs not showing damage overlays for arms
fix: fixed mech not showing damage overlays for destroyed limbs
fix: fixed destroyed limbs not updating when boosting/firing
/:cl:
