### PR TITLE
Fixes Multi z stairs being able to be destroyed (and adjusts layer)

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -10,6 +10,8 @@
 	name = "stairs"
 	anchored = TRUE
 	move_resist = INFINITY
+	layer = ABOVE_WEEDS_LAYER
+	obj_flags = INDESTRUCTIBLE
 
 	var/force_open_above = FALSE //! replaces the turf above this stair obj with /turf/open/openspace
 	///helps us decide if we're the ending stair


### PR DESCRIPTION

## About The Pull Request

Makes MULTI Z STAIRS AND ONLY THOSE indestructible and forces them to layer above weeds
## Why It's Good For The Game

Fix good

## Changelog

:cl:
fix: Makes zstairs indestructible
fix: Zstairs layer above weeds
:cl:
