### PR TITLE
Crash Vendor Points Resurrected.

### DIFF
--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -185,7 +185,7 @@
 				continue
 			var/obj/item/card/id/user_id =  H.get_idcard()
 			for(var/i in user_id.marine_points)
-				user_id.marine_points[i] += 5
+				user_id.marine_points[i] += 3
 
 	update_minimap_icon()
 	running = FALSE

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -177,6 +177,15 @@
 	deltimer(current_timer)
 	current_timer = null
 	completed_segments = min(completed_segments + 1, total_segments)
+
+	// Add 5 Vendor points to all marines.
+	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+		if(!H.job)
+			continue
+		var/obj/item/card/id/user_id =  H.get_idcard()
+		for(var/i in user_id.marine_points)
+			user_id.marine_points[i] += 5
+
 	update_minimap_icon()
 	running = FALSE
 

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -185,7 +185,7 @@
 				continue
 			var/obj/item/card/id/user_id =  H.get_idcard()
 			for(var/i in user_id.marine_points)
-				user_id.marine_points[i] += 3
+				user_id.marine_points[i] += 2
 
 	update_minimap_icon()
 	running = FALSE

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -178,13 +178,14 @@
 	current_timer = null
 	completed_segments = min(completed_segments + 1, total_segments)
 
-	// Add 5 Vendor points to all marines.
-	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
-		if(!H.job)
-			continue
-		var/obj/item/card/id/user_id =  H.get_idcard()
-		for(var/i in user_id.marine_points)
-			user_id.marine_points[i] += 5
+	// If the gamemode is crash, Add 5 Vendor points to all marines.
+	if(iscrashgamemode(SSticker.mode))
+		for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+			if(!H.job)
+				continue
+			var/obj/item/card/id/user_id =  H.get_idcard()
+			for(var/i in user_id.marine_points)
+				user_id.marine_points[i] += 5
 
 	update_minimap_icon()
 	running = FALSE


### PR DESCRIPTION
## About The Pull Request

Every cycle of a nuclear disk completed gives marines +2 Vendor Points.
This totals to 10 points per completed disk and 30 total for all 3 disks.
This totals to a lot less than the original implementation which added 50 on each disk completion for a total of 150.

PR Tested on local thanks to advice from Demir
**[April 3 Update], Disentangles crash and Nuclear War**
After running 1 disk cycle on CRASH:
![image](https://github.com/user-attachments/assets/95e33e42-6c80-4559-8e4b-9a0afd2ec042)
After running 1 disk cycle on NUCLEAR WAR:
![image](https://github.com/user-attachments/assets/3ca4cc96-161c-4243-96ac-3797e90fae0d)


Utilizes slightly modified code from: #16162

## Why It's Good For The Game

The idea was good, this allows marines to have a small trickle of sustained resources without requisitions.
The original implementation was too generous with the points, allowing engineers to buy 3 sentries from gained points.
By halving the total number of gained points this should be reasonable.

## Changelog


:cl: Isy232, Ldip999
add: Marines receive 2 vendor points per disk cycle completed on Crash.
/:cl:
