### PR TITLE
Light medical rig can now hold hyposprays

### DIFF
--- a/code/datums/storage/subtypes/belt.dm
+++ b/code/datums/storage/subtypes/belt.dm
@@ -46,6 +46,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/storage/pill_bottle/packet,
 		/obj/item/stack/medical,
+		/obj/item/reagent_containers/hypospray,
 		/obj/item/reagent_containers/hypospray/autoinjector,
 		/obj/item/reagent_containers/dropper,
 	))


### PR DESCRIPTION

## About The Pull Request

look above at the pr title

## Why It's Good For The Game

It can hold injectors, analyzer other small med stuff - so why shouldn't it hold hypospray? 
hypo is same weight as pills both big rig and lifesaver are still better than this so i think its fine to add hypo


Testing was done to ensure quality.

## Changelog
:cl: Atropos
add: Small medical rig can now hold hyposprays (60u version)
/:cl:
