### PR TITLE
enabling nuke sends message to admins

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -66,6 +66,7 @@
 	// The timer is needed for when the signal is sent
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_START, src)
 	log_game("[reason] has enabled the nuke at [AREACOORD(src)]")
+	message_admins("[reason] has enabled the nuke at [ADMIN_VERBOSEJMP(src)]")
 
 ///Disables nuke timer
 /obj/machinery/nuclearbomb/proc/disable(reason)


### PR DESCRIPTION
## About The Pull Request

title
## Why It's Good For The Game

right now only disabling gives the message while enable is in the logs 
putting both in chat should make it easier to see what happened without having to dig logs

## Changelog

:cl: Atropos
admin: More nuke logging (enabling is seen in chat)
/:cl:
