### PR TITLE
Robo Ac's/Ro's now get their job items

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -659,8 +659,8 @@ requisitions line and later on to be ready to send supplies for marines who are 
 	outfit = /datum/outfit/job/requisitions/officer
 	multiple_outfits = TRUE
 	outfits = list(
-		/datum/outfit/job/command/requisitions/officer,
-		/datum/outfit/job/command/requisitions/officer/robot,
+		/datum/outfit/job/requisitions/officer,
+		/datum/outfit/job/requisitions/officer/robot,
 	)
 	exp_requirements = XP_REQ_UNSEASONED
 	exp_type = EXP_TYPE_REGULAR_ALL

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -408,6 +408,11 @@ You can serve your Division in a variety of roles, so choose carefully."})
 	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_ARMORED, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
 	display_order = JOB_DISPLAY_ORDER_MECH_PILOT
 	outfit = /datum/outfit/job/command/assault_crewman
+	multiple_outfits = TRUE
+	outfits = list(
+		/datum/outfit/job/command/assault_crewman,
+		/datum/outfit/job/command/assault_crewman/robot,
+	)
 	exp_requirements = XP_REQ_EXPERT
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_ALWAYS_VISIBLE_ON_MINIMAP
@@ -652,6 +657,11 @@ requisitions line and later on to be ready to send supplies for marines who are 
 	skills_type = /datum/skills/ro
 	display_order = JOB_DISPLAY_ORDER_REQUISITIONS_OFFICER
 	outfit = /datum/outfit/job/requisitions/officer
+	multiple_outfits = TRUE
+	outfits = list(
+		/datum/outfit/job/command/requisitions/officer,
+		/datum/outfit/job/command/requisitions/officer/robot,
+	)
 	exp_requirements = XP_REQ_UNSEASONED
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_ISCOMMAND|JOB_FLAG_BOLD_NAME_ON_SELECTION|JOB_FLAG_PROVIDES_SQUAD_HUD

--- a/code/datums/outfits/shipside.dm
+++ b/code/datums/outfits/shipside.dm
@@ -167,6 +167,14 @@
 	gloves = /obj/item/clothing/gloves/marine
 	l_pocket = /obj/item/pamphlet/tank_loader
 
+/datum/outfit/job/command/assault_crewman/robot
+	species = SPECIES_COMBAT_ROBOT
+
+	w_uniform = /obj/item/clothing/under/marine/robotic
+	shoes = null
+	gloves = null
+
+
 /datum/outfit/job/command/assault_crewman/fallen
 	ears = null
 
@@ -240,6 +248,12 @@
 	r_pocket = /obj/item/storage/pouch/general/large
 	l_pocket = /obj/item/supplytablet
 
+/datum/outfit/job/requisitions/officer/robot
+	species = SPECIES_COMBAT_ROBOT
+
+	w_uniform = /obj/item/clothing/under/marine/robotic
+	shoes = null
+	gloves = null
 
 /datum/outfit/job/medical/professor
 	name = CHIEF_MEDICAL_OFFICER


### PR DESCRIPTION
## About The Pull Request

Previously as example robo ac's would spawn WITHOUT loader pamphlet - if 2 robo ac's spawn  they literally cant get loader
i also added RO as a bonus

## Why It's Good For The Game

Not having job essential items bad

## Changelog

:cl: Atropos
fix: Robo ac's/ro's now get their job items (pamphlet/tablet)
/:cl:
