### PR TITLE
Fixes setting atrition in campaign to 0 by accident

### DIFF
--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -487,7 +487,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 				return
 			var/combined_attrition = total_attrition_points + active_attrition_points
 			var/choice = tgui_input_number(user, "How much manpower would you like to dedicate to this mission?", "Attrition Point selection", 0, combined_attrition, 0, 60 SECONDS)
-			if(!choice)
+			if(isnull(choice))
 				return
 			//check again so you can't just hold the window open
 			if((current_mode.current_mission?.mission_state != MISSION_STATE_NEW) && (current_mode.current_mission?.mission_state != MISSION_STATE_LOADED))


### PR DESCRIPTION

## About The Pull Request

If you cancel in the middle of setting attrition it sets itself to 0 - which is bad and a noob trap

## Why It's Good For The Game
Fix = good

## Changelog
:cl: Atropos
fix: fixed setting attrition in campaign, you can no longer accidentally set it to 0
/:cl:
