### PR TITLE
bike rev no longer reduces max fuel capacity

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -64,7 +64,7 @@
 	if(!COOLDOWN_FINISHED(src, rev_cooldown)) return FALSE
 	COOLDOWN_START(src, rev_cooldown, 3 SECONDS)
 	to_chat(user, span_notice("You rev the [src]'s engine."))
-	fuel_max -= 5
+	fuel_count -= 5
 	playsound(src, pick(rev_sounds), 50, TRUE, falloff = 3)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
bike rev no longer reduces max fuel capacity

## Why It's Good For The Game
whoopsie, bug bad

## Changelog

:cl:
fix: bike revs no longer appear to give you more fuel, where they were reducing max fuel, now correctly removes fuel
/:cl:
