### PR TITLE
Acid spray, sticky, firenados fall on openspace

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -8,30 +8,6 @@
 	icon = 'icons/Xeno/Effects.dmi'
 	layer = FLY_LAYER
 
-/obj/effect/xenomorph/splatter
-	name = "splatter"
-	desc = "It burns! It burns like hygiene!"
-	icon_state = "splatter"
-	density = FALSE
-	opacity = FALSE
-	anchored = TRUE
-
-/obj/effect/xenomorph/splatter/Initialize(mapload) //Self-deletes after creation & animation
-	. = ..()
-	QDEL_IN(src, 8)
-
-/obj/effect/xenomorph/splatterblob
-	name = "splatter"
-	desc = "It burns! It burns like hygiene!"
-	icon_state = "acidblob"
-	density = FALSE
-	opacity = FALSE
-	anchored = TRUE
-
-/obj/effect/xenomorph/splatterblob/Initialize(mapload) //Self-deletes after creation & animation
-	. = ..()
-	QDEL_IN(src, 4 SECONDS)
-
 /obj/effect/xenomorph/spray
 	name = "splatter"
 	desc = "It burns! It burns like hygiene!"
@@ -62,6 +38,14 @@
 /obj/effect/xenomorph/spray/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	xeno_owner = null
+	return ..()
+
+/obj/effect/xenomorph/spray/can_z_move(direction, turf/start, turf/destination, z_move_flags, mob/living/rider)
+	z_move_flags |= ZMOVE_ALLOW_ANCHORED
+	return ..()
+
+/obj/effect/xenomorph/spray/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
+	impact_flags |= ZIMPACT_NO_SPIN
 	return ..()
 
 /// Signal handler to check if an human is entering the acid spray turf

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -135,6 +135,14 @@
 
 	return ..()
 
+/obj/alien/resin/sticky/can_z_move(direction, turf/start, turf/destination, z_move_flags, mob/living/rider)
+	z_move_flags |= ZMOVE_ALLOW_ANCHORED
+	return ..()
+
+/obj/alien/resin/sticky/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
+	impact_flags |= ZIMPACT_NO_SPIN
+	return ..()
+
 // Hivelord Sticky Resin spit uses this.
 /obj/alien/resin/sticky/thin
 	name = "thin sticky resin"

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -316,6 +316,14 @@
 	for(var/mob/living/living_victim in loc)
 		mob_act(living_victim)
 
+/obj/effect/xenomorph/firenado/can_z_move(direction, turf/start, turf/destination, z_move_flags, mob/living/rider)
+	z_move_flags |= ZMOVE_ALLOW_ANCHORED
+	return ..()
+
+/obj/effect/xenomorph/firenado/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
+	impact_flags |= ZIMPACT_NO_SPIN
+	return ..()
+
 /obj/effect/xenomorph/firenado/Bump(atom/target)
 	. = ..()
 	if(isliving(target))


### PR DESCRIPTION

## About The Pull Request

Same fix as fire
also deleted some unused crap

## Changelog
:cl:
fix: Acid spray, sticky, firenados fall on openspace
/:cl:
