### PR TITLE
Reduces population requirements for King and Dragon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
@@ -28,7 +28,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 13
+	evolve_min_xenos = 11
 	death_evolution_delay = 15 MINUTES
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -29,7 +29,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 12
+	evolve_min_xenos = 10
 	death_evolution_delay = 7 MINUTES
 
 	// *** Flags *** //


### PR DESCRIPTION
## About The Pull Request
Per title. King's is reduced from 12 to 10, and Dragon's is reduced from 13 to 11.

## Why It's Good For The Game
Ungas get tanks, APCs, and mechs, right from the start. These snowball really hard and really quickly and make reaching these pop requirements nigh impossible, because xenos can't really contest these roles viably.

## Changelog
:cl: Lewdcifer
balance: King's population requirement reduced from 12 to 10.
balance: Dragon's population requirement reduced from 13 to 11.
/:cl: