### PR TITLE
No more allocating multiple leaders in a squad

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -398,10 +398,8 @@
 //This reserves a player a spot in the squad by using a mind variable.
 //It is necessary so that they can smoothly reroll a squad role in case of the strict preference.
 /datum/squad/proc/assign_initial(mob/new_player/player, datum/job/job, latejoin = FALSE)
-	if(!(job.title in current_positions))
-		CRASH("Attempted to insert [job.title] into squad [name]")
-	if(!latejoin)
-		current_positions[job.title]++
+	if(!check_entry(job))
+		return FALSE
 	player.assigned_squad = src
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

 SLs are no longer put in a squad if it has another SL in it.
Example: If there is already a Charlie SL, you cannot spawn as a Charlie SL.

You can still transfer yourself to squads with another SL in it, and CIC can still do the same
## Why It's Good For The Game

Should stop 'four delta SLs' and provide a good spread of leadership across squads, making it more likely a squad will have an SL and less likely to have a 'too many cooks in the kitchen' situation

..also, I think this is the intended behaviour. So bugfix good, I guess?
## Changelog
:cl:
add: SLs are no longer put in a squad if it has another SL in it. SLs can still transfer to whatever squad they want, regardless of whether there's a squaddie in it
/:cl:
