### PR TITLE
Mutations: Melter

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -150,6 +150,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define isxenobehemoth(A) (istype(A, /mob/living/carbon/xenomorph/behemoth))
 #define isxenodragon(A) (istype(A, /mob/living/carbon/xenomorph/dragon))
 #define isxenopyrogen(A) (istype(A, /mob/living/carbon/xenomorph/pyrogen))
+#define isxenomelter(A) (istype(A, /mob/living/carbon/xenomorph/runner/melter))
 
 //Silicon mobs
 #define issilicon(A) (istype(A, /mob/living/silicon))

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -80,8 +80,10 @@
 
 	acid_spray_damage = 16
 
-	// -12 melee damage. Attacking does a second instance of melee damage as burn damage + status effect.
+	// -12 melee damage. Attacking does a second instance of melee damage as brute damage (vs. melee) + melting acid status effect.
 	melee_damage = 11
+	melee_damage_type = BURN
+	melee_damage_armor = ACID
 
 	// Gain acid blood for less speed (0.2).
 	speed = -1.2
@@ -102,6 +104,12 @@
 		/datum/action/ability/activable/xeno/charge/acid_dash/melter,
 		/datum/action/ability/activable/xeno/melter_shroud,
 		/datum/action/ability/xeno_action/xenohide,
+	)
+
+	mutations = list(
+		/datum/mutation_upgrade/shell/acid_release,
+		/datum/mutation_upgrade/spur/fully_acid,
+		/datum/mutation_upgrade/veil/acid_reserves
 	)
 
 /datum/xeno_caste/runner/melter/normal

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
@@ -1,0 +1,127 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/acid_release
+	name = "Acid Release"
+	desc = "Upon entering critical, release stunning acid in a radius of 2/3/4 tiles. This resets upon reaching full health."
+	/// For the first structure, the radius in which stunning acid is created.
+	var/radius_initial = 1
+	/// For each structure, the additional radius in which stunning acid is created.
+	var/radius_per_structure = 1
+	/// If the effect can be activated.
+	var/can_be_activated = FALSE
+
+/datum/mutation_upgrade/shell/acid_release/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Upon entering critical, release stunning acid in a radius of [get_radius(new_amount)] tiles. This resets upon reaching full health."
+
+/datum/mutation_upgrade/shell/acid_release/on_mutation_enabled()
+	RegisterSignals(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE), PROC_REF(on_damage))
+	RegisterSignal(xenomorph_owner, COMSIG_MOB_STAT_CHANGED, PROC_REF(on_stat_changed))
+	if(xenomorph_owner.health >= xenomorph_owner.maxHealth)
+		can_be_activated = TRUE
+	return ..()
+
+/datum/mutation_upgrade/shell/acid_release/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE, COMSIG_MOB_STAT_CHANGED))
+	can_be_activated = FALSE
+	return ..()
+
+/// If it isn't ready to activate and they have full health, make it ready to activate.
+/datum/mutation_upgrade/shell/acid_release/proc/on_damage(datum/source, amount, list/amount_mod)
+	SIGNAL_HANDLER
+	if(!can_be_activated && xenomorph_owner.health >= xenomorph_owner.maxHealth)
+		can_be_activated = TRUE
+
+/// Cover the area around them with stunning acid upon entering critical if it is ready to activate.
+/datum/mutation_upgrade/shell/acid_release/proc/on_stat_changed(datum/source, old_stat, new_stat)
+	if(!isturf(xenomorph_owner.loc) || new_stat != UNCONSCIOUS)
+		return
+	var/turf/current_turf = xenomorph_owner.loc
+	for(var/turf/acid_tile AS in RANGE_TURFS(get_radius(get_total_structures()), current_turf))
+		if(!line_of_sight(current_turf, acid_tile))
+			continue
+		new /obj/effect/temp_visual/acid_splatter(acid_tile)
+		if(locate(/obj/effect/xenomorph/spray) in acid_tile.contents)
+			continue
+		new /obj/effect/xenomorph/spray(acid_tile, 6 SECONDS, 16)
+		for (var/atom/movable/atom_in_acid AS in acid_tile)
+			atom_in_acid.acid_spray_act(src)
+	can_be_activated = FALSE
+
+/// Returns the radius for how far the acid will be spawned.
+/datum/mutation_upgrade/shell/acid_release/proc/get_radius(structure_count, include_initial = TRUE)
+	return (include_initial ? radius_initial : 0) + (radius_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/fully_acid
+	name = "Fully Acid"
+	desc = "All of your stash damage is burn damage and is now checked against acid. You inflict 1/2/3 additional melting acid stacks."
+	/// For each structure, the additional stacks of melting acid.
+	var/stacks_per_structure = 1
+
+/datum/mutation_upgrade/spur/fully_acid/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "All of your stash damage is burn damage and is now checked against acid. You inflict [get_stacks(new_amount)] additional melting acid stacks."
+
+/datum/mutation_upgrade/spur/fully_acid/on_mutation_enabled()
+	if(!isxenomelter(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/runner/melter/melter_owner = xenomorph_owner
+	melter_owner.second_damage_type = BURN
+	melter_owner.second_damage_armor = ACID
+	return ..()
+
+/datum/mutation_upgrade/spur/fully_acid/on_mutation_disabled()
+	if(!isxenomelter(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/runner/melter/melter_owner = xenomorph_owner
+	melter_owner.second_damage_type = initial(melter_owner.second_damage_type)
+	melter_owner.second_damage_armor = initial(melter_owner.second_damage_armor)
+	return ..()
+
+/datum/mutation_upgrade/spur/fully_acid/on_structure_update(previous_amount, new_amount)
+	if(!isxenomelter(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/runner/melter/melter_owner = xenomorph_owner
+	melter_owner.applied_acid_stacks += get_stacks(new_amount - previous_amount)
+	return ..()
+
+/// Returns the amount of stacks of melting acid that will be given.
+/datum/mutation_upgrade/spur/fully_acid/proc/get_stacks(structure_count)
+	return stacks_per_structure * structure_count
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/acid_reserves
+	name = "Acid Reserves"
+	desc = "Corrosive Acid is now applied 50/75/100% faster."
+	/// For the first structure, the percentage to speed up Corrosive Acid by.
+	var/speedup_initial = 0.25
+	/// For each structure, the additional percentage to speed up Corrosive Acid by.
+	var/speedup_per_structure = 0.25
+
+/datum/mutation_upgrade/veil/acid_reserves/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Corrosive Acid is now applied [PERCENT(get_speedup(new_amount))]% faster."
+
+/datum/mutation_upgrade/veil/acid_reserves/on_structure_update(previous_amount, new_amount)
+	var/datum/action/ability/activable/xeno/corrosive_acid/melter/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/corrosive_acid/melter]
+	if(!ability)
+		return
+	if(previous_amount)
+		ability.acid_speed_multiplier *= 1 + get_speedup(previous_amount) // First, we reverse...
+	if(new_amount)
+		ability.acid_speed_multiplier /= 1 + get_speedup(new_amount) // ... then we re-apply because math is hard!
+	return ..()
+
+/// Returns the percentage used to speed up Corrosive Acid by.
+/datum/mutation_upgrade/veil/acid_reserves/proc/get_speedup(structure_count, include_initial = TRUE)
+	return (include_initial ? speedup_initial : 0) + (speedup_per_structure * structure_count)
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
@@ -122,6 +122,6 @@
 	return ..()
 
 /// Returns the percentage used to speed up Corrosive Acid by.
-/datum/mutation_upgrade/veil/acid_reserves/proc/get_speedup(structure_count, include_initial = TRUE)
-	return (include_initial ? speedup_initial : 0) + (speedup_per_structure * structure_count)
+/datum/mutation_upgrade/veil/acid_reserves/proc/get_speedup(structure_count)
+	return speedup_initial + (speedup_per_structure * structure_count)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -65,6 +65,12 @@
 
 /mob/living/carbon/xenomorph/runner/melter
 	caste_base_type = /datum/xeno_caste/runner/melter
+	/// What type of damage should the second instance do?
+	var/second_damage_type = BRUTE
+	/// What armor is the second instance of damage calculated against?
+	var/second_damage_armor = MELEE
+	/// The amount of melting acid stacks to be applied.
+	var/applied_acid_stacks = 2
 
 /mob/living/carbon/xenomorph/runner/melter/Initialize(mapload)
 	. = ..()
@@ -82,18 +88,18 @@
 				atom_in_acid.acid_spray_act(src)
 	return ..()
 
-/// Deals a second instance of melee damage as burn damage to damageable objects.
+/// Deals a second instance of melee damage to damageable objects. Damage type and armor type may vary.
 /mob/living/carbon/xenomorph/runner/melter/proc/on_attack_obj(mob/living/carbon/xenomorph/source, obj/target)
 	SIGNAL_HANDLER
 	if(target.resistance_flags & XENO_DAMAGEABLE)
-		target.take_damage(xeno_caste.melee_damage * xeno_melee_damage_modifier, BURN, ACID)
+		target.take_damage(xeno_caste.melee_damage * xeno_melee_damage_modifier, second_damage_type, second_damage_armor)
 
-/// Deals a second instance of melee damage as burn damage to living beings.
+/// Deals a second instance of melee damage to living beings. Damage type and armor type may vary.
 /mob/living/carbon/xenomorph/runner/melter/proc/on_postattack_living(mob/living/carbon/xenomorph/source, mob/living/target, damage)
 	SIGNAL_HANDLER
-	target.apply_damage(xeno_caste.melee_damage * xeno_melee_damage_modifier, BURN, null, ACID)
+	target.apply_damage(xeno_caste.melee_damage * xeno_melee_damage_modifier, second_damage_type, null, second_damage_armor)
 	var/datum/status_effect/stacking/melting_acid/debuff = target.has_status_effect(STATUS_EFFECT_MELTING_ACID)
 	if(!debuff)
-		target.apply_status_effect(STATUS_EFFECT_MELTING_ACID, 2)
+		target.apply_status_effect(STATUS_EFFECT_MELTING_ACID, applied_acid_stacks)
 		return
-	debuff.add_stacks(2)
+	debuff.add_stacks(applied_acid_stacks)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2034,6 +2034,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\abilities_runner.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\castedatum_runner.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\runner\mutations_melter.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\runner.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\scorpion\castedatum_scorpion.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\scorpion\scorpion.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a total of 3 mutations all for Melter (Runner Strain).
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Acid Release | Upon entering critical, release stunning acid in a radius of 2/3/4 tiles. This resets upon reaching full health. |
| Spur | Fully Acid | All of your stash damage is burn damage and is now checked against acid. You inflict 1/2/3 additional melting acid stacks. |
| Veil | Acid Reserves | Corrosive Acid is now applied 50/75/100% faster. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Melter now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
