### PR TITLE
Makes reason window in ban panel bigger

### DIFF
--- a/html/browser/banpanel.css
+++ b/html/browser/banpanel.css
@@ -23,7 +23,7 @@
 
 .reason {
     resize: none;
-    min-height: 40px;
+    min-height: 100px;
     width: 340px;
 }
 


### PR DESCRIPTION

## About The Pull Request

More precisely area where you input the ban reason is bigger 

## Why It's Good For The Game

I can barely read 2 lines and scrolling is kinda weird - more space to see reason good (imo)
Before and after

![image](https://github.com/user-attachments/assets/9df00c71-aa09-44e3-b061-140cce187426)

![image](https://github.com/user-attachments/assets/216eb871-57f0-4035-9b14-0bcff6fb7a15)

## Changelog
:cl: Atropos
admin: Ban reason input window is now bigger to improve readability 
/:cl:
