### PR TITLE
Set xeno buffs shows current autoballance

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1200,7 +1200,7 @@ ADMIN_VERB_AND_CONTEXT_MENU(show_traitor_panel, R_ADMIN, "Show Objective Panel",
 	target_mind.traitor_panel()
 
 ADMIN_VERB(set_xeno_stat_buffs, R_ADMIN, "Set Xeno Buffs", "Allows you to change stats for all xenos. It is a multiplicator buff, so input 100 to put everything back to normal", ADMIN_CATEGORY_MAIN)
-	var/multiplicator_buff_wanted = tgui_input_number(user, "Input the factor in percentage that will multiply xeno stat", "100 is normal stat, 200 is doubling health, regen and melee attack")
+	var/multiplicator_buff_wanted = tgui_input_number(user, "Input the factor in percentage that will multiply xeno stat", "100 is normal stat, 200 is doubling health, regen and melee attack", default = GLOB.xeno_stat_multiplicator_buff * 100)
 
 	if(!multiplicator_buff_wanted)
 		return


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

Only other way to check current state of autoballance is to inspect xeno 
and even then you have to do math to figure out exact %

math bad - numbers being shown to me good

Testing was done to ensure quality.
## Changelog
:cl: Atropos
admin: set xeno buffs verb now also shows current autoballance
/:cl:
