### PR TITLE
Stacking debuff adjustment

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -997,6 +997,8 @@
 	id = "sniped"
 	/// Used for the sniped effect
 	var/obj/vis_sniped/visual_sniped
+	/// Holder for the gun that applied this effect
+	var/obj/item/weapon/gun/shooter
 
 /obj/vis_sniped
 	name = "sniped"
@@ -1007,11 +1009,18 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	vis_flags = VIS_INHERIT_DIR | VIS_INHERIT_ID | VIS_INHERIT_PLANE
 
-/datum/status_effect/incapacitating/recently_sniped/on_creation(mob/living/new_owner, set_duration)
+/datum/status_effect/incapacitating/recently_sniped/on_creation(mob/living/new_owner, set_duration, _shooter)
 	. = ..()
 
 	if(!. || new_owner.stat != CONSCIOUS)
 		return
+
+	if(!_shooter)
+		CRASH("_shooter not passed into sniped status effect.")
+
+	_shooter = shooter
+
+	RegisterSignal(shooter, COMSIG_QDELETING, PROC_REF(clear_shooter))
 
 	visual_sniped = new
 	visual_sniped.icon_state = "sniper_zoom"
@@ -1021,6 +1030,12 @@
 /datum/status_effect/incapacitating/recently_sniped/on_remove()
 	owner.vis_contents -= visual_sniped
 	QDEL_NULL(visual_sniped)
+	clear_shooter()
+
+/// Signal proc to make sure the shooting gun is nulled if it gets deleted
+/datum/status_effect/incapacitating/recently_sniped/proc/clear_shooter(datum/source)
+	SIGNAL_HANDLER
+	shooter = null
 
 // ***************************************
 // *********** Lifedrain

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -997,8 +997,8 @@
 	id = "sniped"
 	/// Used for the sniped effect
 	var/obj/vis_sniped/visual_sniped
-	/// Holder for the gun that applied this effect
-	var/obj/item/weapon/gun/shooter
+	/// Weakref to the gun that applied this effect
+	var/datum/weakref/shooter
 
 /obj/vis_sniped
 	name = "sniped"
@@ -1009,7 +1009,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	vis_flags = VIS_INHERIT_DIR | VIS_INHERIT_ID | VIS_INHERIT_PLANE
 
-/datum/status_effect/incapacitating/recently_sniped/on_creation(mob/living/new_owner, set_duration, _shooter)
+/datum/status_effect/incapacitating/recently_sniped/on_creation(mob/living/new_owner, set_duration, datum/weakref/_shooter)
 	. = ..()
 
 	if(!. || new_owner.stat != CONSCIOUS)
@@ -1020,8 +1020,6 @@
 
 	_shooter = shooter
 
-	RegisterSignal(shooter, COMSIG_QDELETING, PROC_REF(clear_shooter))
-
 	visual_sniped = new
 	visual_sniped.icon_state = "sniper_zoom"
 
@@ -1030,12 +1028,6 @@
 /datum/status_effect/incapacitating/recently_sniped/on_remove()
 	owner.vis_contents -= visual_sniped
 	QDEL_NULL(visual_sniped)
-	clear_shooter()
-
-/// Signal proc to make sure the shooting gun is nulled if it gets deleted
-/datum/status_effect/incapacitating/recently_sniped/proc/clear_shooter(datum/source)
-	SIGNAL_HANDLER
-	shooter = null
 
 // ***************************************
 // *********** Lifedrain

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -860,12 +860,15 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			if(sniped.check_duration())
 				return ..()
 
-			proj.damage = proj.damage * 0.1
-			///The -1 is because we don't want to take away damage from guns firing on cooldown
-			sniped.duration = max(world.time + shooter.fire_delay - 1, sniped.duration)
+			sniped.duration = max(world.time + shooter.fire_delay, sniped.duration)
+
+			if(sniped.shooter != shooter) //different gun shot us, apply the effect.
+				proj.damage = proj.damage * 0.1
+
+			sniped.shooter = shooter
 			return ..()
 
-		apply_status_effect(STATUS_EFFECT_SNIPED, shooter.fire_delay - 1)
+		apply_status_effect(STATUS_EFFECT_SNIPED, shooter.fire_delay, shooter)
 	return ..()
 
 ///visual and audio feedback for hits

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -862,13 +862,13 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 			sniped.duration = max(world.time + shooter.fire_delay, sniped.duration)
 
-			if(sniped.shooter != shooter) //different gun shot us, apply the effect.
+			if(sniped.shooter != WEAKREF(shooter)) //different gun shot us, apply the effect.
 				proj.damage = proj.damage * 0.1
 
-			sniped.shooter = shooter
+			sniped.shooter = WEAKREF(shooter)
 			return ..()
 
-		apply_status_effect(STATUS_EFFECT_SNIPED, shooter.fire_delay, shooter)
+		apply_status_effect(STATUS_EFFECT_SNIPED, shooter.fire_delay, WEAKREF(shooter))
 	return ..()
 
 ///visual and audio feedback for hits


### PR DESCRIPTION

## About The Pull Request

There was an issue with the stacking debuff potentially applying from your own shots and therefore cucking the next shots if the target you shot was moving towards you (because the timer only starts when the bullet hits, target being closer means less bullet travel time, target closing distance in the meantime, shortening the travel time while the timer is still adjusted for the old distance, yadda yadda)

I've just made the effect track the gun it was last shot with and if its the same gun hitting the xeno we just don't apply the damage modifier. This should help address at least some of the edge cases and is the most practical solution I could think of on short notice.
## Why It's Good For The Game

Should hopefully make you cuck yourself less when using marksman weapons.
## Changelog
:cl:
fix: The sniper stacking debuff should be more consistent with not applying the damage modifier when there's only one shooter
/:cl:
