### PR TITLE
Crash ships snack vendors

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -943,6 +943,10 @@
 	},
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
+"Mg" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "Mj" = (
 /obj/machinery/air_alarm{
 	dir = 4
@@ -1661,7 +1665,7 @@ aX
 bA
 aT
 UO
-aX
+Mg
 Kk
 bA
 bg

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -732,7 +732,7 @@
 /turf/open/floor/mainship/red,
 /area/shuttle/canterbury)
 "nN" = (
-/obj/machinery/quick_vendor/beginner,
+/obj/machinery/vending/snack,
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "pY" = (


### PR DESCRIPTION
Added snack vendors to canterbury and bigbury to make nanites viable on crash (access to protein shakes)
## About The Pull Request

I deleted the south quick loadout vendor on the regular canterbury map and replaced it with a snack vendor. On bigbury, I deleted one of the two quick loadout vendors in the prep area and replaced it with a snack vendor.
## Why It's Good For The Game

My intent is to give marines access to protein shakes on crash. It will make nanomachines more viable to use on crash, marines can load up reagent pouches with protein shake instead of having to carry around protein bars or extra food. This strategy already exists on nuclear war ship maps, this change just brings it to crash. To create space for these vendors, I removed one quick loadout vendor out of the 2 or 3 that exist from each ship map. I feel having more than 1 quick loadout vendor per map is redundant.
## Changelog

:cl: Scav
add: Added snack vendors to canterbury and bigbury
del: Removed one quick loadout vendor from canterbury and bigbury
/:cl:
