### PR TITLE
Adds mech shared cooldown weapon groups

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -64,7 +64,7 @@
 //Mecha cooldowns
 #define COOLDOWN_MECHA "mecha"
 #define COOLDOWN_MECHA_MESSAGE "mecha_message"
-#define COOLDOWN_MECHA_EQUIPMENT(type) ("mecha_equip_[type]")
+#define COOLDOWN_MECHA_EQUIPMENT(cooldown_key) ("mecha_equip_[cooldown_key]")
 #define COOLDOWN_MECHA_ARMOR "mecha_armor"
 #define COOLDOWN_MECHA_ASSAULT_ARMOR "mecha_assault_armor"
 #define COOLDOWN_MECHA_MELEE_ATTACK "mecha_melee"

--- a/code/__DEFINES/mecha.dm
+++ b/code/__DEFINES/mecha.dm
@@ -127,3 +127,6 @@
 		MECHA_POWER = 1,\
 		MECHA_ARMOR = 1,\
 	)
+
+#define MECH_COOLDOWN_KEY_RAPIDFIRE "rapidfire"
+#define MECH_COOLDOWN_KEY_HIGHALPHASTRIKE "highalpha_strike"

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -30,6 +30,13 @@
 	destroy_sound = 'sound/mecha/critdestr.ogg'
 	///The weight that we contribute to the max limit, if this is equipped to a greyscale mech
 	var/weight = 10
+	///the key will will use for weapon cooldowns, usually the type, but can be a string
+	var/cooldown_key
+
+/obj/item/mecha_parts/mecha_equipment/Initialize(mapload)
+	. = ..()
+	if(!cooldown_key)
+		cooldown_key = type
 
 /obj/item/mecha_parts/mecha_equipment/Destroy()
 	if(chassis)
@@ -91,7 +98,7 @@
 	if(obj_integrity <= 1)
 		to_chat(chassis.occupants, span_warning("Error -- Equipment critically damaged."))
 		return FALSE
-	if(!ignore_cooldown && TIMER_COOLDOWN_RUNNING(chassis, COOLDOWN_MECHA_EQUIPMENT(type)))
+	if(!ignore_cooldown && TIMER_COOLDOWN_RUNNING(chassis, COOLDOWN_MECHA_EQUIPMENT(cooldown_key)))
 		return FALSE
 	if(!istype(chassis, /obj/vehicle/sealed/mecha/combat/greyscale))
 		return TRUE
@@ -106,7 +113,7 @@
 	return TRUE
 
 /obj/item/mecha_parts/mecha_equipment/proc/action(mob/source, atom/target, list/modifiers)
-	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(type), equip_cooldown)//Cooldown is on the MECH so people dont bypass it by switching equipment
+	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(cooldown_key), equip_cooldown)//Cooldown is on the MECH so people dont bypass it by switching equipment
 	chassis.use_power(energy_drain)
 	return TRUE
 

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -93,6 +93,7 @@
 	ammo_type = MECHA_AMMO_SMG
 	hud_icons = list("smg", "smg_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
+	cooldown_key = MECH_COOLDOWN_KEY_RAPIDFIRE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/burstrifle
 	name = "\improper Tethys burst rifle"
@@ -149,6 +150,7 @@
 	ammo_type = MECHA_AMMO_RIFLE
 	hud_icons = list("rifle", "rifle_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
+	cooldown_key = MECH_COOLDOWN_KEY_RAPIDFIRE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/shotgun
 	name = "\improper Phoebe shotgun"
@@ -179,6 +181,7 @@
 	ammo_type = MECHA_AMMO_SHOTGUN
 	hud_icons = list("shotgun_buckshot", "shotgun_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
+	cooldown_key = MECH_COOLDOWN_KEY_HIGHALPHASTRIKE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/greyscale_lmg
 	name = "\improper Briareus LMG"
@@ -455,6 +458,7 @@
 	ammo_type = MECHA_AMMO_RPG
 	hud_icons = list("rocket_he", "rocket_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
+	cooldown_key = MECH_COOLDOWN_KEY_HIGHALPHASTRIKE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/microrocket
 	name = "\improper Asteria microrocket pod"

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -79,12 +79,15 @@
 	if(!current_target)
 		return
 	if(windup_delay && windup_checked == WEAPON_WINDUP_NOT_CHECKED)
+		LAZYSET(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(cooldown_key), src)
 		windup_checked = WEAPON_WINDUP_CHECKING
 		playsound(chassis.loc, windup_sound, 30, TRUE)
 		if(!do_after(source, windup_delay, NONE, chassis, BUSY_ICON_DANGER, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), current_target)))
 			windup_checked = WEAPON_WINDUP_NOT_CHECKED
+			LAZYREMOVE(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(cooldown_key))
 			return
 		windup_checked = WEAPON_WINDUP_CHECKED
+		LAZYREMOVE(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(cooldown_key))
 	if(QDELETED(current_target))
 		windup_checked = WEAPON_WINDUP_NOT_CHECKED
 		return
@@ -101,7 +104,7 @@
 
 	//not an explicit timer (unwrapped timer start), but I dont think having a mirror timer is a better idea
 	//feel free to improve if think of a better way to make sure cooldowns are shared
-	LAZYSET(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(type), src)
+	LAZYSET(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(cooldown_key), src)
 	// dont wanna call parent because it would override this timer
 	chassis.use_power(energy_drain)
 
@@ -153,8 +156,8 @@
 	current_firer?.client?.mouse_pointer_icon = chassis.mouse_pointer
 	//not an explicit timer (unwrapped timer start), but I dont think having a mirror timer is a better idea
 	//feel free to improve if think of a better way to make sure cooldowns are shared
-	LAZYREMOVE(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(type))
-	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(type), equip_cooldown)
+	LAZYREMOVE(chassis.cooldowns, COOLDOWN_MECHA_EQUIPMENT(cooldown_key))
+	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(cooldown_key), equip_cooldown)
 	set_target(null)
 	current_firer = null
 
@@ -446,7 +449,7 @@
 	projectiles--
 	proj_init(O, source)
 	O.throw_at(target, missile_range, missile_speed, source, FALSE)
-	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(type), equip_cooldown)
+	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(cooldown_key), equip_cooldown)
 	chassis.use_power(energy_drain)
 	if(smoke_effect)
 		var/firing_angle = Get_Angle(get_turf(src), target)

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -321,4 +321,4 @@
 	REMOVE_TRAIT(chassis, TRAIT_SILENT_FOOTSTEPS, type)
 	playsound(chassis, 'sound/effects/pred_cloakoff.ogg', 60, TRUE)
 	for(var/obj/item/mecha_parts/mecha_equipment/weapon/gun in chassis.flat_equipment)
-		TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(gun.type), gun.equip_cooldown)
+		TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(gun.cooldown_key), gun.equip_cooldown)


### PR DESCRIPTION

## About The Pull Request
This is so certain weapons have shared CDs like rapidfire and high alpha strike ones

also fixed dual rocketpod due to the windup

todo put these in the UI

## Why It's Good For The Game
Stop broken combos, kurocracy blabla

## Changelog
:cl:
fix: you can no longer fire the alternate mech gun while winding up a weapon
balance: smg and rifle share cooldown and cannot be fired at the same time
balance: mech shotgun and rocket pod share cooldown
/:cl:
