### PR TITLE
Removes CI windows build

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -195,27 +195,3 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: echo Alternate tests passed.
-
-  test_windows:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
-    name: Windows Build
-    needs: [collect_data]
-    runs-on: windows-latest
-    concurrency:
-      group: test_windows-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node
-        uses: ./.github/actions/setup_node
-        with:
-          restore-yarn-cache: true
-      - name: Compile
-        run: pwsh tools/ci/build.ps1
-        env:
-          DM_EXE: "C:\\byond\\bin\\dm.exe"
-      - name: Check client Compatibility
-        uses: tgstation/byond-client-compatibility-check@v3
-        with:
-          dmb-location: tgmc.dmb
-          max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}


### PR DESCRIPTION

## About The Pull Request
Port of https://github.com/tgstation/tgstation/pull/91186

Removes the windows test build from CI suite.
(I don't know anything about github workflow, but Tivi said I needed to port this or whatever I can from it to fix the error checks.) 

## Why It's Good For The Game
I hate red x's.
![image](https://github.com/user-attachments/assets/77bb0a99-c7a0-4951-ae9e-1d254bbaefa3)

## Changelog
Nothing player-facing.