### PR TITLE
Admin ghosts can now examine mobs to pull up chat links

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -587,7 +587,7 @@
 	if(!isadmin(usr))
 		return ..()
 	msg += separator_hr("Admin only stuff") //other admin related stuff here
-	msg += ("\t>[span_admin("[ADMIN_FULLMONTY(src)]")]")
+	msg += ("\t>[span_admin("<span class='notice linkify'>[ADMIN_FULLMONTY(src)]</span>")]")
 
 	msg += "</span>"
 	return list(msg)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -585,7 +585,7 @@
 		msg += span_userdanger("This player has been slept by staff. Best to leave them be.\n")
 
 	if(isadmin(user))
-		msg += separator_hr("Admin only stuff") //other admin related stuff bellow this point
+		msg += separator_hr("Admin only")
 		msg += ("\t>[span_admin("<span class='notice linkify'>[ADMIN_FULLMONTY(src)]</span>")]")
 
 	msg += "</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -586,7 +586,7 @@
 
 	if(!isadmin(usr))
 		return ..()
-	msg += separator_hr("Admin only stuff") //other admin related stuff here
+	msg += separator_hr("Admin only stuff") //other admin related stuff bellow this point
 	msg += ("\t>[span_admin("<span class='notice linkify'>[ADMIN_FULLMONTY(src)]</span>")]")
 
 	msg += "</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -584,6 +584,11 @@
 		msg += separator_hr("[span_boldwarning("Admin Slept")]")
 		msg += span_userdanger("This player has been slept by staff. Best to leave them be.\n")
 
+	if(!isadmin(usr))
+		return ..()
+	msg += separator_hr("Admin only stuff") //other admin related stuff here
+	msg += ("\t>[span_admin("[ADMIN_FULLMONTY(src)]")]")
+
 	msg += "</span>"
 	return list(msg)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -584,10 +584,9 @@
 		msg += separator_hr("[span_boldwarning("Admin Slept")]")
 		msg += span_userdanger("This player has been slept by staff. Best to leave them be.\n")
 
-	if(!isadmin(usr))
-		return ..()
-	msg += separator_hr("Admin only stuff") //other admin related stuff bellow this point
-	msg += ("\t>[span_admin("<span class='notice linkify'>[ADMIN_FULLMONTY(src)]</span>")]")
+	if(isadmin(user))
+		msg += separator_hr("Admin only stuff") //other admin related stuff bellow this point
+		msg += ("\t>[span_admin("<span class='notice linkify'>[ADMIN_FULLMONTY(src)]</span>")]")
 
 	msg += "</span>"
 	return list(msg)


### PR DESCRIPTION
## About The Pull Request
Inspired with what main TG has

More precisely admin observers can shift click examine mobs and will get all the usual admin options
instead of right clicking or player panel or vv you can just inspect people for all the tools
![image](https://github.com/user-attachments/assets/f83e7ea8-5ec3-43b9-a851-72b492589d56)


## Why It's Good For The Game

Less button pressing = good
Qol = good

## Changelog
:cl: Atropos
admin: Inspecting people while ghosted shows admin buttons
/:cl:
