### PR TITLE
Increased price of tanglefoot minirockets from 200 to 400 points.

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -620,7 +620,7 @@
 	name = "Tanglefoot mini rocket stack"
 	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
-	point_cost = 200
+	point_cost = 400
 	devastating_explosion_range = 0
 	travelling_time = 4 SECONDS
 	heavy_explosion_range = 0


### PR DESCRIPTION
## About The Pull Request

Price of tfoot minirockets increases from 200 to 400 points.
## Why It's Good For The Game

Tanglefoot CAS spam is very boring gameplay, but right now it is one of the most optimal ways to play CAS. Increasing its price is reasonable, especially if #18026 is going to be considered.
## Changelog
:cl:
balance: Tanglefoot minirockets price increased from 200 to 400
/:cl:
