### PR TITLE
Carrier Buffs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -169,12 +169,6 @@
 	if(isxenocarrier(user))
 		var/mob/living/carbon/xenomorph/carrier/C = user
 		C.store_hugger(src)
-	if(ishuman(user))
-		if(stat == DEAD)
-			return
-		user.visible_message(span_warning("[user] crushes [src] in [user.p_their()] hand!"), \
-		span_warning("You crush [src] in your hand!"))
-		kill_hugger()
 
 /obj/item/clothing/mask/facehugger/examine(mob/user)
 	. = ..()
@@ -792,6 +786,7 @@
 		target.adjust_stagger(3 SECONDS)
 		target.add_slowdown(15)
 		target.apply_damage(100, STAMINA, BODY_ZONE_HEAD, BIO, updating_health = TRUE) //This should prevent sprinting
+		target.ExtinguishMob()
 
 	kill_hugger(0.5 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request
Resin huggers now extingush their target
You can no longer crush huggers in hand
mari approved it lole
## Why It's Good For The Game
Being able to invalidate half of a caste by pressing two buttons is kinda bad i think. Extingushing is a more interesting way to stop marines from removing larval huggers than just making flares not ignite or w/e
## Changelog
:cl: Cheese
add: Resin huggers now extinguish their target
balance: You can no longer crush huggers in hand, as a human
/:cl:
