### PR TITLE
Fixes defiler inject egg ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -279,7 +279,6 @@
 	desc = "Inject an egg with toxins, killing the larva, but filling it full with gas ready to explode."
 	ability_cost = 100
 	cooldown_duration = 5 SECONDS
-	keybind_flags = ABILITY_KEYBIND_USE_ABILITY
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_INJECT_EGG_NEUROGAS,
 	)


### PR DESCRIPTION

## About The Pull Request

What title says
For i dont know how long any time you would try to choose ability it would not - if i read the code properly it was due to a flag that shouldnt be used with this ability

## Why It's Good For The Game

Fix good

## Changelog
:cl: Atropos
fix: fixed defiler's inject egg ability not selecting
/:cl:
