### PR TITLE
Crash T3 Penalty Fixed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1216,7 +1216,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1  - SSticker.mode.tier_three_penalty))
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1))
 	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************


### PR DESCRIPTION

## About The Pull Request

Sorry for fucking up, sorry for not testing that.
Here is the fixed version that shouldn't divide by 0.

Crash Test:
https://cdn.discordapp.com/attachments/500801682058379265/1356024294605455440/image.png?ex=67eb0f89&is=67e9be09&hm=109da5ac0bb6c796a5794093058715c0bf2344d5f8b35861f42109d791008387&

Nuke War Test:
https://cdn.discordapp.com/attachments/500801682058379265/1356024768226132140/image.png?ex=67eb0ffa&is=67e9be7a&hm=c472930d840624886a850848c02c1511694d76043410d128f34fa118b6c5ba33&

## Why It's Good For The Game

Fixes my fuckup causing division by 0.

## Changelog

:cl:
fix: Fixes my crash t3 balance change dividing by 0.
/:cl:
