### PR TITLE
Fixes Permanent Immobilizing Throws

### DIFF
--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -1457,16 +1457,15 @@
 ///Toggles AM between throwing states
 /atom/movable/proc/set_throwing(new_throwing)
 	if(throwing == new_throwing)
-		return
+		return FALSE
 	throwing = new_throwing
 	if(throwing)
-		ADD_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT) //prevents moving during the throw
 		add_pass_flags(PASS_THROW, THROW_TRAIT)
 		add_nosubmerge_trait(THROW_TRAIT)
 	else
-		REMOVE_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT)
 		REMOVE_TRAIT(src, TRAIT_NOSUBMERGE, THROW_TRAIT)
 		remove_pass_flags(PASS_THROW, THROW_TRAIT)
+	return TRUE
 
 ///Toggles AM between flying states
 /atom/movable/proc/set_flying(flying, new_layer)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -863,10 +863,10 @@
 
 /mob/set_throwing(new_throwing)
 	. = ..()
-	if(isnull(.))
+	if(!.)
 		return
 	if(throwing)
-		ADD_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT)
+		ADD_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT) // Prevents moving during the throw.
 	else
 		REMOVE_TRAIT(src, TRAIT_IMMOBILE, THROW_TRAIT)
 


### PR DESCRIPTION
## About The Pull Request
Alternative to #18102 which only fixes the throws regarding the ability Pounce - this PR fixes abilities that make use of throws like Oppressor's Advance which has similar conditions and abilities involving wall banging (e.g. Warrior).

Fixes #18100.

Failing to move while being thrown no longer stops the proc that sets flags/traits from being called which means they correctly lose flags/traits for: 
- immobilize (the real issue here),
- throw passthrough (doesn't really work anyways) 
- submerging (only a visual thing where they look like they're walking on water).

The immobilize trait from being thrown is moved from `/atom/movable` level to `/mob` level as only mobs care about being immobilized (because apparently it was already a thing but the trait was never given as `/proc/set_throwing` always returned null.

## Why It's Good For The Game
Fixes a bug that makes certain castes unplayable.

## Changelog
:cl:
fix: Certain abilities that involve throwing yourself to hit a target now correctly removes the trait involving immobilization.
fix: Certain abilities that involve throwing yourself to hit a target no longer causes you to appear to be floating on top of water.
/:cl:
