### PR TITLE
Mutations: Carrier

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1005,6 +1005,8 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LAY_EGG,
 	)
+	/// Should the egg contain the owner's selected_hugger_type instead?
+	var/use_selected_hugger = FALSE
 
 /datum/action/ability/xeno_action/lay_egg/action_activate(mob/living/carbon/xenomorph/user)
 	var/mob/living/carbon/xenomorph/xeno = owner
@@ -1026,7 +1028,7 @@
 	if(!xeno.loc_weeds_type)
 		return fail_activate()
 
-	new /obj/alien/egg/hugger(current_turf, xeno.hivenumber)
+	new /obj/alien/egg/hugger(current_turf, xeno.hivenumber, use_selected_hugger ? xeno_owner.selected_hugger_type : null)
 	playsound(current_turf, 'sound/effects/splat.ogg', 15, 1)
 
 	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -66,6 +66,13 @@
 		/datum/action/ability/xeno_action/choose_hugger_type,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/shared_jelly,
+		/datum/mutation_upgrade/spur/leapfrog,
+		/datum/mutation_upgrade/veil/oviposition,
+		/datum/mutation_upgrade/veil/life_for_life
+	)
+
 /datum/xeno_caste/carrier/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
@@ -1,0 +1,186 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/shared_jelly
+	name = "Shared Jelly"
+	desc = "If you are under the effect of Resin Jelly, all thrown huggers gain fire immunity. Each thrown hugger reduce the duration of the effect by 3/2/1 seconds."
+	/// For the first structure, the length in deciseconds that Throw Facehugger will decrease the owner's Resin Jelly Coating status effect by.
+	var/length_initial = 4 SECONDS
+	/// For each structure, the length in deciseconds that Throw Facehugger will decrease the owner's Resin Jelly Coating status effect by.
+	var/length_per_structure = -1 SECONDS
+
+/datum/mutation_upgrade/shell/shared_jelly/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "If you are under the effect of Resin Jelly, all thrown huggers gain fire immunity. Each thrown hugger reduce the duration of the effect by [get_length(new_amount) / 10] seconds."
+
+/datum/mutation_upgrade/shell/shared_jelly/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fire_immunity_transfer += get_length(0)
+	return ..()
+
+/datum/mutation_upgrade/shell/shared_jelly/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fire_immunity_transfer -= get_length(0)
+
+/datum/mutation_upgrade/shell/shared_jelly/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fire_immunity_transfer += get_length(new_amount - previous_amount, FALSE)
+
+/// Returns the length in deciseconds that Throw Facehugger will decrease the owner's Resin Jelly Coating status effect by.
+/datum/mutation_upgrade/shell/shared_jelly/proc/get_length(structure_count, include_initial = TRUE)
+	return (include_initial ? length_initial : 0) + (length_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/leapfrog
+	name = "Leapfrog"
+	desc = "Thrown huggers can now leap 1 tile at a time. All activation times are 0.8/0.7/0.6x of their original value, but will never be faster than 0.5s."
+	/// The leap range modified to bring it down to 1. This is used to add back range if the mutation is removed.
+	var/leap_range_modified = 0
+	/// For the first structure, the multiplier to add towards the various activation times that thrown facehuggers via Throw Facehugger will have.
+	var/multiplier_initial = -0.1
+	/// For each structure, the multiplier to add towards the various activation times that thrown facehuggers via Throw Facehugger will have.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/spur/leapfrog/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Thrown huggers can now leap 1 tile at a time. All activation times are [1 + get_multiplier(new_amount)]x of their original value, but will never be faster than 0.5s."
+
+/datum/mutation_upgrade/spur/leapfrog/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	leap_range_modified = (hugger_ability.leapping_range - 1)
+	hugger_ability.leapping_range -= leap_range_modified
+	hugger_ability.activation_time_multiplier += get_multiplier(0)
+
+/datum/mutation_upgrade/spur/leapfrog/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.leapping_range += leap_range_modified
+	leap_range_modified = 0
+	hugger_ability.activation_time_multiplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/spur/leapfrog/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.activation_time_multiplier += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add towards the various activation times that thrown facehuggers via Throw Facehugger will have.
+/datum/mutation_upgrade/spur/leapfrog/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/oviposition
+	name = "Oviposition"
+	desc = "Egg Lay now creates eggs with your selected type of hugger inside. The plasma cost is set to 50/40/30% of its their original value and its cooldown is set to 50% of its original value. You lose the ability, Spawn Huggers."
+	/// For the first structure, the multiplier that will be added to the ability cost of Egg Lay.
+	var/multiplier_initial = -0.4
+	/// For each structure, the multiplier that will be added to the ability cost of Egg Lay.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/oviposition/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Egg Lay now creates eggs with your selected type of hugger inside. The plasma cost is set to [PERCENT(1 + get_multiplier(new_amount))]% of its their original value and its cooldown is set to 50% of its original value. You lose the ability, Spawn Huggers."
+
+/datum/mutation_upgrade/veil/oviposition/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	var/datum/action/ability/xeno_action/spawn_hugger/spawn_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(spawn_ability)
+		spawn_ability.remove_action(xenomorph_owner)
+	egg_ability.use_selected_hugger = TRUE
+	egg_ability.cooldown_duration -= initial(egg_ability.cooldown_duration) * 0.5
+	egg_ability.ability_cost += initial(egg_ability.ability_cost) * get_multiplier(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/oviposition/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	var/datum/action/ability/xeno_action/spawn_hugger/spawn_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(!spawn_ability)
+		spawn_ability = new()
+		spawn_ability.give_action(xenomorph_owner)
+	egg_ability.use_selected_hugger = initial(egg_ability.use_selected_hugger)
+	egg_ability.cooldown_duration += initial(egg_ability.cooldown_duration) * 0.5
+	egg_ability.ability_cost -= initial(egg_ability.ability_cost) * get_multiplier(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/oviposition/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	egg_ability.ability_cost += initial(egg_ability.ability_cost) * get_multiplier(new_amount - previous_amount, FALSE)
+
+/datum/mutation_upgrade/veil/oviposition/on_xenomorph_upgrade()
+	var/datum/action/ability/xeno_action/spawn_hugger/spawn_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(spawn_ability)
+		spawn_ability.remove_action(xenomorph_owner)
+
+/// Returns the multiplier that will be added to the ability cost of Egg Lay.
+/datum/mutation_upgrade/veil/oviposition/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/life_for_life
+	name = "Life for Life"
+	desc = "Spawn Facehugger's cooldown is set to 70% of its original value and costs zero plasma, but will deal 50/40/30 true damage to you."
+	/// For the first structure, the amount of damage.
+	var/damage_initial = 60
+	/// For each structure, the additional amount of damage.
+	var/damage_per_structure = -10
+
+/datum/mutation_upgrade/veil/life_for_life/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Spawn Facehugger's cooldown is set to 70% of its original value and costs zero plasma, but will deal [get_damage(new_amount)] true damage to you."
+
+/datum/mutation_upgrade/veil/life_for_life/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/spawn_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(!hugger_ability)
+		return FALSE
+	hugger_ability.ability_cost -= initial(hugger_ability.ability_cost)
+	hugger_ability.cooldown_duration -= initial(hugger_ability.cooldown_duration) * 0.3
+	hugger_ability.health_cost += get_damage(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/life_for_life/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/spawn_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.ability_cost += initial(hugger_ability.ability_cost)
+	hugger_ability.cooldown_duration += initial(hugger_ability.cooldown_duration) * 0.3
+	hugger_ability.health_cost -= get_damage(0)
+
+/datum/mutation_upgrade/veil/life_for_life/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/spawn_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/spawn_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.health_cost += get_damage(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier that will be added to the ability cost of Egg Lay.
+/datum/mutation_upgrade/veil/life_for_life/proc/get_damage(structure_count, include_initial = TRUE)
+	return (include_initial ? damage_initial : 0) + (damage_per_structure * structure_count)

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -88,6 +88,11 @@
 	///What type of hugger are produced here
 	var/hugger_type = /obj/item/clothing/mask/facehugger
 
+/obj/alien/egg/hugger/Initialize(mapload, hivenumber, new_hugger_type)
+	. = ..()
+	if(new_hugger_type)
+		hugger_type = new_hugger_type
+
 /obj/alien/egg/hugger/update_icon_state()
 	. = ..()
 	overlays.Cut()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -62,9 +62,12 @@
 	var/about_to_jump = FALSE
 	///Time to become active after moving into the facehugger's space.
 	var/proximity_time = 0.75 SECONDS
+	/// Should they not die in fire?
+	var/fire_immune = FALSE
+	/// How far can they leap?
+	var/leap_range = 4
 
-
-/obj/item/clothing/mask/facehugger/Initialize(mapload, input_hivenumber, input_source)
+/obj/item/clothing/mask/facehugger/Initialize(mapload, input_hivenumber, input_source, new_fire_immunity)
 	. = ..()
 	if(stat == CONSCIOUS)
 		lifetimer = addtimer(CALLBACK(src, PROC_REF(check_lifecycle)), FACEHUGGER_DEATH, TIMER_STOPPABLE)
@@ -74,6 +77,9 @@
 
 	if(input_source)
 		facehugger_register_source(input_source)
+
+	if(new_fire_immunity)
+		set_fire_immunity(new_fire_immunity)
 
 	var/static/list/connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_cross),
@@ -88,6 +94,13 @@
 
 	source = S //set and register new source
 	RegisterSignal(S, COMSIG_QDELETING, PROC_REF(clear_hugger_source))
+
+/obj/item/clothing/mask/facehugger/proc/set_fire_immunity(new_fire_immunity)
+	if(!fire_immune && new_fire_immunity)
+		add_filter("facehugger_fire_immunity_outline", 2, outline_filter(1, COLOR_TAN_ORANGE))
+	if(fire_immune && !new_fire_immunity)
+		remove_filter("facehugger_fire_immunity_outline")
+	fire_immune = new_fire_immunity
 
 ///Clears the source of our facehugger for the purpose of anti-shuffle mechanics
 /obj/item/clothing/mask/facehugger/proc/clear_hugger_source()
@@ -267,7 +280,7 @@
 	if(chosen_target)
 		visible_message(span_warning("\The scuttling [src] leaps at [chosen_target]!"), null, null, 4)
 		leaping = TRUE
-		throw_at(chosen_target, 4, 1)
+		throw_at(chosen_target, leap_range, 1)
 		return
 
 	remove_danger_overlay() //Remove the danger overlay
@@ -603,6 +616,8 @@
 	deltimer(lifetimer)
 	deltimer(activetimer)
 	remove_danger_overlay() //Remove the danger overlay
+	if(fire_immune)
+		set_fire_immunity(FALSE)
 
 	update_icon()
 	playsound(loc, 'sound/voice/alien/facehugger_dies.ogg', 25, 1)
@@ -647,6 +662,8 @@
 	return TRUE
 
 /obj/item/clothing/mask/facehugger/fire_act(burn_level)
+	if(fire_immune)
+		return
 	kill_hugger()
 
 /obj/item/clothing/mask/facehugger/dropped(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -95,6 +95,7 @@
 	source = S //set and register new source
 	RegisterSignal(S, COMSIG_QDELETING, PROC_REF(clear_hugger_source))
 
+/// Sets the fire immunity and adds/removes an outline filter if it gained or lost fire immunity.
 /obj/item/clothing/mask/facehugger/proc/set_fire_immunity(new_fire_immunity)
 	if(!fire_immune && new_fire_immunity)
 		add_filter("facehugger_fire_immunity_outline", 2, outline_filter(1, COLOR_TAN_ORANGE))

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1975,6 +1975,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\abilities_carrier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\carrier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\castedatum_carrier.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\carrier\mutations_carrier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\crusher\abilities_crusher.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\crusher\castedatum_crusher.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\crusher\crusher.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 4 mutations all for Carrier.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Shared Jelly | If you are under the effect of Resin Jelly, all thrown huggers gain fire immunity. Each thrown hugger reduce the duration of the effect by 3/2/1 seconds. |
| Spur | Leapfrog | Thrown huggers can now leap 1 tile at a time. All activation times are 0.8/0.7/0.6x of their original value, but will never be faster than 0.5s. |
| Veil | Oviposition | Egg Lay now creates eggs with your selected type of hugger inside. The plasma cost is set to 50/40/30% of its their original value and its cooldown is set to 50% of its original value. You lose the ability, Spawn Huggers. |
| Veil | Life for Life | Spawn Facehugger's cooldown is set to 70% of its original value and costs zero plasma, but will deal 50/40/30 true damage to you.|

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Carrier now has 4 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
