### PR TITLE
instant evacuation launch begone

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -23,7 +23,8 @@
 #define EVACUATION_STATUS_IN_PROGRESS 2
 #define EVACUATION_STATUS_COMPLETE 3
 
-#define EVACUATION_AUTOMATIC_DEPARTURE 8 MINUTES //All pods automatically depart in 10 minutes, unless they are full or unable to launch for some reason.
+#define EVACUATION_MANUAL_DEPARTURE 7.5 MINUTES
+#define EVACUATION_AUTOMATIC_DEPARTURE 10 MINUTES // All pods automatically depart in 10 minutes, unless they are full or unable to launch for some reason.
 #define EVACUATION_ESTIMATE_DEPARTURE ((evac_time + EVACUATION_AUTOMATIC_DEPARTURE - world.time) * 0.1)
 #define EVACUATION_POD_LAUNCH_COOLDOWN 5 SECONDS
 

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -105,6 +105,16 @@
 	power_channel = ENVIRON
 	density = FALSE
 
+/obj/machinery/computer/shuttle/escape_pod/examine(mob/user)
+	. = ..()
+	if(SSevacuation.evac_status == EVACUATION_STATUS_INITIATING)
+		var/text = "Time until refueling completion:"
+		var/eta = (SSevacuation.evac_time + EVACUATION_MANUAL_DEPARTURE - world.time) * 0.1
+		if(eta <= 0)
+			text = "Time until automatic launch:"
+			eta = (SSevacuation.evac_time + EVACUATION_AUTOMATIC_DEPARTURE - world.time) * 0.1
+		. += span_notice("[text] [(eta / 60) % 60]:[add_leading(num2text(eta % 60), 2, "0")]")
+
 /obj/machinery/computer/shuttle/escape_pod/escape_shuttle
 	name = "escape shuttle controller"
 
@@ -134,6 +144,9 @@
 
 		if(!M.can_launch)
 			to_chat(usr, span_warning("Evacuation is not enabled!"))
+			return
+		if(SSevacuation.evac_time + EVACUATION_MANUAL_DEPARTURE - world.time > 0)
+			to_chat(usr, span_warning("The escape pod is not fully refueled yet!"))
 			return
 
 		to_chat(usr, span_userdanger("You slam your fist down on the launch button!"))

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -107,13 +107,17 @@
 
 /obj/machinery/computer/shuttle/escape_pod/examine(mob/user)
 	. = ..()
-	if(SSevacuation.evac_status == EVACUATION_STATUS_INITIATING)
-		var/text = "Time until refueling completion:"
-		var/eta = (SSevacuation.evac_time + EVACUATION_MANUAL_DEPARTURE - world.time) * 0.1
-		if(eta <= 0)
-			text = "Time until automatic launch:"
-			eta = (SSevacuation.evac_time + EVACUATION_AUTOMATIC_DEPARTURE - world.time) * 0.1
-		. += span_notice("[text] [(eta / 60) % 60]:[add_leading(num2text(eta % 60), 2, "0")]")
+	var/obj/docking_port/mobile/escape_pod/M = SSshuttle.getShuttle(shuttleId)
+	if(!M || M.launch_status == EARLY_LAUNCHED || M.launch_status == EARLY_LAUNCHED)
+		return
+	if(SSevacuation.evac_status != EVACUATION_STATUS_INITIATING)
+		return
+	var/text = "Time until refueling completion:"
+	var/eta = (SSevacuation.evac_time + EVACUATION_MANUAL_DEPARTURE - world.time) * 0.1
+	if(eta <= 0)
+		text = "Time until automatic launch:"
+		eta = (SSevacuation.evac_time + EVACUATION_AUTOMATIC_DEPARTURE - world.time) * 0.1
+	. += span_notice("[text] [(eta / 60) % 60]:[add_leading(num2text(eta % 60), 2, "0")]")
 
 /obj/machinery/computer/shuttle/escape_pod/escape_shuttle
 	name = "escape shuttle controller"


### PR DESCRIPTION

## About The Pull Request
Marines can no longer immediately hit the launch button on escape pods when evacuation is called to immediately begin the launching process.

Marines can manually launch the escape pod once 7.5 minutes has passed while evacuation is active.
Automatic escape pod launching has been increased from 8 minutes to 10 minutes.

## Why It's Good For The Game
The time spent to go from groundside to shipside during hijack is to prep whatever you want to do shipside, let it self destruct or evac. It shouldn't be for immediately leaving right after xenos land; basically wasting everyone's time.

## Changelog
:cl:
add: Examining the escape pod controller now will tell you how long until you can manually launch and how long until it automatically launches.
balance: Marines can no longer immediately launch escape pods when they are activated.
balance: Escape pods can be manually launched after 7.5 minutes after evacuation is called.
balance: Escape pods automatically launch 10 minutes after evacuation is called rather than 8 minutes.
/:cl:
