### PR TITLE
Melee cooldown walance

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -83,7 +83,9 @@
 		return
 	if(item_flags & NOBLUDGEON)
 		return
-	user.changeNext_move(attack_speed)
+	if(istype(target_object, /obj/vehicle))
+		user.changeNext_move(attack_speed)
+	else user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(target_object, used_item = src)
 	return target_object.attacked_by(src, user)
 


### PR DESCRIPTION
## About The Pull Request

Specifies melee cooldown for vehicle objects instead of all objects.
https://github.com/tgstation/TerraGov-Marine-Corps/pull/17306 changed 6 year old melee behaviors. (without calling it balance 😿 )

## Why It's Good For The Game

Returns Melee attack cooldown to it's earlier behavior vs non player controlled stuff.

## Changelog

:cl:
balance: item melee CD vs objects returned to 0.8 seconds (excluding vehicles)
/:cl:
