### PR TITLE
Less BFG wall pierce

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -107,7 +107,7 @@
 	proj.proj_max_range -= 2
 
 /datum/ammo/energy/bfg/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	proj.proj_max_range -= 2
+	proj.proj_max_range -= 10
 
 /datum/ammo/energy/bfg/drop_nade(turf/T)
 	explosion(T, 0, 0, 4, 0, 0, explosion_cause=src)


### PR DESCRIPTION

## About The Pull Request
BFG wall pierce now reduces range by 10 instead of 2.
i.e. you can pierce 1 wall and actually hit things, instead of like 7+
## Why It's Good For The Game
Funny cave/maze snipes are super wack.
## Changelog
:cl:
balance: Greatly reduced the BFG's ability to pierce walls
/:cl:
