### PR TITLE
Fixes secure crate sprites being ERROR

### DIFF
--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -1,12 +1,12 @@
 /obj/structure/closet/crate/secure
 	desc = "A secure crate."
 	name = "Secure crate"
-	icon_state = "secure_locked_basic"
-	icon_opened = "secure_open_basic"
-	icon_closed = "secure_locked_basic"
+	icon_state = "crate_secure_locked_basic"
+	icon_opened = "crate_secure_basic_open"
+	icon_closed = "crate_secure_locked_basic"
 	closet_flags = CLOSET_ALLOW_OBJS|CLOSET_ALLOW_DENSE_OBJ|CLOSET_IS_SECURE
-	var/icon_locked = "secure_locked_basic"
-	var/icon_unlocked = "secure_unlocked_basic"
+	var/icon_locked = "crate_secure_locked_basic"
+	var/icon_unlocked = "crate_secure_unlocked_basic"
 	var/sparks = "securecratesparks"
 	locked = TRUE
 	max_integrity = 500


### PR DESCRIPTION

## About The Pull Request
The crates now have the proper icon instead of ERROR

![Screenshot_3058](https://github.com/user-attachments/assets/cc45c65d-0dec-4ba3-b70f-86801be8285c)



:cl:
fix: Basic secure crates are no longer an ERROR sprite
/:cl:
