### PR TITLE
Health analyzer: fixes Tramadol advice popping out in nanite users

### DIFF
--- a/code/datums/health_scan/advice/traumatic_shock.dm
+++ b/code/datums/health_scan/advice/traumatic_shock.dm
@@ -3,7 +3,9 @@
 	priority = ADVICE_PRIORITY_SHOCK
 
 /datum/scanner_advice/traumatic_shock/can_show(mob/living/carbon/human/patient, mob/user)
-	if(patient.traumatic_shock > 40 && !patient.reagents.has_reagent(/datum/reagent/medicine/paracetamol) && !patient.reagents.has_reagent(/datum/reagent/medicine/tramadol))
+	if(patient.reagents.has_reagent(/datum/reagent/medicalnanites) || patient.reagents.has_reagent(/datum/reagent/medicine/paracetamol))
+		return FALSE
+	if(patient.traumatic_shock > 40 && !patient.reagents.has_reagent(/datum/reagent/medicine/tramadol))
 		return TRUE
 
 /datum/scanner_advice/traumatic_shock/get_data(mob/living/carbon/human/patient, mob/user)


### PR DESCRIPTION
## About The Pull Request
Tramadol advice will no longer pop out if you are a nanite user, since it gets purged by nanites and only gives you your mega pain reduction for 3-6 Life ticks anyway

Also, it was hidden with nanites in the old system
## Changelog
:cl:
fix: Fixed Tramadol advice showing for people with nanites in their system
/:cl:
