### PR TITLE
Viewing a players playtime is now R_ADMIN and R_MENTOR

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1732,7 +1732,7 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 
 
 	else if(href_list["playtime"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN|R_MENTOR))
 			return
 
 		var/mob/M = locate(href_list["playtime"]) in GLOB.mob_list


### PR DESCRIPTION

## About The Pull Request

Mentors can see playtime now basically

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/df25888e-290d-4e8d-ab61-831b08199d88)
El headmentor wants it I think?

## Changelog
:cl:
admin: mentors can now see players' playtime
/:cl:
