### PR TITLE
Fix Quick Vendor blacklisting vendor usage

### DIFF
--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -229,7 +229,6 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 					if(user_id.marine_buy_choices[option] != GLOB.marine_selector_cats[option])
 						to_chat(ui.user, span_warning("Access denied, continue using the GHHME."))
 						return FALSE
-				user_id.id_flags &= ~CAN_BUY_LOADOUT
 				selected_loadout.quantity --
 				if(drop_worn_items)
 					for(var/obj/item/inventory_items in ui.user)


### PR DESCRIPTION
## About The Pull Request
If you make the mistake of selecting the Quick Vendor during crash, you will be blacklisted from using your points later when disks are printed.

This fix simply removes the blacklist. The existing code already deducts all the points and checks to make sure you have full points before letting you use the Quick Vendor.

## Why It's Good For The Game
No more noob traps.

## Changelog
:cl:
fix: Fix quick vendor blacklisting marines from using points during crash
/:cl:
