### PR TITLE
Crash always has at least two xenos

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -210,7 +210,7 @@
 	// Make sure there is at least two xenos regardless of ratio.
 	var/total_xenos = xeno_hive.get_total_xeno_number() + (xeno_job.total_positions - xeno_job.current_positions)
 	if(total_xenos < 2)
-		xeno_job.add_job_positions(2 - total_xenos)
+		xeno_job.add_job_positions(1)
 		xeno_hive.update_tier_limits()
 
 /// Gets the difference of job points between humans and xenos. Negative means too many xenos. Positive means too many humans.

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -207,10 +207,10 @@
 		xeno_job.add_job_positions(1)
 		xeno_hive.update_tier_limits()
 		return
-	// Make sure there is at least one xeno regardless of ratio.
+	// Make sure there is at least two xenos regardless of ratio.
 	var/total_xenos = xeno_hive.get_total_xeno_number() + (xeno_job.total_positions - xeno_job.current_positions)
-	if(!total_xenos)
-		xeno_job.add_job_positions(1)
+	if(total_xenos < 2)
+		xeno_job.add_job_positions(2 - total_xenos)
 		xeno_hive.update_tier_limits()
 
 /// Gets the difference of job points between humans and xenos. Negative means too many xenos. Positive means too many humans.


### PR DESCRIPTION
Always two there are. No more, no less. A master and an apprentice.
## About The Pull Request
Balance scales will always spawn xenos gradually until there are at least 2.
## Why It's Good For The Game
Solo xeno is the worst experience in the game, two xenos are at minimum needed for ultra-lowpop to be playable.
## Changelog
:cl:
balance: Crash will always have at least two xenos, instead of one.
/:cl:
