### PR TITLE
BYOND memebers ghost orbit fix 

### DIFF
--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -31,7 +31,7 @@
 	GLOB.observer_list |= src
 
 	ghost_others = client.prefs.ghost_others
-	ghost_orbit = canon_client.prefs.ghost_orbit
+	ghost_orbit = client.prefs.ghost_orbit
 
 	pick_form(client.prefs.ghost_form)
 	updateghostimages()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -31,6 +31,7 @@
 	GLOB.observer_list |= src
 
 	ghost_others = client.prefs.ghost_others
+	ghost_orbit = canon_client.prefs.ghost_orbit
 
 	pick_form(client.prefs.ghost_form)
 	updateghostimages()


### PR DESCRIPTION

## About The Pull Request

As byond member you can choose your orbit but it wouldnt load next game

fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/4980
## Why It's Good For The Game
Fix good

## Changelog
:cl: Atropos
fix: fixed BYOND member ghost orbit not working properly after restart
/:cl:
