### PR TITLE
Mutations: Hivelord

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -117,6 +117,7 @@
 #define CONQUEROR_OBLITERATION_TRAIT "conqueror_obliteration_trait"
 #define HEATRAY_BEAM_ABILITY_TRAIT "heatray_ability_trait"
 #define DRAGON_ABILITY_TRAIT "dragon_ability_trait"
+#define HIVELORD_ABILITY_TRAIT "hivelord_ability_trait"
 #define VALHALLA_TRAIT "valhalla"
 #define WEIGHTBENCH_TRAIT "weightbench"
 #define BOILER_ROOTED_TRAIT "boiler_rooted"

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -210,7 +210,8 @@
 		)
 	/// Used for the dragging functionality of pre-shuttter building
 	var/dragging = FALSE
-
+	/// The percentage of maximum health to heal the owner whenever a structure is built.
+	var/heal_percentage = 0
 
 /// Helper for handling the start of mouse-down and to begin the drag-building
 /datum/action/ability/activable/xeno/secrete_resin/proc/start_resin_drag(mob/user, atom/object, turf/location, control, params)
@@ -311,7 +312,9 @@
 		build_resin(get_turf(owner))
 	else
 		build_resin(get_turf(A))
-
+	if(heal_percentage)
+		var/health_healed = xeno_owner.maxHealth * heal_percentage
+		HEAL_XENO_DAMAGE(xeno_owner, health_healed, FALSE)
 /datum/action/ability/activable/xeno/secrete_resin/proc/get_wait()
 	. = base_wait
 	if(!scaling_wait)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -122,7 +122,7 @@
 	if(!can_plasma_regenerate)
 		ADD_TRAIT(xeno_owner, TRAIT_NOPLASMAREGEN, HIVELORD_ABILITY_TRAIT)
 	if(armor_amount)
-		attached_armor = new(armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount)
+		attached_armor = getArmor(armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount)
 		xeno_owner.soft_armor = xeno_owner.soft_armor.attachArmor(attached_armor)
 	set_toggle(TRUE)
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(resinwalk_on_moved))

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -80,6 +80,12 @@
 		/datum/action/ability/activable/xeno/place_pattern,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/hardened_travel,
+		/datum/mutation_upgrade/spur/rejuvenating_build,
+		/datum/mutation_upgrade/veil/protective_light
+	)
+
 /datum/xeno_caste/hivelord/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/mutations_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/mutations_hivelord.dm
@@ -1,0 +1,113 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/hardened_travel
+	name = "Hardened Travel"
+	desc = "Resin Walk now grants 10/15/20 armor in all categories. You cannot regenerate plasma while it is active."
+	/// For the first structure, the amount of armor that Resin Walk should be granting.
+	var/armor_initial = 5
+	/// For each structure, the amount of armor that Resin Walk should be granting.
+	var/armor_per_structure = 5
+
+/datum/mutation_upgrade/shell/hardened_travel/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While Resin Walk is active, you gain [get_armor(new_amount)] armor in all categories. During this time, you cannot regenerate plasma."
+
+/datum/mutation_upgrade/shell/hardened_travel/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/toggle_speed/speed_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toggle_speed]
+	if(!speed_ability)
+		return
+	speed_ability.set_plasma(FALSE)
+	speed_ability.set_armor(speed_ability.armor_amount + get_armor(0))
+
+/datum/mutation_upgrade/shell/hardened_travel/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/toggle_speed/speed_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toggle_speed]
+	if(!speed_ability)
+		return
+	speed_ability.set_plasma(initial(speed_ability.can_plasma_regenerate))
+	speed_ability.set_armor(speed_ability.armor_amount - get_armor(0))
+
+/datum/mutation_upgrade/shell/hardened_travel/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/toggle_speed/speed_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/toggle_speed]
+	if(!speed_ability)
+		return
+	speed_ability.set_armor(speed_ability.armor_amount + get_armor(new_amount - previous_amount, FALSE))
+
+/// Returns the amount of armor that Resin Walk should be granting.
+/datum/mutation_upgrade/shell/hardened_travel/proc/get_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? armor_initial : 0) + (armor_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/rejuvenating_build
+	name = "Rejuvenating Build"
+	desc = "You heal 1/2/3% of your maximum health whenever you successfully use Secrete Resin."
+	/// For each structure, the percentage of maximum health that will be healed when a structure is built via Secrete Resin.
+	var/percentage_per_structure = 0.01
+
+/datum/mutation_upgrade/spur/rejuvenating_build/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You heal [PERCENT(get_percentage(new_amount))]% of your maximum health whenever you successfully use Secrete Resin."
+
+/datum/mutation_upgrade/spur/rejuvenating_build/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/secrete_resin/hivelord/resin_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/secrete_resin/hivelord]
+	if(!resin_ability)
+		return
+	resin_ability.heal_percentage += get_percentage(new_amount - previous_amount)
+
+/// Returns the percentage of maximum health that will be healed when a structure is built via Secrete Resin.
+/datum/mutation_upgrade/spur/rejuvenating_build/proc/get_percentage(structure_count)
+	return percentage_per_structure * structure_count
+
+//*********************//
+//         Veil        //
+//*********************//
+
+/datum/mutation_upgrade/veil/protective_light
+	name = "Protective Light"
+	desc = "Healing Infusion now also applies the effects of resin jelly for 15 seconds. The plasma cost is now 2x/1.75x/1.5x of the original cost."
+	/// For the first structure, the multiplier that will added to the ability cost of Healing Infusion.
+	var/multiplier_initial = 1.25
+	/// For each structure, the multiplier that will added to the ability cost of Healing Infusion.
+	var/multiplier_per_structure = -0.25
+	/// The length in deciseconds of the Resin Jelly applied status effect.
+	var/resin_jelly_length = 15 SECONDS
+
+/datum/mutation_upgrade/veil/protective_light/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Healing Infusion now also applies the effects of resin jelly for [resin_jelly_length / 10] seconds. The plasma cost is now [1 + get_multiplier(new_amount)]x of the original cost."
+
+/datum/mutation_upgrade/veil/protective_light/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/healing_infusion/healing_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/healing_infusion]
+	if(!healing_ability)
+		return
+	healing_ability.resin_jelly_duration += resin_jelly_length
+	healing_ability.ability_cost += initial(healing_ability.ability_cost) * get_multiplier(0)
+
+/datum/mutation_upgrade/veil/protective_light/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/healing_infusion/healing_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/healing_infusion]
+	if(!healing_ability)
+		return
+	healing_ability.resin_jelly_duration -= resin_jelly_length
+	healing_ability.ability_cost -= initial(healing_ability.ability_cost) * get_multiplier(0)
+
+/datum/mutation_upgrade/veil/protective_light/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/healing_infusion/healing_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/healing_infusion]
+	if(!healing_ability)
+		return
+	healing_ability.ability_cost += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier that will added to the ability cost of Healing Infusion.
+/datum/mutation_upgrade/veil/protective_light/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1998,6 +1998,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\abilities_hivelord.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\castedatum_hivelord.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\hivelord.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\mutations_hivelord.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivemind\abilities_hivemind.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivemind\castedatum_hivemind.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivemind\hivemind.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Hivelord.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Hardened Travel | Resin Walk now grants 10/15/20 armor in all categories. You cannot regenerate plasma while it is active. |
| Spur | Rejuvenating Build | You heal 1/2/3% of your maximum health whenever you successfully use Secrete Resin. |
| Veil | Protective Light | Healing Infusion now also applies the effects of resin jelly for 15 seconds. The plasma cost is now 2x/1.75x/1.5x of the original cost. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Hivelord now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
