### PR TITLE
Crash T3 Slots Scaling Increased + Hivelord Pop Reduction + Caste Swap Timer Reduction

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -45,8 +45,10 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/time_between_round = 0
 	///What factions are used in this gamemode, typically TGMC and xenos
 	var/list/factions = list(FACTION_TERRAGOV, FACTION_ALIEN)
-	///Increases the amount of xenos needed to evolve to tier three by the value.
+	///Reduces the number of T3 slots xenos get by the value.
 	var/tier_three_penalty = 0
+	///Includes T3 xenos in the calculation for maximum T3 slots, 1 for yes 0 for no.
+	var/tier_three_inclusion = 0
 	///List of castes we dont want to be evolvable depending on gamemode.
 	var/list/restricted_castes
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -49,6 +49,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/tier_three_penalty = 0
 	///Includes T3 xenos in the calculation for maximum T3 slots, 1 for yes 0 for no.
 	var/tier_three_inclusion = 0
+	///Reduces the caste swap timer by the value.
+	var/caste_swap_timer_reduction = 0 MINUTES
 	///List of castes we dont want to be evolvable depending on gamemode.
 	var/list/restricted_castes
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -47,10 +47,10 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/list/factions = list(FACTION_TERRAGOV, FACTION_ALIEN)
 	///Reduces the number of T3 slots xenos get by the value.
 	var/tier_three_penalty = 0
-	///Includes T3 xenos in the calculation for maximum T3 slots, 1 for yes 0 for no.
-	var/tier_three_inclusion = 0
-	///Reduces the caste swap timer by the value.
-	var/caste_swap_timer_reduction = 0 MINUTES
+	///Includes T3 xenos in the calculation for maximum T3 slots.
+	var/tier_three_inclusion = FALSE
+	///Caste Swap Timer
+	var/caste_swap_timer = 15 MINUTES
 	///List of castes we dont want to be evolvable depending on gamemode.
 	var/list/restricted_castes
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -46,7 +46,7 @@
 	evo_requirements = list(
 		/datum/xeno_caste/king = 14,
 		/datum/xeno_caste/queen = 10,
-		/datum/xeno_caste/hivelord = 8,
+		/datum/xeno_caste/hivelord = 5,
 	)
 
 /datum/game_mode/infestation/crash/pre_setup()

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -25,6 +25,7 @@
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
 	tier_three_inclusion = 1
+	caste_swap_timer_reduction = 10 MINUTES
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -24,7 +24,7 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
-	tier_three_inclusion = 0
+	tier_three_inclusion = 1
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -24,7 +24,12 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
+<<<<<<< Updated upstream
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
+=======
+	tier_three_inclusion = 1
+	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
+>>>>>>> Stashed changes
 
 	// Round end conditions
 	var/shuttle_landed = FALSE

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -24,12 +24,8 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
-<<<<<<< Updated upstream
+	tier_three_inclusion = 0
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
-=======
-	tier_three_inclusion = 1
-	restricted_castes = list(/datum/xeno_caste/hivelord, /datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
->>>>>>> Stashed changes
 
 	// Round end conditions
 	var/shuttle_landed = FALSE

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -24,8 +24,8 @@
 	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
-	tier_three_inclusion = 1
-	caste_swap_timer_reduction = 10 MINUTES
+	tier_three_inclusion = TRUE
+	caste_swap_timer = 5 MINUTES
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -17,7 +17,8 @@
 	set category = "Alien"
 
 	var/time_since = world.time - (GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)
-	if(time_since < (15 MINUTES))
+	var/caste_swap_timer = 15 MINUTES - SSticker.mode.caste_swap_timer_reduction
+	if(time_since < (caste_swap_timer))
 		to_chat(src, span_warning("Your caste swap timer has [(5 MINUTES - time_since)/10] seconds remaining."))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -17,7 +17,7 @@
 	set category = "Alien"
 
 	var/time_since = world.time - (GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)
-	var/caste_swap_timer = 15 MINUTES - SSticker.mode.caste_swap_timer_reduction
+	var/caste_swap_timer = SSticker.mode.caste_swap_timer
 	if(time_since < (caste_swap_timer))
 		to_chat(src, span_warning("Your caste swap timer has [(5 MINUTES - time_since)/10] seconds remaining."))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1214,7 +1214,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1))
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + threes*SSticker.mode.tier_three_inclusion) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1))
 	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -166,7 +166,9 @@
 
 	. += "Regeneration power: [max(regen_power * 100, 0)]%"
 
-	var/casteswap_value = ((GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)  + 15 MINUTES - world.time) * 0.1
+	var/caste_swap_timer = 15 MINUTES - SSticker.mode.caste_swap_timer_reduction
+
+	var/casteswap_value = ((GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)  + caste_swap_timer - world.time) * 0.1
 	if(casteswap_value <= 0)
 		. += "Caste Swap Timer: READY"
 	else

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -166,7 +166,7 @@
 
 	. += "Regeneration power: [max(regen_power * 100, 0)]%"
 
-	var/caste_swap_timer = 15 MINUTES - SSticker.mode.caste_swap_timer_reduction
+	var/caste_swap_timer = SSticker.mode.caste_swap_timer
 
 	var/casteswap_value = ((GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)  + caste_swap_timer - world.time) * 0.1
 	if(casteswap_value <= 0)


### PR DESCRIPTION
## About The Pull Request

Adjusts T3 slot scaling on crash to not fall off with larger hives as they do in nuclear war.
Reduces hivelord xenomorph pop requirement to 5.
Reduces caste swap timer in crash to 5 minutes.


## Why It's Good For The Game

This is to fix the issue with highpop crash being slightly too favourable to marines.

## PR Testing
Shows 2 Open T3 slots at 6 xenos, including a T3.
Also shows hivelord (which I evolved) at this number of xenos.
![image](https://github.com/user-attachments/assets/88cae9d8-8885-47f5-9e17-9ff832075f46)

Shows reduction to caste swap timer in Crash Gamemode
![image](https://github.com/user-attachments/assets/389157f8-15c7-4095-a67b-a3e650d93cba)



## Changelog
:cl:
balance: Xenos Caste swap timer in crash is now only 5 minutes.
balance: Hivelord xenos requirement 8 => 5 in crash.
balance: Xenos T3 slots now scale better beyond the 1st in crash, second slot at 6 instead of 7 now.
/:cl:
