### PR TITLE
Solid plasteel cades give correct material refund

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -1156,6 +1156,7 @@
 	icon_state = "new_plasteel_0"
 	max_integrity = 400
 	stack_type = /obj/item/stack/sheet/plasteel
+	stack_amount = 3
 	destroyed_stack_amount = 2
 	barricade_type = "new_plasteel"
 	soft_armor = list(MELEE = 0, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 100, FIRE = 80, ACID = 50)


### PR DESCRIPTION
## About The Pull Request

An oopsie from when solid plasteel cades were introduced, could generate additional mats.

## Why It's Good For The Game

Bug Fix

closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/17862

## Changelog

:cl:
fix: Solid plasteel cades give correct material refund
/:cl:
