### PR TITLE
Hair under helmets toggling

### DIFF
--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -441,6 +441,39 @@
 		. += "	It has the following attachments:"
 		. += armor_info
 
+#define HAIR_NOT_HIDDEN HIDEEARS
+#define HAIR_ONLY_BEARD HIDEEARS|HIDETOPHAIR
+#define HAIR_SEMI_HIDDEN HIDEEARS|HIDE_EXCESS_HAIR
+#define HAIR_FULLY_HIDDEN HIDEEARS|HIDEALLHAIR
+
+/obj/item/clothing/head/modular/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+
+	switch(flags_inv_hide)
+		if(HAIR_SEMI_HIDDEN)
+			flags_inv_hide = HAIR_FULLY_HIDDEN
+			user.balloon_alert(user, "Fully hiding hair")
+		if(HAIR_FULLY_HIDDEN)
+			flags_inv_hide = HAIR_NOT_HIDDEN
+			user.balloon_alert(user, "Revealing hair entirely")
+		if(HAIR_NOT_HIDDEN)
+			flags_inv_hide = HAIR_ONLY_BEARD
+			user.balloon_alert(user, "Hiding only upper hair")
+		if(HAIR_ONLY_BEARD)
+			flags_inv_hide = HAIR_SEMI_HIDDEN
+			user.balloon_alert(user, "Partially hiding hair")
+
+/obj/item/clothing/head/modular/examine(mob/user)
+	. = ..()
+	. += span_notice("You can make it completely hide or reveal your hair by <b>using it in-hand</b> few times.")
+
+#undef HAIR_NOT_HIDDEN
+#undef HAIR_ONLY_BEARD
+#undef HAIR_SEMI_HIDDEN
+#undef HAIR_FULLY_HIDDEN
+
 /** Colorable masks */
 /obj/item/clothing/mask/gas/modular
 	name = "style mask"

--- a/code/modules/includes.dm
+++ b/code/modules/includes.dm
@@ -1,0 +1,1 @@
+#include "code\modules\clothing\modular_armor\modular.dm"


### PR DESCRIPTION
## About The Pull Request
Takes this code from RUtgmc and put it into our codebase too: https://github.com/Cosmic-Overlord/RU-TerraGov-Marine-Corps/pull/129/files
Allows marines to toggle between different degrees of obscurity with hair underneath helmets, also adds a file into code/modules/ that acted as a dependency for the code on RUtgmc, very likely redundant but better to be safe than sorry.
ping me if you need me to fix things as this is my first time using dm @1tommy

## Why It's Good For The Game

Rather than outright having only half the hairs available to marines looking good with helmets/other headgears, why not allow players to decide if they want to hide their hair or not.

## Changelog


:cl: Tommy
add: Added new mechanics or gameplay changes
fix: fixed a few things
/:cl:
