### PR TITLE
Sniper stacking debuff change

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -888,7 +888,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		return FALSE
 	if(proj.ammo.ammo_behavior_flags & AMMO_SKIPS_ALIENS)
 		return FALSE
-	if(proj.ammo.ammo_behavior_flags & AMMO_SNIPER && proj.iff_signal)
+	if((proj.ammo.ammo_behavior_flags & AMMO_SNIPER) && proj.iff_signal)
 		var/datum/status_effect/incapacitating/recently_sniped/sniped = is_recently_sniped()
 		var/obj/item/weapon/gun/shooter = proj.shot_from
 


### PR DESCRIPTION
## About The Pull Request

No longer applies the sniper stacking debuff if the shooter doesn't have IFF. Still applies the debuff if the shooter is using a method of IFF when they fire, i.e. an IFF sniper like the SR-26 or an aim mode sniper like the SR-127.
## Why It's Good For The Game

The sniper stacking debuff has been a point of contention ever since it was merged into the game. After seeing how it has performed over the past months, it has successfully killed aim mode stacking with snipers. However, there's a problem with how the DMR-37 and SR-127 interact as you'll often see marines arguing that the DMR user is ruining their damage.

This is a pretty shitty problem since it punishes the marine for using the gun and punishes the rest of their team who may be using a sniper for its overwatch support. Therefore, linking the debuff to aim mode will allow marines to push in short to mid range with the DMR-37 without impacting other marines who want to use their snipers in aim mode. It also still prevents marines from aim mode stacking, which was the original purpose of the PR.

Feel free to argue if this is an overall positive or negative change, personally as a xeno main I don't think having to deal with marines frontlining with DMR-37 is a big deal as there are much better weapons marines can use in their arsenal.
## Changelog
:cl:
balance: Snipers no longer apply the sniper stacking debuff if dont have IFF.
/:cl:
