### PR TITLE
Warrior/warlock mech damage nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -444,7 +444,7 @@
 				var/obj/obj_victim = victim
 				var/dam_mult = 0.5
 				if(ismecha(obj_victim))
-					dam_mult = 5
+					dam_mult = 2.3
 				obj_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)
 	stop_crush()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -593,7 +593,7 @@
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
 	var/veh_multi = 4
-	if(ismecha(src))
+	if(isgreyscalemecha(src))
 		veh_multi = 3
 	attack_generic(xeno, punch_damage * (veh_multi), BRUTE, effects = FALSE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -592,9 +592,8 @@
 	. = ..()
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	var/obj/vehicle/veh_victim = src
 	var/mech_penalty = 0
-	if(ismecha(veh_victim))
+	if(ismecha(src))
 		mech_penalty = 1
 	attack_generic(xeno, punch_damage * (4 - mech_penalty), BRUTE, effects = FALSE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -592,10 +592,10 @@
 	. = ..()
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	var/mech_penalty = 0
+	var/veh_multi = 4
 	if(ismecha(src))
-		mech_penalty = 1
-	attack_generic(xeno, punch_damage * (4 - mech_penalty), BRUTE, effects = FALSE)
+		veh_multi = 3
+	attack_generic(xeno, punch_damage * (veh_multi), BRUTE, effects = FALSE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
 	Shake(duration = 0.5 SECONDS)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -592,7 +592,11 @@
 	. = ..()
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	attack_generic(xeno, punch_damage * 4, BRUTE, effects = FALSE)
+	var/obj/vehicle/veh_victim = src
+	var/mech_penalty = 0
+	if(ismecha(veh_victim))
+		mech_penalty = 1
+	attack_generic(xeno, punch_damage * (4 - mech_penalty), BRUTE, effects = FALSE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
 	Shake(duration = 0.5 SECONDS)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -592,10 +592,16 @@
 	. = ..()
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	var/veh_multi = 4
-	if(isgreyscalemecha(src))
-		veh_multi = 3
-	attack_generic(xeno, punch_damage * (veh_multi), BRUTE, effects = FALSE)
+	attack_generic(xeno, punch_damage * 4, BRUTE, effects = FALSE)
+	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
+	Shake(duration = 0.5 SECONDS)
+	return TRUE
+
+/obj/vehicle/sealed/mecha/combat/greyscale/punch_act(...)
+	. = ..()
+	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
+	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
+	attack_generic(xeno, punch_damage * 3, BRUTE, effects = FALSE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
 	Shake(duration = 0.5 SECONDS)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -597,7 +597,7 @@
 	Shake(duration = 0.5 SECONDS)
 	return TRUE
 
-/obj/vehicle/sealed/mecha/combat/greyscale/punch_act(...)
+/obj/vehicle/sealed/mecha/combat/greyscale/punch_act(mob/living/carbon/xenomorph/xeno, punch_damage, ...)
 	. = ..()
 	xeno.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	xeno.do_attack_animation(src, ATTACK_EFFECT_DISARM2)

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -90,10 +90,10 @@
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(isvehicle(target_obj))
 		var/obj/vehicle/veh_victim = target_obj
-		var/mech_penalty = 0
+		var/veh_damage = 200
 		if(isgreyscalemecha(veh_victim))
-			mech_penalty = 175
-		veh_victim.take_damage(200 - mech_penalty, BURN, ENERGY, TRUE, armour_penetration = penetration)
+			veh_damage = 25
+		veh_victim.take_damage(veh_damage, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(target_mob))

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -90,7 +90,10 @@
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(isvehicle(target_obj))
 		var/obj/vehicle/veh_victim = target_obj
-		veh_victim.take_damage(200, BURN, ENERGY, TRUE, armour_penetration = penetration)
+		var/mech_penalty = 0
+		if(isgreyscalemecha(veh_victim))
+			mech_penalty = 175
+		veh_victim.take_damage(200 - mech_penalty, BURN, ENERGY, TRUE, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	if(isxeno(target_mob))


### PR DESCRIPTION

## About The Pull Request
Title, reduces the warrior's punch damage to 68, and warlock's crush and lance damage down to 58 and 85 respectively
## Why It's Good For The Game
These castes are doing too much damage to mechs right now, and this should hopefully make them not delete the mech in half a second
## Changelog
:cl:
balance: Reduced warrior's punch damage against mechs to 68
balance: Reduced warlock's psy crush damage against mechs 58
balance: Reduced  warlock's lance damage against mechs to 85
/:cl:
