### PR TITLE
Adds a wire to BSG on Icy Caves

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -8425,6 +8425,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/dark/red2{
 	dir = 8
 	},


### PR DESCRIPTION

## About The Pull Request
Adds a single wire to Icy Caves to connect the BSG to the colony power grid
## Why It's Good For The Game
Fix good
## Changelog
:cl:
fix: Added missing wire connecting BSG to everything on Icy Caves
/:cl:
