### PR TITLE
Removes infinite mecha rocket refills

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -818,7 +818,7 @@
 			/obj/item/mecha_ammo/vendable/sniper = -1,
 			/obj/item/mecha_ammo/vendable/grenade = -1,
 			/obj/item/mecha_ammo/vendable/flamer = -1,
-			/obj/item/mecha_ammo/vendable/rpg = -1,
+			/obj/item/mecha_ammo/vendable/rpg = 2,
 		)
 	)
 
@@ -1986,7 +1986,7 @@
 			/obj/item/mecha_ammo/vendable/smg = -1,
 			/obj/item/mecha_ammo/vendable/burstpistol = -1,
 			/obj/item/mecha_ammo/vendable/pistol = -1,
-			/obj/item/mecha_ammo/vendable/rpg = -1,
+			/obj/item/mecha_ammo/vendable/rpg = 2,
 			/obj/item/mecha_ammo/vendable/minigun = -1,
 			/obj/item/mecha_ammo/vendable/grenade = -1,
 		),

--- a/code/modules/reqs/supplypacks/explosives_packs.dm
+++ b/code/modules/reqs/supplypacks/explosives_packs.dm
@@ -46,6 +46,11 @@ EXPLOSIVES
 	contains = list(/obj/item/storage/box/visual/grenade/incendiary)
 	cost = 350
 
+/datum/supply_packs/explosives/mecha_explosives_refill
+	name = "Mecha high explosive missiles"
+	notes = "Contains 10 high explosive missiles for mecha"
+	contains = list(/obj/item/mecha_ammo/vendable/rpg)
+	cost = 200 // Price based on cost of RR (at 30 points per) rather than Sadar (at 50 points per). Given high price already, discount of 33.3% given since it is mech-exclusive. Calculated as: (30 * 10 * (2/3))
 
 /datum/supply_packs/explosives/explosives_cloaker
 	name = "M45 Cloaker grenade box crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A recreation of #17703, except it is for the rockets from #17764.

Vendors no longer provide infinite rocket refills. They are now limited to 2 per vendor. They will effectively have 20 per vendor + 10 rockets for each missile-based weapon they pick with their vendor.

Refills can be purchased for 150 req points for 1 refill or 10 rockets.

## Why It's Good For The Game
Marines do not typically get access to rockets round start. However when they do, it is seasonal in limited quantities. Mechs shouldn't be encouraged to rocket spam and be wise with how they spend their rockets. 

## Changelog
:cl:
balance: Vendors no longer supply infinite mecha rockets. It is now limited to 2 refills per vendor.
/:cl:
