### PR TITLE
Friendly obstacle avoidance improvement for NPCs

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -83,6 +83,8 @@ GLOBAL_LIST_EMPTY(nodes_with_construction)
 #define AI_OBSTACLE_ATTACK "ai_obstacle_attack"
 ///Obstacle can be jumped
 #define AI_OBSTACLE_JUMP "ai_obstacle_jump"
+///Obstacle can't be resolved, and is friendly so shouldn't be destroyed
+#define AI_OBSTACLE_FRIENDLY "ai_obstacle_friendly"
 ///Obstacle has already been handled
 #define AI_OBSTACLE_RESOLVED "ai_obstacle_resolved"
 

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -178,7 +178,7 @@
 	if(user.can_jump() && is_jumpable(user))
 		return AI_OBSTACLE_JUMP
 	if(faction == user.faction) //don't break our shit
-		return AI_OBSTACLE_RESOLVED //not sure if I need something new here
+		return AI_OBSTACLE_FRIENDLY
 	if(!(resistance_flags & INDESTRUCTIBLE) && (obj_flags & CAN_BE_HIT))
 		return AI_OBSTACLE_ATTACK
 

--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -210,6 +210,10 @@
 		if(!object.density)
 			continue
 		var/obstacle_reaction = object.ai_handle_obstacle(mob_parent, direction)
+		if(!obstacle_reaction)
+			return
+		if(obstacle_reaction == AI_OBSTACLE_FRIENDLY)
+			return
 		if(obstacle_reaction == AI_OBSTACLE_RESOLVED)
 			return COMSIG_OBSTACLE_DEALT_WITH //we've dealt with it on the obstacle side
 		if(obstacle_reaction == AI_OBSTACLE_JUMP)


### PR DESCRIPTION

## About The Pull Request
NPC's are much better at pathing around friendly obstacles (i.e. barbed cades, friendly mechs), or indestructable ones.
## Why It's Good For The Game
Less getting stuck.
## Changelog
:cl:
fix: Improved NPC obstacles avoidance for friendly and indestructable obstacles
/:cl:
