### PR TITLE
Improves the mech builder UI yet again

### DIFF
--- a/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
@@ -177,7 +177,7 @@ export const MechAssembly = (props) => {
   const left_weapon_scatter = left_weapon ? left_weapon.scatter : 0;
   const right_weapon_scatter = right_weapon ? right_weapon.scatter : 0;
   return (
-    <Stack>
+    <Stack fill>
       <Stack.Item>
         <Stack vertical maxWidth={'166px'}>
           <Stack.Item>
@@ -355,9 +355,9 @@ export const MechAssembly = (props) => {
           </Stack.Item>
         </Stack>
       </Stack.Item>
-      <Stack.Item>
-        <Stack>
-          <Stack.Item>
+      <Stack.Item grow>
+        <Stack fill>
+          <Stack.Item grow overflowY="auto">
             <ColorSelector
               type={'primary'}
               listtoshow={data.colors}
@@ -365,7 +365,7 @@ export const MechAssembly = (props) => {
               setSelectedBodypart={setSelectedBodypart}
             />
           </Stack.Item>
-          <Stack.Item>
+          <Stack.Item grow overflowY="auto">
             <ColorSelector
               type={'secondary'}
               listtoshow={data.colors}
@@ -373,7 +373,7 @@ export const MechAssembly = (props) => {
             />
           </Stack.Item>
           {selectedBodypart === 'HEAD' && (
-            <Stack.Item>
+            <Stack.Item grow maxWidth={'130px'} overflowY="auto">
               <ColorSelector
                 type={'visor'}
                 listtoshow={data.visor_colors}
@@ -391,9 +391,9 @@ const ColorSelector = (props) => {
   const { act, data } = useBackend<MechVendData>();
   const { type, listtoshow, selectedBodypart } = props;
   return (
-    <Section title={capitalize(type) + ' colors'}>
+    <Section title={capitalize(type)} align="center">
       {Object.keys(listtoshow).map((title) => (
-        <Collapsible ml={1} minWidth={11} key={title} title={title}>
+        <Collapsible align="left" ml={1} key={title} title={title}>
           <Stack justify="space-between" vertical fill>
             {Object.keys(listtoshow[title]).map((palette) => (
               <Stack.Item key={palette} my={0}>

--- a/tgui/packages/tgui/interfaces/MechVendor/MechWeapons.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechWeapons.tsx
@@ -300,12 +300,12 @@ const WeaponsTab = (props) => {
   const { weapons, back_weapons } = data.all_equipment;
   const { setShowDesc } = props;
   return (
-    <Stack.Item>
-      <Stack>
-        <Stack.Item>
+    <Stack.Item grow>
+      <Stack fill>
+        <Stack.Item grow>
           <WeaponModuleList listtoshow={weapons} setShowDesc={setShowDesc} />
         </Stack.Item>
-        <Stack.Item>
+        <Stack.Item grow>
           <WeaponModuleList
             listtoshow={back_weapons}
             setShowDesc={setShowDesc}
@@ -497,12 +497,12 @@ export const MechWeapons = (props) => {
   const [equipmentTab, setequipmentTab] = useState(equipTabs[0]);
   const { setShowDesc } = props;
   return (
-    <Stack>
+    <Stack fill>
       <Stack.Item>
         <SelectedEquipment />
       </Stack.Item>
-      <Stack.Item>
-        <Section lineHeight={1.75} maxWidth={'740px'} fontSize={'13px'}>
+      <Stack.Item grow>
+        <Section lineHeight={1.75} fontSize={'13px'}>
           <Tabs fluid>
             {equipTabs.map((tabname) => {
               return (

--- a/tgui/packages/tgui/interfaces/MechVendor/MechWeapons.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechWeapons.tsx
@@ -427,6 +427,7 @@ const WeaponModuleList = (props) => {
           <Collapsible
             key={module.type}
             title={module.name}
+            icon={useback ? 'person' : 'hand'}
             buttons={
               <>
                 <Button

--- a/tgui/packages/tgui/interfaces/MechVendor/index.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/index.tsx
@@ -30,25 +30,24 @@ export const MechVendor = (props) => {
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
   const { act, data } = useBackend<MechVendData>();
   return (
-    <Window title={'Mecha Assembler'} width={1080} height={620}>
+    <Window title={'Mecha Assembler'} width={1080} height={570}>
       {showDesc ? (
         <Modal width="500px">
           <Section
+            fill
             title={showDesc.name}
             buttons={
               <Button content="Dismiss" onClick={() => setShowDesc(null)} />
             }
           >
-            <Stack>
-              <Stack.Item>
+            <Stack fill>
+              <Stack.Item grow>
                 <Box
                   className={classes([
                     'mech_builder64x32',
                     showDesc.icon_state,
                   ])}
                   ml={5}
-                  mr={20}
-                  mt={3}
                   mb={9}
                   style={{
                     transform: 'scale(3) translate(20%, 20%)',
@@ -102,7 +101,7 @@ export const MechVendor = (props) => {
                 </LabeledList>
               </Stack.Item>
               <Stack.Item>
-                <Box ml={-38}>
+                <Box>
                   {showDesc.desc +
                     (showDesc.ammo_type
                       ? ' Loaded with: ' + showDesc.ammo_type + '.'
@@ -129,7 +128,7 @@ export const MechVendor = (props) => {
             );
           })}
         </Tabs>
-        <Stack>
+        <Stack fill>
           <Stack.Item>
             <Tooltip
               content="Weight determines the maximum weight of equipment and limbs mounted on your mech. Increased by equipping heavier legs."
@@ -138,9 +137,9 @@ export const MechVendor = (props) => {
               <ProgressBar
                 style={{
                   transform: 'rotate(270deg) translateX(-48%)',
-                  width: 535,
-                  marginLeft: -255,
-                  marginRight: -255,
+                  width: 480,
+                  marginLeft: -230,
+                  marginRight: -230,
                 }}
                 ranges={{
                   bad: [0.8, Infinity],
@@ -158,7 +157,7 @@ export const MechVendor = (props) => {
               </ProgressBar>
             </Tooltip>
           </Stack.Item>
-          <Stack.Item>
+          <Stack.Item grow>
             {selectedTab === MECHA_ASSEMBLY && <MechAssembly />}
             {selectedTab === MECHA_WEAPONS && (
               <MechWeapons setShowDesc={setShowDesc} />


### PR DESCRIPTION

## About The Pull Request
See CL for list of  p player facing changes
I also started using fill and grow cus uhh me bald so it should look better on 516

## Changelog
:cl:
qol: Mech builder colors are scrollable now
fix: Mech builder UI looks less scrunched oup on 516
qol: Mech builder weapon extra detail is smaller and better formatted now
qol: Mech builder UI is less tall
qol: Mech Builder UI now shows you more explicitly the Hand and Back weapons with an icon
qol: Mech builder UI scales better when being dragged around
/:cl:
