### PR TITLE
LasMG Standard Mode Buff.

### DIFF
--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -81,7 +81,10 @@
 	if(!(to_check_flags & ABILITY_USE_STAGGERED) && carbon_owner.IsStaggered())
 		if(!silent)
 			carbon_owner.balloon_alert(carbon_owner, "Cannot while staggered")
+		GLOB.round_statistics.ability_staggered++
+		SSblackbox.record_feedback("tally", "round_statistics", 1, "ability_staggered")
 		return FALSE
+
 
 	if(!(to_check_flags & ABILITY_USE_NOTTURF) && !isturf(carbon_owner.loc))
 		if(!silent)

--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -81,8 +81,6 @@
 	if(!(to_check_flags & ABILITY_USE_STAGGERED) && carbon_owner.IsStaggered())
 		if(!silent)
 			carbon_owner.balloon_alert(carbon_owner, "Cannot while staggered")
-		GLOB.round_statistics.ability_staggered++
-		SSblackbox.record_feedback("tally", "round_statistics", 1, "ability_staggered")
 		return FALSE
 
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -395,9 +395,11 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.total_projectile_hits[FACTION_XENO])
 		parts += "[GLOB.round_statistics.total_projectile_hits[FACTION_XENO]] projectiles managed to hit xenomorphs. For a [(GLOB.round_statistics.total_projectile_hits[FACTION_XENO] / max(GLOB.round_statistics.total_projectiles_fired[FACTION_TERRAGOV], 1)) * 100]% accuracy total!"
 	if(GLOB.round_statistics.grenades_thrown)
-		parts += "[GLOB.round_statistics.grenades_thrown] total grenades exploding."
+		parts += "[GLOB.round_statistics.grenades_thrown] total grenades exploded."
 	else
 		parts += "No grenades exploded."
+	if(GLOB.round_statistics.ability_staggered)
+		parts += "[GLOB.round_statistics.ability_staggered] number of times a Xenomorph attempted to use an ability while staggered."
 	if(GLOB.round_statistics.mortar_shells_fired)
 		parts += "[GLOB.round_statistics.mortar_shells_fired] mortar shells were fired."
 	if(GLOB.round_statistics.howitzer_shells_fired)
@@ -423,24 +425,28 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.crusher_stomp_victims] people stomped by Crushers."
 	if(GLOB.round_statistics.praetorian_spray_direct_hits)
 		parts += "[GLOB.round_statistics.praetorian_spray_direct_hits] people hit directly by Praetorian acid spray."
+	if(GLOB.round_statistics.behemoth_rock_victims)
+		parts += "[GLOB.round_statistics.behemoth_rock_victims] people hit directly by a Behemoth boulder."
 	if(GLOB.round_statistics.weeds_planted)
 		parts += "[GLOB.round_statistics.weeds_planted] weed nodes planted."
 	if(GLOB.round_statistics.weeds_destroyed)
 		parts += "[GLOB.round_statistics.weeds_destroyed] weed tiles removed."
+	if(GLOB.round_statistics.all_acid_applied)
+		parts += "[GLOB.round_statistics.all_acid_applied] objects vomitted on with corrosive acid."
 	if(GLOB.round_statistics.trap_holes)
 		parts += "[GLOB.round_statistics.trap_holes] holes for acid and huggers were made."
 	if(GLOB.round_statistics.sentinel_drain_stings)
 		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times Sentinel drain sting was used."
 	if(GLOB.round_statistics.defender_charge_victims)
-		parts += "[GLOB.round_statistics.defender_charge_victims] people charged by Defenders."
+		parts += "[GLOB.round_statistics.defender_charge_victims] number of times people were charged down by Defenders."
 	if(GLOB.round_statistics.runner_savage_attacks)
 		parts += "[GLOB.round_statistics.runner_savage_attacks] number of times Runners savaged an enemy."
 	if(GLOB.round_statistics.runner_evasions)
-		parts += "[GLOB.round_statistics.runner_evasions] number of times Runners began evading."
+		parts += "[GLOB.round_statistics.runner_evasions] number of times Runners began to evade."
 	if(GLOB.round_statistics.runner_items_stolen)
 		parts += "[GLOB.round_statistics.runner_items_stolen] items stolen by Runners."
 	if(GLOB.round_statistics.melter_acid_shrouds)
-		parts += "[GLOB.round_statistics.melter_acid_shrouds] number of acid clouds created by Melters."
+		parts += "[GLOB.round_statistics.melter_acid_shrouds] number of times Melters created an acid shroud."
 	if(GLOB.round_statistics.melter_acidic_missiles)
 		parts += "[GLOB.round_statistics.melter_acidic_missiles] number of times Melters became an Acidic Missile."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
@@ -470,9 +476,9 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.spitter_scatter_spits)
 		parts += "[GLOB.round_statistics.spitter_scatter_spits] number of times Spitters horked up scatter spits."
 	if(GLOB.round_statistics.globadier_grenades_thrown)
-		parts += "[GLOB.round_statistics.globadier_grenades_thrown] number of grenades thrown by Globadiers."
+		parts += "[GLOB.round_statistics.globadier_grenades_thrown] number of times grenades were thrown by Globadiers."
 	if(GLOB.round_statistics.globadier_mines_placed)
-		parts += "[GLOB.round_statistics.globadier_mines_placed] number of mines placed by Globadiers."
+		parts += "[GLOB.round_statistics.globadier_mines_placed] number of times Globadiers placed a mine."
 	if(GLOB.round_statistics.globadier_XADAR_fired)
 		parts += "[GLOB.round_statistics.globadier_XADAR_fired] number of times Globadiers fired an Acid Rocket."
 	if(GLOB.round_statistics.ravager_endures)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -422,7 +422,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.crusher_stomp_victims)
 		parts += "[GLOB.round_statistics.crusher_stomp_victims] people stomped by Crushers."
 	if(GLOB.round_statistics.praetorian_spray_direct_hits)
-		parts += "[GLOB.round_statistics.praetorian_spray_direct_hits] people hit directly by Praetorian acid spray."
+		parts += "[GLOB.round_statistics.praetorian_spray_direct_hits] people hit directly by a Praetorian acid spray."
 	if(GLOB.round_statistics.behemoth_rock_victims)
 		parts += "[GLOB.round_statistics.behemoth_rock_victims] people hit directly by a Behemoth boulder."
 	if(GLOB.round_statistics.weeds_planted)
@@ -437,8 +437,10 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times Sentinel drain sting was used."
 	if(GLOB.round_statistics.defender_charge_victims)
 		parts += "[GLOB.round_statistics.defender_charge_victims] number of times people were charged down by Defenders."
-	if(GLOB.round_statistics.runner_savage_attacks)
-		parts += "[GLOB.round_statistics.runner_savage_attacks] number of times Runners savaged an enemy."
+	if(GLOB.round_statistics.defender_tail_sweeps)
+		parts += "[GLOB.round_statistics.defender_tail_sweeps] number of times people were tail swept by Defenders, knocking down [GLOB.round_statistics.defender_tail_sweep_hits] people."
+	if(GLOB.round_statistics.runner_pounce_victims)
+		parts += "[GLOB.round_statistics.runner_pounce_victims] number of times Runners and Hunters pounced on people, out of which [GLOB.round_statistics.runner_savage_attacks] were savage attacks."
 	if(GLOB.round_statistics.runner_evasions)
 		parts += "[GLOB.round_statistics.runner_evasions] number of times Runners began to evade."
 	if(GLOB.round_statistics.runner_items_stolen)
@@ -446,15 +448,19 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.melter_acid_shrouds)
 		parts += "[GLOB.round_statistics.melter_acid_shrouds] number of times Melters created an acid shroud."
 	if(GLOB.round_statistics.melter_acidic_missiles)
-		parts += "[GLOB.round_statistics.melter_acidic_missiles] number of times Melters became an Acidic Missile."
+		parts += "[GLOB.round_statistics.melter_acidic_missiles] number of times Melters became an acidic missile."
+	if(GLOB.round_statistics.psychic_flings)
+		parts += "[GLOB.round_statistics.psychic_flings] number of times Shrikes used psychic fling."
+	if(GLOB.round_statistics.psychic_cures)
+		parts += "[GLOB.round_statistics.psychic_cures] number of times Shrikes healed a Xenomorph with psychic cure."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		parts += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
 	if(GLOB.round_statistics.pyrogen_fireballs)
-		parts += "[GLOB.round_statistics.pyrogen_fireballs] number of times Pyrogens conjured a Fireball."
+		parts += "[GLOB.round_statistics.pyrogen_fireballs] number of times Pyrogens conjured a fireball."
 	if(GLOB.round_statistics.pyrogen_infernos)
-		parts += "[GLOB.round_statistics.pyrogen_infernos] number of times Pyrogens erupted into an Inferno."
+		parts += "[GLOB.round_statistics.pyrogen_infernos] number of times Pyrogens erupted into an inferno."
 	if(GLOB.round_statistics.pyrogen_firestorms)
-		parts += "[GLOB.round_statistics.pyrogen_firestorms] number of times Pyrogens conjured a Firestorm."
+		parts += "[GLOB.round_statistics.pyrogen_firestorms] number of times Pyrogens conjured a firestorm."
 	if(GLOB.round_statistics.ozelomelyn_stings)
 		parts += "[GLOB.round_statistics.ozelomelyn_stings] number of times ozelomelyn sting was used."
 	if(GLOB.round_statistics.defiler_defiler_stings)
@@ -468,9 +474,9 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.xeno_rally_hive)
 		parts += "[GLOB.round_statistics.xeno_rally_hive] number of times xeno leaders rallied the hive."
 	if(GLOB.round_statistics.hivelord_healing_infusions)
-		parts += "[GLOB.round_statistics.hivelord_healing_infusions] number of times Hivelords used Healing Infusion."
+		parts += "[GLOB.round_statistics.hivelord_healing_infusions] number of times Hivelords used healing infusion."
 	if(GLOB.round_statistics.spitter_acid_sprays)
-		parts += "[GLOB.round_statistics.spitter_acid_sprays] number of times Spitters spewed an Acid Spray."
+		parts += "[GLOB.round_statistics.spitter_acid_sprays] number of times Spitters spewed an acid spray."
 	if(GLOB.round_statistics.spitter_scatter_spits)
 		parts += "[GLOB.round_statistics.spitter_scatter_spits] number of times Spitters horked up scatter spits."
 	if(GLOB.round_statistics.globadier_grenades_thrown)
@@ -478,9 +484,9 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.globadier_mines_placed)
 		parts += "[GLOB.round_statistics.globadier_mines_placed] number of times Globadiers placed a mine."
 	if(GLOB.round_statistics.globadier_XADAR_fired)
-		parts += "[GLOB.round_statistics.globadier_XADAR_fired] number of times Globadiers fired an Acid Rocket."
+		parts += "[GLOB.round_statistics.globadier_XADAR_fired] number of times Globadiers fired an acid rocket."
 	if(GLOB.round_statistics.ravager_endures)
-		parts += "[GLOB.round_statistics.ravager_endures] number of times Ravagers used Endure."
+		parts += "[GLOB.round_statistics.ravager_endures] number of times Ravagers used endure."
 	if(GLOB.round_statistics.bull_crush_hit)
 		parts += "[GLOB.round_statistics.bull_crush_hit] number of times Bulls crushed marines."
 	if(GLOB.round_statistics.bull_gore_hit)
@@ -491,6 +497,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.hunter_silence_targets] number of targets silenced by Hunters."
 	if(GLOB.round_statistics.hunter_marks)
 		parts += "[GLOB.round_statistics.hunter_marks] number of times Hunters marked a target for death."
+	if(GLOB.round_statistics.hunter_cloaks)
+		parts += "[GLOB.round_statistics.hunter_cloaks] number of times Hunters cloaked themselves in darkness."
 	if(GLOB.round_statistics.ravager_rages)
 		parts += "[GLOB.round_statistics.ravager_rages] number of times Ravagers raged."
 	if(GLOB.round_statistics.boiler_acid_smokes)
@@ -498,15 +506,15 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.boiler_neuro_smokes)
 		parts += "[GLOB.round_statistics.boiler_neuro_smokes] number of times Boilers spat out a glob of neurotoxin."
 	if(GLOB.round_statistics.psy_crushes)
-		parts += "[GLOB.round_statistics.psy_crushes] number of times Warlocks used Psychic Crush."
+		parts += "[GLOB.round_statistics.psy_crushes] number of times Warlocks used psychic crush."
 	if(GLOB.round_statistics.psy_blasts)
-		parts += "[GLOB.round_statistics.psy_blasts] number of times Warlocks used Psychic Blast."
+		parts += "[GLOB.round_statistics.psy_blasts] number of times Warlocks used psychic blast."
 	if(GLOB.round_statistics.psy_lances)
-		parts += "[GLOB.round_statistics.psy_lances] number of times Warlocks used Psychic Lance."
+		parts += "[GLOB.round_statistics.psy_lances] number of times Warlocks used psychic lance."
 	if(GLOB.round_statistics.psy_shields)
-		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used Psychic Shield."
+		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used psychic shield."
 	if(GLOB.round_statistics.psy_shield_blasts)
-		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a Psychic Shield."
+		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a psychic shield."
 	if(GLOB.round_statistics.larva_from_psydrain)
 		parts += "[GLOB.round_statistics.larva_from_psydrain] larvas came from psydrain."
 	if(GLOB.round_statistics.larva_from_silo)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -491,6 +491,20 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.hunter_marks] number of times Hunters marked a target for death."
 	if(GLOB.round_statistics.ravager_rages)
 		parts += "[GLOB.round_statistics.ravager_rages] number of times Ravagers raged."
+	if(GLOB.round_statistics.boiler_acid_smokes)
+		parts += "[GLOB.round_statistics.boiler_acid_smokes] number of times Boilers spat out a glob of acid."
+	if(GLOB.round_statistics.boiler_neuro_smokes)
+		parts += "[GLOB.round_statistics.boiler_neuro_smokes] number of times Boilers spat out a glob of neurotoxin."
+	if(GLOB.round_statistics.psy_crushes)
+		parts += "[GLOB.round_statistics.psy_crushes] number of times Warlocks used Psychic Crush."
+	if(GLOB.round_statistics.psy_blasts)
+		parts += "[GLOB.round_statistics.psy_blasts] number of times Warlocks used Psychic Blast."
+	if(GLOB.round_statistics.psy_lances)
+		parts += "[GLOB.round_statistics.psy_lances] number of times Warlocks used Psychic Lance."
+	if(GLOB.round_statistics.psy_shields)
+		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used Psychic Shield."
+	if(GLOB.round_statistics.psy_shield_blasts)
+		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a Psychic Shield."
 	if(GLOB.round_statistics.hunter_silence_targets)
 		parts += "[GLOB.round_statistics.hunter_silence_targets] number of targets silenced by Hunters."
 	if(GLOB.round_statistics.larva_from_psydrain)
@@ -503,16 +517,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.larva_from_marine_spawning] larvas came from marine spawning."
 	if(GLOB.round_statistics.larva_from_siloing_body)
 		parts += "[GLOB.round_statistics.larva_from_siloing_body] larvas came from siloing bodies."
-	if(GLOB.round_statistics.psy_crushes)
-		parts += "[GLOB.round_statistics.psy_crushes] number of times Warlocks used Psychic Crush."
-	if(GLOB.round_statistics.psy_blasts)
-		parts += "[GLOB.round_statistics.psy_blasts] number of times Warlocks used Psychic Blast."
-	if(GLOB.round_statistics.psy_lances)
-		parts += "[GLOB.round_statistics.psy_lances] number of times Warlocks used Psychic Lance."
-	if(GLOB.round_statistics.psy_shields)
-		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used Psychic Shield."
-	if(GLOB.round_statistics.psy_shield_blasts)
-		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a Psychic Shield."
 	if(GLOB.round_statistics.points_from_objectives)
 		parts += "[GLOB.round_statistics.points_from_objectives] requisitions points gained from objectives."
 	if(GLOB.round_statistics.points_from_mining)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -445,6 +445,12 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.melter_acidic_missiles] number of times Melters became an Acidic Missile."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		parts += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
+	if(GLOB.round_statistics.pyrogen_fireballs)
+		parts += "[GLOB.round_statistics.pyrogen_fireballs] number of times Pyrogens conjured a Fireball."
+	if(GLOB.round_statistics.pyrogen_infernos)
+		parts += "[GLOB.round_statistics.pyrogen_infernos] number of times Pyrogens summoned an Inferno."
+	if(GLOB.round_statistics.pyrogen_firestorms)
+		parts += "[GLOB.round_statistics.pyrogen_firestorms] number of times Pyrogens conjured a Firestorm."
 	if(GLOB.round_statistics.ozelomelyn_stings)
 		parts += "[GLOB.round_statistics.ozelomelyn_stings] number of times ozelomelyn sting was used."
 	if(GLOB.round_statistics.defiler_defiler_stings)
@@ -467,6 +473,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.globadier_grenades_thrown] number of grenades thrown by Globadiers."
 	if(GLOB.round_statistics.globadier_mines_placed)
 		parts += "[GLOB.round_statistics.globadier_mines_placed] number of mines placed by Globadiers."
+	if(GLOB.round_statistics.globadier_XADAR_fired)
+		parts += "[GLOB.round_statistics.globadier_XADAR_fired] number of times Globadiers fired an Acid Rocket."
 	if(GLOB.round_statistics.ravager_endures)
 		parts += "[GLOB.round_statistics.ravager_endures] number of times Ravagers used Endure."
 	if(GLOB.round_statistics.bull_crush_hit)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -398,8 +398,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.grenades_thrown] total grenades exploded."
 	else
 		parts += "No grenades exploded."
-	if(GLOB.round_statistics.ability_staggered)
-		parts += "[GLOB.round_statistics.ability_staggered] number of times a Xenomorph attempted to use an ability while staggered."
 	if(GLOB.round_statistics.mortar_shells_fired)
 		parts += "[GLOB.round_statistics.mortar_shells_fired] mortar shells were fired."
 	if(GLOB.round_statistics.howitzer_shells_fired)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -420,7 +420,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.warrior_lunges)
 		parts += "[GLOB.round_statistics.warrior_lunges] Warriors lunges."
 	if(GLOB.round_statistics.crusher_stomp_victims)
-		parts += "[GLOB.round_statistics.crusher_stomp_victims] people stomped by crushers."
+		parts += "[GLOB.round_statistics.crusher_stomp_victims] people stomped by Crushers."
 	if(GLOB.round_statistics.praetorian_spray_direct_hits)
 		parts += "[GLOB.round_statistics.praetorian_spray_direct_hits] people hit directly by Praetorian acid spray."
 	if(GLOB.round_statistics.weeds_planted)
@@ -430,7 +430,19 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.trap_holes)
 		parts += "[GLOB.round_statistics.trap_holes] holes for acid and huggers were made."
 	if(GLOB.round_statistics.sentinel_drain_stings)
-		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times sentinel drain sting was used."
+		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times Sentinel drain sting was used."
+	if(GLOB.round_statistics.defender_charge_victims)
+		parts += "[GLOB.round_statistics.defender_charge_victims] people charged by Defenders."
+	if(GLOB.round_statistics.runner_savage_attacks)
+		parts += "[GLOB.round_statistics.runner_savage_attacks] number of times Runners savaged an enemy."
+	if(GLOB.round_statistics.runner_evasions)
+		parts += "[GLOB.round_statistics.runner_evasions] number of times Runners began evading."
+	if(GLOB.round_statistics.runner_items_stolen)
+		parts += "[GLOB.round_statistics.runner_items_stolen] items stolen by Runners."
+	if(GLOB.round_statistics.melter_acid_shrouds)
+		parts += "[GLOB.round_statistics.melter_acid_shrouds] number of acid clouds created by Melters."
+	if(GLOB.round_statistics.melter_acidic_missiles)
+		parts += "[GLOB.round_statistics.melter_acidic_missiles] number of times Melters became an Acidic Missile."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		parts += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
 	if(GLOB.round_statistics.ozelomelyn_stings)
@@ -451,6 +463,10 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.spitter_acid_sprays] number of times Spitters spewed an Acid Spray."
 	if(GLOB.round_statistics.spitter_scatter_spits)
 		parts += "[GLOB.round_statistics.spitter_scatter_spits] number of times Spitters horked up scatter spits."
+	if(GLOB.round_statistics.globadier_grenades_thrown)
+		parts += "[GLOB.round_statistics.globadier_grenades_thrown] number of grenades thrown by Globadiers."
+	if(GLOB.round_statistics.globadier_mines_placed)
+		parts += "[GLOB.round_statistics.globadier_mines_placed] number of mines placed by Globadiers."
 	if(GLOB.round_statistics.ravager_endures)
 		parts += "[GLOB.round_statistics.ravager_endures] number of times Ravagers used Endure."
 	if(GLOB.round_statistics.bull_crush_hit)
@@ -493,8 +509,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.points_from_research] requisitions points gained from research."
 	if(GLOB.round_statistics.points_from_xenos)
 		parts += "[GLOB.round_statistics.points_from_xenos] requisitions points gained from xenomorph sales."
-	if(GLOB.round_statistics.runner_items_stolen)
-		parts += "[GLOB.round_statistics.runner_items_stolen] items stolen by runners."
 	if(GLOB.round_statistics.acid_maw_fires)
 		parts += "[GLOB.round_statistics.acid_maw_fires] Acid Maw uses."
 	if(GLOB.round_statistics.acid_jaw_fires)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -498,7 +498,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.hunter_marks)
 		parts += "[GLOB.round_statistics.hunter_marks] number of times Hunters marked a target for death."
 	if(GLOB.round_statistics.hunter_cloaks)
-		parts += "[GLOB.round_statistics.hunter_cloaks] number of times Hunters cloaked themselves in darkness."
+		parts += "[GLOB.round_statistics.hunter_cloaks] number of times Hunters cloaked themselves in darkness, resulting in [GLOB.round_statistics.hunter_cloak_victims] successful stealth attacks."
 	if(GLOB.round_statistics.ravager_rages)
 		parts += "[GLOB.round_statistics.ravager_rages] number of times Ravagers raged."
 	if(GLOB.round_statistics.boiler_acid_smokes)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -487,6 +487,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.bull_gore_hit] number of times Bulls gored marines."
 	if(GLOB.round_statistics.bull_headbutt_hit)
 		parts += "[GLOB.round_statistics.bull_headbutt_hit] number of times Bulls headbutted marines."
+	if(GLOB.round_statistics.hunter_silence_targets)
+		parts += "[GLOB.round_statistics.hunter_silence_targets] number of targets silenced by Hunters."
 	if(GLOB.round_statistics.hunter_marks)
 		parts += "[GLOB.round_statistics.hunter_marks] number of times Hunters marked a target for death."
 	if(GLOB.round_statistics.ravager_rages)
@@ -505,8 +507,6 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used Psychic Shield."
 	if(GLOB.round_statistics.psy_shield_blasts)
 		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a Psychic Shield."
-	if(GLOB.round_statistics.hunter_silence_targets)
-		parts += "[GLOB.round_statistics.hunter_silence_targets] number of targets silenced by Hunters."
 	if(GLOB.round_statistics.larva_from_psydrain)
 		parts += "[GLOB.round_statistics.larva_from_psydrain] larvas came from psydrain."
 	if(GLOB.round_statistics.larva_from_silo)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -448,7 +448,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.pyrogen_fireballs)
 		parts += "[GLOB.round_statistics.pyrogen_fireballs] number of times Pyrogens conjured a Fireball."
 	if(GLOB.round_statistics.pyrogen_infernos)
-		parts += "[GLOB.round_statistics.pyrogen_infernos] number of times Pyrogens summoned an Inferno."
+		parts += "[GLOB.round_statistics.pyrogen_infernos] number of times Pyrogens erupted into an Inferno."
 	if(GLOB.round_statistics.pyrogen_firestorms)
 		parts += "[GLOB.round_statistics.pyrogen_firestorms] number of times Pyrogens conjured a Firestorm."
 	if(GLOB.round_statistics.ozelomelyn_stings)

--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -85,6 +85,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	var/generator_repairs_performed = 0
 	var/miner_repairs_performed = 0
 	var/apcs_repaired = 0
+	var/acid_applied = 0
 
 	var/generator_sabotages_performed = 0
 	var/miner_sabotages_performed = 0
@@ -272,6 +273,8 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 		support_stats += "Gave birth to [huggers_created] hugger\s."
 	if(impregnations)
 		support_stats += "Impregnated [impregnations] host\s."
+	if(acid_applied)
+		support_stats += "Applied acid to [acid_applied] object\s."
 
 	if(LAZYLEN(support_stats))
 		stats += "<hr>"

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -34,23 +34,16 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/total_bullet_hits_on_marines = 0
 	var/total_bullet_hits_on_xenos = 0
 	var/workout_counts = list()
-	var/total_larva_burst = 0
-	var/trap_holes = 0
+	///Xeno Stats
+	var/acid_maw_fires = 0
+	var/acid_jaw_fires = 0
 	var/boiler_acid_smokes = 0
 	var/boiler_neuro_smokes = 0
+	var/bull_crush_hit = 0
+	var/bull_gore_hit = 0
+	var/bull_headbutt_hit = 0
 	var/crusher_stomps = 0
 	var/crusher_stomp_victims = 0
-	var/praetorian_acid_sprays = 0
-	var/praetorian_spray_direct_hits = 0
-	var/psychic_flings = 0
-	var/psychic_cures = 0
-	var/warrior_flings = 0
-	var/warrior_punches = 0
-	var/warrior_lunges = 0
-	var/warrior_agility_toggles = 0
-	var/warrior_grabs = 0
-	var/globadier_grenades_thrown = 0
-	var/globadier_mines_placed = 0
 	var/defender_charges = 0
 	var/defender_charge_victims = 0
 	var/defender_headbutts = 0
@@ -59,54 +52,81 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/defender_crest_lowerings = 0
 	var/defender_crest_raises = 0 //manual disabling of the crest
 	var/defender_fortifiy_toggles = 0
-	var/runner_savage_attacks = 0
-	var/runner_evasions = 0
-	var/melter_acid_shrouds = 0
-	var/melter_acidic_missiles = 0
-	var/weeds_planted = 0
-	var/weeds_destroyed = 0
-	var/grenades_thrown = 0
-	var/mortar_shells_fired = 0
-	var/howitzer_shells_fired = 0
-	var/rocket_shells_fired = 0
-	var/obs_fired = 0
-	var/queen_screech = 0
-	var/now_pregnant = 0
-	var/sentinel_drain_stings = 0
-	var/sentinel_neurotoxin_stings = 0
-	var/ozelomelyn_stings = 0
 	var/defiler_defiler_stings = 0
 	var/defiler_neurogas_uses = 0
 	var/defiler_inject_egg_neurogas = 0
 	var/defiler_reagent_slashes = 0
-	var/xeno_unarmed_attacks = 0
-	var/xeno_bump_attacks = 0
-	var/xeno_rally_hive = 0
-	var/hivelord_healing_infusions = 0
-	var/spitter_acid_sprays = 0
-	var/spitter_scatter_spits = 0
-	var/wraith_phase_shifts = 0
-	var/bull_crush_hit = 0
-	var/bull_gore_hit = 0
-	var/bull_headbutt_hit = 0
-	var/ravager_endures = 0
+	var/globadier_grenades_thrown = 0
+	var/globadier_mines_placed = 0
+	var/globadier_XADAR_fired = 0
 	var/hunter_marks = 0
 	var/hunter_silence_targets = 0
-	var/xeno_acid_wells = 0
-	var/ravager_rages = 0
 	var/larva_from_marine_spawning = 0
 	var/larva_from_silo = 0
 	var/larva_from_cocoon = 0
 	var/larva_from_psydrain = 0
 	var/larva_from_siloing_body = 0
-	var/req_items_produced = list()
+	var/melter_acid_shrouds = 0
+	var/melter_acidic_missiles = 0
+	var/now_pregnant = 0
+	var/ozelomelyn_stings = 0
+	var/praetorian_acid_sprays = 0
+	var/praetorian_spray_direct_hits = 0
+	var/psychic_flings = 0
+	var/psychic_cures = 0
 	var/psy_crushes = 0
 	var/psy_blasts = 0
 	var/psy_lances = 0
 	var/psy_shields = 0
 	var/psy_shield_blasts = 0
+	var/pyrogen_fireballs = 0
+	var/pyrogen_firestorms = 0
+	var/pyrogen_infernos
+	var/queen_screech = 0
+	var/runner_savage_attacks = 0
+	var/runner_evasions = 0
+	var/runner_items_stolen = 0
+	var/ravager_endures = 0
+	var/ravager_rages = 0
+	var/sentinel_drain_stings = 0
+	var/sentinel_neurotoxin_stings = 0
+	var/spitter_acid_sprays = 0
+	var/spitter_scatter_spits = 0
+	var/total_larva_burst = 0
+	var/trap_holes = 0
+	var/warrior_flings = 0
+	var/warrior_punches = 0
+	var/warrior_lunges = 0
+	var/warrior_agility_toggles = 0
+	var/warrior_grabs = 0
+	var/hivelord_healing_infusions = 0
+	var/weeds_planted = 0
+	var/weeds_destroyed = 0
+	var/wraith_phase_shifts = 0
+	var/xeno_acid_wells = 0
+	var/xeno_unarmed_attacks = 0
+	var/xeno_bump_attacks = 0
+	var/xeno_rally_hive = 0
+	///Human Stats
+	var/grenades_thrown = 0
+	var/mortar_shells_fired = 0
+	var/howitzer_shells_fired = 0
+	var/rocket_shells_fired = 0
+	var/obs_fired = 0
 	var/sandevistan_uses = 0
 	var/sandevistan_gibs = 0
-	var/runner_items_stolen = 0
-	var/acid_maw_fires = 0
-	var/acid_jaw_fires = 0
+	var/req_items_produced = list()
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -49,6 +49,10 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/warrior_lunges = 0
 	var/warrior_agility_toggles = 0
 	var/warrior_grabs = 0
+	var/globadier_grenades_thrown = 0
+	var/globadier_mines_placed = 0
+	var/defender_charges = 0
+	var/defender_charge_victims = 0
 	var/defender_headbutts = 0
 	var/defender_tail_sweeps = 0
 	var/defender_tail_sweep_hits = 0

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -64,6 +64,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/hunter_marks = 0
 	var/hunter_silence_targets = 0
 	var/hunter_cloaks = 0
+	var/hunter_cloak_victims = 0
 	var/larva_from_marine_spawning = 0
 	var/larva_from_silo = 0
 	var/larva_from_cocoon = 0

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -35,7 +35,6 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/total_bullet_hits_on_xenos = 0
 	var/workout_counts = list()
 	///Xeno Stats
-	var/ability_staggered = 0 // Checks to see if a Xeno is trying to use an ability while staggered. Funny.
 	var/acid_maw_fires = 0
 	var/acid_jaw_fires = 0
 	var/all_acid_applied = 0 // Acid applied to walls, items, etc. Seperate from the personal tracking.

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -57,6 +57,8 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/defender_fortifiy_toggles = 0
 	var/runner_savage_attacks = 0
 	var/runner_evasions = 0
+	var/melter_acid_shrouds = 0
+	var/melter_acidic_missiles = 0
 	var/weeds_planted = 0
 	var/weeds_destroyed = 0
 	var/grenades_thrown = 0

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -37,6 +37,8 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	///Xeno Stats
 	var/acid_maw_fires = 0
 	var/acid_jaw_fires = 0
+	var/all_acid_applied = 0 // Acid applied to walls, items, etc. Seperate from the personal tracking.
+	var/behemoth_rock_victims = 0
 	var/boiler_acid_smokes = 0
 	var/boiler_neuro_smokes = 0
 	var/bull_crush_hit = 0

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -35,6 +35,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/total_bullet_hits_on_xenos = 0
 	var/workout_counts = list()
 	///Xeno Stats
+	var/ability_staggered = 0 // Checks to see if a Xeno is trying to use an ability while staggered. Funny.
 	var/acid_maw_fires = 0
 	var/acid_jaw_fires = 0
 	var/all_acid_applied = 0 // Acid applied to walls, items, etc. Seperate from the personal tracking.

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -63,6 +63,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/globadier_XADAR_fired = 0
 	var/hunter_marks = 0
 	var/hunter_silence_targets = 0
+	var/hunter_cloaks = 0
 	var/larva_from_marine_spawning = 0
 	var/larva_from_silo = 0
 	var/larva_from_cocoon = 0
@@ -86,6 +87,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/pyrogen_infernos
 	var/queen_screech = 0
 	var/runner_savage_attacks = 0
+	var/runner_pounce_victims = 0
 	var/runner_evasions = 0
 	var/runner_items_stolen = 0
 	var/ravager_endures = 0

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -631,6 +631,9 @@
 	X.visible_message(span_xenowarning("\The [X] vomits globs of vile stuff all over \the [A]. It begins to sizzle and melt under the bubbling mess of acid!"), \
 	span_xenowarning("We vomit globs of vile stuff all over \the [A]. It begins to sizzle and melt under the bubbling mess of acid!"), null, 5)
 	playsound(X.loc, "sound/bullets/acid_impact1.ogg", 25)
+	if(owner.client)
+		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]
+		personal_statistics.acid_applied++
 
 // ***************************************
 // *********** Super strong acid

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -634,6 +634,8 @@
 	if(owner.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]
 		personal_statistics.acid_applied++
+	GLOB.round_statistics.all_acid_applied++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "all_acid_applied")
 
 // ***************************************
 // *********** Super strong acid

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -1421,6 +1421,8 @@
 				shake_camera(affected_living, 1, 0.8)
 				affected_living.Paralyze(paralyze_duration)
 				affected_living.apply_damage(attack_damage, BRUTE, blocked = MELEE)
+				GLOB.round_statistics.behemoth_rock_victims++
+				SSblackbox.record_feedback("tally", "round_statistics", 1, "behemoth_rock_victims")
 			else if(isearthpillar(affected_atom) || isvehicle(affected_atom) || ishitbox(affected_atom) || istype(affected_atom, /obj/structure/reagent_dispensers/fueltank))
 				affected_atom.do_jitter_animation()
 				new /obj/effect/temp_visual/behemoth/landslide/hit(affected_atom.loc)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -137,6 +137,8 @@
 	target_turf = get_step_rand(target_turf) //Scatter
 	carbon_victim.throw_at(get_turf(target_turf), charge_range, 5, src)
 	carbon_victim.Paralyze(4 SECONDS)
+	GLOB.round_statistics.defender_charge_victims++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_charge_victims")
 
 /datum/action/ability/activable/xeno/charge/forward_charge/ai_should_use(atom/target)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -197,6 +197,8 @@
 	target.adjust_stagger(staggerslow_stacks SECONDS)
 	target.add_slowdown(staggerslow_stacks)
 	target.ParalyzeNoChain(1 SECONDS)
+	GLOB.round_statistics.hunter_cloak_victims++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "hunter_cloak_victims")
 
 	cancel_stealth()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -48,6 +48,8 @@
 	to_chat(owner, "<span class='xenodanger'>We vanish into the shadows...</span>")
 	last_stealth = world.time
 	stealth = TRUE
+	GLOB.round_statistics.hunter_cloaks++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "hunter_cloaks")
 
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(handle_stealth_move))
 	RegisterSignal(owner, COMSIG_XENOMORPH_POUNCE_END, PROC_REF(sneak_attack_pounce))
@@ -343,6 +345,8 @@
 	xeno_owner.Immobilize(XENO_POUNCE_STANDBY_DURATION)
 	xeno_owner.forceMove(get_turf(living_target))
 	living_target.Knockdown(XENO_POUNCE_STUN_DURATION)
+	GLOB.round_statistics.runner_pounce_victims++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_pounce_victims")
 
 /datum/action/ability/activable/xeno/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -94,6 +94,8 @@
 	magic_bullshit.fire_at(target, xeno_owner, xeno_owner, PYROGEN_FIREBALL_MAXDIST, PYROGEN_FIREBALL_SPEED)
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.pyrogen_fireballs++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "pyrogen_fireballs")
 
 /datum/action/ability/activable/xeno/fireball/ai_should_start_consider()
 	return TRUE
@@ -157,6 +159,8 @@
 
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.pyrogen_firestorms++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "pyrogen_firestorms")
 
 /datum/action/ability/activable/xeno/firestorm/ai_should_start_consider()
 	return TRUE
@@ -213,6 +217,8 @@
 
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.pyrogen_infernos++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "pyrogen_infernos")
 
 // ***************************************
 // *********** Infernal Trigger

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -434,6 +434,8 @@
 	emitted_gas.start()
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.melter_acid_shrouds
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "melter_acid_shrouds")
 
 /datum/action/ability/activable/xeno/charge/acid_dash/melter/mob_hit(datum/source, mob/living/living_target)
 	. = ..()
@@ -542,6 +544,8 @@
 	if(xeno_owner.xeno_flags & XENO_LEAPING)
 		xeno_owner.xeno_flags &= ~XENO_LEAPING
 	acid_level = 0
+	GLOB.round_statistics.melter_acidic_missiles++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "melter_acidic_missiles")
 	add_cooldown()
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -434,7 +434,7 @@
 	emitted_gas.start()
 	succeed_activate()
 	add_cooldown()
-	GLOB.round_statistics.melter_acid_shrouds
+	GLOB.round_statistics.melter_acid_shrouds++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "melter_acid_shrouds")
 
 /datum/action/ability/activable/xeno/charge/acid_dash/melter/mob_hit(datum/source, mob/living/living_target)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -230,6 +230,8 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	update_button_icon()
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.globadier_grenades_thrown++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "globadier_grenades_thrown")
 
 /datum/action/ability/activable/xeno/toss_grenade/alternate_action_activate()
 	INVOKE_ASYNC(src, PROC_REF(selectgrenade))
@@ -520,6 +522,8 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	update_button_icon()
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.globadier_mines_placed++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "globadier_mines_placed")
 
 /datum/action/ability/xeno_action/acid_mine/process()
 	if(!timeleft(timer))

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -565,6 +565,8 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	update_button_icon()
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.globadier_mines_placed++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "globadier_mines_placed")
 
 // ***************************************
 // *********** Acid Rocket
@@ -600,3 +602,5 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	xeno_owner.adjustBruteLoss(xeno_owner.health * GLOBADIER_XADAR_PERCENT_HEALTH_PLAS_COST, TRUE)
 	succeed_activate(xeno_owner.plasma_stored * GLOBADIER_XADAR_PERCENT_HEALTH_PLAS_COST)
 	add_cooldown()
+	GLOB.round_statistics.globadier_XADAR_fired++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "globadier_XADAR_fired")

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -355,7 +355,7 @@
 
 /datum/ammo/energy/lasgun/marine/autolaser
 	name = "machine laser bolt"
-	damage = 18
+	damage = 20
 	penetration = 15
 	sundering = 1
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -917,7 +917,7 @@
 	message_to_user = "You set the machine laser's charge mode to standard fire."
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 	icon_state = "tem"
-	description = "Fires a rapid laser pulse with slightly reduced damage, but improved penetration and vastly improved energy efficiency."
+	description = "Fires a rapid laser pulse with slightly reduced sunder, but improved penetration and vastly improved energy efficiency."
 
 /datum/lasrifle/energy_mg_mode/standard/burst
 	rounds_per_shot = 8


### PR DESCRIPTION
## About The Pull Request

Increases the damage of the LasMG's standard mode from:

18 / 15 / 1   ->    20 / 15 / 1

## Why It's Good For The Game

The LasMG currently has more falloff, less sunder, less damage, less movement speed, and more scatter in exchange for a whole 5 more AP on its standard firemode, and better ammo capacity per magazine - which to me doesnt justify how pitiful it performs.

Increasing the damage to at least MATCH its Lasrifle counterpart will give a reason to use it for its standard firemode, as opposed to just using it almost exclusively for melting.

## Changelog

:cl:
balance: LasMG Standard Mode does 20 damage from 18
/:cl:
