### PR TITLE
Fixes Kutjevo nuke having no ceiling

### DIFF
--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -305,6 +305,7 @@
 	name = "Kutjevo - Central Colony Elevator"
 	icon_state = "colony_caves_0"
 	ambience = list('sound/ambience/ambicave.ogg', 'sound/ambience/ambilava1.ogg', 'sound/ambience/ambilava2.ogg', 'sound/ambience/ambicave2.ogg', 'sound/effects/rocksfalling1.ogg', 'sound/effects/rocksfalling2.ogg')
+	ceiling = CEILING_UNDERGROUND
 	minimap_color = MINIMAP_AREA_SEC
 
 /area/kutjevo/exterior/colony_north


### PR DESCRIPTION

## About The Pull Request
Seems someone put it as interior instead of exterior, which I am too lazy to change so it is just ceiling_underground now
## Why It's Good For The Game
Maybe caves shouldn't be able to be podded into, erm
## Changelog
:cl:
fix: Kutjevo Refinery cave nuke is now actually caves
/:cl:
