### PR TITLE
Removes hunter sneak attack stun, increases pounce stun duration

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -194,7 +194,6 @@
 	span_danger("We strike [target] with [flavour] precision!"))
 	target.adjust_stagger(staggerslow_stacks SECONDS)
 	target.add_slowdown(staggerslow_stacks)
-	target.ParalyzeNoChain(1 SECONDS)
 
 	cancel_stealth()
 
@@ -269,7 +268,7 @@
 // ***************************************
 #define HUNTER_POUNCE_RANGE 7 // in tiles
 #define XENO_POUNCE_SPEED 2
-#define XENO_POUNCE_STUN_DURATION 2 SECONDS
+#define XENO_POUNCE_STUN_DURATION 2.4 SECONDS
 #define XENO_POUNCE_STANDBY_DURATION 0.5 SECONDS
 #define XENO_POUNCE_SHIELD_STUN_DURATION 6 SECONDS
 


### PR DESCRIPTION

## About The Pull Request
Removes the 1-second stun from Hunter's sneak attack. As compensation, this buffs its pounce from 2.0 -> 2.4 seconds.

## Why It's Good For The Game

Sneak attack was originally re-added back to Hunter in response to the addition of aim mode (#8543). With aim mode now gone again, Hunter has become an incredibly frustrating caste to play against. If you get hit by a stealth attack you're often almost always guaranteed a fracture at a minimum due to the ability to chain the stealth attack stun into a pounce. With aim mode gone, there's often not a lot teammates can do to prevent this.

Moving some of the stun from the sneak attack into the pounce means that you'll have to actually choose between getting a stun off for some extra damage or using pounce as an escape tool, rather than getting both every single time. Adding 0.4 seconds to the pounce stun specifically allows the Hunter to get off 1 more slash.

It's worth noting that chaining the sneak attack into the pounce isn't something you have to aim, and after even a small amount of practice you can guarantee the chain-stun every single time via sprite-clicking a downed marine while they're still stunned.
## Changelog
:cl:
balance: The stun has been removed from Hunter's sneak attack. Hunter's pounce stun has been buffed from 2.0 -> 2.4 seconds.
/:cl:
