### PR TITLE
Fix attachment activation sound

### DIFF
--- a/code/modules/projectiles/gun_attachables/attachable.dm
+++ b/code/modules/projectiles/gun_attachables/attachable.dm
@@ -295,8 +295,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 /obj/item/attachable/ui_action_click(mob/living/user, datum/action/item_action/action, obj/item/weapon/gun/G)
 	if(G == user.get_active_held_item() || G == user.get_inactive_held_item() || CHECK_BITFIELD(G.item_flags, IS_DEPLOYED))
+		playsound(user, activation_sound, 15, 1)
 		if(activate(user))
-			playsound(user, activation_sound, 15, 1)
 			return TRUE
 	else
 		to_chat(user, span_warning("[G] must be in our hands to do this."))


### PR DESCRIPTION
## About The Pull Request

Fixes attachment activation sound. Flashlights and other attachments will create sounds when activated again

if(activate(user)) always returns false which skips the activation sound effect, you could probably remove it all together but I'm having strange problems with localhosting right now so I don't want to change it

After PRing this I realized there's another bug with attachments, which may be also present in other things, where the UI button in the top left to activate flashlight sometimes does nothing (reproduceable on localhost and the server) 


## Changelog
:cl:
fix: Fixes attachment activation sound
/:cl:
