### PR TITLE
Alt Health analyzer UI

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -160,6 +160,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/accessible_tgui_themes = FALSE
 	/// If we can be shown a health scan by friends with right click
 	var/allow_being_shown_health_scan = TRUE
+	/// Use alt healthscan ui?
+	var/alt_health_analyzer = FALSE
 
 	/// Chat on map
 	var/chat_on_map = TRUE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -177,6 +177,7 @@
 	READ_FILE(S["radio_tts_flags"], radio_tts_flags)
 	READ_FILE(S["accessible_tgui_themes"], accessible_tgui_themes)
 	READ_FILE(S["allow_being_shown_health_scan"], allow_being_shown_health_scan)
+	READ_FILE(S["alt_health_analyzer"], alt_health_analyzer)
 	READ_FILE(S["fast_mc_refresh"], fast_mc_refresh)
 	READ_FILE(S["split_admin_tabs"], split_admin_tabs)
 	READ_FILE(S["hear_ooc_anywhere_as_staff"], hear_ooc_anywhere_as_staff)
@@ -249,6 +250,7 @@
 	radio_tts_flags = sanitize_bitfield(radio_tts_flags, GLOB.all_radio_tts_options, (RADIO_TTS_SL | RADIO_TTS_SQUAD | RADIO_TTS_COMMAND | RADIO_TTS_HIVEMIND))
 	accessible_tgui_themes = sanitize_integer(accessible_tgui_themes, FALSE, TRUE, initial(accessible_tgui_themes))
 	allow_being_shown_health_scan = sanitize_integer(allow_being_shown_health_scan, FALSE, TRUE, initial(allow_being_shown_health_scan))
+	alt_health_analyzer = sanitize_integer(alt_health_analyzer, FALSE, TRUE, initial(alt_health_analyzer))
 
 	key_bindings = sanitize_islist(key_bindings, list())
 	if (!length(key_bindings))
@@ -408,6 +410,7 @@
 	WRITE_FILE(S["radio_tts_flags"], radio_tts_flags)
 	WRITE_FILE(S["accessible_tgui_themes"], accessible_tgui_themes)
 	WRITE_FILE(S["allow_being_shown_health_scan"], allow_being_shown_health_scan)
+	WRITE_FILE(S["alt_health_analyzer"], alt_health_analyzer)
 	WRITE_FILE(S["slot_draw_order"], slot_draw_order_pref)
 	WRITE_FILE(S["status_toggle_flags"], status_toggle_flags)
 

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -130,6 +130,7 @@
 			data["radio_tts_flags"] = radio_tts_flags
 			data["accessible_tgui_themes"] = accessible_tgui_themes
 			data["allow_being_shown_health_scan"] = allow_being_shown_health_scan
+			data["alt_health_analyzer"] = alt_health_analyzer
 			data["tgui_fancy"] = tgui_fancy
 			data["tgui_lock"] = tgui_lock
 			data["ui_scale"] = ui_scale
@@ -705,6 +706,9 @@
 
 		if("allow_being_shown_health_scan")
 			allow_being_shown_health_scan = !allow_being_shown_health_scan
+
+		if("alt_health_analyzer")
+			alt_health_analyzer = !alt_health_analyzer
 
 		if("tgui_fancy")
 			tgui_fancy = !tgui_fancy

--- a/tgui/packages/tgui/interfaces/MedScanner/data.ts
+++ b/tgui/packages/tgui/interfaces/MedScanner/data.ts
@@ -61,6 +61,8 @@ export type MedScannerData = {
   patient: string;
   species: Record<string, SpeciesData>;
   dead: boolean;
+  dead_timer: number;
+  dead_unrevivable: number;
   health: number;
   max_health: number;
   crit_threshold: number;

--- a/tgui/packages/tgui/interfaces/MedScannerAlt/MedDamageType.tsx
+++ b/tgui/packages/tgui/interfaces/MedScannerAlt/MedDamageType.tsx
@@ -1,0 +1,45 @@
+import { Box, ProgressBar, Tooltip } from 'tgui-core/components';
+
+type Props = {
+  tooltip: string;
+  name: string;
+  color?: string;
+  damage?: number;
+  disabled?: boolean;
+  noPadding?: boolean;
+};
+
+/**
+ * A component for damage types on the health analyzer
+ *
+ * `disabled` will color the entire component grey if true.
+ *
+ * `noPadding` will not put padding to the left of this if true, use for
+ * things that are the first entry in an inline list (brute damage!)
+ */
+export function MedDamageType(props: Props) {
+  const { tooltip, name, color, damage, disabled, noPadding } = props;
+  return (
+    <Tooltip content={tooltip}>
+      <Box inline width="95%" ml="5px">
+        {!disabled ? (
+          <ProgressBar value={0}>
+            <Box inline>
+              {name}
+              {': '}
+              <Box inline bold color={color}>
+                {damage}
+              </Box>
+            </Box>
+          </ProgressBar>
+        ) : (
+          <ProgressBar value={0} color="grey">
+            <Box inline color="grey">
+              <del>{name}</del>
+            </Box>
+          </ProgressBar>
+        )}
+      </Box>
+    </Tooltip>
+  );
+}

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
@@ -159,6 +159,14 @@ export const GameSettings = (props) => {
                 tooltip="Governs if others can show you your health scan."
               />
               <ToggleFieldPreference
+                label="Use alt health analyzer ui"
+                value="alt_health_analyzer"
+                action="alt_health_analyzer"
+                leftLabel={'Enabled'}
+                rightLabel={'Disabled'}
+                tooltip="An alternate health scan ui, has less advice."
+              />
+              <ToggleFieldPreference
                 label="Fullscreen mode"
                 value="fullscreen_mode"
                 action="fullscreen_mode"


### PR DESCRIPTION
## About The Pull Request

Adds an alternative health analyzer UI with less advice and different layout, opt in via preferences.

## Why It's Good For The Game

Cutting additional information that doesn't assist in triage is handy for those who already know what to do, this does that. Also turns the revivable information into a "heal X amount of damage" instead of "heal patient to X%"

I'm not sold on using boxes for chems, as i'd envisioned them being organizable via columns as well as rows, which is not how this'd implement them. Also couldn't figure out how to fix the regular UI's zebra striping for chem's background when using the Chem Priority, so it's not implemented here.

![LessIsMore](https://github.com/user-attachments/assets/9236d100-5fe3-4c05-8d2c-09a036314baf)
![Medical scanner](https://github.com/user-attachments/assets/7a0fcb08-f501-449d-bc8f-62b37d8900ef)
Should probably shrink the Y value on the window...

## Changelog

:cl:
add: Adds a Alternative Health analyzer UI to prefs
/:cl:
