### PR TITLE
Changed name/desc of SAA R-44 speedloaders

### DIFF
--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -112,8 +112,8 @@
 	max_rounds = 6
 
 /obj/item/ammo_magazine/revolver/single_action/m44
-	name = "\improper R-44 magnum speed loader (.44)"
-	desc = "A SAA R-44 revolver speed loader."
+	name = "\improper R-44 SAA magnum speed loader (.44)"
+	desc = "A R-44 SAA revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver
 	equip_slot_flags = NONE
 	caliber = CALIBER_44


### PR DESCRIPTION
I'm back...
## About The Pull Request

Changed the name of the R-44 SAA speedloader and the description.
## Why It's Good For The Game

https://github.com/tgstation/TerraGov-Marine-Corps/pull/17648 was supposed to address a bug with the NanoAmmo PR that's in progress, but it turned out that the typing wasn't the (only?) issue.  The R-44 speedloaders and R-44 SAA speedloaders share the same exact name and that causes an issue with the NanoAmmo, so I just added "SAA" to the name and matched the description to it.
## Changelog
:cl:
fix: Changed R-44 SAA speedloader's name
/:cl:
