### PR TITLE
MP19 Damage Nerf

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -72,6 +72,7 @@
 	accuracy_mult_unwielded = 0.9
 	recoil_unwielded = 0
 	fire_delay = 0.15 SECONDS
+	damage_mult = 0.8
 
 	scatter = 0
 	scatter_unwielded = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Applies a 0.8 damage modifier to the MP19.

## Why It's Good For The Game

The MP19 has above rifle dps vertified by 2 different calculations.
Calculator 1, assumes 0 xeno armour.
![image](https://github.com/user-attachments/assets/3b662a83-ee3c-4a26-97a0-a32b17e59a3a)
![image](https://github.com/user-attachments/assets/12923e05-77d0-49e6-8bbb-8adc2b3a4e8d)
Calculator 2, assuming 50 xeno armour.
![image](https://github.com/user-attachments/assets/db6243c9-b592-44b6-9778-973e3607780a)
![image](https://github.com/user-attachments/assets/9406c238-f118-4d1c-ad1d-dc87f5133776)

This is unreasonable for a 1 handed weapon combo'able with vali to provide additional utility and damage.
Ex: Tram vali slow combo'd with MP19 boosts the dps even further while even applying slowdown.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Added MP19 damage modifier to 0.8.
/:cl:
