### PR TITLE
Minion cade fix

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -359,7 +359,7 @@
 	return AI_OBSTACLE_RESOLVED
 
 /obj/structure/barricade/folding/ai_handle_obstacle(mob/living/user, move_dir)
-	if(!can_interact(user))
+	if(!can_interact(user) || !user.dextrous)
 		return ..()
 	toggle_open(null, user)
 	return AI_OBSTACLE_RESOLVED


### PR DESCRIPTION

## About The Pull Request
Fixes #18033
## Why It's Good For The Game
Minions (and zombies) opening cades is bad
## Changelog
:cl:
balance: Minion proof latches have been installed on all folding cades
/:cl:
