### PR TITLE
Fix mechs being destroyed while not facing south and without an occupant making overlays layer wrong

### DIFF
--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_core.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_core.dm
@@ -96,6 +96,7 @@
 		return ..()
 	for(var/mob/occupant AS in occupants)
 		mob_exit(occupant, FALSE, TRUE)
+	setDir(dir_in) // in case of no occupants we need to fix layering and dir
 	is_wreck = TRUE
 	obj_integrity = max_integrity
 	update_appearance()


### PR DESCRIPTION

https://tenor.com/de/view/ahui-gif-26935354
## About The Pull Request

Kinda specific I know

## Changelog
:cl:
fix: Fix mechs being destroyed while not facing south and without an occupant making overlays layer wrong
/:cl:
