### PR TITLE
Decrease M40 Flare fuel

### DIFF
--- a/code/game/objects/items/explosives/grenades/flares.dm
+++ b/code/game/objects/items/explosives/grenades/flares.dm
@@ -13,8 +13,8 @@
 	light_range = 6
 	light_color = LIGHT_COLOR_FLARE
 	var/fuel = 0
-	var/lower_fuel_limit = 800
-	var/upper_fuel_limit = 1000
+	var/lower_fuel_limit = 300
+	var/upper_fuel_limit = 450
 
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2


### PR DESCRIPTION

## About The Pull Request

Right now max flare life time is 34~ minutes. Minimum is 27~ minutes.
PR reduces it to minimum of 10 to maximum* of 15 minutes
*ticks are being funny, so it can give another 10 seconds or so (worst result out of pack of flares was 15:14)
## Why It's Good For The Game

Marines leave the area with a huge long-lasting visual advantage, leaving xenos with a choice of A: Reweeding area without aciding (risky and open to long range attack/chase with having light advantage) and B: Reweeding area with aciding every flare (time and plasma consuming). Flares are free, boring/painful to acid if theres a large amount of them, one marine who has a funny idea can and will paint the map red for a very long time, removing the need in light. 

Reasoning behind 10-15 minutes was that in the perfect world disk takes 7 minutes 30 seconds minutes to make, so flares in theory shouldnt be replaced with a second one by the time they finish it, reducing gameplay annoyance for marines. And Xenos have now an option to simply wait out flares if they decide not to interact with them, although they still have a long lifetime.
## Changelog
:cl:
balance: Decreased M40 flares burn time.
/:cl:
