### PR TITLE
Fix miners saying mineral value instead of ammount

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -304,7 +304,7 @@
 			return
 		stored_mineral += 1
 		add_tick = 0
-		say("[mineral_value] Ore shipment\s is ready to be exported.")
+		say("[stored_mineral] Ore shipment\s is ready to be exported.")
 		playsound(loc,'sound/machines/ping.ogg', 20, FALSE)
 	if(stored_mineral >= 8)	//Stores 8 boxes worth of minerals
 		stop_processing()


### PR DESCRIPTION

## About The Pull Request

Title
NEVER let me code fr 
## Why It's Good For The Game

Fix good

## Changelog

:cl: Atropos
fix: fixed miners saying mineral value instead of ammount
/:cl:
