### PR TITLE
actually adds the tadpole fabricator to shipmap

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -128,6 +128,11 @@
 	dir = 8
 	},
 /area/mainship/medical/upper_medical)
+"ahW" = (
+/obj/vehicle/ridden/powerloader,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "ahX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -3459,11 +3464,9 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "cWr" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
+/obj/structure/rack,
+/turf/open/floor/mainship/orange{
+	dir = 9
 	},
 /area/mainship/hallways/hangar)
 "cWv" = (
@@ -3862,11 +3865,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "dmG" = (
-/obj/structure/rack,
-/obj/item/tool/weldingtool,
-/obj/item/clothing/head/welding,
-/obj/item/tool/weldpack,
-/obj/item/storage/belt/utility/full,
 /turf/open/floor/mainship/orange{
 	dir = 6
 	},
@@ -4103,7 +4101,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "dxQ" = (
 /obj/machinery/camera/autoname/mainship{
@@ -4876,10 +4874,10 @@
 	},
 /area/mainship/squads/req)
 "ehy" = (
-/obj/vehicle/ridden/powerloader,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/machinery/dropship_part_fabricator/tadpole,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "eik" = (
@@ -6499,6 +6497,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -6813,17 +6814,14 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "fHx" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/rack,
+/obj/item/tool/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/item/tool/weldpack,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/mainship/orange{
+	dir = 5
 	},
-/obj/machinery/landinglight/alamo{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fIp" = (
 /obj/structure/table/mainship/nometal,
@@ -8986,7 +8984,7 @@
 	on = 1
 	},
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "htX" = (
 /obj/structure/morgue{
@@ -16333,6 +16331,7 @@
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "nmG" = (
@@ -25318,6 +25317,9 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -36243,7 +36245,7 @@ sfI
 tys
 tys
 ftJ
-cWr
+kBf
 kBf
 kBf
 lTg
@@ -36344,8 +36346,8 @@ szE
 szE
 szE
 ssO
-hYD
-hjH
+bMK
+cWr
 hIO
 dSy
 fcW
@@ -36447,7 +36449,7 @@ qAQ
 rto
 iyA
 nlT
-hjH
+ahW
 hIO
 ehy
 dxv
@@ -36548,8 +36550,8 @@ vlB
 vlB
 mwK
 hIO
-hYD
-hjH
+bMK
+fHx
 hIO
 dmG
 htw
@@ -36651,7 +36653,7 @@ vlB
 wGG
 hIO
 uKE
-fHx
+pCj
 bwD
 pCj
 rPw

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2928,6 +2928,15 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
+"dAV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "dBm" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck/kotahi,
@@ -4315,6 +4324,11 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
+"fnB" = (
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "fnS" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -5214,6 +5228,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"gja" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "gjA" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -8401,6 +8421,16 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"kHy" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/landinglight/alamo{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "kHN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10728,6 +10758,9 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nku" = (
@@ -11689,6 +11722,12 @@
 /obj/machinery/bot/cleanbot,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"oBQ" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "oCo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
@@ -12450,6 +12489,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"psX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "ptb" = (
 /obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/mainship/floor,
@@ -17074,6 +17125,17 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"ves" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/dropship_part_fabricator/tadpole,
+/obj/machinery/dropship_part_fabricator/tadpole,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
 "vfH" = (
 /turf/closed/wall/mainship,
@@ -48592,7 +48654,7 @@ ufq
 wEZ
 tyN
 nkm
-dpY
+oBQ
 cPE
 kDx
 kDx
@@ -48848,9 +48910,9 @@ sVR
 ufq
 uud
 tyN
-ePE
-dpY
-cPE
+ves
+fnB
+kHy
 kDx
 kDx
 kDx
@@ -49105,9 +49167,9 @@ sVR
 ufq
 wEZ
 tyN
-ePE
-dpY
-cPE
+dAV
+fnB
+kHy
 xDq
 xDq
 qWy
@@ -49362,8 +49424,8 @@ tyN
 tyN
 bDH
 tyN
-ePE
-dpY
+psX
+gja
 cPE
 kDx
 kDx

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -421,6 +421,12 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/living/briefing)
+"aDU" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "aDZ" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/squad_changer,
@@ -2928,15 +2934,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
-"dAV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar)
 "dBm" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck/kotahi,
@@ -4324,11 +4321,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
-"fnB" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
 "fnS" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -5228,12 +5220,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"gja" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "gjA" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -6575,6 +6561,16 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
+"iay" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/landinglight/alamo{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "iaH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
@@ -7384,6 +7380,15 @@
 	dir = 8
 	},
 /area/mainship/living/pilotbunks)
+"jfb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "jfQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -8421,16 +8426,6 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"kHy" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/machinery/landinglight/alamo{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "kHN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -9133,6 +9128,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"luk" = (
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "lun" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/mechpilot,
@@ -10242,6 +10242,16 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
+"mJI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/dropship_part_fabricator/tadpole,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "mJL" = (
 /obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/orange{
@@ -11722,12 +11732,6 @@
 /obj/machinery/bot/cleanbot,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"oBQ" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "oCo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
@@ -12489,18 +12493,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"psX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "ptb" = (
 /obj/structure/dropship_equipment/cas/weapon/heavygun,
 /turf/open/floor/mainship/floor,
@@ -13229,6 +13221,18 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
+"qor" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "qpf" = (
 /obj/machinery/light/mainship/small{
 	dir = 4
@@ -17126,17 +17130,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ves" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/dropship_part_fabricator/tadpole,
-/obj/machinery/dropship_part_fabricator/tadpole,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar)
 "vfH" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
@@ -19596,6 +19589,12 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/self_destruct)
+"xZP" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "yaf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48654,7 +48653,7 @@ ufq
 wEZ
 tyN
 nkm
-oBQ
+aDU
 cPE
 kDx
 kDx
@@ -48910,9 +48909,9 @@ sVR
 ufq
 uud
 tyN
-ves
-fnB
-kHy
+mJI
+luk
+iay
 kDx
 kDx
 kDx
@@ -49167,9 +49166,9 @@ sVR
 ufq
 wEZ
 tyN
-dAV
-fnB
-kHy
+jfb
+luk
+iay
 xDq
 xDq
 qWy
@@ -49424,8 +49423,8 @@ tyN
 tyN
 bDH
 tyN
-psX
-gja
+qor
+xZP
 cPE
 kDx
 kDx

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -21516,6 +21516,10 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"qtW" = (
+/obj/machinery/dropship_part_fabricator/tadpole,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "quS" = (
 /obj/effect/landmark/start/latejoin,
 /obj/effect/ai_node,
@@ -66154,7 +66158,7 @@ aaa
 aaa
 nzi
 bFa
-aPF
+qtW
 aPF
 aPF
 aPF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out we went a month and a half without a tad pilot simultaneously bald enough to lose their sentries but smart enough to try and find replacements through a fabricator. They only exist on the Theseus, changing that here.

Pillar of slop:
![image](https://github.com/user-attachments/assets/3232bf37-4cdd-4a72-ba26-ae776e04f779)

Arachshit:
![image](https://github.com/user-attachments/assets/30227ca9-a7a4-493c-9e10-6160549054de)

Shitlaco:
![image](https://github.com/user-attachments/assets/214c53bd-0892-4909-a82a-ef7d431b3f42)


each map tested locally

## Why It's Good For The Game

PRing a thing and actually adding it to map good.

## Changelog

:cl:

fix: tadpole parts fabricator was not added to all maps, this corrects that

/:cl:
