### PR TITLE
Apc's first turn off lighting then equipment

### DIFF
--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -454,8 +454,8 @@
 			environ = autoset(environ, 1)
 			area.poweralert(0, src)
 		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off equipment
-			equipment = autoset(equipment, 2)
-			lighting = autoset(lighting, 1)
+			equipment = autoset(equipment, 1)
+			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			area.poweralert(0, src)
 		else									// otherwise all can be on

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -453,7 +453,7 @@
 			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			area.poweralert(0, src)
-		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off equipment
+		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off lighting
 			equipment = autoset(equipment, 1)
 			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)


### PR DESCRIPTION

## About The Pull Request

As title says 
right now at 30% first equipment are turned off then lights and then everything

## Why It's Good For The Game

Why should equipment be turned off before lights? 
Lights turning off first seem better in like every way
you get more runtime from stuff while most of the time lights groundside are smashed in the first place - while shipside you might get extra 10 20 seconds out of the autodoc/whatever else

## Changelog

:cl: Atropos
qol: Apc's will first turn off lights then equipment
/:cl:
