### PR TITLE
Piercing Laser Nerf

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -535,8 +535,11 @@
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_HITSCAN|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	damage = 25
 	penetration = 100
-	max_range = 10
+	max_range = 9
 	hitscan_effect_icon = "xray_beam"
+
+/datum/ammo/energy/lasgun/marine/xray/piercing/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
+	proj.proj_max_range -= 3
 
 /datum/ammo/energy/lasgun/marine/heavy_laser
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_BETTER_COVER_RNG|AMMO_ENERGY|AMMO_HITSCAN|AMMO_INCENDIARY


### PR DESCRIPTION
## About The Pull Request
The piercing fire modes on TE-X now has a max range of 9 (down from 10) and loses 3 max range each time it goes through a turf / wall.

This effectively makes it so that shooting it from the edge of the screen will only pierce one wall and stop there, midrange will pierce two walls and stop there, and pointblank will pierce three walls and stop there.

## Why It's Good For The Game
TE-X, as of its current state, is not only a gun that can shoot through walls (and do things like deny drains and hits xenos from behind cover), but it also happens to be a great tool at deleting walls (and I'm not talking about resin walls here). 

Sustained by infinite ammo, it can hit up to 10 walls at once, and effectively deals 25 true damage with its 100 armor piercing. Tools which are designed for clearing walls like plasma cutters and detonation packs are just worse compared to it. While this nerf won't entirely remove its ability to clear walls, it will encourage people to use a tool that was purpose built for it by having the user to be at least be upclose (just like plasma cutter & detonation pack) to be effective at massive wall clearing.

## Changelog
:cl:
balance: TE-X's piercing laser now has 9 max range (down from 10) and loses 3 max range each time it hits a wall / turf.
/:cl:
