### PR TITLE
Queen no longer requires 8 xenos to evolve on nukewar

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -29,7 +29,6 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
-	evolve_min_xenos = 8
 	maximum_active_caste = 1
 	death_evolution_delay = 5 MINUTES
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Queen no longer requires 8 xenos to evolve on nukewar
#17397 handles queen differently for crash so crash will not be affected by this.

## Why It's Good For The Game

I cant sum up the entire discussion on this, its been discussed so many times and its so long.
Nukewar without Queen is slop, marines have access to CAS, OB, Req, sometimes mech.
Xenos need Queen to fight this.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Queen no longer requires 8 xenos to evolve on nukewar.
/:cl:
