### PR TITLE
LasMG Standard Mode buff.

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -355,7 +355,7 @@
 
 /datum/ammo/energy/lasgun/marine/autolaser
 	name = "machine laser bolt"
-	damage = 18
+	damage = 20
 	penetration = 15
 	sundering = 1
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -917,7 +917,7 @@
 	message_to_user = "You set the machine laser's charge mode to standard fire."
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 	icon_state = "tem"
-	description = "Fires a rapid laser pulse with slightly reduced damage, but improved penetration and vastly improved energy efficiency."
+	description = "Fires a rapid laser pulse with slightly reduced sunder, but improved penetration and vastly improved energy efficiency."
 
 /datum/lasrifle/energy_mg_mode/standard/burst
 	rounds_per_shot = 8


### PR DESCRIPTION
## About The Pull Request

Increases the damage of the LasMG's standard mode from:

18 / 15 / 1   ->    20 / 15 / 1

## Why It's Good For The Game

The LasMG currently has more falloff, less sunder, less damage, less movement speed, and more scatter in exchange for a whole 5 more AP on its standard firemode, and better ammo capacity per magazine - which to me doesnt justify how pitiful it performs.

Increasing the damage to at least MATCH its Lasrifle counterpart will give a reason to use it for its standard firemode, as opposed to just using it almost exclusively for melting.


## Changelog
:cl:
balance: LasMG Standard does 20 damage from 18
/:cl:
