### PR TITLE
Reduces skink's HP

### DIFF
--- a/code/modules/vehicles/unmanned/deployable_vehicles.dm
+++ b/code/modules/vehicles/unmanned/deployable_vehicles.dm
@@ -74,7 +74,7 @@
 	name = "\improper UV-T Skink"
 	desc = "A Skink B-type drone, ready to be deployed."
 	icon_state = "tiny_uv_folded"
-	max_integrity = 50
+	max_integrity = 20
 	w_class = WEIGHT_CLASS_SMALL
 	deployable_item = /obj/vehicle/unmanned/deployable/tiny
 

--- a/code/modules/vehicles/unmanned/deployable_vehicles.dm
+++ b/code/modules/vehicles/unmanned/deployable_vehicles.dm
@@ -85,7 +85,7 @@
 	move_delay = 1.5
 	hud_possible = list(MACHINE_HEALTH_HUD)
 	atom_flags = NONE
-	soft_armor = list(MELEE = 25, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 25, BIO = 100, FIRE = 25, ACID = 25)
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
 	pass_flags = PASS_LOW_STRUCTURE|PASS_GRILLE|PASS_MOB
 	turret_pattern = NO_PATTERN


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
With how cheap, small, fast, and stealthy a skink is, 50 HP is way to much; this is about two to three slashes from most (if not all) castes in the game, a task which is quite frankly _impossible_ unless the skink pilot decides to commit suicide.
## Changelog
:cl:
balance: reduces skink HP (50 -> 20)
balance: removes skink armour
/:cl:
