### PR TITLE
Offhand icon layers under other hud objects

### DIFF
--- a/code/datums/elements/riding.dm
+++ b/code/datums/elements/riding.dm
@@ -106,6 +106,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ITEM_ABSTRACT | DELONDROP | NOBLUDGEON
 	resistance_flags = INDESTRUCTIBLE | UNACIDABLE | PROJECTILE_IMMUNE
+	layer = BELOW_OBJ_LAYER
 	var/mob/living/carbon/rider
 	var/mob/living/parent
 	var/selfdeleting = FALSE

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -130,6 +130,7 @@
 	name = "offhand"
 	item_flags = DELONDROP|TWOHANDED|WIELDED
 	resistance_flags = RESIST_ALL
+	layer = BELOW_OBJ_LAYER
 
 /obj/item/weapon/twohanded/offhand/Destroy()
 	if(ismob(loc))


### PR DESCRIPTION

## About The Pull Request
What is says on the tin.
Wielding a gun with a large sprite now renders the gun over the offhand icon.
## Why It's Good For The Game
Looks better.
## Changelog
:cl:
qol: Large sprites in hand slots layer over offhand icons
/:cl:
