### PR TITLE
Synths can use AG (and tangle) nades

### DIFF
--- a/code/game/objects/items/explosives/grenades/smoke_grenades.dm
+++ b/code/game/objects/items/explosives/grenades/smoke_grenades.dm
@@ -95,7 +95,7 @@
 	hud_state = "grenade_drain"
 	det_time = 6 SECONDS
 	icon_state_mini = "grenade_blue"
-	dangerous = TRUE
+	dangerous = FALSE
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss
 	smoke_duration = 11
 	smokeradius = 7
@@ -108,7 +108,7 @@
 	hud_state = "grenade_antigas"
 	det_time = 3 SECONDS
 	icon_state_mini = "grenade_antigas"
-	dangerous = TRUE
+	dangerous = FALSE
 	smoketype = /datum/effect_system/smoke_spread/antigas
 	smoke_duration = 11
 	smokeradius = 7


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game

If kuro says no its a no
if kuro says yes then i happy and synth more
like synths can use smoke nades - why not anti smoke?

## Changelog
:cl: Atropos
balance: Synths can now use AG (and tangle) nades
/:cl:
