### PR TITLE
You can no longer put tanks, apcs and mechs into closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -471,6 +471,9 @@
 	destination.item_size_counter += item_size
 	return TRUE
 
+/obj/vehicle/sealed/closet_insertion_allowed(obj/structure/closet/destination)
+	return FALSE
+
 ///Action delay when going out of a closet
 /mob/living/proc/on_closet_dump(obj/structure/closet/origin)
 	SetStun(origin.closet_stun_delay)


### PR DESCRIPTION

## About The Pull Request
Gogo gadget pocket bfg

## Changelog
:cl:
fix: You can no longer put tanks, apcs and mechs into closets
/:cl:
