### PR TITLE
King Evolution Requirement fix

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -18,7 +18,6 @@
 	 * [caste datum] = [amount of xenos needed]
 	 */
 	var/list/evo_requirements = list(
-		/datum/xeno_caste/king = 12,
 		/datum/xeno_caste/queen = 8,
 	)
 

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -38,7 +38,6 @@
 	)
 
 	evo_requirements = list(
-		/datum/xeno_caste/king = 12,
 		/datum/xeno_caste/queen = 8,
 	)
 


### PR DESCRIPTION
## About The Pull Request
The Nuclear War gamemode (and its parent) no longer overrides King's evolution requirement which caused it to forcibly be set to 12 (which #17896 did not account for).

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: King's evolution requirement is no longer overridden by the Nuclear War's evolution requirement of 12.
/:cl:
