### PR TITLE
Gyroscopic Stabiliser for the MG42.

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -911,6 +911,7 @@
 		/obj/item/attachable/foldable/bipod,
 		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/gyro,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/suppressor,


### PR DESCRIPTION
## About The Pull Request

For some reason the MG42 just doesnt have the capability to mount a gyro for ???, it seemed quite weird since even the lasguns (which dont even have recoil) have gyro compatability.

This PR lets the MG42 take the gyro-stabiliser, which slightly reduces scatter and increases accuracy (% to hit) whilst moving.

## Why It's Good For The Game

Attachment parity within the T12- I mean AR12 family of guns. I tested it out just in case the gyro annihilated the unwielded / mid-wield recoil and it made barely any difference, so it probably wont do any harm. 

A tiny bit more attachment variety for the MG42 seems nice, in case for whatever reason you dont want to use a underbarrel weapon or a vertical grip.

## Changelog

:cl:
balance: MG42 can take the gyro stabiliser.
/:cl:
