### PR TITLE
Fixes directionalburst(canister) hitting solid objects if it spawns inside them (tank hitbox)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -266,7 +266,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		var/obj/projectile/hitscan/main_proj_hitscan = main_proj
 		effect_icon = main_proj_hitscan.effect_icon
 	for(var/i = 1 to projectile_amount) //Want to run this for the number of bonus projectiles.
-		var/obj/projectile/new_proj = new proj_type(loc_override ? loc_override : main_proj.loc, effect_icon)
+		var/atom/used_loc = loc_override ? loc_override : main_proj.loc
+		var/obj/projectile/new_proj = new proj_type(used_loc, effect_icon)
+		// we do this so if we place inside something, we fly out of it instead of hitting it
+		new_proj.hit_atoms += used_loc.contents
 		if(bonus_projectiles_type)
 			new_proj.generate_bullet(bonus_projectiles_type)
 		else //If no bonus type is defined then the extra projectiles are the same as the main one.


### PR DESCRIPTION
…nside them (tank hitbox)
## About The Pull Request

TM this, this is what was causing canister bursts to hit the tank hitbox, since they were initing and then trying to move out of a valid target. Likely affected other similar cases but tank is the most notable. Dunno about any other knock-on effects this might have.

## Changelog
:cl:
fix: Fixes directiona lbursts (canister,  buckshot) hitting solid objects if it spawns inside them (tank hitbox, walls, etc)
/:cl:
