### PR TITLE
Adds some hypnosprays into the NanoTrasnMed Plus vender

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -175,6 +175,11 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 10,
 			/obj/item/reagent_containers/hypospray/advanced = 30,
+			/obj/item/reagent_containers/hypospray/advanced/bicaridine = -1,
+			/obj/item/reagent_containers/hypospray/advanced/kelotane = -1,
+			/obj/item/reagent_containers/hypospray/advanced/tramadol = -1,
+			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = -1,
+			/obj/item/reagent_containers/hypospray/advanced/dylovene = -1,
 		),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = -1,


### PR DESCRIPTION

## About The Pull Request

Adds Bicaridine, kelotane, tramadol, tricordrazine, and dylovene hypospray that are found in the Valhall NanoMed plus to the normal NanoMed Plus

## Why It's Good For The Game

This is really just a QoL compaired to just vending out a hypospray and then filling it up from one of the medical bottles you can get in another tab.

## Changelog


:cl:

add: Added Bicaridine, kelotane, tramadol, tricordrazine, and dylovene hypospray to NanoMed Plus vender

/:cl:
