### PR TITLE
Foam and smoke microdose removal

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -8,6 +8,11 @@
 	taste_description = "bitterness"
 	reagent_ui_priority = REAGENT_UI_MEDICINE
 
+/datum/reagent/medicine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
+	if(method == VAPOR)
+		volume = floor(volume) //prevents microdosing from foam/smoke etc which duplicates chems
+	return ..()
+
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
 	description = "Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients."

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -10,7 +10,9 @@
 
 /datum/reagent/medicine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	if(method == VAPOR)
-		volume = floor(volume) //prevents microdosing from foam/smoke etc which duplicates chems
+		if(volume < 1)
+			return FALSE //prevents microdosing from foam/smoke etc which duplicates chems
+		volume *= 0.3
 	return ..()
 
 /datum/reagent/medicine/inaprovaline


### PR DESCRIPTION

## About The Pull Request
Floors the volume of medical reagents (and only medical reagents) added from vapor reactions - namely foam and smoke.

This prevents microdosing small amounts of powerful chems like neuraline in these reactions to get absurd amounts of AOE healing from tiny volumes.

So you can still have healing foam/smoke, but the higher reagent requirement means that if you want to do it with more powerful/limited chems, you'll need to use a lot more of them.
## Why It's Good For The Game
These kinds of transfer methods duplicate chems significantly, which is amplified by the number of mobs they can effect at the same time.

This allows a single neuraline injector and a pill or 2 of meraderm to do rediculously huge amounts of healing - far more than the original amounts would otherwise allow.
## Changelog
:cl:
balance: Foam and smoke reagents apply a floor to medical reagent amounts - very low volumes will no longer heal mobs
/:cl:
