### PR TITLE
RSR sell prices nerf

### DIFF
--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -297,5 +297,5 @@
 	export_points = 200
 
 /obj/item/research_product/money/rare
-	name = "credits - 500"
-	export_points = 500
+	name = "credits - 400"
+	export_points = 400

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -289,13 +289,13 @@
 	export_points = 50
 
 /obj/item/research_product/money/common
-	name = "credits - 150"
-	export_points = 150
+	name = "credits - 100"
+	export_points = 100
 
 /obj/item/research_product/money/uncommon
-	name = "credits - 250"
-	export_points = 250
+	name = "credits - 200"
+	export_points = 200
 
 /obj/item/research_product/money/rare
-	name = "credits - 800"
-	export_points = 800
+	name = "credits - 500"
+	export_points = 500


### PR DESCRIPTION
## About The Pull Request
As title says nerfs numbers on rsr 
mainly because xeno sell prices got lowered after introduction of disk req and rsr was missed

previous: 50/150/250/800
New: 50/100/200/400

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/42e4e3a5-edf9-41f9-8f75-fe97769e91cc)

## Changelog
:cl: Atropos
balance: credits earned from research sell for less points (50/100/200/400)
/:cl:
