### PR TITLE
Makes tcomms powered on jungle outpost (campaign)

### DIFF
--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -8506,6 +8506,9 @@
 	dir = 1
 	},
 /area/campaign/jungle_outpost/outpost/req)
+"NF" = (
+/turf/closed/mineral/smooth/indestructible,
+/area/campaign/jungle_outpost/ground/jungle/south_west/tcomms)
 "NG" = (
 /turf/closed/wall,
 /area/campaign/jungle_outpost/ground/river/east)
@@ -8910,7 +8913,7 @@
 "Py" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/closed/mineral/smooth/indestructible,
-/area/campaign/jungle_outpost/ground/jungle/south_west)
+/area/campaign/jungle_outpost/ground/jungle/south_west/tcomms)
 "Pz" = (
 /obj/structure/platform{
 	dir = 1
@@ -9124,6 +9127,9 @@
 	},
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/campaign/jungle_outpost/ground/jungle/south_east)
+"Qv" = (
+/turf/closed/gm/dense,
+/area/campaign/jungle_outpost/ground/jungle/south_west/tcomms)
 "Qx" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -11382,7 +11388,7 @@ xS
 xS
 xS
 xS
-xS
+NF
 Py
 "}
 (2,1,1) = {"
@@ -11534,8 +11540,8 @@ cm
 Gd
 Gd
 Gd
-Gd
-xS
+Qv
+NF
 "}
 (3,1,1) = {"
 ST

--- a/code/game/area/campaign_maps/jungle_outpost.dm
+++ b/code/game/area/campaign_maps/jungle_outpost.dm
@@ -18,6 +18,11 @@
 	name = "Southwestern Jungle"
 	icon_state = "southwest"
 
+/area/campaign/jungle_outpost/ground/jungle/south_west/tcomms
+	icon_state = "tcomsatcham"
+	area_flags = NO_DROPPOD
+	requires_power = FALSE
+
 /area/campaign/jungle_outpost/ground/jungle/south_east
 	name = "Southeastern Jungle"
 	icon_state = "southeast"


### PR DESCRIPTION

## About The Pull Request
Adds an area with requires_power = false so that groundside actually has radio
## Why It's Good For The Game
fix bug
## Changelog
:cl:
fix: Jungle outpost radio is now powered
/:cl:
