### PR TITLE
Adds View latest ticket verb - allowing players to see their latest ticket

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -753,12 +753,12 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
 			html = "[span_notice("PM to-<b>Staff</b>: <span class='linkify'>[rawmsg]")]</font>")
-		var/datum/admin_help/AH = admin_ticket_log(src,
+		var/datum/admin_help/new_admin_help = admin_ticket_log(src,
 			"<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, TRUE)] to <i>External</i>: [keywordparsedmsg]</font>",
 			player_message = "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, FALSE)]</b> to <i>External</i>: [keywordparsedmsg]</font>")
 
 		externalreplyamount--
-		send2adminchat("[AH ? "#[AH.id] " : ""]Reply: [ckey]", sanitizediscord(rawmsg))
+		send2adminchat("[new_admin_help ? "#[new_admin_help.id] " : ""]Reply: [ckey]", sanitizediscord(rawmsg))
 	else
 		if(check_other_rights(recipient, R_ADMINTICKET, FALSE) || is_mentor(recipient))
 			if(check_rights(R_ADMINTICKET, FALSE) || is_mentor(src)) //Both are staff
@@ -786,7 +786,8 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 
 			else //Recipient is a staff member, sender is not.
 				SEND_SIGNAL(current_ticket, COMSIG_ADMIN_HELP_REPLIED)
-				admin_ticket_log(src, "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, recipient, TRUE)]</b>: [span_linkify("[keywordparsedmsg]")]</font>")
+				admin_ticket_log(src, "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, recipient, TRUE)]</b>: [span_linkify("[keywordparsedmsg]")]</font>",
+					player_message = "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, recipient, FALSE)]</b>: [span_linkify("[keywordparsedmsg]")]</font>" )
 				to_chat(recipient,
 					type = MESSAGE_TYPE_ADMINPM,
 					html = "<font size='4' color='red'><b>-- Private message --</b></font>\n[span_adminsay("Reply from- <b>[key_name(src, recipient, TRUE)]</b>: [span_linkify("[keywordparsedmsg]")]")]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -753,7 +753,10 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
 			html = "[span_notice("PM to-<b>Staff</b>: <span class='linkify'>[rawmsg]")]</font>")
-		var/datum/admin_help/AH = admin_ticket_log(src, "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, TRUE)] to <i>External</i>: [keywordparsedmsg]</font>")
+		var/datum/admin_help/AH = admin_ticket_log(src,
+			"<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, TRUE)] to <i>External</i>: [keywordparsedmsg]</font>",
+			player_message = "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, FALSE)]</b> to <i>External</i>: [keywordparsedmsg]</font>")
+
 		externalreplyamount--
 		send2adminchat("[AH ? "#[AH.id] " : ""]Reply: [ckey]", sanitizediscord(rawmsg))
 	else
@@ -776,9 +779,10 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 				window_flash(src, TRUE)
 
 				var/interaction_message = "<font color='#cea7f1'>PM from-<b>[key_name(src, recipient, TRUE)]</b> to-<b>[key_name(recipient, src, TRUE)]</b>: [keywordparsedmsg]</font>"
-				admin_ticket_log(src, interaction_message)
+				var/player_interaction_message = "<font color='#cea7f1'>PM from-<b>[key_name(src, recipient, FALSE)]</b> to-<b>[key_name(recipient, src, FALSE)]</b>: [keywordparsedmsg]</font>"
+				admin_ticket_log(src, interaction_message, player_message = player_interaction_message)
 				if(recipient != src)
-					admin_ticket_log(recipient, interaction_message)
+					admin_ticket_log(recipient, interaction_message, player_message = player_interaction_message)
 
 			else //Recipient is a staff member, sender is not.
 				SEND_SIGNAL(current_ticket, COMSIG_ADMIN_HELP_REPLIED)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -755,7 +755,7 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 			html = "[span_notice("PM to-<b>Staff</b>: <span class='linkify'>[rawmsg]")]</font>")
 		var/datum/admin_help/new_admin_help = admin_ticket_log(src,
 			"<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, TRUE)] to <i>External</i>: [keywordparsedmsg]</font>",
-			player_message = "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, FALSE)]</b> to <i>External</i>: [keywordparsedmsg]</font>")
+			player_message = "<font color='#ff8c8c'>Reply PM from-<b>[key_name(src, TRUE, TRUE)]</b> to <i>External</i>: [keywordparsedmsg]</font>")
 
 		externalreplyamount--
 		send2adminchat("[new_admin_help ? "#[new_admin_help.id] " : ""]Reply: [ckey]", sanitizediscord(rawmsg))
@@ -839,7 +839,7 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 					SEND_SOUND(recipient, sound('sound/effects/mentorhelp.ogg', channel = CHANNEL_ADMIN))
 					window_flash(recipient)
 
-				admin_ticket_log(recipient, "<font color='#a7f2ef'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>")
+				admin_ticket_log(recipient, "<font color='#a7f2ef'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>", player_message = "<font color='#a7f2ef'>PM From [key_name_admin(src, FALSE)]: [keywordparsedmsg]</font>")
 
 
 			else		//neither are admins
@@ -996,7 +996,7 @@ ADMIN_VERB(private_message_panel, R_ADMIN|R_MENTOR, "Private Message", "Private 
 		type = MESSAGE_TYPE_ADMINPM,
 		html = "<font color='red'><i>Click on the administrator's name to reply.</i></font>")
 
-	admin_ticket_log(C, "<font color='#a7f2ef'>PM From [tgs_tagged]: [msg]</font>")
+	admin_ticket_log(C, "<font color='#a7f2ef'>PM From [tgs_tagged]: [msg]</font>", player_message = "<font color='#a7f2ef'>PM From [tgs_tagged]: [msg]</font>")
 
 	//always play non-admin recipients the adminhelp sound
 	SEND_SOUND(C, sound('sound/effects/adminhelp.ogg', channel = CHANNEL_ADMIN))

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -281,7 +281,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	player_interactions = list()
 
 	if(is_bwoink)
-		AddInteraction("<font color='#a7f2ef'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>", player_message = "<font color='blue'>[key_name_admin(usr, include_name = FALSE)] PM'd [LinkedReplyName()]</font>")
+		AddInteraction("<font color='#a7f2ef'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>", player_message = "<font color='blue'>[key_name_admin(usr, FALSE)] PM'd [LinkedReplyName()]</font>")
 		if(tier == TICKET_MENTOR)
 			message_staff("Ticket [TicketHref("#[id]")] created.")
 		else if(tier == TICKET_ADMIN)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -248,6 +248,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	var/static/ticket_counter = 0
 
+	var/list/player_interactions
+
 //call this on its own to create a ticket, don't manually assign current_ticket
 //msg is the title of the ticket: usually the ahelp text
 //is_bwoink is TRUE if this ticket was started by an admin PM
@@ -276,9 +278,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	statclick = new(null, src)
 	_interactions = list()
+	player_interactions = list()
 
 	if(is_bwoink)
-		AddInteraction("<font color='#a7f2ef'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>")
+		AddInteraction("<font color='#a7f2ef'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>", player_message = "<font color='blue'>[key_name_admin(usr, include_name = FALSE)] PM'd [LinkedReplyName()]</font>")
 		if(tier == TICKET_MENTOR)
 			message_staff("Ticket [TicketHref("#[id]")] created.")
 		else if(tier == TICKET_ADMIN)
@@ -305,11 +308,14 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	return ..()
 
 
-/datum/admin_help/proc/AddInteraction(formatted_message)
+/datum/admin_help/proc/AddInteraction(formatted_message, player_message)
 	if(heard_by_no_admins && usr && usr.ckey != initiator_ckey)
 		heard_by_no_admins = FALSE
 		send2adminchat(initiator_ckey, "Ticket #[id]: Answered by [key_name(usr)]")
+
 	_interactions += "[stationTimestamp()]: [formatted_message]"
+	if (!isnull(player_message))
+		player_interactions += "[time_stamp()]: [player_message]"
 
 //private
 /datum/admin_help/proc/FullMonty(ref_src)
@@ -370,7 +376,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	//message to be sent to all admins
 
 
-	AddInteraction("<font color='#ff8c8c'>[LinkedReplyName(ref_src)]: [msg]</font>")
+	AddInteraction("<font color='#ff8c8c'>[LinkedReplyName(ref_src)]: [msg]</font>", player_message = "<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [msg]")
 
 	//Send this to the relevant people
@@ -428,7 +434,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	else if(tier == TICKET_ADMIN)
 		message_admins("Ticket [TicketHref("#[id]")] has been made reopened by [ref].")
 
-	AddInteraction("<font color='#cea7f1'>Reopened by [key_name_admin(usr)]</font>")
+	AddInteraction("<font color='#cea7f1'>Reopened by [key_name_admin(usr)]</font>", player_message = "Ticket Reopened!")
 	log_admin_private("Ticket (#[id]) reopened by [key_name(usr)].")
 	to_chat(initiator, span_adminhelp("Your ticket has been reopened."))
 	TicketPanel()	//can only be done from here, so refresh it
@@ -450,7 +456,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(tier == TICKET_MENTOR)
 		tier = TICKET_ADMIN
 		msg = "an admin ticket"
-		AddInteraction("<font color='#ff8c8c'>Made admin ticket by: [key_name_admin(usr)].</font>")
+		AddInteraction("<font color='#ff8c8c'>Made admin ticket by: [key_name_admin(usr)].</font>", player_message = "<font color='#ff8c8c'>Ticket made adminhelp!</font>")
 		message_admins("Ticket [TicketHref("#[id]")] has been made [msg] by [ref].")
 		to_chat(initiator, span_adminhelp("Your ticket has been tiered to an adminhelp."))
 		for(var/client/admin_client in GLOB.admins)
@@ -462,7 +468,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	else if(tier == TICKET_ADMIN)
 		tier = TICKET_MENTOR
 		msg = "a mentor ticket"
-		AddInteraction("<font color='#ff8c8c'>Made mentor ticket by: [key_name_admin(usr)].</font>")
+		AddInteraction("<font color='#ff8c8c'>Made mentor ticket by: [key_name_admin(usr)].</font>", player_message = "<font color='#ff8c8c'>Ticket made mentorhelp!</font>")
 		message_staff("Ticket [TicketHref("#[id]")] has been made [msg] by [ref].")
 		to_chat(initiator, span_adminhelp("Your ticket has been tiered to a mentorhelp."))
 		if(!irc)
@@ -539,7 +545,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	RemoveActive()
 	state = AHELP_CLOSED
 	GLOB.ahelp_tickets.ListInsert(src)
-	AddInteraction("<font color='#ff8c8c'>Closed by [key_name_admin(usr)].</font>")
+	AddInteraction("<font color='#ff8c8c'>Closed by [key_name_admin(usr)].</font>", player_message = "<font color='red'>Ticket closed!</font>")
 	if(!silent)
 		log_admin_private("Ticket (#[id]) closed by [key_name(usr)].")
 		to_chat(initiator, span_adminhelp("Your ticket has been closed."))
@@ -566,7 +572,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
 
-	AddInteraction("<font color='#9adb92'>Resolved by [key_name_admin(usr)].</font>")
+	AddInteraction("<font color='#9adb92'>Resolved by [key_name_admin(usr)].</font>", player_message = "<font color='green'>Ticket resolved!</font>")
 	if(tier == TICKET_MENTOR)
 		to_chat(initiator, span_adminhelp("Your mentor ticket has been resolved, if you need to ask something again, feel free to send another one."))
 	else if(tier == TICKET_ADMIN)
@@ -617,7 +623,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	message_admins("Ticket [TicketHref("#[id]")] rejected by [ref].")
 	log_admin_private("Ticket (#[id]) rejected by [key_name(usr)].")
-	AddInteraction("Rejected by [key_name_admin(usr)].")
+	AddInteraction("Rejected by [key_name_admin(usr)].", player_message = "Ticket rejected!")
 	Close(TRUE, irc)
 
 
@@ -659,7 +665,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	message_admins("Ticket [TicketHref("#[id]")] marked as IC by [ref].")
 	log_admin_private("Ticket (#[id]) marked as IC by [key_name(usr)].")
-	AddInteraction("Marked as IC issue by [key_name_admin(usr)]")
+	AddInteraction("Marked as IC issue by [key_name_admin(usr)]", player_message = "Marked as IC issue!")
 	Resolve(TRUE, irc)
 
 
@@ -756,6 +762,30 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if("mark")
 			Mark()
 
+/datum/admin_help/proc/player_ticket_panel()
+	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Player Ticket</title></head>")
+	dat += "<b>State: "
+	switch(state)
+		if(AHELP_ACTIVE)
+			dat += "<font color='red'>OPEN</font></b>"
+		if(AHELP_RESOLVED)
+			dat += "<font color='green'>RESOLVED</font></b>"
+		if(AHELP_CLOSED)
+			dat += "CLOSED</b>"
+		else
+			dat += "UNKNOWN</b>"
+	dat += "\n[FOURSPACES]<A href='byond://?_src_=holder;[HrefToken(forceGlobal = TRUE)];player_ticket_panel=1'>Refresh</A>"
+	dat += "<br><br>Opened at: [gameTimestamp("hh:mm:ss", opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	if(closed_at)
+		dat += "<br>Closed at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
+	dat += "<br><br>"
+	dat += "<br><b>Log:</b><br><br>"
+	for (var/interaction in player_interactions)
+		dat += "[interaction]<br>"
+
+	var/datum/browser/player_panel = new(usr, "ahelp[id]", 0, 620, 480)
+	player_panel.set_content(dat.Join())
+	player_panel.open()
 
 //
 // TICKET STATCLICK
@@ -875,6 +905,31 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if("Admins")
 			adminhelp(message)
 
+/client/verb/view_latest_ticket()
+	set category = "Admin"
+	set name = "View Latest Ticket"
+
+	if(!current_ticket)
+		var/list/prev_tickets = list()
+		var/datum/admin_help/last_ticket
+
+		for(var/datum/admin_help/resolved_ticket in GLOB.ahelp_tickets.resolved_tickets)
+			if(resolved_ticket.initiator_ckey == ckey) // Initiator is a misnomer, it's always the non-admin player even if an admin bwoinks first
+				prev_tickets += resolved_ticket
+
+		for(var/datum/admin_help/closed_ticket in GLOB.ahelp_tickets.closed_tickets)
+			if(closed_ticket.initiator_ckey == ckey)
+				prev_tickets += closed_ticket
+
+		if(LAZYLEN(prev_tickets))
+			last_ticket = pop(prev_tickets)
+			last_ticket.player_ticket_panel()
+			return
+
+		to_chat(src, span_warning("You have not had an ahelp ticket this round."))
+		return
+
+	current_ticket.player_ticket_panel()
 
 //
 // LOGGING
@@ -882,21 +937,28 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 //Use this proc when an admin takes action that may be related to an open ticket on what
 //what can be a client, ckey, or mob
-/proc/admin_ticket_log(what, message)
-	var/client/C
+/proc/admin_ticket_log(what, message, player_message)
+	var/client/mob_client
 	var/mob/Mob = what
 	if(istype(Mob))
-		C = Mob.client
+		mob_client = Mob.client
 	else
-		C = what
-	if(istype(C) && C.current_ticket)
-		C.current_ticket.AddInteraction(message)
-		return C.current_ticket
+		mob_client = what
+	if(istype(mob_client) && mob_client.current_ticket)
+		if (isnull(player_message))
+			mob_client.current_ticket.AddInteraction(message)
+		else
+			mob_client.current_ticket.AddInteraction(message, player_message)
+		mob_client.current_ticket.AddInteraction(message)
+		return mob_client.current_ticket
 	if(istext(what))	//ckey
-		var/datum/admin_help/AH = GLOB.ahelp_tickets.CKey2ActiveTicket(what)
-		if(AH)
-			AH.AddInteraction(message)
-			return AH
+		var/datum/admin_help/active_admin_help = GLOB.ahelp_tickets.CKey2ActiveTicket(what)
+		if(active_admin_help)
+			if (isnull(player_message))
+				active_admin_help.AddInteraction(message)
+			else
+				active_admin_help.AddInteraction(message, player_message)
+		return active_admin_help
 
 
 //

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -572,7 +572,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
 
-	AddInteraction("<font color='#9adb92'>Resolved by [key_name_admin(usr)].</font>", player_message = "<font color='green'>Ticket resolved!</font>")
+	AddInteraction("<font color='#9adb92'>Resolved by [key_name_admin(usr)].</font>", player_message = "<font color='#9adb92'>Ticket resolved!</font>")
 	if(tier == TICKET_MENTOR)
 		to_chat(initiator, span_adminhelp("Your mentor ticket has been resolved, if you need to ask something again, feel free to send another one."))
 	else if(tier == TICKET_ADMIN)
@@ -910,22 +910,24 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "View Latest Ticket"
 
 	if(!current_ticket)
+		// Check if the client had previous tickets, and show the latest one
 		var/list/prev_tickets = list()
 		var/datum/admin_help/last_ticket
-
+		// Check all resolved tickets for this player
 		for(var/datum/admin_help/resolved_ticket in GLOB.ahelp_tickets.resolved_tickets)
 			if(resolved_ticket.initiator_ckey == ckey) // Initiator is a misnomer, it's always the non-admin player even if an admin bwoinks first
 				prev_tickets += resolved_ticket
-
+		// Check all closed tickets for this player
 		for(var/datum/admin_help/closed_ticket in GLOB.ahelp_tickets.closed_tickets)
 			if(closed_ticket.initiator_ckey == ckey)
 				prev_tickets += closed_ticket
-
+		// Take the most recent entry of prev_tickets and open the panel on it
 		if(LAZYLEN(prev_tickets))
 			last_ticket = pop(prev_tickets)
 			last_ticket.player_ticket_panel()
 			return
 
+		// client had no tickets this round
 		to_chat(src, span_warning("You have not had an ahelp ticket this round."))
 		return
 
@@ -949,8 +951,6 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			mob_client.current_ticket.AddInteraction(message)
 		else
 			mob_client.current_ticket.AddInteraction(message, player_message)
-		mob_client.current_ticket.AddInteraction(message)
-		return mob_client.current_ticket
 	if(istext(what))	//ckey
 		var/datum/admin_help/active_admin_help = GLOB.ahelp_tickets.CKey2ActiveTicket(what)
 		if(active_admin_help)
@@ -958,7 +958,6 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 				active_admin_help.AddInteraction(message)
 			else
 				active_admin_help.AddInteraction(message, player_message)
-		return active_admin_help
 
 
 //

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -97,6 +97,9 @@
 	if(href_list["priv_msg"])
 		private_message(href_list["priv_msg"], null)
 		return
+	if (href_list["player_ticket_panel"])
+		view_latest_ticket()
+		return
 
 	if(href_list["commandbar_typing"])
 		handle_commandbar_typing(href_list)


### PR DESCRIPTION

## About The Pull Request

Port of main tg! which was a port from skyrat

What the title says 
players can see who said what in their latest ticket

## Why It's Good For The Game

Nice QOL for players letting them see the ticket history - and easily respond to admins (outside of using the ahelp)
Since currently it can be hard to find the messages from admins after few minutes cuz chat keeps on scrolling
images bellow

(yes i know its a lot of shitcode but im _trying_)

<details>
  <summary>Screenshots</summary>
  
  ![img](https://github.com/user-attachments/assets/83927f06-038a-45f6-b9bd-988de6858619)
  
![image](https://github.com/user-attachments/assets/700a3431-859d-4cf5-8c76-c17376452c8e)

</details>



## Changelog
:cl: Atropos
add: You can now View latest ticket from admins/mentors with the new verb!
code: Made some ahelp code easier to read
/:cl:
