### PR TITLE
Mutations: Drone

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -19,6 +19,8 @@
 
 #define STATUS_EFFECT_XENO_ESSENCE_LINK /datum/status_effect/stacking/essence_link
 
+#define STATUS_EFFECT_XENO_ESSENCE_LINK_REVENGE /datum/status_effect/essence_link_revenge
+
 #define STATUS_EFFECT_XENO_SALVE_REGEN /datum/status_effect/salve_regen
 
 #define STATUS_EFFECT_XENO_ENHANCEMENT /datum/status_effect/drone_enhancement

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -67,16 +67,24 @@
 	COOLDOWN_DECLARE(plasma_warning)
 	/// The beam used to represent the link between linked xenos.
 	var/datum/beam/current_beam
+	/// The percentage of lifesteal given to link_owner based on damage dealt from link_target.
+	var/lifesteal_percentage
+	/// The additive amount to increase melee damage modifier to the survivor if the link ends due to death.
+	var/revenge_modifier
 
-/datum/status_effect/stacking/essence_link/on_creation(mob/living/new_owner, stacks_to_apply, mob/living/carbon/link_target)
+/datum/status_effect/stacking/essence_link/on_creation(mob/living/new_owner, stacks_to_apply, mob/living/carbon/link_target, expected_lifesteal_percentage, expected_revenge_modifier)
 	link_owner = new_owner
 	src.link_target = link_target
 	essence_link_action = link_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
 	ADD_TRAIT(link_owner, TRAIT_ESSENCE_LINKED, TRAIT_STATUS_EFFECT(id))
 	ADD_TRAIT(link_target, TRAIT_ESSENCE_LINKED, TRAIT_STATUS_EFFECT(id))
-	RegisterSignals(link_owner, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), PROC_REF(end_link))
-	RegisterSignals(link_target, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), PROC_REF(end_link))
+	RegisterSignals(link_owner, list(COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), PROC_REF(end_link))
+	RegisterSignals(link_target, list(COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), PROC_REF(end_link))
+	RegisterSignal(link_owner, COMSIG_MOB_DEATH, PROC_REF(end_link_from_death))
+	RegisterSignal(link_target, COMSIG_MOB_DEATH, PROC_REF(end_link_from_death))
 	toggle_link(TRUE)
+	set_lifesteal(expected_lifesteal_percentage)
+	revenge_modifier = expected_revenge_modifier
 	to_chat(link_owner, span_xenonotice("We have established an Essence Link with [link_target]. Stay within [DRONE_ESSENCE_LINK_RANGE] tiles to maintain it."))
 	to_chat(link_target, span_xenonotice("[link_owner] has established an Essence Link with us. Stay within [DRONE_ESSENCE_LINK_RANGE] tiles to maintain it."))
 	return ..()
@@ -95,6 +103,7 @@
 	essence_link_action.end_ability()
 	UnregisterSignal(link_owner, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED))
 	UnregisterSignal(link_target, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED))
+	set_lifesteal(0)
 	REMOVE_TRAIT(link_owner, TRAIT_ESSENCE_LINKED, TRAIT_STATUS_EFFECT(id))
 	REMOVE_TRAIT(link_target, TRAIT_ESSENCE_LINKED, TRAIT_STATUS_EFFECT(id))
 	return ..()
@@ -195,10 +204,39 @@
 /datum/status_effect/stacking/essence_link/proc/update_beam()
 	current_beam?.visuals.alpha = round(255 / (max_stacks+1 - stacks))
 
-/// Ends the link prematurely.
+/// Ends the link prematurely via evolution/devolution.
 /datum/status_effect/stacking/essence_link/proc/end_link(datum/source)
 	SIGNAL_HANDLER
 	essence_link_action.end_ability()
+
+/// Ends the link prematurely via death.
+/datum/status_effect/stacking/essence_link/proc/end_link_from_death(datum/source, gibbed)
+	SIGNAL_HANDLER
+	if(!revenge_modifier)
+		essence_link_action.end_ability()
+		return
+
+	// Need to offload these effects elsewhere since this status effect is being deleted.
+	if(source == link_owner)
+		link_target.apply_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK_REVENGE, revenge_modifier)
+	if(source == link_target)
+		link_owner.apply_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK_REVENGE, revenge_modifier)
+	essence_link_action.end_ability()
+
+/datum/status_effect/stacking/essence_link/proc/set_lifesteal(desired_lifesteal_percentage)
+	if(lifesteal_percentage && !desired_lifesteal_percentage)
+		UnregisterSignal(link_owner, COMSIG_XENOMORPH_POSTATTACK_LIVING)
+	if(!lifesteal_percentage && desired_lifesteal_percentage)
+		RegisterSignal(link_owner, COMSIG_XENOMORPH_POSTATTACK_LIVING, PROC_REF(handle_lifesteal))
+	lifesteal_percentage = desired_lifesteal_percentage
+
+/// Heals the link_owner a percentage of the damage dealt by the link_target if they're within range.
+/datum/status_effect/stacking/essence_link/proc/handle_lifesteal(datum/source, mob/living/attacked_target, damage_dealt, list/damage_modifiers)
+	SIGNAL_HANDLER
+	if(!was_within_range || !lifesteal_percentage)
+		return
+	var/damage_to_heal = damage_dealt * lifesteal_percentage
+	HEAL_XENO_DAMAGE(link_owner, damage_to_heal, FALSE)
 
 // ***************************************
 // *********** Salve Regeneration
@@ -932,3 +970,31 @@
 	scale = generator(GEN_VECTOR, list(0.1, 0.1), list(0.6,0.6), NORMAL_RAND)
 	rotation = 0
 	spin = generator(GEN_NUM, 10, 20)
+
+/datum/status_effect/essence_link_revenge
+	id = "essence_link_revenge"
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null
+	duration = 7 SECONDS
+	// How much should the xenomorph owner's melee_damage_modifier be increased by?
+	var/damage_modifier = 0
+
+/datum/status_effect/essence_link_revenge/on_creation(mob/living/new_owner, new_damage_modifier)
+	owner = new_owner
+	damage_modifier = new_damage_modifier
+	return ..()
+
+/datum/status_effect/essence_link_revenge/on_apply()
+	. = ..()
+	if(!isxeno(owner) || !damage_modifier)
+		return FALSE
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	xeno_owner.xeno_melee_damage_modifier += damage_modifier
+	xeno_owner.add_filter("[id]_outline", 3, outline_filter(1, COLOR_VIVID_RED))
+
+/datum/status_effect/essence_link_revenge/on_remove()
+	if(!isxeno(owner) || !damage_modifier)
+		return
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+	xeno_owner.xeno_melee_damage_modifier -= damage_modifier
+	xeno_owner.remove_filter("[id]_outline")

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -32,6 +32,12 @@
 	var/mob/living/carbon/xenomorph/linked_target
 	/// Time it takes for the attunement levels to increase.
 	var/attunement_cooldown = 60 SECONDS
+	/// A percentage of health to restore to the owner whenever the linked target deals slash damage.
+	var/lifesteal_percentage = 0
+	/// The additive amount to increase melee damage modifier to the survivor if the link ends due to death.
+	var/revenge_modifier = 0
+	/// The percentage of max health healed to the linked target (and dealt to owner) if it was disconnected via alternative action.
+	var/disconnection_heal_percentage = 0
 
 /datum/action/ability/activable/xeno/essence_link/can_use_ability(mob/living/carbon/xenomorph/target, silent = FALSE, override_flags)
 	if(!isxeno(target) || target.get_xeno_hivenumber() != xeno_owner.get_xeno_hivenumber())
@@ -56,7 +62,7 @@
 		if(!do_after(xeno_owner, DRONE_ESSENCE_LINK_WINDUP, NONE, target, BUSY_ICON_FRIENDLY, BUSY_ICON_FRIENDLY))
 			xeno_owner.balloon_alert(xeno_owner, "Link cancelled")
 			return
-		xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK, 1, target)
+		xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK, 1, target, lifesteal_percentage, revenge_modifier)
 		existing_link = xeno_owner.has_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
 		linked_target = target
 		target.balloon_alert(target, "Essence Link established")
@@ -66,14 +72,19 @@
 	if(!HAS_TRAIT(xeno_owner, TRAIT_ESSENCE_LINKED))
 		xeno_owner.balloon_alert(xeno_owner, "No link to cancel")
 		return
-	end_ability()
+	end_ability(TRUE)
 	return COMSIG_KB_ACTIVATED
 
 /// Ends the ability, removing signals and buffs.
-/datum/action/ability/activable/xeno/essence_link/proc/end_ability()
+/datum/action/ability/activable/xeno/essence_link/proc/end_ability(was_manually_disconnected = FALSE)
 	var/datum/action/ability/xeno_action/enhancement/enhancement_action = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/enhancement]
 	enhancement_action?.end_ability()
 	xeno_owner.remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
+	if(was_manually_disconnected && existing_link.stacks)
+		var/health_to_heal = linked_target.maxHealth * disconnection_heal_percentage * existing_link.stacks
+		var/leftover_healing = health_to_heal
+		HEAL_XENO_DAMAGE(linked_target, leftover_healing, FALSE)
+		xeno_owner.adjustBruteLoss(health_to_heal - leftover_healing, TRUE)
 	existing_link = null
 	linked_target = null
 	add_cooldown()
@@ -89,7 +100,7 @@
 	name = "Acidic Salve"
 	action_icon_state = "heal_xeno"
 	action_icon = 'icons/Xeno/actions/drone.dmi'
-	desc = "Apply a minor heal to the target. If applied to a linked sister, it will also apply a regenerative buff. Additionally, if that linked sister is near death, the heal's potency is increased"
+	desc = "Apply a minor heal to the target. If applied to a linked sister, it will also apply a regenerative buff. Additionally, if that linked sister is near death, the heal's potency is increased."
 	cooldown_duration = 5 SECONDS
 	ability_cost = 150
 	keybinding_signals = list(
@@ -97,12 +108,20 @@
 	)
 	heal_range = DRONE_HEAL_RANGE
 	target_flags = ABILITY_MOB_TARGET
+	/// Should cast time / do_after be ignored if the target meets the health threshold?
+	var/bypass_cast_time_on_threshold = FALSE
+	/// The max health threshold the target needs to be under to qualify for bonus healing. Target must be connected to the owner with Essence Link with 1+ stacks.
+	var/bonus_healing_threshold = 0.1
+	/// The additional multiplier of healing if they meet the health threshold.
+	var/bonus_healing_additive_multiplier = 2
 
 /datum/action/ability/activable/xeno/psychic_cure/acidic_salve/use_ability(atom/target)
 	if(xeno_owner.do_actions)
 		return FALSE
-	if(!do_after(xeno_owner, 1 SECONDS, NONE, target, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-		return FALSE
+	var/mob/living/living_target = target
+	if((!bypass_cast_time_on_threshold || (living_target.health > (living_target.maxHealth * bonus_healing_threshold))))
+		if(!do_after(xeno_owner, 1 SECONDS, NONE, target, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+			return FALSE
 	xeno_owner.visible_message(span_xenowarning("\the [xeno_owner] vomits acid over [target], mending their wounds!"))
 	owner.changeNext_move(CLICK_CD_RANGE)
 	salve_healing(target)
@@ -117,11 +136,9 @@
 	var/datum/action/ability/activable/xeno/essence_link/essence_link_action = owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
 	var/heal_multiplier = 1
 	if(essence_link_action.existing_link?.link_target == target)
-		var/remaining_health = round(target.maxHealth - (target.getBruteLoss() + target.getFireLoss()))
-		var/health_threshold = round(target.maxHealth / 10) // 10% of the target's maximum health
 		target.apply_status_effect(STATUS_EFFECT_XENO_SALVE_REGEN)
-		if(essence_link_action.existing_link.stacks > 0 && remaining_health <= health_threshold)
-			heal_multiplier = 3
+		if(essence_link_action.existing_link.stacks > 0 && (target.health <= (target.maxHealth * bonus_healing_threshold)))
+			heal_multiplier += bonus_healing_additive_multiplier
 	playsound(target, SFX_ALIEN_DROOL, 25)
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/heal_amount = (DRONE_BASE_SALVE_HEAL + target.recovery_aura * target.maxHealth * 0.01) * heal_multiplier

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -67,6 +67,14 @@
 		/datum/action/ability/activable/xeno/place_pattern,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/scout,
+		/datum/mutation_upgrade/shell/together_in_claws,
+		/datum/mutation_upgrade/spur/revenge,
+		/datum/mutation_upgrade/veil/saving_grace,
+		/datum/mutation_upgrade/veil/vitality_transfer
+	)
+
 /datum/xeno_caste/drone/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/mutations_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/mutations_drone.dm
@@ -1,0 +1,212 @@
+//*********************//
+//        Shell        //
+//*********************//
+
+/datum/mutation_upgrade/shell/scout
+	name = "Scout"
+	desc = "You gain 5/10/15 armor in all categories. You lose this armor if you've been on weeds for longer than 5 seconds."
+	/// For each structure, the additional amount of armor for all categories when entering weeds.
+	var/armor_per_structure = 5
+	/// The attached armor that been given, if any.
+	var/datum/armor/attached_armor
+	/// Timer ID for a proc that revokes the armor given when it times out.
+	var/timer_id
+	/// How long should the armor be given?
+	var/timer_length = 5 SECONDS
+
+/datum/mutation_upgrade/shell/scout/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You gain [armor_per_structure * new_amount] armor in all categories. You lose this armor if you've been on weeds for longer than [timer_length/10] seconds."
+
+/datum/mutation_upgrade/shell/scout/on_mutation_enabled()
+	. = ..()
+	RegisterSignal(xenomorph_owner, COMSIG_LIVING_WEEDS_AT_LOC_CREATED, PROC_REF(entered_weeds))
+	RegisterSignal(xenomorph_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_movement))
+	if(!xenomorph_owner.loc_weeds_type)
+		grant_armor()
+		return
+	entered_weeds(xenomorph_owner, xenomorph_owner.loc_weeds_type)
+
+/datum/mutation_upgrade/shell/scout/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_LIVING_WEEDS_AT_LOC_CREATED, COMSIG_MOVABLE_MOVED))
+	revoke_armor()
+	return ..()
+
+/// Grants armor and removes the timer.
+/datum/mutation_upgrade/shell/scout/proc/grant_armor()
+	if(timer_id)
+		deltimer(timer_id)
+		timer_id = null
+	if(attached_armor)
+		return
+	var/total_armor = get_total_structures() * armor_per_structure
+	attached_armor = new(total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor)
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(attached_armor)
+
+/// Removes armor and the timer.
+/datum/mutation_upgrade/shell/scout/proc/revoke_armor()
+	if(timer_id)
+		deltimer(timer_id)
+		timer_id = null
+	if(!attached_armor)
+		return
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.detachArmor(attached_armor)
+	attached_armor = null
+
+/// Grant armor if they entered a location without weeds. Otherwise, set a timer that will revoke armor later.
+/datum/mutation_upgrade/shell/scout/proc/on_movement(datum/source, atom/old_loc, movement_dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	var/obj/alien/weeds/found_weed = locate(/obj/alien/weeds) in xenomorph_owner.loc
+	if(found_weed)
+		entered_weeds(xenomorph_owner, found_weed)
+		return
+	grant_armor()
+
+/datum/mutation_upgrade/shell/scout/proc/entered_weeds(datum/source, obj/alien/weeds/location_weeds)
+	SIGNAL_HANDLER
+	if(timer_id)
+		return
+	timer_id = addtimer(CALLBACK(src, PROC_REF(revoke_armor)), timer_length, TIMER_STOPPABLE|TIMER_UNIQUE)
+
+/datum/mutation_upgrade/shell/together_in_claws
+	name = "Together In Claws"
+	desc = "While connected with Essence Link, you heal for 10/15/20% of your partner's damage when they slash a human."
+	/// For the first structure, the percentage to lifesteal.
+	var/lifesteal_percentage_initial = 0.05
+	/// For each structure, the additional percentage to lifesteal.
+	var/lifesteal_percentage_per_structure = 0.05
+
+/datum/mutation_upgrade/shell/together_in_claws/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While connected with Essence Link, you heal for [(lifesteal_percentage_initial + (lifesteal_percentage_per_structure * new_amount)) * 100]% of your partner's damage when they slash a human."
+
+/datum/mutation_upgrade/shell/together_in_claws/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.lifesteal_percentage += lifesteal_percentage_initial
+	if(ability.existing_link)
+		ability.existing_link.set_lifesteal(ability.lifesteal_percentage)
+	return ..()
+
+/datum/mutation_upgrade/shell/together_in_claws/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.lifesteal_percentage -= lifesteal_percentage_initial
+	return ..()
+
+/datum/mutation_upgrade/shell/together_in_claws/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.lifesteal_percentage += (new_amount - previous_amount) * lifesteal_percentage_per_structure
+	if(ability.existing_link)
+		ability.existing_link.set_lifesteal(ability.lifesteal_percentage)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/revenge
+	name = "Revenge"
+	desc = "While connected with Essence Link and it ends due to death, the survivor temporarily gains 75/100/125% additional melee damage for 10 seconds."
+	/// For the first structure, the melee damage multiplier to increase by.
+	var/percentage_initial = 0.50
+	/// For each structure, the additional melee damage multiplier to increase by.
+	var/percentage_per_structure = 0.25
+
+/datum/mutation_upgrade/spur/revenge/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While connected with Essence Link and it ends due to death, the survivor temporarily gains [(percentage_initial + (percentage_per_structure * new_amount)) * 100]% additional melee damage for 10 seconds."
+
+/datum/mutation_upgrade/spur/revenge/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.revenge_modifier += percentage_initial
+	if(ability.existing_link)
+		ability.existing_link.revenge_modifier  += percentage_initial
+	return ..()
+
+/datum/mutation_upgrade/spur/revenge/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.revenge_modifier -= percentage_initial
+	if(ability.existing_link)
+		ability.existing_link.revenge_modifier += percentage_initial
+	return ..()
+
+/datum/mutation_upgrade/spur/revenge/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.revenge_modifier += (new_amount - previous_amount) * percentage_per_structure
+	if(ability.existing_link)
+		ability.existing_link.revenge_modifier += (new_amount - previous_amount) * percentage_per_structure
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/saving_grace
+	name = "Saving Grace"
+	desc = "Salve Heal has no cast time on your Essence Link partner if they qualify for bonus healing. Bonus healing multiplier is increased by an additive of 1/2/3."
+	/// For each structure, the multiplier as an additive to increase the bonus healing by.
+	var/additive_multiplier_per_structure = 1
+
+/datum/mutation_upgrade/veil/saving_grace/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Salve Heal has no cast time on your Essence Link partner if they qualify for bonus healing. Bonus healing multiplier is increased by an additive of [additive_multiplier_per_structure * new_amount]."
+
+/datum/mutation_upgrade/veil/saving_grace/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/psychic_cure/acidic_salve/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure/acidic_salve]
+	if(!ability)
+		return
+	ability.bypass_cast_time_on_threshold = TRUE
+	return ..()
+
+/datum/mutation_upgrade/veil/saving_grace/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/psychic_cure/acidic_salve/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure/acidic_salve]
+	if(!ability)
+		return
+	ability.bypass_cast_time_on_threshold = initial(ability.bypass_cast_time_on_threshold)
+	return ..()
+
+/datum/mutation_upgrade/veil/saving_grace/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/psychic_cure/acidic_salve/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure/acidic_salve]
+	if(!ability)
+		return
+	ability.bonus_healing_additive_multiplier += (new_amount - previous_amount) * additive_multiplier_per_structure
+
+/datum/mutation_upgrade/veil/vitality_transfer
+	name = "Vitality Transfer"
+	desc = "While connected with Essence Link, you can manually disconnect to heal your partner for 5/10/15% of their maximum health multiplied by the attunement amount. However, you take true damage equal to the amount healed. This damage can kill you."
+	/// For each structure, the additional percentage of maximum health to heal by.
+	var/max_health_percentage_per_structure = 0.05
+
+/datum/mutation_upgrade/veil/vitality_transfer/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While connected with Essence Link, you can manually disconnect to heal your partner for [max_health_percentage_per_structure * new_amount * 100]% of their maximum health multiplied by the attunement amount. However, you take true damage equal to the amount healed. This damage can kill you."
+
+/datum/mutation_upgrade/veil/vitality_transfer/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/essence_link/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/essence_link]
+	if(!ability)
+		return
+	ability.disconnection_heal_percentage += (new_amount - previous_amount) * max_health_percentage_per_structure

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1990,6 +1990,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\abilities_drone.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\castedatum_drone.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\drone.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\drone\mutations_drone.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\abilities_gorger.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\castedatum_gorger.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\gorger.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 5 mutations all for Drone.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Scout  |You gain 5/10/15 armor in all categories. You lose this armor if you've been on weeds for longer than 5 seconds. |
| Shell | Together In Claws | While connected with Essence Link, you heal for 10/15/20% of your partner's damage when they slash a human. |
| Spur | Revenge | While connected with Essence Link and it ends due to death, the survivor temporarily gains 75/100/125% additional melee damage for 10 seconds. |
| Veil | Saving Grace | Salve Heal has no cast time on your Essence Link partner if they qualify for bonus healing. Bonus healing multiplier is increased by an additive of 1/2/3. |
| Veil | Vitality Transfer | While connected with Essence Link, you can manually disconnect to heal your partner for 5/10/15% of their maximum health multiplied by the attunement amount. However, you take true damage equal to the amount healed. This damage can kill you. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Drone now has 5 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
