### PR TITLE
xeno turret targetting fix

### DIFF
--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -173,7 +173,7 @@
 		distance = buffer_distance
 		. = nearby_hostile
 
-///Return TRUE if a possible target is near
+///Populates the target list on process
 /obj/structure/xeno/xeno_turret/proc/scan()
 	potential_hostiles.Cut()
 	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(src, TURRET_SCAN_RANGE))
@@ -182,17 +182,17 @@
 		if(nearby_human.get_xeno_hivenumber() == hivenumber)
 			continue
 		potential_hostiles += nearby_human
-	for (var/mob/living/carbon/xenomorph/nearby_xeno AS in cheap_get_xenos_near(src, range))
+	for (var/mob/living/carbon/xenomorph/nearby_xeno AS in cheap_get_xenos_near(src, TURRET_SCAN_RANGE))
 		if(GLOB.hive_datums[hivenumber] == nearby_xeno.hive)
 			continue
 		if(nearby_xeno.stat == DEAD)
 			continue
 		potential_hostiles += nearby_xeno
 	for(var/obj/vehicle/unmanned/vehicle AS in GLOB.unmanned_vehicles)
-		if(vehicle.z == z && get_dist(vehicle, src) <= range)
+		if(vehicle.z == z && get_dist(vehicle, src) <= TURRET_SCAN_RANGE)
 			potential_hostiles += vehicle
 	for(var/obj/vehicle/sealed/mecha/mech AS in GLOB.mechas_list)
-		if(mech.z == z && get_dist(mech, src) <= range)
+		if(mech.z == z && get_dist(mech, src) <= TURRET_SCAN_RANGE)
 			potential_hostiles += mech
 
 ///Signal handler to make the turret shoot at its target


### PR DESCRIPTION

## About The Pull Request
Fixed turrets using the wrong range value when putting together its target list (this is separate from actually trying to hit one of these targets).
## Why It's Good For The Game
Will reliably target mechs/tanks etc.
## Changelog
:cl:
fix: fixed xeno turrets not targeting mechs/tanks in some cases
/:cl:
