### PR TITLE
Fix caste swap timer showing the wrong time

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -612,6 +612,9 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define CASTE_CAN_RIDE_CRUSHER (1<<5) // Can we ride a crusher (or behemoth)?
 #define CASTE_CAN_BE_RULER (1<<6) // Caste can become a ruler if no queen / shrike / king exists in the hive.
 
+///How often we can swap strains
+#define XENO_STRAIN_SWAP_COOLDOWN 5 MINUTES
+
 //Charge-Crush
 #define CHARGE_OFF 0
 #define CHARGE_BUILDINGUP 1

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -49,8 +49,8 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	var/tier_three_penalty = 0
 	///Includes T3 xenos in the calculation for maximum T3 slots.
 	var/tier_three_inclusion = FALSE
-	///Caste Swap Timer
-	var/caste_swap_timer = 15 MINUTES
+	///How often you can caste swap
+	var/caste_swap_cooldown = 15 MINUTES
 	///List of castes we dont want to be evolvable depending on gamemode.
 	var/list/restricted_castes
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -25,7 +25,7 @@
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_CHIGUSA, MAP_LAVA_OUTPOST, MAP_CORSAT, MAP_KUTJEVO_REFINERY, MAP_BLUESUMMERS)
 	tier_three_penalty = 1
 	tier_three_inclusion = TRUE
-	caste_swap_timer = 5 MINUTES
+	caste_swap_cooldown = 5 MINUTES
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)
 
 	// Round end conditions

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -17,9 +17,9 @@
 	set category = "Alien"
 
 	var/time_since = world.time - (GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)
-	var/caste_swap_timer = SSticker.mode.caste_swap_timer
-	if(time_since < (caste_swap_timer))
-		to_chat(src, span_warning("Your caste swap timer has [(5 MINUTES - time_since)/10] seconds remaining."))
+	var/caste_swap_duration = SSticker.mode.caste_swap_cooldown
+	if(time_since < (caste_swap_duration))
+		to_chat(src, span_warning("Your caste swap timer has [(caste_swap_duration - time_since)/10] seconds remaining."))
 		return
 
 	SStgui.close_user_uis(src, GLOB.evo_panel)
@@ -32,8 +32,8 @@
 	set category = "Alien"
 
 	var/time_since = world.time - (GLOB.key_to_time_of_strain_swap[key] ? GLOB.key_to_time_of_strain_swap[key] : -INFINITY)
-	if(time_since < (5 MINUTES))
-		to_chat(src, span_warning("Your strain swap timer has [(5 MINUTES - time_since)/10] seconds remaining."))
+	if(time_since < (XENO_STRAIN_SWAP_COOLDOWN))
+		to_chat(src, span_warning("Your strain swap timer has [(XENO_STRAIN_SWAP_COOLDOWN - time_since)/10] seconds remaining."))
 		return
 
 	SStgui.close_user_uis(src, GLOB.evo_panel)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -169,9 +169,7 @@
 
 	. += "Regeneration power: [max(regen_power * 100, 0)]%"
 
-	var/caste_swap_timer = SSticker.mode.caste_swap_timer
-
-	var/casteswap_value = ((GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)  + caste_swap_timer - world.time) * 0.1
+	var/casteswap_value = ((GLOB.key_to_time_of_caste_swap[key] ? GLOB.key_to_time_of_caste_swap[key] : -INFINITY)  + SSticker.mode.caste_swap_cooldown - world.time) * 0.1
 	if(casteswap_value <= 0)
 		. += "Caste Swap Timer: READY"
 	else


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

The STATUS TAB has the right time, but the actual caste swap button was showing the wrong time since it was referring to the old 5 minute timer instead of the actual time.

Also changed the var name to be more accurate, since its just a cooldown duration, not an actual timer.
## Why It's Good For The Game
bugfix
## Changelog
:cl:
fix: fixed the caste swap button displaying the wrong time in nuke war
/:cl:
