### PR TITLE
Don't run CI on pushed commits (while keeping pull requests)

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -1,11 +1,5 @@
 name: CI Suite
 on:
-  push:
-    branches:
-    - master
-    - 'project/**'
-    - 'gh-readonly-queue/master/**'
-    - 'gh-readonly-queue/project/**'
   pull_request:
     branches:
     - master


### PR DESCRIPTION
Significantly lowers the CI usage of this repository by not running the tests on every single commit--it will still run on PRs