### PR TITLE
Mutations: Sentinel

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -497,6 +497,10 @@
 	consumed_on_threshold = FALSE
 	/// Owner of the debuff is limited to carbons.
 	var/mob/living/carbon/debuff_owner
+	/// The xenomorph who will receive healing.
+	var/mob/living/carbon/xenomorph/xenomorph_to_heal
+	/// The amount of health to restore for each stack.
+	var/healing_per_stack = 0
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
 
@@ -505,12 +509,19 @@
 		return FALSE
 	return ..()
 
-/datum/status_effect/stacking/intoxicated/on_creation(mob/living/new_owner, stacks_to_apply)
+/datum/status_effect/stacking/intoxicated/on_apply()
+	if(HAS_TRAIT(owner, TRAIT_INTOXICATION_IMMUNE))
+		return FALSE
+	return ..()
+
+/datum/status_effect/stacking/intoxicated/on_creation(mob/living/new_owner, stacks_to_apply, mob/living/carbon/xenomorph/expected_xenomorph_to_heal, expected_healing_per_stack = 0)
 	if(new_owner.status_flags & GODMODE || new_owner.stat == DEAD)
 		qdel(src)
 		return
 	. = ..()
 	debuff_owner = new_owner
+	xenomorph_to_heal = expected_xenomorph_to_heal
+	healing_per_stack = expected_healing_per_stack
 	RegisterSignal(debuff_owner, COMSIG_LIVING_DO_RESIST, PROC_REF(call_resist_debuff))
 	debuff_owner.balloon_alert(debuff_owner, "Intoxicated")
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 30)
@@ -540,6 +551,9 @@
 	if(stacks >= 20)
 		debuff_owner.adjust_slowdown(1)
 		debuff_owner.adjust_stagger(1 SECONDS)
+	if(healing_per_stack && xenomorph_to_heal?.Adjacent(debuff_owner))
+		var/amount_to_heal = stacks * healing_per_stack
+		HEAL_XENO_DAMAGE(xenomorph_to_heal, amount_to_heal, FALSE)
 
 /// Called when the debuff's owner uses the Resist action for this debuff.
 /datum/status_effect/stacking/intoxicated/proc/call_resist_debuff()

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -173,15 +173,10 @@
 
 	var/bonus_potency = 0
 	if(xenochemicals_unit_per_stack)
-		var/neurotox_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin)
-		var/hemodile_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile)
-		var/transvitox_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox)
-		var/sanguinal_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal)
-		var/ozelomelyn_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn)
-		bonus_potency = round((neurotox_amount + hemodile_amount + transvitox_amount + sanguinal_amount + ozelomelyn_amount) / xenochemicals_unit_per_stack)
+		for(var/datum/reagent/toxin/reagent_typepath_in_list in GLOB.defiler_toxins_typecache_list)
+			bonus_potency += xeno_target.reagents.get_reagent_amount(reagent_typepath_in_list)
+	bonus_potency = round(bonus_potency) / xenochemicals_unit_per_stack
 	var/drain_potency = (debuff.stacks + bonus_potency) * SENTINEL_DRAIN_MULTIPLIER * (xeno_owner.Adjacent(xeno_target) ? 1 : ranged_effectiveness)
-	to_chat(world, "Bonus count was: [bonus_potency] Debuff count was: [debuff.stacks]")
-	to_chat(world, "Final drain potency was: [drain_potency]")
 	if(debuff.stacks > debuff.max_stacks - 10)
 		xeno_target.emote("scream")
 		xeno_owner.apply_status_effect(STATUS_EFFECT_DRAIN_SURGE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -51,6 +51,8 @@
 	var/remaining_slashes = 0
 	/// Timer for the ability; we reference this to delete the timer if the effect lapses before the timer does.
 	var/ability_duration
+	/// The amount of health to heal the owner multiplied by stack amount whenever Intoxicated status effect ticks.
+	var/healing_per_stack = 0
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
 
@@ -77,10 +79,13 @@
 		xeno_target.balloon_alert(xeno_owner, "Immune to Intoxication")
 		return
 	playsound(xeno_target, 'sound/effects/spray3.ogg', 20, TRUE)
-	if(xeno_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
-		var/datum/status_effect/stacking/intoxicated/debuff = xeno_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
+	var/datum/status_effect/stacking/intoxicated/debuff = xeno_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
+	if(debuff)
 		debuff.add_stacks(intoxication_stacks)
-	xeno_target.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxication_stacks)
+		debuff.xenomorph_to_heal = xeno_owner
+		debuff.healing_per_stack = healing_per_stack
+	else
+		xeno_target.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxication_stacks, xeno_owner, healing_per_stack)
 	remaining_slashes-- //Decrement the toxic slash count
 	if(!remaining_slashes) //Deactivate if we have no toxic slashes remaining
 		toxic_slash_deactivate(xeno_owner)
@@ -135,6 +140,12 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DRAIN_STING,
 	)
+	/// How far can the target be in order for the ability to work?
+	var/targetable_range = 1
+	/// If the ability was used from a range that was above 1, then all effects are mulitplied by this value.
+	var/ranged_effectiveness = 0
+	/// If the target has any xeno-chemicals in them, how many units will be counted as one stack of Intoxicated? Only activated if it is more than 1.
+	var/xenochemicals_unit_per_stack = 0
 
 /datum/action/ability/activable/xeno/drain_sting/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
@@ -145,8 +156,9 @@
 			A.balloon_alert(owner, "Cannot sting")
 		return FALSE
 	var/mob/living/carbon/target = A
-	if(!owner.Adjacent(target))
-		target.balloon_alert(owner, "Cannot reach")
+	if((get_dist(owner, target) > targetable_range) || !line_of_sight(owner, target))
+		if(!silent)
+			target.balloon_alert(owner, "Cannot reach")
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_INTOXICATION_IMMUNE))
 		target.balloon_alert(owner, "Immune to intoxication")
@@ -158,7 +170,18 @@
 /datum/action/ability/activable/xeno/drain_sting/use_ability(atom/A)
 	var/mob/living/carbon/xeno_target = A
 	var/datum/status_effect/stacking/intoxicated/debuff = xeno_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
-	var/drain_potency = debuff.stacks * SENTINEL_DRAIN_MULTIPLIER
+
+	var/bonus_potency = 0
+	if(xenochemicals_unit_per_stack)
+		var/neurotox_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin)
+		var/hemodile_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile)
+		var/transvitox_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox)
+		var/sanguinal_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal)
+		var/ozelomelyn_amount = xeno_target.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn)
+		bonus_potency = round((neurotox_amount + hemodile_amount + transvitox_amount + sanguinal_amount + ozelomelyn_amount) / xenochemicals_unit_per_stack)
+	var/drain_potency = (debuff.stacks + bonus_potency) * SENTINEL_DRAIN_MULTIPLIER * (xeno_owner.Adjacent(xeno_target) ? 1 : ranged_effectiveness)
+	to_chat(world, "Bonus count was: [bonus_potency] Debuff count was: [debuff.stacks]")
+	to_chat(world, "Final drain potency was: [drain_potency]")
 	if(debuff.stacks > debuff.max_stacks - 10)
 		xeno_target.emote("scream")
 		xeno_owner.apply_status_effect(STATUS_EFFECT_DRAIN_SURGE)
@@ -170,7 +193,7 @@
 	xeno_owner.do_attack_animation(xeno_target, ATTACK_EFFECT_DRAIN_STING)
 	playsound(owner.loc, 'sound/effects/alien/tail_swipe1.ogg', 30)
 	xeno_owner.visible_message(message = span_xenowarning("\A [xeno_owner] stings [xeno_target]!"), self_message = span_xenowarning("We sting [xeno_target]!"))
-	debuff.stacks -= round(debuff.stacks * 0.7)
+	debuff.add_stacks(-round(debuff.stacks * 0.7))
 	succeed_activate()
 	add_cooldown()
 	GLOB.round_statistics.sentinel_drain_stings++

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -173,8 +173,10 @@
 
 	var/bonus_potency = 0
 	if(xenochemicals_unit_per_stack)
-		for(var/datum/reagent/toxin/reagent_typepath_in_list in GLOB.defiler_toxins_typecache_list)
-			bonus_potency += xeno_target.reagents.get_reagent_amount(reagent_typepath_in_list)
+		for(var/datum/reagent/target_reagent AS in xeno_target.reagents.reagent_list)
+			if(!is_type_in_typecache(target_reagent, GLOB.defiler_toxins_typecache_list))
+				continue
+			bonus_potency += target_reagent.reagents.get_reagent_amount(target_reagent)
 	bonus_potency = round(bonus_potency) / xenochemicals_unit_per_stack
 	var/drain_potency = (debuff.stacks + bonus_potency) * SENTINEL_DRAIN_MULTIPLIER * (xeno_owner.Adjacent(xeno_target) ? 1 : ranged_effectiveness)
 	if(debuff.stacks > debuff.max_stacks - 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -176,7 +176,7 @@
 		for(var/datum/reagent/target_reagent AS in xeno_target.reagents.reagent_list)
 			if(!is_type_in_typecache(target_reagent, GLOB.defiler_toxins_typecache_list))
 				continue
-			bonus_potency += target_reagent.reagents.get_reagent_amount(target_reagent)
+			bonus_potency += xeno_target.reagents.get_reagent_amount(target_reagent)
 	bonus_potency = round(bonus_potency) / xenochemicals_unit_per_stack
 	var/drain_potency = (debuff.stacks + bonus_potency) * SENTINEL_DRAIN_MULTIPLIER * (xeno_owner.Adjacent(xeno_target) ? 1 : ranged_effectiveness)
 	if(debuff.stacks > debuff.max_stacks - 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -57,6 +57,14 @@
 		/datum/action/ability/activable/xeno/drain_sting,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/toxic_blood,
+		/datum/mutation_upgrade/shell/comforting_acid,
+		/datum/mutation_upgrade/spur/acidic_slasher,
+		/datum/mutation_upgrade/spur/far_sting,
+		/datum/mutation_upgrade/veil/toxic_compatibility
+	)
+
 /datum/xeno_caste/sentinel/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
@@ -1,0 +1,205 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/toxic_blood
+	name = "Toxic Blood"
+	desc = "Every 100/75/50 damage you take, 1 stacks of Intoxicated will be applied to nearby humans."
+	/// For the first structure, the damage needed to be taken.
+	var/damage_initial = 125
+	/// For each structure, the additional damage needed to be taken.
+	var/damage_per_structure = -25
+	/// The amount of damage taken so far before threshold is calculated.
+	var/damage_taken_so_far = 0
+	/// The amount of intoxicated stacks to apply.
+	var/intoxicated_stacks_to_apply = 1
+
+/datum/mutation_upgrade/shell/toxic_blood/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Every [damage_initial + (damage_per_structure * new_amount)] damage you take, [intoxicated_stacks_to_apply] stacks of Intoxicated will be applied to nearby humans."
+
+/datum/mutation_upgrade/shell/toxic_blood/on_mutation_enabled()
+	RegisterSignals(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE), PROC_REF(on_damage))
+	return ..()
+
+/datum/mutation_upgrade/shell/toxic_blood/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE, COMSIG_MOB_STAT_CHANGED))
+	return ..()
+
+/datum/mutation_upgrade/shell/toxic_blood/on_structure_update(previous_amount, new_amount)
+	damage_taken_so_far = min(damage_taken_so_far, damage_initial + (damage_per_structure * new_amount) - 1)
+	return ..()
+
+/// Apply intoxicated stacks to nearby alive humans if the damage threshold is reached.
+/datum/mutation_upgrade/shell/toxic_blood/proc/on_damage(datum/source, amount, list/amount_mod)
+	SIGNAL_HANDLER
+	if(amount <= 0 || xenomorph_owner.stat == DEAD) // It is fine to be unconscious!
+		return
+	damage_taken_so_far += amount
+	if(damage_taken_so_far < (damage_initial + (damage_per_structure * get_total_structures())))
+		return
+	damage_taken_so_far = 0
+	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(xenomorph_owner, 1))
+		if(nearby_human.stat == DEAD)
+			continue
+		var/datum/status_effect/stacking/intoxicated/debuff = nearby_human.has_status_effect(STATUS_EFFECT_INTOXICATED)
+		if(!debuff)
+			nearby_human.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxicated_stacks_to_apply)
+			continue
+		debuff.add_stacks(intoxicated_stacks_to_apply)
+
+/datum/mutation_upgrade/shell/comforting_acid
+	name = "Comforting Acid"
+	desc = "Toxic Slash will cause humans to passively heal you for 1/1.5/2 health per stack of Intoxicated as long you stay near them."
+	/// For the first structure, the health to heal.
+	var/healing_initial = 0.5
+	/// For each structure, the additional health to heal.
+	var/healing_per_structure = 0.5
+
+/datum/mutation_upgrade/shell/comforting_acid/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Toxic Slash will cause humans to passively heal you for [healing_initial + (healing_per_structure * new_amount)] health per stack of Intoxicated as long you stay near them."
+
+/datum/mutation_upgrade/shell/comforting_acid/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/toxic_slash/ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toxic_slash]
+	if(!ability)
+		return
+	ability.healing_per_stack += healing_initial
+	return ..()
+
+/datum/mutation_upgrade/shell/comforting_acid/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/toxic_slash/ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toxic_slash]
+	if(!ability)
+		return
+	ability.healing_per_stack -= healing_initial
+	return ..()
+
+/datum/mutation_upgrade/shell/comforting_acid/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/xeno_action/toxic_slash/ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toxic_slash]
+	if(!ability)
+		return
+	ability.healing_per_stack += (new_amount - previous_amount) * healing_per_structure
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/acidic_slasher
+	name = "Acidic Slasher"
+	desc = "Your attack delay will be 0.05/0.1/0.15s faster and will always apply 1/2/3 stacks of Intoxicated against humans, but all melee damage is reduced by 50%."
+	/// For each structure, the additional amount of deciseconds to decrease their next move by.
+	var/attack_speed_decrease_per_structure = 0.5
+	/// For each structure, the additional amount of intoxicated to apply. decisecond to decrease their next move by.
+	var/intoxicated_stack_per_structure = 1
+	/// The amount to decrease the melee damage modifier by.
+	var/melee_damage_modifier = 0.5
+
+/datum/mutation_upgrade/spur/acidic_slasher/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Your attack delay will be [(attack_speed_decrease_per_structure * new_amount) * 0.1]s faster and will always apply [(intoxicated_stack_per_structure * new_amount)] stacks of Intoxicated against humans, but all melee damage is reduced by [melee_damage_modifier * 100]%."
+
+/datum/mutation_upgrade/spur/acidic_slasher/on_mutation_enabled()
+	UnregisterSignal(src, COMSIG_XENOMORPH_POSTATTACK_LIVING)
+	xenomorph_owner.xeno_melee_damage_modifier -= melee_damage_modifier
+	return ..()
+
+/datum/mutation_upgrade/spur/acidic_slasher/on_mutation_disabled()
+	UnregisterSignal(src, COMSIG_XENOMORPH_POSTATTACK_LIVING)
+	xenomorph_owner.xeno_melee_damage_modifier += melee_damage_modifier
+	return ..()
+
+/datum/mutation_upgrade/spur/acidic_slasher/on_structure_update(previous_amount, new_amount)
+	xenomorph_owner.next_move_adjust -= (new_amount - previous_amount) * attack_speed_decrease_per_structure
+	return ..()
+
+/// Applies a variable amount of Intoxicated stacks to those that they attack.
+/datum/mutation_upgrade/spur/acidic_slasher/proc/on_postattack(mob/living/source, mob/living/target, damage)
+	SIGNAL_HANDLER
+	var/datum/status_effect/stacking/intoxicated/debuff = target.has_status_effect(STATUS_EFFECT_INTOXICATED)
+	if(!debuff)
+		target.apply_status_effect(STATUS_EFFECT_INTOXICATED, intoxicated_stack_per_structure)
+		return
+	debuff.add_stacks(intoxicated_stack_per_structure)
+
+/datum/mutation_upgrade/spur/far_sting
+	name = "Far Sting"
+	desc = "Drain Sting can be used at targets 1 additional tile away. If the target is at maximum range, Drain Sting is 50/75/100% effective."
+	/// For the first structure, the range to increase by.
+	var/range_initial = 1
+	/// For each structure, the effectiveness of Drain Sting at a range that isn't upclose.
+	var/effectiveness_initial = 0.25
+	/// For each structure, the additional effectiveness of Drain Sting at a range that isn't upclose.
+	var/effectiveness_per_structure = 0.25
+
+/datum/mutation_upgrade/spur/far_sting/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Drain Sting can be used at targets [range_initial] additional tile away. If the target is at maximum range, Drain Sting is [effectiveness_initial + (effectiveness_per_structure * new_amount)]% effective."
+
+/datum/mutation_upgrade/spur/far_sting/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.targetable_range += range_initial
+	ability.ranged_effectiveness += effectiveness_initial
+	return ..()
+
+/datum/mutation_upgrade/spur/far_sting/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.targetable_range -= range_initial
+	ability.ranged_effectiveness -= effectiveness_initial
+	return ..()
+
+/datum/mutation_upgrade/spur/far_sting/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.ranged_effectiveness += (new_amount - previous_amount) * effectiveness_per_structure
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/toxic_compatibility
+	name = "Toxic Compatibility"
+	desc = "Every 5/4/3u of xeno-chemicals in your target will count as one stack of Intoxicated when calculating the the strength of your Drain Sting."
+	/// For each structure, the amount of xeno-chemicals to convert to one stack of Intoxicated.
+	var/amount_initial = 6
+	/// For each structure, the additional amount of xeno-chemicals to convert to one stack of Intoxicated.
+	var/amount_per_structure = -1
+
+/datum/mutation_upgrade/veil/toxic_compatibility/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Every [amount_initial + (amount_per_structure * new_amount)]u of xeno-chemicals in your target will count as one stack of Intoxicated when calculating the the strength of your Drain Sting."
+
+/datum/mutation_upgrade/veil/toxic_compatibility/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.xenochemicals_unit_per_stack += amount_initial
+	return ..()
+
+/datum/mutation_upgrade/veil/toxic_compatibility/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.xenochemicals_unit_per_stack -= amount_initial
+	return ..()
+
+/datum/mutation_upgrade/veil/toxic_compatibility/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!.)
+		return
+	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
+	if(!ability)
+		return
+	ability.xenochemicals_unit_per_stack += (new_amount - previous_amount) * amount_per_structure

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
@@ -6,7 +6,7 @@
 	desc = "Every 100/75/50 damage you take, 1 stacks of Intoxicated will be applied to nearby humans."
 	/// For the first structure, the damage needed to be taken.
 	var/damage_initial = 125
-	/// For each structure, the additional damage needed to be taken.
+	/// For each structure, the damage needed to be taken.
 	var/damage_per_structure = -25
 	/// The amount of damage taken so far before threshold is calculated.
 	var/damage_taken_so_far = 0
@@ -90,9 +90,9 @@
 /datum/mutation_upgrade/spur/acidic_slasher
 	name = "Acidic Slasher"
 	desc = "Your attack delay will be 0.05/0.1/0.15s faster and will always apply 1/2/3 stacks of Intoxicated against humans, but all melee damage is reduced by 50%."
-	/// For each structure, the additional amount of deciseconds to decrease their next move by.
+	/// For each structure, the amount of deciseconds to decrease their next move by.
 	var/attack_speed_decrease_per_structure = 0.5
-	/// For each structure, the additional amount of intoxicated to apply. decisecond to decrease their next move by.
+	/// For each structure, the amount of intoxicated to apply.
 	var/intoxicated_stack_per_structure = 1
 	/// The amount to decrease the melee damage modifier by.
 	var/melee_damage_modifier = 0.5

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2038,6 +2038,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\scorpion\scorpion.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\sentinel\abilities_sentinel.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\sentinel\castedatum_sentinel.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\sentinel\mutations_sentinel.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\sentinel\sentinel.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\shrike\abilities_shrike.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\shrike\castedatum_shrike.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a total of 5 mutations all for Sentinel.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Toxic Blood | Every 100/75/50 damage you take, 1 stacks of Intoxicated will be applied to nearby humans. |
| Shell | Comforting Acid | Toxic Slash will cause humans to passively heal you for 1/1.5/2 health per stack of Intoxicated as long you stay near them. |
| Spur | Acidic Slasher | Your attack delay will be 0.05/0.1/0.15s faster and will always apply 1/2/3 stacks of Intoxicated against humans, but all melee damage is reduced by 50%. |
| Spur | Far Sting | Drain Sting can be used at targets 1 additional tile away. If the target is at maximum range, Drain Sting is 50/75/100% effective. |
| Veil | Toxic Compatibility | Every 5/4/3u of xeno-chemicals in your target will count as one stack of Intoxicated when calculating the the strength of your Drain Sting. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Sentinel now has 5 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
