### PR TITLE
SSD Widow burrowed fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -277,7 +277,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BURROW,
 	)
-	use_state_flags = ABILITY_USE_BURROWED
+	use_state_flags = ABILITY_USE_BURROWED|ABILITY_USE_LYING
 
 /datum/action/ability/xeno_action/burrow/action_activate()
 	. = ..()
@@ -311,6 +311,7 @@
 	xeno_owner.update_icons()
 	add_cooldown()
 	owner.unbuckle_all_mobs(TRUE)
+	xeno_owner.get_up()
 
 /// Called by xeno_burrow only when burrowing
 /datum/action/ability/xeno_action/burrow/proc/xeno_burrow_doafter()


### PR DESCRIPTION
## About The Pull Request

Let's Widows unburrow if something forces them to lay down while burrowed, primarily from taking an SSD Widow.

## Why It's Good For The Game

Spider fix

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/14483

## Changelog

:cl:
fix: Burrowed SSD Widows can now unburrow
/:cl:
