### PR TITLE
Nerfs easy method to instakill any full health xeno

### DIFF
--- a/code/game/objects/items/explosives/grenades/bullet_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/bullet_grenade.dm
@@ -61,7 +61,7 @@
 	hud_state = "grenade_hefa2"
 	rotations = -1
 	fire_sound = null
-	projectile_count = 50
+	projectile_count = 30
 	ammo_type = /datum/ammo/bullet/hefa_buckshot
 
 /obj/item/explosive/grenade/bullet/hefa/prime()


### PR DESCRIPTION

## About The Pull Request
During testing I discovered that HEFA grenades are able to instantly crit any full health xeno. The only two exceptions were king and crusher that were close to crit. Every other xeno caste was either gibbed or in crit from one grenade detonating at their feet. 

SADAR, CAS, tank shots, flak guns, etc. do not possess this capability. 

Furthermore, by using heavy armor and attaching the Hod Ballistic Deflection module (standard equipment) this guarantees that you won't receive any shrapnel unless you are standing next to the grenade at point blank range. You can also load this grenade into a grenade launcher and spam them to your heart's content.

The two methods to obtain these grenades are ordering a box from req which costs 500 points for 25 grenades or using a factory to produce them. It's not that hard or expensive.

My solution is simple. Instead of a grenade firing 50 shotgun blasts, I lowered it to 30. This should still kill most T1/T2s at full health, but at least give T3s/T4s a chance to survive if they are above half health. 

## Why It's Good For The Game
Xeno Insta-Pop? Not anymore!

## Changelog
:cl:
balance: HEFA grenades no longer instakill every xeno (minus crusher/king) if grenade explodes on the same tile as xeno. Decreased HEFA grenades firing 50 pellets to 30 pellets, which still kills most T1/T2s at full health, and can kill T3/T4s if lower than half health. 
/:cl:
