### PR TITLE
Reverts #17952, re-adds beacon offsets, fixes movable radiopack beacons for real

### DIFF
--- a/code/datums/components/beacon.dm
+++ b/code/datums/components/beacon.dm
@@ -240,11 +240,11 @@
 	/// Name printed on the supply console
 	var/name = ""
 	/// Where the supply drops will land
-	var/atom/drop_location
+	var/turf/drop_location
 	/// The faction of the beacon
 	var/faction = ""
 
-/datum/supply_beacon/New(_name, atom/_drop_location, _faction, life_time = 0 SECONDS)
+/datum/supply_beacon/New(_name, turf/_drop_location, _faction, life_time = 0 SECONDS)
 	name = _name
 	drop_location = _drop_location
 	faction = _faction

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -111,11 +111,11 @@
 			if(!length(supplies))
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("There wasn't any supplies found on the squads supply pad. Double check the pad.")]")
 				return
-			var/turf/land_turf = get_turf(supply_beacon.drop_location)
-			if(!land_turf || !is_ground_level(supply_beacon.drop_location.z))
+
+			if(!istype(supply_beacon.drop_location) || !is_ground_level(supply_beacon.drop_location.z))
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("The [supply_beacon.name] was not detected on the ground.")]")
 				return
-			if(isspaceturf(land_turf) || land_turf.density)
+			if(isspaceturf(supply_beacon.drop_location) || supply_beacon.drop_location.density)
 				to_chat(usr, "[icon2html(src, usr)] [span_warning("The [supply_beacon.name]'s landing zone appears to be obstructed or out of bounds.")]")
 				return
 
@@ -148,8 +148,8 @@
 	if(!length(supplies) || length(supplies) > MAX_SUPPLY_DROPS)
 		stack_trace("Trying to send a supply drop with an invalid amount of items [length(supplies)]")
 		return
-	var/turf/land_turf = get_turf(supply_beacon.drop_location)
-	if(!istype(land_turf) || isspaceturf(land_turf) || land_turf.density)
+
+	if(!istype(supply_beacon.drop_location) || isspaceturf(supply_beacon.drop_location) || supply_beacon.drop_location.density)
 		stack_trace("Trying to send a supply drop to a beacon on an invalid turf")
 		return
 
@@ -187,7 +187,7 @@
 		return
 
 	playsound(supply_pad.loc,'sound/effects/bamf.ogg', 50, TRUE)
-	var/turf/droploc = get_turf(supply_beacon.drop_location)
+	var/turf/droploc = locate(supply_beacon.drop_location.x + x_offset, supply_beacon.drop_location.y + y_offset, supply_beacon.drop_location.z)
 	playsound(droploc, 'sound/items/fultext_deploy.ogg', 30, TRUE)
 	var/image/chute_cables = image('icons/effects/32x64.dmi', src, "chute_cables_static")
 	chute_cables.pixel_y -= 12


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As far as I can tell, https://github.com/tgstation/TerraGov-Marine-Corps/pull/17542 somehow broke radiopacks for three months and nobody seemed to notice. Radiopacks were not showing up in the beacon list with my testing, and that's with https://github.com/tgstation/TerraGov-Marine-Corps/pull/18030. This makes radiopacks actually work, with added movable beacon functionality from the earlier PR.
It also re-adds x-y supply drop offsets, which were stealth-removed (nobody seemed to notice...?).
Not compatible with https://github.com/tgstation/TerraGov-Marine-Corps/pull/18030, probably.

Known issue(s):
- Beacons sometimes cause ghost entries in GLOB.supply_beacon. You can't actually drop supplies on ghost entries, but they sure clog up the supply console list. I wasn't able to precisely replicate this, but it seems related to toggling your beacon off and on after you receive a supply drop...?
- Beacon names don't update in the drop console beacon list as the beacon moves around, and are stuck with the name from when they were first activated (e.g. "Hydroponics - Urist McLeader"). Only the list seems to be stuck with the initial name -- selecting a beacon makes it display the correct name just fine.
- The UI doesn't auto-update.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Movable beacons aside, radiopacks should function at all. Also restoring x-y offset functionality, which I think was used by some ROs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
fix: Radiopacks should have proper beacon functionality now.
fix: You should be able to see active beacons in the supply console again.
fix: Supply drop X-Y offsets now work.
/:cl:
