### PR TITLE
fix light mech rockets

### DIFF
--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -34,7 +34,7 @@
 	max_range = 30
 	sundering = 15
 
-/datum/ammo/rocket/mech/light/drop_nade(turf/T)
+/datum/ammo/rocket/mech/drop_nade(turf/T)
 	explosion(T, 0, 0, 4, 0, 0, explosion_cause=src)
 
 /datum/ammo/rocket/mech/heavy


### PR DESCRIPTION

## About The Pull Request
'Light' mech rockets were doing sadar level explosions because someone didn't check the typepaths.
Currently its 0, 4, 6 when it should be 0, 0, 4.
## Why It's Good For The Game
THis should be obvious
## Changelog
:cl:
fix: fixed mech light rockets being hugely more powerful than intended
/:cl:
