### PR TITLE
Updates xeno chem examine + adds more for defiler

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -567,19 +567,42 @@
 		if(status_flags & XENO_HOST)
 			msg += "[t_He] [t_is] impregnated.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
-			msg += "Neurotoxin: Causes increasingly intense pain and stamina damage over time, increasing in intensity at the 40 second and the minute and a half mark of metabolism.\n"
+			msg += "Neurotoxin([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin)]u): Causes increasingly intense pain and stamina damage over time, increasing in intensity at the 40 second and the minute and a half mark of metabolism.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))
-			msg += "Hemodile: Slows down the target, doubling in power with each other xeno-based toxin present.\n"
+			msg += "Hemodile([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))]u): Slows down the target, doubling in power with each other xeno-based toxin present.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox))
-			msg += "Transvitox: Converts burns to toxin over time, as well as causing incoming brute damage to deal additional toxin damage. Both effects intensifying with each xeno-based toxin present. Toxin damage is capped at 180.\n"
+			msg += "Transvitox([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox)]u): Converts burns to toxin over time, as well as causing incoming brute damage to deal additional toxin damage. Both effects intensifying with each xeno-based toxin present. Toxin damage is capped at 180.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn))
-			msg += "Ozelomelyn: Rapidly purges all medicine in the body, causes toxin damage capped at 40. Metabolizes very quickly.\n"
+			msg += "Ozelomelyn([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn)]u): Rapidly purges all medicine in the body, causes toxin damage capped at 40. Metabolizes very quickly.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal))
-			msg += "Sanguinal: Causes brute damage and bleeding from the brute damage. Does additional damage types in the presence of other xeno-based toxins. Toxin damage for Neuro, Stamina damage for Hemodile, and Burn damage for Transvitox.\n"
+			msg += "Sanguinal([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal)]u): Causes brute damage and bleeding from the brute damage. Does additional damage types in the presence of other xeno-based toxins. Toxin damage for Neuro, Stamina damage for Hemodile, and Burn damage for Transvitox.\n"
 
+//defiler specific examine info
 		if(istype(user, /mob/living/carbon/xenomorph/defiler))
-			if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal))
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine))
+				msg += "Bicardine([reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine)]u): Weak brute medication used by most marines. Heals slowly.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/kelotane))
+				msg += "Kelotane([reagents.get_reagent_amount(/datum/reagent/medicine/kelotane)]u): Weak burn medication used by most marines. Heals slowly.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine))
+				msg += "Tricodrazine([reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine)]u): General healing chem, heals all types of common damage by a small ammount.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/meralyne))
+				msg += "Meralyne([reagents.get_reagent_amount(/datum/reagent/medicine/meralyne)]u): Strong brute medication used commonly by corpsman.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/dermaline))
+				msg += "Dermaline([reagents.get_reagent_amount(/datum/reagent/medicine/dermaline)]u): Strong burn medication used commonly by corpsman.\n"
 
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/tramadol))
+				msg += "Tramadol([reagents.get_reagent_amount(/datum/reagent/medicine/tramadol)]u): General use anti-pain medication used by most marines.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol))
+				msg += "Paracetamol([reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol)]u): Weak anti-pain medication rarely used.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone))
+				msg += "Oxycodne([reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone)]u): Very strong anti-pain medication commonly found on corpsman.\n"
+
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/dylovene))
+				msg += "Dylovene([reagents.get_reagent_amount(/datum/reagent/medicine/dylovene)]u): Toxin removal medication.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline))
+				msg += "Inaprovaline([reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)]u):  Heals vast ammount of damage after injection in crit and prevents further oxygen damage while present.\n"
+			if(reagents.get_reagent_amount(/datum/reagent/medicalnanites))
+				msg += "Medical nanites([reagents.get_reagent_amount(/datum/reagent/medicalnanites)]u): Use marines blood healing moderate ammounts of burn and brute all the time. Cannot be purged by ozelomelyn but can be by defiling.\n"
 
 	if(has_status_effect(STATUS_EFFECT_ADMINSLEEP))
 		msg += separator_hr("[span_boldwarning("Admin Slept")]")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -584,7 +584,7 @@
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/kelotane))
 				msg += "Kelotane([reagents.get_reagent_amount(/datum/reagent/medicine/kelotane)]u): Weak burn medication used by most marines. Heals slowly.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine))
-				msg += "Tricodrazine([reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine)]u): General healing chem, heals all types of common damage by a small ammount.\n"
+				msg += "Tricordrazine([reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine)]u): General healing chem, heals all types of common damage by a small ammount.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/meralyne))
 				msg += "Meralyne([reagents.get_reagent_amount(/datum/reagent/medicine/meralyne)]u): Strong brute medication used commonly by corpsman.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/dermaline))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -569,7 +569,7 @@
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
 			msg += "Neurotoxin([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin)]u): Causes increasingly intense pain and stamina damage over time, increasing in intensity at the 40 second and the minute and a half mark of metabolism.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))
-			msg += "Hemodile([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))]u): Slows down the target, doubling in power with each other xeno-based toxin present.\n"
+			msg += "Hemodile([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile)]u): Slows down the target, doubling in power with each other xeno-based toxin present.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox))
 			msg += "Transvitox([reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox)]u): Converts burns to toxin over time, as well as causing incoming brute damage to deal additional toxin damage. Both effects intensifying with each xeno-based toxin present. Toxin damage is capped at 180.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn))
@@ -593,7 +593,7 @@
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/tramadol))
 				msg += "Tramadol([reagents.get_reagent_amount(/datum/reagent/medicine/tramadol)]u): General use anti-pain medication used by most marines.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol))
-				msg += "Paracetamol([reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol)]u): Weak anti-pain medication rarely used.\n"
+				msg += "Paracetamol([reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol)]u): Weak anti-pain medication. rarely used.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone))
 				msg += "Oxycodne([reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone)]u): Very strong anti-pain medication commonly found on corpsman.\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -577,6 +577,10 @@
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal))
 			msg += "Sanguinal: Causes brute damage and bleeding from the brute damage. Does additional damage types in the presence of other xeno-based toxins. Toxin damage for Neuro, Stamina damage for Hemodile, and Burn damage for Transvitox.\n"
 
+		if(istype(user, /mob/living/carbon/xenomorph/defiler))
+			if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal))
+
+
 	if(has_status_effect(STATUS_EFFECT_ADMINSLEEP))
 		msg += separator_hr("[span_boldwarning("Admin Slept")]")
 		msg += span_userdanger("This player has been slept by staff. Leave them be.\n")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -580,7 +580,7 @@
 //defiler specific examine info
 		if(istype(user, /mob/living/carbon/xenomorph/defiler))
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine))
-				msg += "Bicardine([reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine)]u): Weak brute medication used by most marines. Heals slowly.\n"
+				msg += "Bicaridine([reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine)]u): Weak brute medication used by most marines. Heals slowly.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/kelotane))
 				msg += "Kelotane([reagents.get_reagent_amount(/datum/reagent/medicine/kelotane)]u): Weak burn medication used by most marines. Heals slowly.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -595,7 +595,7 @@
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol))
 				msg += "Paracetamol([reagents.get_reagent_amount(/datum/reagent/medicine/paracetamol)]u): Weak anti-pain medication. rarely used.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone))
-				msg += "Oxycodne([reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone)]u): Very strong anti-pain medication commonly found on corpsman.\n"
+				msg += "Oxycodone([reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone)]u): Very strong anti-pain medication commonly found on corpsman.\n"
 
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/dylovene))
 				msg += "Dylovene([reagents.get_reagent_amount(/datum/reagent/medicine/dylovene)]u): Toxin removal medication.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -598,11 +598,11 @@
 				msg += "Oxycodone([reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone)]u): Very strong anti-pain medication commonly found on corpsman.\n"
 
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/dylovene))
-				msg += "Dylovene([reagents.get_reagent_amount(/datum/reagent/medicine/dylovene)]u): Toxin removal medication.\n"
+				msg += "Dylovene([reagents.get_reagent_amount(/datum/reagent/medicine/dylovene)]u): Basic toxin removal medication.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline))
 				msg += "Inaprovaline([reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)]u):  Heals vast ammount of damage after injection in crit and prevents further oxygen damage while present.\n"
 			if(reagents.get_reagent_amount(/datum/reagent/medicalnanites))
-				msg += "Medical nanites([reagents.get_reagent_amount(/datum/reagent/medicalnanites)]u): Use marines blood healing moderate ammounts of burn and brute all the time. Cannot be purged by ozelomelyn but can be by defiling.\n"
+				msg += "Medical nanites([reagents.get_reagent_amount(/datum/reagent/medicalnanites)]u): Uses marines blood healing moderate ammounts of burn and brute all the time. Cannot be purged by ozelomelyn but can be by defiling.\n"
 
 	if(has_status_effect(STATUS_EFFECT_ADMINSLEEP))
 		msg += separator_hr("[span_boldwarning("Admin Slept")]")


### PR DESCRIPTION
## About The Pull Request

What the title says - now when xenos examine humans they will see how many U of X reagent is inside them
and defiler can now see common meds like bic kelo + some special ones like nanites oxy etc. (look code for full list)

<details open>
<summary>image (as defiler) </summary>

![image](https://github.com/user-attachments/assets/e536b22c-cc2b-461a-99d1-0b9069cb214e)
</details>




whole idea came from looking at NTFvsALIENS so this is technically a port? but not fully shrug
also suggest any description changes as its very basic at the moment

## Why It's Good For The Game

Extra info for the defiler seems like a good idea since they can get the idea of what marine is using - a lot of chems? time for some ozy. no dylo at any point? neuro spam etc.
while update for normal xenos is a nice QOL 
## Changelog
:cl: Atropos
balance: Defiler can now see common medicine like bic. kelo. and other like oxy. or nanites
balance: Xenos can now see amount of reagents present inside humans
/:cl:
