### PR TITLE
Fire counter abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -571,6 +571,10 @@
 				continue
 			if(!isobj(impacted_atom))
 				continue
+			if(isfire(impacted_atom))
+				var/obj/fire/fire = impacted_atom
+				fire.reduce_fire(20)
+				continue
 			if(!(impacted_atom.resistance_flags & XENO_DAMAGEABLE))
 				continue
 			var/obj/impacted_obj = impacted_atom

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -266,16 +266,22 @@
 			shake_camera(carbon_victim, 3 * severity, 3 * severity)
 			carbon_victim.apply_effect(1 SECONDS, EFFECT_PARALYZE)
 			to_chat(carbon_victim, "You are smashed to the ground!")
-		else if(isvehicle(victim) || ishitbox(victim))
+			continue
+		if(isvehicle(victim) || ishitbox(victim))
 			var/obj/obj_victim = victim
 			var/hitbox_penalty = 0
 			if(ishitbox(victim))
 				hitbox_penalty = 20
 			obj_victim.take_damage((SHATTERING_ROAR_DAMAGE - hitbox_penalty) * 5 * severity, BRUTE, MELEE)
-		else if(istype(victim, /obj/structure/window))
+		continue
+		if(istype(victim, /obj/structure/window))
 			var/obj/structure/window/window_victim = victim
 			if(window_victim.damageable)
 				window_victim.ex_act(EXPLODE_DEVASTATE)
+			continue
+		if(isfire(victim))
+			var/obj/fire/fire = victim
+			fire.reduce_fire(10)
 
 ///cleans up when the charge up is finished or interrupted
 /datum/action/ability/activable/xeno/shattering_roar/proc/finish_charging()

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -183,6 +183,10 @@
 	for(var/turf/affected_tile in block(lower_left, upper_right)) //everything in the 3x3 block is found.
 		affected_tile.Shake(duration = 0.5 SECONDS)
 		for(var/atom/movable/affected AS in affected_tile)
+			if(isfire(affected))
+				var/obj/fire/fire = affected
+				fire.reduce_fire(10)
+				continue
 			if(!ishuman(affected) && !istype(affected, /obj/item) && !isdroid(affected))
 				affected.Shake(duration = 0.5 SECONDS)
 				continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -440,12 +440,18 @@
 				carbon_victim.apply_damage(PSY_CRUSH_DAMAGE * 1.5, STAMINA, blocked = BOMB)
 				carbon_victim.adjust_stagger(5 SECONDS)
 				carbon_victim.add_slowdown(6)
-			else if(isvehicle(victim) || ishitbox(victim))
+				continue
+			if(isvehicle(victim) || ishitbox(victim))
 				var/obj/obj_victim = victim
 				var/dam_mult = 0.5
 				if(ismecha(obj_victim))
 					dam_mult = 5
 				obj_victim.take_damage(PSY_CRUSH_DAMAGE * dam_mult, BRUTE, BOMB)
+				continue
+			if(isfire(victim))
+				var/obj/fire/fire = victim
+				fire.reduce_fire(10)
+				continue
 	stop_crush()
 
 /// stops channeling and unregisters all listeners, resetting the ability

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -150,7 +150,7 @@
 
 ///Reduces duration of fire
 /obj/fire/proc/reduce_fire(amount = 1)
-	if(amount >= 0)
+	if(amount <= 0)
 		return
 	burn_ticks -= amount
 	if(burn_ticks > 0)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -156,7 +156,7 @@
 	if(burn_ticks > 0)
 		update_appearance(UPDATE_ICON)
 	else
-		qdel(fire)
+		qdel(src)
 
 /////////////////////////////
 //      FLAMER FIRE        //

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -148,6 +148,16 @@
 /obj/fire/proc/affect_atom(atom/affected)
 	return
 
+///Reduces duration of fire
+/obj/fire/proc/reduce_fire(amount = 1)
+	if(amount >= 0)
+		return
+	burn_ticks -= amount
+	if(burn_ticks > 0)
+		update_appearance(UPDATE_ICON)
+	else
+		qdel(fire)
+
 /////////////////////////////
 //      FLAMER FIRE        //
 /////////////////////////////


### PR DESCRIPTION
## About The Pull Request
Adding some fire interactions for some xeno abilities. Let me know if there are others that could logically/plausible do so that I've missed.

The following abilities weaken/extinguish fire in their areas of effect.
- Psycrush (warlock)
- Roar(king)
- Wind current (dragon)
- Unrelenting force (shrike)

## Why It's Good For The Game
More fire interactions for xeno is good for active gameplay, instead of jelly or bust.
## Changelog
:cl:
balance: Psycrush, roar, wind current and unrelenting force all weaken fire in their AOE's
/:cl:
