### PR TITLE
Makes sizzler's opaque gas transparent, increases damage on spit and bomblets

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -389,7 +389,7 @@
 /datum/ammo/xeno/acid/airburst_bomblet/smokescreen
 	max_range = 5
 	damage = 0
-	smoketype = /datum/effect_system/smoke_spread/xeno/acid/opaque
+	smoketype = /datum/effect_system/smoke_spread/xeno/acid
 	smoke_radius = 1
 	smoke_duration = 4
 

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -311,7 +311,7 @@
 /datum/ammo/xeno/acid/airburst
 	name = "acid steam spittle"
 	spit_cost = 50
-	damage = 15
+	damage = 20
 	ammo_behavior_flags = AMMO_XENO|AMMO_TARGET_TURF
 	bonus_projectiles_type = /datum/ammo/xeno/acid/airburst_bomblet
 	bonus_projectiles_scatter = 10
@@ -340,7 +340,7 @@
 	ammo_behavior_flags = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_PASS_THROUGH_MOB|AMMO_LEAVE_TURF
 	max_range = 3
 	shell_speed = 1
-	damage = 10
+	damage = 15
 	penetration = 0
 	/// smoke type created when the projectile detonates
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/xeno/acid
@@ -388,7 +388,7 @@
 
 /datum/ammo/xeno/acid/airburst_bomblet/smokescreen
 	max_range = 5
-	damage = 0
+	damage = 6
 	smoketype = /datum/effect_system/smoke_spread/xeno/acid
 	smoke_radius = 1
 	smoke_duration = 4


### PR DESCRIPTION
## About The Pull Request
Title, makes the sizzler's smokescreen shoot transparent gas, instead of opaque. Also increases their spit damage by 5, and the gas cloud by 5 (effectively 10 if it's a direct hit). The bomblets will also now do up to 6 damage each (up from 0).
## Why It's Good For The Game
As it currently stands, sizzler is just a straight upgrade to boiler, being able to do everything a boiler can much faster, safer, and more frequently. Making the gas transparent will at least mean going sizzler is giving up the ranged cloak that boiler provides for more front-line AoE damage. The damage increases is meant to compensate from the lack of opaque gas.
## Changelog
:cl:
balance: Sizzler's smokescreen is now transparent
balance: Sizzler's smokescreen bomblets now do 6 damage each
balance:: Sizzler's spit now does 20 damage, and the gas cloud does 15 damage.
/:cl:
