### PR TITLE
AntiGasHalving

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -121,7 +121,7 @@
 			/obj/item/explosive/grenade/incendiary = 50,
 			/obj/item/explosive/grenade/smokebomb = 25,
 			/obj/item/explosive/grenade/smokebomb/cloak = 25,
-			/obj/item/explosive/grenade/smokebomb/antigas = 20,
+			/obj/item/explosive/grenade/smokebomb/antigas = 10,
 			/obj/item/explosive/grenade/sticky/cloaker = 10,
 			/obj/item/explosive/grenade/mirage = 100,
 			/obj/item/explosive/grenade/bullet/laser = 30,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Halves Antigas Grenades available for free in vendors.

## Why It's Good For The Game

Antigas spam has become excessive, shutting down disruptor castes such as boiler and defiler constantly.
Antigas grenades should be limited such that marines have to plan their usage for important times instead of consistently at every single gas, and be at risk of running out or needing to purchase more.

With 20 antigas grenades, its possible to shut down a defiler for 13 whole minutes, antigassing their gas every single time, assuming the gas ability was used every 40 seconds as it came off cooldown.
While a bad representation of highpop rounds, in lowpop or midpop rounds where T3 slots are quite limited its possible to completely shut down a defiler for almost the entire combat phase of some rounds.

Furthermore, with antigas being so prevalent xenos find it extremely difficult to contest open areas.
Boiler needs this especially, with its primary purpose being to provide gas cover at long rage being almost completely shut down.

## Changelog


:cl:
balance: Free Roundstart AntiGas Grenades 20 => 10.
/:cl:
