### PR TITLE
Xenos can unrest/rest while staggered

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -6,7 +6,7 @@
 	name = "Rest"
 	action_icon_state = "resting"
 	desc = "Rest on weeds to regenerate health and plasma."
-	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_CRESTED|ABILITY_USE_SOLIDOBJECT
+	use_state_flags = ABILITY_USE_LYING|ABILITY_USE_CRESTED|ABILITY_USE_SOLIDOBJECT|ABILITY_USE_STAGGERED
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REST,
 	)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Xenos probably shouldn't be resting so close to the front but it's pretty lame to have a basic mechanic denied by stagger when stuff like spits aren't either.
## Changelog
:cl:
balance: Xenos can rest/unrest while staggered
/:cl:
