### PR TITLE
Untied vehicle_collision from sound timer

### DIFF
--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -291,12 +291,12 @@
 	var/list/drivers = return_drivers()
 	if(length(drivers))
 		pilot = drivers[1]
+	A.vehicle_collision(src, get_dir(src, A), pilot)
 	if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_VEHICLE_CRUSHSOUND))
 		return
 	visible_message(span_danger("[src] rams [A]!"))
 	playsound(A, 'sound/effects/metal_crash.ogg', 45)
 	TIMER_COOLDOWN_START(src, COOLDOWN_VEHICLE_CRUSHSOUND, 1 SECONDS)
-	A.vehicle_collision(src, get_dir(src, A), pilot)
 
 /obj/vehicle/sealed/armored/auto_assign_occupant_flags(mob/new_occupant)
 	if(interior) //handled by interior seats


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/17856/commits/9921552976f98d30c1b312eca6ef0614fa594506 accidentally tied the vehicle_collision proc to the vehicle crush sound cooldown, which caused a multifold delay in crush speed (because only one tile would trigger damage and only at 1s intervals).

I simply moved the vehicle_collision proc before the early return to solve this.
## Why It's Good For The Game

Bugfix good.  APC was crushing objects and walls, in the worst case scenario, less than 1/3rd its original speed.  Tank was less affected, but still affected and this should help.
## Changelog
:cl:
fix: fixed vehicle collision damage trigger speed
/:cl:
