### PR TITLE
Objective Based Requisitions Points Gain.

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -481,6 +481,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used Psychic Shield."
 	if(GLOB.round_statistics.psy_shield_blasts)
 		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a Psychic Shield."
+	if(GLOB.round_statistics.points_from_objectives)
+		parts += "[GLOB.round_statistics.points_from_objectives] requisitions points gained from objectives."
 	if(GLOB.round_statistics.points_from_mining)
 		parts += "[GLOB.round_statistics.points_from_mining] requisitions points gained from mining."
 	if(GLOB.round_statistics.points_from_research)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -16,6 +16,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	///All projectiles fired during the round, listed by faction
 	var/list/total_projectiles_fired = list()
 	var/human_bump_attacks = 0
+	var/points_from_objectives = 0
 	var/points_from_research = 0
 	var/points_from_mining = 0
 	var/points_from_xenos = 0

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -193,13 +193,13 @@
 
 	// Requisitions points bonus per cycle.
 	var/disk_cycle_reward = DISK_CYCLE_REWARD_MIN + ((DISK_CYCLE_REWARD_MAX - DISK_CYCLE_REWARD_MIN) * (SSmonitor.maximum_connected_players_count / HIGH_PLAYER_POP))
-	disk_cycle_reward = clamp(disk_cycle_reward, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX)
+	disk_cycle_reward = ROUND_UP(clamp(disk_cycle_reward, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX))
 
 	SSpoints.supply_points[FACTION_TERRAGOV] += disk_cycle_reward
 	SSpoints.dropship_points += disk_cycle_reward/10
 	GLOB.round_statistics.points_from_objectives += disk_cycle_reward
 
-	say("Program has execution has rewarded "+disk_cycle_reward+" requisitions points!")
+	say("Program has execution has rewarded [disk_cycle_reward] requisitions points!")
 
 ///Change minimap icon if its on or off
 /obj/machinery/computer/nuke_disk_generator/proc/update_minimap_icon()

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -1,5 +1,5 @@
-#define DISK_CYCLE_REWARD_MIN = 150
-#define DISK_CYCLE_REWARD_MAX = 500
+#define DISK_CYCLE_REWARD_MIN 100
+#define DISK_CYCLE_REWARD_MAX 300
 
 ///How much faster disk generators get while the colony power speed boost is active
 #define OVERCLOCK_MULTIPLIER 3
@@ -192,12 +192,12 @@
 	say("Program run has concluded! Standing by...")
 
 	// Requisitions points bonus per cycle.
-	var/disk_cycle_value = DISK_CYCLE_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (DISK_CYCLE_REWARD_MAX - DISK_CYCLE_REWARD_MIN))
-	disk_cycle_value = clamp(disk_cycle_value, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX)
+	var/disk_cycle_reward = DISK_CYCLE_REWARD_MIN + ((DISK_CYCLE_REWARD_MAX - DISK_CYCLE_REWARD_MIN) * (SSmonitor.maximum_connected_players_count / HIGH_PLAYER_POP))
+	disk_cycle_reward = clamp(disk_cycle_reward, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX)
 
-	SSpoints.supply_points[faction] += disk_cycle_value
-	SSpoints.dropship_points += disk_cycle_value/10
-	GLOB.round_statistics.points_from_objectives += disk_cycle_value
+	SSpoints.supply_points[faction] += disk_cycle_reward
+	SSpoints.dropship_points += disk_cycle_reward/10
+	GLOB.round_statistics.points_from_objectives += disk_cycle_reward
 
 ///Change minimap icon if its on or off
 /obj/machinery/computer/nuke_disk_generator/proc/update_minimap_icon()

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -1,3 +1,6 @@
+#define DISK_CYCLE_REWARD_MIN = 150
+#define DISK_CYCLE_REWARD_MAX = 500
+
 ///How much faster disk generators get while the colony power speed boost is active
 #define OVERCLOCK_MULTIPLIER 3
 
@@ -187,6 +190,14 @@
 		return
 
 	say("Program run has concluded! Standing by...")
+
+	// Requisitions points bonus per cycle.
+	var/disk_cycle_value = DISK_CYCLE_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (DISK_CYCLE_REWARD_MAX - DISK_CYCLE_REWARD_MIN))
+	disk_cycle_value = clamp(disk_cycle_value, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX)
+
+	SSpoints.supply_points[faction] += disk_cycle_value
+	SSpoints.dropship_points += disk_cycle_value/10
+	GLOB.round_statistics.points_from_objectives += disk_cycle_value
 
 ///Change minimap icon if its on or off
 /obj/machinery/computer/nuke_disk_generator/proc/update_minimap_icon()

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -195,9 +195,11 @@
 	var/disk_cycle_reward = DISK_CYCLE_REWARD_MIN + ((DISK_CYCLE_REWARD_MAX - DISK_CYCLE_REWARD_MIN) * (SSmonitor.maximum_connected_players_count / HIGH_PLAYER_POP))
 	disk_cycle_reward = clamp(disk_cycle_reward, DISK_CYCLE_REWARD_MIN, DISK_CYCLE_REWARD_MAX)
 
-	SSpoints.supply_points[faction] += disk_cycle_reward
+	SSpoints.supply_points[FACTION_TERRAGOV] += disk_cycle_reward
 	SSpoints.dropship_points += disk_cycle_reward/10
 	GLOB.round_statistics.points_from_objectives += disk_cycle_reward
+
+	say("Program has execution has rewarded "+disk_cycle_reward+" requisitions points!")
 
 ///Change minimap icon if its on or off
 /obj/machinery/computer/nuke_disk_generator/proc/update_minimap_icon()

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -15,7 +15,7 @@
 	var/atom/movable/vis_obj/fulton_balloon/baloon
 	var/obj/effect/fulton_extraction_holder/holder_obj
 	/// How many times you can use the fulton before it goes poof
-	var/uses = 3
+	var/uses = 6
 
 /obj/item/fulton_extraction_pack/examine(mob/user)
 	. = ..()

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -47,20 +47,20 @@
 		if(XENO_TIER_MINION)
 			. = list(10, 1)
 		if(XENO_TIER_ZERO)
-			. = list(70, 7)
+			. = list(35, 4)
 		if(XENO_TIER_ONE)
-			. = list(150, 15)
+			. = list(75, 8)
 		if(XENO_TIER_TWO)
-			. = list(350, 30)
+			. = list(175, 18)
 		if(XENO_TIER_THREE)
-			. = list(600, 50)
+			. = list(300, 30)
 		if(XENO_TIER_FOUR)
-			. = list(1100, 100)
+			. = list(550, 55)
 	return
 
 //I hate it but it's how it was so I'm not touching it further than this
 /mob/living/carbon/xenomorph/shrike/get_export_value()
-	return list(600, 50)
+	return list(300, 30)
 
 /obj/item/reagent_containers/food/snacks/req_pizza/get_export_value()
 	return list(10, 0)


### PR DESCRIPTION
## About The Pull Request

Completing a disk cycle rewards requisitions points per cycle equivalent to the function with x as the number of current players.
CAS Points are also added at a rate of 1/10.
![image](https://github.com/user-attachments/assets/8a8c80bd-7a43-4be6-a059-bc3c645488f2)
Notable points are highlighted.
![image](https://github.com/user-attachments/assets/2ab86041-3cbb-40c2-81f7-17c5426cc95e)

The points gain is dependent on player count because point gain based on selling dead xenos correlated to player count, with more xenos having more chances to die and be sold. Additionally, more players should generally have more points spread between them.

To maintain balance xenomorph sell prices are halved, including CAS points.
T1 150 => 75
T2 350 => 175
T3 600 => 300
_(Shrike included in T3, unchanged)_
T4 1100 => 550

To avoid a nerf to fulton packs, fulton packs have had their uses doubled to 6.


## Why It's Good For The Game

Reduction to snowballing and increase to objective based gameplay.
Rounds that are closer and more competitive are generally more enjoyable.

Currently the requisitions system functions to massively amplify snowballing.
If marines kill xenos at the start of a round, they get gear which increases their killing power, snowballing into more xeno deaths and marines running away with the game.
If marines are fighting a desperate stand to keep a risk running, they're not getting many requisitions points. 

Exact numbers are subject to change from feedback or play testing.

## PR Testing

Prior to running disk:
![image](https://github.com/user-attachments/assets/f472ba38-f1a5-45d8-913b-a5879355375d)
Running Disk:
![image](https://github.com/user-attachments/assets/d9c09405-f18c-431a-bc3e-ee9b77ec3068)
![image](https://github.com/user-attachments/assets/80df7c78-5342-4341-b2c3-d92230806912)
Returning to requisitions:
![image](https://github.com/user-attachments/assets/e3ae268a-6075-4ba8-8b71-6a4452d4fa57)

Note numbers are not exact due to time passing and passive req point gain not being disabled.


## Changelog
:cl:
add: Completion of a disk cycle rewards marines requisitions points scaling with player count.
balance: To counterbalance, xenomorph sell prices halved.
balance: Fulton packs uses 3 => 6.
/:cl:
