### PR TITLE
You cant move during the throws

### DIFF
--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -1459,9 +1459,11 @@
 		return
 	throwing = new_throwing
 	if(throwing)
+		ADD_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT) //prevents moving during the throw
 		add_pass_flags(PASS_THROW, THROW_TRAIT)
 		add_nosubmerge_trait(THROW_TRAIT)
 	else
+		REMOVE_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT)
 		REMOVE_TRAIT(src, TRAIT_NOSUBMERGE, THROW_TRAIT)
 		remove_pass_flags(PASS_THROW, THROW_TRAIT)
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -120,17 +120,9 @@
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 	var/throw_distance = setting * LERP(5, 3, M.mob_size / MOB_SIZE_BIG)
 
-	RegisterSignal(M, COMSIG_MOVABLE_POST_THROW, PROC_REF(After_throw))
-	ADD_TRAIT(M, TRAIT_IMMOBILE, THROW_TRAIT)
 	M.knockback(user, throw_distance, 0.5 + (setting / 2))
 	cell.charge -= powerused
 	return ..()
-
-/// Called when the throw has ended.
-/obj/item/weapon/powerfist/proc/After_throw(datum/Thrown_mob)
-	SIGNAL_HANDLER
-	UnregisterSignal(Thrown_mob, COMSIG_MOVABLE_POST_THROW)
-	REMOVE_TRAIT(Thrown_mob, TRAIT_IMMOBILE, THROW_TRAIT)
 
 /obj/item/weapon/powerfist/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/cell))


### PR DESCRIPTION
## About The Pull Request

Any form of throw be it build mode powerfist etc. will now make you immobile aka. you cant move to counter the throw

## Why It's Good For The Game
Big bug fix of throws being bypassable = good

## Changelog
:cl: Atropos
balance: You can no longer move during throws
/:cl:
