### PR TITLE
Fixes applying corruption to bluespace gen

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -283,8 +283,6 @@ GLOBAL_LIST_EMPTY(gens_corruption_by_hive)
 	var/corrupted = XENO_HIVE_NORMAL
 	//Last hive to corrupt the generator
 	var/last_corrupted = XENO_HIVE_NORMAL
-	///whether we wil allow these to be corrupted
-	var/is_corruptible = FALSE
 
 	COOLDOWN_DECLARE(toggle_power)
 
@@ -414,17 +412,15 @@ GLOBAL_LIST_EMPTY(gens_corruption_by_hive)
 	. = ..()
 	if(corrupted)
 		. += "It is covered in writhing tendrils [!isxeno(user) ? "that could be cut away with a welder" : ""]."
-	if(!isxeno(user) && !is_corruptible)
-		. += "It is reinforced, making us not able to corrupt it."
 
 /obj/machinery/power/geothermal/tbg/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
-	if(corrupted) //you have no reason to interact with it if its already corrupted
+	if(corrupted == xeno_attacker.hivenumber) //you have no reason to interact with it if its already corrupted
 		return
 	if(xeno_attacker.status_flags & INCORPOREAL || HAS_TRAIT_FROM(xeno_attacker, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT))
 		return
 
 	. = ..()
-	if(xeno_attacker.do_actions && buildstate == GENERATOR_HEAVY_DAMAGE && CHECK_BITFIELD(xeno_attacker.xeno_caste.can_flags, CASTE_CAN_CORRUPT_GENERATOR)  && is_corruptible)
+	if(!xeno_attacker.do_actions && buildstate == GENERATOR_HEAVY_DAMAGE && CHECK_BITFIELD(xeno_attacker.xeno_caste.can_flags, CASTE_CAN_CORRUPT_GENERATOR))
 		balloon_alert(xeno_attacker, "You begin corrupting the generator...")
 		if(!do_after(xeno_attacker, 10 SECONDS, NONE, src, BUSY_ICON_HOSTILE))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bluespace gens can now be corrupted properly (as long as you are a caste that can corrupt, e.g shrike)

NOTE: Regular geothermals still cannot be corrupted, this is intentional & if you want to change it feel free to make the PR (I'm taking a break from coderstuff for a bit)

Let me know if there's any other problems with generators

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
fix: Bluespace gens can now be re-corrupted properly, if damaged but not exploded
/:cl:
