### PR TITLE
Walance: Resin jelly buff duration

### DIFF
--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -3,7 +3,7 @@
 // ***************************************
 /datum/status_effect/resin_jelly_coating
 	id = "resin jelly"
-	duration = 15 SECONDS
+	duration = 30 SECONDS
 	tick_interval = 30
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resin jelly buff duration 15 -> 30

## Why It's Good For The Game

Jelly resin buff always falls short and goes off in the middle of the engagement. Flamethrower also has been very oppressive recently, as it should and I'd rather have that than a flamer or surt nerf.

## Changelog
:cl:
balance: Resin jelly buff duration 15 -> 30 seconds
/:cl:
