### PR TITLE
More mech balance changes

### DIFF
--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -107,7 +107,7 @@
 	sundering = 5
 	penetration = 15
 	damage = 75
-	damage_falloff = 8
+	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/mech/spread
 	name = "super-heavy additional buckshot"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -572,9 +572,9 @@
 
 /datum/ammo/rocket/homing/microrocket /// this is basically a tgmc version of the above
 	name = "homing HE microrocket"
-	shell_speed = 0.4
-	damage = 15
-	penetration = 25
+	shell_speed = 0.3
+	damage = 75
+	penetration = 40
 	sundering = 5
 	turn_rate = 10
 
@@ -583,14 +583,14 @@
 
 /datum/ammo/rocket/homing/microrocket/mech
 	name = "homing mech HE microrocket"
-	shell_speed = 0.3
-	damage = 75
-	penetration = 40
-	sundering = 10
+	shell_speed = 0.4
+	damage = 5
+	penetration = 20
+	sundering = 3
 	turn_rate = 10
 
 /datum/ammo/rocket/homing/microrocket/drop_nade(turf/T)
-	explosion(T, 0, 0, 0, 4, 1, explosion_cause=src)
+	explosion(T, 0, 0, 0, 2, 1, explosion_cause=src)
 
 /datum/ammo/rocket/homing/tow
 	name = "TOW-III missile"

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -589,7 +589,7 @@
 	sundering = 3
 	turn_rate = 10
 
-/datum/ammo/rocket/homing/microrocket/drop_nade(turf/T)
+/datum/ammo/rocket/homing/microrocket/mech/drop_nade(turf/T)
 	explosion(T, 0, 0, 0, 2, 1, explosion_cause=src)
 
 /datum/ammo/rocket/homing/tow

--- a/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
@@ -44,7 +44,7 @@
 	icon_state = "armor_acid"
 	iconstate_name = "armor_acid"
 	protect_name = "Lightweight Booster"
-	weight = 45
+	weight = 30
 	dash_consumption = 300
 	speed_mod = 0.5
 	dash_range = 5
@@ -75,7 +75,7 @@
 	name = "fusion engine"
 	desc = "A highly experimental phoron fusion core. Optimized for energy generation."
 	icon_state = "phoron_engine_adv"
-	weight = 150
+	weight = 110
 	cell_type = /obj/item/cell/mecha/medium
 
 /obj/item/mecha_parts/mecha_equipment/melee_core

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -175,7 +175,7 @@
 	slowdown = 0
 	harmful = TRUE
 	rearm_time = 4 SECONDS
-	weight = 90
+	weight = 80
 	ammo_type = MECHA_AMMO_SHOTGUN
 	hud_icons = list("shotgun_buckshot", "shotgun_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
@@ -374,14 +374,14 @@
 	equipment_slot = MECHA_BACK
 	ammotype = /obj/item/explosive/grenade
 	max_integrity = 350
-	projectiles = 10
-	projectiles_cache = 40
-	projectiles_cache_max = 40
+	projectiles = 5
+	projectiles_cache = 25
+	projectiles_cache_max = 25
 	projectile_delay = 1 SECONDS
 	variance = 10
 	missile_speed = 1.5
 	equip_cooldown = 2 SECONDS
-	weight = 130
+	weight = 110
 	slowdown = 0
 	rearm_time = 4 SECONDS
 	ammo_type = MECHA_AMMO_GRENADE
@@ -420,7 +420,7 @@
 	projectile_delay = 2 SECONDS
 	slowdown = 0
 	harmful = TRUE
-	weight = 100
+	weight = 90
 	ammo_type = MECHA_AMMO_FLAMER
 	hud_icons = list("flame", "flame_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
@@ -448,7 +448,7 @@
 	variance = 20
 	projectile_delay = 4 SECONDS
 	slowdown = 0
-	weight = 130
+	weight = 120
 	rearm_time = 5 SECONDS
 	windup_delay = 1 SECONDS
 	harmful = TRUE
@@ -478,7 +478,7 @@
 	burst_amount = 3
 	projectile_burst_delay = 0.2 SECONDS
 	slowdown = 0
-	weight = 75
+	weight = 90
 	rearm_time = 8 SECONDS
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_RPG


### PR DESCRIPTION
## About The Pull Request

Mech light booster/gen is lighter now to allow for better weight control
Mech GL has halved ammo capacity to curb spam, has lower weight to compensate
Mech micro rockets are actually nerfed now (i nerfed the wrong ones last time lol), and had their weight adjusted upwards since theyre pretty good
Mech shotgun has the same falloff as marine shotgun now as opposed to double, and lower weight
Mech flamer has lower weight
Mech rocket launcher has lower weight

## Why It's Good For The Game

Better balance for mech

## Changelog

:cl:
balance: Mech light booster/gen is lighter now to allow for better weight control
balance: Mech GL has halved ammo capacity to curb spam, has lower weight to compensate
balance: Mech micro rockets have been properly nerfed, their weight has been increased
balance: Mech shotgun has the same falloff as marine shotgun now as opposed to double, as well as lower weight
balance: Mech flamer has lower weight
balance: Mech rocket launcher has lower weight
/:cl:
