### PR TITLE
Reduces Crash Xeno Respawn Rate to counter ultra aggressive hunter / runner spam.

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -39,7 +39,7 @@
 	// Round start info
 	var/starting_squad = "Alpha"
 	///How long between two larva check
-	var/larva_check_interval = 4 MINUTES
+	var/larva_check_interval = 5 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 	bioscan_interval = 0

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -39,7 +39,7 @@
 	// Round start info
 	var/starting_squad = "Alpha"
 	///How long between two larva check
-	var/larva_check_interval = 2 MINUTES
+	var/larva_check_interval = 4 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 	bioscan_interval = 0


### PR DESCRIPTION
## About The Pull Request

**Average xenos respawn time on crash 1 minute => 2.5 minutes.**

On Crash, Xenos receive a larva check every X minutes, if the ratio of xenos to marines is below ideal another xeno is spawned.
If xenos are already at the ratio, nothing happens.

Keep in mind this is averages, the check happens in response to global time, it is possible for a xeno to die and have a check happen 5 seconds or X minutes minus 5 seconds, producing another larva.

This changes the X from 2 => 5, significantly reducing the Average respawn rate of Xenos on crash.

## Why It's Good For The Game

Killing xenos on crash has become relatively pointless, as on average a dead xeno respawns a new larva within a minute (on average with a single death).
This incentivizes xenos to play extremely aggressively on crash as deaths are FAR less penalized than on nuclear war.
Designed to counter ultra aggressive hunter / runner spam.

Absolute slop of xeno wave tactics because their deaths are meaningless.
![image](https://github.com/user-attachments/assets/4fce6d8c-44d8-4261-8536-7700341ded02)


## Changelog

:cl:
balance: Average xenos respawn time on crash 1 minute => 2.5 minutes.
/:cl: