### PR TITLE
Lays foundation for Reagent Priority in health analyzers chemical contents list

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -15,9 +15,9 @@
 #define TRANSPARENT (1<<4)
 /// For non-transparent containers that still have the general amount of reagents in them visible.
 #define AMOUNT_VISIBLE (1<<5)
-///For containers which apply a skill check for wheter showing their reagents to the user or not.
+/// For containers which apply a skill check for wheter showing their reagents to the user or not.
 #define AMOUNT_SKILLCHECK (1<<6)
-///For containers without volume meters on (e.g. drinking glasses, cans, sprays)
+/// For containers without volume meters on (e.g. drinking glasses, cans, sprays)
 #define AMOUNT_ESTIMEE (1<<7)
 
 #define NO_REACT (1<<8)
@@ -32,11 +32,11 @@
 #define HEARTSTOPPER (1<<2)
 #define CHEARTSTOPPER (1<<3)
 
-#define TOUCH 1	// splashing
-#define INGEST 2	// ingestion
-#define VAPOR 3	// foam, spray, blob attack
-#define PATCH 4	// patches
-#define INJECT 5	// injection
+#define TOUCH 1  // splashing
+#define INGEST 2 // ingestion
+#define VAPOR 3  // foam, spray, blob attack
+#define PATCH 4  // patches
+#define INJECT 5 // injection
 
 #define DEL_REAGENT 1	// reagent deleted (fully cleared)
 #define ADD_REAGENT 2	// reagent added
@@ -59,3 +59,13 @@
 #define SPECIFIC_HEAT_DEFAULT 200
 
 #define SPECIFIC_HEAT_PLASMA 500
+
+// Reagent ordering, lower the number the higher the priority
+#define REAGENT_UI_IMMEDIATE 1 // Reagents that should be seen immediatly
+#define REAGENT_UI_TOXINS 2    // Xenomorph chems and other deliberatly hostile chems
+#define REAGENT_UI_UNIQUE 3    // Unique healing chems that should come before others
+#define REAGENT_UI_BKTT 4      // Chems that are normally in use by patients
+#define REAGENT_UI_SPACEA 5    // Normally taken chems that last a long time
+#define REAGENT_UI_MEDICINE 6  // Generic positive effect chems
+#define REAGENT_UI_BASE 7      // Base /datum/reagent order level
+#define REAGENT_UI_MUNDANE 10  // Who cares about these chems?

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -182,7 +182,8 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 			"od_threshold" = reagent.overdose_threshold,
 			"crit_od_threshold" = reagent.overdose_crit_threshold,
 			"color" = reagent.color,
-			"metabolism_factor" = reagent.custom_metabolism
+			"metabolism_factor" = reagent.custom_metabolism,
+			"ui_priority" = reagent.reagent_ui_priority
 		)
 	data["has_chemicals"] = length(patient.reagents.reagent_list)
 	data["chemicals_lists"] = chemicals_lists

--- a/code/game/objects/items/scanners/health_analyzer.dm
+++ b/code/game/objects/items/scanners/health_analyzer.dm
@@ -182,8 +182,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 			"od_threshold" = reagent.overdose_threshold,
 			"crit_od_threshold" = reagent.overdose_crit_threshold,
 			"color" = reagent.color,
-			"metabolism_factor" = reagent.custom_metabolism,
-			"ui_priority" = reagent.reagent_ui_priority
+			"metabolism_factor" = reagent.custom_metabolism
 		)
 	data["has_chemicals"] = length(patient.reagents.reagent_list)
 	data["chemicals_lists"] = chemicals_lists

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -49,6 +49,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/addiction_stage = 0
 	/// does this show up on health analyzers
 	var/scannable = TRUE
+	/// Reagent priority in UI, lower value is higher priority
+	var/reagent_ui_priority = REAGENT_UI_BASE
 	/// if false stops metab in liverless mobs
 	var/self_consuming = FALSE
 	/// List of reagents removed by this chemical

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -8,6 +8,7 @@
 	custom_metabolism = FOOD_METABOLISM
 	taste_description = "generic food"
 	taste_multi = 4
+	reagent_ui_priority = REAGENT_UI_MUNDANE
 	var/nutriment_factor = 1
 	var/adj_temp = 0
 	var/targ_temp = BODYTEMP_NORMAL
@@ -36,6 +37,7 @@
 	description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 	nutriment_factor = 15
 	color = "#664330" // rgb: 102, 67, 48
+	reagent_ui_priority =  REAGENT_UI_BASE // nutriment is more important than other food chems
 	var/brute_heal = 1
 	var/burn_heal = 0
 	var/blood_gain = 0.4
@@ -279,6 +281,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "mushroom"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/psilocybin/on_mob_life(mob/living/L, metabolism)
 	L.druggy = max(L.druggy, 30)
@@ -405,6 +408,7 @@
 	nutriment_factor = 0
 	color = "#66801e"
 	taste_description = "burning"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/larvajelly/on_mob_life(mob/living/L, metabolism)
 	L.adjustBruteLoss(-0.5*effect_str)
@@ -419,6 +423,7 @@
 	nutriment_factor = 1
 	color = "#66801e"
 	taste_description = "victory"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/consumable/larvajellyprepared/on_mob_life(mob/living/L, metabolism)
 	L.adjustBruteLoss(-0.5*effect_str)

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -6,6 +6,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_MEDICINE
 
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
@@ -14,6 +15,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2
 	trait_flags = TACHYCARDIC
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/medicine/inaprovaline/on_mob_add(mob/living/L, metabolism)
 	ADD_TRAIT(L, TRAIT_IGNORE_SUFFOCATION, REAGENT_TRAIT(src))
@@ -97,6 +99,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/medicine/paracetamol/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_HEAVY
@@ -120,6 +123,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/tramadol/on_mob_life(mob/living/L)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
@@ -142,6 +146,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 1.25
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/oxycodone/on_mob_add(mob/living/L, metabolism)
 	if(TIMER_COOLDOWN_RUNNING(L, name))
@@ -232,6 +237,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -259,6 +265,7 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/dermaline/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -348,6 +355,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "grossness"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
@@ -376,6 +384,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "a roll of gauze"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
 	L.add_stamina_regen_modifier(name, -0.5)
@@ -453,6 +462,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	purge_list = list(/datum/reagent/toxin/mindbreaker)
 	purge_rate = 5
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/synaptizine/on_mob_add(mob/living/L, metabolism)
 	if(TIMER_COOLDOWN_RUNNING(L, name))
@@ -499,6 +509,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = 5
 	overdose_crit_threshold = 6
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/neuraline/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
@@ -589,6 +600,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	overdose_threshold = REAGENTS_OVERDOSE/2   //so it makes the OD threshold effectively 15 so two pills is too much but one is fine
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2.5 //and this makes the Critical OD 20
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/russian_red/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
@@ -683,6 +695,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/30
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/25
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/peridaxon_plus/on_mob_life(mob/living/L, metabolism)
 	L.reagents.add_reagent(/datum/reagent/toxin/scannable,5)
@@ -716,6 +729,7 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
 	L.heal_overall_damage(effect_str, 0)
@@ -741,6 +755,7 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	purge_list = list(/datum/reagent/medicine/oxycodone)
 	purge_rate = 0.2
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, metabolism)
 	L.heal_overall_damage(2*effect_str, 0)
@@ -770,6 +785,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/2 //Was 4, now 6 //Now 15
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
+	reagent_ui_priority = REAGENT_UI_SPACEA
 
 /datum/reagent/medicine/quickclot/on_mob_life(mob/living/L, metabolism)
 	L.adjust_blood_volume(0.2)
@@ -800,6 +816,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //12u
 	custom_metabolism = REAGENTS_METABOLISM * 2.5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 	///The IB wound this dose of QCP will cure, if it lasts long enough
 	var/datum/wound/internal_bleeding/target_IB
 	///Ticks remaining before the target_IB is cured
@@ -877,6 +894,8 @@
 	color = COLOR_REAGENT_NANOBLOOD
 	overdose_threshold = REAGENTS_OVERDOSE/5 //6u
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5 //10u
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
+
 
 /datum/reagent/medicine/nanoblood/on_mob_life(mob/living/L, metabolism)
 	L.adjust_blood_volume(2.4)
@@ -910,6 +929,7 @@
 	overdose_crit_threshold = 20
 	addiction_threshold = 0.4 // Adios Addiction Virus
 	taste_multi = 2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/ultrazine/on_mob_add(mob/living/L, metabolism)
 	. = ..()
@@ -1043,6 +1063,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "fish"
+	reagent_ui_priority = REAGENT_UI_BKTT
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1081,6 +1102,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.05
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_SPACEA
 
 /datum/reagent/medicine/spaceacillin/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, TOX)
@@ -1099,6 +1121,7 @@
 	color = COLOR_REAGENT_POLYHEXANIDE
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/polyhexanide/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1122,6 +1145,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 0.5
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/larvaway/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1151,6 +1175,7 @@
 	color = COLOR_REAGENT_ETHYLREDOXRAZINE
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_BASE
 
 /datum/reagent/medicine/ethylredoxrazine/on_mob_life(mob/living/L, metabolism)
 	L.dizzy(-1)
@@ -1179,6 +1204,7 @@
 	purge_rate = 5
 	taste_description = "punishment"
 	taste_multi = 8
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 
 /datum/reagent/hypervene/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_HEAVY //Significant pain while metabolized.
@@ -1205,6 +1231,7 @@
 	color = COLOR_REAGENT_ROULETTIUM
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	taste_description = "Poor life choices"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/medicine/roulettium/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_HEAVY * 4
@@ -1221,6 +1248,7 @@
 	reagent_state = LIQUID
 	color = COLOR_REAGENT_LEMOLINE
 	taste_description = "piss"
+	reagent_ui_priority = REAGENT_UI_BASE
 
 /datum/reagent/medicine/bihexajuline
 	name = "Bihexajuline"
@@ -1260,6 +1288,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 
 /datum/reagent/medicine/research/quietus
@@ -1329,6 +1358,7 @@
 	custom_metabolism = 0
 	taste_description = "metal, followed by mild burning"
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
+	reagent_ui_priority = REAGENT_UI_UNIQUE
 	purge_list = list(
 		/datum/reagent/medicine/bicaridine,
 		/datum/reagent/medicine/kelotane,
@@ -1428,6 +1458,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE/5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/5
 	custom_metabolism = REAGENTS_METABOLISM * 5
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/medicine/regrow/on_mob_add(mob/living/L, metabolism)
 	if(volume < 5 || L.stat == DEAD || (!ishuman(L)))

--- a/code/modules/reagents/chemistry/reagents/other.dm
+++ b/code/modules/reagents/chemistry/reagents/other.dm
@@ -218,6 +218,7 @@
 	reagent_state = LIQUID
 	color = "#484848" // rgb: 72, 72, 72
 	taste_multi = 0
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/mercury/on_mob_life(mob/living/L, metabolism)
 	if(!L.incapacitated(TRUE) && !L.pulledby && isfloorturf(L.loc))
@@ -258,6 +259,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "chlorine"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/chlorine/on_mob_life(mob/living/L, metabolism)
 	L.take_limb_damage(0.5*effect_str, 0)
@@ -277,6 +279,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "acid"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/fluorine/on_mob_life(mob/living/L, metabolism)
 	L.adjustToxLoss(0.5*effect_str)
@@ -346,6 +349,7 @@
 	reagent_state = SOLID
 	color = "#C7C7C7" // rgb: 199,199,199
 	taste_description = "the colour blue and regret"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/radium/on_mob_life(mob/living/L, metabolism)
 	L.apply_effect(effect_str/L.metabolism_efficiency, EFFECT_STAMLOSS)
@@ -390,6 +394,7 @@
 	description = "A silvery-white metallic chemical element in the actinide series, weakly radioactive."
 	color = "#B8B8C0" // rgb: 184, 184, 192
 	taste_description = "the inside of a reactor"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/uranium/on_mob_life(mob/living/L, metabolism)
 	L.apply_effect(1/L.metabolism_efficiency, EFFECT_STAMLOSS)//WHAT THE HELL DID YOU THINK WOULD HAPPEN
@@ -423,6 +428,7 @@
 	taste_description = "gross metal"
 	///The effect creates when this reagent is splashed on the ground
 	var/effect_type = /obj/effect/decal/cleanable/liquid_fuel
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/fuel/reaction_turf(turf/T, volume)
 	if(volume <= 3 || !isfloorturf(T))
@@ -506,6 +512,7 @@
 	taste_description = "numbness"
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/impedrezene/on_mob_life(mob/living/L, metabolism)
 	L.jitter(-5)
@@ -575,7 +582,7 @@
 	color = "#604030" // rgb: 96, 64, 48
 	taste_description = "iron"
 
-/datum/reagent/lipozine
+/datum/reagent/consumable/lipozine
 	name = "Lipozine" // The anti-nutriment.
 	description = "A chemical compound that causes a powerful fat-burning reaction."
 	reagent_state = LIQUID
@@ -583,8 +590,9 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "bitterness"
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
-/datum/reagent/lipozine/on_mob_life(mob/living/L, metabolism)
+/datum/reagent/consumable/lipozine/on_mob_life(mob/living/L, metabolism)
 	if(!iscarbon(L))
 		return ..()
 	var/mob/living/carbon/C = L
@@ -609,6 +617,7 @@
 	name = "Sterilizine"
 	description = "Sterilizes wounds in preparation for surgery."
 	color = "#C8A5DC" // rgb: 200, 165, 220
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 
 /datum/reagent/sterilizine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)

--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -11,6 +11,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	taste_description = "bitterness"
 	taste_multi = 1.2
+	reagent_ui_priority = REAGENT_UI_TOXINS
 
 /datum/reagent/toxin/on_mob_life(mob/living/L, metabolism)
 	if(toxpwr)
@@ -110,6 +111,7 @@
 	color = COLOR_TOXIN_MINTTOXIN
 	toxpwr = 0
 	taste_description = "mint"
+	reagent_ui_priority = REAGENT_UI_MUNDANE // not currently implimented, so it's inert
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"
@@ -125,6 +127,7 @@
 	color = COLOR_TOXIN_HUSKPOWDER
 	toxpwr = 0.5
 	taste_description = "death"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/huskpowder/on_mob_add(mob/living/L, metabolism)
 	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
@@ -172,6 +175,7 @@
 	description = "A chemical mix good for growing plants with."
 	toxpwr = 0.2 //It's not THAT poisonous.
 	color = COLOR_TOXIN_FERTILIZER
+	reagent_ui_priority = REAGENT_UI_SPACEA // current toxpwr formula makes it do 0.1 toxin, which will be healed by a healthy organ
 
 /datum/reagent/toxin/fertilizer/eznutrient
 	name = "EZ Nutrient"
@@ -253,6 +257,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -277,6 +282,7 @@
 	toxpwr = 0
 	overdose_threshold = REAGENTS_OVERDOSE
 	trait_flags = CHEARTSTOPPER
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/potassium_chloride/overdose_process(mob/living/L, metabolism)
 	if(iscarbon(L))
@@ -296,6 +302,7 @@
 	description = "A specific chemical based on Potassium Chloride to stop the heart for surgery. Not safe to eat!"
 	color = COLOR_TOXIN_POTASSIUM_CHLORIDE
 	toxpwr = 2
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/potassium_chlorophoride/on_mob_life(mob/living/L, metabolism)
 	if(L.stat != UNCONSCIOUS)
@@ -317,6 +324,7 @@
 	custom_metabolism = 0
 	toxpwr = 0
 	taste_description = "ow ow ow"
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE // It's a testing chem
 
 /datum/reagent/toxin/pain/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier = volume
@@ -421,6 +429,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	medbayblacklist = TRUE
 	reactindeadmob = FALSE
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/toxin/nanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your body begins to twist and deform! Get out of the razorburn!"))
@@ -639,6 +648,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	overdose_threshold = 20
 	overdose_crit_threshold = 50
+	reagent_ui_priority = REAGENT_UI_IMMEDIATE
 
 /datum/reagent/zombium/on_overdose_start(mob/living/L, metabolism)
 	RegisterSignal(L, COMSIG_HUMAN_SET_UNDEFIBBABLE, PROC_REF(zombify))

--- a/code/modules/reagents/chemistry/recipes/other.dm
+++ b/code/modules/reagents/chemistry/recipes/other.dm
@@ -109,7 +109,7 @@
 
 /datum/chemical_reaction/lipozine
 	name = "Lipozine"
-	results = list(/datum/reagent/lipozine = 3)
+	results = list(/datum/reagent/consumable/lipozine = 3)
 	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/consumable/ethanol = 1, /datum/reagent/radium = 1)
 
 /datum/chemical_reaction/phoronsolidification

--- a/tgui/packages/tgui/interfaces/MedScanner/data.ts
+++ b/tgui/packages/tgui/interfaces/MedScanner/data.ts
@@ -38,6 +38,7 @@ type ChemData = {
   color: string;
   metabolism_factor: number;
   dangerous: boolean;
+  ui_priority: number;
 };
 
 type OrganData = {

--- a/tgui/packages/tgui/interfaces/MedScanner/index.tsx
+++ b/tgui/packages/tgui/interfaces/MedScanner/index.tsx
@@ -268,6 +268,7 @@ function PatientChemicals() {
       <Stack vertical>
         {Object.values(chemicals_lists).map((chemical) => (
           <Stack.Item
+            order={chemical.ui_priority}
             key={chemical.name}
             backgroundColor={row_transparency++ % 2 === 0 ? COLOR_ZEBRA_BG : ''}
             style={ROUNDED_BORDER}


### PR DESCRIPTION

## About The Pull Request

Adds a means of prioritizing reagents in the health scanner UI.

Also fixes Lipozine's OD, as it was written incorrectly.

## Why It's Good For The Game

Promotes a more consistent chemical contents look, more important chems at the top, less important at the bottom.
![Reagent_priority](https://github.com/user-attachments/assets/0204fc05-47ea-4a12-8bd5-778d404c129a)


## Changelog
:cl:
qol: Health scanner reagents have some semblance of order
fix: Lipozine OD works
/:cl:
