### PR TITLE
Multi z shooting mechanics

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -80,3 +80,9 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1)
 #define ZMOVE_STAIRS_FLAGS (ZMOVE_CHECK_PULLEDBY|ZMOVE_ALLOW_BUCKLED)
 /// Used for falling down open space.
 #define ZMOVE_FALL_FLAGS (ZMOVE_FALL_CHECKS|ZMOVE_ALLOW_BUCKLED)
+
+/// Used for shooting upwards
+#define ZMOVE_PROJECTILE_UP_CHECKS (ZMOVE_ALLOW_ANCHORED)
+
+/// Used for shooting downwards
+#define ZMOVE_PROJECTILE_DOWN_CHECKS (ZMOVE_ALLOW_ANCHORED)


### PR DESCRIPTION

## About The Pull Request
Works as follows:
UP: Is the turf above passable? if yes go there
DOWN: is the turf below passable? if no check if the first turf in direction of travel is passable, if yes go there
```
		 * Specifically, you have to on an edge or flying to shoot DOWN (so people can see you)
		 * but, if you're below, you want to only be able to shoot up if people can see you
```
This is intended to be paired with a multiz shadow thing I am working on for the ledge stuff

## Why It's Good For The Game

Yay shooting up and down

## Changelog
:cl:
add: Added  shooting upwards on multiz, you can shoot up as long as the turf above you is free
add: Added shooting downwards on multiz, you can shoot downwards as long as the turf below you is free or you are next to a ledge you can shoot down
/:cl:
