### PR TITLE
Fix many shuttle tiles not setting a baseturf and thus creating really wierd shit

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -71,6 +71,11 @@
 			continue
 		place.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
 
+		// tgmc special. we don't want any space tiles on shuttles unlike usual ss13
+		// however, making mappers place these is kinda unsafe, and a lot of work
+		// so, as a precaution, we'll just add this as the topmost baseturf
+		place.baseturfs += /turf/open/floor/plating
+
 		for(var/obj/docking_port/mobile/port in place)
 			port.calculate_docking_port_information(src)
 			if(register)


### PR DESCRIPTION

## About The Pull Request

TM before merge just to make sure we dont have any new wierd edge cases
maybe I should put it in a different order idk
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/17443

## Changelog
:cl:
fix: fixed wierd behaviour with things under shuttles showing when they shouldnt. Shuttles will now always try to revert a plating instead
/:cl:
