### PR TITLE
Powercreeps Freyr (Flash Protection), fixes permanent Freyr buff on helmets.

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -721,20 +721,27 @@
 
 /obj/item/armor_module/module/binoculars/artemis_mark_two // a little cheating with subtypes
 	name = "\improper Freyr Mk.2 visual assistance helmet system"
-	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, allowing them to see clearly even in the harshest of circumstances. This version is enhanced and allows the marine to peer through the visor, akin to binoculars."
+	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, preventing blur and protecting against harsh flashes. This version is enhanced and allows the marine to peer through the visor, akin to binoculars."
 	icon_state = "artemis_head"
 	worn_icon_state = "artemis_head_mk2_a"
+	var/eye_protection_mod = 1
 
 /obj/item/armor_module/module/binoculars/artemis_mark_two/on_attach(obj/item/attaching_to, mob/user)
 	. = ..()
 	parent.AddComponent(/datum/component/blur_protection)
+	parent.eye_protection += eye_protection_mod
+
+/obj/item/armor_module/module/binoculars/artemis_mark_two/on_detach(obj/item/detaching_from, mob/user)
+	parent.remove_component(/datum/component/blur_protection)
+	parent.eye_protection -= eye_protection_mod
 
 /obj/item/armor_module/module/artemis
 	name = "\improper Freyr Mk.1 visual assistance helmet system"
-	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, allowing them to see clearly even in the harshest of circumstances."
+	desc = "Designed for mounting on a modular helmet. The Freyr module is designed with an overlay visor that clarifies the user's vision, preventing blur and protecting against harsh flashes."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "artemis_head"
 	worn_icon_state = "artemis_head_a"
+	var/eye_protection_mod = 1
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	attach_features_flags = ATTACH_REMOVABLE|ATTACH_APPLY_ON_MOB
 	prefered_slot = SLOT_HEAD
@@ -742,6 +749,11 @@
 /obj/item/armor_module/module/artemis/on_attach(obj/item/attaching_to, mob/user)
 	. = ..()
 	parent.AddComponent(/datum/component/blur_protection)
+	parent.eye_protection += eye_protection_mod
+
+/obj/item/armor_module/module/artemis/on_detach(obj/item/detaching_from, mob/user)
+	parent.remove_component(/datum/component/blur_protection)
+	parent.eye_protection -= eye_protection_mod
 
 #define COMMS_OFF 0
 #define COMMS_SETTING 1


### PR DESCRIPTION

## About The Pull Request

*hits blunt*

Freyr module previously added blur protection permanently, even if module was fixed, this is rectified.
There's a lot of confusion about what the module does, many people don't think it's worth it.  I updated the description to specify exactly what it does.
There's also now a flash protection akin to the aviator sunglasses.


## Why It's Good For The Game

Freyr's currently a very narrow module who's description confuses people on its exact use. Updating the description and giving it one additional protection (against a source that's mostly caused by friendly-fire, and already had some other apparel that gave the same protection) gives it a more defined use case.

## Changelog

:cl:
add: The Freyr Modules (Mk. 1 and 2) now provide flash protection. 
fix: Freyr Module buffs now remove themselves when the module is removed.
/:cl:
