### PR TITLE
Illegally small icy caves fix

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1123,7 +1123,6 @@
 /area/icy_caves/caves/northwestmonorail/hallway)
 "ff" = (
 /obj/structure/rack,
-/obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/item/clothing/glasses/welding,


### PR DESCRIPTION

## About The Pull Request

removed single duped rack on picture bellow - thats it
![image](https://github.com/user-attachments/assets/d2d01609-6f95-4de7-9889-4f4566f26435)


## Why It's Good For The Game
Fix good

## Changelog
:cl: Atropos
fix: removed extra rack from icy caves
/:cl:
