### PR TITLE
Added check for attempt_restock() feedback

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -729,13 +729,15 @@
 	if(item_to_stock.storage_datum) //Nice try, specialists/engis
 		var/datum/storage/storage_to_stock = item_to_stock.storage_datum
 		if(!(storage_to_stock.storage_flags & BYPASS_VENDOR_CHECK)) //If your storage has this flag, it can be restocked
-			if(show_feedback) user?.balloon_alert(user, "Can't restock containers!")
+			if(show_feedback)
+				user?.balloon_alert(user, "Can't restock containers!")
 			return FALSE
 
 	else if(isgrenade(item_to_stock))
 		var/obj/item/explosive/grenade/grenade = item_to_stock
 		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
-			if(show_feedback) user?.balloon_alert(user, "You panic and erratically fumble around!")
+			if(show_feedback)
+				user?.balloon_alert(user, "You panic and erratically fumble around!")
 			return FALSE
 
 	else if(amount >= 0) //Item is finite so we are more strict on its condition
@@ -743,25 +745,29 @@
 		if(isammomagazine(item_to_stock))
 			var/obj/item/ammo_magazine/A = item_to_stock
 			if(A.current_rounds < A.max_rounds)
-				if(show_feedback) user?.balloon_alert(user, "Magazine isn't full!")
+				if(show_feedback)
+					user?.balloon_alert(user, "Magazine isn't full!")
 				return FALSE
 
 		if(iscell(item_to_stock))
 			var/obj/item/cell/cell = item_to_stock
 			if(cell.charge < cell.maxcharge)
-				if(show_feedback) user?.balloon_alert(user, "Cell isn't at full charge!")
+				if(show_feedback)
+					user?.balloon_alert(user, "Cell isn't at full charge!")
 				return FALSE
 
 		if(isitemstack(item_to_stock))
 			var/obj/item/stack/stack = item_to_stock
 			if(stack.amount != initial(stack.amount))
-				if(show_feedback) user?.balloon_alert(user, "[stack] has been partially used. Refill it!")
+				if(show_feedback)
+					user?.balloon_alert(user, "[stack] has been partially used. Refill it!")
 				return FALSE
 
 		if(isreagentcontainer(item_to_stock))
 			var/obj/item/reagent_containers/reagent_container = item_to_stock
 			if(!(reagent_container.item_flags & CAN_REFILL) && !reagent_container.has_initial_reagents())
-				if(show_feedback) user?.balloon_alert(user, "\The [reagent_container] is missing some of its reagents!")
+				if(show_feedback)
+					user?.balloon_alert(user, "\The [reagent_container] is missing some of its reagents!")
 				return FALSE
 
 	//Actually restocks the item after our checks

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -729,13 +729,13 @@
 	if(item_to_stock.storage_datum) //Nice try, specialists/engis
 		var/datum/storage/storage_to_stock = item_to_stock.storage_datum
 		if(!(storage_to_stock.storage_flags & BYPASS_VENDOR_CHECK)) //If your storage has this flag, it can be restocked
-			user?.balloon_alert(user, "Can't restock containers!")
+			if(show_feedback) user?.balloon_alert(user, "Can't restock containers!")
 			return FALSE
 
 	else if(isgrenade(item_to_stock))
 		var/obj/item/explosive/grenade/grenade = item_to_stock
 		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
-			user?.balloon_alert(user, "You panic and erratically fumble around!")
+			if(show_feedback) user?.balloon_alert(user, "You panic and erratically fumble around!")
 			return FALSE
 
 	else if(amount >= 0) //Item is finite so we are more strict on its condition
@@ -743,25 +743,25 @@
 		if(isammomagazine(item_to_stock))
 			var/obj/item/ammo_magazine/A = item_to_stock
 			if(A.current_rounds < A.max_rounds)
-				user?.balloon_alert(user, "Magazine isn't full!")
+				if(show_feedback) user?.balloon_alert(user, "Magazine isn't full!")
 				return FALSE
 
 		if(iscell(item_to_stock))
 			var/obj/item/cell/cell = item_to_stock
 			if(cell.charge < cell.maxcharge)
-				user?.balloon_alert(user, "Cell isn't at full charge!")
+				if(show_feedback) user?.balloon_alert(user, "Cell isn't at full charge!")
 				return FALSE
 
 		if(isitemstack(item_to_stock))
 			var/obj/item/stack/stack = item_to_stock
 			if(stack.amount != initial(stack.amount))
-				user?.balloon_alert(user, "[stack] has been partially used. Refill it!")
+				if(show_feedback) user?.balloon_alert(user, "[stack] has been partially used. Refill it!")
 				return FALSE
 
 		if(isreagentcontainer(item_to_stock))
 			var/obj/item/reagent_containers/reagent_container = item_to_stock
 			if(!(reagent_container.item_flags & CAN_REFILL) && !reagent_container.has_initial_reagents())
-				user?.balloon_alert(user, "\The [reagent_container] is missing some of its reagents!")
+				if(show_feedback) user?.balloon_alert(user, "\The [reagent_container] is missing some of its reagents!")
 				return FALSE
 
 	//Actually restocks the item after our checks


### PR DESCRIPTION

## About The Pull Request

The attempt_restock proc did not acknowledge the show feedback variable for its balloon alerts so I added a simple check to each one.

The attempt_restock proc can't make use of the display_message_and_visuals proc due to scoping or else I would've used that.
## Why It's Good For The Game

If the nanoammo PR is merged, this solves a visual bug, but it was generally bad that the attempt_restock proc was not acknowledging the feedback argument.
## Changelog
:cl:
fix: Attempt_restock() proc now values your feedback
/:cl:
