### PR TITLE
Woyers can now activate buttons with punches

### DIFF
--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -90,11 +90,11 @@
 			else
 				M.close()
 
-/obj/machinery/door_control/attack_hand(mob/living/user)
+/obj/machinery/door_control/attack_hand(mob/living/user, bypass_xenomorph_check)
 	. = ..()
 	if(.)
 		return
-	if(istype(user,/mob/living/carbon/xenomorph))
+	if(!bypass_xenomorph_check && istype(user,/mob/living/carbon/xenomorph))
 		return
 	if(machine_stat & (NOPOWER|BROKEN))
 		to_chat(user, span_warning("[src] doesn't seem to be working."))
@@ -124,6 +124,10 @@
 
 /obj/machinery/door_control/attack_ai(mob/living/silicon/ai/AI)
 	return attack_hand(AI)
+
+/obj/machinery/door_control/punch_act(mob/living/carbon/xenomorph/xeno)
+	..()
+	return !attack_hand(xeno, TRUE)
 
 
 /obj/machinery/door_control/proc/unpress()


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

I think its pretty funny - punch the button hard enough and it will let you in
thanks again ... im learning slowly

## Changelog
:cl: Atropos
balance: Warrior punches can now activate buttons (id locks still apply)
/:cl:
