### PR TITLE
Mutation Bugfixes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -968,7 +968,7 @@
 	. = ..()
 	playsound(owner.loc, "sound/bullets/acid_impact1.ogg", 30)
 	particle_holder = new(owner, /particles/melting_acid_status)
-	particle_holder.particles.spawning = 1 + round(stacks / 2)
+	particle_holder.particles.spawning = 1 + round(stacks / 4)
 
 /datum/status_effect/stacking/melting_acid/on_remove()
 	QDEL_NULL(particle_holder)
@@ -979,7 +979,7 @@
 	if(!owner)
 		return
 	playsound(owner.loc, "sound/bullets/acid_impact1.ogg", 4)
-	particle_holder.particles.spawning = 1 + round(stacks / 2)
+	particle_holder.particles.spawning = 1 + round(stacks / 4)
 	particle_holder.pixel_x = -2
 	particle_holder.pixel_y = 0
 	owner.apply_damage(5, BURN, null, ACID)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/mutations_defender.dm
@@ -257,8 +257,6 @@
 
 /datum/mutation_upgrade/veil/carapace_sweat/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
 		return
@@ -300,8 +298,6 @@
 
 /datum/mutation_upgrade/veil/slow_and_steady/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/xeno_action/fortify/fortify = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/fortify]
 	if(!fortify)
 		return
@@ -324,8 +320,6 @@
 
 /datum/mutation_upgrade/veil/carapace_sharing/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/xeno_action/regenerate_skin/regenerate_skin = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/regenerate_skin]
 	if(!regenerate_skin)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/mutations_melter.dm
@@ -42,12 +42,7 @@
 	for(var/turf/acid_tile AS in RANGE_TURFS(get_radius(get_total_structures()), current_turf))
 		if(!line_of_sight(current_turf, acid_tile))
 			continue
-		new /obj/effect/temp_visual/acid_splatter(acid_tile)
-		if(locate(/obj/effect/xenomorph/spray) in acid_tile.contents)
-			continue
-		new /obj/effect/xenomorph/spray(acid_tile, 6 SECONDS, 16)
-		for (var/atom/movable/atom_in_acid AS in acid_tile)
-			atom_in_acid.acid_spray_act(src)
+		xenomorph_spray(acid_tile, 6 SECONDS, 16, xenomorph_owner, TRUE, TRUE)
 	can_be_activated = FALSE
 
 /// Returns the radius for how far the acid will be spawned.

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -177,7 +177,7 @@
 			if(!is_type_in_typecache(target_reagent, GLOB.defiler_toxins_typecache_list))
 				continue
 			bonus_potency += xeno_target.reagents.get_reagent_amount(target_reagent)
-	bonus_potency = round(bonus_potency) / xenochemicals_unit_per_stack
+		bonus_potency = round(bonus_potency) / xenochemicals_unit_per_stack
 	var/drain_potency = (debuff.stacks + bonus_potency) * SENTINEL_DRAIN_MULTIPLIER * (xeno_owner.Adjacent(xeno_target) ? 1 : ranged_effectiveness)
 	if(debuff.stacks > debuff.max_stacks - 10)
 		xeno_target.emote("scream")

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_retrograde.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_retrograde.dm
@@ -139,8 +139,6 @@
 
 /datum/mutation_upgrade/veil/toxic_spillage/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/activable/xeno/neurotox_sting/sting_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/neurotox_sting]
 	if(!sting_ability)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/mutations_sentinel.dm
@@ -81,8 +81,6 @@
 
 /datum/mutation_upgrade/shell/comforting_acid/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/xeno_action/toxic_slash/ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toxic_slash]
 	if(!ability)
 		return
@@ -111,12 +109,12 @@
 	return "Your attack delay will be [(get_move_adjust(new_amount)) * 0.1]s faster and will always apply [get_intoxicated_stacks(intoxicated_stack_per_structure)] stacks of Intoxicated against humans, but all melee damage is reduced by [melee_damage_modifier * 100]%."
 
 /datum/mutation_upgrade/spur/acidic_slasher/on_mutation_enabled()
-	UnregisterSignal(src, COMSIG_XENOMORPH_POSTATTACK_LIVING)
+	RegisterSignal(xenomorph_owner, COMSIG_XENOMORPH_POSTATTACK_LIVING, PROC_REF(on_postattack))
 	xenomorph_owner.xeno_melee_damage_modifier -= melee_damage_modifier
 	return ..()
 
 /datum/mutation_upgrade/spur/acidic_slasher/on_mutation_disabled()
-	UnregisterSignal(src, COMSIG_XENOMORPH_POSTATTACK_LIVING)
+	UnregisterSignal(xenomorph_owner, COMSIG_XENOMORPH_POSTATTACK_LIVING)
 	xenomorph_owner.xeno_melee_damage_modifier += melee_damage_modifier
 	return ..()
 
@@ -174,8 +172,6 @@
 
 /datum/mutation_upgrade/spur/far_sting/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
 	if(!ability)
 		return
@@ -217,8 +213,6 @@
 
 /datum/mutation_upgrade/veil/toxic_compatibility/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	if(!.)
-		return
 	var/datum/action/ability/activable/xeno/drain_sting/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/drain_sting]
 	if(!ability)
 		return


### PR DESCRIPTION
## About The Pull Request
Drain Sting was dividing by zero. That was fixed and now the ability works as intended.
Acidic Slasher didn't correctly register signals. That was fixed.
Some mutations that still had leftover `if(!.)` in the structure update proc now has it removed which let it continue and do the rest of the mutation effects.

Updates Melter's mutations so it uses the proc from #18082
Makes the melting acid status effect spawn less particles in general.

## Why It's Good For The Game
Various bugfixes from mutations.

## Changelog
:cl:
fix: Sentinel's Drain Sting now works as intended.
fix: Sentinel's mutation Acidic Slasher now correctly deals its Intoxicated Stacks on slash.
fix: Various mutations now correctly get their effects when mutation structures are updated.
/:cl:
