### PR TITLE
Makes mortars/howitzers unusable on tad

### DIFF
--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -44,7 +44,7 @@
 /area/shuttle/minidropship
 	name = "Tadpole Drop Shuttle"
 	area_flags = NO_CONSTRUCTION
-	ceiling = CEILING_METAL
+	ceiling = CEILING_OBSTRUCTED
 
 /area/shuttle/minidropship/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title
(say if code bad, the areas code looks like a mess to me)

## Why It's Good For The Game

Main idea behind this is to make as title suggests mortars unusable on tad but usable near it

One might ask why? most tads has 6 turrets guarding them, making the mortar "indestructible"
Idea is to not make mortars on tad unusable but to make them require mininum effort of taking the crate outside to fire
so marines have to either cade up to defend said mortar - or xenos can look into options of crusher

again its to prevent having a free mortar by the console that you can afk fire without having to do anything special
I want minimum effort to fire it (taking outside, doing cades etc. also funny if it gets forgotten on take off)

## Changelog
:cl: Atropos
balance: Mortars/howitzers are no longer usable inside tad
/:cl:
