### PR TITLE
Lowered the price of the SST-574 Sniper Sentry from 600 to 400 points.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -205,7 +205,7 @@ WEAPONS
 /datum/supply_packs/weapons/sentry_sniper
 	name = "SST-574 sniper sentry"
 	contains = list(/obj/item/storage/box/crate/sentry_sniper)
-	cost = 600
+	cost = 400
 
 /datum/supply_packs/weapons/sentry_sniper_ammo
 	name = "SST-571 sniper sentry ammunition"


### PR DESCRIPTION
## About The Pull Request

SST-574 Sniper Sentry price reduced from 600 to 400 points in requisitions.
## Why It's Good For The Game

Sniper Sentry is 50% more expensive than every other sentry marines can purchase, and if #18024 ends up being merged then the price should be lowered to match its counterparts. This sentry loses some of its appeal since you can no longer stack several together for large bursts of damage, and it can grief other sniper users when it hits xenos.

Will most likely close this PR if #18024 ends up not being merged.
## Changelog
:cl:
balance: Reduced price of sniper sentry from 600 to 400 points.
/:cl:
