### PR TITLE
Campaign Axeman general storage belt items

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
@@ -398,6 +398,13 @@
 		wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/flashbang/stun, SLOT_IN_BACKPACK)
 		wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary/som, SLOT_IN_BACKPACK)
 		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine, SLOT_IN_BACKPACK)
+	if(istype(wearer.belt, /obj/item/storage/belt/sparepouch))
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/paracetamol, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/isotonic, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/ryetalyn, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/clothing/mask/cigarette/cigar/cohiba, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/box/matches, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BELT)
 
 /datum/loadout_item/suit_store/main_gun/som_marine/suppressed_rifle
 	name = "V-31-suppressed"

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
@@ -387,7 +387,7 @@
 	if(istype(wearer.belt, /obj/item/storage/belt/sparepouch))
 		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/paracetamol, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/isotonic, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/ryetalyn, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/tricordrazine, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/clothing/mask/cigarette/cigar/cohiba, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/storage/box/matches, SLOT_IN_BELT)
 		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BELT)

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/suit_storage/standard.dm
@@ -384,6 +384,14 @@
 	wearer.equip_to_slot_or_del(new /obj/item/storage/box/MRE/som, SLOT_IN_ACCESSORY)
 	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary/som, SLOT_IN_ACCESSORY)
 
+	if(istype(wearer.belt, /obj/item/storage/belt/sparepouch))
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/paracetamol, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/isotonic, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/ryetalyn, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/clothing/mask/cigarette/cigar/cohiba, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/storage/box/matches, SLOT_IN_BELT)
+		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BELT)
+
 	if(!isstorageobj(wearer.back))
 		return
 	wearer.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
@@ -398,13 +406,6 @@
 		wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/flashbang/stun, SLOT_IN_BACKPACK)
 		wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary/som, SLOT_IN_BACKPACK)
 		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine, SLOT_IN_BACKPACK)
-	if(istype(wearer.belt, /obj/item/storage/belt/sparepouch))
-		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/paracetamol, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/isotonic, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/packet/ryetalyn, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/clothing/mask/cigarette/cigar/cohiba, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/storage/box/matches, SLOT_IN_BELT)
-		wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline, SLOT_IN_BELT)
 
 /datum/loadout_item/suit_store/main_gun/som_marine/suppressed_rifle
 	name = "V-31-suppressed"


### PR DESCRIPTION
## About The Pull Request

Gives SoM's axe squaddies Paracetamol, Isotonic, Rye pill packets, a cigar, matches, and a inaprovaline injector when taking the G8 General purpose belt.

## Why It's Good For The Game

Currently the axe gets nothing but an empty belt when they take it, this gives them some stuff.
Alternatively i could shove a bunch of throwing knives in it, cause lmao.

## Changelog

:cl:
balance: Campaign axemen get items inside general belt
/:cl:
