### PR TITLE
Tesla turret nerfs

### DIFF
--- a/code/game/objects/machinery/tesla_turret.dm
+++ b/code/game/objects/machinery/tesla_turret.dm
@@ -1,6 +1,8 @@
-#define TESLA_TURRET_MAX_RANGE 7
+#define TESLA_TURRET_MAX_RANGE 6
+///How many targets it can hit per activation
+#define TESLA_TURRET_MAX_TARGETS 3
 #define TESLA_TURRET_COST_PASSIVE 25
-#define TESLA_TURRET_COST_ACTIVE 75
+#define TESLA_TURRET_COST_ACTIVE 100
 
 /obj/item/tesla_turret
 	name = "tesla turret"
@@ -203,21 +205,22 @@
 		balloon_alert_to_viewers("shuts off!")
 		toggle(FALSE, TRUE)
 		return
-	if(battery.use(passive_cost))
-		/// Needs to have enough charge to hit at least one xeno
-		var/max_targets = max(trunc(battery.charge / active_cost), 0)
-		if(!max_targets)
-			hud_set_tesla_battery()
-			return
-		var/xeno_amount = length(zap_beam(src, max_range, 4, max_targets = max_targets))
-		if(!xeno_amount)
-			hud_set_tesla_battery()
-			return
-		battery.use(active_cost * xeno_amount)
-		playsound(src, 'sound/weapons/guns/fire/tesla.ogg', 60, TRUE)
-	else
+	if(!battery.use(passive_cost))
 		balloon_alert_to_viewers("shuts off!")
 		toggle(FALSE, TRUE)
+		hud_set_tesla_battery()
+		return
+	/// Needs to have enough charge to hit at least one xeno
+	var/max_zap_targets = clamp(trunc(battery.charge / active_cost), 0, TESLA_TURRET_MAX_TARGETS)
+	if(!max_zap_targets)
+		hud_set_tesla_battery()
+		return
+	var/xeno_amount = length(zap_beam(src, max_range, 4, max_targets = max_zap_targets))
+	if(!xeno_amount)
+		hud_set_tesla_battery()
+		return
+	battery.use(active_cost * xeno_amount)
+	playsound(src, 'sound/weapons/guns/fire/tesla.ogg', 60, TRUE)
 	hud_set_tesla_battery()
 
 /obj/machinery/deployable/tesla_turret/disassemble(mob/marine)

--- a/code/modules/reqs/supplypacks/engineering_packs.dm
+++ b/code/modules/reqs/supplypacks/engineering_packs.dm
@@ -129,4 +129,4 @@ ENGINEERING
 /datum/supply_packs/engineering/tesla_turret
 	name = "Tesla turret"
 	contains = list(/obj/item/tesla_turret)
-	cost = 250
+	cost = 400


### PR DESCRIPTION
## About The Pull Request
Max range reduced to 6 from 7.
Max targets reduced to 3 from ONE HUNDRED OR MORE DEPENDING ON THE CELL
Increased req cost to 400 from 250 (same as a turret)
Increased power use per hit to 100 from 75.
## Why It's Good For The Game
Tries to rein in the utter bullshit of this item, I don't know why it was even merged honestly, its just a tesla gun turret only 20 times better in every way.
This item is really fucking poorly balanced, even with these nerfs holy shit is it completely bad design.

It has no target cap, and doesn't require LOS, so even in smoke it will hit 20 xenos nonstop and prevent them from using abilities.

Xenos have literally no way to counter or mitigate this in any way, other than destroying it.

It uses normal cells which means it can have 10,000 power with a basic high cap cell, so it has absurd amounts of ammo.

It reaches almost the entire screen, and they can be stacked, to create complete deadzones where xenos just lose all their abilities.
## Changelog
:cl:
balance: Nerfed the cost and strength of the tesla turret
/:cl:
