### PR TITLE
Adds a cooldown for electric wire

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -12,6 +12,7 @@
 #define COOLDOWN_ZOOM "zoom"
 #define COOLDOWN_BUMP "bump"
 #define COOLDOWN_ENTANGLE "entangle"
+#define COOLDOWN_ELECTROCUTED "cooldown_electrocuted"
 #define COOLDOWN_NEST "nest"
 #define COOLDOWN_BUMP_ATTACK "bump_attack"
 #define COOLDOWN_TASTE "taste"

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -217,6 +217,8 @@
 /proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE)
 	if(!M)
 		return 0	//feckin mechs are dumb
+	if(TIMER_COOLDOWN_RUNNING(M, COOLDOWN_ELECTROCUTED))
+		return
 	if(dist_check)
 		if(!in_range(source,M))
 			return 0
@@ -267,6 +269,7 @@
 		power_source = C
 		shock_damage = cell_damage
 	var/drained_hp = M.electrocute_act(min(shock_damage, 150), source, siemens_coeff) //zzzzzzap!
+	TIMER_COOLDOWN_START(M, COOLDOWN_ELECTROCUTED, 2 SECONDS)
 	log_combat(source, M, "electrocuted")
 
 	var/drained_energy = drained_hp*20

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -266,7 +266,7 @@
 	else
 		power_source = C
 		shock_damage = cell_damage
-	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
+	var/drained_hp = M.electrocute_act(min(shock_damage, 150), source, siemens_coeff) //zzzzzzap!
 	log_combat(source, M, "electrocuted")
 
 	var/drained_energy = drained_hp*20

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -268,7 +268,7 @@
 	else
 		power_source = C
 		shock_damage = cell_damage
-	var/drained_hp = M.electrocute_act(min(shock_damage, 150), source, siemens_coeff) //zzzzzzap!
+	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	TIMER_COOLDOWN_START(M, COOLDOWN_ELECTROCUTED, 2 SECONDS)
 	log_combat(source, M, "electrocuted")
 


### PR DESCRIPTION
## About The Pull Request

Adds a cooldown for electric wire damage

## Why It's Good For The Game

When attached to a generator, electrified razorwire can instakill some castes and deals massive amount of damage to any others. This is funny but also a little ridiculous if properly utilised
## Changelog
:cl:
balance: Electrified razorwire has a cooldown, instead of being applied as fast as you can accidentally walk into it
/:cl:
