### PR TITLE
Missing NPC hazards

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -871,6 +871,7 @@
 /obj/effect/temp_visual/dragon/warning/Initialize(mapload, _duration)
 	if(isnum(_duration))
 		duration = _duration
+	notify_ai_hazard()
 	return ..()
 
 /obj/effect/temp_visual/dragon/directional

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -353,6 +353,7 @@
 
 /obj/effect/ebeam/zeroform/Initialize(mapload)
 	. = ..()
+	notify_ai_hazard()
 	alpha = 0
 	animate(src, alpha = 255, time = ZEROFORM_CHARGE_TIME)
 


### PR DESCRIPTION

## About The Pull Request
Added a couple of missing hazards - dragon warning thingos, and king murderbeam.
## Why It's Good For The Game
Standing in death beam is bad.
## Changelog
:cl:
add: Added a few more hazards for NPCs to look out for
/:cl:
