### PR TITLE
Heavy projectile feedback

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -121,6 +121,7 @@
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, paralyze = 2 SECONDS, stagger = 4 SECONDS, slowdown = 2, knockback = 2)
+	shake_camera(target_mob, 0.2 SECONDS, 2)
 
 /datum/ammo/bullet/railgun/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	proj.proj_max_range -= 3
@@ -147,6 +148,7 @@
 
 /datum/ammo/bullet/railgun/smart/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, stagger = 3 SECONDS, slowdown = 3)
+	shake_camera(target_mob, 0.2 SECONDS, 1)
 
 /datum/ammo/bullet/apfsds
 	name = "\improper APFSDS round"
@@ -160,6 +162,9 @@
 	sundering = 0
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.85
+
+/datum/ammo/bullet/apfsds/on_hit_mob(mob/target_mob, obj/projectile/proj)
+	shake_camera(target_mob, 0.2 SECONDS, 2)
 
 /datum/ammo/bullet/apfsds/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	if(ishitbox(target_obj) || ismecha(target_obj) || isarmoredvehicle(target_obj))

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -134,6 +134,7 @@
 /datum/ammo/bullet/isg_apfds/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	proj.proj_max_range -= 2
 	staggerstun(target_mob, proj, max_range = 20, slowdown = 0.5)
+	shake_camera(target_mob, 0.3 SECONDS, 3)
 
 /datum/ammo/bullet/isg_apfds/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	proj.proj_max_range -= 5
@@ -449,6 +450,7 @@
 	staggerstun(target_mob, proj, max_range = 20, stagger = 1 SECONDS, slowdown = 0.5, knockback = 2, hard_size_threshold = 3)
 	drop_nade(target_turf)
 	proj.proj_max_range -= 5
+	shake_camera(target_mob, 0.2 SECONDS, 2)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	proj.proj_max_range -= 5
@@ -534,6 +536,9 @@
 	proj.proj_max_range -= 2
 	if(ishuman(target_mob) && !(target_mob.status_flags & GODMODE) && prob(35))
 		target_mob.gib()
+		return
+	shake_camera(target_mob, 0.3 SECONDS, 3)
+
 
 /datum/ammo/bullet/tank_apfds/on_hit_obj(obj/target_object, obj/projectile/proj)
 	if(!isvehicle(target_object) && !ishitbox(target_object))


### PR DESCRIPTION

## About The Pull Request
Certain powerful projectiles that lack notable feedback (because they're just high damage, not explosions) now cause very brief screenshake (0.2/0.3 seconds).
## Why It's Good For The Game
Makes it a bit clearer when a tank has shot you with an AP round etc.
## Changelog
:cl:
qol: Some powerful projectiles such as tank AP rounds have brief screenshake on hit for user feedback
/:cl:
