### PR TITLE
Weather changes

### DIFF
--- a/code/datums/weather/weather_types/sand_storm.dm
+++ b/code/datums/weather/weather_types/sand_storm.dm
@@ -27,8 +27,14 @@
 		return
 	if(is_storm_immune(L))
 		return
-	L.adjustBruteLoss(6)
 	to_chat(L, span_danger("You are battered by the coarse sand!"))
+	if(!ishuman(L))
+		L.adjustBruteLoss(6)
+		return
+
+	L.adjustBruteLoss(2)
+	L.Stagger(2 SECONDS)
+
 
 /datum/weather/ash_storm/sand/harmless
 	name = "Sandfall"

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -22,3 +22,10 @@
 	aesthetic = TRUE
 
 	barometer_predictable = TRUE
+
+/datum/weather/snow_storm/weather_act(mob/living/L)
+	if(L.stat == DEAD)
+		return
+	if(L.mob_size > MOB_SIZE_HUMAN)
+		return
+	L.adjust_slowdown(1)

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -19,7 +19,6 @@
 	protect_indoors = TRUE
 	target_trait = ZTRAIT_SNOWSTORM
 	use_glow = FALSE
-	aesthetic = TRUE
 
 	barometer_predictable = TRUE
 


### PR DESCRIPTION

## About The Pull Request
Ruins the game.

Changes some weather interactions for humans (xenos are unchanged).

Sand: Does 2 damage per second instead of 6, but ALSO applies 2 seconds of stagger (this doesn't stack).
Snow: Applies 1 unit of slowdown (again, this doesn't stack).
## Why It's Good For The Game
Weather is kinda shitty. It either does absolutely nothing, or it just fucking kills you super fast, neither of which are very engaging.

These changes means these two weather types have distinct and clear downsides that aren't just utterly lethal, so it's an actual decision point for marines if they want to fight in the weather, or hunker down inside.
Fighting in the weather will put marines at a disadvantage, instead of just wiping them entirely.

The damage values of sand now means it will counter your premed, but it won't actually kill you unless you stand outside for 5 minutes or something.
## Changelog
:cl:
balance: Sand now does 2 damage instead of 6 to humans, but also applies stagger
balance: Snow now applies slowdown to humans and other small mobs
/:cl:
