### PR TITLE
Cap cloak gun cooldown CD after uncloaking to 1 second, and treat the fire cooldown as half of it's reality

### DIFF
--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -321,4 +321,4 @@
 	REMOVE_TRAIT(chassis, TRAIT_SILENT_FOOTSTEPS, type)
 	playsound(chassis, 'sound/effects/pred_cloakoff.ogg', 60, TRUE)
 	for(var/obj/item/mecha_parts/mecha_equipment/weapon/gun in chassis.flat_equipment)
-		TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(gun.cooldown_key), gun.equip_cooldown)
+		TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(gun.cooldown_key), min(gun.equip_cooldown/2, 1 SECONDS))


### PR DESCRIPTION

## About The Pull Request

What it says on the tin
## Why It's Good For The Game
very hard to use long cd things like the micromissiles

## Changelog
:cl:
balance: Caps cloak mech gun cooldown CD after uncloaking to 1 second, and treats the fire cooldown as half of it's reality for this purpose
/:cl:
