### PR TITLE
Pyrogen Health 400 => 380. Damage per fire stack over time 2.5 => 2.0.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -706,7 +706,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 
 // Pyrogen defines
 /// Damage per melting fire stack
-#define PYROGEN_DAMAGE_PER_STACK 2.5
+#define PYROGEN_DAMAGE_PER_STACK 2
 /// Amount of ticks of fire removed when helped by another human to extinguish
 #define PYROGEN_ASSIST_REMOVAL_STRENGTH 2
 /// How fast the pyrogen moves when charging using fire charge

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -24,7 +24,7 @@
 	plasma_gain = 25
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 360
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -24,7 +24,7 @@
 	plasma_gain = 25
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 380
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_THRESHOLD

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -241,9 +241,6 @@
 	if(human_affected.soft_armor.getRating(FIRE) >= 100)
 		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
-	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
-	if(debuff)
-		debuff.add_stacks(PYROGEN_MELTING_FIRE_EFFECT_STACK, creator)
 	else
 		human_affected.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK, creator)
 	human_affected.take_overall_damage(PYROGEN_MELTING_FIRE_DAMAGE, BURN, FIRE, updating_health = TRUE, max_limbs = 2)

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -241,6 +241,9 @@
 	if(human_affected.soft_armor.getRating(FIRE) >= 100)
 		to_chat(human_affected, span_warning("You are untouched by the flames."))
 		return FALSE
+	var/datum/status_effect/stacking/melting_fire/debuff = human_affected.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
+	if(debuff)
+		debuff.add_stacks(PYROGEN_MELTING_FIRE_EFFECT_STACK, creator)
 	else
 		human_affected.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, PYROGEN_MELTING_FIRE_EFFECT_STACK, creator)
 	human_affected.take_overall_damage(PYROGEN_MELTING_FIRE_DAMAGE, BURN, FIRE, updating_health = TRUE, max_limbs = 2)


### PR DESCRIPTION
## About The Pull Request

Pyrogen HP 400 => 380.
Pyrogen damage per fire tick per fire stack 2.5 => 2.0.
20% DOT Reduction.

PRIOR To these changes, a Pyrogen fireball landing 1 tile beside a medium armour marine who stood still would deal **60 burn damage.**
AFTER these changes, a Pyrogen fireball landing 1 tile beside a medium armour marine who stood still would deal **50 burn damage.**

## Why It's Good For The Game

Pyrogen tends to significantly outperform spitter in ranged damage and area denial even when only relying on ranged abilities such as fireball and firestorm.
Pyrogen also has health, speed and armour superior to spitter.
Pyrogen also has superior melee utility and screech/gas follow up with inferno.

Pyrogen is generally just too stacked as a caste, especially in the risk to reward tradeoff. Reducing its health will force it to play safer or risky dying.

I specifically discussing in Walance with people who play pyrogen who preffered reduced health over increased cooldowns or decreased damage, which I think is fair.

After discussion with Kuro, we're keeping the health a bit higher but reducing the pyrogen fire stacks per fire action.

## Changelog

:cl:
balance: Pyrogen HP 400 => 380.
balance: Pyrogen damage per fire tick per fire stack 2.5 => 2.0.
/:cl:

## PR Testing
Shot pyrogen fireball beside human wearing medium armour before and after firestack change.
![image](https://github.com/user-attachments/assets/bcf5374b-6981-4638-83f6-c820aded1b83)
![image](https://github.com/user-attachments/assets/03b84bdd-3d93-4d62-8201-58f9336f69ed)

