### PR TITLE
NPC loadout tweaks

### DIFF
--- a/code/datums/outfits/npc_marines.dm
+++ b/code/datums/outfits/npc_marines.dm
@@ -105,14 +105,14 @@
 	gloves = /obj/item/clothing/gloves/marine/black
 	l_pocket = /obj/item/storage/pouch/medkit/medic
 	r_pocket = /obj/item/storage/pouch/magazine/large
-	suit_store = /obj/item/weapon/gun/rifle/standard_carbine/npc
+	suit_store = /obj/item/weapon/gun/rifle/tx11/freelancerone
 	ears = /obj/item/radio/headset/mainship/marine
 	shoes = /obj/item/clothing/shoes/marine/full
 
 	backpack_contents = list(
 		/obj/item/storage/box/MRE = 1,
 		/obj/item/defibrillator = 1,
-		/obj/item/ammo_magazine/rifle/standard_carbine = 6,
+		/obj/item/ammo_magazine/rifle/tx11 = 6,
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = 1,
 	)
 	suit_contents = list(
@@ -139,7 +139,7 @@
 		/obj/item/healthanalyzer = 1,
 	)
 	r_pocket_contents = list(
-		/obj/item/ammo_magazine/rifle/standard_carbine = 3,
+		/obj/item/ammo_magazine/rifle/tx11 = 3,
 	)
 	head_contents = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = 2,
@@ -284,6 +284,6 @@
 	head_contents = list(/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = 2)
 	webbing_contents = list(
 		/obj/item/explosive/grenade/m15 = 2,
-		/obj/item/explosive/grenade/smokebomb/cloak = 1,
-		/obj/item/explosive/grenade/smokebomb/antigas = 2,
+		/obj/item/explosive/grenade/smokebomb/antigas = 1,
+		/obj/item/cell/high = 2,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Couple minor tweaks.
Corpsman loadout has a TX11 instead of T18 due to rapid ammo use.
Engie has 2 high cap power cells, so they can actually fix up APC's.

:cl:
balance: A couple of minor tweaks to NPC medic/engie loadouts
/:cl:
