### PR TITLE
Mutations: Defender

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -824,6 +824,7 @@
 
 #define COMSIG_XENOMORPH_BRUTE_DAMAGE "xenomorph_brute_damage" // (amount, amount_mod, passive)
 #define COMSIG_XENOMORPH_BURN_DAMAGE "xenomorph_burn_damage" // (amount, amount_mod, passive)
+#define COMSIG_XENOMORPH_SUNDER_CHANGE "xenomorph_sunder_change" // (old, new)
 
 #define COMSIG_XENOMORPH_EVOLVED "xenomorph_evolved"
 #define COMSIG_XENOMORPH_DEEVOLVED "xenomorph_deevolved"

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -13,6 +13,16 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TAIL_SWEEP,
 	)
+	/// How far does it knockback?
+	var/knockback_distance = 1
+	/// How long does it stagger?
+	var/stagger_duration = 0 SECONDS
+	/// How long does it paralyze?
+	var/paralyze_duration = 0.5 SECONDS
+	/// If this deals damage, what type of damage is it?
+	var/damage_type = BRUTE
+	/// The multiplier of the damage to be applied.
+	var/damage_multiplier = 1
 
 /datum/action/ability/xeno_action/tail_sweep/can_use_action(silent, override_flags)
 	. = ..()
@@ -43,10 +53,14 @@
 		var/affecting = H.get_limb(ran_zone(null, 0))
 		if(!affecting) //Still nothing??
 			affecting = H.get_limb("chest") //Gotta have a torso?!
-		H.knockback(xeno_owner, sweep_range, 4)
-		H.apply_damage(damage, BRUTE, affecting, MELEE)
-		H.apply_damage(damage, STAMINA, updating_health = TRUE)
-		H.Paralyze(0.5 SECONDS) //trip and go
+		if(damage_multiplier > 0)
+			H.apply_damage(damage * damage_multiplier, damage_type, updating_health = TRUE)
+		if(knockback_distance >= 1)
+			H.knockback(xeno_owner, knockback_distance, 4)
+		if(stagger_duration)
+			H.adjust_stagger(stagger_duration)
+		if(paralyze_duration)
+			H.Paralyze(paralyze_duration)
 		GLOB.round_statistics.defender_tail_sweep_hits++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_tail_sweep_hits")
 		shake_camera(H, 2, 1)
@@ -94,7 +108,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FORWARD_CHARGE,
 	)
 	charge_range = DEFENDER_CHARGE_RANGE
-	///How long is the windup before charging
+	/// How long is the windup before charging?
 	var/windup_time = 0.5 SECONDS
 
 /datum/action/ability/activable/xeno/charge/forward_charge/use_ability(atom/A)
@@ -240,7 +254,12 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FORTIFY,
 	)
+	/// The amount of armor to be given when this ability is active.
 	var/last_fortify_bonus = 0
+	/// Should TRAIT_IMMOBILE be given while this ability is active.
+	var/should_immobilize = TRUE
+	/// If they were to move somehow while this ability is active, how many deciseconds should be added to their next move? Do not set this directly. Use `set_movement_delay` instead.
+	var/movement_delay = 0 SECONDS
 
 /datum/action/ability/xeno_action/fortify/give_action()
 	. = ..()
@@ -289,7 +308,10 @@
 	GLOB.round_statistics.defender_fortifiy_toggles++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_fortifiy_toggles")
 	if(on)
-		ADD_TRAIT(xeno_owner, TRAIT_IMMOBILE, FORTIFY_TRAIT)
+		if(should_immobilize)
+			ADD_TRAIT(xeno_owner, TRAIT_IMMOBILE, FORTIFY_TRAIT)
+		if(movement_delay)
+			RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 		ADD_TRAIT(xeno_owner, TRAIT_STOPS_TANK_COLLISION, FORTIFY_TRAIT)
 		if(!silent)
 			to_chat(xeno_owner, span_xenowarning("We tuck ourselves into a defensive stance."))
@@ -300,13 +322,32 @@
 			to_chat(xeno_owner, span_xenowarning("We resume our normal stance."))
 		xeno_owner.soft_armor = xeno_owner.soft_armor.modifyAllRatings(-last_fortify_bonus)
 		xeno_owner.soft_armor = xeno_owner.soft_armor.modifyRating(BOMB = -last_fortify_bonus)
-		REMOVE_TRAIT(xeno_owner, TRAIT_IMMOBILE, FORTIFY_TRAIT)
+		if(should_immobilize)
+			REMOVE_TRAIT(xeno_owner, TRAIT_IMMOBILE, FORTIFY_TRAIT)
+		if(movement_delay)
+			UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
 		REMOVE_TRAIT(xeno_owner, TRAIT_STOPS_TANK_COLLISION, FORTIFY_TRAIT)
 
 	xeno_owner.fortify = on
 	xeno_owner.anchored = on
 	playsound(xeno_owner.loc, 'sound/effects/stonedoor_openclose.ogg', 30, TRUE)
 	xeno_owner.update_icons()
+
+/// Sets the movement delay. Will register or unregister the signals accordingly.
+/datum/action/ability/xeno_action/fortify/proc/set_movement_delay(new_movement_delay)
+	if(xeno_owner.fortify)
+		if(!movement_delay && new_movement_delay)
+			RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+		if(movement_delay && !new_movement_delay)
+			UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
+	movement_delay = new_movement_delay
+
+/// Increases the owner's next move slowdown by a variable amount.
+/datum/action/ability/xeno_action/fortify/proc/on_move(datum/source)
+	SIGNAL_HANDLER
+	if(!movement_delay)
+		return
+	xeno_owner.next_move_slowdown += movement_delay
 
 // ***************************************
 // *********** Regenerate Skin
@@ -323,6 +364,20 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REGENERATE_SKIN,
 	)
+	/// The amount to multiply the owner's maximum health by & to heal with.
+	var/heal_multiplier = 0.12
+	/// The amount of stacks to reduce (negative) status effects by. For non-stacking status effects, this reduces 2x as seconds instead.
+	var/debuff_removal_amount = 0
+	/// The duration in deciseconds of the Resin Jelly status effect that the owner will get. This will also set nearby humans on fire (if appliable).
+	var/resin_jelly_duration = 0 SECONDS
+	/// The amount to multiply the nearest allied xenomorph's sunder by & to heal with.
+	var/ally_unsunder_multiplier = 0
+	/// The armor that was given to the owner, if any.
+	var/datum/armor/armor_debuff
+	/// Should a temporary soft armor debuff be applied? If so, how much soft armor should be taken away?
+	var/armor_debuff_amount
+	/// ID of the timer that will revert the armor given.
+	var/armor_debuff_timer_id
 
 /datum/action/ability/xeno_action/regenerate_skin/on_cooldown_finish()
 	to_chat(xeno_owner, span_notice("We feel we are ready to shred our skin and grow another."))
@@ -332,7 +387,7 @@
 	if(!can_use_action(TRUE))
 		return fail_activate()
 
-	if(xeno_owner.on_fire)
+	if(xeno_owner.on_fire && !resin_jelly_duration)
 		to_chat(xeno_owner, span_xenowarning("We can't use that while on fire."))
 		return fail_activate()
 
@@ -342,10 +397,66 @@
 
 	xeno_owner.do_jitter_animation(1000)
 	xeno_owner.set_sunder(0)
-	xeno_owner.heal_overall_damage(25, 25, updating_health = TRUE)
+	if(heal_multiplier)
+		var/health_to_heal = heal_multiplier * xeno_owner.xeno_caste.max_health
+		HEAL_XENO_DAMAGE(xeno_owner, health_to_heal, FALSE)
+		xeno_owner.updatehealth()
+	if(debuff_removal_amount)
+		var/list/datum/status_effect/status_effects_to_decrease_or_remove = list(
+			STATUS_EFFECT_SHATTER,
+			STATUS_EFFECT_MICROWAVE
+		)
+		for(var/datum/status_effect/status_effect in status_effects_to_decrease_or_remove)
+			if(!xeno_owner.has_status_effect(status_effect))
+				continue
+			if(istype(status_effect, /datum/status_effect/stacking))
+				var/datum/status_effect/stacking/stacking_status_effect = status_effect
+				stacking_status_effect.add_stacks(-debuff_removal_amount)
+				continue
+			if(status_effect.duration == -1)
+				continue
+			status_effect.duration -= debuff_removal_amount * 2 SECONDS
+			status_effect.check_duration()
+	if(resin_jelly_duration)
+		xeno_owner.apply_status_effect(STATUS_EFFECT_RESIN_JELLY_COATING, resin_jelly_duration)
+		if(xeno_owner.on_fire)
+			for (var/mob/living/carbon/human/nearby_human in orange(1, xeno_owner))
+				if(nearby_human.stat == DEAD || !xeno_owner.Adjacent(nearby_human))
+					continue
+				nearby_human.adjust_fire_stacks(xeno_owner.fire_stacks)
+				nearby_human.IgniteMob()
+			xeno_owner.ExtinguishMob()
+	if(ally_unsunder_multiplier)
+		var/mob/living/carbon/xenomorph/ideal_xenomorph_target
+		for(var/mob/living/carbon/xenomorph/nearby_xenomorph in orange(1, xeno_owner))
+			if(nearby_xenomorph.stat == DEAD || !xeno_owner.Adjacent(nearby_xenomorph))
+				continue
+			if(!xeno_owner.issamexenohive(nearby_xenomorph))
+				continue
+			if(!ideal_xenomorph_target || nearby_xenomorph.sunder > ideal_xenomorph_target.sunder)
+				ideal_xenomorph_target = nearby_xenomorph
+				continue
+		if(ideal_xenomorph_target)
+			ideal_xenomorph_target.adjust_sunder(ideal_xenomorph_target.sunder * -ally_unsunder_multiplier)
+			ideal_xenomorph_target.do_jitter_animation(1000)
+	if(armor_debuff_amount)
+		reverse_armor_debuff()
+		armor_debuff = getArmor()
+		armor_debuff = armor_debuff.modifyAllRatings(-armor_debuff_amount)
+		xeno_owner.soft_armor = xeno_owner.soft_armor.attachArmor(armor_debuff)
+		armor_debuff_timer_id = addtimer(CALLBACK(src, PROC_REF(reverse_armor_debuff)), 6 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
 	add_cooldown()
 	return succeed_activate()
 
+/// Reverses the armor debuff, if any.
+/datum/action/ability/xeno_action/regenerate_skin/proc/reverse_armor_debuff()
+	if(!armor_debuff)
+		return
+	if(armor_debuff_timer_id)
+		deltimer(armor_debuff_timer_id)
+		armor_debuff_timer_id = null
+	xeno_owner.soft_armor = xeno_owner.soft_armor.detachArmor(armor_debuff)
+	armor_debuff = null
 
 // ***************************************
 // *********** Centrifugal force

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -53,6 +53,18 @@
 		/datum/action/ability/xeno_action/regenerate_skin,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/brittle_upclose,
+		/datum/mutation_upgrade/shell/carapace_waxing,
+		/datum/mutation_upgrade/shell/carapace_regrowth,
+		/datum/mutation_upgrade/spur/breathtaking_spin,
+		/datum/mutation_upgrade/spur/sharpening_claws,
+		/datum/mutation_upgrade/spur/power_spin,
+		/datum/mutation_upgrade/veil/carapace_sweat,
+		/datum/mutation_upgrade/veil/carapace_sharing,
+		/datum/mutation_upgrade/veil/slow_and_steady
+	)
+
 /datum/xeno_caste/defender/ancient
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
@@ -1,0 +1,337 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/carapace_waxing
+	name = "Carapace Waxing"
+	desc = "Regenerate Skin additionally reduces various debuffs by 1/2/3 stacks or 2/4/6 seconds."
+	/// For each structure, the amount (in stacks / 2x seconds) that Regenerate Skin will increase negative status effects by.
+	var/debuffs_per_structure = -1
+
+/datum/mutation_upgrade/shell/carapace_waxing/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Regenerate Skin additionally reduces various debuffs by [-get_debuff_stacks(new_amount)] stacks or [-get_debuff_stacks(new_amount) * 2] seconds."
+
+/datum/mutation_upgrade/shell/carapace_waxing/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.debuff_removal_amount += -get_debuff_stacks(new_amount - previous_amount)
+
+/// Returns the amount that Regenerate Skin will increase negative status effects by.
+/datum/mutation_upgrade/shell/carapace_waxing/proc/get_debuff_stacks(structure_count)
+	return debuffs_per_structure * structure_count
+
+/datum/mutation_upgrade/shell/brittle_upclose
+	name = "Brittle Upclose"
+	desc = "You can no longer be staggered by projectiles. You gain 5/7.5/10 bullet armor, but lose 30/35/40 melee armor."
+	/// For the first structure, the amount of bullet armor to increase by.
+	var/bullet_armor_increase_initial = 2.5
+	/// For each structure, the amount of additional bullet armor to increase by.
+	var/bullet_armor_increase_per_structure = 2.5
+	/// For the first structure, the amount of melee armor to increase by.
+	var/melee_armor_reduction_initial = -25
+	/// For each structure, the amount of additional melee armor to increase by.
+	var/melee_armor_reduction_per_structure = -5
+
+/datum/mutation_upgrade/shell/brittle_upclose/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You can no longer be staggered by projectiles. You gain [get_bullet_armor(new_amount)] bullet armor, but lose [-get_melee_armor(new_amount)] melee armor."
+
+/datum/mutation_upgrade/shell/brittle_upclose/on_mutation_enabled()
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyRating(get_melee_armor(0), get_bullet_armor(0))
+	ADD_TRAIT(xenomorph_owner, TRAIT_STAGGER_RESISTANT, MUTATION_TRAIT)
+	return ..()
+
+/datum/mutation_upgrade/shell/brittle_upclose/on_mutation_disabled()
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyRating(get_melee_armor(0), get_bullet_armor(0))
+	REMOVE_TRAIT(xenomorph_owner, TRAIT_STAGGER_RESISTANT, MUTATION_TRAIT)
+	return ..()
+
+/datum/mutation_upgrade/shell/brittle_upclose/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyRating(get_melee_armor(new_amount - previous_amount, FALSE), get_bullet_armor(new_amount - previous_amount, FALSE))
+
+/// Returns the amount of bullet armor that should be given.
+/datum/mutation_upgrade/shell/brittle_upclose/proc/get_bullet_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? bullet_armor_increase_initial : 0) + (bullet_armor_increase_per_structure * structure_count)
+
+/// Returns the amount of melee armor that should be given.
+/datum/mutation_upgrade/shell/brittle_upclose/proc/get_melee_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? melee_armor_reduction_initial : 0) + (melee_armor_reduction_per_structure * structure_count)
+
+/datum/mutation_upgrade/shell/carapace_regrowth
+	name = "Carapace Regrowth"
+	desc = "Regenerate Skin additionally recovers 50/60/70% of your maximum health, but will reduce all of your armor values by 30 for 6 seconds."
+	/// For the first structure, the amount to increase Regenerate Skin's healing multiplier by.
+	var/heal_multiplier_initial = 0.4
+	/// For each structure, the amount to increase Regenerate Skin's healing multiplier by.
+	var/heal_multiplier_per_structure = 0.1
+	/// How much should the armor debuff value be?
+	var/armor_debuff_amount = 30
+
+/datum/mutation_upgrade/shell/carapace_regrowth/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Regenerate Skin additionally recovers [PERCENT(get_heal_multiplier(new_amount))]% of your maximum health, but will reduce all of your armor values by [armor_debuff_amount] for 6 seconds."
+
+/datum/mutation_upgrade/shell/carapace_regrowth/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.heal_multiplier += get_heal_multiplier(0)
+	regenerate_skin.armor_debuff_amount += armor_debuff_amount
+	return ..()
+
+/datum/mutation_upgrade/shell/carapace_regrowth/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.heal_multiplier -= get_heal_multiplier(0)
+	regenerate_skin.armor_debuff_amount -= armor_debuff_amount
+	return ..()
+
+/datum/mutation_upgrade/shell/carapace_regrowth/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.heal_multiplier += get_heal_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to increase Regenerate Skin's healing multiplier by.
+/datum/mutation_upgrade/shell/carapace_regrowth/proc/get_heal_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? heal_multiplier_initial : 0) + (heal_multiplier_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/breathtaking_spin
+	name = "Breathtaking Spin"
+	desc = "Tail Swipe deals stamina damage instead. It no longer paralyzes and deals 2x/2.25/2.5x more damage."
+	/// For the first structure, the amount to increase Tail Swipe's damage multiplier by.
+	var/damage_multiplier_initial = 1.75
+	/// For each structure, the amount to increase Tail Swipe's damage multiplier by.
+	var/damage_multiplier_per_structure = 0.25
+
+/datum/mutation_upgrade/spur/breathtaking_spin/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Tail Swipe deals stamina damage instead. It no longer paralyzes and deals [get_damage_multiplier(new_amount)]x more damage."
+
+/datum/mutation_upgrade/spur/breathtaking_spin/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.damage_multiplier += get_damage_multiplier(0)
+	tail_sweep.damage_type = STAMINA
+	tail_sweep.paralyze_duration -= initial(tail_sweep.paralyze_duration)
+	return ..()
+
+/datum/mutation_upgrade/spur/breathtaking_spin/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.damage_multiplier -= get_damage_multiplier(0)
+	tail_sweep.damage_type = initial(tail_sweep.damage_type)
+	tail_sweep.paralyze_duration += initial(tail_sweep.paralyze_duration)
+	return ..()
+
+/datum/mutation_upgrade/spur/breathtaking_spin/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.damage_multiplier += get_damage_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to increase Tail Swipe's damage multiplier by.
+/datum/mutation_upgrade/spur/breathtaking_spin/proc/get_damage_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? damage_multiplier_initial : 0) + (damage_multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/spur/power_spin
+	name = "Power Spin"
+	desc = "Tail Swipe's knockback is increased by 1 tile and staggers for 1/2/3 seconds."
+	/// The amount to increase Tail Swipe's knockback by.
+	var/knockback_amount = 1
+	/// For each structure, the amount of deciseconds to increase Tail Swipe's stagger duration by.
+	var/stagger_per_structure = 1 SECONDS
+
+/datum/mutation_upgrade/spur/power_spin/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Tail Swipe's knockback is increased by [knockback_amount] tile and staggers for [get_stagger_duration(new_amount) * 0.1] seconds."
+
+/datum/mutation_upgrade/spur/power_spin/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.knockback_distance += knockback_amount
+	return ..()
+
+/datum/mutation_upgrade/spur/power_spin/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.knockback_distance -= knockback_amount
+	return ..()
+
+/datum/mutation_upgrade/spur/power_spin/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
+	if(!tail_sweep)
+		return FALSE
+	tail_sweep.stagger_duration += get_stagger_duration(new_amount - previous_amount)
+
+/// Returns the amount of deciseconds to increase Tail Swipe's stagger duration by.
+/datum/mutation_upgrade/spur/power_spin/proc/get_stagger_duration(structure_count)
+	return stagger_per_structure * structure_count
+
+/datum/mutation_upgrade/spur/sharpening_claws
+	name = "Sharpening Claws"
+	desc = "For each 10 sunder / missing armor, your melee damage multiplier is increased by 3/6/9%."
+	/// The amount of sunder used to determine the final multiplier.
+	var/sunder_repeating_threshold = 10
+	/// For each structure, the amount to increase the melee damage modifier by for each time the sunder threshold is passed.
+	var/modifier_per_structure = 0.03
+	/// The amount that the melee damage modifier has been increased by so far.
+	var/modifier_so_far = 0
+
+/datum/mutation_upgrade/spur/sharpening_claws/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "For each [sunder_repeating_threshold] sunder / missing armor, your melee damage multiplier is increased by [PERCENT(get_modifier(new_amount))]%."
+
+/datum/mutation_upgrade/spur/sharpening_claws/on_mutation_enabled()
+	RegisterSignal(xenomorph_owner, COMSIG_XENOMORPH_SUNDER_CHANGE, PROC_REF(on_sunder_change))
+	return ..()
+
+/datum/mutation_upgrade/spur/sharpening_claws/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, COMSIG_XENOMORPH_SUNDER_CHANGE)
+	return ..()
+
+/datum/mutation_upgrade/spur/sharpening_claws/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	xenomorph_owner.xeno_melee_damage_modifier -= modifier_so_far
+	modifier_so_far = 0
+	on_sunder_change(null, 0, xenomorph_owner.sunder)
+
+/// Changes melee damage modifier based on the difference between old and current sunder values.
+/datum/mutation_upgrade/spur/sharpening_claws/proc/on_sunder_change(datum/source, old_sunder, new_sunder)
+	SIGNAL_HANDLER
+	var/new_modifier = round(new_sunder / sunder_repeating_threshold) * get_modifier(get_total_structures())
+	if(new_modifier == modifier_so_far)
+		return
+	xenomorph_owner.xeno_melee_damage_modifier += (new_modifier - modifier_so_far)
+	modifier_so_far = new_modifier
+
+/// Returns the amount to increase the melee damage modifier by for each time the sunder threshold is passed.
+/datum/mutation_upgrade/spur/sharpening_claws/proc/get_modifier(structure_count)
+	return modifier_per_structure * structure_count
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/carapace_sweat
+	name = "Carapace Sweat"
+	desc = "Regenerate Skin can be used while on fire and will apply Resin Jelly to you for 2/4/6 seconds. If you were on fire, you will be extinguished and set nearby humans on fire."
+	/// For each structure, the amount of deciseconds that the Resin Jelly status effect will have.
+	var/duration_per_structure = 2 SECONDS
+
+/datum/mutation_upgrade/veil/carapace_sweat/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Regenerate Skin can be used while on fire and grants fire immunity for [get_duration(new_amount) * 0.1] seconds. If you were on fire, you will be extinguished and set nearby humans on fire."
+
+/datum/mutation_upgrade/veil/carapace_sweat/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.resin_jelly_duration += get_duration(new_amount - previous_amount)
+
+/// Returns the amount of deciseconds that the Resin Jelly status effect will have.
+/datum/mutation_upgrade/veil/carapace_sweat/proc/get_duration(structure_count)
+	return duration_per_structure * structure_count
+
+/datum/mutation_upgrade/veil/slow_and_steady
+	name = "Slow and Steady"
+	desc = "You are no longer immobilized during Fortify. However, your move delay is increased by 1.4/1.2/1 seconds while it is active."
+	/// For the first structure, the amount of deciseconds of delay to add to movement while Fortify is active.
+	var/movement_delay_initial = 1.6 SECONDS
+	/// For each structure, the amount of deciseconds of delay to add to movement while Fortify is active.
+	var/movement_delay_per_structure = -0.2 SECONDS
+
+/datum/mutation_upgrade/veil/slow_and_steady/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You are no longer immobilized during Fortify. However, your move delay is increased by [get_delay(new_amount) * 0.1] seconds while it is active."
+
+/datum/mutation_upgrade/veil/slow_and_steady/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
+	if(!fortify)
+		return FALSE
+
+	fortify.should_immobilize = FALSE
+	fortify.set_movement_delay(fortify.movement_delay + get_delay(0))
+	return ..()
+
+/datum/mutation_upgrade/veil/slow_and_steady/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
+	if(!fortify)
+		return FALSE
+	fortify.should_immobilize = initial(fortify.should_immobilize)
+	fortify.set_movement_delay(fortify.movement_delay - get_delay(0))
+	return ..()
+
+/datum/mutation_upgrade/veil/slow_and_steady/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
+	if(!fortify)
+		return FALSE
+	fortify.set_movement_delay(fortify.movement_delay + get_delay(new_amount - previous_amount, FALSE))
+
+/// Returns the amount of deciseconds of delay to add to movement while Fortify is active.
+/datum/mutation_upgrade/veil/slow_and_steady/proc/get_delay(structure_count, include_initial = TRUE)
+	return (include_initial ? movement_delay_initial : 0) + (movement_delay_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/carapace_sharing
+	name = "Carapace Sharing"
+	desc = "Regenerate Skin additionally removes 8/16/24% sunder of a nearby friendly xenomorph. This prioritizes those with the highest sunder."
+	/// For each structure, the amount to increase Regenerate Skin's ally sunder healing multiplier by.
+	var/ally_unsunder_multiplier_per_structure = 0.08
+
+/datum/mutation_upgrade/veil/carapace_sharing/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Regenerate Skin additionally removes [PERCENT(get_multiplier(new_amount))]% sunder of a nearby friendly xenomorph. This prioritizes those with the highest sunder."
+
+/datum/mutation_upgrade/veil/carapace_sharing/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
+	if(!regenerate_skin)
+		return FALSE
+	regenerate_skin.ally_unsunder_multiplier += get_multiplier(new_amount - previous_amount)
+
+/// Returns the amount to increase Regenerate Skin's ally sunder healing multiplier by.
+/datum/mutation_upgrade/veil/carapace_sharing/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return ally_unsunder_multiplier_per_structure * structure_count
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
@@ -18,7 +18,7 @@
 		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.debuff_removal_amount += -get_debuff_stacks(new_amount - previous_amount)
 
 /// Returns the amount that Regenerate Skin will increase negative status effects by.
@@ -84,7 +84,7 @@
 /datum/mutation_upgrade/shell/carapace_regrowth/on_mutation_enabled()
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.heal_multiplier += get_heal_multiplier(0)
 	regenerate_skin.armor_debuff_amount += armor_debuff_amount
 	return ..()
@@ -92,7 +92,7 @@
 /datum/mutation_upgrade/shell/carapace_regrowth/on_mutation_disabled()
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.heal_multiplier -= get_heal_multiplier(0)
 	regenerate_skin.armor_debuff_amount -= armor_debuff_amount
 	return ..()
@@ -103,7 +103,7 @@
 		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.heal_multiplier += get_heal_multiplier(new_amount - previous_amount, FALSE)
 
 /// Returns the amount to increase Regenerate Skin's healing multiplier by.
@@ -129,7 +129,7 @@
 /datum/mutation_upgrade/spur/breathtaking_spin/on_mutation_enabled()
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.damage_multiplier += get_damage_multiplier(0)
 	tail_sweep.damage_type = STAMINA
 	tail_sweep.paralyze_duration -= initial(tail_sweep.paralyze_duration)
@@ -138,7 +138,7 @@
 /datum/mutation_upgrade/spur/breathtaking_spin/on_mutation_disabled()
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.damage_multiplier -= get_damage_multiplier(0)
 	tail_sweep.damage_type = initial(tail_sweep.damage_type)
 	tail_sweep.paralyze_duration += initial(tail_sweep.paralyze_duration)
@@ -150,7 +150,7 @@
 		return
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.damage_multiplier += get_damage_multiplier(new_amount - previous_amount, FALSE)
 
 /// Returns the amount to increase Tail Swipe's damage multiplier by.
@@ -173,14 +173,14 @@
 /datum/mutation_upgrade/spur/power_spin/on_mutation_enabled()
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.knockback_distance += knockback_amount
 	return ..()
 
 /datum/mutation_upgrade/spur/power_spin/on_mutation_disabled()
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.knockback_distance -= knockback_amount
 	return ..()
 
@@ -190,7 +190,7 @@
 		return
 	var/datum/action/ability/xeno_action/tail_sweep/tail_sweep = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/tail_sweep]
 	if(!tail_sweep)
-		return FALSE
+		return
 	tail_sweep.stagger_duration += get_stagger_duration(new_amount - previous_amount)
 
 /// Returns the amount of deciseconds to increase Tail Swipe's stagger duration by.
@@ -261,7 +261,7 @@
 		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.resin_jelly_duration += get_duration(new_amount - previous_amount)
 
 /// Returns the amount of deciseconds that the Resin Jelly status effect will have.
@@ -284,7 +284,7 @@
 /datum/mutation_upgrade/veil/slow_and_steady/on_mutation_enabled()
 	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
 	if(!fortify)
-		return FALSE
+		return
 
 	fortify.should_immobilize = FALSE
 	fortify.set_movement_delay(fortify.movement_delay + get_delay(0))
@@ -293,7 +293,7 @@
 /datum/mutation_upgrade/veil/slow_and_steady/on_mutation_disabled()
 	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
 	if(!fortify)
-		return FALSE
+		return
 	fortify.should_immobilize = initial(fortify.should_immobilize)
 	fortify.set_movement_delay(fortify.movement_delay - get_delay(0))
 	return ..()
@@ -304,7 +304,7 @@
 		return
 	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
 	if(!fortify)
-		return FALSE
+		return
 	fortify.set_movement_delay(fortify.movement_delay + get_delay(new_amount - previous_amount, FALSE))
 
 /// Returns the amount of deciseconds of delay to add to movement while Fortify is active.
@@ -328,7 +328,7 @@
 		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
-		return FALSE
+		return
 	regenerate_skin.ally_unsunder_multiplier += get_multiplier(new_amount - previous_amount)
 
 /// Returns the amount to increase Regenerate Skin's ally sunder healing multiplier by.

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -542,7 +542,9 @@
 	. = ..()
 	if(.)
 		return
+	var/old_sunder = sunder
 	sunder = clamp(sunder + (adjustment > 0 ? adjustment * xeno_caste.sunder_multiplier : adjustment), 0, xeno_caste.sunder_max)
+	SEND_SIGNAL(src, COMSIG_XENOMORPH_SUNDER_CHANGE, old_sunder, sunder)
 //Applying sunder is an adjustment value above 0, healing sunder is an adjustment value below 0. Use multiplier when taking sunder, not when healing.
 
 /mob/living/carbon/xenomorph/set_sunder(new_sunder)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1981,6 +1981,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\defender\abilities_defender.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\defender\castedatum_defender.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\defender\defender.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\defender\mutations_defender.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\defiler\abilities_defiler.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\defiler\castedatum_defiler.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\defiler\defiler.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a total of 9 mutations all for Defender.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Carapace Waxing | Regenerate Skin additionally reduces various debuffs by 1/2/3 stacks or 2/4/6 seconds. |
| Shell | Brittle Upclose |You can no longer be staggered by projectiles. You gain 5/7.5/10 bullet armor, but lose 30/35/40 melee armor. |
| Shell | Carapace Regrowth | Regenerate Skin additionally recovers 50/60/70% of your maximum health, but will reduce all of your armor values by 30 for 6 seconds. |
| Spur | Breathtaking Spin | Tail Swipe deals stamina damage instead. It no longer paralyzes and deals 2x/2.25/2.5x more damage. |
| Spur | Power Spin | Tail Swipe's knockback is increased by 1 tile and staggers for 1/2/3 seconds. |
| Spur | Sharpening Claws | For each 10 sunder / missing armor, your melee damage multiplier is increased by 3/6/9%. |
| Veil | Carapace Sweat | Regenerate Skin can be used while on fire and will apply Resin Jelly to you for 2/4/6 seconds. If you were on fire, you will be extinguished and set nearby humans on fire. |
| Veil | Slow and Steady | You are no longer immobilized during Fortify. However, your move delay is increased by 1.4/1.2/1 seconds while it is active. |
| Veil | Carapace Sharing | Regenerate Skin additionally removes 8/16/24% sunder of a nearby friendly xenomorph. This prioritizes those with the highest sunder.|

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Defender now has 9 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
balance: Regenerate Skin now deals 12% of maximum health (50) total rather than: 25 burn damage and 25 brute damage.
/:cl:
