### PR TITLE
Respawn time on crash is now 15 minutes

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -20,6 +20,7 @@
 		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
+	respawn_time = 15 MINUTES
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1


### PR DESCRIPTION

## About The Pull Request

15 minutes is less than 30 minutes
pretty simple

## Why It's Good For The Game

Xenos get "infinite" respawns every 5-2 minutes - marines after death have to wait for 30
15 minutes would make it so deaths still matter but you have a chance to play game again
instead of rotting in cope chat for 25 minutes 

Testing was done to ensure quality
## Changelog
:cl: Atropos
balance: Marine respawn time on crash is now 15 minutes
/:cl:
