### PR TITLE
Prison Station Free Plat Miner Removal

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -44823,12 +44823,6 @@
 "okw" = (
 /turf/open/floor/wood,
 /area/prison/library)
-"onm" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/prison/cellblock/highsec/south/south)
 "ooN" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -69690,7 +69684,7 @@ aYR
 cmO
 cnF
 dAR
-onm
+dAR
 dAR
 dAR
 dAR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Plat miner from prison station
![image](https://github.com/user-attachments/assets/ba625ade-d6b3-4d4a-a2e4-e285ff0a6d5f)

## Why It's Good For The Game

This miner location is:
1: not underground, free to pod or tadpole into
2: surrounded on 2 sides by indestructible walls and on another side by a full set of walls with only a single 5 tile wide opening to the north.

There should not be a miner here, especially not a platinum miner.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Prison Station platinum miner by crashed ship (not underground and trivial to defend) removed.
/:cl:
