### PR TITLE
Attack hand alternate on guns no longer toggles safety

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -16,7 +16,8 @@
 /obj/item/weapon/gun/attack_hand_alternate(mob/user)
 	. = ..()
 	if(!active_attachable)
-		return toggle_gun_safety()
+		balloon_alert(user, "no attachment to unload")
+		return
 
 	var/mob/living/living_user = user
 	if(living_user.get_active_held_item() != src && living_user.get_inactive_held_item() != src)


### PR DESCRIPTION

## About The Pull Request

I added this years ago as the first thing to use rclick for since I didnt have many ideas, but we now have the better functionality of the underbarrel gun for this so I think its hindering that, and who is really using this

## Changelog
:cl:
del: Attack hand alternate on guns no longer toggles safety if there is no underbarrel gun
/:cl:
