### PR TITLE
Fix xeno observe not setting the xeno var

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -248,6 +248,7 @@
 		return
 	if(old_xeno)
 		stop_overwatch(FALSE)
+	watcher.observed_xeno = target
 	if(isxenoqueen(watcher)) // Only queen needs the eye shown.
 		target.hud_set_queen_overwatch()
 	watcher.reset_perspective(target)
@@ -261,6 +262,7 @@
 /datum/action/ability/xeno_action/watch_xeno/proc/stop_overwatch(do_reset_perspective = TRUE)
 	var/mob/living/carbon/xenomorph/watcher = owner
 	var/mob/living/carbon/xenomorph/observed = watcher.observed_xeno
+	watcher.observed_xeno = null
 	watcher.reset_perspective()
 	if(!QDELETED(observed))
 		UnregisterSignal(observed, list(COMSIG_HIVE_XENO_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED))


### PR DESCRIPTION

## About The Pull Request

Was making it so clicking it again didnt unobserve, oops

## Changelog
:cl:
fix: fixed the UI button to follow a xeno being clicked again not stoppping you from watching the currently watched xeno
/:cl:
