### PR TITLE
Jellypod landmarks now actually work 

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -174,7 +174,7 @@
 	icon_state = "resinpod"
 
 /obj/effect/landmark/resin_jelly_pod/Initialize(mapload)
-	GLOB.xeno_tunnel_spawn_turfs += loc
+	GLOB.xeno_jelly_pod_turfs += loc
 	..()
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game

Resin landmarks were actually landmarks for tunnels, this fixes that

Does not change any actual landmarks as jelly pod landmarks are unused
## Changelog

Spotted it by chance, codefix good
:cl:
fix: Jellypod landmarks no longer spawn tunnels
/:cl:
