### PR TITLE
Update SOM medium shield armor name and description

### DIFF
--- a/code/modules/clothing/modular_armor/som.dm
+++ b/code/modules/clothing/modular_armor/som.dm
@@ -2,7 +2,7 @@
 
 /obj/item/clothing/suit/modular/som
 	name = "\improper SOM medium battle armor"
-	desc = "The M-21 battle armor is typically used by SOM infantry. Utilizes special light-weight alloys that provides good protection with only minor impairment to the users mobility. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
+	desc = "The M-21 battle armor is typically used by SOM infantry. It utilizes special light-weight alloys that provides good protection with only minor impairment to the users mobility. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
 	soft_armor = list(MELEE = 45, BULLET = 65, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 55, ACID = 50)
 	icon = 'icons/mob/modular/som_armor.dmi'
 	worn_icon_list = list(

--- a/code/modules/clothing/modular_armor/som.dm
+++ b/code/modules/clothing/modular_armor/som.dm
@@ -1,8 +1,8 @@
 //SOM modular armour
 
 /obj/item/clothing/suit/modular/som
-	name = "\improper SOM light battle armor"
-	desc = "The M-21 battle armor is typically used by SOM light infantry, or other specialists that require more mobility at the cost of some protection. Provides good protection without minor impairment to the users mobility. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
+	name = "\improper SOM medium battle armor"
+	desc = "The M-21 battle armor is typically used by SOM infantry. Utilizes special light-weight alloys that provides good protection with only minor impairment to the users mobility. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
 	soft_armor = list(MELEE = 45, BULLET = 65, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 55, ACID = 50)
 	icon = 'icons/mob/modular/som_armor.dmi'
 	worn_icon_list = list(


### PR DESCRIPTION
## About The Pull Request

Updates the SOM medium shield armor name and description. In campaign and everywhere else in the code it is called medium armor or just battle armor, but the item name is called light armor.

## Why It's Good For The Game
This PR brings the item in line with it's other references, making it less misleading.

## Changelog
:cl:
fix: Update SOM medium shield armor name and description
/:cl:
