### PR TITLE
Fix failed diag movement making the atom dir diagonal (ft. king buff)

### DIFF
--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -392,13 +392,14 @@
 	var/atom/movable/pullee = pulling
 	if(!moving_from_pull)
 		check_pulling(z_allowed = TRUE)
-	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc, direction) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
-		return FALSE
 	if(!loc || !newloc || loc == newloc)
 		return FALSE
 
 	if(!direction)
 		direction = get_dir(src, newloc)
+
+	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc, direction) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
+		return FALSE
 
 	var/can_pass_diagonally = NONE
 	if (direction & (direction - 1)) //Check if the first part of the diagonal move is possible
@@ -415,6 +416,7 @@
 			can_pass_diagonally = WEST
 		else
 			moving_diagonally = FALSE
+			setDir(direction &~ (NORTH|SOUTH))
 			return
 		moving_diagonally = FALSE
 		if(!get_step(loc, can_pass_diagonally)?.Exit(src, direction & ~can_pass_diagonally))

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -116,7 +116,7 @@
 	return ..()
 
 /// Humans caught in the aoe_leash will be pulled back if they leave it's radius
-/obj/structure/xeno/aoe_leash/proc/check_dist(datum/leash_victim, atom/newloc)
+/obj/structure/xeno/aoe_leash/proc/check_dist(atom/source, atom/newloc, direction)
 	SIGNAL_HANDLER
 	if(get_dist(newloc, src) >= leash_radius)
 		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE


### PR DESCRIPTION

## About The Pull Request
Diag wasnt resetting the dir to nondiag on failed move, so we now do that
To make sure king can still beam diagonally, it now tracks the last attempted move dir, which means you no longer need to hug a wall to use diag mech beam

## Changelog
:cl:
fix: Fixed failed diag movement making the atom dir diagonal
qol: As a side effect of the above, king no longer needs to hug a wall to shoot laser diagonally, and just tracks the last attempted movement
/:cl:
