### PR TITLE
Plane fixes

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -162,6 +162,7 @@
 #define RUNE_LAYER (17 + TOPDOWN_LAYER)
 #define CLEANABLE_FLOOR_OBJECT_LAYER (21 + TOPDOWN_LAYER)
 #define XENO_WEEDS_LAYER (24 + TOPDOWN_LAYER)
+#define EXPOSED_ATMOS_LAYER (26 + TOPDOWN_LAYER)
 #define ABOVE_WEEDS_LAYER (29 + TOPDOWN_LAYER)
 
 //Placeholders in case the game plane and possibly other things between it and the floor plane are ever made into topdown planes

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -233,7 +233,7 @@
 	desc = "Stairs.  You walk up and down them."
 	icon_state = "rampbottom"
 	plane = FLOOR_PLANE // we want this to render below walls if we place them on top
-	layer = ABOVE_OPEN_TURF_LAYER
+	layer = LOWER_RUNE_LAYER
 	density = FALSE
 	opacity = FALSE
 

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -80,7 +80,8 @@
 	density = FALSE
 	opacity = FALSE
 	max_integrity = 36
-	layer = BELOW_OBJ_LAYER
+	plane = FLOOR_PLANE
+	layer = ABOVE_WEEDS_LAYER
 	hit_sound = SFX_ALIEN_RESIN_MOVE
 	var/slow_amt = 8
 	/// Does this refund build points when destoryed?

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -53,7 +53,7 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/update_layer()
-	layer = (showpipe ? initial(layer) : ABOVE_WEEDS_LAYER) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE
+	layer = (showpipe ? initial(layer) : EXPOSED_ATMOS_LAYER) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE
 
 /obj/machinery/atmospherics/components/proc/get_pipe_underlay(state, dir, color = null)
 	if(color)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -529,6 +529,7 @@
 	icon_state = "floortube_empty"
 	base_icon_state = "floortube"
 	layer = MAP_SWITCH(ABOVE_OPEN_TURF_LAYER, LOW_OBJ_LAYER)
+	plane = FLOOR_PLANE
 	fitting = "large tube"
 	light_type = /obj/item/light_bulb/tube/large
 	brightness = 12
@@ -542,6 +543,7 @@
 	anchored = TRUE
 	density = FALSE
 	layer = BELOW_TABLE_LAYER
+	plane = FLOOR_PLANE
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 20

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -672,6 +672,7 @@
 		ripples += new /obj/effect/abstract/ripple(t, animate_time)
 	if(uses_dust)
 		particle_holder = new(S1.loc, /particles/shuttle_dust)
+		particle_holder.plane = WALL_PLANE //otherwise this will cause rendering issues due to sidemap
 		particle_holder.particles.position = generator(GEN_CIRCLE, width*12, height*12, NORMAL_RAND)
 		particle_holder.particles.width = width * 65
 		particle_holder.particles.height = height * 65

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -672,7 +672,7 @@
 		ripples += new /obj/effect/abstract/ripple(t, animate_time)
 	if(uses_dust)
 		particle_holder = new(S1.loc, /particles/shuttle_dust)
-		particle_holder.plane = WALL_PLANE //otherwise this will cause rendering issues due to sidemap
+		SET_PLANE_EXPLICIT(particle_holder, WALL_PLANE, src) //otherwise this will cause rendering issues due to sidemap
 		particle_holder.particles.position = generator(GEN_CIRCLE, width*12, height*12, NORMAL_RAND)
 		particle_holder.particles.width = width * 65
 		particle_holder.particles.height = height * 65

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -9,6 +9,8 @@
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
+	plane = FLOOR_PLANE
+	layer = ABOVE_WEEDS_LAYER
 
 	hit_sound = SFX_ALIEN_RESIN_MOVE
 	destroy_sound = SFX_ALIEN_RESIN_MOVE


### PR DESCRIPTION

## About The Pull Request
Let me know if there are other obvious ones to fix.

Fixes catwalks layering over stairs.
Fixes dropship smoke effects layering badly with the warning shadow, hiding northern warning turfs.
Fixes floor lights layering over objects.

:cl:
fix: fixed some floor layering/plane issues
/:cl:
