### PR TITLE
Adds anti player z spam swap code

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -42,9 +42,9 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1)
 #define CURRENTLY_Z_ASCENDING 4
 
 //buffer time before we log someone as spammming z changes
-#define HUMAN_ZCHANGE_BUFFER_TIME 1 SECONDS
+#define LIVING_ZCHANGE_BUFFER_TIME 1 SECONDS
 //max z changes after which we stun them as an anti spam measure
-#define HUMAN_ZCHANGE_MAX_BUFFER_COUNT 5
+#define LIVING_ZCHANGE_MAX_BUFFER_COUNT 5
 
 /// possible bitflag return values of [atom/proc/intercept_zImpact] calls
 /// Stops the movable from falling further and crashing on the ground. Example: stairs.

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -41,6 +41,11 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1)
 /// This one is for going upstairs.
 #define CURRENTLY_Z_ASCENDING 4
 
+//buffer time before we log someone as spammming z changes
+#define HUMAN_ZCHANGE_BUFFER_TIME 1 SECONDS
+//max z changes after which we stun them as an anti spam measure
+#define HUMAN_ZCHANGE_MAX_BUFFER_COUNT 5
+
 /// possible bitflag return values of [atom/proc/intercept_zImpact] calls
 /// Stops the movable from falling further and crashing on the ground. Example: stairs.
 #define FALL_INTERCEPTED (1<<0)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -83,6 +83,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/stairs/multiz, 0)
 	var/turf/target = get_step_multiz(get_turf(src), (dir|UP))
 	if(istype(target) && !climber.can_z_move(DOWN, target, z_move_flags = ZMOVE_FALL_FLAGS)) //Don't throw them into a tile that will just dump them back down.
 		climber.zMove(target = target, z_move_flags = ZMOVE_STAIRS_FLAGS)
+		if(isliving(climber))
+			var/mob/living/living_climber = climber
+			living_climber.z_change_spam_check()
+		else if(issealedvehicle(climber))
+			var/obj/vehicle/sealed/vehicle_climber = climber
+			for(var/mob/living/occupant in vehicle_climber.return_drivers())
+				occupant.z_change_spam_check()
 		/// Moves anything that's being dragged by src or anything buckled to it to the stairs turf.
 		climber.pulling?.move_from_pull(climber, loc, climber.glide_size)
 		for(var/mob/living/buckled as anything in climber.buckled_mobs)
@@ -127,6 +134,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/stairs/multiz, 0)
 	. = ..()
 	if(levels == 1 && isTerminator()) // Stairs won't save you from a steep fall.
 		. |= FALL_INTERCEPTED | FALL_NO_MESSAGE | FALL_RETAIN_PULL
+		for(var/atom/movable/faller AS in falling_movables)
+			if(isliving(faller))
+				var/mob/living/fallingmob = faller
+				fallingmob.z_change_spam_check()
+			else if(issealedvehicle(faller))
+				var/obj/vehicle/sealed/vehicle_faller = faller
+				for(var/mob/living/occupant in vehicle_faller.return_drivers())
+					occupant.z_change_spam_check()
 
 /obj/structure/stairs/multiz/proc/isTerminator() //If this is the last stair in a chain and should move mobs up
 	if(terminator_mode != STAIR_TERMINATOR_AUTOMATIC)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -153,6 +153,11 @@
 	/// This is the cooldown on suffering additional effects for when we exhaust all stamina
 	COOLDOWN_DECLARE(last_stamina_exhaustion)
 
+	/// buffer for how many times z_travel_cd was violated by src
+	var/z_change_buffer_count = 0
+	//cooldown done when you change z levels willingly
+	COOLDOWN_DECLARE(z_travel_cd)
+
 	///The world.time of when this mob was last lying down
 	var/last_rested = 0
 	///The world.time of when this mob became unconscious

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -20,3 +20,14 @@
 	if(stat > CONSCIOUS)
 		return
 	facedir(direction)
+
+///check for if this user is willingly moving up and down a z level a lot to cheese. ignores any stun resistsnace so its less cheesable
+/mob/living/proc/z_change_spam_check()
+	if(!COOLDOWN_FINISHED(src, z_travel_cd))
+		z_change_buffer_count++
+		if(z_change_buffer_count > HUMAN_ZCHANGE_MAX_BUFFER_COUNT)
+			Stun(1 SECONDS, TRUE)
+			balloon_alert(src, "Confused!")
+	else
+		z_change_buffer_count = 0
+	COOLDOWN_START(src, z_travel_cd, HUMAN_ZCHANGE_BUFFER_TIME)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -25,9 +25,9 @@
 /mob/living/proc/z_change_spam_check()
 	if(!COOLDOWN_FINISHED(src, z_travel_cd))
 		z_change_buffer_count++
-		if(z_change_buffer_count > HUMAN_ZCHANGE_MAX_BUFFER_COUNT)
+		if(z_change_buffer_count > LIVING_ZCHANGE_MAX_BUFFER_COUNT)
 			Stun(1 SECONDS, TRUE)
 			balloon_alert(src, "Confused!")
 	else
 		z_change_buffer_count = 0
-	COOLDOWN_START(src, z_travel_cd, HUMAN_ZCHANGE_BUFFER_TIME)
+	COOLDOWN_START(src, z_travel_cd, LIVING_ZCHANGE_BUFFER_TIME)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rapidly swapping zlevels willingly will stun you for a second
(5 times swap each within 1 seconds of the previous)

## Why It's Good For The Game

Preempts melee bullshittery of running up and down stairs rapidly to make it hard to hit you thats used on tg

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Rapidly swapping zlevels willingly on multiz will stun you for a second as an anti-cheese measure
/:cl:
