### PR TITLE
Some extra grammar & style stuff (part two?)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -786,7 +786,7 @@
 
 #define COMSIG_XENOMORPH_CORE_RETURN "xenomorph_core_return"
 #define COMSIG_XENOMORPH_HIVEMIND_CHANGE_FORM "xenomorph_hivemind_change_form"
-#define COMISG_XENOMORPH_HIVEMIND_TELEPORT "xeno_hivemind_teleport"
+#define COMSIG_XENOMORPH_HIVEMIND_TELEPORT "xeno_hivemind_teleport"
 
 #define COMSIG_XENO_OBJ_THROW_HIT "xeno_obj_throw_hit"				///from [/mob/living/carbon/xenomorph/throw_impact]: (obj/target, speed)
 #define COMSIG_XENO_LIVING_THROW_HIT "xeno_living_throw_hit"		///from [/mob/living/carbon/xenomorph/throw_impact]: (mob/living/target)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -265,8 +265,8 @@ You are in charge of logistics and the overwatch system. You are also in line to
 
 /datum/job/terragov/command/transportofficer/radio_help_message(mob/M)
 	. = ..()
-	to_chat(M, {"Your job is to support marines mobile dropship support with the Tadpole.
-You are to ensure the Tadpole's survival and to transport marines around, acting as a mobile bunker. In the case of it's death, you may perform the role of Combat Engineer.
+	to_chat(M, {"Your job is to provide mobile dropship support with the Tadpole, which is capable of both mass-transporting marines as well as holding vast amounts of equipment on it.
+Try to ensure the Tadpole's survival. In the case of its destruction, you may request a repair board from requisitions or perform the role of Combat Engineer.
 "})
 
 
@@ -322,7 +322,7 @@ You are to ensure the Tadpole's survival and to transport marines around, acting
 
 /datum/job/terragov/command/pilot/radio_help_message(mob/M)
 	. = ..()
-	to_chat(M, {"Your job is to support marines with either close air support via the Condor.
+	to_chat(M, {"Your job is to support marines with close air support via the Condor.
 You are expected to use the Condor as the Alamo is able to be ran automatically, though at some points you will be required to take control of the Alamo for the operation's success, though highly unlikey.
 Though you are an officer, your authority is limited to the dropship and the Condor, where you have authority over the enlisted personnel.
 "})

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -614,7 +614,7 @@
 	name = "teleport_minimap"
 	full_name = "Hivemind: Open teleportation minimap"
 	description = "Opens up the minimap which, when you click somewhere, tries to teleport you to the selected location"
-	keybind_signal = COMISG_XENOMORPH_HIVEMIND_TELEPORT
+	keybind_signal = COMSIG_XENOMORPH_HIVEMIND_TELEPORT
 	hotkey_keys = list("C")
 
 /datum/keybinding/xeno/hunter_pounce

--- a/code/game/buckling.dm
+++ b/code/game/buckling.dm
@@ -145,14 +145,14 @@
 	if(!silent)
 		if(buckled_mob == user)
 			buckled_mob.visible_message(
-				span_notice("[buckled_mob] unbuckled [buckled_mob.p_them()]self from [src]."),
+				span_notice("[buckled_mob] unbuckles [buckled_mob.p_them()]self from [src]."),
 				span_notice("You unbuckle yourself from [src]."),
 				span_notice("You hear metal clanking"))
 		else
-			var/by_user = user ? " by [user]" : ""
+			var/by_user = user ? "by [user]" : ""
 			buckled_mob.visible_message(
-				span_notice("[buckled_mob] was unbuckled[by_user]!"),
-				span_notice("You were unbuckled from [src][by_user]]."),
+				span_notice("[buckled_mob] was unbuckled [by_user]!"),
+				span_notice("You were unbuckled from [src] [by_user]]."),
 				span_notice("You hear metal clanking."))
 	add_fingerprint(user, "unbuckle")
 	if(isliving(unbuckling_living.pulledby))

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -266,7 +266,7 @@
 	N.fields["last_scan_time"] = od["stationtime"]
 	N.fields["last_scan_result"] = dat
 	N.fields["autodoc_data"] = generate_autodoc_surgery_list(H)
-	visible_message(span_notice("\The [src] pings as it stores the scan report of [H.real_name]"))
+	visible_message(span_notice("\The [src] pings as it stores the scan report of [H.real_name]."))
 	playsound(loc, 'sound/machines/ping.ogg', 25, 1)
 	use_power(active_power_usage)
 	return dat

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -145,7 +145,8 @@
 			if(completed_segments == total_segments) //If we're done, there's no need to run a segment again
 				busy = TRUE
 
-				usr.visible_message(span_notice("[usr] inserts a floppy disk into the [src] and begins to type...", "You insert a floppy disk into the [src] and begin to type..."))
+				usr.visible_message(span_notice("[usr] inserts a floppy disk into the [src] and begins to type..."),
+				span_notice("You insert a floppy disk into the [src] and begin to type..."))
 				if(!do_after(usr, printing_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
 					busy = FALSE
 					return
@@ -158,7 +159,8 @@
 
 			busy = TRUE
 
-			usr.visible_message(span_notice("[usr] begins typing away at the [src]'s keyboard...", "You begin typing away at the [src]'s keyboard..."))
+			usr.visible_message(span_notice("[usr] begins typing away at the [src]'s keyboard..."),
+			span_notice("You begin typing away at the [src]'s keyboard..."))
 			if(!do_after(usr, start_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
 				busy = FALSE
 				return

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -9,7 +9,7 @@
 
 /obj/machinery/computer/nuke_disk_generator
 	name = "nuke disk generator"
-	desc = "Used to generate the correct auth discs for the nuke."
+	desc = "A secure terminal used to retrieve nuclear authentication codes and print them onto disks."
 	icon_state = "computer"
 	screen_overlay = "nuke_red"
 	broken_icon = "computer_red_broken"
@@ -145,20 +145,20 @@
 			if(completed_segments == total_segments) //If we're done, there's no need to run a segment again
 				busy = TRUE
 
-				usr.visible_message("[usr] started a program to generate a new copy of the program.", "You started a program to generate a new copy of the program.")
+				usr.visible_message(span_notice("[usr] inserts a floppy disk into the [src] and begins to type...", "You insert a floppy disk into the [src] and begin to type..."))
 				if(!do_after(usr, printing_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
 					busy = FALSE
 					return
 
 				new disk_type(get_turf(src))
-				visible_message(span_notice("[src] beeps as it finishes printing the disc."))
+				visible_message(span_notice("[src] beeps, and spits out a [disk_color] floppy disk!"))
 				SEND_GLOBAL_SIGNAL(COMSIG_GLOB_DISK_GENERATED, src)
 				busy = FALSE
 				return
 
 			busy = TRUE
 
-			usr.visible_message("[usr] started a program to generate a nuclear disk code.", "You started a program to generate a nuclear disk code.")
+			usr.visible_message(span_notice("[usr] begins typing away at the [src]'s keyboard...", "You begin typing away at the [src]'s keyboard..."))
 			if(!do_after(usr, start_time, NONE, src, BUSY_ICON_GENERIC, null, null, CALLBACK(src, TYPE_PROC_REF(/datum, process))))
 				busy = FALSE
 				return
@@ -181,10 +181,10 @@
 	running = FALSE
 
 	if(completed_segments == total_segments)
-		visible_message(span_notice("[src] beeps as it ready to print."))
+		say("Program retrieval successful. Standing by to print...")
 		return
 
-	visible_message(span_notice("[src] beeps as it's program requires attention."))
+	say("Program run has concluded! Standing by...")
 
 ///Change minimap icon if its on or off
 /obj/machinery/computer/nuke_disk_generator/proc/update_minimap_icon()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -82,6 +82,6 @@
 	else
 		adjustOxyLoss(CARBON_RECOVERY_OXYLOSS, TRUE)
 		if(breath_failing)
-			to_chat(src, span_notice("Fresh air fills your lungs; you can breath again!"))
+			to_chat(src, span_notice("Fresh air fills your lungs; you can breathe again!"))
 			clear_alert(ALERT_NOT_ENOUGH_OXYGEN)
 			breath_failing = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Toggle Long Range Sight"
 	action_icon_state = "toggle_long_range"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Activates your weapon sight in the direction you are facing. Must remain stationary to use."
+	desc = "Extend your sight off into the distance. Must remain stationary to use."
 	ability_cost = 20
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LONG_RANGE_SIGHT,
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Bombard"
 	action_icon_state = "bombard"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Launch a glob of neurotoxin or acid. Must be rooted to use."
+	desc = "Dig yourself into place in order to launch a glob of acid or neurotoxin."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BOMBARD,
 	)
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	return xeno_owner.xeno_caste.bomb_delay - ((xeno_owner.neuro_ammo + xeno_owner.corrosive_ammo) * (BOILER_BOMBARD_COOLDOWN_REDUCTION SECONDS))
 
 /datum/action/ability/activable/xeno/bombard/on_cooldown_finish()
-	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))
+	to_chat(owner, span_notice("We feel our toxin glands swell. We are able to bombard an area again."))
 	if(xeno_owner.selected_ability == src)
 		xeno_owner.set_bombard_pointer()
 	return ..()
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Acid Shroud"
 	action_icon_state = "acid_shroud"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Creates a smokescreen below yourself, at the cost of a longer cooldown for firing your Bombard."
+	desc = "Create a smokescreen of gas, setting your Bombard on a longer cooldown. Does not require or consume a reserved globule."
 	ability_cost = 200
 	cooldown_duration = 30 SECONDS
 	use_state_flags = ABILITY_USE_BUSY|ABILITY_USE_LYING
@@ -371,7 +371,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Steam Rush"
 	action_icon_state = "steam_rush"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Grants a short speed boost. Slashes deal extra burn damage and extend the duration."
+	desc = "Gain a short-lived speed boost. Slashes deal extra burn damage and extend the duration of the sped boost.."
 	ability_cost = 100
 	cooldown_duration = 25 SECONDS
 	keybinding_signals = list(
@@ -396,7 +396,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		return
 
 	X.emote("roar")
-	X.visible_message(span_danger("[X]'s body is hissing with steam!"), \
+	X.visible_message(span_danger("[X]'s body starts to hiss with steam!"), \
 	span_xenowarning("We feel steam spraying from our body!"))
 
 	X.steam_rush = TRUE
@@ -423,7 +423,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 
 	carbon_target.apply_damage(steam_damage, damagetype = BURN, blocked = ACID)
 	playsound(carbon_target, 'sound/voice/alien/hiss2.ogg', 25)
-	to_chat(carbon_target, span_danger("We are burned by the hot steam!"))
+	to_chat(carbon_target, span_danger("You are burned by the hot steam!")) //I'm just going to operate under the assumption that xvx combat will never be a meaningful thing.
 
 	if(steam_rush_ability.steam_rush_duration)
 		deltimer(steam_rush_ability.steam_rush_duration)
@@ -444,7 +444,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	UnregisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING)
 
 /datum/action/ability/xeno_action/steam_rush/on_cooldown_finish()
-	owner.balloon_alert(owner, "Our blood is boiling once more; we can use steam rush again.")
+	owner.balloon_alert(owner, "Steam rush ready.")
 	owner.playsound_local(owner, 'sound/effects/alien/new_larva.ogg', 25, 0, 1)
 	return ..()
 
@@ -472,7 +472,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Smokescreen Spit"
 	action_icon_state = "acid_glob"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Empowers your next spit to create a wide smokescreen."
+	desc = "Empower your next spit, causing it to create a wide smokescreen."
 	ability_cost = 350
 	cooldown_duration = 30 SECONDS
 	keybinding_signals = list(
@@ -510,10 +510,10 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 // *********** High-Pressure Spit
 // ***************************************
 /datum/action/ability/activable/xeno/high_pressure_spit
-	name = "High Pressure Spit"
+	name = "High-Pressure Spit"
 	action_icon_state = "acid_lance_glob"
 	action_icon = 'icons/Xeno/actions/boiler.dmi'
-	desc = "Fires a high pressure glob of acid that knocks back, stuns, and shatters the target."
+	desc = "Fire a high pressure glob of acid that knocks back, stuns, and shatters the target."
 	ability_cost = 150
 	cooldown_duration = 25 SECONDS
 	keybinding_signals = list(
@@ -542,6 +542,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	add_cooldown()
 
 /datum/action/ability/activable/xeno/high_pressure_spit/on_cooldown_finish()
-	owner.balloon_alert(owner, "Our steam is welling up; we can use high pressure spit again.")
+	owner.balloon_alert(owner, "High-pressure spit ready.")
 	owner.playsound_local(owner, 'sound/voice/alien/hiss2.ogg', 25, 0, 1)
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -39,7 +39,7 @@
 		return FALSE
 	if(xeno_owner.eaten_mob)
 		if(!silent)
-			to_chat(xeno_owner, span_warning("You have already swallowed one."))
+			to_chat(xeno_owner, span_warning("We have already swallowed one."))
 		return FALSE
 	if(xeno_owner.on_fire)
 		if(!silent)
@@ -88,7 +88,7 @@
 	name = "Drain"
 	action_icon_state = "drain"
 	action_icon = 'icons/Xeno/actions/gorger.dmi'
-	desc = "Hold a marine for some time and drain their blood, while healing. You can't attack during this time and can be shot by the marine. When used on a dead human, you heal, or gain overheal, gradually and don't gain blood."
+	desc = "Root a marine and attack them twice after a windup, gaining blood and healing yourself. You cannot attack while doing this. When used on a human corpse, instead enter a channeled heal that grants overheal once health is full."
 	use_state_flags = ABILITY_KEYBIND_USE_ABILITY
 	cooldown_duration = 15 SECONDS
 	ability_cost = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -102,7 +102,7 @@
 	action_icon_state = "resync" // TODO: i think i missed an icon
 	desc = "Pick a location on the map and instantly manifest there if possible."
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMISG_XENOMORPH_HIVEMIND_TELEPORT,
+		KEYBINDING_NORMAL = COMSIG_XENOMORPH_HIVEMIND_TELEPORT,
 	)
 	use_state_flags = ABILITY_USE_SOLIDOBJECT
 	///Is the map being shown to the player right now?

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -535,7 +535,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 			continue
 		if(living_target.stat == DEAD)
 			continue
-		to_chat(living_target, span_xenowarning("\The [xeno_owner] hooks into our flesh and yanks us towards them!"))
+		to_chat(living_target, span_xenowarning("\The [xeno_owner] hooks into your flesh and yanks you towards it!"))
 		var/buffed = living_target.has_status_effect(STATUS_EFFECT_DANCER_TAGGED)
 		living_target.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
 		living_target.Shake(duration = 0.1 SECONDS)

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -272,7 +272,7 @@
 // Sniper Sentry
 
 /obj/item/weapon/gun/sentry/sniper_sentry
-	name = "\improper SRT-574 sentry gun"
+	name = "\improper SST-574 sentry gun"
 	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a heavy caliber AM-5 antimaterial rifle and a 75-round drum magazine."
 	icon_state = "sniper_sentry"
 	icon = 'icons/obj/machines/deployable/sentry/sniper.dmi'

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -37,8 +37,8 @@
 // Sniper Sentry
 
 /obj/item/ammo_magazine/sentry/sniper
-	name = "\improper AM-5 box magazine (10x28mm Caseless)"
-	desc = "A drum of 50 10x28mm caseless rounds for the SST-574 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
+	name = "\improper SST-574 box magazine (10x28mm Caseless)"
+	desc = "A magazine of 50 10x28mm caseless rounds for the SST-574 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	icon_state = "sniper_sentry"
 	max_rounds = 75
 	default_ammo = /datum/ammo/bullet/turret/sniper
@@ -46,7 +46,7 @@
 // Shotgun Sentry
 
 /obj/item/ammo_magazine/sentry/shotgun
-	name = "\improper SM-10 box magazine (12G Caseless)"
+	name = "\improper SHT-573 drum magazine (12G Caseless)"
 	desc = "A drum of 200 specialized telescopic 12G rounds for the SST-573 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	caliber = CALIBER_12G
 	icon_state = "shotgun_sentry"

--- a/code/modules/reqs/supplypacks/weapons_packs.dm
+++ b/code/modules/reqs/supplypacks/weapons_packs.dm
@@ -42,7 +42,7 @@ WEAPONS
 	cost = 600
 
 /datum/supply_packs/weapons/sentry_sniper_ammo
-	name = "SST-571 sniper sentry ammunition"
+	name = "SST-574 sniper sentry ammunition"
 	contains = list(/obj/item/ammo_magazine/sentry/sniper)
 	cost = 100
 


### PR DESCRIPTION

## About The Pull Request
mawp mawp mawp mawp
## Why It's Good For The Game
free gbp?
## Changelog
:cl:
spellcheck: fixes tense in unbuckling text
spellcheck: standardizes sentry and ammunition names for the sniper sentry, and the magazine names for both the sniper and shotgun sentry
spellcheck: updates nuke disk generator text
spellcheck: COMISG -> COMSIG
spellcheck: rewords TO job spawnin description
spellcheck: adds a missing period to the body scanner's chat log message
spellcheck: corrects breath -> breathe in the "fresh air fills your lungs" message
spellcheck: adjusts wording for boiler, praetorian, and gorger abilities
/:cl:
