### PR TITLE
Desant throw changes

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -157,15 +157,24 @@
 			tank_desant.forceMove(get_step(tank_desant, direction))
 		if(move_dist > 1)
 			continue
-		if(isxeno(tank_desant) || !isliving(tank_desant))
+		var/throw_dist = 2
+		if(isobj(tank_desant) && !isitem(tank_desant))
 			continue
-		var/mob/living/living_rider = tank_desant
-		if(!living_rider.l_hand || !living_rider.r_hand)
-			continue
-		balloon_alert(living_rider, "poor grip!")
-		var/away_dir = REVERSE_DIR(get_dir(living_rider, root) || pick(GLOB.alldirs))
-		var/turf/target = get_ranged_target_turf(living_rider, away_dir, 3)
-		living_rider.throw_at(target, 3, 3, root)
+		if(ismob(tank_desant))
+			if(!isliving(tank_desant))
+				continue
+			var/mob/living/living_rider = tank_desant
+			if(!living_rider.stat)
+				if(isxeno(tank_desant))
+					continue
+				if(!living_rider.l_hand || !living_rider.r_hand)
+					continue
+			balloon_alert(living_rider, "poor grip!")
+			throw_dist = 3
+
+		var/away_dir = REVERSE_DIR(get_dir(tank_desant, root) || pick(GLOB.alldirs))
+		var/turf/target = get_ranged_target_turf(tank_desant, away_dir, throw_dist)
+		tank_desant.throw_at(target, throw_dist, 3, root)
 
 ///called when the tank is off movement cooldown and someone tries to move it
 /obj/hitbox/proc/on_attempt_drive(atom/movable/movable_parent, mob/living/user, direction)


### PR DESCRIPTION

## About The Pull Request
Changes how desants are effected by movement slightly.

Mobs are now thrown off if not conscious (i.e. dead xenos don't stay on)
Items are also thrown off (slightly lower distance though)
## Why It's Good For The Game
Cluttering vehicles with shit on top of them is very exploitable since it can be used to make the tank extremely difficult to click.
Also just using the tank as an inventory mule is cringe.
## Changelog
:cl:
balance: Corpses and items are thrown off vehicles on move
/:cl:
