### PR TITLE
Clones are added to the take SSD list

### DIFF
--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -260,6 +260,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 	occupant.set_blindness(10) // Temp fix until blindness is fixed.
 	// Blindness doenst't trigger with just the disability, you need to set_blindness
 
+	LAZYOR(GLOB.ssd_living_mobs, occupant)
 	GLOB.offered_mob_list += occupant
 	notify_ghosts(span_boldnotice("A new clone is available! Name: [name]"), enter_link = "claim=[REF(occupant)]", source = src, action = NOTIFY_ORBIT, flashwindow = TRUE)
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
## Why It's Good For The Game
A lot of people don't know or check the 'take offered mob' button in the status panel, so clones are probably taken less often than they would otherwise be.
## Changelog
:cl:
qol: Clones are available via the take SSD mob ghost action
/:cl:
