### PR TITLE
APCs can now be right clicked to unlock

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -221,3 +221,32 @@
 		return
 
 	interact(user)
+
+//Alternate attack with hand - lock/unlock the interface
+/obj/machinery/power/apc/attack_hand_alternate(mob/living/user)
+	. = ..()
+	if(!can_use(user))
+		return
+
+	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_ENGI)
+		return
+
+	if(opened)
+		balloon_alert(user, "Close the cover first")
+		return
+
+	if(CHECK_BITFIELD(machine_stat, PANEL_OPEN))
+		balloon_alert(user, "Close the panel first")
+		return
+
+	if(machine_stat & (BROKEN|MAINT))
+		balloon_alert(user, "Nothing happens")
+		return
+
+	if(!allowed(user))
+		balloon_alert(user, "Access denied")
+		return
+
+	locked = !locked
+	balloon_alert_to_viewers("[locked ? "locked" : "unlocked"]")
+	update_appearance()


### PR DESCRIPTION

## About The Pull Request
Right clicking an APC with an open hand will now unlock it (assuming you have the correct access and skill to use the APC).

Engineer powercreep?
## Why It's Good For The Game
Helps with muscle memory, feature many other servers have, helps reduce tedium when fixing APCs.
## Changelog
:cl:
add: APCs can now be unlocked with right click.
/:cl:
