### PR TITLE
Xeno fire patting

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -802,6 +802,7 @@
 
 ///after attacking, accounts for armor
 #define COMSIG_XENOMORPH_POSTATTACK_LIVING "xenomorph_postattack_living"
+#define COMSIG_XENOMORPH_ATTACK_TURF "xenomorph_attack_turf"
 #define COMSIG_XENOMORPH_ATTACK_HUMAN "xenomorph_attack_human"
 #define COMSIG_XENOMORPH_DISARM_HUMAN "xenomorph_disarm_human"
 	#define COMPONENT_BYPASS_SHIELDS (1<<0)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -18,6 +18,8 @@
 /atom/proc/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	return
 
+/turf/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	SEND_SIGNAL(src, COMSIG_XENOMORPH_ATTACK_TURF, xeno_attacker)
 
 /mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, has_proximity, modifiers)
 	if(lying_angle)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -182,7 +182,7 @@
 
 	xeno_attacker.changeNext_move(xeno_attacker.xeno_caste.attack_delay)
 	burn_ticks -= 10
-	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
+	playsound(src, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 
 	xeno_attacker.visible_message(span_danger("[xeno_attacker] tries to put out the fire!"), \
 		span_warning("We try to put out the fire!"), null, 5)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -173,7 +173,7 @@
 		return PROCESS_KILL
 
 /obj/fire/flamer/on_xeno_attack(datum/source, mob/living/carbon/xenomorph/xeno_attacker)
-	if(xeno_attacker.a_intent != INTENT_DISARM)
+	if(xeno_attacker.a_intent != INTENT_HELP)
 		return
 	if(xeno_attacker.do_actions)
 		return

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -179,20 +179,19 @@
 		return
 	if(xeno_attacker.incapacitated())
 		return
-	INVOKE_ASYNC(src, PROC_REF(pat_out), xeno_attacker)
 
-///Pats out the fire
-/obj/fire/flamer/proc/pat_out(mob/living/patter)
-	if(!do_after(patter, 0.5 SECONDS, target = src, user_display = BUSY_ICON_FRIENDLY))
-		return
-
+	xeno_attacker.changeNext_move(xeno_attacker.xeno_caste.attack_delay)
 	burn_ticks -= 10
-	if(burn_ticks <= 0)
-		playsound(loc, 'sound/effects/smoke_extinguish.ogg', 20)
-		qdel(src)
-		return
-	update_appearance(UPDATE_ICON)
+	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 
+	xeno_attacker.visible_message(span_danger("[xeno_attacker] tries to put out the fire!"), \
+		span_warning("We try to put out the fire!"), null, 5)
+	if(burn_ticks > 0)
+		update_appearance(UPDATE_ICON)
+		return
+	xeno_attacker.visible_message(span_danger("[xeno_attacker] has successfully extinguished the fire!"), \
+		span_notice("We extinguished the fire."), null, 5)
+	qdel(src)
 
 ///////////////////////////////
 //        MELTING FIRE       //


### PR DESCRIPTION
## About The Pull Request
Xeno can pat fire on help intent to put it out.

Each pat = 10 fire stacks.
Cooldown is whatever your caste's attack delay is.

Dunno if UP or OP on numbers.
## Why It's Good For The Game
Minor but universally accessible way for xenos to engage with fire.
## Changelog
:cl:
balance: Xenos can pat out fire on open turfs with help intent
/:cl:
