### PR TITLE
Health analyzer UI reagent ordering and Health bar values

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -15,9 +15,9 @@
 #define TRANSPARENT (1<<4)
 /// For non-transparent containers that still have the general amount of reagents in them visible.
 #define AMOUNT_VISIBLE (1<<5)
-///For containers which apply a skill check for wheter showing their reagents to the user or not.
+/// For containers which apply a skill check for wheter showing their reagents to the user or not.
 #define AMOUNT_SKILLCHECK (1<<6)
-///For containers without volume meters on (e.g. drinking glasses, cans, sprays)
+/// For containers without volume meters on (e.g. drinking glasses, cans, sprays)
 #define AMOUNT_ESTIMEE (1<<7)
 
 #define NO_REACT (1<<8)
@@ -32,11 +32,11 @@
 #define HEARTSTOPPER (1<<2)
 #define CHEARTSTOPPER (1<<3)
 
-#define TOUCH 1	// splashing
-#define INGEST 2	// ingestion
-#define VAPOR 3	// foam, spray, blob attack
-#define PATCH 4	// patches
-#define INJECT 5	// injection
+#define TOUCH 1	 // splashing
+#define INGEST 2 // ingestion
+#define VAPOR 3	 // foam, spray, blob attack
+#define PATCH 4	 // patches
+#define INJECT 5 // injection
 
 #define DEL_REAGENT 1	// reagent deleted (fully cleared)
 #define ADD_REAGENT 2	// reagent added
@@ -55,7 +55,17 @@
 // Factor of how fast mob nutrition decreases
 #define HUNGER_FACTOR 0.05
 
-//Specific Heat, unused stuff right now..
+// Specific Heat, unused stuff right now..
 #define SPECIFIC_HEAT_DEFAULT 200
 
 #define SPECIFIC_HEAT_PLASMA 500
+
+// Reagent UI ordering, lower the number the higher the priority
+#define REAGENT_UI_BASE 7      // Base /datum/reagent order level
+#define REAGENT_UI_MUNDANE 10  // Who cares about these chems?
+#define REAGENT_UI_MEDICINE 6  // Generic healing chems
+#define REAGENT_UI_SPACEA 5    // Spaceacillin, it lasts a long time, and i don't want it above nomally taken chems
+#define REAGENT_UI_BKTT 4      // Chems that are normally inside ones body, to promote a consistent UI look
+#define REAGENT_UI_UNIQUE 3    // Unique healing chems that should come before others
+#define REAGENT_UI_TOXINS 2    // Xenomorph chems and other deliberatly hostile chems
+#define REAGENT_UI_IMMEDIATE 1 // Reagents that should be seen immediatly

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -127,14 +127,19 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 		"patient" = patient.name,
 		"dead" = (patient.stat == DEAD || HAS_TRAIT(patient, TRAIT_FAKEDEATH)),
 		"health" = patient.health,
+		"abs_health" = abs(patient.get_death_threshold()) + patient.health,
 		"max_health" = patient.maxHealth,
+		"abs_max_health" = abs(patient.get_death_threshold()) + patient.maxHealth,
 		"crit_threshold" = patient.get_crit_threshold(),
+		"abs_crit_threshold" = abs(patient.get_crit_threshold()),
 		"dead_threshold" = patient.get_death_threshold(),
+		"abs_dead_threshold" = abs(patient.get_death_threshold()),
 		"total_brute" = round(patient.getBruteLoss()),
 		"total_burn" = round(patient.getFireLoss()),
 		"toxin" = round(patient.getToxLoss()),
 		"oxy" = round(patient.getOxyLoss()),
 		"clone" = round(patient.getCloneLoss()),
+		"time_dead" = patient.dead_ticks,
 
 		"blood_type" = patient.blood_type,
 		"blood_amount" = patient.blood_volume,
@@ -182,7 +187,8 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 			"od_threshold" = reagent.overdose_threshold,
 			"crit_od_threshold" = reagent.overdose_crit_threshold,
 			"color" = reagent.color,
-			"metabolism_factor" = reagent.custom_metabolism
+			"metabolism_factor" = reagent.custom_metabolism,
+			"ui_order" = reagent.reagent_ui_priority
 		)
 	data["has_chemicals"] = length(patient.reagents.reagent_list)
 	data["chemicals_lists"] = chemicals_lists

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -49,6 +49,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/addiction_stage = 0
 	/// does this show up on health analyzers
 	var/scannable = TRUE
+	/// Reagent priority in UI, lower value is higher priority
+	var/reagent_ui_priority = REAGENT_UI_BASE
+	/// Reagent priority in UI purgelist modifier, i have no idea if this is needed or how to implement
+	var/reagent_ui_purgelist = 0
 	/// if false stops metab in liverless mobs
 	var/self_consuming = FALSE
 	/// List of reagents removed by this chemical

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -8,6 +8,7 @@
 	custom_metabolism = FOOD_METABOLISM
 	taste_description = "generic food"
 	taste_multi = 4
+	reagent_ui_priority = REAGENT_UI_MUNDANE
 	var/nutriment_factor = 1
 	var/adj_temp = 0
 	var/targ_temp = BODYTEMP_NORMAL
@@ -36,6 +37,7 @@
 	description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 	nutriment_factor = 15
 	color = "#664330" // rgb: 102, 67, 48
+	reagent_ui_priority = REAGENT_UI_BASE //nutriment is more important than other food chems
 	var/brute_heal = 1
 	var/burn_heal = 0
 	var/blood_gain = 0.4
@@ -279,6 +281,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "mushroom"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/psilocybin/on_mob_life(mob/living/L, metabolism)
 	L.druggy = max(L.druggy, 30)
@@ -405,6 +408,7 @@
 	nutriment_factor = 0
 	color = "#66801e"
 	taste_description = "burning"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/larvajelly/on_mob_life(mob/living/L, metabolism)
 	L.adjustBruteLoss(-0.5*effect_str)
@@ -419,6 +423,7 @@
 	nutriment_factor = 1
 	color = "#66801e"
 	taste_description = "victory"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/larvajellyprepared/on_mob_life(mob/living/L, metabolism)
 	L.adjustBruteLoss(-0.5*effect_str)

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -6,6 +6,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_MEDICINE
 
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
@@ -14,6 +15,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2
 	trait_flags = TACHYCARDIC
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/medicine/inaprovaline/on_mob_add(mob/living/L, metabolism)
 	ADD_TRAIT(L, TRAIT_IGNORE_SUFFOCATION, REAGENT_TRAIT(src))
@@ -97,6 +99,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/medicine/paracetamol/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_HEAVY
@@ -120,6 +123,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/tramadol/on_mob_life(mob/living/L)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
@@ -142,6 +146,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 1.25
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/oxycodone/on_mob_add(mob/living/L, metabolism)
 	if(TIMER_COOLDOWN_RUNNING(L, name))
@@ -232,6 +237,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -259,6 +265,7 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/dermaline/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -348,6 +355,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "grossness"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
@@ -376,6 +384,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "a roll of gauze"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
 	L.add_stamina_regen_modifier(name, -0.5)
@@ -453,6 +462,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	purge_list = list(/datum/reagent/toxin/mindbreaker)
 	purge_rate = 5
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/synaptizine/on_mob_add(mob/living/L, metabolism)
 	if(TIMER_COOLDOWN_RUNNING(L, name))
@@ -499,6 +509,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = 5
 	overdose_crit_threshold = 6
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/neuraline/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
@@ -589,6 +600,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	overdose_threshold = REAGENTS_OVERDOSE/2   //so it makes the OD threshold effectively 15 so two pills is too much but one is fine
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2.5 //and this makes the Critical OD 20
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/russian_red/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
@@ -683,6 +695,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/30
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/25
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/peridaxon_plus/on_mob_life(mob/living/L, metabolism)
 	L.reagents.add_reagent(/datum/reagent/toxin/scannable,5)
@@ -716,6 +729,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
 	L.heal_overall_damage(effect_str, 0)
@@ -741,6 +755,7 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, metabolism)
 	L.heal_overall_damage(2*effect_str, 0)
@@ -800,6 +815,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //12u
 	custom_metabolism = REAGENTS_METABOLISM * 2.5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 	///The IB wound this dose of QCP will cure, if it lasts long enough
 	var/datum/wound/internal_bleeding/target_IB
 	///Ticks remaining before the target_IB is cured
@@ -877,6 +893,7 @@
 	color = COLOR_REAGENT_NANOBLOOD
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //10u
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/nanoblood/on_mob_life(mob/living/L, metabolism)
 	L.adjust_blood_volume(2.4)
@@ -910,6 +927,7 @@
 	overdose_crit_threshold = 20
 	addiction_threshold = 0.4 // Adios Addiction Virus
 	taste_multi = 2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/ultrazine/on_mob_add(mob/living/L, metabolism)
 	. = ..()
@@ -1043,6 +1061,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "fish"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1081,6 +1100,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.05
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_SPACEA
 
 /datum/reagent/medicine/spaceacillin/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, TOX)
@@ -1099,6 +1119,7 @@
 	color = COLOR_REAGENT_POLYHEXANIDE
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/polyhexanide/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1122,6 +1143,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/larvaway/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1151,6 +1173,7 @@
 	color = COLOR_REAGENT_ETHYLREDOXRAZINE
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BASE
 
 /datum/reagent/medicine/ethylredoxrazine/on_mob_life(mob/living/L, metabolism)
 	L.dizzy(-1)
@@ -1179,6 +1202,7 @@
 	purge_rate = 5
 	taste_description = "punishment"
 	taste_multi = 8
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/hypervene/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_HEAVY //Significant pain while metabolized.
@@ -1205,6 +1229,7 @@
 	color = COLOR_REAGENT_ROULETTIUM
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	taste_description = "Poor life choices"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/roulettium/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_HEAVY * 4
@@ -1221,6 +1246,7 @@
 	reagent_state = LIQUID
 	color = COLOR_REAGENT_LEMOLINE
 	taste_description = "piss"
+	reagent_ui_priority = REAGENT_UI_BASE
 
 /datum/reagent/medicine/bihexajuline
 	name = "Bihexajuline"
@@ -1260,6 +1286,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 
 /datum/reagent/medicine/research/quietus
@@ -1329,6 +1356,7 @@
 	custom_metabolism = 0
 	taste_description = "metal, followed by mild burning"
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 	purge_list = list(
 		/datum/reagent/medicine/bicaridine,
 		/datum/reagent/medicine/kelotane,
@@ -1428,6 +1456,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5
 	custom_metabolism = REAGENTS_METABOLISM * 5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/regrow/on_mob_add(mob/living/L, metabolism)
 	if(volume < 5 || L.stat == DEAD || (!ishuman(L)))

--- a/code/modules/reagents/chemistry/reagents/other.dm
+++ b/code/modules/reagents/chemistry/reagents/other.dm
@@ -218,6 +218,7 @@
 	reagent_state = LIQUID
 	color = "#484848" // rgb: 72, 72, 72
 	taste_multi = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/mercury/on_mob_life(mob/living/L, metabolism)
 	if(!L.incapacitated(TRUE) && !L.pulledby && isfloorturf(L.loc))
@@ -258,6 +259,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "chlorine"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/chlorine/on_mob_life(mob/living/L, metabolism)
 	L.take_limb_damage(0.5*effect_str, 0)
@@ -277,6 +279,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "acid"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/fluorine/on_mob_life(mob/living/L, metabolism)
 	L.adjustToxLoss(0.5*effect_str)
@@ -310,6 +313,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "metal"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/lithium/on_mob_life(mob/living/L, metabolism)
 	if(!L.incapacitated(TRUE) && !L.pulledby && isfloorturf(L.loc))
@@ -346,6 +350,7 @@
 	reagent_state = SOLID
 	color = "#C7C7C7" // rgb: 199,199,199
 	taste_description = "the colour blue and regret"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/radium/on_mob_life(mob/living/L, metabolism)
 	L.apply_effect(effect_str/L.metabolism_efficiency, EFFECT_STAMLOSS)
@@ -390,6 +395,7 @@
 	description = "A silvery-white metallic chemical element in the actinide series, weakly radioactive."
 	color = "#B8B8C0" // rgb: 184, 184, 192
 	taste_description = "the inside of a reactor"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/uranium/on_mob_life(mob/living/L, metabolism)
 	L.apply_effect(1/L.metabolism_efficiency, EFFECT_STAMLOSS)//WHAT THE HELL DID YOU THINK WOULD HAPPEN
@@ -421,6 +427,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "gross metal"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 	///The effect creates when this reagent is splashed on the ground
 	var/effect_type = /obj/effect/decal/cleanable/liquid_fuel
 
@@ -506,6 +513,7 @@
 	taste_description = "numbness"
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/impedrezene/on_mob_life(mob/living/L, metabolism)
 	L.jitter(-5)
@@ -583,6 +591,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/lipozine/on_mob_life(mob/living/L, metabolism)
 	if(!iscarbon(L))
@@ -609,6 +618,7 @@
 	name = "Sterilizine"
 	description = "Sterilizes wounds in preparation for surgery."
 	color = "#C8A5DC" // rgb: 200, 165, 220
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 
 /datum/reagent/sterilizine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)

--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -11,7 +11,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	taste_description = "bitterness"
 	taste_multi = 1.2
- 	reagent_ui_priority = REAGENT_UI_MEDICINE // Raise this to REAGENT_UI_TOXINS if toxpwr damage calculation gets buffed or var gets raised.
+	reagent_ui_priority = REAGENT_UI_MEDICINE // Raise this to REAGENT_UI_TOXINS if toxpwr damage calculation gets buffed or var gets raised.
 
 /datum/reagent/toxin/on_mob_life(mob/living/L, metabolism)
 	if(toxpwr)

--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -11,6 +11,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	taste_description = "bitterness"
 	taste_multi = 1.2
+ 	reagent_ui_priority = REAGENT_UI_MEDICINE // Raise this to REAGENT_UI_TOXINS if toxpwr damage calculation gets buffed or var gets raised.
 
 /datum/reagent/toxin/on_mob_life(mob/living/L, metabolism)
 	if(toxpwr)
@@ -63,6 +64,7 @@
 	description = "Phoron in its liquid form."
 	color = COLOR_TOXIN_PHORON
 	toxpwr = 3
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/phoron/on_mob_life(mob/living/L, metabolism)
 	holder.remove_reagent(/datum/reagent/medicine/inaprovaline, effect_str)
@@ -76,6 +78,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "acid"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/lexorin/on_mob_life(mob/living/L, metabolism)
 	if(prob(33))
@@ -97,6 +100,7 @@
 	color = COLOR_TOXIN_CYANIDE
 	toxpwr = 3
 	custom_metabolism = REAGENTS_METABOLISM * 2
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/cyanide/on_mob_life(mob/living/L, metabolism)
 	L.adjustOxyLoss(2*effect_str)
@@ -117,6 +121,7 @@
 	color = COLOR_TOXIN_CARPOTOXIN
 	toxpwr = 2
 	taste_description = "fish"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/huskpowder
 	name = "Zombie Powder"
@@ -125,6 +130,7 @@
 	color = COLOR_TOXIN_HUSKPOWDER
 	toxpwr = 0.5
 	taste_description = "death"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/huskpowder/on_mob_add(mob/living/L, metabolism)
 	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
@@ -172,6 +178,7 @@
 	description = "A chemical mix good for growing plants with."
 	toxpwr = 0.2 //It's not THAT poisonous.
 	color = COLOR_TOXIN_FERTILIZER
+	reagent_ui_priority = REAGENT_UI_BASE
 
 /datum/reagent/toxin/fertilizer/eznutrient
 	name = "EZ Nutrient"
@@ -188,6 +195,7 @@
 	color = COLOR_TOXIN_PLANTBGONE
 	toxpwr = 1
 	taste_multi = 1
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/plantbgone/reaction_obj(obj/O, volume)
 	if(istype(O,/obj/alien/weeds))
@@ -219,6 +227,7 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "cough syrup"
 	trait_flags = BRADYCARDICS
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/sleeptoxin/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -253,6 +262,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -277,6 +287,7 @@
 	toxpwr = 0
 	overdose_threshold = REAGENTS_OVERDOSE
 	trait_flags = CHEARTSTOPPER
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/potassium_chloride/overdose_process(mob/living/L, metabolism)
 	if(iscarbon(L))
@@ -296,6 +307,7 @@
 	description = "A specific chemical based on Potassium Chloride to stop the heart for surgery. Not safe to eat!"
 	color = COLOR_TOXIN_POTASSIUM_CHLORIDE
 	toxpwr = 2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/potassium_chlorophoride/on_mob_life(mob/living/L, metabolism)
 	if(L.stat != UNCONSCIOUS)
@@ -317,6 +329,7 @@
 	custom_metabolism = 0
 	toxpwr = 0
 	taste_description = "ow ow ow"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE // For ease of testing
 
 /datum/reagent/toxin/pain/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier = volume
@@ -328,6 +341,7 @@
 	color = COLOR_TOXIN_PLASTICIDE
 	toxpwr = 0.2
 	taste_description = "plastic"
+	reagent_ui_priority = REAGENT_UI_MEDICINE
 
 /datum/reagent/toxin/plasticide/on_mob_life(mob/living/L, metabolism)
 	L.adjustToxLoss(0.2)
@@ -340,6 +354,7 @@
 	toxpwr = 1
 	var/meltprob = 10
 	taste_description = "acid"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/acid/on_mob_life(mob/living/L, metabolism)
 	L.take_limb_damage(0, 0.5*effect_str)
@@ -421,6 +436,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	medbayblacklist = TRUE
 	reactindeadmob = FALSE
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/nanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your body begins to twist and deform! Get out of the razorburn!"))
@@ -448,6 +464,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = 10000 //Overdosing for neuro is what happens when you run out of stamina to avoid its oxy and toxin damage
 	toxpwr = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/xeno_neurotoxin/on_mob_life(mob/living/L, metabolism)
 	var/power
@@ -494,6 +511,7 @@
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
 	toxpwr = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/xeno_hemodile/on_mob_life(mob/living/L, metabolism)
 
@@ -530,6 +548,7 @@
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
 	toxpwr = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/xeno_transvitox/on_mob_add(mob/living/L, metabolism, affecting)
 	RegisterSignal(L, COMSIG_HUMAN_DAMAGE_TAKEN, PROC_REF(transvitox_human_damage_taken))
@@ -585,6 +604,7 @@
 	custom_metabolism = 0.4
 	overdose_threshold = 10000
 	toxpwr = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/xeno_sanguinal/on_mob_life(mob/living/L, metabolism)
 	if(L.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))
@@ -620,6 +640,7 @@
 	toxpwr = 0 // This is going to do slightly snowflake tox damage.
 	purge_list = list(/datum/reagent/medicine)
 	purge_rate = 5
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/xeno_ozelomelyn/on_mob_life(mob/living/L, metabolism)
 	if(L.getToxLoss() < 40) // if our toxloss is below 40, do 0.75 tox damage.
@@ -639,6 +660,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	overdose_threshold = 20
 	overdose_crit_threshold = 50
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/zombium/on_overdose_start(mob/living/L, metabolism)
 	RegisterSignal(L, COMSIG_HUMAN_SET_UNDEFIBBABLE, PROC_REF(zombify))
@@ -677,6 +699,7 @@
 	overdose_threshold = 10000
 	custom_metabolism = REAGENTS_METABOLISM
 	toxpwr = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 	purge_list = list(
 		/datum/reagent/medicine/tramadol,
 		/datum/reagent/medicine/paracetamol,

--- a/tgui/packages/tgui/interfaces/MedScanner/data.ts
+++ b/tgui/packages/tgui/interfaces/MedScanner/data.ts
@@ -38,6 +38,8 @@ type ChemData = {
   color: string;
   metabolism_factor: number;
   dangerous: boolean;
+  ui_order: number;
+  ui_od_modifier: number;
 };
 
 type OrganData = {
@@ -61,9 +63,13 @@ export type MedScannerData = {
   species: Record<string, SpeciesData>;
   dead: boolean;
   health: number;
+  abs_health: number;
   max_health: number;
+  abs_max_health: number;
   crit_threshold: number;
+  abs_crit_threshold: number;
   dead_threshold: number;
+  abs_dead_threshold: number;
   total_brute: number;
   total_burn: number;
   toxin: number;
@@ -71,6 +77,7 @@ export type MedScannerData = {
   clone: number;
   revivable_boolean: boolean;
   revivable_string: number;
+  time_dead: number;
   has_chemicals: boolean;
   has_unknown_chemicals: boolean;
   chemicals_lists?: Record<string, ChemData>;

--- a/tgui/packages/tgui/interfaces/MedScanner/index.tsx
+++ b/tgui/packages/tgui/interfaces/MedScanner/index.tsx
@@ -86,9 +86,13 @@ function PatientBasics() {
     dead,
 
     health,
+    abs_health,
     max_health,
+    abs_max_health,
     crit_threshold,
+    abs_crit_threshold,
     dead_threshold,
+    abs_dead_threshold,
 
     total_brute,
     total_burn,
@@ -100,6 +104,7 @@ function PatientBasics() {
 
     revivable_boolean,
     revivable_string,
+    time_dead,
 
     ssd,
 
@@ -135,26 +140,25 @@ function PatientBasics() {
             'How healthy the patient is.' +
             ((!species.is_robotic_species &&
               " If the patient's health dips below " +
-                crit_threshold +
+                (abs_crit_threshold / abs_max_health) * 100 +
                 '%, they enter critical condition and suffocate rapidly.') ||
               '') +
-            " If the patient's health hits " +
-            (dead_threshold / max_health) * 100 +
-            '%, they die.'
+            " If the patient's health hits 0%, they die."
           }
         >
-          {health >= 0 ? (
+          {abs_health > dead_threshold ? (
             <ProgressBar
-              value={health / max_health}
+              value={abs_health / abs_max_health}
               ranges={{
-                good: [0.4, Infinity],
-                average: [0.2, 0.4],
-                bad: [-Infinity, 0.2],
+                good: [0.7, Infinity],
+                average: [0.6, 0.7],
+                bad: [-Infinity, 0.6],
               }}
             />
           ) : (
             <ProgressBar value={1 + health / max_health} color="bad">
-              {Math.trunc((health / max_health) * 100)}%
+              {Math.trunc((health / max_health) * 100)}% // TODO, make this a
+              death timer to perma
             </ProgressBar>
           )}
         </LabeledList.Item>
@@ -268,6 +272,7 @@ function PatientChemicals() {
       <Stack vertical>
         {Object.values(chemicals_lists).map((chemical) => (
           <Stack.Item
+            order={chemical.ui_order}
             key={chemical.name}
             backgroundColor={row_transparency++ % 2 === 0 ? COLOR_ZEBRA_BG : ''}
             style={ROUNDED_BORDER}


### PR DESCRIPTION

## About The Pull Request

Gives order to analyzer's chem display, adds a compact mode, changes the healthbar from ((0 - max_health) and (0 - death threashold)) to ((death_threashold - max_health) and (dead_ticks - TIME_BEFORE_DNR))

- [ ] make compact mode
- [ ] add info for ordering chems into columns and rows
- [ ]  probably some other bologna

## Why It's Good For The Game

I'm not actually wedded to the idea of reorganizing via chem priority instead of when the chem was added for the base UI, i've got a lot of time spent into just muscle memory and intuiting what the fuck is going on, but with what i have in mind for a compact mode it'd be important. 

Have a shitty MSpaint3d render of what's in my head for a compacter UI.

![Medical scanner](https://github.com/user-attachments/assets/d7c64adb-9e4e-45f3-891d-1371ec11b809)


Showing the absolute health units in a health bar makes more sense to me, as essentially every point above death is health, dunno how to add a tick mark or something to denote crit threshold to the progress bar.

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more things
qol: Health analyzer's health bar shows absolute health
code: changed some code
/:cl:
