### PR TITLE
escort order fix

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -411,7 +411,7 @@
 	if(isliving(movable_target))
 		var/mob/living/living_target = target
 		if(!living_target.stat)
-			set_escorted_atom(living_target)
+			set_escorted_atom(null, living_target)
 	set_interact_target(movable_target)
 	try_speak(pick(receive_order_chat))
 


### PR DESCRIPTION

## About The Pull Request
Ordering an NPC to escort a mob will now actually work.

I had the arg in the wrong place, so they'd go to them, but not follow.

:cl:
fix: fixed NPC's being told to follow someone, not actually doing so
/:cl:
