### PR TITLE
Cigarette/Cigar smoketime fix

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -111,7 +111,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/tool/match/process()
 	smoketime--
-	if(smoketime < 1)
+	if(smoketime < 0)
 		burn_out()
 		return
 
@@ -324,7 +324,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(isliving(loc))
 		M.IgniteMob()
 	smoketime--
-	if(smoketime < 1)
+	if(smoketime < 0)
 		if(ismob(loc))
 			to_chat(M, span_notice("Your [name] goes out."))
 			playsound(src, 'sound/items/cig_snuff.ogg', 15, 1)
@@ -490,7 +490,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/pipe/process()
 	var/turf/location = get_turf(src)
 	smoketime--
-	if(smoketime < 1)
+	if(smoketime < 0)
 		new /obj/effect/decal/cleanable/ash(location)
 		if(ismob(loc))
 			var/mob/living/M = loc


### PR DESCRIPTION
## About The Pull Request

Fixes smoketime miscalculation, Chemerettes were made with this in mind. Only really notable with the Russian Red cig that has been removed from use. Was bugging me though.

## Why It's Good For The Game

Bug bad.

## Changelog

:cl:
fix: Cigarettes/Cigars burn to their last tick.
/:cl:
