### PR TITLE
Adds mech pods on sulaco and theseus

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -9908,6 +9908,9 @@
 /obj/machinery/light/mainship/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "bZa" = (
@@ -12276,10 +12279,8 @@
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel)
 "eXT" = (
-/obj/structure/rack,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
+/obj/structure/drop_pod_launcher/mech,
+/obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "eYn" = (
@@ -17887,8 +17888,9 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/cap_office)
 "lJV" = (
-/obj/structure/rack,
-/obj/item/tool/analyzer,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "lLP" = (
@@ -19047,6 +19049,11 @@
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/prison/plate,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"nnt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/prison,
+/area/sulaco/hangar/storage)
 "nnz" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -21606,6 +21613,10 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/marine/chapel)
+"qAw" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/prison,
+/area/sulaco/hangar/storage)
 "qAU" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
@@ -23993,8 +24004,9 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "tmE" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/engineering/radio/highspawn,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "tmP" = (
@@ -74144,7 +74156,7 @@ hTF
 fZU
 kZl
 pWS
-pWS
+lJV
 tmE
 kOr
 aTM
@@ -74401,7 +74413,7 @@ ehU
 lSs
 noQ
 pWS
-jYO
+nnt
 eXT
 kOr
 mDu
@@ -74658,8 +74670,8 @@ mWm
 tXc
 jYO
 pWS
-pWS
-uIe
+qAw
+eXT
 kOr
 mDu
 mDu
@@ -74910,7 +74922,7 @@ mDu
 kOr
 kOr
 wnq
-lJV
+uIe
 cSO
 kBx
 cSO

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2125,13 +2125,17 @@
 /turf/open/floor/plating,
 /area/mainship/medical/cmo_office)
 "aNC" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/obj/machinery/vending/nanomed,
-/obj/item/robot_parts/robot_suit,
-/obj/item/clothing/under/wedding/bride_white,
-/turf/open/floor/mainship/black{
+/obj/structure/table/mainship/nometal,
+/obj/item/restraints/handcuffs/zip,
+/obj/item/tool/screwdriver,
+/obj/effect/spawner/random/engineering/cable{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
 /area/mainship/living/tankerbunks)
@@ -7765,13 +7769,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
 "daD" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 9
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/mainship/living/tankerbunks)
+/obj/machinery/computer/dropship_picker,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "daP" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/cic_maptable,
@@ -9106,10 +9106,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/machinery/door_control/mainship/mech{
+	dir = 4
 	},
-/obj/machinery/computer/dropship_picker,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "flf" = (
@@ -9644,6 +9643,9 @@
 /area/mainship/hallways/hangar)
 "fWU" = (
 /obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/door_control/mainship/mech{
+	dir = 1
+	},
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/living/tankerbunks)
 "fYx" = (
@@ -10649,11 +10651,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
 "hvt" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/obj/item/clothing/head/modular/robot/heavy,
-/turf/open/floor/mainship/black{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/machinery/computer/mech_builder{
+	dir = 2
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
 	},
 /area/mainship/living/tankerbunks)
 "hvM" = (
@@ -10782,12 +10787,8 @@
 	},
 /area/mainship/squads/req)
 "hFy" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
+/obj/machinery/vending/nanomed,
+/turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "hFz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12668,7 +12669,8 @@
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
-/obj/machinery/computer/mech_builder,
+/obj/structure/drop_pod_launcher/mech,
+/obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
 	},
@@ -16091,12 +16093,11 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "qmJ" = (
-/obj/machinery/door_control/mainship/mech{
-	dir = 1
-	},
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
 	},
+/obj/structure/drop_pod_launcher/mech,
+/obj/structure/droppod/nonmob/mech_pod,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 6
 	},
@@ -16129,13 +16130,11 @@
 	},
 /area/mainship/living/port_emb)
 "qoC" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 5
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/bow_hallway)
 "qpI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -16953,6 +16952,9 @@
 "rGG" = (
 /obj/structure/cable,
 /obj/machinery/firealarm{
+	dir = 4
+	},
+/obj/machinery/power/apc/mainship{
 	dir = 4
 	},
 /turf/open/floor/mainship/black{
@@ -18874,13 +18876,17 @@
 /turf/open/floor/plating,
 /area/mainship/medical/operating_room_one)
 "uHk" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/food/drinks/britcup,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/black{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/machinery/computer/mech_builder{
+	dir = 2
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
 	},
 /area/mainship/living/tankerbunks)
 "uHQ" = (
@@ -39559,11 +39565,11 @@ vGR
 vGR
 dkd
 xUR
-uyz
+hFy
 tOy
 xUR
 hvt
-daD
+hgh
 hgh
 kQH
 xUR
@@ -39820,7 +39826,7 @@ bEk
 uyz
 xUR
 aNC
-hFy
+sjM
 sjM
 fWU
 xUR
@@ -40077,7 +40083,7 @@ rfQ
 kGl
 xUR
 uHk
-qoC
+bWc
 bWc
 qmJ
 xUR
@@ -40338,7 +40344,7 @@ lQh
 lQh
 qQG
 xUR
-vTn
+qoC
 bqt
 vTn
 vTn
@@ -43935,7 +43941,7 @@ dbC
 blA
 txa
 ofI
-blA
+daD
 blA
 blA
 vDT


### PR DESCRIPTION

## About The Pull Request

what it says on the title
how did nobody notice??? (or care)

## Why It's Good For The Game
I mean mechs should have pods right?
also theseus was missing 2nd computer 

Sulaco before 
![image](https://github.com/user-attachments/assets/7064745b-34bf-4e23-8b84-a8a7f2fe5566)

Sulaco After
![image](https://github.com/user-attachments/assets/2302e597-6bec-4e36-a214-48eb147ef0f5)

And theseus (tad picker was moved east closer to tad stuff)
![image](https://github.com/user-attachments/assets/b21fdc0f-a062-4b07-bb15-01944c4623b5)

## Changelog
:cl: Atropos
add: Added mech drop pods on sulaco and theseus
add: Added 2nd mech (builder) computer on theseus
/:cl:
