### PR TITLE
RavEndureCrit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -233,7 +233,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ENDURE,
 	)
-	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_SOLIDOBJECT //Can use this while staggered
+	use_state_flags = ABILITY_USE_STAGGERED | ABILITY_USE_SOLIDOBJECT| ABILITY_USE_INCAP //Can use this while staggered
 	///How low the Ravager's health can go while under the effects of Endure before it dies
 	var/endure_threshold = RAVAGER_ENDURE_HP_LIMIT
 	///Timer for Endure's duration
@@ -344,7 +344,7 @@
 	ability_cost = 0 //We're limited by cooldowns, not plasma
 	cooldown_duration = 60 SECONDS
 	keybind_flags = ABILITY_KEYBIND_USE_ABILITY | ABILITY_IGNORE_SELECTED_ABILITY
-	use_state_flags = ABILITY_USE_SOLIDOBJECT
+	use_state_flags = ABILITY_USE_SOLIDOBJECT | ABILITY_USE_STAGGERED | ABILITY_USE_INCAP
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RAGE,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ravager can now Endure or Rage while in crit.

## Why It's Good For The Game

Makes playing ravager easier, reducing how difficult it is to time usage of endure exactly.
Rage included as well, for making the use of pressing endure + rage at the same time consistent.


## PR Testing

works
![image](https://github.com/user-attachments/assets/8cf30bfe-19a6-4bef-9a6c-0e8feef0df70)
![image](https://github.com/user-attachments/assets/35e3cfd3-8db7-4621-9567-32a36afac8b5)


## Changelog

:cl:
balance: Ravager can now use Endure or Rage while in critical condition.
/:cl:
