### PR TITLE
Fix wrong req timers

### DIFF
--- a/code/modules/factory/machines.dm
+++ b/code/modules/factory/machines.dm
@@ -28,7 +28,7 @@
 /obj/machinery/factory/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	. += "It is currently facing [dir2text(dir)] and [anchored ? "" : "un"]secured."
-	. += "Processes one package every [cooldown_time*10] seconds."
+	. += "Processes one package every [cooldown_time / 10] seconds."
 
 /obj/machinery/factory/wrench_act(mob/living/user, obj/item/I)
 	anchored = !anchored


### PR DESCRIPTION

## About The Pull Request

for factory machines - it was saying 100 instead of 1 

## Why It's Good For The Game

Fix good

## Changelog

:cl: Atropos
fix: fixed factory machines displaying incorrect times
/:cl:
