### PR TITLE
Catwalk destruction now on Disarm intent [MDB Ignore]

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -109,7 +109,7 @@
 /obj/structure/catwalk/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return
-	if(xeno_attacker.a_intent != INTENT_HARM)
+	if(xeno_attacker.a_intent != INTENT_DISARM)
 		return
 	xeno_attacker.balloon_alert(xeno_attacker, "Destroying")
 	if(!do_after(xeno_attacker, 5 SECONDS, NONE, src, BUSY_ICON_BUILD))


### PR DESCRIPTION

## About The Pull Request
Xenos now need to use disarm intent instead of harm intent to destroy catwalks

## Why It's Good For The Game
In the heat of combat, it can be very annoying to be met with a do_after while trying to either hit or grab a marine thats standing on a catwalk. I believe this is also the reason as to why you remove snow on disarm and not harm.

## Changelog
:cl:
qol: Destroying catwalks now requires disarm intent instead of harm intent.
/:cl:
