### PR TITLE
Fixes xeno keybindings

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -38,14 +38,14 @@
 	name = "place_pattern"
 	full_name = "Place Pattern"
 	description = "Place a template of hive walls."
-	keybind_signal = COMSIG_XENOABILITY_DROP_WEEDS
+	keybind_signal = COMSIG_XENOABILITY_PLACE_PATTERN
 	hotkey_keys = list("E")
 
 /datum/keybinding/xeno/select_pattern
 	name = "select_pattern"
 	full_name = "Select Pattern"
 	description = "Select the template to use when using Place Pattern"
-	keybind_signal = COMSIG_XENOABILITY_DROP_WEEDS
+	keybind_signal = COMSIG_XENOABILITY_SELECT_PATTERN
 	hotkey_keys = list("Q")
 
 /datum/keybinding/xeno/choose_weeds


### PR DESCRIPTION

## About The Pull Request

More precisely plant weeds is being used on 2 other places where it shouldnt be (place and select pattern)
look code for more info

## Why It's Good For The Game

Fix good
## Changelog

:cl: Atropos
fix: Fixed place and select pattern keybindings for xenos
/:cl:
