### PR TITLE
Hunter stealth attack consistancy

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -178,6 +178,7 @@
 /datum/action/ability/xeno_action/stealth/proc/sneak_attack_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
 	SIGNAL_HANDLER
 	if(!can_sneak_attack)
+		cancel_stealth()
 		return
 
 	var/staggerslow_stacks = 2


### PR DESCRIPTION

## About The Pull Request
Hunters attacking in stealth will now always break stealth.

Currently stealth only breaks once you've fully charged up stealth (i.e. you can do a stunning stealth attack).
## Why It's Good For The Game
Consistant with object attacks.

Its wack to smack someone repeatedly while still increasing stealth level.
## Changelog
:cl:
balance: Hunter attacks now always break stealth
/:cl:
