### PR TITLE
Randomised magazine ejection offsets

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1481,6 +1481,8 @@
 		if(user)
 			user.put_in_hands(mag)
 		else
+			mag.pixel_x = rand(-16, 16)
+			mag.pixel_y = rand(-16, 16)
 			mag.forceMove(get_turf(src))
 	if(CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_ROTATES_CHAMBER))
 		chamber_items[chamber_items.Find(mag)] = null


### PR DESCRIPTION
## About The Pull Request

For literally forever magazines have always ejected in the DEAD CENTRE of the tile, and I'm SICK AND TIRED OF IT

This randomises their placement, preserving my remaining sanity.

## Why It's Good For The Game

Makes the debris marines leave behind when fighting a bit less monotonous to look at.

https://cdn.discordapp.com/attachments/1119971876148609065/1370798865841655962/autism.mp4?ex=6820cf6d&is=681f7ded&hm=d96ffb5d8536d4bbb13f64c0db88f5e44ee8911034d4cd635f994a7d1baf3356&

## Changelog

:cl:
add: Randomises the offset of ejected magazines.
/:cl:
