### PR TITLE
Nerfs Conqueror's Endurance ability

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -575,7 +575,7 @@
 
 	if(isxeno(M))
 		var/mob/living/carbon/xenomorph/xeno_victim = M
-		if(xeno_victim.fortify || xeno_victim.endure || HAS_TRAIT_FROM(xeno_victim, TRAIT_IMMOBILE, BOILER_ROOTED_TRAIT)) //If we're fortified or use endure we don't give a shit about staggerstun.
+		if(xeno_victim.fortify || xeno_victim.endure || xeno_victim.endurance_active || HAS_TRAIT_FROM(xeno_victim, TRAIT_IMMOBILE, BOILER_ROOTED_TRAIT)) //If we're fortified or use endure we don't give a shit about staggerstun.
 			return
 
 		if(xeno_victim.crest_defense) //Crest defense protects us from the stun.

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -195,7 +195,7 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
-	if (xeno_attacker.fortify || xeno_attacker.behemoth_charging)
+	if (xeno_attacker.fortify || xeno_attacker.behemoth_charging || xeno_attacker.endurance_active)
 		return FALSE
 
 	switch(xeno_attacker.a_intent)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
@@ -45,6 +45,8 @@
 		return
 	if(!xeno_owner.canmove)
 		return FALSE
+	if(xeno_owner.endurance_active)
+		return FALSE
 	return TRUE
 
 /datum/action/ability/xeno_action/conqueror_dash/action_activate()
@@ -523,7 +525,7 @@
 
 /datum/action/ability/xeno_action/conqueror_endurance/give_action(mob/living/L)
 	. = ..()
-	xeno_owner.endurance_health_max = xeno_owner.xeno_caste.max_health * 2
+	xeno_owner.endurance_health_max = xeno_owner.xeno_caste.max_health * 1.5
 	xeno_owner.endurance_health = xeno_owner.endurance_health_max
 	START_PROCESSING(SSprocessing, src)
 	particle_holder = new(xeno_owner, /particles/conqueror_endurance)
@@ -548,6 +550,8 @@
 	if(!.)
 		return
 	if(xeno_owner.endurance_broken)
+		return FALSE
+	if(xeno_owner.endurance_active)
 		return FALSE
 	return TRUE
 
@@ -598,7 +602,7 @@
 /datum/action/ability/xeno_action/conqueror_endurance/proc/enable_ability(keybind)
 	toggled = TRUE
 	set_toggle(TRUE)
-	xeno_owner.fortify = TRUE
+	xeno_owner.endurance_active = TRUE
 	xeno_owner.add_movespeed_modifier(MOVESPEED_ID_CONQUEROR_ENDURANCE, TRUE, 0, NONE, TRUE, CONQUEROR_ENDURANCE_SPEED_MODIFIER)
 	xeno_owner.xeno_caste.sunder_multiplier = CONQUEROR_ENDURANCE_SUNDER_MULTIPLIER
 	RegisterSignal(xeno_owner, COMSIG_MOB_DEATH, PROC_REF(disable_ability))
@@ -611,7 +615,7 @@
 	SIGNAL_HANDLER
 	toggled = FALSE
 	set_toggle(FALSE)
-	xeno_owner.fortify = FALSE
+	xeno_owner.endurance_active = FALSE
 	xeno_owner.remove_movespeed_modifier(MOVESPEED_ID_CONQUEROR_ENDURANCE)
 	xeno_owner.xeno_caste.sunder_multiplier = initial(xeno_owner.xeno_caste.sunder_multiplier)
 	add_cooldown()
@@ -694,6 +698,8 @@
 	if(!.)
 		return
 	if(!xeno_owner.canmove)
+		return FALSE
+	if(xeno_owner.endurance_active)
 		return FALSE
 	return TRUE
 
@@ -821,6 +827,8 @@
 	if(!.)
 		return
 	if(!xeno_owner.canmove)
+		return FALSE
+	if(xeno_owner.endurance_active)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -410,6 +410,8 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	var/steam_rush = FALSE
 
 	// *** Conqueror vars *** //
+	/// If Endurance is currently active.
+	var/endurance_active = FALSE
 	/// The amount of remaining health that Endurance has.
 	var/endurance_health = 1
 	/// The maximum amount of health that Endurance can have.

--- a/code/modules/vehicles/__vehicle.dm
+++ b/code/modules/vehicles/__vehicle.dm
@@ -70,6 +70,11 @@
 /obj/vehicle/ai_should_stay_buckled(mob/living/carbon/npc)
 	return !is_driver(npc) //NPC's can't operate vehicles so we generally only want them buckled as a passenger
 
+/obj/vehicle/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount, damage_type, armor_type, effects, armor_penetration, isrightclick)
+	if(xeno_attacker.endurance_active)
+		return FALSE
+	return ..()
+
 /obj/vehicle/proc/is_key(obj/item/I)
 	return istype(I, key_type)
 


### PR DESCRIPTION
## About The Pull Request
Per title. These are the changes:
- Endurance's maximum block health reduced from 1600 to 1200.
- Endurance no longer allows the usage of other abilities while it is active.
- Vehicles (such as mechs and tanks) cannot be attacked while Endurance is active.

## Why It's Good For The Game
Conqueror is currently able to get away with some things it shouldn't, and this is a good start as any (and hopefully sufficient enough) to stop that from happening.

## Changelog
:cl: Lewdcifer
balance: Conqueror's Endurance's maximum block health reduced from 1600 to 1200.
balance: Conqueror's Endurance no longer allows the usage of other abilities while it is active.
balance: Vehicles (such as mechs and tanks) cannot be attacked while Conqueror's Endurance is active.
/:cl: