### PR TITLE
Fixes supply beacons missing if the beacon moves

### DIFF
--- a/code/datums/components/beacon.dm
+++ b/code/datums/components/beacon.dm
@@ -126,7 +126,7 @@
 	playsound(source, 'sound/machines/twobeep.ogg', 15, 1)
 	user.visible_message("[user] activates [source]'s signal.")
 	user.show_message(span_notice("The [source] beeps and states, \"Your current coordinates were registered by the supply console. LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(source)]\""), EMOTE_AUDIBLE, span_notice("The [source] vibrates but you can not hear it!"))
-	beacon_datum = new /datum/supply_beacon("[user.name] + [A]", get_turf(source), user.faction)
+	beacon_datum = new /datum/supply_beacon("[user.name] + [A]", source, user.faction)
 	RegisterSignal(beacon_datum, COMSIG_QDELETING, PROC_REF(clean_beacon_datum))
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SUPPLY_BEACON_CREATED, src)
 	source.update_appearance()
@@ -207,11 +207,11 @@
 	/// Name printed on the supply console
 	var/name = ""
 	/// Where the supply drops will land
-	var/turf/drop_location
+	var/atom/drop_location
 	/// The faction of the beacon
 	var/faction = ""
 
-/datum/supply_beacon/New(_name, turf/_drop_location, _faction, life_time = 0 SECONDS)
+/datum/supply_beacon/New(_name, atom/_drop_location, _faction, life_time = 0 SECONDS)
 	name = _name
 	drop_location = _drop_location
 	faction = _faction

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -111,11 +111,11 @@
 			if(!length(supplies))
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("There wasn't any supplies found on the squads supply pad. Double check the pad.")]")
 				return
-
-			if(!istype(supply_beacon.drop_location) || !is_ground_level(supply_beacon.drop_location.z))
+			var/turf/land_turf = get_turf(supply_beacon.drop_location)
+			if(!land_turf || !is_ground_level(supply_beacon.drop_location.z))
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("The [supply_beacon.name] was not detected on the ground.")]")
 				return
-			if(isspaceturf(supply_beacon.drop_location) || supply_beacon.drop_location.density)
+			if(isspaceturf(land_turf) || land_turf.density)
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("The [supply_beacon.name]'s landing zone appears to be obstructed or out of bounds.")]")
 				return
 
@@ -148,8 +148,8 @@
 	if(!length(supplies) || length(supplies) > MAX_SUPPLY_DROPS)
 		stack_trace("Trying to send a supply drop with an invalid amount of items [length(supplies)]")
 		return
-
-	if(!istype(supply_beacon.drop_location) || isspaceturf(supply_beacon.drop_location) || supply_beacon.drop_location.density)
+	var/turf/land_turf = get_turf(supply_beacon.drop_location)
+	if(!istype(land_turf) || isspaceturf(land_turf) || land_turf.density)
 		stack_trace("Trying to send a supply drop to a beacon on an invalid turf")
 		return
 
@@ -187,7 +187,7 @@
 		return
 
 	playsound(supply_pad.loc,'sound/effects/bamf.ogg', 50, TRUE)
-	var/turf/droploc = locate(supply_beacon.drop_location.x + x_offset, supply_beacon.drop_location.y + y_offset, supply_beacon.drop_location.z)
+	var/turf/droploc = get_turf(supply_beacon.drop_location)
 	playsound(droploc, 'sound/items/fultext_deploy.ogg', 30, TRUE)
 	var/image/chute_cables = image('icons/effects/32x64.dmi', src, "chute_cables_static")
 	chute_cables.pixel_y -= 12


### PR DESCRIPTION

## About The Pull Request
Chnages the tracking to be the owner instead of a turf
most noticable when trying to drop something on tram

## Changelog
:cl:
fix: Fixed supply beacons missing if the beacon moves
/:cl:
