### PR TITLE
Items deal 10% damage while attacker is lying down.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -6,8 +6,7 @@
 	if(tool_behaviour && tool_attack_chain(user, target))
 		return
 	if(user.lying_angle)
-		user.balloon_alert(user, "Can't while prone!")
-		return
+		user.balloon_alert(user, "Bad form!")
 	// Return TRUE in attackby() to prevent afterattack() effects (when safely moving items for example)
 	var/resolved = target.attackby(src, user, params)
 	if(resolved || QDELETED(target) || QDELETED(src))
@@ -97,6 +96,8 @@
 		span_warning("You hit [src] with [attacking_item]!"), visible_message_flags = COMBAT_MESSAGE)
 	log_combat(user, src, "attacked", attacking_item)
 	var/power = attacking_item.force + round(attacking_item.force * MELEE_SKILL_DAM_BUFF * user.skills.getRating(SKILL_MELEE_WEAPONS))
+	if(user.lying_angle)
+		power *= user.lying_damage_mult
 	take_damage(power, attacking_item.damtype, MELEE, blame_mob = user)
 	return TRUE
 
@@ -141,7 +142,8 @@
 	user.do_attack_animation(src, used_item = attacking_item)
 
 	var/power = attacking_item.force + round(attacking_item.force * MELEE_SKILL_DAM_BUFF * user.skills.getRating(SKILL_MELEE_WEAPONS))
-
+	if(user.lying_angle)
+		power *= user.lying_damage_mult
 	switch(attacking_item.damtype)
 		if(BRUTE)
 			apply_damage(power, BRUTE, user.zone_selected, MELEE, attacking_item.sharp, attacking_item.edge, FALSE, attacking_item.penetration)
@@ -371,7 +373,8 @@
 	user.do_attack_animation(src, used_item = I)
 
 	var/power = I.force + round(I.force * MELEE_SKILL_DAM_BUFF * user.skills.getRating(SKILL_MELEE_WEAPONS))
-
+	if(user.lying_angle)
+		power *= user.lying_damage_mult
 	switch(I.damtype)
 		if(BRUTE)
 			apply_damage(power, BRUTE, user.zone_selected, MELEE, I.sharp, I.edge, FALSE, I.penetration)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -210,6 +210,10 @@
 	if(!loaded_reagent)
 		return
 
+	if(user.lying_angle)
+		to_chat(user, span_warning("You struggle to fight from this position!"))
+		return
+
 	if(target.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL) //Incorporeal beings cannot attack or be attacked
 		return
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -92,6 +92,10 @@
 		to_chat(user, span_warning("\The [src] can't operate without a source of power!"))
 		return
 
+	if(user.lying_angle)
+		to_chat(user, span_warning("You can't operate [src] from this position!"))
+		return
+
 	if(M.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL) //Incorporeal beings cannot attack or be attacked
 		return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -120,6 +120,8 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/hit_area = affecting.display_name
 
 	var/damage = I.force + round(I.force * MELEE_SKILL_DAM_BUFF * user.skills.getRating(SKILL_MELEE_WEAPONS))
+	if(user.lying_angle)
+		damage *= user.lying_damage_mult
 	if(user != src)
 		damage = check_shields(COMBAT_MELEE_ATTACK, damage, "melee")
 		if(!damage)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -60,6 +60,8 @@
 	///Mob's angle in BYOND degrees. 0 is north (up/standing for humans), 90 and 270 are east and west respectively (lying horizontally), and 90 is south (upside-down).
 	var/lying_angle = 0
 	var/lying_prev = 0
+	///Damage multiplier while laying down
+	var/lying_damage_mult = 0.1
 
 	//Security
 	var/computer_id


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/16125
Removed the ability to attack while lying down, this changes it so items deal 10% damage instead, Harvesters and Powerfists have their own check to disable their unique functions.

## Why It's Good For The Game

Lets people struggle helplessly instead of do nothing, i've had both my legs cut out from under me several times since the above PR was merged, and i'm relegated to just twiddling my thumbs and doing nothing, as suicide verbs aren't permitted.

Powerfist currently has its own attack proc, i'm not sure how to make it fail into the default obj/item/attack() so it can use the existing code like other items, my pea brain struggles.
## Changelog

:cl:
add: Permits items to melee attack while prone
/:cl:
