### PR TITLE
Disposal units can now be emptied with right click.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -185,7 +185,7 @@
 	if(!can_interact(user))
 		return
 	user.visible_message(span_notice("[user] presses the eject button on [src]."),
-	"<span class ='notice'>You press the eject button on [src].</span>")
+	span_notice("You press the eject button on [src]."))
 	eject()
 
 //Attempt to move while inside

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -182,6 +182,8 @@
 
 /obj/machinery/disposal/attack_hand_alternate(mob/living/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	user.visible_message(span_notice("[user] presses the eject button on [src]."),
 	"<span class ='notice'>You press the eject button on [src].</span>")
 	eject()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -8,7 +8,7 @@
 
 /obj/machinery/disposal
 	name = "disposal unit"
-	desc = "A pneumatic waste disposal unit."
+	desc = "A pneumatic waste disposal unit. Right click to eject."
 	icon = 'icons/obj/pipes/disposal.dmi'
 	icon_state = "disposal"
 	anchored = TRUE
@@ -179,6 +179,12 @@
 	target.forceMove(src)
 	flush()
 	update()
+
+/obj/machinery/disposal/attack_hand_alternate(mob/living/user)
+	. = ..()
+	user.visible_message(span_notice("[user] presses the eject button on [src]."),
+	"<span class ='notice'>You press the eject button on [src].</span>")
+	eject()
 
 //Attempt to move while inside
 /obj/machinery/disposal/relaymove(mob/user)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -379,6 +379,9 @@ GLOBAL_LIST_EMPTY(tagger_locations)
 /obj/machinery/disposal/deliveryChute/interact()
 	return
 
+/obj/machinery/disposal/deliveryChute/attack_hand_alternate(mob/living/user)
+	return
+
 /obj/machinery/disposal/deliveryChute/update()
 	return
 


### PR DESCRIPTION

## About The Pull Request
Powered and unpowered disposal units can now be emptied with right click.
## Why It's Good For The Game
No more misclicks causing guns to be trapped in a disposal bin forever.
## Changelog
:cl:
add: Disposal units can be right clicked to eject their contents.
/:cl:
