### PR TITLE
Fixes eyes hopping all zlevels

### DIFF
--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -293,7 +293,7 @@
 		user_image = image(icon, top, icon_state, FLY_LAYER)
 		eye_user.client.images += user_image
 
-/mob/camera/aiEye/remote/relaymove(mob/user, direct)
+/mob/camera/aiEye/remote/relaymove(mob/user, direction)
 	if(istype(origin, /obj/machinery/computer/camera_advanced))
 		var/obj/machinery/computer/camera_advanced/CA = origin
 		CA.tracking_target = null
@@ -301,7 +301,7 @@
 		return
 	tiles_moved = ((cooldown + move_delay * 5) > world.time) ? 0 : tiles_moved
 	cooldown = world.time + move_delay * (1 - acceleration * tiles_moved / 10)
-	var/turf/T = get_turf(get_step(src, direct))
+	var/turf/T = get_step_multiz(src, direction)
 	// check for dir change , if we changed then remove all acceleration
 	if(get_dir(src, T) != direction_moved)
 		tiles_moved = 0


### PR DESCRIPTION

## About The Pull Request

CAS shouldnt be able to see shipside ideally

## Changelog
:cl:
fix: Fixed player cameras hopping over zlevels when they shouldnt
/:cl:
