### PR TITLE
Reduces hunter leap range to 3 tiles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -267,7 +267,7 @@
 // ***************************************
 // *********** Hunter's Pounce
 // ***************************************
-#define HUNTER_POUNCE_RANGE 7 // in tiles
+#define HUNTER_POUNCE_RANGE 3 // in tiles
 #define XENO_POUNCE_SPEED 2
 #define XENO_POUNCE_STUN_DURATION 2 SECONDS
 #define XENO_POUNCE_STANDBY_DURATION 0.5 SECONDS


### PR DESCRIPTION

## About The Pull Request
Reduces the hunter's leap range from 7 to 3. Meant to be an alternative to #17882.
## Why It's Good For The Game
7 tiles is a ridiculous amount of range, and is being used to let hunter's effectively teleport off-screen the moment any kind of threat appears. Reducing it to 3 tiles will still let it be used as an escape tool, without it being a "get-out-of-jail free card"
## Changelog
:cl:
balance: Reduced Hunter's leap range from 7 (tiles) to 3
/:cl:
