### PR TITLE
Mateba packets are now small

### DIFF
--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -173,6 +173,7 @@
 	desc = "A packet containing 42 rounds of .454 casull."
 	icon_state = "454"
 	default_ammo = /datum/ammo/bullet/revolver/highimpact
+	w_class = WEIGHT_CLASS_SMALL
 	caliber = CALIBER_454
 	current_rounds = 42
 	max_rounds = 42


### PR DESCRIPTION

## About The Pull Request

all other pistols + even 357 packets are small unsure why mateba is medium
if kuro thinks its bad he can just close this simple as


## Why It's Good For The Game

Every pistol + revolver packet is small sized so i dont see why mateba should be different - yes its a req weapon and? why should it be harder to store

## Changelog
:cl: Atropos
balance: Mateba ammo packets are now small sized (previously medium)
/:cl:
