### PR TITLE
Permanently reenables mechs

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -362,6 +362,16 @@ Though you are an officer, your authority is limited to the dropship and the Con
 	to_chat(M, {"\nYou are the operator of a very expensive and valuable Mech, and are trained and expected to use it in the field of combat.
 You can serve your Division in a variety of roles, so choose carefully."})
 
+/datum/job/terragov/command/mech_pilot/on_pre_setup()
+	if(total_positions)
+		return
+	var/client_count = length(GLOB.clients)
+	client_count -= 20
+	client_count = FLOOR(client_count / 20, 1)
+	// effectively, 1 at 40, 2 at 60, 3 at 80, etc
+	if(client_count > 1)
+		add_job_positions(client_count)
+
 /datum/job/terragov/command/mech_pilot/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
 	if(!ishuman(new_mob))


### PR DESCRIPTION

## About The Pull Request

 One slot will be granted every 20 players, starting at 40 players.

## Why It's Good For The Game

Kuro thinks they're ready for general use and the last few tests went okay, most tweaks needed are balance finetuning

## Changelog
:cl: Tiviplus, Kuro, Tyeagg, GregorMN, Lumipharon
add: XvH Mechs have been permanently reenabled. One slot will be granted every 20 players, starting at 40 players.
add: Mechs have been reworked to be faster compared to humans, but less tanky (sort of a diver/flanker role)
balance: Mechs no longer have directional armor, and are more mobile (diagonal movement, spinning to fire)
add: Mechs have been resprited and repaletted and will update their sprite on boosting or being destroyed, and they will leave a wreck
qol: Mechs also have many new visual effects
add: Mech weapons are now split into back and hand weapons, and they can switch between them quickly
add: Mechs now have a limb mechanic. Aiming arms (weakest limb, breaks in only a few slashes) will disable the weapon on that limb, aiming the head will disable it's NV, aiming legs will increasingly slow it down with damage taken until  it's movement speed is halved at 0 HP. Slashing torso or an already destroyed limb damages the actual mechs HP
balance: crusher charges will always aim legs, which they will oneshot if they manage to hit them
balance: All mech weapons and (new) modules have been rebalanced and remade from scratch
add: Mech now has a dash it can activate by double tapping into a direction, which consumes energy
qol: The mech Builder UI has been revamped
balance: Only one mech can be spawned per person at the mech builder. Spatial agents (the admin debug job) are exempt
/:cl:
