### PR TITLE
Makes tank/apc fabricator indestructible

### DIFF
--- a/code/modules/vehicles/armored/tank_fabricator.dm
+++ b/code/modules/vehicles/armored/tank_fabricator.dm
@@ -9,6 +9,7 @@
 	bound_width = 64
 	icon = 'icons/obj/machines/drone_fab.dmi'
 	icon_state = "drone_fab_idle"
+	resistance_flags = RESIST_ALL
 	/// actual UI that will be interacted with
 	var/datum/supply_ui/vehicles/supply_ui
 


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

all other fabricators are - why should this one be excluded - this feels like someone forgor to put a flag

## Changelog
:cl: Atropos
fix: Tank/APC fabricator is now indestructible 
/:cl:
