### PR TITLE
Spatial agents can now speak xeno

### DIFF
--- a/code/datums/jobs/job/other.dm
+++ b/code/datums/jobs/job/other.dm
@@ -25,6 +25,10 @@
 	skills_type = /datum/skills/spatial_agent
 	outfit = /datum/outfit/job/other/spatial_agent
 
+/datum/job/spatial_agent/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
+	. = ..()
+	H.grant_language(/datum/language/xenocommon)
+
 /datum/job/spatial_agent/galaxy_red
 	outfit = /datum/outfit/job/other/spatial_agent/galaxy_red
 

--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -263,7 +263,7 @@ ADMIN_VERB(spatial_agent, R_FUN, "Spatial Agent", "Become a spatial agent", ADMI
 		M.mind.transfer_to(H, TRUE)
 		var/datum/job/J = SSjob.GetJobType(/datum/job/spatial_agent)
 		H.apply_assigned_role_to_spawn(J)
-		H.grant_language(/datum/language/xenocommon)
+		J.after_spawn(H)
 		qdel(M)
 
 		log_admin("[key_name(H)] became a spatial agent.")

--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -263,6 +263,7 @@ ADMIN_VERB(spatial_agent, R_FUN, "Spatial Agent", "Become a spatial agent", ADMI
 		M.mind.transfer_to(H, TRUE)
 		var/datum/job/J = SSjob.GetJobType(/datum/job/spatial_agent)
 		H.apply_assigned_role_to_spawn(J)
+		H.grant_language(/datum/language/xenocommon)
 		qdel(M)
 
 		log_admin("[key_name(H)] became a spatial agent.")


### PR DESCRIPTION
## About The Pull Request
read title

## Why It's Good For The Game

I dont want to emote - i want to speak while griefing
aka its annoying having to use looc instead of directly speaking to xenos while doing admemery

## Changelog
:cl:
qol: Spatial agents can now speak xeno common
/:cl:
