### PR TITLE
Mutations: Sizzler

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -387,6 +387,8 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	var/steam_rush_duration
 	/// How much extra burn damage is dealt on slash
 	var/steam_damage = 10
+	/// The duration in deciseconds in which a trail of opaque gas will last.
+	var/gas_trail_duration = 0
 
 /datum/action/ability/xeno_action/steam_rush/action_activate()
 	var/mob/living/carbon/xenomorph/boiler/sizzler/X = owner
@@ -410,6 +412,8 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	particle_holder.pixel_x = 10
 
 	RegisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(steam_slash))
+	if(gas_trail_duration)
+		RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_movement))
 
 	succeed_activate()
 	add_cooldown()
@@ -442,6 +446,16 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	X.steam_rush = FALSE
 	QDEL_NULL(particle_holder)
 	UnregisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING)
+	if(gas_trail_duration)
+		UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
+
+/// Creates a trail of acid smoke when moving.
+/datum/action/ability/xeno_action/steam_rush/proc/on_movement(datum/source, atom/old_loc, movement_dir, forced, list/old_locs)
+	if(!gas_trail_duration || xeno_owner.stat != CONSCIOUS)
+		return
+	var/datum/effect_system/smoke_spread/xeno/acid/opaque/smoke = new()
+	smoke.set_up(0, get_turf(xeno_owner), gas_trail_duration / (2 SECONDS))
+	smoke.start()
 
 /datum/action/ability/xeno_action/steam_rush/on_cooldown_finish()
 	owner.balloon_alert(owner, "Steam rush ready.")
@@ -479,15 +493,17 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SMOKESCREEN_SPIT,
 	)
 	use_state_flags = ABILITY_USE_STAGGERED
-	/// Timer for the window you have to fire smokescreen spit
+/// Timer for the window you have to fire smokescreen spit.
 	var/smokescreen_spit_window
-	/// Duration of the window you have to fire smokescreen spit
+	/// Duration of the window you have to fire smokescreen spit.
 	var/window_duration = 1.5 SECONDS
+	/// The ammo type to change the owner's ammo to when activated.
+	var/datum/ammo/xeno/ammo_type = /datum/ammo/xeno/acid/airburst/heavy
 
 /datum/action/ability/xeno_action/smokescreen_spit/action_activate()
 	var/mob/living/carbon/xenomorph/boiler/sizzler/X = owner
 
-	X.ammo = /datum/ammo/xeno/acid/airburst/heavy
+	X.ammo = ammo_type
 	X.update_spits(TRUE)
 	X.balloon_alert(owner, "We prepare to fire a smokescreen!")
 
@@ -502,7 +518,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 		return
 	var/mob/living/carbon/xenomorph/boiler/sizzler/X = owner
 
-	X.ammo = /datum/ammo/xeno/acid/airburst
+	X.ammo = null // update_spits() will reselect their ammo.
 	X.update_spits(TRUE)
 	X.balloon_alert(owner, "Our spit returns to normal.")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -121,6 +121,12 @@
 		/datum/action/ability/xeno_action/steam_rush,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/gaseous_trail,
+		/datum/mutation_upgrade/spur/neurotoxin_swap,
+		/datum/mutation_upgrade/veil/fast_acid
+	)
+
 /datum/xeno_caste/boiler/sizzler/primordial
 	upgrade_name = "Primordial"
 	upgrade = XENO_UPGRADE_PRIMO

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/mutations_sizzler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/mutations_sizzler.dm
@@ -1,0 +1,101 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/gaseous_trail
+	name = "Gaseous Trail"
+	desc = "Steam Rush leaves a trail of opaque gas behind you. The gas lasts for 2/4/6 seconds."
+	/// For each structure, the duration in deciseconds that the gas from Steam Rush will last.
+	var/duration_per_structure = 2 SECONDS
+
+/datum/mutation_upgrade/shell/gaseous_trail/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Steam Rush leaves a trail of opaque gas behind you. The gas lasts for [get_duration(new_amount) * 0.1] seconds."
+
+/datum/mutation_upgrade/shell/gaseous_trail/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/steam_rush/rush_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/steam_rush]
+	if(!rush_ability)
+		return
+	rush_ability.gas_trail_duration += get_duration(new_amount - previous_amount)
+
+/// Returns the duration in deciseconds that the gas from Steam Rush will last.
+/datum/mutation_upgrade/shell/gaseous_trail/proc/get_duration(structure_count)
+	return duration_per_structure * structure_count
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/neurotoxin_swap
+	name = "Neurotoxin Swap"
+	desc = "Smokescreen Spit does stamina damage and emits Neurotoxin instead. Smokescreen Spit's plasma cost is 200/150/100% of its original cost."
+	/// For the first structure, the multiplier to add to Smokescreen Spit's ability cost.
+	var/cost_multiplier_initial = 1.5
+	/// For each structure, the multiplier to add to Smokescreen Spit's ability cost.
+	var/cost_multiplier_per_structure = -0.5
+	/// The ammo type used to replace Smokescreen Spit with.
+	var/datum/ammo/xeno/smokescreen_spit_ammotype = /datum/ammo/xeno/acid/airburst/heavy/neurotoxin
+
+/datum/mutation_upgrade/spur/neurotoxin_swap/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Smokescreen Spit does stamina damage emits Neurotoxin instead. Smokescreen Spit's plasma cost is [PERCENT(1 + get_cost_multiplier(new_amount))]% of its original cost."
+
+/datum/mutation_upgrade/spur/neurotoxin_swap/on_mutation_enabled()
+	var/datum/action/ability/xeno_action/smokescreen_spit/smokescreen_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/smokescreen_spit]
+	if(!smokescreen_ability)
+		return
+	smokescreen_ability.ammo_type = smokescreen_spit_ammotype
+	smokescreen_ability.ability_cost += initial(smokescreen_ability.ability_cost) * get_cost_multiplier(0)
+	return ..()
+
+/datum/mutation_upgrade/spur/neurotoxin_swap/on_mutation_disabled()
+	var/datum/action/ability/xeno_action/smokescreen_spit/smokescreen_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/smokescreen_spit]
+	if(!smokescreen_ability)
+		return
+	smokescreen_ability.ammo_type = initial(smokescreen_ability.ammo_type)
+	smokescreen_ability.ability_cost -= initial(smokescreen_ability.ability_cost) * get_cost_multiplier(0)
+	return ..()
+
+/datum/mutation_upgrade/spur/neurotoxin_swap/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/smokescreen_spit/smokescreen_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/smokescreen_spit]
+	if(!smokescreen_ability)
+		return
+	smokescreen_ability.ability_cost += initial(smokescreen_ability.ability_cost) * get_cost_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add to Smokescreen Spit's ability cost.
+/datum/mutation_upgrade/spur/neurotoxin_swap/proc/get_cost_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? cost_multiplier_initial : 0) + (cost_multiplier_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/fast_acid
+	name = "Fast Acid"
+	desc = "Corrosive Acid is now applied 20/35/50% faster."
+	/// For the first structure, the percentage to speed up Corrosive Acid by.
+	var/speedup_initial = 0.05
+	/// For each structure, the additional percentage to speed up Corrosive Acid by.
+	var/speedup_per_structure = 0.15
+
+/datum/mutation_upgrade/veil/fast_acid/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Corrosive Acid is now applied [PERCENT(get_speedup(new_amount))]% faster."
+
+/datum/mutation_upgrade/veil/fast_acid/on_structure_update(previous_amount, new_amount)
+	var/datum/action/ability/activable/xeno/corrosive_acid/strong/ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/corrosive_acid/strong]
+	if(!ability)
+		return
+	if(previous_amount)
+		ability.acid_speed_multiplier *= 1 + get_speedup(previous_amount) // First, we reverse...
+	if(new_amount)
+		ability.acid_speed_multiplier /= 1 + get_speedup(new_amount) // ... then we re-apply because math is hard!
+	return ..()
+
+/// Returns the percentage used to speed up Corrosive Acid by.
+/datum/mutation_upgrade/veil/fast_acid/proc/get_speedup(structure_count)
+	return speedup_initial + (speedup_per_structure * structure_count)
+
+

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -386,12 +386,20 @@
 		target_carbon.adjust_stagger(stagger_duration)
 		target_carbon.add_slowdown(slowdown_stacks)
 
+/datum/ammo/xeno/acid/airburst/heavy/neurotoxin
+	damage_type = STAMINA
+	bonus_projectiles_type = /datum/ammo/xeno/acid/airburst_bomblet/smokescreen/neurotoxin
+
 /datum/ammo/xeno/acid/airburst_bomblet/smokescreen
 	max_range = 5
 	damage = 6
+	damage_type = STAMINA
 	smoketype = /datum/effect_system/smoke_spread/xeno/acid
 	smoke_radius = 1
 	smoke_duration = 4
+
+/datum/ammo/xeno/acid/airburst_bomblet/smokescreen/neurotoxin
+	smoketype = /datum/effect_system/smoke_spread/xeno/neuro/light
 
 ///For the Sizzler Boiler's primo
 /datum/ammo/xeno/acid/heavy/high_pressure_spit

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1969,6 +1969,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\boiler\abilities_boiler.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\boiler\boiler.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\boiler\castedatum_boiler.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\boiler\mutations_sizzler.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\abilities_bull.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\bull.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\bull\castedatum_bull.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Sizzler (Boiler Strain).
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Gaseous Trail | Steam Rush leaves a trail of opaque gas behind you. The gas lasts for 2/4/6 seconds. |
| Spur | Neurotoxin Swap | Smokescreen Spit does stamina damage and emits Neurotoxin instead. Smokescreen Spit's plasma cost is 200/150/100% of its original cost. |
| Veil | Fast Acid | Corrosive Acid is now applied 20/35/50% faster. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Sizzler now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
