### PR TITLE
Fixed Warrior throw bug

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -26,6 +26,8 @@
 
 
 /obj/item/grab/on_thrown(mob/living/carbon/user, atom/target)
+	if(!ishuman(user))
+		return
 	if(!ismob(grabbed_thing))
 		return
 	if(user.grab_state < GRAB_NECK)


### PR DESCRIPTION
## About The Pull Request

Fixed Warrior being able to aggressive grab throw marines, resulting in much further fishes and less abilities used.
## Why It's Good For The Game

Warrior being able to throw marines over 7 tiles with their lunge ability, then fling them even more tiles away is slightly broken I think. Admins also see it as bug abuse so krill it.

https://github.com/user-attachments/assets/265c37e4-f473-464c-85e5-7cb12fea1f8b


## Changelog
:cl:
fix: Fixed Warrior aggressive grab throw bug.
/:cl:
