### PR TITLE
Equipping clothing without the limbs for them will no longer disappear the clothing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -544,6 +544,9 @@
 	if(H.species.hud?.equip_slots)
 		mob_equip = H.species.hud.equip_slots
 
+	if(!H.has_limb_for_slot(slot))
+		return FALSE
+
 	if(bitslot)
 		var/old_slot = slot
 		slot = slotbit2slotdefine(old_slot)


### PR DESCRIPTION
## About The Pull Request
Adds a check has_limb_for_slot into mob_can_equip, which stops you from equipping gloves when you're missing hands or boots when you're missing feet etc
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/17978
## Why It's Good For The Game
No more disappearing gloves/boots causing ahelps. Also preventing weird ghost items, I'm still not exactly sure where the gloves were going.
## Changelog
:cl:
fix: You can no longer equip items if you don't actually have the limbs for them.
/:cl:
