### PR TITLE
Adjusts the Crash T3 Xeno Penalty.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1216,7 +1216,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) - SSticker.mode.tier_three_penalty) / 3 + length(psychictowers) + 1, 1))
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1  - SSticker.mode.tier_three_penalty))
 	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************


### PR DESCRIPTION

## About The Pull Request

Note the T3 penalty for crash is current 1 (unchanged) and 0 for all other modes.

Previous Functionality:
The T3 penalty of 1 would remove 1/3rd of the 2nd T3 slot from the hive on crash.
The hive would always have a minimum of at least 1 T3 slot.
The penalty only impacts the 2nd T3 slot by a single xenomorph.

New Functionality:
The T3 penalty of 1 removes 1 whole T3 slot.
The hive has a minimum of 0 T3 slots. (No T3 slots on ultra lowpop crash).
The T3 penalty removes the 1st T3 slot.

## Why It's Good For The Game

The minimum of always 1 T3 slot isn't sensible for crash balance.

Reducing the number of T3 slots on Crash is a good way to reduce the power of xenomorphs on Crash without reducing their numbers.
We have a lot of xeno players who I do not want to deny their play any more.

## Changelog

:cl:
balance: Adjusted how the T3 penalty is handled on crash, removing 1 whole T3 slot with a new minimum of 0 slots.
/:cl:
