### PR TITLE
Increase the telegraph timer for harmful weather

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -3,7 +3,7 @@
 	name = "acid rain"
 	desc = "The planet's thunderstorms are by nature acidic, and will incinerate anyone standing beneath them without protection."
 
-	telegraph_duration = 400
+	telegraph_duration = 600
 	telegraph_message = span_userdanger("Thunder rumbles far above. You hear acidic droplets hissing against the canopy. Seek shelter!")
 	telegraph_overlay = "rain_med"
 	telegraph_sound = 'sound/effects/siren.ogg'
@@ -60,6 +60,7 @@
 /datum/weather/acid_rain/harmless
 	target_trait = ZTRAIT_RAIN
 
+	telegraph_duration = 400
 	telegraph_message = span_danger("Thunder rumbles far above. You hear droplets drumming against the canopy.")
 	telegraph_overlay = "rain_med"
 	telegraph_sound = null

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -4,7 +4,7 @@
 	desc = "An intense atmospheric storm lifts ash off of the planet's surface and billows it down across the area, dealing intense fire damage to the unprotected."
 
 	telegraph_message = span_userdanger("An eerie moan rises on the wind. Sheets of burning ash blacken the horizon. Seek shelter.")
-	telegraph_duration = 300
+	telegraph_duration = 600
 	telegraph_overlay = "light_ash"
 
 	weather_message = span_userdanger("<i>Smoldering clouds of scorching ash billow down around you! Get inside!</i>")
@@ -83,6 +83,7 @@
 	name = "emberfall"
 	desc = "A passing ash storm blankets the area in harmless embers."
 
+	telegraph_duration = 300
 	telegraph_message = span_danger("An eerie moan rises on the wind. Sheets of burning ash blacken the horizon.")
 
 	weather_message = span_notice("Gentle embers waft down around you like grotesque snow. The storm seems to have passed you by...")

--- a/code/datums/weather/weather_types/sand_storm.dm
+++ b/code/datums/weather/weather_types/sand_storm.dm
@@ -2,7 +2,7 @@
 /datum/weather/ash_storm/sand
 	name = "severe sandstorm"
 	telegraph_message = span_userdanger("You see a dust cloud rising over the horizon. That can't be good...")
-	telegraph_duration = 300
+	telegraph_duration = 600
 	telegraph_overlay = "dust_med"
 	telegraph_sound = 'sound/effects/siren.ogg'
 
@@ -34,6 +34,7 @@
 	name = "Sandfall"
 	desc = "A passing sandstorm blankets the area in sand."
 
+	telegraph_duration = 300
 	telegraph_message = span_danger("The wind begins to intensify, blowing sand up from the ground...")
 	telegraph_overlay = "dust_low"
 	telegraph_sound = null


### PR DESCRIPTION

## About The Pull Request
Increases the time between the harmful weather warning being sent and the weather actually hitting from 30 seconds to 60 seconds.
## Why It's Good For The Game
Make new map with harmful weather -> "wow this weather sucks guys we should remove it" -> only big red keeps weather

Giving both teams more time to actually act around weather will allow them to actually shift their plans to deal with it instead of instantly dying to the death storm and we can hopefully use the system instead of blaming maps for having it.

*probably needs a testmerge to see if this is still too little or is too long.
## Changelog
:cl:
balance: Harmful weather will now warn 60 seconds before hitting instead of 30.
/:cl:
