### PR TITLE
Rally minions for queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -81,6 +81,7 @@
 		/datum/action/ability/xeno_action/hive_message,
 		/datum/action/ability/xeno_action/rally_hive,
 		/datum/action/ability/activable/xeno/command_minions,
+		/datum/action/ability/xeno_action/rally_minion,
 		/datum/action/ability/activable/xeno/place_pattern,
 	)
 


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

For those unaware - previously queen only had command minions
with this she gets both command (long range rally button that costs plasma) and rally (screen ish range without plasma cost aka what shrike/leaders have)

someone very special asked me for this and i found myself lacking this button few times too so yeah

## Changelog

:cl: Atropos
balance: Queen now has Rally minions button
/:cl:
