### PR TITLE
Mutations: Bull

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -107,6 +107,7 @@
 #define TIMESHIFT_TRAIT "timeshift"
 #define BRAIN_TRAIT "brain"
 #define WIDOW_ABILITY_TRAIT "widow_ability_trait"
+#define BULL_ABILITY_TRAIT "bull_ability_trait"
 #define PSYCHIC_CRUSH_ABILITY_TRAIT "psychic_crush_ability_trait"
 #define VORTEX_ABILITY_TRAIT "vortex_ability_trait"
 #define PETRIFY_ABILITY_TRAIT "petrify_ability_trait"

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -53,6 +53,12 @@
 		/datum/action/ability/xeno_action/toggle_long_range/bull,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/unstoppable,
+		/datum/mutation_upgrade/spur/speed_demon,
+		/datum/mutation_upgrade/veil/railgun
+	)
+
 /datum/xeno_caste/bull/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
@@ -68,14 +68,14 @@
 //*********************//
 /datum/mutation_upgrade/veil/railgun
 	name = "Railgun"
-	desc = "Charging now takes 4/8/12 more steps to reach maximum charge."
+	desc = "Charge's maximum steps is increased by 4/8/12."
 	/// For each structure, the amount of additional steps required to reach maximum charge.
 	var/steps_per_structure = 4
 
 /datum/mutation_upgrade/veil/railgun/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Charging now takes [get_steps(new_amount)]  more steps to reach maximum charge."
+	return "Charge's maximum steps is increased by [get_steps(new_amount)]."
 
 /datum/mutation_upgrade/veil/railgun/on_structure_update(previous_amount, new_amount)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
@@ -63,7 +63,6 @@
 /datum/mutation_upgrade/spur/speed_demon/proc/get_speed(structure_count)
 	return speed_per_structure * structure_count
 
-
 //*********************//
 //         Veil        //
 //*********************//

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/mutations_bull.dm
@@ -1,0 +1,90 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/unstoppable
+	name = "Unstoppable"
+	desc = "Charging will grant you complete stagger immunity if you reach the maximum number of steps minus 1/2/3."
+	/// For each structure, the amount of steps below the maximum that needs to be reached in order to gain stagger immunity.
+	var/step_per_structure = 1
+
+/datum/mutation_upgrade/shell/unstoppable/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Charging will grant you complete stagger immunity if you reach the maximum number of steps minus [get_steps(new_amount)]."
+
+/datum/mutation_upgrade/shell/unstoppable/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/ready_charge/bull_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/ready_charge/bull_charge]
+	if(!charge_ability)
+		return
+	charge_ability.stagger_immunity_steps += (new_amount - previous_amount) * step_per_structure
+
+/// Returns the amount of steps below the maximum that needs to be reached in order to gain stagger immunity.
+/datum/mutation_upgrade/shell/unstoppable/proc/get_steps(structure_count)
+	return step_per_structure * structure_count
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/speed_demon
+	name = "Speed Demon"
+	desc = "Charging costs twice as much plasma. The speed multiplier per step is increased by 0.02/0.04/0.06."
+	/// For each structure, the additional increase of the speed per step.
+	var/speed_per_structure = 0.02
+
+/datum/mutation_upgrade/spur/speed_demon/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Charging costs twice as much plasma. The speed multiplier per step is increased by [get_speed(new_amount)]."
+
+/datum/mutation_upgrade/spur/speed_demon/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/ready_charge/bull_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/ready_charge/bull_charge]
+	if(!charge_ability)
+		return
+	charge_ability.plasma_use_multiplier += initial(charge_ability.plasma_use_multiplier)
+	return ..()
+
+/datum/mutation_upgrade/spur/speed_demon/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/ready_charge/bull_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/ready_charge/bull_charge]
+	if(!charge_ability)
+		return
+	charge_ability.plasma_use_multiplier -= initial(charge_ability.plasma_use_multiplier)
+
+/datum/mutation_upgrade/spur/speed_demon/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/ready_charge/bull_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/ready_charge/bull_charge]
+	if(!charge_ability)
+		return
+	charge_ability.speed_per_step += get_speed(new_amount - previous_amount)
+
+/// Returns the amount of additional speed to add per step.
+/datum/mutation_upgrade/spur/speed_demon/proc/get_speed(structure_count)
+	return speed_per_structure * structure_count
+
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/railgun
+	name = "Railgun"
+	desc = "Charging now takes 4/8/12 more steps to reach maximum charge."
+	/// For each structure, the amount of additional steps required to reach maximum charge.
+	var/steps_per_structure = 4
+
+/datum/mutation_upgrade/veil/railgun/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Charging now takes [get_steps(new_amount)]  more steps to reach maximum charge."
+
+/datum/mutation_upgrade/veil/railgun/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/ready_charge/bull_charge/charge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/ready_charge/bull_charge]
+	if(!charge_ability)
+		return
+	charge_ability.max_steps_buildup += get_steps(new_amount - previous_amount)
+
+/// Returns the amount of additional steps required to reach maximum charge.
+/datum/mutation_upgrade/veil/railgun/proc/get_steps(structure_count)
+	return steps_per_structure * structure_count

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -206,7 +206,7 @@
 		charger.add_movespeed_modifier(MOVESPEED_ID_XENO_CHARGE, TRUE, 100, NONE, TRUE, -CHARGE_SPEED(src))
 
 	if(valid_steps_taken > steps_for_charge)
-		charger.plasma_stored -= round(CHARGE_SPEED(src) * plasma_use_multiplier) //Eats up plasma the faster you go. //now uses a multiplier
+		charger.use_plasma(round(CHARGE_SPEED(src) * plasma_use_multiplier)) //Eats up plasma the faster you go. //now uses a multiplier
 
 		switch(charge_type)
 			if(CHARGE_CRUSH) //Xeno Crusher
@@ -362,7 +362,10 @@
 	max_steps_buildup = 10
 	crush_living_damage = 37
 	plasma_use_multiplier = 2
-
+	// How many steps below the maximum (`max_steps_buildup`) must be reached before the owner gets complete stagger immunity?
+	var/stagger_immunity_steps = 0
+	/// Has the trait TRAIT_STAGGERIMMUNE been given yet?
+	var/currently_stagger_immune = FALSE
 
 /datum/action/ability/xeno_action/ready_charge/bull_charge/give_action(mob/living/L)
 	. = ..()
@@ -399,6 +402,19 @@
 /datum/action/ability/xeno_action/ready_charge/bull_charge/on_xeno_upgrade()
 	var/mob/living/carbon/xenomorph/X = owner
 	agile_charge = (X.upgrade == XENO_UPGRADE_PRIMO)
+
+/datum/action/ability/xeno_action/ready_charge/bull_charge/handle_momentum()
+	. = ..()
+	if(!stagger_immunity_steps)
+		return
+	var/reached_stagger_immunity_steps = valid_steps_taken >= (max_steps_buildup - stagger_immunity_steps)
+	if(!currently_stagger_immune && reached_stagger_immunity_steps)
+		ADD_TRAIT(xeno_owner, TRAIT_STAGGERIMMUNE, BULL_ABILITY_TRAIT)
+		currently_stagger_immune = TRUE
+		return
+	if(currently_stagger_immune && !reached_stagger_immunity_steps)
+		REMOVE_TRAIT(xeno_owner, TRAIT_STAGGERIMMUNE, BULL_ABILITY_TRAIT)
+		currently_stagger_immune = FALSE
 
 /datum/action/ability/xeno_action/ready_charge/queen_charge
 	action_icon_state = "queen_ready_charge"

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1972,6 +1972,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\abilities_bull.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\bull.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\castedatum_bull.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\bull\mutations_bull.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\abilities_carrier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\carrier.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\carrier\castedatum_carrier.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a total of 3 mutations all for Bull.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Unstoppable | Charging will grant you complete stagger immunity if you reach the maximum number of steps minus 1/2/3. |
| Spur | Speed Demon | Charging costs twice as much plasma. The speed multiplier per step is increased by 0.02/0.04/0.06. |
| Veil | Railgun | Charging now takes 4/8/12 more steps to reach maximum charge. |

Charging no longer directly sets your stored plasma and instead use the `use_plasma` proc; this means your plasma HUD now updates to reflect your current plasma and that it is no longer possible to have negative stored plasma from this.

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Bull now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
fix: Charging abilities no longer can cause your plasma to go negative and also updates your plasma HUD.
/:cl:
