### PR TITLE
Lockers can now be unlocked with right click

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -238,6 +238,12 @@
 		if(!togglelock(user, TRUE))
 			toggle(user)
 
+/obj/structure/closet/attack_hand_alternate(mob/living/user)
+	. = ..()
+	if(user in src)
+		return
+	togglelock(user)
+
 /obj/structure/closet/attack_powerloader(mob/living/user, obj/item/powerloader_clamp/attached_clamp)
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Right clicking is very a lot nicer than pulling the ID off of your chest to open something.
## Changelog
:cl:
add: Lockers can now be unlocked with right click.
/:cl:
