### PR TITLE
Recasting Dragon Breaths ends it early

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -370,12 +370,10 @@
 	/// The timer id for the timer that occurs every tick while the ability is active.
 	var/tick_timer
 
-/datum/action/ability/activable/xeno/backhand/dragon_breath/can_use_ability(atom/A, silent, override_flags)
-	if(ability_timer)
-		if(!silent)
-			xeno_owner.balloon_alert(xeno_owner, "already breathing fire")
-		return FALSE
-	return ..()
+/datum/action/ability/activable/xeno/backhand/dragon_breath/use_ability(atom/target)
+	if(!ability_timer)
+		return ..()
+	end_ability()
 
 /datum/action/ability/activable/xeno/backhand/dragon_breath/get_damage()
 	return 20 * xeno_owner.xeno_melee_damage_modifier


### PR DESCRIPTION

## About The Pull Request
Reactivating the Dragon Breath ability while it is in the middle of breathing fire now ends the ability instead of giving the "already breathing fire" balloon alert.

## Why It's Good For The Game
Apparently it was not intuitive to just switch abilities, so adding recasting to cancel it is cool.
 
## Changelog
:cl:
qol: You can now cancel Dragon Breath by reactivating the ability.
/:cl:
