### PR TITLE
Dont crash the chat if we fail to play an admin sound

### DIFF
--- a/tgui/packages/tgui-panel/audio/player.tsx
+++ b/tgui/packages/tgui-panel/audio/player.tsx
@@ -67,7 +67,7 @@ export class AudioPlayer {
       });
     }
 
-    audio.play();
+    audio.play()?.catch((error) => logger.log('playback error', error));
 
     this.onPlaySubscribers.forEach((subscriber) => subscriber());
   }


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/90445
## About The Pull Request
https://github.com/tgstation/tgstation/pull/90445

## Why It's Good For The Game

idk you tell me

## Changelog
:cl:
fix: Chat wont crash if we fail to play an admin sound
/:cl:
