### PR TITLE
bike revving now no longer removes fuel to negatives

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -61,7 +61,7 @@
 
 /obj/vehicle/ridden/motorbike/AltClick(mob/user)
 	if(!(user in buckled_mobs)) return FALSE
-	if(!COOLDOWN_FINISHED(src, rev_cooldown)) return FALSE
+	if(!COOLDOWN_FINISHED(src, rev_cooldown) || fuel_count < 5) return FALSE
 	COOLDOWN_START(src, rev_cooldown, 3 SECONDS)
 	to_chat(user, span_notice("You rev the [src]'s engine."))
 	fuel_count -= 5

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -60,8 +60,10 @@
 	. += "The fuel gauge on the bike reads \"[fuel_count/fuel_max*100]%\""
 
 /obj/vehicle/ridden/motorbike/AltClick(mob/user)
-	if(!(user in buckled_mobs)) return FALSE
-	if(!COOLDOWN_FINISHED(src, rev_cooldown) || fuel_count < 5) return FALSE
+	if(!(user in buckled_mobs))
+		return FALSE
+	if(!COOLDOWN_FINISHED(src, rev_cooldown) || fuel_count < 5)
+		return FALSE
 	COOLDOWN_START(src, rev_cooldown, 3 SECONDS)
 	to_chat(user, span_notice("You rev the [src]'s engine."))
 	fuel_count -= 5

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -64,7 +64,7 @@
 	if(!COOLDOWN_FINISHED(src, rev_cooldown)) return FALSE
 	COOLDOWN_START(src, rev_cooldown, 3 SECONDS)
 	to_chat(user, span_notice("You rev the [src]'s engine."))
-	fuel_max -= 5
+	fuel_count -= 5
 	playsound(src, pick(rev_sounds), 50, TRUE, falloff = 3)
 	return TRUE
 

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -62,7 +62,9 @@
 /obj/vehicle/ridden/motorbike/AltClick(mob/user)
 	if(!(user in buckled_mobs))
 		return FALSE
-	if(!COOLDOWN_FINISHED(src, rev_cooldown) || fuel_count < 5)
+	if(!COOLDOWN_FINISHED(src, rev_cooldown))
+		return FALSE
+	if(fuel_count < 5)
 		return FALSE
 	COOLDOWN_START(src, rev_cooldown, 3 SECONDS)
 	to_chat(user, span_notice("You rev the [src]'s engine."))


### PR DESCRIPTION

## About The Pull Request
bike revving now no longer removes fuel to negatives, as it was lacking sanity

## Why It's Good For The Game
bug bad

## Changelog

no cl
