### PR TITLE
Fireproof resin walls block flamer shots

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -185,7 +185,7 @@
 	icon_state = "genghis-charge"
 
 /obj/item/explosive/plastique/genghis_charge/afterattack(atom/target, mob/user, flag)
-	if(istype(target, /turf/closed/wall/resin))
+	if(turf_to_check.allow_pass_flags & PASS_FIRE)
 		return ..()
 	if(istype(target, /obj/structure/mineral_door/resin))
 		return ..()
@@ -219,7 +219,7 @@
 
 ///Returns TRUE if the supplied turf has something we can ignite on, either a resin wall or door
 /obj/fire/flamer/autospread/proc/turf_contains_valid_burnable(turf/turf_to_check)
-	if(istype(turf_to_check, /turf/closed/wall/resin) && !(turf_to_check.allow_pass_flags & PASS_FIRE))
+	if(turf_to_check.allow_pass_flags & PASS_FIRE)
 		return TRUE
 	if(locate(/obj/structure/mineral_door/resin) in turf_to_check)
 		return TRUE

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -185,7 +185,7 @@
 	icon_state = "genghis-charge"
 
 /obj/item/explosive/plastique/genghis_charge/afterattack(atom/target, mob/user, flag)
-	if(turf_to_check.allow_pass_flags & PASS_FIRE)
+	if(target.allow_pass_flags & PASS_FIRE)
 		return ..()
 	if(istype(target, /obj/structure/mineral_door/resin))
 		return ..()

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -218,8 +218,8 @@
 			addtimer(CALLBACK(src, PROC_REF(spread_flames), direction, turf_to_check), rand(2, 7))
 
 ///Returns TRUE if the supplied turf has something we can ignite on, either a resin wall or door
-/obj/fire/flamer/autospread/proc/turf_contains_valid_burnable(turf_to_check)
-	if(istype(turf_to_check, /turf/closed/wall/resin))
+/obj/fire/flamer/autospread/proc/turf_contains_valid_burnable(turf/turf_to_check)
+	if(istype(turf_to_check, /turf/closed/wall/resin) && !(turf_to_check.allow_pass_flags & PASS_FIRE))
 		return TRUE
 	if(locate(/obj/structure/mineral_door/resin) in turf_to_check)
 		return TRUE

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -18,6 +18,7 @@
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hard_armor = list(MELEE = 0, BULLET = 15, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	resistance_flags = UNACIDABLE
+	allow_pass_flags = PASS_FIRE
 
 /turf/closed/wall/resin/add_debris_element()
 	AddElement(/datum/element/debris, null, -40, 8, 0.7)
@@ -254,6 +255,7 @@
 	max_upgradable_health = 200
 	soft_armor = list(MELEE = 0, BULLET = 65, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 200, ACID = 0)
 	color = COLOR_WALL_FIREPROOF
+	allow_pass_flags = NONE // To prevent fire from passing beyond it.
 
 /turf/closed/wall/resin/regenerating/special/hardy
 	name = "hardy resin wall"

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -197,11 +197,10 @@
 		turf_to_check = path_to_target[iteration - 1]
 	if(LinkBlocked(turf_to_check, path_to_target[iteration], PASS_AIR|PASS_XENO)) //checks if it's actually possible to get to the next tile in the line
 		return
-	if(turf_to_check.density && istype(turf_to_check, /turf/closed/wall/resin))
-		if(istype(turf_to_check,/turf/closed/wall/resin/regenerating/special/fireproof))
-			walls_penetrated = 0
-		else if(istype(turf_to_check, /turf/closed/wall/resin))
-			walls_penetrated -= 1
+	if(turf_to_check.density)
+		if(!(turf_to_check.allow_pass_flags & PASS_FIRE))
+			return
+		walls_penetrated -= 1
 	//how many resin walls we've penetrated check
 	if(walls_penetrated <= 0)
 		return
@@ -224,7 +223,9 @@
 	for(var/turf/turf AS in turfs_to_ignite)
 		if(get_dist(turf, flame_source) == iteration)
 			//Checks if turf is resin wall
-			if(turf.density && istype(turf, /turf/closed/wall/resin))
+			if(turf.density)
+				if(!(turf.allow_pass_flags & PASS_FIRE))
+					break
 				walls_penetrated_wide -= 1
 			//Checks if there is a resin door on the turf
 			var/obj/structure/mineral_door/resin/door_to_check = locate() in turf

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -198,7 +198,10 @@
 	if(LinkBlocked(turf_to_check, path_to_target[iteration], PASS_AIR|PASS_XENO)) //checks if it's actually possible to get to the next tile in the line
 		return
 	if(turf_to_check.density && istype(turf_to_check, /turf/closed/wall/resin))
-		walls_penetrated -= 1
+		if(istype(turf_to_check,/turf/closed/wall/resin/regenerating/special/fireproof))
+			walls_penetrated = 0
+		else if(istype(turf_to_check, /turf/closed/wall/resin))
+			walls_penetrated -= 1
 	//how many resin walls we've penetrated check
 	if(walls_penetrated <= 0)
 		return


### PR DESCRIPTION

## About The Pull Request
Fireproof resin walls now prevent flamers from penetrating them, making them immediately stop upon reaching the fireproof wall.

![sexy](https://github.com/user-attachments/assets/0515b1f2-4fb3-4fb3-93a5-fc0956987e2e)

## Why It's Good For The Game
They will now not suck as much because flamers will no longer be flame through the "fireproof" resin wall. Now xenos can stand immediately behind the wall instead of 5 tiles away from the wall because the other side of wall just so happen to be an ocean of fire.


## Changelog
:cl:
balance: Fireproof resin walls now prevent flamers from penetrating them, making them immediately stop upon reaching the fireproof wall.
/:cl:
