### PR TITLE
Rebalance xeno tiers on crash

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1214,8 +1214,15 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + threes*SSticker.mode.tier_three_inclusion) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1))
-	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
+	if(iscrashgamemode(SSticker.mode))
+		tier3_xeno_limit = FLOOR((zeros + ones + twos + threes + fours) / 3.5)
+		tier3_xeno_limit = max(threes, tier3_xeno_limit)
+
+		tier2_xeno_limit = FLOOR((zeros + ones + twos + threes + fours) / 2.5)
+		tier2_xeno_limit = max(twos, tier2_xeno_limit)
+	else
+		tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + threes*SSticker.mode.tier_three_inclusion) / 3 + length(psychictowers) + 1  - SSticker.mode.tier_three_penalty, 1))
+		tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(psychictowers) * 2 + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos
@@ -1567,7 +1574,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 // Everything below can have a hivenumber set and these ensure easy hive comparisons can be made
 
-// atom level because of /atom/movable/projectile/var/atom/firer
+// atom level because of /obj/projectile/var/atom/firer
 /atom/proc/issamexenohive(atom/A)
 	if(!get_xeno_hivenumber() || !A?.get_xeno_hivenumber())
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Pretty simple balance change.

T3 slots are calculated via `Xenos/3.5`
T2 slots are calculated via `Xenos/2.5`

This translates into:
1st T3 slot is 4 xeno pop, 2nd T3 slot is 7 xeno pop, etc.
1st T2 slot is 3 xeno pop, 2nd T2 slot is 5 xeno pop, etc.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Crash is horribly unbalanced during low pops due to xenos being able to spam many T2/T3 castes. There have been countless times I have seen 6-8 marine pop fighting off a hunter, rav, and a shrike at the same time. Which ends up with repeated wipes before a disk is even printed.

There have also been practice rounds where xenos agreed to restrict themselves to T1s only while marine population was low and those rounds felt more competitive. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Rebalance Xeno tiers on Crash gamemode. T3s slots are calculated via xenos/3.5 and T2s slots are calculated via xenos/2.5 
/:cl:
