### PR TITLE
Add a button to toggle tadpole shutters within the tadpole console

### DIFF
--- a/_maps/shuttles/minidropship_big.dmm
+++ b/_maps/shuttles/minidropship_big.dmm
@@ -177,7 +177,7 @@
 /obj/structure/bed/chair/dropship/pilot{
 	dir = 1
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control";

--- a/_maps/shuttles/minidropship_factorio.dmm
+++ b/_maps/shuttles/minidropship_factorio.dmm
@@ -106,7 +106,7 @@
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/minidropship)
 "S" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control";

--- a/_maps/shuttles/minidropship_food.dmm
+++ b/_maps/shuttles/minidropship_food.dmm
@@ -200,7 +200,7 @@
 	},
 /area/shuttle/minidropship)
 "P" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control";

--- a/_maps/shuttles/minidropship_mobile_bar.dmm
+++ b/_maps/shuttles/minidropship_mobile_bar.dmm
@@ -54,7 +54,7 @@
 	},
 /area/shuttle/minidropship)
 "r" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control";

--- a/_maps/shuttles/minidropship_outrider.dmm
+++ b/_maps/shuttles/minidropship_outrider.dmm
@@ -19,7 +19,7 @@
 	dir = 2;
 	id = "minidropship_podlock"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 8;
 	id = "minidropship_podlock";
 	name = "inner door-control"

--- a/_maps/shuttles/minidropship_panopticon.dmm
+++ b/_maps/shuttles/minidropship_panopticon.dmm
@@ -92,7 +92,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "L" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control"

--- a/_maps/shuttles/minidropship_standard.dmm
+++ b/_maps/shuttles/minidropship_standard.dmm
@@ -77,7 +77,7 @@
 /area/shuttle/minidropship)
 "u" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship,
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 2;
 	id = "minidropship_podlock";
 	name = "inner door-control"

--- a/_maps/shuttles/minidropship_umbilical.dmm
+++ b/_maps/shuttles/minidropship_umbilical.dmm
@@ -111,7 +111,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/transparent/dark_blue/full,
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	dir = 4;
 	id = "minidropship_podlock";
 	name = "inner door-control";

--- a/_maps/shuttles/minidropship_urbantower.dmm
+++ b/_maps/shuttles/minidropship_urbantower.dmm
@@ -38,7 +38,7 @@
 /obj/structure/bed/chair/dropship/pilot,
 /obj/structure/closet/crate/delta,
 /obj/item/book/manual/engineering_construction,
-/obj/machinery/door_control{
+/obj/machinery/door_control/minidropship{
 	id = "minidropship_podlock";
 	name = "inner door-control"
 	},

--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -88,6 +88,7 @@
 
 //Signals for shuttle
 #define COMSIG_GLOB_SHUTTLE_TAKEOFF "!shuttle_take_off"
+#define COMSIG_GLOB_TADPOLE_SHUTTER "!shutter_toggle"
 
 /// sent after world.maxx and/or world.maxy are expanded: (has_exapnded_world_maxx, has_expanded_world_maxy)
 #define COMSIG_GLOB_EXPANDED_WORLD_BOUNDS "!expanded_world_bounds"

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -45,9 +45,6 @@
 		pixel_y = ( (dir & 3) ? (dir == 1 ? -16 : 28) : 0 )
 		update_icon()
 
-	if(id == "minidropship_podlock")
-		RegisterSignal(SSdcs, COMSIG_GLOB_TADPOLE_SHUTTER , PROC_REF(handle_pod))
-
 /obj/machinery/door_control/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(.)
@@ -353,3 +350,10 @@
 
 /obj/machinery/door_control/old/unmeltable
 	resistance_flags = RESIST_ALL
+
+/obj/machinery/door_control/minidropship
+	id = "minidropship_podlock"
+
+/obj/machinery/door_control/minidropship/Initialize()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_TADPOLE_SHUTTER, PROC_REF(handle_pod))

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -45,6 +45,9 @@
 		pixel_y = ( (dir & 3) ? (dir == 1 ? -16 : 28) : 0 )
 		update_icon()
 
+	if(id == "minidropship_podlock")
+		RegisterSignal(SSdcs, COMSIG_GLOB_TADPOLE_SHUTTER , PROC_REF(handle_pod))
+
 /obj/machinery/door_control/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(.)
@@ -83,6 +86,7 @@
 					D.safe = 1
 
 /obj/machinery/door_control/proc/handle_pod()
+	SIGNAL_HANDLER
 	for(var/obj/machinery/door/poddoor/M in GLOB.machines)
 		if(M.id == id)
 			if(M.density)

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -151,8 +151,9 @@
 
 // Toggle the transit shutters from the shuttle computer
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/toggle_shutters()
-	if(shutter_button != null)
-		shutter_button.attack_hand(ui_user)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_TADPOLE_SHUTTER)
+		//RegisterSignal(/obj/machinery/door_control, COMSIG_GLOB_TADPOLE_SHUTTER)
+		// SEND_SIGNAL(src, COMSIG_PLANE_OFFSET_INCREASE, old_max, max_plane_offset)
 
 ///The action of sending the shuttle back to its shuttle port on main ship
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/return_to_ship()

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -149,6 +149,11 @@
 		destination_fly_state = SHUTTLE_IN_ATMOSPHERE
 	SSshuttle.moveShuttleToTransit(shuttleId, TRUE)
 
+// Toggle the transit shutters from the shuttle computer
+/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/toggle_shutters()
+	if(shutter_button != null)
+		shutter_button.attack_hand(ui_user)
+
 ///The action of sending the shuttle back to its shuttle port on main ship
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/return_to_ship()
 	shuttle_port = SSshuttle.getShuttle(shuttleId)
@@ -294,6 +299,8 @@
 	switch(action)
 		if("take_off")
 			take_off()
+		if("toggle_shutters")
+			toggle_shutters()
 		if("return_to_ship")
 			return_to_ship()
 		if("toggle_nvg")

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -152,8 +152,6 @@
 // Toggle the transit shutters from the shuttle computer
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/toggle_shutters()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_TADPOLE_SHUTTER)
-		//RegisterSignal(/obj/machinery/door_control, COMSIG_GLOB_TADPOLE_SHUTTER)
-		// SEND_SIGNAL(src, COMSIG_PLANE_OFFSET_INCREASE, old_max, max_plane_offset)
 
 ///The action of sending the shuttle back to its shuttle port on main ship
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/return_to_ship()

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -149,7 +149,7 @@
 		destination_fly_state = SHUTTLE_IN_ATMOSPHERE
 	SSshuttle.moveShuttleToTransit(shuttleId, TRUE)
 
-// Toggle the transit shutters from the shuttle computer
+// Toggle the podlock shutters from the shuttle computer
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/proc/toggle_shutters()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_TADPOLE_SHUTTER)
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -19,6 +19,8 @@
 	var/obj/docking_port/stationary/my_port
 	/// The previous custom docking port that was safely landed at, for emergency landings
 	var/obj/docking_port/stationary/last_valid_ground_port
+	/// The shutter button of the shuttle
+	var/obj/machinery/door_control/shutter_button
 	/// The mobile docking port of the connected shuttle
 	var/obj/docking_port/mobile/shuttle_port
 	/// Traits forbided for custom docking
@@ -58,6 +60,10 @@
 		if(jumpto_ports[S.id])
 			z_lock |= S.z
 	whitelist_turfs = typecacheof(whitelist_turfs)
+	for(var/obj/machinery/door_control/D in range(3, src))
+		if(D.id == "minidropship_podlock")
+			shutter_button = D
+			break
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	if(my_port?.get_docked())

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -19,8 +19,6 @@
 	var/obj/docking_port/stationary/my_port
 	/// The previous custom docking port that was safely landed at, for emergency landings
 	var/obj/docking_port/stationary/last_valid_ground_port
-	/// The shutter button of the shuttle
-	var/obj/machinery/door_control/shutter_button
 	/// The mobile docking port of the connected shuttle
 	var/obj/docking_port/mobile/shuttle_port
 	/// Traits forbided for custom docking
@@ -60,10 +58,6 @@
 		if(jumpto_ports[S.id])
 			z_lock |= S.z
 	whitelist_turfs = typecacheof(whitelist_turfs)
-	for(var/obj/machinery/door_control/D in range(3, src))
-		if(D.id == "minidropship_podlock")
-			shutter_button = D
-			break
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	if(my_port?.get_docked())

--- a/tgui/packages/tgui/interfaces/Minidropship.tsx
+++ b/tgui/packages/tgui/interfaces/Minidropship.tsx
@@ -30,7 +30,7 @@ export const Minidropship = (_props) => {
             Take off
           </Button>
           <Button onClick={() => act('toggle_shutters')}>
-            Toggle transit shutters
+            Toggle shutters
           </Button>
           <Button
             disabled={return_to_ship_locked}

--- a/tgui/packages/tgui/interfaces/Minidropship.tsx
+++ b/tgui/packages/tgui/interfaces/Minidropship.tsx
@@ -29,6 +29,9 @@ export const Minidropship = (_props) => {
           <Button disabled={take_off_locked} onClick={() => act('take_off')}>
             Take off
           </Button>
+          <Button onClick={() => act('toggle_shutters')}>
+            Toggle transit shutters
+          </Button>
           <Button
             disabled={return_to_ship_locked}
             onClick={() => act('return_to_ship')}


### PR DESCRIPTION
## About The Pull Request

Adds a button to toggle tadpole shutters within the tadpole console

## Why It's Good For The Game

This PR should make TOs and others close the shutters more often, them not activating the shutters is a problem. I cant remember the last time during an evac the shutters have been closed in an appropriate amount of time, a delay of a few seconds could cost the lives of most people on board for no reason

- It's like how a good xeno uses hotkeys sure you could just click the UI button but in a combat situation you don't want to scan your buttons looking for the right one
- The position changes with the rotation making it harder to find
- The button is already very tiny
- Reduce UI physical and mechanical load
- It will allow the pilot to multitask better, they don't have to worry about finding the button in time to save the passengers

If it's on the same screen pilots wont have to scan the shuttle looking for the button, there will be less stress and pressure on them

## Changelog
:cl:
qol: Adds a button to toggle tadpole shutters within the tadpole console
/:cl:
