### PR TITLE
NPC resist fixes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -555,6 +555,8 @@
 	if(!do_after(debuff_owner, 5 SECONDS, NONE, debuff_owner, BUSY_ICON_GENERIC))
 		debuff_owner?.balloon_alert(debuff_owner, "Interrupted")
 		return
+	if(QDELETED(src))
+		return
 	playsound(debuff_owner, 'sound/effects/slosh.ogg', 30)
 	debuff_owner.balloon_alert(debuff_owner, "Succeeded")
 	stacks -= SENTINEL_INTOXICATED_RESIST_REDUCTION

--- a/code/modules/ai/ai_behaviors/human_mobs/healing.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/healing.dm
@@ -116,14 +116,6 @@
 	UnregisterSignal(old_patient, COMSIG_AI_HEALING_MOB)
 	heal_list -= old_patient
 
-///Returns true if the mob is on fire
-/mob/living/proc/is_on_fire()
-	if(on_fire) //todo: someone please make normal fire a status effect
-		return TRUE
-	if(has_status_effect(STATUS_EFFECT_MELTING_FIRE))
-		return TRUE
-	return FALSE
-
 ///Tries healing themselves
 /datum/ai_behavior/human/proc/try_heal()
 	var/mob/living/living_parent = mob_parent

--- a/code/modules/ai/ai_behaviors/human_mobs/healing.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/healing.dm
@@ -116,13 +116,21 @@
 	UnregisterSignal(old_patient, COMSIG_AI_HEALING_MOB)
 	heal_list -= old_patient
 
+///Returns true if the mob is on fire
+/mob/living/proc/is_on_fire()
+	if(on_fire) //todo: someone please make normal fire a status effect
+		return TRUE
+	if(has_status_effect(STATUS_EFFECT_MELTING_FIRE))
+		return TRUE
+	return FALSE
+
 ///Tries healing themselves
 /datum/ai_behavior/human/proc/try_heal()
 	var/mob/living/living_parent = mob_parent
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_AI_NEED_HEAL, mob_parent)
 
 	var/turf/owner_turf = get_turf(mob_parent)
-	if(living_parent.on_fire && can_cross_lava_turf(owner_turf) && check_hazards())
+	if((living_parent.is_on_fire() || living_parent.has_status_effect(STATUS_EFFECT_INTOXICATED)) && can_cross_lava_turf(owner_turf) && check_hazards())
 		living_parent.do_resist()
 		return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,6 +151,14 @@
 	update_fire()
 	UnregisterSignal(src, COMSIG_LIVING_DO_RESIST)
 
+///Returns true if the mob is on fire
+/mob/living/proc/is_on_fire()
+	if(on_fire) //todo: someone please make normal fire a status effect
+		return TRUE
+	if(has_status_effect(STATUS_EFFECT_MELTING_FIRE))
+		return TRUE
+	return FALSE
+
 ///Updates fire visuals
 /mob/living/proc/update_fire()
 	return


### PR DESCRIPTION

## About The Pull Request
NPC's will actually try resist out of melting fire and intoxication.

Fixed a runtime in intoxication where it runs out mid resist channel.
## Why It's Good For The Game
NPC melting to death bad.
## Changelog
:cl:
fix: fixed NPC's not putting out melting fire and intoxication
/:cl:
