### PR TITLE
Health Analyzer's Health bar uses Crit threshold instead of 0 as 0%, displays a dead timer on death

### DIFF
--- a/code/datums/health_scan/health_scan.dm
+++ b/code/datums/health_scan/health_scan.dm
@@ -180,9 +180,12 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	var/list/data = list(
 		"patient" = patient.name,
 		"dead" = (patient.stat == DEAD || HAS_TRAIT(patient, TRAIT_FAKEDEATH)),
+		"dead_timer" = patient.dead_ticks,
+		"dead_dnr" = TIME_BEFORE_DNR,
 		"health" = patient.health,
 		"max_health" = patient.maxHealth,
 		"crit_threshold" = patient.get_crit_threshold(),
+		"synth_crit_threshold" = SYNTHETIC_CRIT_THRESHOLD,
 		"dead_threshold" = patient.get_death_threshold(),
 		"total_brute" = round(patient.getBruteLoss()),
 		"total_burn" = round(patient.getFireLoss()),
@@ -357,7 +360,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 		data["revivable_string"] = "Ready to [organic_patient ? "defibrillate" : "reboot"]" // Ternary for defibrillate or reboot for some IC flavor
 		data["revivable_boolean"] = TRUE
 	else
-		data["revivable_string"] = "Not ready to [organic_patient ? "defibrillate" : "reboot"] - repair damage above [patient.get_death_threshold() / patient.maxHealth * 100 - (organic_patient ? (DEFIBRILLATOR_HEALING_TIMES_SKILL(user.skills.getRating(SKILL_MEDICAL), DEFIBRILLATOR_BASE_HEALING_VALUE)) : 0)]%"
+		data["revivable_string"] = "Not ready to [organic_patient ? "defibrillate" : "reboot"] - repair [patient.get_death_threshold() - patient.health - patient.getOxyLoss() - (organic_patient ? (DEFIBRILLATOR_HEALING_TIMES_SKILL(user.skills.getRating(SKILL_MEDICAL), DEFIBRILLATOR_BASE_HEALING_VALUE)) : 0)] more damage"
 		data["revivable_boolean"] = FALSE
 
 	var/list/advice = list()

--- a/tgui/packages/tgui/interfaces/MedScanner/data.ts
+++ b/tgui/packages/tgui/interfaces/MedScanner/data.ts
@@ -64,6 +64,7 @@ export type MedScannerData = {
   health: number;
   max_health: number;
   crit_threshold: number;
+  synth_crit_threshold: number;
   dead_threshold: number;
   total_brute: number;
   total_burn: number;
@@ -72,6 +73,8 @@ export type MedScannerData = {
   clone: number;
   revivable_boolean: boolean;
   revivable_string: number;
+  dead_timer: number;
+  dead_dnr: number;
   has_chemicals: boolean;
   has_unknown_chemicals: boolean;
   chemicals_lists?: Record<string, ChemData>;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the health bar in the Health scan use Crit_threshold/synth_crit_threshold as 0%,

adjusts the tooltips,

and changes revivability string to display amount of damage needed to make them revivable instead of a percentage to get them to.

## Why It's Good For The Game

Better use of limited space.

https://github.com/user-attachments/assets/1894710f-1cb7-4806-bccd-aff28259f024

I think this code is ugly though, damn, couldn't figure out how to use any of the early return things inside the tooltip.



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl: 
qol: Health analyzer progress bar uses crit_health as 0% and displays dead_ticks on death
/:cl:
