### PR TITLE
Mutations: Globadier

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_PICK_GRENADE,
 	)
 	/// In exchange for using a grenade while at none, the percentage of maximum health to lose.
-	var/health_loss_percentage_per_grenade
+	var/health_loss_percentage_per_grenade = 0
 	/// The amount of deciseconds to add to the detonation if the grenade was thrown at themselves.
 	var/bonus_self_detonation_time
 	/// The current amount of grenades this ability has.
@@ -224,7 +224,7 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 /datum/action/ability/activable/xeno/toss_grenade/use_ability(atom/target)
 	if(current_grenades <= 0)
 		// For balance reasons, no exchanging life for healing grenades. The reason: infinite healing grenades.
-		if(health_loss_percentage_per_grenade == 0 || xeno_owner.selected_grenade == /obj/item/explosive/grenade/globadier/heal)
+		if(!health_loss_percentage_per_grenade || xeno_owner.selected_grenade == /obj/item/explosive/grenade/globadier/heal)
 			owner.balloon_alert(owner, "No grenades!")
 			return fail_activate()
 		var/health_to_lose = xeno_owner.xeno_caste.max_health * health_loss_percentage_per_grenade;

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -172,11 +172,17 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOSS_GRENADE,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_PICK_GRENADE,
 	)
-	///The current amount of grenades this ability has
+	/// In exchange for using a grenade while at none, the percentage of maximum health to lose.
+	var/health_loss_percentage_per_grenade
+	/// The amount of deciseconds to add to the detonation if the grenade was thrown at themselves.
+	var/bonus_self_detonation_time
+	/// The current amount of grenades this ability has.
 	var/current_grenades = 6
-	///The max amount of grenades this ability can store
+	/// The max amount of grenades this ability can store.
 	var/max_grenades = 6
-	///The timer untill we regenerate another grenade
+	/// The amount of deciseconds for the timer that will restore a grenade charge.
+	var/grenade_cooldown = GLOBADIER_GRENADE_REGEN_COOLDOWN
+	/// The timer used for restoring a grenade charge.
 	var/timer
 
 /datum/action/ability/activable/xeno/toss_grenade/give_action(mob/living/L)
@@ -217,15 +223,25 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 
 /datum/action/ability/activable/xeno/toss_grenade/use_ability(atom/target)
 	if(current_grenades <= 0)
-		owner.balloon_alert(owner, "No Grenades!")
-		return fail_activate()
+		// For balance reasons, no exchanging life for healing grenades. The reason: infinite healing grenades.
+		if(health_loss_percentage_per_grenade == 0 || xeno_owner.selected_grenade == /obj/item/explosive/grenade/globadier/heal)
+			owner.balloon_alert(owner, "No grenades!")
+			return fail_activate()
+		var/health_to_lose = xeno_owner.xeno_caste.max_health * health_loss_percentage_per_grenade;
+		if(xeno_owner.health_threshold_crit > xeno_owner.health - health_to_lose) // Hugbox to stop them from suiciding into critical.
+			owner.balloon_alert(owner, "Not enough health!")
+			return fail_activate()
+		xeno_owner.adjustBruteLoss(health_to_lose, TRUE)
+		current_grenades++
 	var/obj/item/explosive/grenade/globadier/nade = new xeno_owner.selected_grenade(owner.loc, owner)
+	if(xeno_owner == target && bonus_self_detonation_time)
+		nade.det_time = max(0.5 SECONDS, nade.det_time + bonus_self_detonation_time)
 	nade.activate(owner)
 	nade.throw_at(target,GLOBADIER_GRENADE_THROW_RANGE,GLOBADIER_GRENADE_THROW_SPEED)
 	owner.visible_message(span_xenowarning("\The [owner] throws something towards \the [target]!"), \
 	span_xenowarning("We throw a grenade towards \the [target]!"))
 	current_grenades--
-	timer = addtimer(CALLBACK(src, PROC_REF(regen_grenade)), GLOBADIER_GRENADE_REGEN_COOLDOWN, TIMER_UNIQUE|TIMER_STOPPABLE)
+	timer = addtimer(CALLBACK(src, PROC_REF(regen_grenade)), grenade_cooldown, TIMER_UNIQUE|TIMER_STOPPABLE)
 	START_PROCESSING(SSprocessing, src)
 	update_button_icon()
 	succeed_activate()
@@ -248,14 +264,14 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	visual_references[VREF_MUTABLE_GLOB_GRENADES_CHARGETIMER] = time
 	button.add_overlay(visual_references[VREF_MUTABLE_GLOB_GRENADES_CHARGETIMER])
 
-///Handle automatic regeneration of grenades, every GLOBADIER_GRENADE_REGEN_COOLDOWN seconds
+/// Handle automatic regeneration of grenades. The cooldown is based on grenade_cooldown.
 /datum/action/ability/activable/xeno/toss_grenade/proc/regen_grenade()
 	if(!(current_grenades < max_grenades))
 		return
 	current_grenades++
 	update_button_icon()
 	if((current_grenades < max_grenades)) // Second if check as current_grenades has changed
-		timer = addtimer(CALLBACK(src, PROC_REF(regen_grenade)), GLOBADIER_GRENADE_REGEN_COOLDOWN, TIMER_UNIQUE|TIMER_STOPPABLE)
+		timer = addtimer(CALLBACK(src, PROC_REF(regen_grenade)), grenade_cooldown, TIMER_UNIQUE|TIMER_STOPPABLE)
 		return
 	owner.balloon_alert(owner, "Max Grenades!")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -101,6 +101,12 @@
 		/datum/action/ability/xeno_action/acid_mine/gas_mine,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/self_explosion,
+		/datum/mutation_upgrade/spur/blood_grenades,
+		/datum/mutation_upgrade/veil/repurposed_capacity
+	)
+
 /datum/xeno_caste/spitter/globadier/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/mutations_globadier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/mutations_globadier.dm
@@ -18,7 +18,7 @@
 	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
 	if(!grenade_ability)
 		return
-	ENABLE_BITFIELD(grenade_ability.use_state_flags, ABILITY_TARGET_SELF)
+	grenade_ability.use_state_flags |= ABILITY_TARGET_SELF
 	grenade_ability.bonus_self_detonation_time += get_duration(0)
 	return ..()
 
@@ -26,7 +26,7 @@
 	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
 	if(!grenade_ability)
 		return
-	DISABLE_BITFIELD(grenade_ability.use_state_flags, ABILITY_TARGET_SELF)
+	grenade_ability.use_state_flags &= ~ABILITY_TARGET_SELF
 	grenade_ability.bonus_self_detonation_time -= get_duration(0)
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/mutations_globadier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/mutations_globadier.dm
@@ -1,0 +1,116 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/self_explosion
+	name = "Self Explosion"
+	desc = "Toss Grenade can target yourself. Targeting yourself will toss the grenade under you and reduce the detonation time by 0.5/0.75/1 seconds. The resulting detonation time can never go under 0.5 seconds."
+	/// For the first structure, the amount of deciseconds to increase the detonation time by.
+	var/duration_initial = -0.25 SECONDS
+	/// For each structure, the amount of deciseconds to increase the detonation time by.
+	var/duration_per_structure = -0.25 SECONDS
+
+/datum/mutation_upgrade/shell/self_explosion/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Toss Grenade can target yourself. Targeting yourself will toss the grenade under you and reduce the detonation time by [-get_duration(new_amount) * 0.1] seconds. The resulting detonation time can never go under 0.5 seconds."
+
+/datum/mutation_upgrade/shell/self_explosion/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	ENABLE_BITFIELD(grenade_ability.use_state_flags, ABILITY_TARGET_SELF)
+	grenade_ability.bonus_self_detonation_time += get_duration(0)
+	return ..()
+
+/datum/mutation_upgrade/shell/self_explosion/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	DISABLE_BITFIELD(grenade_ability.use_state_flags, ABILITY_TARGET_SELF)
+	grenade_ability.bonus_self_detonation_time -= get_duration(0)
+	return ..()
+
+/datum/mutation_upgrade/shell/self_explosion/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	grenade_ability.bonus_self_detonation_time += get_duration(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of deciseconds that the detonation time will be increased by if Toss Grenade self-targetted.
+/datum/mutation_upgrade/shell/self_explosion/proc/get_duration(structure_count, include_initial = TRUE)
+	return (include_initial ? duration_initial : 0) + (duration_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/blood_grenades
+	name = "Blood Grenades"
+	desc = "Toss Grenade will deal damage equal to 20/17.5/15% of your maximum health and allow you to throw a non-healing grenade if you had none."
+	/// For the first structure, the percentage of maximum health to lose.
+	var/percentage_initial = 0.225
+	/// For each structure, the additional percentage of maximum health to lose.
+	var/percentage_per_structure = -0.025
+
+/datum/mutation_upgrade/spur/blood_grenades/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Toss Grenade will deal damage equal to [PERCENT(get_percentage(new_amount))]% of your maximum health and allow you to throw a non-healing grenade if you had none."
+
+/datum/mutation_upgrade/spur/blood_grenades/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	grenade_ability.health_loss_percentage_per_grenade += get_percentage(0)
+	return ..()
+
+/datum/mutation_upgrade/spur/blood_grenades/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	grenade_ability.health_loss_percentage_per_grenade -= get_percentage(0)
+	return ..()
+
+/datum/mutation_upgrade/spur/blood_grenades/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/toss_grenade/grenade_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!grenade_ability)
+		return
+	grenade_ability.health_loss_percentage_per_grenade += get_percentage(new_amount - previous_amount, FALSE)
+
+/// Returns the percentage of maximum health that will be dealt in order to gain a grenade charge.
+/datum/mutation_upgrade/spur/blood_grenades/proc/get_percentage(structure_count, include_initial = TRUE)
+	return (include_initial ? percentage_initial : 0) + (percentage_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/repurposed_capacity
+	name = "Repurposed Capacity"
+	desc = "Toss Grenade stores 1/2/3 less grenades, but recharges a grenade 2/4/6 seconds faster."
+	/// For each structure, the amount to increase Toss Grenade's maximum grenade capacity by.
+	var/capacity_per_structure = -1
+	/// For each structure, the amount of deciseconds to increase Toss Grenade's recharge cooldown by.
+	var/recharge_per_structure = -2 SECONDS
+
+/datum/mutation_upgrade/veil/repurposed_capacity/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Toss Grenade stores [-get_capacity(new_amount)] less grenades, but recharges a grenade [-get_recharge(new_amount) * 0.1] seconds faster."
+
+/datum/mutation_upgrade/veil/repurposed_capacity/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/toss_grenade/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/toss_grenade]
+	if(!ability)
+		return
+	ability.max_grenades += get_capacity(new_amount - previous_amount)
+	ability.grenade_cooldown += get_recharge(new_amount - previous_amount)
+	ability.current_grenades = min(ability.current_grenades, ability.max_grenades)
+
+/// Returns the amount to increase Toss Grenade's maximum grenade capacity by.
+/datum/mutation_upgrade/veil/repurposed_capacity/proc/get_capacity(structure_count)
+	return capacity_per_structure * structure_count
+
+/// Returns the amount of deciseconds to increase Toss Grenade's recharge cooldown by.
+/datum/mutation_upgrade/veil/repurposed_capacity/proc/get_recharge(structure_count)
+	return recharge_per_structure * structure_count

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2047,6 +2047,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\spiderling\spiderling.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\spitter\abilities_spitter.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\spitter\castedatum_spitter.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\spitter\mutations_globadier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\spitter\spitter.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\warlock\abilities_warlock.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\warlock\castedatum_warlock.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Globadier (Spitter Strain).
| Category | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Self Explosion | Toss Grenade can target yourself. Targeting yourself will toss the grenade under you and reduce the detonation time by 0.5/0.75/1 seconds. The resulting detonation time can never go under 0.5 seconds. |
| Spur | Blood Grenades | Toss Grenade will deal damage equal to 20/17.5/15% of your maximum health and allow you to throw a non-healing grenade if you had none. |
| Veil | Repurposed Capacity | Toss Grenade stores 1/2/3 less grenades, but recharges a grenade 2/4/6 seconds faster. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Globadier now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.)
/:cl:
