### PR TITLE
Anti-juggling Fire Delay

### DIFF
--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -1,7 +1,11 @@
 /datum/component/anti_juggling
-	/// The next time the gun we just fired will be able to fire
+	/// The next time the gun we just fired will be able to fire.
 	var/next_fire_time = 0
+	/// The default multiplier for fire delay when weapon swapping.
+	var/multiplier = 2
+	/// The type of gun last fired.
 	var/last_gun_type = null
+	/// The instance of the gun last fired.
 	var/last_gun_instance = null
 
 /datum/component/anti_juggling/Initialize(...)
@@ -18,7 +22,6 @@
 	if(!isgun(fired_gun) || fired_gun.master_gun || fired_gun.dual_wield)
 		return //Attached guns and guns being dual wielded aren't taken into account.
 
-	var/multiplier = 2 // Default multiplier
 	if(istype(fired_gun, /obj/item/weapon/gun/revolver) || istype(fired_gun, /obj/item/weapon/gun/pistol))
 		multiplier = 8 // Higher delay multiplier for revolvers and pistols
 

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -1,6 +1,8 @@
 /datum/component/anti_juggling
 	/// The next time the gun we just fired will be able to fire
 	var/next_fire_time = 0
+	var/last_gun_type = null
+	var/last_gun_instance = null
 
 /datum/component/anti_juggling/Initialize(...)
 	. = ..()
@@ -15,7 +17,14 @@
 
 	if(!isgun(fired_gun) || fired_gun.master_gun || fired_gun.dual_wield)
 		return //Attached guns and guns being dual wielded aren't taken into account.
-	next_fire_time = world.time + fired_gun.fire_delay
+
+	var/multiplier = 2 // Default multiplier for most guns
+	if(istype(fired_gun, /obj/item/weapon/gun/revolver) || istype(fired_gun, /obj/item/weapon/gun/pistol))
+		multiplier = 8 // Higher delay multiplier for revolvers and pistols
+
+	next_fire_time = world.time + (fired_gun.fire_delay * mult)
+	last_gun_type = fired_gun.type
+	last_gun_instance = fired_gun
 
 /// Checks if the cooldown of the gun we previously fired is up.
 /datum/component/anti_juggling/proc/check_cooldown(datum/source, obj/item/weapon/gun/cool_gun)
@@ -23,6 +32,11 @@
 
 	if(cool_gun.master_gun)
 		return TRUE
-	if(world.time < next_fire_time)
-		return FALSE
+
+	// If same type but different instance, apply delay
+	if(last_gun_type == cool_gun.type && last_gun_instance != cool_gun)
+		if(world.time < next_fire_time)
+			return FALSE
+
+	// If same instance, or different type, allow firing
 	return TRUE

--- a/code/datums/components/anti_juggling.dm
+++ b/code/datums/components/anti_juggling.dm
@@ -18,11 +18,11 @@
 	if(!isgun(fired_gun) || fired_gun.master_gun || fired_gun.dual_wield)
 		return //Attached guns and guns being dual wielded aren't taken into account.
 
-	var/multiplier = 2 // Default multiplier for most guns
+	var/multiplier = 2 // Default multiplier
 	if(istype(fired_gun, /obj/item/weapon/gun/revolver) || istype(fired_gun, /obj/item/weapon/gun/pistol))
 		multiplier = 8 // Higher delay multiplier for revolvers and pistols
 
-	next_fire_time = world.time + (fired_gun.fire_delay * mult)
+	next_fire_time = world.time + (fired_gun.fire_delay * multiplier)
 	last_gun_type = fired_gun.type
 	last_gun_instance = fired_gun
 


### PR DESCRIPTION
## About The Pull Request

This makes it so that swapping to an IDENTICAL weapon after shooting appllies a lengthy delay, equivalent to 2x of its original fire delay. Pistols and revolvers have a 8x delay.

It does not apply the delay to OTHER weapons, or the same weapon you originally fired with (if knocked out of your hand, stunned, dropped, put into storage, etc.) It also doesn't apply to artillery pieces in case that was a concern.

This is my first PR that actually involves proper "code" so literally any feedback would be greatly appreciated.

## Why It's Good For The Game

For the longest time juggling has ruined weapons that would otherwise probably be fine. Weapons like the revolver and the Double-Barrel shotgun were mostly balanced around their finnicky reloads; pure burst weapons that had a moderate downtime to compensate for their high damagae output.

Juggling completely circumvented the intended design and let you achieve insane damage with little to no effort on the part of the user.

Doubling the fire-delay for most weapons, and timesing it by eight for revolvers and sidearms will put this strategy in the ground for good and hopefully open the way for some weapons to have their performance increased without fear of someone using them to juggle xenos to death.

## Changelog
:cl:
balance: Added a 2x fire delay modifier when swapping to a different instance of the same gun. 8x fire delay modifier for revolvers and pistols. 
/:cl:
