### PR TITLE
Priority candidates for hive leadership now need the appropriate flag to become rulers

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -742,6 +742,8 @@
 	var/list/mob/living/carbon/xenomorph/seco_candidates = xenos_by_tier[XENO_TIER_THREE]
 
 	for(var/mob/living/carbon/xenomorph/potential_successor in prio_candidates)
+		if(!(potential_successor.xeno_caste.can_flags & CASTE_CAN_BE_RULER))
+			continue
 		successor = potential_successor
 		if(isxenoqueen(potential_successor))
 			break


### PR DESCRIPTION
## About The Pull Request
Didn't really know how to word it correctly on the title so I'll just describe it here.

Currently, it is possible for priority candidates (tier 4 xenos) to obtain hive leadership without the appropriate flag. This means that a dragon, a caste without pheros, can become a ruler, and since it doesn't have pheromones, well... you probably see the issue by now.

What I did here is add a check for the appropriate flag, so that priority candidates without it are not valid choices. I also went through the tier 4s and made sure they all had the flag, which they do, except for Dragon. Probably not a coincidence.

## Why It's Good For The Game
Dragons have no pheros, and hives shouldn't be made to suffer for it.

## Changelog
:cl: Lewdcifer
code: Priority candidates for hive leadership now need the appropriate flag to become rulers. This basically means that Dragon can no longer be a hive ruler (and it shouldn't be, because it doesn't have pheros).
/:cl:
