### PR TITLE
Reset button for adjustable pane splitters

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
@@ -17,7 +17,7 @@ import { clearChat, saveChatToDisk } from '../chat/actions';
 import { THEMES } from '../themes';
 import { updateSettings } from './actions';
 import { FONTS } from './constants';
-import { setEditPaneSplitters } from './scaling';
+import { resetPaneSplitters, setEditPaneSplitters } from './scaling';
 import { selectSettings } from './selectors';
 
 export function SettingsGeneral(props) {
@@ -50,18 +50,27 @@ export function SettingsGeneral(props) {
           ))}
         </LabeledList.Item>
         <LabeledList.Item label="UI sizes">
-          <Button
-            onClick={() =>
-              setEditingPanes((val) => {
-                setEditPaneSplitters(!val);
-                return !val;
-              })
-            }
-            color={editingPanes ? 'red' : undefined}
-            icon={editingPanes ? 'save' : undefined}
-          >
-            {editingPanes ? 'Save' : 'Adjust UI Sizes'}
-          </Button>
+          <Stack>
+            <Stack.Item>
+              <Button
+                onClick={() =>
+                  setEditingPanes((val) => {
+                    setEditPaneSplitters(!val);
+                    return !val;
+                  })
+                }
+                color={editingPanes ? 'red' : undefined}
+                icon={editingPanes ? 'save' : undefined}
+              >
+                {editingPanes ? 'Save' : 'Adjust UI Sizes'}
+              </Button>
+            </Stack.Item>
+            <Stack.Item>
+              <Button onClick={resetPaneSplitters} icon="refresh" color="red">
+                Reset
+              </Button>
+            </Stack.Item>
+          </Stack>
         </LabeledList.Item>
         <LabeledList.Item label="Font style">
           <Stack.Item>

--- a/tgui/packages/tgui-panel/settings/scaling.ts
+++ b/tgui/packages/tgui-panel/settings/scaling.ts
@@ -30,17 +30,27 @@ export async function setDisplayScaling() {
   Byond.winset(null, newSizes);
 }
 
-const PANE_SPLITTERS = [
-  'info_button_child',
-  'input_buttons_child',
-  'output_input_child',
-];
+const PANE_SPLITTERS = {
+  info_button_child: 2,
+  input_buttons_child: 80,
+  output_input_child: 96,
+};
 
 export function setEditPaneSplitters(editing: boolean) {
   const toSet: { [element: string]: any } = {};
 
-  for (const pane of PANE_SPLITTERS) {
+  for (const pane of Object.keys(PANE_SPLITTERS)) {
     toSet[`${pane}.show-splitter`] = editing;
+  }
+
+  Byond.winset(null, toSet);
+}
+
+export function resetPaneSplitters() {
+  const toSet: { [element: string]: any } = {};
+
+  for (const default_obj of Object.entries(PANE_SPLITTERS)) {
+    toSet[`${default_obj[0]}.splitter`] = default_obj[1];
   }
 
   Byond.winset(null, toSet);


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/90634


## Changelog
:cl:
qol: you can now reset the adjustable pane splitters in chat settings
/:cl:
