### PR TITLE
Handmade attachment points

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -118,6 +118,7 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 GLOBAL_LIST_INIT(plasteel_radial_images, list(
 	"folding" = image('icons/obj/structures/barricades/plasteel.dmi', icon_state = "plasteel_0"),
 	"normal" = image('icons/obj/structures/barricades/plasteel.dmi', icon_state = "new_plasteel_0"),
+	"hardpoint" = image('icons/obj/structures/prop/mainship.dmi', icon_state = "equip_base"),
 	))
 
 /obj/item/stack/sheet/plasteel
@@ -136,6 +137,7 @@ GLOBAL_LIST_INIT(plasteel_radial_images, list(
 GLOBAL_LIST_INIT(plasteel_recipes, list( \
 	new/datum/stack_recipe("folding plasteel barricade", /obj/structure/barricade/folding, 5, time = 8 SECONDS, crafting_flags = CRAFT_CHECK_DIRECTION | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_PLASTEEL), \
 	new/datum/stack_recipe("plasteel barricade", /obj/structure/barricade/solid/plasteel, 3, time = 8 SECONDS, crafting_flags = CRAFT_CHECK_DIRECTION | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_PLASTEEL), \
+	new/datum/stack_recipe("hardpoint", /obj/effect/attach_point/crew_weapon/handmade, 30, time = 20 SECONDS, crafting_flags = CRAFT_ONE_PER_TURF | CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_EXPERT), \
 ))
 
 /obj/item/stack/sheet/plasteel/select_radial(mob/user)
@@ -153,6 +155,8 @@ GLOBAL_LIST_INIT(plasteel_recipes, list( \
 			create_object(user, new/datum/stack_recipe("folding plasteel barricade", /obj/structure/barricade/folding, 5, time = 8 SECONDS, crafting_flags = CRAFT_CHECK_DIRECTION | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_PLASTEEL), 1)
 		if("normal")
 			create_object(user, new/datum/stack_recipe("plasteel barricade", /obj/structure/barricade/solid/plasteel, 3, time = 8 SECONDS, crafting_flags = CRAFT_CHECK_DIRECTION | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_PLASTEEL), 1)
+		if("hardpoint")
+			create_object(user, new/datum/stack_recipe("hardpoint", /obj/effect/attach_point/crew_weapon/handmade, 30, time = 20 SECONDS, crafting_flags = CRAFT_ONE_PER_TURF | CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND, skill_req = SKILL_CONSTRUCTION_EXPERT), 1)
 
 	return FALSE
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -110,6 +110,10 @@
 	layer = RUNE_LAYER //Keeps xenos from hiding under them
 	plane = FLOOR_PLANE //Doesn't layer under weeds unless it has this
 
+/obj/effect/attach_point/crew_weapon/handmade
+	name = "handcrafted attach point"
+	resistance_flags = PROJECTILE_IMMUNE | PLASMACUTTER_IMMUNE
+
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = SHUTTLE_ALAMO
 


### PR DESCRIPTION
## About The Pull Request

Lets people build dropship "hardpoints" to deploy the associated weapons wherever walls can be built. Still requires powerlifters, ammunition, as well as the modules themselves to utilize. Can be destroyed by xeno's acid.

## Why It's Good For The Game

Let's people utilize more equipment, foreseeable use case could be SD holds where the the spare Machinegun deployment system has been left to gather dust. The Tad's relocation on PoS has made hangar holds not feasible, which is very sad in my opinion.

Used the Reinforced walls as a baseline cost for this (30 plasteel), specifics can be whatever walance determines it to be, just let me know.

## Changelog

:cl:
add: Dropship hardpoints can be built, off dropships
/:cl:
