### PR TITLE
Fixes OpenDream Lint Failure from Holopad Parameter

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -25,10 +25,10 @@
 
 	var/call_start_time
 
-//creates a holocall made by `caller` from `calling_pad` to `callees`
-/datum/holocall/New(mob/living/caller, obj/machinery/holopad/calling_pad, list/callees)
+//creates a holocall made by `new_user` from `calling_pad` to `callees`
+/datum/holocall/New(mob/living/new_user, obj/machinery/holopad/calling_pad, list/callees)
 	call_start_time = world.time
-	user = caller
+	user = new_user
 	calling_pad.outgoing_call = src
 	calling_holopad = calling_pad
 	dialed_holopads = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames a parameter from holocall.dm to correct the error message that the lint is outputting that affected other PRs like https://github.com/tgstation/TerraGov-Marine-Corps/pull/18006 through unchanged files:
![image](https://github.com/user-attachments/assets/9f7c436b-9a39-49e9-b346-cbdf0d1a75c8)


## Why It's Good For The Game
Lint no longer fails when it shouldn't.

## Changelog
Nothing player-facing.
