### PR TITLE
Increase cooldown time of minion maw shot to 10 minutes

### DIFF
--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -167,7 +167,7 @@
 /datum/maw_ammo/minion
 	name = "ball of minions"
 	radial_icon_state = "minion"
-	cooldown_time = 5 MINUTES
+	cooldown_time = 10 MINUTES
 	impact_time = 12 SECONDS
 	/// range_turfs that minions will be dropped around the target
 	var/drop_range = 7


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increase minion maw cooldown from 5 minutes to 10 minutes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Minion ammo type in the MAW XOB structure is overused and the clear favourite of the two ammo types. This is primarily due to its cooldown time being half the time of huggers, which is 10 minutes, and it being stronger than huggers in most scenarios. Bringing the cooldown more in line with huggers would see the latter ammo used more often, and not be seen as a throw choice anymore. XOB in general is overperforming right now for a structure that can be rushed relatively quickly by xenos and can be seen as a instant win button (especially at low to mid pop).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Increased minion maw cooldown to 10 minutes.
/:cl:
