### PR TITLE
Dragon / King Population Locks

### DIFF
--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -1,3 +1,1 @@
 GLOBAL_VAR_INIT(master_mode, "Nuclear War")
-
-GLOBAL_VAR(roundstart_players)

--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -1,1 +1,3 @@
 GLOBAL_VAR_INIT(master_mode, "Nuclear War")
+
+GLOBAL_VAR(roundstart_players)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -113,7 +113,6 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	// Determine roundstart player count, used for population locks.
 	GLOB.roundstart_players = length(GLOB.clients)
 	to_chat(world, "Round initialized with a Population of [GLOB.roundstart_players]")
-	game_log("Round initialized with a Population of [GLOB.roundstart_players]")
 
 	for(var/datum/job/job AS in valid_job_types)
 		job = SSjob.GetJobType(job)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -114,8 +114,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 
 	// Determine roundstart player count, used for population locks.
 	SSticker.mode.roundstart_players = length(GLOB.clients)
-	to_chat(world, "Round initialized with a Population of [GLOB.roundstart_players]")
-	SSblackbox.record_feedback("text", "initial_players", 1, GLOB.roundstart_players)
+	to_chat(world, "Round initialized with a Population of [SSticker.mode.roundstart_players]")
+	SSblackbox.record_feedback("text", "initial_players", 1, SSticker.mode.roundstart_players)
 	for(var/datum/job/job AS in valid_job_types)
 		job = SSjob.GetJobType(job)
 		if(!job) //dunno how or why but it errored in ci and i couldnt reproduce on local

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -73,6 +73,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///if fun tads are enabled by default
 	var/enable_fun_tads = FALSE
 
+	var/roundstart_players = 0
+
 
 /datum/game_mode/New()
 	initialize_emergency_calls()
@@ -111,9 +113,9 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 		L.after_round_start()
 
 	// Determine roundstart player count, used for population locks.
-	GLOB.roundstart_players = length(GLOB.clients)
+	SSticker.mode.roundstart_players = length(GLOB.clients)
 	to_chat(world, "Round initialized with a Population of [GLOB.roundstart_players]")
-
+	SSblackbox.record_feedback("text", "initial_players", 1, GLOB.roundstart_players)
 	for(var/datum/job/job AS in valid_job_types)
 		job = SSjob.GetJobType(job)
 		if(!job) //dunno how or why but it errored in ci and i couldnt reproduce on local

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -113,6 +113,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	// Determine roundstart player count, used for population locks.
 	GLOB.roundstart_players = length(GLOB.clients)
 	to_chat(world, "Round initialized with a Population of [GLOB.roundstart_players]")
+	game_log("Round initialized with a Population of [GLOB.roundstart_players]")
 
 	for(var/datum/job/job AS in valid_job_types)
 		job = SSjob.GetJobType(job)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -110,6 +110,10 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 		GLOB.landmarks_round_start.len--
 		L.after_round_start()
 
+	// Determine roundstart player count, used for population locks.
+	GLOB.roundstart_players = length(GLOB.clients)
+	to_chat(world, "Round initialized with a Population of [GLOB.roundstart_players]")
+
 	for(var/datum/job/job AS in valid_job_types)
 		job = SSjob.GetJobType(job)
 		if(!job) //dunno how or why but it errored in ci and i couldnt reproduce on local

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
@@ -28,8 +28,9 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 13
+	evolve_min_xenos = 12
 	death_evolution_delay = 15 MINUTES
+	evolve_population_lock = 50 // Tank
 
 	// *** Flags *** //
 	caste_flags = CASTE_FIRE_IMMUNE|CASTE_IS_INTELLIGENT|CASTE_INSTANT_EVOLUTION|CASTE_LEADER_TYPE

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
@@ -28,7 +28,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 12
+	evolve_min_xenos = 8
 	death_evolution_delay = 15 MINUTES
 	evolve_population_lock = 50 // Tank
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -29,7 +29,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 10
+	evolve_min_xenos = 8
 	death_evolution_delay = 7 MINUTES
 	evolve_population_lock = 40 // Mech
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -29,8 +29,9 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 12
+	evolve_min_xenos = 10
 	death_evolution_delay = 7 MINUTES
+	evolve_population_lock = 40 // Mech
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_STAGGER_RESISTANT|CASTE_LEADER_TYPE|CASTE_INSTANT_EVOLUTION|CASTE_HAS_WOUND_MASK

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -312,12 +312,8 @@
 
 	var/population_lock = new_caste.evolve_population_lock
 	if(population_lock > GLOB.roundstart_players)
-		balloon_alert(src, "[population_lock] Minds are required to evolve [initial(new_caste.display_name)]")
-		to_chat(src, "[population_lock] Minds are required to evolve [initial(new_caste.display_name)]")
-		to_chat(src, "Population check failed")
+		balloon_alert(src, "[population_lock] Initial Players are required to evolve [initial(new_caste.display_name)]")
 		return FALSE
-	else
-		to_chat(src, "Population check passed")
 
 	var/min_xenos = new_caste.evolve_min_xenos
 	if(min_xenos && (hive.total_xenos_for_evolving() < min_xenos))

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -310,6 +310,15 @@
 			to_chat(src, span_warning("[get_exp_format(xenojob.required_playtime_remaining(client))] as [xenojob.get_exp_req_type()] required to play queen like roles."))
 			return FALSE
 
+	var/population_lock = new_caste.evolve_population_lock
+	if(population_lock > GLOB.roundstart_players)
+		balloon_alert(src, "[population_lock] Minds are required to evolve [initial(new_caste.display_name)]")
+		to_chat(src, "[population_lock] Minds are required to evolve [initial(new_caste.display_name)]")
+		to_chat(src, "Population check failed")
+		return FALSE
+	else
+		to_chat(src, "Population check passed")
+
 	var/min_xenos = new_caste.evolve_min_xenos
 	if(min_xenos && (hive.total_xenos_for_evolving() < min_xenos))
 		balloon_alert(src, "[min_xenos] xenos needed to become a [initial(new_caste.display_name)]")

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -311,7 +311,7 @@
 			return FALSE
 
 	var/population_lock = new_caste.evolve_population_lock
-	if(population_lock > GLOB.roundstart_players)
+	if(population_lock > SSticker.mode.roundstart_players)
 		balloon_alert(src, "[population_lock] Initial Players are required to evolve [initial(new_caste.display_name)]")
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -68,6 +68,12 @@
 	var/evolution_threshold = 0
 	///Threshold amount of upgrade points to next maturity
 	var/upgrade_threshold = 0
+	// The amount of xenos that must be alive in the hive for this caste to be able to evolve
+	var/evolve_min_xenos = 0
+	// Starting Population lock, equivalent to assault crewman availability.
+	var/evolve_population_lock = 0
+	// How many of this caste may be alive at once
+	var/maximum_active_caste = INFINITY
 
 	///Singular type path for the caste to deevolve to when forced to by the queen.
 	var/deevolves_to
@@ -206,10 +212,6 @@
 	var/vent_exit_speed = XENO_DEFAULT_VENT_EXIT_TIME
 	///Whether the caste enters and crawls through vents silently
 	var/silent_vent_crawl = FALSE
-	// The amount of xenos that must be alive in the hive for this caste to be able to evolve
-	var/evolve_min_xenos = 0
-	// How many of this caste may be alive at once
-	var/maximum_active_caste = INFINITY
 	// Accuracy malus, 0 by default. Should NOT go over 70.
 	var/accuracy_malus = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Designed to mirror the Tank / Mech roundstart players checks.

Dragon requires a roundstart population of 50.
King requires a roundstart population of 40.

Xenos requirements reduced to alleviate the case of lobby sitters enabling tank but blocking Dragon / King.

Dragon xenos requirement 13 => 8.
King xenos requirement 12 => 8.

For code reviewers, the var/evolve_min_xenos and var/maximum_active_caste were not located in the section of xeno_defines.dm where the other evolution variables were which was annoying so I moved them.

## Why It's Good For The Game

Parity between sides for better balanced rounds.

With lots of lobby sitters, Marines get access to Tank but Xeno numbers may never reach dragon, Favouring Marines.
With plenty of midround joiners, Marines have no Tank but Xenos reach dragon, Favouring Xenos.

![image](https://github.com/user-attachments/assets/d5d64492-969d-4515-8673-4e989561be5d)
![image](https://github.com/user-attachments/assets/9d06b94e-1b99-4cdb-bdb2-5e50ac0e3999)

![image](https://github.com/user-attachments/assets/5fc80cb5-a4fc-40c9-83cd-f3d20c5cbde2)
_True and real._


## PR Testing

Can we keep the testing functions in for the TM period?
I'd also like to keep the part where it tells all players what population the round initialized with on roundstart.

![image](https://github.com/user-attachments/assets/02af9041-1663-46ec-98d5-d860cafb2095)
![image](https://github.com/user-attachments/assets/0072fdbe-479d-46df-8b78-7308e868a117)
![image](https://github.com/user-attachments/assets/90f03db8-2124-4c9e-89a6-aee9a9115f11)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->


:cl:
add: Roundstart population value provided to all players when the round starts.
balance: Dragon locked to 50 roundstart population, King to 40.
balance: Dragon xenos evolution requirement 13 => 8, King xenos evolution requirement 12 => 8.
/:cl:
