### PR TITLE
Moved SAA speedloaders from base type to subtype

### DIFF
--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -250,7 +250,7 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/revolver/small = -1,
 		/obj/item/ammo_magazine/revolver/small = -1,
 		/obj/item/weapon/gun/revolver/single_action/m44 = -1,
-		/obj/item/ammo_magazine/revolver = -1,
+		/obj/item/ammo_magazine/revolver/single_action/m44 = -1,
 		/obj/item/weapon/gun/revolver/judge = -1,
 		/obj/item/ammo_magazine/revolver/judge = -1,
 		/obj/item/ammo_magazine/revolver/judge/buckshot = -1,

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -609,10 +609,10 @@
 	new /obj/item/weapon/gun/revolver/single_action/m44(src)
 	new /obj/item/ammo_magazine/revolver/heavy(src)
 	new /obj/item/ammo_magazine/revolver/marksman(src)
-	new /obj/item/ammo_magazine/revolver(src)
-	new /obj/item/ammo_magazine/revolver(src)
-	new /obj/item/ammo_magazine/revolver(src)
-	new /obj/item/ammo_magazine/revolver(src)
+	new /obj/item/ammo_magazine/revolver/single_action/m44(src)
+	new /obj/item/ammo_magazine/revolver/single_action/m44(src)
+	new /obj/item/ammo_magazine/revolver/single_action/m44(src)
+	new /obj/item/ammo_magazine/revolver/single_action/m44(src)
 
 /obj/item/storage/holster/belt/mateba
 	name = "\improper M276 pattern Mateba holster rig"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1640,7 +1640,7 @@
 			/obj/item/weapon/gun/revolver/small = -1,
 			/obj/item/ammo_magazine/revolver/small = -1,
 			/obj/item/weapon/gun/revolver/single_action/m44 = -1,
-			/obj/item/ammo_magazine/revolver = -1,
+			/obj/item/ammo_magazine/revolver/single_action/m44 = -1,
 			/obj/item/weapon/gun/revolver/judge = -1,
 			/obj/item/ammo_magazine/revolver/judge = -1,
 			/obj/item/ammo_magazine/revolver/judge/buckshot = -1,

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -357,8 +357,8 @@
 	worn_icon_state = "m44"
 	caliber = CALIBER_44 //codex
 	max_chamber_items = 6
-	default_ammo_type = /obj/item/ammo_magazine/revolver
-	allowed_ammo_types = list(/obj/item/ammo_magazine/revolver, /obj/item/ammo_magazine/revolver/marksman, /obj/item/ammo_magazine/revolver/heavy)
+	default_ammo_type = /obj/item/ammo_magazine/revolver/single_action/m44
+	allowed_ammo_types = list(/obj/item/ammo_magazine/revolver/single_action/m44, /obj/item/ammo_magazine/revolver/marksman, /obj/item/ammo_magazine/revolver/heavy)
 	force = 8
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet/converted,

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -96,3 +96,29 @@
 	caliber = CALIBER_12x7
 	icon_state = "t76"
 	icon_state_mini = "mag_revolver_red"
+
+// Single action army revolver ammunition.  Base class is unused.
+
+/obj/item/ammo_magazine/revolver/single_action
+	name = "\improper Single action revolver speed-loader (.44)"
+	desc = "A single action revolver speed-loader."
+	default_ammo = /datum/ammo/bullet/revolver
+	equip_slot_flags = NONE
+	caliber = CALIBER_44
+	icon_state = "m44"
+	icon = 'icons/obj/items/ammo/revolver.dmi'
+	icon_state_mini = "mag_revolver_bronze"
+	w_class = WEIGHT_CLASS_SMALL
+	max_rounds = 6
+
+/obj/item/ammo_magazine/revolver/single_action/m44
+	name = "\improper R-44 magnum speed loader (.44)"
+	desc = "A SAA R-44 revolver speed loader."
+	default_ammo = /datum/ammo/bullet/revolver
+	equip_slot_flags = NONE
+	caliber = CALIBER_44
+	icon_state = "m44"
+	icon = 'icons/obj/items/ammo/revolver.dmi'
+	icon_state_mini = "mag_revolver_bronze"
+	w_class = WEIGHT_CLASS_SMALL
+	max_rounds = 6

--- a/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/code/modules/reqs/supplypacks/imports_packs.dm
@@ -237,7 +237,7 @@ Imports
 
 /datum/supply_packs/imports/rev357/ammo
 	name = "R-44 SAA revolver speed loader"
-	contains = list(/obj/item/ammo_magazine/revolver)
+	contains = list(/obj/item/ammo_magazine/revolver/single_action/m44)
 	cost = 3
 
 /datum/supply_packs/imports/g22


### PR DESCRIPTION

## About The Pull Request

The speedloaders for the R-44 SAA are the base type for all revolver speedloaders, which is atypical as base types are often abstract base types for other subtypes.  I created a new type for the R-44 SAA speedloader that derived from a second abstract base type.  The purpose of the double abstract base type is because the R-44 SAA itself is also based off two abstract base types, so I wanted to ensure the gun and the magazine have similar type paths.

I replaced all instances where loadouts or items were being loaded with the old SAA speedloaders with the new one.
## Why It's Good For The Game

Avoids potential errors for other work regarding revolver ammunition.  If the NanoAmmo PR is merged, it will allow the NanoAmmo to stock the SAA speedloaders because the base type pathing was causing an error with the build_inventory proc.
## Changelog
:cl:
fix: Adjusted the base class of the SAA revolver speedloader
/:cl:
