### PR TITLE
Tram/elevator hitbox/desant fixes

### DIFF
--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -128,12 +128,15 @@
 	transport_contents -= potential_rider
 	changed_gliders -= potential_rider
 
-	UnregisterSignal(potential_rider, list(COMSIG_QDELETING, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE))
+	UnregisterSignal(potential_rider, list(COMSIG_QDELETING, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, SIGNAL_ADDTRAIT(TRAIT_TANK_DESANT)))
 
 /obj/structure/transport/linear/proc/add_item_on_transport(datum/source, atom/movable/new_transport_contents)
 	SIGNAL_HANDLER
-	var/static/list/blacklisted_types = typecacheof(list(/obj/structure/fluff/tram_rail, /obj/effect/decal/cleanable, /obj/structure/transport/linear, /mob/camera))
+	var/static/list/blacklisted_types = typecacheof(list(/obj/structure/fluff/tram_rail, /obj/effect/decal/cleanable, /obj/structure/transport/linear, /mob/camera, /obj/hitbox))
 	if(is_type_in_typecache(new_transport_contents, blacklisted_types) || new_transport_contents.invisibility == INVISIBILITY_ABSTRACT || level == 1) //prevents the tram from stealing things like landmarks
+		return FALSE
+	// how many layers of riding can we fit
+	if(HAS_TRAIT(new_transport_contents, TRAIT_TANK_DESANT))
 		return FALSE
 	if(new_transport_contents in transport_contents)
 		return FALSE
@@ -142,7 +145,7 @@
 		ADD_TRAIT(new_transport_contents, TRAIT_CANNOT_BE_UNBUCKLED, VEHICLE_TRAIT)
 
 	transport_contents += new_transport_contents
-	RegisterSignal(new_transport_contents, COMSIG_QDELETING, PROC_REF(remove_item_from_transport))
+	RegisterSignals(new_transport_contents, list(COMSIG_QDELETING, SIGNAL_ADDTRAIT(TRAIT_TANK_DESANT)), PROC_REF(remove_item_from_transport))
 
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fixes hitboxes teleporting wherever and desants also teleporting wherever

## Changelog
:cl:
fix: fixed wierd teleporting riding interactions on trams with tank riders and the tank hitbox
/:cl:
