### PR TITLE
Mutations: Pyrogen

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -752,6 +752,8 @@
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"	//from mob/living/carbon/human/UnarmedAttack(): (atom/target)
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK_ALTERNATE "human_melee_unarmed_attack_alternate"	//same as above, but right click
 #define COMSIG_HUMAN_DAMAGE_TAKEN "human_damage_taken"					//from human damage receiving procs: (mob/living/carbon/human/wearer, damage)
+#define COMSIG_HUMAN_BRUTE_DAMAGE "human_brute_damage" // from [/mob/living/carbon/human/adjustBruteLoss] (amount, amount_mod)
+#define COMSIG_HUMAN_BURN_DAMAGE "human_burn_damage" // from [/mob/living/carbon/human/adjustFireLoss] (amount, amount_mod)
 #define COMSIG_HUMAN_LIMB_FRACTURED "human_limb_fractured"				//from [datum/limb/proc/fracture]: (mob/living/carbon/human/wearer, datum/limb/limb)
 ///from [/mob/living/carbon/human/proc/apply_overlay]: (cache_index, list/overlays_to_apply)
 #define COMSIG_HUMAN_APPLY_OVERLAY "human_overlay_applied"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -620,7 +620,6 @@
 
 /// on remove has owner set to null
 /datum/status_effect/stacking/melting_fire/on_remove()
-	if(healing_debuff)
 	owner.vis_contents -= visual_fire
 	set_creator(null)
 	QDEL_NULL(visual_fire)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -595,6 +595,8 @@
 	var/mob/living/carbon/xenomorph/pyrogen/debuff_creator
 	/// Used for the fire effect.
 	var/obj/vis_melt_fire/visual_fire
+	// The percentage of brute/burn healing that should be negated.
+	var/healing_debuff = 0
 
 /obj/vis_melt_fire
 	name = "ouch ouch ouch"
@@ -614,13 +616,13 @@
 	debuff_owner.balloon_alert(debuff_owner, "Melting fire")
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 30)
 	RegisterSignal(debuff_owner, COMSIG_LIVING_DO_RESIST, PROC_REF(call_resist_debuff))
-	if(new_creator && isxenopyrogen(new_creator)) // It is possible for a non-pyrogen to create this.
-		debuff_creator = new_creator
+	set_creator(new_creator)
 
 /// on remove has owner set to null
 /datum/status_effect/stacking/melting_fire/on_remove()
+	if(healing_debuff)
 	owner.vis_contents -= visual_fire
-	debuff_owner = null
+	set_creator(null)
 	QDEL_NULL(visual_fire)
 	return ..()
 
@@ -645,10 +647,23 @@
 	HEAL_XENO_DAMAGE(debuff_creator, amount_to_heal, FALSE)
 	debuff_creator.gain_plasma(5, TRUE)
 
-/datum/status_effect/stacking/melting_fire/add_stacks(stacks_added, atom/xeno_cause)
+/datum/status_effect/stacking/melting_fire/add_stacks(stacks_added, atom/xeno_creator)
 	. = ..()
-	if(xeno_cause && isxenopyrogen(xeno_cause))
-		debuff_creator = xeno_cause
+	set_creator(xeno_creator)
+
+/datum/status_effect/stacking/melting_fire/proc/set_creator(atom/xeno_creator)
+	if(!xeno_creator || !isxenopyrogen(xeno_creator))
+		xeno_creator = null
+	if(!debuff_creator)
+		debuff_creator = xeno_creator
+		return
+	var/mob/living/carbon/xenomorph/pyrogen/new_creator = xeno_creator
+	if(healing_debuff && !new_creator?.melting_fire_healing_reduction)
+		UnregisterSignal(owner, list(COMSIG_HUMAN_BRUTE_DAMAGE, COMSIG_HUMAN_BURN_DAMAGE))
+	if(!healing_debuff && new_creator?.melting_fire_healing_reduction)
+		RegisterSignals(debuff_owner, list(COMSIG_HUMAN_BRUTE_DAMAGE, COMSIG_HUMAN_BURN_DAMAGE), PROC_REF(on_heal))
+	debuff_creator = new_creator
+	healing_debuff = new_creator?.melting_fire_healing_reduction
 
 /// Called when the debuff's owner uses the Resist action for this debuff.
 /datum/status_effect/stacking/melting_fire/proc/call_resist_debuff()
@@ -671,6 +686,13 @@
 		debuff_owner.visible_message(span_danger("[debuff_owner] has successfully extinguished themselves!"), \
 		span_notice("You extinguish yourself."), null, 5)
 	add_stacks(-PYROGEN_MELTING_FIRE_STACKS_PER_RESIST) // If their stacks hit zero, it is qdel'd right here.
+
+// If the owner of this status effect were to heal, a percentage of that healing will be negated.
+/datum/status_effect/stacking/melting_fire/proc/on_heal(datum/source, amount, list/amount_mod)
+	SIGNAL_HANDLER
+	if(amount >= 0 || !healing_debuff)
+		return
+	amount_mod += floor(amount) * healing_debuff
 
 // ***************************************
 // *********** dread

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -652,17 +652,18 @@
 
 /datum/status_effect/stacking/melting_fire/proc/set_creator(atom/xeno_creator)
 	if(!xeno_creator || !isxenopyrogen(xeno_creator))
-		xeno_creator = null
-	if(!debuff_creator)
-		debuff_creator = xeno_creator
+		if(healing_debuff)
+			UnregisterSignal(owner, list(COMSIG_HUMAN_BRUTE_DAMAGE, COMSIG_HUMAN_BURN_DAMAGE))
+			healing_debuff = 0
+		debuff_creator = null
 		return
 	var/mob/living/carbon/xenomorph/pyrogen/new_creator = xeno_creator
-	if(healing_debuff && !new_creator?.melting_fire_healing_reduction)
+	if(healing_debuff && !new_creator.melting_fire_healing_reduction)
 		UnregisterSignal(owner, list(COMSIG_HUMAN_BRUTE_DAMAGE, COMSIG_HUMAN_BURN_DAMAGE))
-	if(!healing_debuff && new_creator?.melting_fire_healing_reduction)
+	if(!healing_debuff && new_creator.melting_fire_healing_reduction)
 		RegisterSignals(debuff_owner, list(COMSIG_HUMAN_BRUTE_DAMAGE, COMSIG_HUMAN_BURN_DAMAGE), PROC_REF(on_heal))
 	debuff_creator = new_creator
-	healing_debuff = new_creator?.melting_fire_healing_reduction
+	healing_debuff = new_creator.melting_fire_healing_reduction
 
 /// Called when the debuff's owner uses the Resist action for this debuff.
 /datum/status_effect/stacking/melting_fire/proc/call_resist_debuff()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -650,6 +650,7 @@
 	. = ..()
 	set_creator(xeno_creator)
 
+/// Sets the debuff creator of this status effect. Sets and (un)registers signals regarding healing reduction accordingly.
 /datum/status_effect/stacking/melting_fire/proc/set_creator(atom/xeno_creator)
 	if(!xeno_creator || !isxenopyrogen(xeno_creator))
 		if(healing_debuff)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -94,6 +94,11 @@
 
 
 /mob/living/carbon/human/adjustBruteLoss(amount, updating_health = FALSE)
+	var/list/amount_mod = list()
+	SEND_SIGNAL(src, COMSIG_HUMAN_BRUTE_DAMAGE, amount, amount_mod)
+	for(var/i in amount_mod)
+		amount -= i
+
 	if(species?.brute_mod && amount > 0)
 		amount = amount*species.brute_mod
 
@@ -102,8 +107,12 @@
 	else
 		heal_overall_damage(-amount, 0, updating_health = updating_health)
 
-
 /mob/living/carbon/human/adjustFireLoss(amount, updating_health = FALSE)
+	var/list/amount_mod = list()
+	SEND_SIGNAL(src, COMSIG_HUMAN_BURN_DAMAGE, amount, amount_mod)
+	for(var/i in amount_mod)
+		amount -= i
+
 	if(species?.burn_mod && amount > 0)
 		amount = amount*species.burn_mod
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -11,6 +11,16 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FIRECHARGE,
 	)
+	// Should they also slash upon hitting a mob?
+	var/should_slash = TRUE
+	/// How much damage is dealt for hitting through a mob?
+	var/charge_damage = PYROGEN_FIRECHARGE_DAMAGE
+	/// How much damage to add for each consumed melting fire stack? Only consumes melting fire stacks if it is above zero.
+	var/stack_damage = PYROGEN_FIRECHARGE_DAMAGE_PER_STACK
+	/// How much stacks of melting fire to add? These stacks are not consumed.
+	var/stacks_to_add = 0
+	/// Upon hitting a mob, should they keep going or stop?
+	var/pierces_mobs = FALSE
 
 /datum/action/ability/activable/xeno/charge/fire_charge/use_ability(atom/target)
 	if(!target)
@@ -45,20 +55,28 @@
 	target.hitby(owner, speed) //This resets throwing.
 	charge_complete()
 
-///Deals with hitting mobs. Triggered by bump instead of throw impact as we want to plow past mobs
+/// Deals with hitting mobs. Triggered by bump instead of throw impact as we want to plow past mobs.
 /datum/action/ability/activable/xeno/charge/fire_charge/mob_hit(datum/source, mob/living/living_target)
 	. = TRUE
-	if(living_target.stat || isxeno(living_target) || living_target.status_flags & GODMODE) //we leap past xenos
+	if(living_target.stat || isxeno(living_target) || living_target.status_flags & GODMODE) // We leap past xenos.
 		return
-	living_target.attack_alien_harm(xeno_owner, xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
-	var/fire_damage = PYROGEN_FIRECHARGE_DAMAGE
-	if(living_target.has_status_effect(STATUS_EFFECT_MELTING_FIRE))
-		var/datum/status_effect/stacking/melting_fire/debuff = living_target.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
-		fire_damage += debuff.stacks * PYROGEN_FIRECHARGE_DAMAGE_PER_STACK
-		living_target.remove_status_effect(STATUS_EFFECT_MELTING_FIRE)
-	living_target.take_overall_damage(fire_damage, BURN, FIRE, max_limbs = 2)
-	living_target.hitby(owner)
-
+	if(should_slash)
+		living_target.attack_alien_harm(xeno_owner, xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier, FALSE, TRUE, FALSE, TRUE, INTENT_HARM) //Location is always random, cannot crit, harm only
+	var/fire_damage = charge_damage
+	var/datum/status_effect/stacking/melting_fire/debuff = living_target.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
+	if(!debuff)
+		if(stacks_to_add)
+			living_target.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, stacks_to_add, xeno_owner)
+	else
+		var/stacks_to_give = stacks_to_add ? stacks_to_add : 0
+		if(stack_damage)
+			fire_damage += debuff.stacks * stack_damage
+			stacks_to_give -= debuff.stacks
+		debuff.add_stacks(stacks_to_give, xeno_owner)
+	if(fire_damage)
+		living_target.take_overall_damage(fire_damage, BURN, FIRE, max_limbs = 2)
+	if(!pierces_mobs)
+		living_target.hitby(owner)
 
 ///Cleans up after charge is finished
 /datum/action/ability/activable/xeno/charge/fire_charge/charge_complete()

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -53,6 +53,12 @@
 		/datum/action/ability/activable/xeno/inferno,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/flame_cloak,
+		/datum/mutation_upgrade/spur/only_fire,
+		/datum/mutation_upgrade/veil/burnt_wounds
+	)
+
 /datum/xeno_caste/pyrogen/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
@@ -31,7 +31,7 @@
 	if(attached_armor || !chosen_fire)
 		return
 	var/total_armor = get_armor(get_total_structures())
-	attached_armor = new(total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor)
+	attached_armor = getArmor(total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor)
 	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(attached_armor)
 	set_armor_granting_fire(chosen_fire)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
@@ -1,0 +1,182 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/flame_cloak
+	name = "Flame Cloak"
+	desc = "If you are ontop of fire, you gain 5/10/15 armor in all categories."
+	/// For each structure, the armor that is given for being ontop of any fire.
+	var/armor_per_structure = 5
+	/// The attached armor that been given, if any.
+	var/datum/armor/attached_armor
+	/// The fire that granted the armor.
+	var/obj/fire/armor_granting_fire
+
+/datum/mutation_upgrade/shell/flame_cloak/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "If you are ontop of fire, you gain [get_armor(new_amount)] in all categories."
+
+/datum/mutation_upgrade/shell/flame_cloak/on_mutation_enabled()
+	. = ..()
+	RegisterSignal(xenomorph_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_movement))
+	grant_armor(get_fire_in_turf(get_turf(xenomorph_owner)))
+
+/datum/mutation_upgrade/shell/flame_cloak/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, COMSIG_MOVABLE_MOVED)
+	revoke_armor()
+	return ..()
+
+/// Grants armor.
+/datum/mutation_upgrade/shell/flame_cloak/proc/grant_armor(obj/fire/chosen_fire)
+	if(attached_armor || !chosen_fire)
+		return
+	var/total_armor = get_armor(get_total_structures())
+	attached_armor = new(total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor, total_armor)
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(attached_armor)
+	set_armor_granting_fire(chosen_fire)
+
+/// Removes armor.
+/datum/mutation_upgrade/shell/flame_cloak/proc/revoke_armor()
+	if(!attached_armor)
+		return
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.detachArmor(attached_armor)
+	attached_armor = null
+	set_armor_granting_fire()
+
+/// Sets signals for the chosen fire.
+/datum/mutation_upgrade/shell/flame_cloak/proc/set_armor_granting_fire(obj/fire/chosen_fire)
+	if(armor_granting_fire)
+		UnregisterSignal(armor_granting_fire, COMSIG_QDELETING, PROC_REF(on_fire_qdel))
+		armor_granting_fire = null
+	if(chosen_fire)
+		armor_granting_fire = chosen_fire
+		RegisterSignal(armor_granting_fire, COMSIG_QDELETING, PROC_REF(on_fire_qdel))
+
+/// Gets the longest lasting fire on a turf.
+/datum/mutation_upgrade/shell/flame_cloak/proc/get_fire_in_turf(turf/turf_to_search)
+	var/obj/fire/longest_lasting_fire
+	for(var/obj/fire/fire_in_turf in turf_to_search)
+		if(QDELING(fire_in_turf))
+			continue
+		if(!longest_lasting_fire)
+			longest_lasting_fire = fire_in_turf
+			continue
+		var/current_duration = longest_lasting_fire.burn_ticks / max(1, longest_lasting_fire.burn_decay)
+		var/opposing_duration = fire_in_turf.burn_ticks / max(1, fire_in_turf.burn_decay)
+		if(current_duration >= opposing_duration)
+			continue
+		longest_lasting_fire = fire_in_turf
+	return longest_lasting_fire
+
+// Revokes / grant armor based on if their location that has a fire. Assigns a fire that will basically re-proc this if it is deleted.
+/datum/mutation_upgrade/shell/flame_cloak/proc/set_armor_adjustingly()
+	var/obj/fire/fire_here = get_fire_in_turf(get_turf(xenomorph_owner))
+	if(!attached_armor)
+		if(fire_here)
+			grant_armor(fire_here)
+		return
+	if(!fire_here)
+		revoke_armor()
+		return
+	set_armor_granting_fire(fire_here)
+
+/// Called when the owner moves. Functionally revokes or grant armor if there are any fire. If they are already have armor and the new location has fire, assigns a new fire.
+/datum/mutation_upgrade/shell/flame_cloak/proc/on_movement(datum/source, atom/old_loc, movement_dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	set_armor_adjustingly()
+
+/// Called when the fire associated with the armor is deleted. Functionally revokes armor if fire is not found. Otherwise, assigns a new fire.
+/datum/mutation_upgrade/shell/flame_cloak/proc/on_fire_qdel(datum/source, atom/old_loc, movement_dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	set_armor_adjustingly()
+
+/// Returns the amount of armor that should be given for being on the same turf as fire.
+/datum/mutation_upgrade/shell/flame_cloak/proc/get_armor(structure_count)
+	return armor_per_structure * structure_count
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/only_fire
+	name = "Only Fire"
+	desc = "Fire Charge deals no damage, does not consume melting fire stacks, and now pierces humans. Humans who are hit get 2/4/6 melting fire stacks."
+	/// For each structure, the additional melting fire stacks to apply.
+	var/stacks_per_structure = 2
+
+/datum/mutation_upgrade/spur/only_fire/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Fire Charge deals no damage, does not consume melting fire stacks, and pierces humans. Humans who are hit get [stacks_per_structure * new_amount] melting fire stacks."
+
+/datum/mutation_upgrade/spur/only_fire/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/charge/fire_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/charge/fire_charge]
+	if(!charge_ability)
+		return
+	charge_ability.should_slash = FALSE
+	charge_ability.charge_damage -= initial(charge_ability.charge_damage)
+	charge_ability.stack_damage -= initial(charge_ability.stack_damage)
+	charge_ability.pierces_mobs = TRUE
+	return ..()
+
+/datum/mutation_upgrade/spur/only_fire/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/charge/fire_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/charge/fire_charge]
+	if(!charge_ability)
+		return
+	charge_ability.should_slash = initial(charge_ability.should_slash)
+	charge_ability.charge_damage += initial(charge_ability.charge_damage)
+	charge_ability.stack_damage += initial(charge_ability.stack_damage)
+	charge_ability.pierces_mobs = initial(charge_ability.pierces_mobs)
+	return ..()
+
+/datum/mutation_upgrade/spur/only_fire/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/charge/fire_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/charge/fire_charge]
+	if(!charge_ability)
+		return FALSE
+	charge_ability.stacks_to_add += get_stacks(new_amount - previous_amount)
+
+/// Returns the amount of melting fire stacks that Fire Charge should inflict.
+/datum/mutation_upgrade/spur/only_fire/proc/get_stacks(structure_count)
+	return stacks_per_structure * structure_count
+
+//*********************//
+//         Veil        //
+//*********************//
+
+/datum/mutation_upgrade/veil/burnt_wounds
+	name = "Burnt Wounds"
+	desc = "Melting fire stacks you inflict causes 15/25/35% healing reduction against brute and burn."
+	/// For the first structure, the percentage in which those inflicted with Melting Fire stacks will have their brute/burn healing reduced by.
+	var/percentage_initial = 0.05
+	/// For each structure, the percentage in which those inflicted with Melting Fire stacks will have their brute/burn healing reduced by.
+	var/percentage_per_structure = 0.1
+
+/datum/mutation_upgrade/veil/burnt_wounds/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Melting fire stacks you inflict cause [PERCENT(get_percentage(new_amount)) ]% healing reduction against brute and burn."
+
+/datum/mutation_upgrade/veil/burnt_wounds/on_mutation_enabled()
+	if(!isxenopyrogen(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/pyrogen/pyrogen_owner = xenomorph_owner
+	pyrogen_owner.melting_fire_healing_reduction += get_percentage(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/burnt_wounds/on_mutation_disabled()
+	if(!isxenopyrogen(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/pyrogen/pyrogen_owner = xenomorph_owner
+	pyrogen_owner.melting_fire_healing_reduction -= get_percentage(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/burnt_wounds/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(!isxenopyrogen(xenomorph_owner))
+		return
+	var/mob/living/carbon/xenomorph/pyrogen/pyrogen_owner = xenomorph_owner
+	pyrogen_owner.melting_fire_healing_reduction += get_percentage(new_amount - previous_amount, FALSE)
+
+/// Returns the percentage in which those inflicted with Melting Fire stacks will have their brute/burn healing reduced by.
+/datum/mutation_upgrade/veil/burnt_wounds/proc/get_percentage(structure_count, include_initial = TRUE)
+	return (include_initial ? percentage_initial : 0) + (percentage_per_structure * structure_count)

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/mutations_pyrogen.dm
@@ -154,7 +154,7 @@
 /datum/mutation_upgrade/veil/burnt_wounds/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Melting fire stacks you inflict cause [PERCENT(get_percentage(new_amount)) ]% healing reduction against brute and burn."
+	return "Melting fire stacks you inflict cause [PERCENT(get_percentage(new_amount))]% healing reduction against brute and burn."
 
 /datum/mutation_upgrade/veil/burnt_wounds/on_mutation_enabled()
 	if(!isxenopyrogen(xenomorph_owner))

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/pyrogen.dm
@@ -13,6 +13,8 @@
 	upgrade = XENO_UPGRADE_NORMAL
 	pixel_x = -16
 	bubble_icon = "alienroyal"
+	/// The percentage of brute/burn healing that will be negated for all Melting Fire status effects that this xenomorph caused.
+	var/melting_fire_healing_reduction = 0
 
 /mob/living/carbon/xenomorph/pyrogen/Initialize(mapload)
 	. = ..()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2026,6 +2026,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppeteer\puppeteer.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\abilities_pyrogen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\castedatum_pyrogen.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\mutations_pyrogen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\pyrogen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\queen\abilities_queen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\queen\castedatum_queen.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a total of 3 mutations all for Pyrogen.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Flame Cloak | If you are ontop of fire, you gain 5/10/15 armor in all categories. |
| Spur | Only Fire | Fire Charge deals no damage, does not consume melting fire stacks, and now pierces humans. Humans who are hit get 2/4/6 melting fire stacks. |
| Veil | Burnt Wounds | Melting fire stacks you inflict causes 15/25/35% healing reduction against brute and burn. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Pyrogen now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
