### PR TITLE
Tangle emitter disabled by default

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -392,7 +392,7 @@
 	point_cost = 150
 	dropship_equipment_flags = IS_INTERACTABLE
 	/// Whether the system is currently enabled to activate on landing or not
-	var/enabled = TRUE
+	var/enabled = FALSE
 	/// What type of smoke to use
 	var/obj/item/explosive/grenade/smokebomb/drain/pellet/pellet_type
 	/// Cooldown for emitting smoke
@@ -417,8 +417,9 @@
 	if(ship_base)
 		setDir(ship_base.dir)
 		if(enabled)
-			update_appearance()
-			RegisterSignal(linked_shuttle, COMSIG_SHUTTLE_SETMODE, PROC_REF(drop_pellet_to_location))
+			balloon_alert_to_viewers("Enabled")
+		else
+			balloon_alert_to_viewers("Disabled")
 	else
 		setDir(initial(dir))
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

Currently: tangle emitter does not produce tangle until it is turned off/on again

This is because dropship equipment's "linked_console" var is null until the player does something with the equipment (???)

As far as my tired 2am brain can tell this is the only way for equipment to know which console it is linked to so this PR just disables the emitter roundstart and adds some balloon alerts so new players figure out "oh I have to enable it in the console"
## Why It's Good For The Game

Fixes buggy behaviour

Probably makes more sense to just have it start enabled, but there is literally no way to get a reference to the console & this makes sure new players know about enabling/disabling the emitter ig
## Changelog
:cl:
add: Tangle emitter starts disabled to prevent a bug
qol: Tangle emitter now gives feedback on whether it's enabled/disabled when attached
/:cl:
