### PR TITLE
Crash Xeno Spawn Fix

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -128,8 +128,8 @@
 	. = ..()
 
 	if(world.time > last_larva_check + larva_check_interval)
-		balance_scales()
 		last_larva_check = world.time
+		balance_scales()
 
 /datum/game_mode/infestation/crash/proc/crash_shuttle(obj/docking_port/stationary/target)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CRASH_SHIP_LANDED)
@@ -192,6 +192,7 @@
 
 /// Adds more xeno job slots if needed.
 /datum/game_mode/infestation/crash/proc/balance_scales()
+	SHOULD_NOT_SLEEP(TRUE)
 	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	// Spawn more xenos to help maintain the ratio.


### PR DESCRIPTION
## About The Pull Request

Attempts to fix crash spawning >1 xenos every 2 minutes "larva spawn cycle".
We aren't sure this is actually the cause, however as mentioned the change to put the balance scales call after the check time update is a good idea to avoid any potential problems if balance scales check somehow was slow.

## Why It's Good For The Game

Fixes a bug slopping crash rounds.

## Changelog

:cl: Isy232, ivanmixo
fix: Attempts to fix crash spawning >1 xeno per larva spawn cycle.
/:cl:
