### PR TITLE
NPC movement improvements

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(ai_instances_active)
 //To be implemented in later updates
 GLOBAL_LIST_EMPTY(nodes_with_enemies)
 GLOBAL_LIST_EMPTY(nodes_with_construction)
-#define can_cross_lava_turf(turf_to_check) (!islava(turf_to_check) || locate(/obj/structure/catwalk) in turf_to_check) //todo: this needs work
+#define can_cross_lava_turf(turf_to_check) (!islava(turf_to_check) || turf_to_check.is_covered())
 
 ///Obstacle needs attacking
 #define AI_OBSTACLE_ATTACK "ai_obstacle_attack"

--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -416,6 +416,7 @@
 #define COMSIG_TURF_RESUME_PROJECTILE_MOVE "resume_projetile"
 #define COMSIG_TURF_PROJECTILE_MANIPULATED "projectile_manipulated"
 #define COMSIG_TURF_CHECK_COVERED "turf_check_covered" //from /turf/open/liquid/Entered checking if something is covering the turf
+	#define TURF_COVERED (1<<0) //Something is covering it, like a catwalk
 #define COMSIG_TURF_TELEPORT_CHECK "turf_teleport_check" //from /turf/proc/can_teleport_here()
 #define COMSIG_TURF_SUBMERGE_CHECK "turf_submerge_check" //from /turf/proc/get_submerge_height() checking if something on the turf should submerge an AM
 ///from base of /datum/turf_reservation/proc/Release: (datum/turf_reservation/reservation)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -46,6 +46,8 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 
 #define isrwallturf(A) (istype(A, /turf/closed/wall/r_wall))
 
+#define isresinwall(A) (istype(A, /turf/closed/wall/resin))
+
 #define ismineralturf(A) (istype(A, /turf/closed/mineral))
 
 #define istransparentturf(A) (HAS_TRAIT(A, TURF_Z_TRANSPARENT_TRAIT))

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -1637,7 +1637,7 @@ GLOBAL_LIST_EMPTY(submerge_filter_timer_list)
 ///returns that src is covering its turf. Used to prevent turf interactions such as water
 /atom/movable/proc/turf_cover_check(atom/movable/source)
 	SIGNAL_HANDLER
-	return TRUE
+	return TURF_COVERED
 
 ///Wrapper for setting the submerge trait. This trait should ALWAYS be set via this proc so we can listen for the trait removal in all cases
 /atom/movable/proc/add_nosubmerge_trait(trait_source = TRAIT_GENERIC)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -85,7 +85,7 @@
 
 ///Builds a catwalk
 /obj/item/stack/rods/proc/place_catwalk(turf/target_turf, mob/living/user)
-	if(SEND_SIGNAL(target_turf, COMSIG_TURF_CHECK_COVERED))
+	if(target_turf.is_covered())
 		user.balloon_alert(user, "Already covered!")
 		return
 	if(amount < CATWALK_ROD_REQ)
@@ -94,7 +94,7 @@
 	user.balloon_alert(user, "Building")
 	if(!do_after(user, 5 SECONDS, NONE, src, BUSY_ICON_BUILD))
 		return
-	if(SEND_SIGNAL(target_turf, COMSIG_TURF_CHECK_COVERED))
+	if(target_turf.is_covered())
 		user.balloon_alert(user, "Already covered!")
 		return
 	if(!use(CATWALK_ROD_REQ))

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -34,14 +34,14 @@
 
 /turf/open/liquid/get_submerge_height(turf_only = FALSE)
 	. = ..()
-	if(SEND_SIGNAL(src, COMSIG_TURF_CHECK_COVERED))
+	if(is_covered())
 		return
 	if(length(canSmoothWith) && !CHECK_MULTIPLE_BITFIELDS(smoothing_junction, (SOUTH_JUNCTION|EAST_JUNCTION|WEST_JUNCTION)))
 		return
 	. += mob_liquid_height
 
 /turf/open/liquid/get_submerge_depth()
-	if(SEND_SIGNAL(src, COMSIG_TURF_CHECK_COVERED))
+	if(is_covered())
 		return 0
 	if(length(canSmoothWith) && !CHECK_MULTIPLE_BITFIELDS(smoothing_junction, (SOUTH_JUNCTION|EAST_JUNCTION|WEST_JUNCTION)))
 		return 0
@@ -57,7 +57,7 @@
 
 ///Returns TRUE if the AM is actually in the liquid instead of above it
 /turf/open/liquid/proc/check_submerge(atom/movable/submergee)
-	if(SEND_SIGNAL(src, COMSIG_TURF_CHECK_COVERED))
+	if(is_covered())
 		return FALSE
 	if(submergee.throwing)
 		return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1038,3 +1038,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 ///Returns the number that shows how far an AM is offset when submerged in this turf
 /turf/proc/get_submerge_depth()
 	return 0
+
+///Checks if the turf is covered by something, like a catwalk
+/turf/proc/is_covered()
+	if(SEND_SIGNAL(src, COMSIG_TURF_CHECK_COVERED) & TURF_COVERED)
+		return TRUE
+	return FALSE

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -376,7 +376,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	if(new_loc?.atom_flags & AI_BLOCKED)
 		move_dir = pick(LeftAndRightOfDir(move_dir))
 		new_loc = get_step(mob_parent, move_dir)
-		if(new_loc?.atom_flags & AI_BLOCKED)
+		if(new_loc?.atom_flags & AI_BLOCKED || !can_cross_lava_turf(new_loc))
 			return
 	if(!mob_parent.Move(new_loc, move_dir))
 		if(!(SEND_SIGNAL(mob_parent, COMSIG_OBSTRUCTED_MOVE, move_dir) & COMSIG_OBSTACLE_DEALT_WITH) && try_sidestep)

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -352,6 +352,8 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	if(current_action == MOVING_TO_ATOM && (atom_to_walk_to == combat_target))
 		max_range = upper_engage_dist
 		min_range = lower_engage_dist
+	//An actual accurate angle, unlike get_dir
+	var/dir_to_target = angle2dir(Get_Angle(get_turf(mob_parent), get_turf(atom_to_walk_to)))
 	var/list/dir_options = list()
 
 	if((dist_to_target >= min_range) && (dist_to_target <= max_range)) //in optimal range
@@ -362,11 +364,11 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		if(prob(50)) //placeholder number, will probs be a var like sidestep prob, so they're not just constantly wiggling about
 			return
 		if(prob(sidestep_prob)) //shuffle about
-			dir_options += LeftAndRightOfDir(get_dir(mob_parent, atom_to_walk_to))
+			dir_options += LeftAndRightOfDir(dir_to_target)
 	if(dist_to_target > min_range) //above min range, its valid to come closer
-		dir_options += get_dir(mob_parent, atom_to_walk_to)
+		dir_options += dir_to_target
 	if(dist_to_target < max_range) //less than max range, its valid to walk away
-		dir_options += get_dir(atom_to_walk_to, mob_parent)
+		dir_options += REVERSE_DIR(dir_to_target)
 
 	return dir_options
 

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -361,7 +361,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 			return
 		if(!get_dir(mob_parent, atom_to_walk_to)) //We're right on top, move out of it
 			return CARDINAL_ALL_DIRS
-		if(prob(50)) //placeholder number, will probs be a var like sidestep prob, so they're not just constantly wiggling about
+		if(prob(atom_to_walk_to == escorted_atom ? 80 : 50)) //If we're holding around an escort target, we don't move too much
 			return
 		if(prob(sidestep_prob)) //shuffle about
 			dir_options += LeftAndRightOfDir(dir_to_target)

--- a/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
@@ -37,7 +37,12 @@
 				continue
 			if(turf_option.is_covered())
 				continue
-			exclude_dirs += dir_option
+			exclude_dirs |= dir_option
+
+		dir_options -= exclude_dirs
+		if(!length(dir_options))
+			return NONE //if we're NOT in lava, we do not deliberately path into lava
+			//todo: Need to have NPC path around lava entirely (or jump over it), if their direct path is into lava
 
 	//hazards
 	for(var/atom/movable/thing AS in hazard_list)

--- a/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
@@ -26,6 +26,20 @@
 	var/list/dir_options = .
 	dir_options = dir_options.Copy()
 	var/list/exclude_dirs = list()
+
+	var/turf/owner_turf = get_turf(mob_parent)
+
+	//lava
+	if(can_cross_lava_turf(owner_turf)) //if we're already in lava, we skip these checks since we're probs gonna have to walk through more to get out
+		for(var/dir_option in dir_options)
+			var/turf/turf_option = get_step(owner_turf, dir_option)
+			if(!islava(turf_option))
+				continue
+			if(turf_option.is_covered())
+				continue
+			exclude_dirs += dir_option
+
+	//hazards
 	for(var/atom/movable/thing AS in hazard_list)
 		var/dist = get_dist(mob_parent, thing)
 		if(dist > hazard_list[thing] + 1)


### PR DESCRIPTION

## About The Pull Request
NPC's are significantly less likely to walk into lava, unless they have no other choice.

NPC's more accurately path towards a target (the direction to target provided by get_dir is quite often not the closest dir you'd expect).

NPC's mill about less, when escorting another atom. i.e. following a friendly mob, and within the desired range, they will be far more likely to just  hold still.

The lava fix isn't perfect, as they will at times get stuck (similar to being stuck behind a wall), but thats generally  better than suicide, and in the future I should be able to setup a pathing system so it can find a way out when stuck.
## Why It's Good For The Game
More sensible pathing, less tweaking out, less lava suicide.
## Changelog
:cl:
qol: NPC's move around far less, when escorting someone
fix: NPC's path more accurately towards their target
fix: NPC's will generally avoid going into lava unless they have no choice
/:cl:
