### PR TITLE
Crushers charging mech legs will instead target chest if legs have no hp

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -321,9 +321,9 @@
 		else if(isgreyscalemecha(crushed)) // dont oneshot mechs... thats bad. should be punishing though
 			var/obj/vehicle/sealed/mecha/combat/greyscale/mech = crushed
 			var/datum/mech_limb/legs/legs = mech.limbs[MECH_GREY_LEGS]
-			legs?.take_damage(precrush)
-			do_stop_momentum()
-			return COMPONENT_MOVABLE_PREBUMP_STOPPED
+			if(legs?.part_health)
+				legs.take_damage(precrush)
+				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 		crushed_obj.take_damage(precrush * obj_damage_mult, BRUTE, MELEE)
 		if(QDELETED(crushed_obj))
 			charger.visible_message(span_danger("[charger] crushes [preserved_name]!"),


### PR DESCRIPTION
## About The Pull Request

Crushers charging mech legs will instead target chest if legs have no hp
Effectively one charge oneshots legs two shots oneshot the entire thing

## Why It's Good For The Game

If you managed to get it off twice in a row it should be valid to get the kill imo?
## Changelog
:cl:
balance: Crushers charging mech legs will instead target chest if legs have no hp
/:cl:
