### PR TITLE
Makes sticky items (grenades) a component

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -498,6 +498,9 @@
 
 #define COMSIG_ITEM_VARIANT_CHANGE "item_variant_change"			// called in color_item : (mob/user, variant)
 
+#define COMSIG_ITEM_STICKY_STICK_TO "sticky_item_stick_to"
+#define COMSIG_ITEM_STICKY_CLEAN_REFS "sticky_item_clean_refs"
+
 #define COMSIG_CLOTHING_MECHANICS_INFO "clothing_mechanics_info"	//from base of /obj/item/clothing/get_mechanics_info()
 	#define COMPONENT_CLOTHING_MECHANICS_TINTED (1<<0)
 	#define COMPONENT_CLOTHING_BLUR_PROTECTION (1<<1)

--- a/code/datums/components/sticky_item.dm
+++ b/code/datums/components/sticky_item.dm
@@ -1,0 +1,84 @@
+/datum/component/sticky_item
+	///Current atom this item is attached to
+	var/atom/stuck_to
+	///Current image overlay applied to stuck_to
+	var/image/saved_overlay
+	///Custom icon file to be used for the overlay when item is stuck on
+	var/icon/icon_file
+	///Custom icon state to be used for the overlay when item is stuck on
+	var/icon_state
+
+/datum/component/sticky_item/Initialize(_icon_file, _icon_state)
+	. = ..()
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	var/obj/item/item_parent = parent
+
+	if(_icon_file)
+		icon_file = _icon_file
+	else
+		icon_file = item_parent.icon
+
+	if(_icon_state)
+		icon_state = _icon_state
+	else
+		icon_state = item_parent.icon_state
+
+	RegisterSignal(item_parent, COMSIG_MOVABLE_IMPACT, PROC_REF(on_impact))
+	RegisterSignal(item_parent, COMSIG_ITEM_STICKY_STICK_TO, PROC_REF(stick_to))
+	RegisterSignal(item_parent, COMSIG_ITEM_STICKY_CLEAN_REFS, PROC_REF(clean_refs))
+
+/datum/component/sticky_item/Destroy(force=FALSE, silent=FALSE)
+	clean_refs()
+	return ..()
+
+/// Deals with actually making the parent stick to the target
+/datum/component/sticky_item/proc/stick_to(datum/source, atom/target)
+	SIGNAL_HANDLER
+	if(!isitem(source)) //somehow...
+		CRASH("Sticky item component was somehow not on an item upon attach. Component attached to: [parent]")
+	var/obj/item/item_source = source
+	if(!item_source.can_stick_to(target))
+		return
+	var/image/stuck_overlay = image(icon_file, target, icon_state)
+	stuck_overlay.pixel_x = rand(-5, 5)
+	stuck_overlay.pixel_y = rand(-7, 7)
+	target.add_overlay(stuck_overlay)
+	item_source.forceMove(target)
+	saved_overlay = stuck_overlay
+	stuck_to = target
+	target.visible_message(span_warning("[item_source] sticks to [target]!"))
+	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
+
+/// Called on throw impact via signal
+/datum/component/sticky_item/proc/on_impact(datum/source, atom/movable/hit_atom, speed)
+	SIGNAL_HANDLER
+	stick_to(source, hit_atom)
+
+/// Handles cleaning up the overlay and nulling out the stuck_to atom
+/datum/component/sticky_item/proc/clean_refs()
+	SIGNAL_HANDLER
+	if(stuck_to)
+		stuck_to.cut_overlay(saved_overlay)
+		UnregisterSignal(stuck_to, COMSIG_QDELETING)
+		stuck_to = null
+	QDEL_NULL(saved_overlay)
+
+/// Same as normal, except this one has special behaviour on move, like deploying smoke
+/datum/component/sticky_item/move_behaviour/stick_to(datum/source, atom/target)
+	. = ..()
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+
+/datum/component/sticky_item/move_behaviour/Destroy(force, silent)
+	if(stuck_to)
+		UnregisterSignal(stuck_to, COMSIG_MOVABLE_MOVED)
+	return ..()
+
+/// Behaviour on stuck_to move
+/datum/component/sticky_item/move_behaviour/proc/on_move(datum/source, old_loc, movement_dir, forced, old_locs)
+	SIGNAL_HANDLER
+	if(!isitem(parent)) //somehow...
+		CRASH("Sticky item component was somehow not on an item upon move. Component attached to: [source]")
+	var/obj/item/item_parent = parent
+	item_parent.on_move_sticky()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1546,3 +1546,16 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /// Returns the strip delay of the item.
 /obj/item/proc/getstripdelay()
 	return strip_delay
+
+/// Can the item stick to target if it has the sticky item component. Must return TRUE or FALSE
+/obj/item/proc/can_stick_to(atom/target)
+	return TRUE
+
+/// Additional behaviour for when we stick to target
+/obj/item/proc/stuck_to(atom/target)
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src, COMSIG_ITEM_STICKY_STICK_TO, target)
+
+/// What happens when the atom we're stuck to moves
+/obj/item/proc/on_move_sticky()
+	return

--- a/code/game/objects/items/explosives/grenades/sticky_grenades.dm
+++ b/code/game/objects/items/explosives/grenades/sticky_grenades.dm
@@ -7,20 +7,18 @@
 	det_time = 5 SECONDS
 	light_impact_range = 2
 	weak_impact_range = 3
-	///Current atom this grenade is attached to, used to remove the overlay.
-	var/atom/stuck_to
-	///Current image overlay applied to stuck_to, used to remove the overlay after detonation.
-	var/image/saved_overlay
+
 	///if this specific grenade should be allowed to self sticky
 	var/self_sticky = FALSE
 
-/obj/item/explosive/grenade/sticky/throw_impact(atom/hit_atom, speed)
+/obj/item/explosive/grenade/sticky/Initialize(mapload)
 	. = ..()
-	if(!.)
-		return
-	if(!active || stuck_to || isturf(hit_atom))
-		return
-	stuck_to(hit_atom)
+	give_component()
+
+/obj/item/explosive/grenade/sticky/can_stick_to(atom/hit_atom)
+	if(!active || isturf(hit_atom))
+		return FALSE
+	return TRUE
 
 /obj/item/explosive/grenade/sticky/afterattack(atom/target, mob/user, has_proximity, click_parameters)
 	. = ..()
@@ -32,32 +30,12 @@
 	activate()
 	stuck_to(target)
 
-/obj/item/explosive/grenade/sticky/prime()
-	if(stuck_to)
-		clean_refs()
-	return ..()
-
 /obj/item/explosive/grenade/sticky/launched_det_time()
 	det_time -= 1 SECONDS
 
-///Cleans references to prevent hard deletes.
-/obj/item/explosive/grenade/sticky/proc/clean_refs()
-	stuck_to.cut_overlay(saved_overlay)
-	SIGNAL_HANDLER
-	UnregisterSignal(stuck_to, COMSIG_QDELETING)
-	stuck_to = null
-	saved_overlay = null
-
-///handles sticky overlay and attaching the grenade itself to the target
-/obj/item/explosive/grenade/sticky/proc/stuck_to(atom/hit_atom)
-	var/image/stuck_overlay = image(icon, hit_atom, initial(icon_state) + "_stuck")
-	stuck_overlay.pixel_x = rand(-5, 5)
-	stuck_overlay.pixel_y = rand(-7, 7)
-	hit_atom.add_overlay(stuck_overlay)
-	forceMove(hit_atom)
-	saved_overlay = stuck_overlay
-	stuck_to = hit_atom
-	RegisterSignal(stuck_to, COMSIG_QDELETING, PROC_REF(clean_refs))
+/// Handles giving the appropriate component to the grenade. Exists because Initialize is forced to call parent, and subtypes don't want to have both components
+/obj/item/explosive/grenade/sticky/proc/give_component()
+	AddComponent(/datum/component/sticky_item, icon, initial(icon_state) + "_stuck")
 
 /obj/item/explosive/grenade/sticky/trailblazer
 	name = "\improper M45 Trailblazer grenade"
@@ -71,26 +49,20 @@
 /obj/item/explosive/grenade/sticky/trailblazer/prime()
 	flame_radius(0.5, get_turf(src))
 	playsound(loc, SFX_INCENDIARY_EXPLOSION, 35)
-	if(stuck_to)
-		clean_refs()
 	qdel(src)
 
-/obj/item/explosive/grenade/sticky/trailblazer/stuck_to(atom/hit_atom)
+/obj/item/explosive/grenade/sticky/trailblazer/give_component()
+	AddComponent(/datum/component/sticky_item/move_behaviour, icon, initial(icon_state) + "_stuck")
+
+/obj/item/explosive/grenade/sticky/trailblazer/stuck_to(atom/target)
 	. = ..()
-	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_fire))
 	var/turf/T = get_turf(src)
 	T.ignite(25, 25)
 
 ///causes fire tiles underneath target when stuck_to
-/obj/item/explosive/grenade/sticky/trailblazer/proc/make_fire(datum/source, old_loc, movement_dir, forced, old_locs)
-	SIGNAL_HANDLER
+/obj/item/explosive/grenade/sticky/trailblazer/on_move_sticky()
 	var/turf/T = get_turf(src)
 	T.ignite(25, 25)
-
-/obj/item/explosive/grenade/sticky/trailblazer/clean_refs()
-	stuck_to.cut_overlay(saved_overlay)
-	UnregisterSignal(stuck_to, COMSIG_MOVABLE_MOVED)
-	return ..()
 
 /obj/item/explosive/grenade/sticky/cloaker
 	name = "\improper M45 Cloaker grenade"
@@ -101,34 +73,19 @@
 	det_time = 5 SECONDS
 	light_impact_range = 1
 	self_sticky = TRUE
-	/// smoke type created when the grenade is primed
-	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/tactical
-	///radius this smoke grenade will encompass
-	var/smokeradius = 1
-	///The duration of the smoke
-	var/smoke_duration = 8
+
+/obj/item/explosive/grenade/sticky/cloaker/give_component()
+	AddComponent(/datum/component/sticky_item/move_behaviour, icon, initial(icon_state) + "_stuck")
 
 /obj/item/explosive/grenade/sticky/cloaker/prime()
-	var/datum/effect_system/smoke_spread/smoke = new smoketype()
+	var/datum/effect_system/smoke_spread/smoke = new /datum/effect_system/smoke_spread/tactical()
 	playsound(loc, 'sound/effects/smoke_bomb.ogg', 35)
-	smoke.set_up(smokeradius, loc, smoke_duration)
+	smoke.set_up(1, loc, 8)
 	smoke.start()
-	if(stuck_to)
-		clean_refs()
 	qdel(src)
 
-/obj/item/explosive/grenade/sticky/cloaker/stuck_to(atom/hit_atom)
-	. = ..()
-	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(make_smoke))
-
 ///causes fire tiles underneath target when stuck_to
-/obj/item/explosive/grenade/sticky/cloaker/proc/make_smoke(datum/source, old_loc, movement_dir, forced, old_locs)
-	SIGNAL_HANDLER
-	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	smoke.set_up(smokeradius, loc, smoke_duration)
+/obj/item/explosive/grenade/sticky/cloaker/on_move_sticky()
+	var/datum/effect_system/smoke_spread/smoke = new /datum/effect_system/smoke_spread/tactical()
+	smoke.set_up(1, loc, 8)
 	smoke.start()
-
-/obj/item/explosive/grenade/sticky/cloaker/clean_refs()
-	stuck_to.cut_overlay(saved_overlay)
-	UnregisterSignal(stuck_to, COMSIG_MOVABLE_MOVED)
-	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -170,7 +170,7 @@
 	if(!(status_flags & INCORPOREAL) && TIMER_COOLDOWN_FINISHED(src, COOLDOWN_HIVEMIND_MANIFESTATION))
 		do_change_form()
 	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in contents)
-		sticky_bomb.clean_refs()
+		SEND_SIGNAL(sticky_bomb, COMSIG_ITEM_STICKY_CLEAN_REFS)
 		sticky_bomb.forceMove(loc)
 	forceMove(get_turf(get_core()))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -168,29 +168,22 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	worn_icon_list = null
 	var/acid_spray_damage = 15
 
+/obj/item/explosive/grenade/sticky/xeno/give_component()
+	AddComponent(/datum/component/sticky_item/move_behaviour, icon, initial(icon_state) + "_stuck")
+
 /obj/item/explosive/grenade/sticky/xeno/prime()
 	for(var/turf/acid_tile AS in RANGE_TURFS(1, loc))
 		new /obj/effect/temp_visual/acid_splatter(acid_tile) //SFX
 		new /obj/effect/xenomorph/spray(acid_tile, 5 SECONDS, acid_spray_damage)
 	playsound(loc, SFX_ACID_BOUNCE, 35)
-	if(stuck_to)
-		clean_refs()
 	qdel(src)
 
 /obj/item/explosive/grenade/sticky/xeno/stuck_to(atom/hit_atom)
 	. = ..()
-	RegisterSignal(stuck_to, COMSIG_MOVABLE_MOVED, PROC_REF(drop_acid))
 	new /obj/effect/xenomorph/spray(get_turf(src), 5 SECONDS, acid_spray_damage)
 
-///causes acid tiles underneath target when stuck_to
-/obj/item/explosive/grenade/sticky/xeno/proc/drop_acid(datum/source, old_loc, movement_dir, forced, old_locs)
-	SIGNAL_HANDLER
+/obj/item/explosive/grenade/sticky/xeno/on_move_sticky()
 	new /obj/effect/xenomorph/spray(get_turf(src), 5 SECONDS, acid_spray_damage)
-
-/obj/item/explosive/grenade/sticky/xeno/clean_refs()
-	stuck_to.cut_overlay(saved_overlay)
-	UnregisterSignal(stuck_to, COMSIG_MOVABLE_MOVED)
-	return ..()
 
 //Deals with picking up and using the grenade
 /obj/item/explosive/grenade/sticky/xeno/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -163,19 +163,19 @@
 	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 		if(charges_used >= charges)
 			break
-		if(sticky_bomb.stuck_to == stepper)
-			sticky_bomb.clean_refs()
+		if(sticky_bomb.active)
+			SEND_SIGNAL(sticky_bomb, COMSIG_ITEM_STICKY_CLEAN_REFS)
 			sticky_bomb.forceMove(loc)
-			charges_used ++
+			charges_used++
 
 	if(stepper.on_fire && (charges_used < charges))
 		stepper.ExtinguishMob()
-		charges_used ++
+		charges_used++
 
 	if(!isxeno(stepper))
 		stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
-		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33)
-		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33)
+		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID, penetration = 33)
+		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID, penetration = 33)
 		stepper.visible_message(span_danger("[stepper] is immersed in [src]'s acid!") , \
 		span_danger("We are immersed in [src]'s acid!") , null, 5)
 		playsound(stepper, "sound/bullets/acid_impact1.ogg", 10 * charges)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -512,6 +512,7 @@
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stamina_behavior.dm"
+#include "code\datums\components\sticky_item.dm"
 #include "code\datums\components\stun_mitigation.dm"
 #include "code\datums\components\submerge_mod.dm"
 #include "code\datums\components\suit_autodoc.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns the sticky behaviour of sticky grenades into a component. 

This is prep for a future PR where I want to swap out prae and globadier spitter primos, and those will have to have different paths due to how globadier nades are coded.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Something something compartmentalization. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
refactor: Sticky items/grenades are now a component
/:cl:
