### PR TITLE
Mortar Tanglefoot Nerf

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1005,7 +1005,7 @@ EXPLOSIVES
 /datum/supply_packs/explosives/mortar_ammo_plasmaloss
 	name = "T-50S mortar tanglefoot shell"
 	contains = list(/obj/item/mortal_shell/plasmaloss)
-	cost = 10
+	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/explosives/mlrs
@@ -2516,7 +2516,7 @@ FACTORY
 /datum/supply_packs/factory/mortar_shell_tfoot_refill
 	name = "T-50S mortar tanglefoot Gas shell assembly refill"
 	contains = list(/obj/item/factory_refill/mortar_shell_tfoot_refill)
-	cost = 200
+	cost = 800
 
 /datum/supply_packs/factory/mortar_shell_flare_refill
 	name = "T-50S mortar flare shell assembly refill"


### PR DESCRIPTION
## About The Pull Request

Increased price of mortar tanglefoot shell from 10 to 40 points. Increased price of mortar factory tanglefoot from 200 to 800 points.
## Why It's Good For The Game

Mortar tanglefoot spam is extremely difficult to deal with with how cheap shells are to buy and produce. For example, howitzer tanglefoot is 60 a shell and 1000 for 30. Being able to deny xenos from pushing for this cheap of a price is ridiculously strong.
## Changelog
:cl:

balance: Increased price of mortar tfoot shell to 40. Increased price of mortar factory tfoot to 800.
/:cl:
