### PR TITLE
Griddles can now be jumped on like tables

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -27,7 +27,6 @@
 		variant = rand(1,3)
 
 	var/static/list/connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_cross),
 		COMSIG_ATOM_EXIT = PROC_REF(on_try_exit),
 		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
 		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override),

--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -26,6 +26,15 @@
 	if(isnum(variant))
 		variant = rand(1,3)
 
+	var/static/list/connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_cross),
+		COMSIG_ATOM_EXIT = PROC_REF(on_try_exit),
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override),
+		COMSIG_TURF_CHECK_COVERED = TYPE_PROC_REF(/atom/movable, turf_cover_check),
+	)
+	AddElement(/datum/element/connect_loc, connections)
+
 /obj/machinery/griddle/Destroy()
 	QDEL_NULL(grill_loop)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -7,6 +7,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	layer = BELOW_OBJ_LAYER
+	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
 
 	///Things that are being griddled right now
 	var/list/griddled_objects = list()


### PR DESCRIPTION

## About The Pull Request
Griddles can now be jumped and walked over like tables.
## Why It's Good For The Game
Table sized object that is usually next to tables should be jumpable like tables.
## Changelog
:cl:
add: Griddles can now be jumped over and walked on.
/:cl:
