### PR TITLE
Mech/Tank Reduces Evo Requirement for Queen

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -155,3 +155,7 @@
 
 #define SENSOR_CAP_ADDITION_TIME_BONUS 3 MINUTES //additional time granted by capturing a sensor tower
 #define SENSOR_CAP_TIMER_PAUSED "paused"
+
+#define NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED 40 // This amount of clients must be connected at gamemode setup to get the first mech pilot slot.
+#define NUCLEAR_WAR_MECH_INTERVAL_PER_SLOT 20 // After meeting NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED, a mech pilot slot is open for each set of X clients.
+#define NUCLEAR_WAR_TANK_MINIMUM_POP_REQUIRED 50 // This amount of clients must be connected at gamemode setup to get two assault crewman jobs (and thus tank).

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -43,6 +43,12 @@
 	)
 
 /datum/game_mode/infestation/nuclear_war/post_setup()
+	var/client_count = length(GLOB.clients)
+	if(client_count >= NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED)
+		evo_requirements[/datum/xeno_caste/queen] -= 2
+	if(client_count >= NUCLEAR_WAR_TANK_MINIMUM_POP_REQUIRED)
+		evo_requirements[/datum/xeno_caste/queen] -= 2
+
 	. = ..()
 
 	SSpoints.add_strategic_psy_points(XENO_HIVE_NORMAL, 1400)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -367,10 +367,8 @@ Though you are an officer, your authority is limited to the dropship and the Con
 	if(total_positions)
 		return
 	var/client_count = length(GLOB.clients)
-	client_count -= 20
-	client_count = FLOOR(client_count / 20, 1)
-	// effectively, 1 at 40, 2 at 60, 3 at 80, etc
-	if(client_count >= 1)
+	if(client_count >= NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED)
+		client_count = 1 + FLOOR((client_count - NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED) / NUCLEAR_WAR_MECH_INTERVAL_PER_SLOT, 1)
 		add_job_positions(client_count)
 
 /datum/job/terragov/command/mech_pilot/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
@@ -394,9 +392,6 @@ Though you are an officer, your authority is limited to the dropship and the Con
 			new_human.wear_id.paygrade = "E9A" //If you play way too much TGMC. 1000 hours.
 	new_human.wear_id.update_label()
 
-
-
-#define ASSAULT_CREWMAN_POPLOCK 50
 //tank/arty driver+gunner
 /datum/job/terragov/command/assault_crewman
 	title = ASSAULT_CREWMAN
@@ -435,7 +430,7 @@ Though you are an officer, your authority is limited to the dropship and the Con
 /datum/job/terragov/command/assault_crewman/on_pre_setup()
 	if(total_positions)
 		return
-	if(length(GLOB.clients) >= ASSAULT_CREWMAN_POPLOCK)
+	if(length(GLOB.clients) >= NUCLEAR_WAR_TANK_MINIMUM_POP_REQUIRED)
 		add_job_positions(2) //always 2 there are, a master and an apprentice
 
 /datum/job/terragov/command/assault_crewman/get_spawn_message_information(mob/M)


### PR DESCRIPTION

## About The Pull Request
The amount of xenomorphs required to evolve into Queen is reduced by 2 if there are enough population for the first mech pilot job slot to be opened and reduced by another 2 when assault crewman job slots are opened.

This means the required xenomorphs will be 6 when the population is 40 and then 4 when the population is 50.

## Why It's Good For The Game
It is possible that mech pilot and assault crewman job slots to open on so-called lowpop (20 people in lobby/observing while the other half plays the game). I think it's cringe that marines are able to get their specialist role(s) while xenos don't get anything for it. Roles meant for higher pop should be opened on both sides instead of just one.

## Changelog
:cl:
balance: On Nuclear War, the amount of xenomorphs required to evolve into Queen is decreased by 2 if there can be a mech and another 2 if there can be a tank roundstart.
/:cl:
