### PR TITLE
Fix non-radial plasteel build menu being empty

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -158,7 +158,8 @@ GLOBAL_LIST_INIT(plasteel_recipes, list( \
 
 /obj/item/stack/sheet/plasteel/get_main_recipes()
 	. = ..()
-	. += GLOB.plasteel_recipes
+	for(var/item in GLOB.plasteel_recipes)
+		. += GLOB.plasteel_recipes[item]
 
 /obj/item/stack/sheet/plasteel/small_stack
 	amount = 10


### PR DESCRIPTION

## About The Pull Request

Closes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/17947

## Why It's Good For The Game

Fix good

## Changelog
:cl: Atropos
fix: fixed non-radial plasteel build menu being empty
/:cl:
