### PR TITLE
Fixes the fuel cell recycler lagging out the game

### DIFF
--- a/code/game/objects/machinery/fuelcell_recycler.dm
+++ b/code/game/objects/machinery/fuelcell_recycler.dm
@@ -99,9 +99,9 @@
 
 	if(machine_stat & (BROKEN|NOPOWER))
 		if(cell_left != null)
-			src.overlays += "recycler-left-cell"
+			. += "recycler-left-cell"
 		if(cell_right != null)
-			src.overlays += "recycler-right-cell"
+			. += "recycler-right-cell"
 		return
 
 	var/overlay_builder = "recycler-"


### PR DESCRIPTION

## About The Pull Request
The overlays were being added improperly when the machine was depowered/broken.
I recreated the lag without the fix, did it in the same way with the fix and it didn't spam out infinite overlays.

closes #17898

![Screenshot_3067](https://github.com/user-attachments/assets/746daec8-5ee6-4ed7-ad2b-69450c6037a1)
## Why It's Good For The Game
Lag is bad
## Changelog
:cl:
fix: fixes the fuel cell recycler lagging out the game
/:cl:
