### PR TITLE
Flare Crates purchasable from req.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -280,7 +280,7 @@
 
 /obj/structure/largecrate/supply/supplies/flares
 	name = "flare supply crate (x140)"
-	desc = "A supply crate containing ten fourteen-flare boxes."
+	desc = "A supply crate containing ten boxes of fourteen flares each."
 	supplies = list(/obj/item/storage/box/m94 = 10)
 
 /obj/structure/largecrate/supply/supplies/coifs

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -279,8 +279,8 @@
 	icon_state = "secure_crate"
 
 /obj/structure/largecrate/supply/supplies/flares
-	name = "flare supply crate (x100)"
-	desc = "A supply crate containing twenty five-flare boxes."
+	name = "flare supply crate (x140)"
+	desc = "A supply crate that contains ten fourteen-flare boxes."
 	supplies = list(/obj/item/storage/box/m94 = 10)
 
 /obj/structure/largecrate/supply/supplies/coifs

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -280,7 +280,7 @@
 
 /obj/structure/largecrate/supply/supplies/flares
 	name = "flare supply crate (x140)"
-	desc = "A supply crate that contains ten fourteen-flare boxes."
+	desc = "A supply crate containing ten fourteen-flare boxes."
 	supplies = list(/obj/item/storage/box/m94 = 10)
 
 /obj/structure/largecrate/supply/supplies/coifs

--- a/code/modules/reqs/supplypacks/operations_packs.dm
+++ b/code/modules/reqs/supplypacks/operations_packs.dm
@@ -52,7 +52,7 @@ OPERATIONS
 	access = ACCESS_MARINE_BRIDGE //Better be safe.
 	cost = 130
 
-	/datum/supply_packs/operations/flare_crate
+/datum/supply_packs/operations/flare_crate
 	name = "Surplus flare crate"
 	contains = list(/obj/structure/largecrate/supply/supplies/flares)
 	cost = 75

--- a/code/modules/reqs/supplypacks/operations_packs.dm
+++ b/code/modules/reqs/supplypacks/operations_packs.dm
@@ -52,6 +52,11 @@ OPERATIONS
 	access = ACCESS_MARINE_BRIDGE //Better be safe.
 	cost = 130
 
+	/datum/supply_packs/operations/flare_crate
+	name = "Surplus flare crate"
+	contains = list(/obj/structure/largecrate/supply/supplies/flares)
+	cost = 75
+
 /datum/supply_packs/operations/deployable_camera
 	name = "3 deployable cameras"
 	contains = list(


### PR DESCRIPTION
## About The Pull Request

Makes flare crates (containing 140 flares / 10 packs) available to purchase from requisitions for 75 points. 

This also ammends the description of the flare crate to correctly state how much it contains, since last I checked I don't think 20 flare boxes equals 100 flares.

## Why It's Good For The Game

As of Runian's latest pr (#17948) flares will no longer be infinitely obtainable through surplus flare pouches from the clothing vendor. 

This isn't really an issue since marines start with 200 flare boxes, but assuming it is merged then if for whatever reason they run out (E.G: Highpop rounds, marine stupidity) the RO would not be able to buy more.

Considering the RO can buy an infinite number of the rest of the grenades (and also flare shells for the mortar / howi), having flares also available shouldn't do any harm.

## Changelog
:cl:
balance: Flare crates are now available to buy in requsitions for 75 points per 10 flare boxes (or 140 flares).
/:cl:
