### PR TITLE
Pyro charge CD fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -6,7 +6,7 @@
 	action_icon_state = "fireslash"
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
 	desc = "Charge up to 3 tiles, attacking any organic you come across. Extinguishes the target if they were set on fire, but deals extra damage depending on how many fire stacks they have."
-	cooldown_duration = 4 SECONDS
+	cooldown_duration = 12 SECONDS
 	ability_cost = 30
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FIRECHARGE,


### PR DESCRIPTION

## About The Pull Request
Charge CD is 12 seconds instead of 4.
Kuro said it was always meant to be this.
## Why It's Good For The Game
Highly spammable movement ability on a ranged caste is lame as fuck. You can still use it for entry or escape, but now you can't so easily use it for both.
## Changelog
:cl:
balance: Pyrogen flame dash CD is 12 seconds instead of 4
/:cl:
