### PR TITLE
Moves big red's bsg to marshall

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -1151,13 +1151,13 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akS" = (
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/open/floor/wood,
+/obj/machinery/vending/tool,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akU" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
@@ -1259,7 +1259,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
 "alB" = (
-/turf/open/floor/grimy,
+/obj/machinery/floor_warn_light/toggleable/generator,
+/obj/effect/turf_decal/warning_stripes,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "alC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -1267,7 +1269,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "alF" = (
 /turf/open/floor/marking/asteroidwarning{
@@ -1381,13 +1383,8 @@
 /turf/open/floor/engine/cult,
 /area/bigredv2/outside/marshal_office)
 "amA" = (
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/marshal_office)
-"amC" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/closed/wall/r_wall,
+/obj/machinery/pipedispenser,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "amJ" = (
 /turf/open/floor/plating/warning{
@@ -1491,7 +1488,7 @@
 	id = "Office Complex 2";
 	name = "Storm Shutters"
 	},
-/turf/open/floor/wood,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "anl" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
@@ -1579,6 +1576,10 @@
 	},
 /turf/open/floor/engine/cult,
 /area/bigredv2/outside/marshal_office)
+"anH" = (
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall,
+/area/bigredv2/outside/marshal_office)
 "anI" = (
 /turf/closed/wall,
 /area/bigredv2/outside/general_offices)
@@ -1661,7 +1662,7 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "aoo" = (
 /obj/machinery/light{
@@ -1730,6 +1731,10 @@
 	dir = 4
 	},
 /turf/open/floor/tile/red/full,
+/area/bigredv2/outside/marshal_office)
+"apa" = (
+/obj/structure/closet/radiation,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "apb" = (
 /obj/effect/landmark/weed_node,
@@ -10543,11 +10548,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"iEW" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/grimy,
-/area/bigredv2/outside/marshal_office)
 "iFp" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -11093,7 +11093,8 @@
 "jCB" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/floor_warn_light/toggleable/generator,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/warning_stripes,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "jCI" = (
 /obj/machinery/miner/damaged,
@@ -11988,10 +11989,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"lHO" = (
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/open/floor/grimy,
-/area/bigredv2/outside/marshal_office)
 "lIi" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -12602,7 +12599,7 @@
 /area/bigredv2/outside/virology)
 "mZU" = (
 /obj/effect/landmark/start/job/survivor,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "mZZ" = (
 /obj/structure/cargo_container/green{
@@ -13366,6 +13363,11 @@
 	},
 /turf/open/floor/plating/warning,
 /area/bigredv2/outside/space_port)
+"oCF" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/marshal_office)
 "oDv" = (
 /obj/machinery/light{
 	dir = 8
@@ -14260,8 +14262,8 @@
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
 "qNp" = (
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/closed/wall,
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "qOC" = (
 /obj/machinery/light{
@@ -14330,7 +14332,7 @@
 "qYI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "qYO" = (
 /obj/machinery/floodlight/landing,
@@ -14640,7 +14642,7 @@
 "ryc" = (
 /obj/machinery/light,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ryP" = (
 /obj/structure/table,
@@ -15460,7 +15462,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "twI" = (
 /obj/effect/landmark/weed_node,
@@ -16003,7 +16005,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "uFe" = (
 /obj/structure/cable,
@@ -17046,6 +17048,10 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"wLK" = (
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/marshal_office)
 "wMd" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
@@ -17475,7 +17481,7 @@
 "xLL" = (
 /obj/machinery/power/tbg_turbine/heat,
 /obj/structure/cable,
-/turf/open/floor/grimy,
+/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "xLT" = (
 /obj/machinery/light{
@@ -31733,7 +31739,7 @@ acp
 pBS
 iTO
 iTO
-amA
+wLK
 acp
 acp
 acp
@@ -32596,7 +32602,7 @@ axl
 gUD
 gUD
 acp
-amA
+wLK
 acp
 fpi
 fpi
@@ -33042,7 +33048,7 @@ acp
 lGn
 tbH
 aic
-amA
+wLK
 aiY
 afS
 bUW
@@ -33253,7 +33259,7 @@ ebn
 eaq
 uhr
 acr
-qNp
+anH
 acr
 acp
 lGn
@@ -33894,7 +33900,7 @@ lap
 axl
 axl
 axl
-amC
+oCF
 ldo
 eaq
 uOi
@@ -34121,18 +34127,18 @@ ebn
 nch
 eaq
 acr
-qNp
+anH
 acr
 acp
 agz
 ote
 qvb
-amA
+wLK
 ady
 gcY
 akg
 akN
-qNp
+anH
 cHh
 xnM
 anx
@@ -34983,7 +34989,7 @@ qEU
 acp
 acp
 acp
-amA
+wLK
 vax
 acp
 coC
@@ -35426,7 +35432,7 @@ acp
 acp
 acp
 acp
-amA
+wLK
 acp
 acp
 acp
@@ -36508,12 +36514,12 @@ twI
 gzM
 twI
 gzM
-amA
+wLK
 vVw
 uHi
 lOi
 iHP
-amA
+wLK
 iOO
 uHi
 uHi
@@ -37380,9 +37386,9 @@ acp
 acp
 acp
 agI
-amA
+wLK
 acp
-amA
+wLK
 aer
 ajK
 aer
@@ -38037,7 +38043,7 @@ aiL
 lGe
 hsr
 lGe
-amA
+wLK
 agz
 xFB
 aic
@@ -38459,7 +38465,7 @@ gCQ
 gzM
 twI
 acp
-qNp
+anH
 aer
 aer
 aer
@@ -39332,7 +39338,7 @@ aeu
 hNA
 afs
 adW
-amA
+wLK
 lGe
 luR
 aiO
@@ -39556,7 +39562,7 @@ aiO
 ajg
 ajO
 akt
-amA
+wLK
 alA
 alA
 lGe
@@ -40424,13 +40430,13 @@ acp
 lGe
 ajL
 acp
-amA
+wLK
 acr
 acr
 acr
 acr
 acr
-qNp
+anH
 acr
 gzM
 gzM
@@ -40641,13 +40647,13 @@ acp
 lGe
 ajL
 aer
-adW
-adW
-adW
+lGe
+akS
+amA
 ani
-adW
-adW
-adW
+lGe
+lGe
+qNp
 acr
 gzM
 gzM
@@ -40858,13 +40864,13 @@ acp
 lGe
 hVt
 acp
-adW
+lGe
+lGe
 alB
-lHO
+lGe
 alB
-lHO
-alB
-adW
+lGe
+qNp
 acr
 gzM
 twI
@@ -41076,7 +41082,7 @@ lGe
 aCB
 akv
 akT
-iEW
+akT
 twH
 alC
 qYI
@@ -41291,15 +41297,15 @@ dVz
 aiQ
 wcT
 luR
-amA
-adW
-alB
+wLK
+lGe
+lGe
 mZU
 uFc
-alB
-alB
-adW
-qNp
+lGe
+lGe
+apa
+anH
 aqN
 gzM
 ash
@@ -41509,13 +41515,13 @@ lGe
 lGe
 pId
 aer
-adW
-alB
-alB
+lGe
+lGe
+lGe
 xLL
-alB
-alB
-adW
+lGe
+lGe
+apa
 acr
 aqO
 gzM
@@ -41726,13 +41732,13 @@ acp
 toK
 aka
 aer
-adW
-adW
+lGe
+lGe
 jCB
-adW
-akS
-adW
-pCh
+lGe
+alB
+lGe
+toK
 acr
 gzM
 twI

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -1151,7 +1151,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akS" = (
-/obj/structure/bed/chair,
+/obj/machinery/floor_warn_light/toggleable/generator,
 /turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "akT" = (
@@ -1381,16 +1381,13 @@
 /turf/open/floor/engine/cult,
 /area/bigredv2/outside/marshal_office)
 "amA" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall/r_wall,
 /area/bigredv2/outside/marshal_office)
 "amC" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/grimy,
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall/r_wall,
 /area/bigredv2/outside/marshal_office)
 "amJ" = (
 /turf/open/floor/plating/warning{
@@ -1489,9 +1486,6 @@
 /turf/open/floor/engine/cult,
 /area/bigredv2/outside/marshal_office)
 "ani" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/door_control{
 	dir = 4;
 	id = "Office Complex 2";
@@ -1584,10 +1578,6 @@
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
-/area/bigredv2/outside/marshal_office)
-"anH" = (
-/obj/structure/bed/chair,
-/turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
 "anI" = (
 /turf/closed/wall,
@@ -1740,12 +1730,6 @@
 	dir = 4
 	},
 /turf/open/floor/tile/red/full,
-/area/bigredv2/outside/marshal_office)
-"apa" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "apb" = (
 /obj/effect/landmark/weed_node,
@@ -11107,8 +11091,8 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "jCB" = (
-/obj/structure/table/wood,
 /obj/effect/landmark/weed_node,
+/obj/machinery/floor_warn_light/toggleable/generator,
 /turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "jCI" = (
@@ -11499,14 +11483,6 @@
 	dir = 4
 	},
 /area/bigredv2/caves/southwest)
-"kqT" = (
-/obj/structure/table/wood,
-/obj/item/paper/courtroom{
-	name = "A Crash Course in Legal SOP"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/bigredv2/outside/marshal_office)
 "krA" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -12013,10 +11989,9 @@
 /turf/open/floor/tile/dark/red2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "lHO" = (
-/obj/effect/turf_decal/warning_stripes,
 /obj/machinery/floor_warn_light/toggleable/generator,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor/grimy,
+/area/bigredv2/outside/marshal_office)
 "lIi" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -13201,10 +13176,6 @@
 	dir = 10
 	},
 /area/bigredv2/caves/lambda_lab)
-"oib" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/bigredv2/outside/marshal_office)
 "oit" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -13395,10 +13366,6 @@
 	},
 /turf/open/floor/plating/warning,
 /area/bigredv2/outside/space_port)
-"oCF" = (
-/obj/structure/table/wood,
-/turf/open/floor/grimy,
-/area/bigredv2/outside/marshal_office)
 "oDv" = (
 /obj/machinery/light{
 	dir = 8
@@ -13414,10 +13381,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
-"oFm" = (
-/obj/machinery/floor_warn_light/toggleable/generator,
-/turf/closed/wall,
-/area/bigredv2/outside/filtration_plant)
 "oFP" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -14297,9 +14260,8 @@
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
 "qNp" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/turf/open/floor/wood,
+/obj/machinery/floor_warn_light/toggleable/generator,
+/turf/closed/wall,
 /area/bigredv2/outside/marshal_office)
 "qOC" = (
 /obj/machinery/light{
@@ -15393,11 +15355,6 @@
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 4
 	},
-/area/bigredv2/outside/marshal_office)
-"tgz" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/storage/lawyer/bluejacket,
-/turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "thx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -17089,11 +17046,6 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
-"wLK" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/turf/open/floor/wood,
-/area/bigredv2/outside/marshal_office)
 "wMd" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
@@ -31781,7 +31733,7 @@ acp
 pBS
 iTO
 iTO
-acp
+amA
 acp
 acp
 acp
@@ -32644,7 +32596,7 @@ axl
 gUD
 gUD
 acp
-acp
+amA
 acp
 fpi
 fpi
@@ -33090,7 +33042,7 @@ acp
 lGn
 tbH
 aic
-acp
+amA
 aiY
 afS
 bUW
@@ -33301,7 +33253,7 @@ ebn
 eaq
 uhr
 acr
-acr
+qNp
 acr
 acp
 lGn
@@ -33942,7 +33894,7 @@ lap
 axl
 axl
 axl
-qEU
+amC
 ldo
 eaq
 uOi
@@ -34169,18 +34121,18 @@ ebn
 nch
 eaq
 acr
-acr
+qNp
 acr
 acp
 agz
 ote
 qvb
-acp
+amA
 ady
 gcY
 akg
 akN
-acr
+qNp
 cHh
 xnM
 anx
@@ -35031,7 +34983,7 @@ qEU
 acp
 acp
 acp
-acp
+amA
 vax
 acp
 coC
@@ -35474,7 +35426,7 @@ acp
 acp
 acp
 acp
-acp
+amA
 acp
 acp
 acp
@@ -36556,12 +36508,12 @@ twI
 gzM
 twI
 gzM
-acp
+amA
 vVw
 uHi
 lOi
 iHP
-acp
+amA
 iOO
 uHi
 uHi
@@ -37428,9 +37380,9 @@ acp
 acp
 acp
 agI
+amA
 acp
-acp
-acp
+amA
 aer
 ajK
 aer
@@ -37741,12 +37693,12 @@ yhc
 wzM
 oxP
 djb
-oFm
+bkt
 bmK
 bqo
 bkE
 btJ
-oFm
+bkt
 xOD
 kCz
 hLG
@@ -38085,7 +38037,7 @@ aiL
 lGe
 hsr
 lGe
-acp
+amA
 agz
 xFB
 aic
@@ -38397,7 +38349,7 @@ btj
 bkE
 bkE
 bnC
-oFm
+bkt
 bjZ
 hLG
 hLG
@@ -38507,7 +38459,7 @@ gCQ
 gzM
 twI
 acp
-acr
+qNp
 aer
 aer
 aer
@@ -38592,15 +38544,14 @@ wzM
 lKw
 wzM
 aMc
-oFm
+bkt
 bkt
 blw
 blw
 blw
-oFm
+bkt
 bnA
 bnA
-oFm
 bkt
 bkt
 bkt
@@ -38609,7 +38560,8 @@ bkt
 bkt
 bkt
 bkt
-oFm
+bkt
+bkt
 bkO
 bkE
 bkE
@@ -39034,9 +38986,9 @@ xwD
 wOO
 bnC
 boe
-oFm
 bkt
-oFm
+bkt
+bkt
 kFm
 dyO
 kvX
@@ -39380,7 +39332,7 @@ aeu
 hNA
 afs
 adW
-acp
+amA
 lGe
 luR
 aiO
@@ -39482,7 +39434,7 @@ bkt
 bpo
 fWy
 bkt
-oFm
+bkt
 vdg
 wMP
 wMP
@@ -39604,7 +39556,7 @@ aiO
 ajg
 ajO
 akt
-acp
+amA
 alA
 alA
 lGe
@@ -39904,10 +39856,10 @@ bkv
 bkv
 bkv
 bkt
-oFm
+bkt
 bpT
 bqt
-oFm
+bkt
 bkt
 bkt
 bkt
@@ -40339,9 +40291,9 @@ bkJ
 bkv
 boY
 fOe
-lHO
+liH
 wXg
-lHO
+liH
 lfR
 wOO
 scx
@@ -40472,13 +40424,13 @@ acp
 lGe
 ajL
 acp
-acp
+amA
 acr
 acr
 acr
 acr
 acr
-acr
+qNp
 acr
 gzM
 gzM
@@ -40689,13 +40641,13 @@ acp
 lGe
 ajL
 aer
-akS
 adW
-amA
+adW
+adW
 ani
-tgz
-wLK
-qNp
+adW
+adW
+adW
 acr
 gzM
 gzM
@@ -40906,11 +40858,11 @@ acp
 lGe
 hVt
 acp
-akS
+adW
 alB
+lHO
 alB
-alB
-alB
+lHO
 alB
 adW
 acr
@@ -41207,9 +41159,9 @@ eBw
 ayV
 qlj
 fST
-lHO
+liH
 owc
-lHO
+liH
 wOA
 wOO
 bsG
@@ -41339,7 +41291,7 @@ dVz
 aiQ
 wcT
 luR
-acp
+amA
 adW
 alB
 mZU
@@ -41347,7 +41299,7 @@ uFc
 alB
 alB
 adW
-acr
+qNp
 aqN
 gzM
 ash
@@ -41557,13 +41509,13 @@ lGe
 lGe
 pId
 aer
-akS
-oCF
-amC
+adW
+alB
+alB
 xLL
-anH
-oCF
-apa
+alB
+alB
+adW
 acr
 aqO
 gzM
@@ -41774,13 +41726,13 @@ acp
 toK
 aka
 aer
-akS
-oib
+adW
+adW
 jCB
 adW
 akS
-oib
-kqT
+adW
+pCh
 acr
 gzM
 twI
@@ -43149,7 +43101,7 @@ aaa
 aXp
 beI
 bgx
-oFm
+bkt
 wOO
 wOO
 bFo

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -884,6 +884,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajO" = (
@@ -891,6 +892,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajP" = (
@@ -899,6 +901,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajQ" = (
@@ -907,6 +910,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajT" = (
@@ -989,6 +993,7 @@
 /area/bigredv2/outside/marshal_office)
 "ako" = (
 /obj/item/detective_scanner,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akp" = (
@@ -1016,6 +1021,7 @@
 	name = "\improper Marshal Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akw" = (
@@ -1141,6 +1147,7 @@
 	dir = 1;
 	name = "\improper Marshal Office"
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "akS" = (
@@ -1149,14 +1156,11 @@
 /area/bigredv2/outside/marshal_office)
 "akT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "akU" = (
 /obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "Office Complex 2";
-	name = "\improper Marshal Office Complex Shutters"
-	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
 "akW" = (
@@ -1259,6 +1263,10 @@
 /area/bigredv2/outside/marshal_office)
 "alC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/power/tbg_turbine/cold{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
 "alF" = (
@@ -2992,6 +3000,7 @@
 	},
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "aCJ" = (
@@ -8261,6 +8270,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "dxa" = (
@@ -9336,6 +9346,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/black,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "fVM" = (
@@ -10242,6 +10253,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "hWw" = (
@@ -10256,6 +10268,15 @@
 "hXy" = (
 /turf/closed/mineral/smooth/bigred/indestructible,
 /area/space)
+"hXz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "hXQ" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2,
@@ -10539,12 +10560,10 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "iEW" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/obj/machinery/power/tbg_turbine/heat{
-	dir = 4
-	},
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor/grimy,
+/area/bigredv2/outside/marshal_office)
 "iFp" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -11536,6 +11555,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/space_port)
+"kyZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "kzl" = (
 /obj/machinery/light{
 	dir = 1
@@ -11694,6 +11721,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /obj/effect/landmark/excavation_site_spawner,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "kVM" = (
@@ -12637,6 +12665,7 @@
 "ncW" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ndi" = (
@@ -13336,6 +13365,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ozz" = (
@@ -14788,6 +14818,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"rNl" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
+/area/bigredv2/outside/marshal_office)
 "rNZ" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -15466,6 +15502,7 @@
 "twH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
 "twI" = (
@@ -16005,12 +16042,12 @@
 /turf/open/floor/plating/ground/mars/cavetodirt,
 /area/bigredv2/caves/northeast/garbledradio)
 "uFc" = (
-/obj/structure/cable,
 /obj/machinery/power/geothermal/tbg{
 	dir = 4
 	},
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/obj/structure/cable,
+/turf/open/floor/grimy,
+/area/bigredv2/outside/marshal_office)
 "uFe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -17484,12 +17521,10 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "xLL" = (
+/obj/machinery/power/tbg_turbine/heat,
 /obj/structure/cable,
-/obj/machinery/power/tbg_turbine/cold{
-	dir = 8
-	},
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor/grimy,
+/area/bigredv2/outside/marshal_office)
 "xLT" = (
 /obj/machinery/light{
 	dir = 4
@@ -37618,7 +37653,7 @@ wdZ
 lGe
 acp
 agz
-wWX
+hXz
 xnM
 acp
 acp
@@ -37834,7 +37869,7 @@ lGe
 ozk
 ako
 akR
-agz
+rNl
 kUV
 aic
 aer
@@ -38048,7 +38083,7 @@ lGe
 aer
 aiL
 lGe
-ote
+hsr
 lGe
 acp
 agz
@@ -38482,7 +38517,7 @@ acp
 acp
 aiN
 lGe
-wdZ
+kyZ
 akq
 acp
 acr
@@ -40218,7 +40253,7 @@ ahu
 lGe
 lGe
 lGe
-wdZ
+kyZ
 ajj
 acp
 luR
@@ -40522,7 +40557,7 @@ bkv
 boX
 bpo
 xTt
-xLL
+bqp
 uWz
 wOO
 nRv
@@ -40739,7 +40774,7 @@ bou
 bkE
 fOe
 liH
-uFc
+bqp
 liH
 lfR
 wOO
@@ -40956,7 +40991,7 @@ pOu
 bkE
 bpo
 wKN
-iEW
+bqp
 uWz
 bkE
 brZ
@@ -41089,7 +41124,7 @@ lGe
 aCB
 akv
 akT
-alC
+iEW
 twH
 alC
 qYI
@@ -41308,7 +41343,7 @@ acp
 adW
 alB
 mZU
-alB
+uFc
 alB
 alB
 adW
@@ -41525,7 +41560,7 @@ aer
 akS
 oCF
 amC
-alB
+xLL
 anH
 oCF
 apa
@@ -42609,7 +42644,7 @@ gQv
 gzM
 rCn
 twI
-rww
+gzM
 gzM
 gzM
 twI


### PR DESCRIPTION
## About The Pull Request
Moves the bsg on big red to marshalls.
![tgmc dme  BigRed_v2 dmm  - StrongDMM 7_9_2025 6_57_03 PM](https://github.com/user-attachments/assets/4bf894ca-bcc2-4243-b4c5-22e2a22ab964)
Also removes the shutters attached to these windows, and the miner just east of the room.
## Why It's Good For The Game
Current bsg location is bad, being incredibly centralized making it really easy to defend, essentially trippling marines req gain from disks/disk generation on the map. Moving it to marshals, while making less in-universe sense, will hopefully make it move of a side-objective you have to go out of your way to get, rather than something marines are guaranteed to get. It'll also hopefully give some incentive to use the north lz. Removing the shutters and the miner is to prevent the location from being to easy/profitable to defend.
## Changelog
:cl:
balance: Moved big red's bsg to marshals
balance: Removed a miner outside the east side of marshals
balance: Removed some shutters on the far east windows of marshals
/:cl:
