### PR TITLE
Adds medical overwatch to canter and big bury

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -249,8 +249,12 @@
 /area/shuttle/canterbury)
 "bc" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/surgical_tray,
-/obj/item/storage/firstaid/adv,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 8
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "bd" = (
@@ -260,11 +264,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "be" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 8
-	},
+/obj/machinery/computer/camera_advanced/overwatch/medical,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "bg" = (
@@ -567,8 +567,8 @@
 /area/shuttle/canterbury)
 "fL" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "gv" = (
@@ -1199,10 +1199,10 @@ ay
 aq
 ay
 az
-aU
+aV
 vF
 Xf
-bc
+aU
 ap
 ag
 "}
@@ -1232,7 +1232,7 @@ aB
 aq
 aB
 az
-aV
+aW
 aA
 aA
 bd
@@ -1265,7 +1265,7 @@ aC
 aq
 aH
 az
-aW
+bc
 aA
 fL
 be

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -553,7 +553,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cf" = (
-/obj/machinery/computer/crew,
+/obj/machinery/computer/camera_advanced/overwatch/medical,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cg" = (


### PR DESCRIPTION

## About The Pull Request

Title
on small bury it replaces crew monitoring on big bury i did some shuffling of chem to make it nicer

## Why It's Good For The Game

i dont believe a single person used crew monitor more than once - we have new content let players use it
also cmo should be in med not sitting in cic
## Changelog
:cl: Atropos
add: Added medical overwatch to canterbury and big bury
/:cl:
