### PR TITLE
Mutations: Gorger

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -175,15 +175,6 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 	} \
 } while(FALSE)
 
-///Adjusts overheal and returns the amount by which it was adjusted
-#define adjustOverheal(xeno, amount) \
-	xeno.overheal = max(min(xeno.overheal + amount, xeno.xeno_caste.overheal_max), 0); \
-	if(xeno.overheal > 0) { \
-		xeno.add_filter("overheal_vis", 1, outline_filter(4 * (xeno.overheal / xeno.xeno_caste.overheal_max), "#60ce6f60")); \
-	} else { \
-		xeno.remove_filter("overheal_vis"); \
-	}
-
 /// Used by the is_valid_for_resin_structure proc.
 /// 0 is considered valid , anything thats not 0 is false
 /// Simply not allowed by the area to build

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -521,6 +521,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.psy_shields] number of times Warlocks used psychic shield."
 	if(GLOB.round_statistics.psy_shield_blasts)
 		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a psychic shield."
+	if(GLOB.round_statistics.transfusion_overheal)
+		parts += "[GLOB.round_statistics.transfusion_overheal] points of overheal Gorgers gave through Transfusion."
 	if(GLOB.round_statistics.larva_from_psydrain)
 		parts += "[GLOB.round_statistics.larva_from_psydrain] larvas came from psydrain."
 	if(GLOB.round_statistics.larva_from_silo)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -522,7 +522,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.psy_shield_blasts)
 		parts += "[GLOB.round_statistics.psy_shield_blasts] number of times Warlocks detonated a psychic shield."
 	if(GLOB.round_statistics.transfusion_overheal)
-		parts += "[GLOB.round_statistics.transfusion_overheal] points of overheal Gorgers gave through Transfusion."
+		parts += "[GLOB.round_statistics.transfusion_overheal] points of overhealing were given by Gorgers through Transfusion."
 	if(GLOB.round_statistics.larva_from_psydrain)
 		parts += "[GLOB.round_statistics.larva_from_psydrain] larvas came from psydrain."
 	if(GLOB.round_statistics.larva_from_silo)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -83,6 +83,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/psy_lances = 0
 	var/psy_shields = 0
 	var/psy_shield_blasts = 0
+	var/transfusion_overheal = 0
 	var/pyrogen_fireballs = 0
 	var/pyrogen_firestorms = 0
 	var/pyrogen_infernos

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -553,7 +553,7 @@
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	var/owner_heal = healing_on_hit
 	HEAL_XENO_DAMAGE(owner_xeno, owner_heal, FALSE)
-	adjustOverheal(owner_xeno, owner_heal * 0.5)
+	owner_xeno.adjustOverheal(owner_heal * 0.5)
 
 	if(plasma_mod >= HIGN_THRESHOLD)
 		owner_xeno.AdjustImmobilized(KNOCKDOWN_DURATION)
@@ -614,7 +614,7 @@
 		return
 	var/heal_amount = X.maxHealth * 0.08
 	HEAL_XENO_DAMAGE(X, heal_amount, FALSE)
-	adjustOverheal(X, heal_amount / 2)
+	X.adjustOverheal(heal_amount / 2)
 	X.use_plasma(plasma_drain)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -96,6 +96,8 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DRAIN,
 	)
+	/// The multiplier to determine how much max health to heal when using Drain on a dead human.
+	var/dead_multiplier = 2.2
 
 /datum/action/ability/activable/xeno/drain/can_use_ability(atom/target, silent = FALSE, override_flags)
 	. = ..()
@@ -123,25 +125,12 @@
 			to_chat(xeno_owner, span_xenowarning("No need, we feel sated for now..."))
 		return FALSE
 
-#define DO_DRAIN_ACTION(xeno_owner, target_human) \
-	xeno_owner.do_attack_animation(target_human, ATTACK_EFFECT_REDSTAB);\
-	xeno_owner.visible_message(target_human, span_danger("[xeno_owner] stabs its tail into [target_human]!"));\
-	playsound(target_human, SFX_ALIEN_CLAW_FLESH, 25, TRUE);\
-	target_human.emote("scream");\
-	target_human.apply_damage(damage = 4, damagetype = BRUTE, def_zone = BODY_ZONE_HEAD, blocked = 0, sharp = TRUE, edge = FALSE, updating_health = TRUE);\
-\
-	var/drain_healing = GORGER_DRAIN_HEAL;\
-	HEAL_XENO_DAMAGE(xeno_owner, drain_healing, TRUE);\
-	adjustOverheal(xeno_owner, drain_healing);\
-	SEND_SIGNAL(target_human, COMSIG_XENO_DRAIN_HIT, xeno_owner.xeno_caste.drain_plasma_gain, xeno_owner);\
-	xeno_owner.gain_plasma(xeno_owner.xeno_caste.drain_plasma_gain)
-
 /datum/action/ability/activable/xeno/drain/use_ability(mob/living/carbon/human/target_human)
 	if(target_human.stat == DEAD)
 		var/overheal_gain = 0
-		while((xeno_owner.health < xeno_owner.maxHealth || xeno_owner.overheal < xeno_owner.xeno_caste.overheal_max) &&do_after(xeno_owner, 2 SECONDS, NONE, target_human, BUSY_ICON_HOSTILE))
-			overheal_gain = xeno_owner.heal_wounds(2.2)
-			adjustOverheal(xeno_owner, overheal_gain)
+		while((xeno_owner.health < xeno_owner.maxHealth || xeno_owner.overheal < xeno_owner.xeno_caste.overheal_max) && do_after(xeno_owner, 2 SECONDS, NONE, target_human, BUSY_ICON_HOSTILE))
+			overheal_gain = xeno_owner.heal_wounds(dead_multiplier)
+			xeno_owner.adjustOverheal(overheal_gain)
 			xeno_owner.adjust_sunder(-2.5)
 		to_chat(xeno_owner, span_notice("We feel fully restored."))
 		return
@@ -153,13 +142,20 @@
 		target_human.Immobilize(GORGER_DRAIN_DELAY)
 		if(!do_after(xeno_owner, GORGER_DRAIN_DELAY, IGNORE_HELD_ITEM, target_human))
 			break
-		DO_DRAIN_ACTION(xeno_owner, target_human)
+		xeno_owner.do_attack_animation(target_human, ATTACK_EFFECT_REDSTAB);
+		xeno_owner.visible_message(target_human, span_danger("[xeno_owner] stabs its tail into [target_human]!"));
+		playsound(target_human, SFX_ALIEN_CLAW_FLESH, 25, TRUE);
+		target_human.emote("scream");
+		target_human.apply_damage(damage = 4, damagetype = BRUTE, def_zone = BODY_ZONE_HEAD, blocked = 0, sharp = TRUE, edge = FALSE, updating_health = TRUE);
+		var/drain_healing = GORGER_DRAIN_HEAL
+		HEAL_XENO_DAMAGE(xeno_owner, drain_healing, TRUE)
+		xeno_owner.adjustOverheal(drain_healing)
+		SEND_SIGNAL(target_human, COMSIG_XENO_DRAIN_HIT, xeno_owner.xeno_caste.drain_plasma_gain, xeno_owner)
+		xeno_owner.gain_plasma(xeno_owner.xeno_caste.drain_plasma_gain)
 
 	REMOVE_TRAIT(xeno_owner, TRAIT_HANDS_BLOCKED, src)
 	target_human.blur_eyes(1)
 	add_cooldown()
-
-#undef DO_DRAIN_ACTION
 
 /datum/action/ability/activable/xeno/drain/ai_should_use(atom/target)
 	return can_use_ability(target, TRUE)
@@ -183,8 +179,9 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TRANSFUSION,
 	)
-
-	///Used to keep track of the target's previous health for extra_health_check()
+	/// The percentage of the target's maximum health to heal by.
+	var/heal_percentage = GORGER_TRANSFUSION_HEAL
+	/// Used to keep track of the target's previous health for extra_health_check().
 	var/target_health
 
 /datum/action/ability/activable/xeno/transfusion/can_use_ability(atom/target, silent = FALSE, override_flags) //it is set up to only return true on specific xeno or human targets
@@ -227,12 +224,12 @@
 
 /datum/action/ability/activable/xeno/transfusion/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/target_xeno = target
-	var/heal_amount = target_xeno.maxHealth * GORGER_TRANSFUSION_HEAL
+	var/heal_amount = target_xeno.maxHealth * heal_percentage
 	HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
 	if(owner.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]
 		personal_statistics.heals++
-	adjustOverheal(target_xeno, heal_amount)
+	GLOB.round_statistics.transfusion_overheal += target_xeno.adjustOverheal(heal_amount)
 	new /obj/effect/temp_visual/healing(get_turf(target_xeno))
 	if(target_xeno.overheal)
 		target_xeno.balloon_alert(xeno_owner, "Overheal: [target_xeno.overheal]/[target_xeno.xeno_caste.overheal_max]")
@@ -247,7 +244,7 @@
 	if(target_xeno.get_xeno_hivenumber() != owner.get_xeno_hivenumber())
 		return FALSE
 	// no overhealing
-	if(target_xeno.health > target_xeno.maxHealth * (1 - GORGER_TRANSFUSION_HEAL))
+	if(target_xeno.health > target_xeno.maxHealth * (1 - heal_percentage))
 		return FALSE
 	return can_use_ability(target, TRUE)
 
@@ -296,7 +293,7 @@
 			var/mob/living/carbon/xenomorph/target_xeno = M
 			var/heal_amount = M.maxHealth * GORGER_OPPOSE_HEAL
 			HEAL_XENO_DAMAGE(target_xeno, heal_amount, FALSE)
-			adjustOverheal(target_xeno, heal_amount)
+			target_xeno.adjustOverheal(heal_amount)
 			new /obj/effect/temp_visual/healing(get_turf(target_xeno))
 			if(owner.client)
 				var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[owner.ckey]
@@ -331,26 +328,41 @@
 	desc = "Link to a xenomorph and take some damage in their place. Unrest to cancel."
 	cooldown_duration = 50 SECONDS
 	ability_cost = 0
+	use_state_flags = ABILITY_USE_LYING
 	target_flags = ABILITY_MOB_TARGET
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_LINK,
 	)
-	///Timer for activating the link
+	/// The psychic link status effect, if any.
+	var/datum/status_effect/xeno_psychic_link/psychic_link_status_effect
+	/// Timer for activating the link.
 	var/apply_psychic_link_timer
-	///Overlay applied on the target xeno while linking
+	/// Overlay applied on the target xeno while linking.
 	var/datum/progressicon/target_overlay
+	/// Will they be forced to rest upon using this? Use `set_required_resting` to change this variable.
+	var/required_rest = TRUE
+	/// The attached armor that been given, if any.
+	var/datum/armor/attached_armor
+	/// Once the link starts, attaches to the owner this amount of soft armor.
+	var/armor_amount
+	/// Once the link starts, sets the owner's move_resist to this.
+	var/movement_resistance = MOVE_FORCE_VERY_STRONG // This is the default move_resist for xenomorphs.
+	/// Once the link starts and until it ends, multiply Drain's healing multiplier on corpses by this amount.
+	var/drain_healing_multiplier = 1
 
 /datum/action/ability/activable/xeno/psychic_link/can_use_ability(atom/target, silent = FALSE, override_flags)
 	. = ..()
 	if(!.)
 		return
+	if(xeno_owner.do_actions)
+		return FALSE
 	if(apply_psychic_link_timer)
 		if(!silent)
 			owner.balloon_alert(owner, "cancelled")
 		link_cleanup()
 		return FALSE
-	if(owner.do_actions)
-		return FALSE
+	if(psychic_link_status_effect)
+		return TRUE // Only just removing the link.
 	if(!isxeno(target))
 		if(!silent)
 			to_chat(owner, span_notice("We can only link to familiar biological lifeforms."))
@@ -374,43 +386,75 @@
 	return TRUE
 
 /datum/action/ability/activable/xeno/psychic_link/use_ability(atom/target)
+	if(psychic_link_status_effect)
+		cancel_psychic_link()
+		return
 	apply_psychic_link_timer = addtimer(CALLBACK(src, PROC_REF(apply_psychic_link), target), GORGER_PSYCHIC_LINK_CHANNEL, TIMER_UNIQUE|TIMER_STOPPABLE)
 	target_overlay = new (target, BUSY_ICON_MEDICAL)
 	owner.balloon_alert(owner, "linking...")
 
-///Activates the link
+/// Activates the link.
 /datum/action/ability/activable/xeno/psychic_link/proc/apply_psychic_link(atom/target)
 	link_cleanup()
 	if(HAS_TRAIT(owner, TRAIT_PSY_LINKED) || HAS_TRAIT(target, TRAIT_PSY_LINKED))
 		return fail_activate()
 
-	var/psychic_link = xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, xeno_owner.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH, TRUE)
-	RegisterSignal(psychic_link, COMSIG_XENO_PSYCHIC_LINK_REMOVED, PROC_REF(status_removed))
-	target.balloon_alert(xeno_owner, "link successul")
+	var/psychic_link_status_effect = xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, xeno_owner.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH, TRUE)
+	RegisterSignal(psychic_link_status_effect, COMSIG_XENO_PSYCHIC_LINK_REMOVED, PROC_REF(status_removed))
+	if(!attached_armor)
+		attached_armor = getArmor(armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount)
+		xeno_owner.soft_armor = xeno_owner.soft_armor.attachArmor(attached_armor)
+	xeno_owner.move_resist = movement_resistance
+	target.balloon_alert(xeno_owner, "link successful")
 	xeno_owner.balloon_alert(target, "linked to [xeno_owner]")
-	if(!xeno_owner.resting)
-		xeno_owner.set_resting(TRUE, TRUE)
-	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_UNREST, PROC_REF(cancel_psychic_link))
+	if(required_rest)
+		if(!xeno_owner.resting)
+			xeno_owner.set_resting(TRUE, TRUE)
+		RegisterSignal(xeno_owner, COMSIG_XENOMORPH_UNREST, PROC_REF(cancel_psychic_link))
+	var/datum/action/ability/activable/xeno/drain/drain_ability = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/drain]
+	if(drain_ability)
+		drain_ability.dead_multiplier = initial(drain_ability.dead_multiplier) * drain_healing_multiplier
 	succeed_activate()
 
-///Removes the status effect on unrest
+/// Removes the status effect.
 /datum/action/ability/activable/xeno/psychic_link/proc/cancel_psychic_link(datum/source)
 	SIGNAL_HANDLER
 	xeno_owner.remove_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK)
 
-///Cancels the status effect
+/// Sets the `required_to_rest` variable and (un)registers signals accordingly.
+/datum/action/ability/activable/xeno/psychic_link/proc/set_required_rest(new_required_rest)
+	if(psychic_link_status_effect)
+		if(required_rest && !new_required_rest)
+			UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_UNREST)
+		if(!required_rest && new_required_rest)
+			RegisterSignal(xeno_owner, COMSIG_XENOMORPH_UNREST, PROC_REF(cancel_psychic_link))
+	required_rest = new_required_rest
+	desc =  "Link to a xenomorph and take some damage in their place.";
+	if(required_rest)
+		desc += " Unrest to cancel."
+	update_button_icon()
+
+/// Happens when the status effect is deleted. Unregisters signals and begins the cooldown.
 /datum/action/ability/activable/xeno/psychic_link/proc/status_removed(datum/source)
 	SIGNAL_HANDLER
+	psychic_link_status_effect = null
 	UnregisterSignal(source, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
-	UnregisterSignal(owner, COMSIG_XENOMORPH_UNREST)
+	if(attached_armor)
+		xeno_owner.soft_armor = xeno_owner.soft_armor.detachArmor(attached_armor)
+		attached_armor = null
+	xeno_owner.move_resist = initial(xeno_owner.move_resist)
+	if(required_rest)
+		UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_UNREST)
+	var/datum/action/ability/activable/xeno/drain/drain_ability = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/drain]
+	if(drain_ability)
+		drain_ability.dead_multiplier = initial(drain_ability.dead_multiplier)
 	add_cooldown()
 
-///Clears up things used for the linking
+/// Clears up things used for the linking.
 /datum/action/ability/activable/xeno/psychic_link/proc/link_cleanup()
 	QDEL_NULL(target_overlay)
 	deltimer(apply_psychic_link_timer)
 	apply_psychic_link_timer = null
-
 
 /datum/action/ability/activable/xeno/psychic_link/ai_should_use(atom/target)
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -60,6 +60,12 @@
 		/datum/action/ability/activable/xeno/devour,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/unmoving_link,
+		/datum/mutation_upgrade/spur/necrotic_link,
+		/datum/mutation_upgrade/veil/burst_healing
+	)
+
 /datum/xeno_caste/gorger/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
@@ -1,0 +1,137 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/unmoving_link
+	name = "Unmoving Link"
+	desc = "While Psychic Link is active, you gain maximum movement resistance and gain 5/15/25 armor."
+	/// For the first structure, the amount of soft armor that Psychic Link should grant while it is active.
+	var/armor_initial = -5
+	/// For each structure, the amount of soft armor that Psychic Link should grant while it is active.
+	var/armor_per_structure = 10
+
+/datum/mutation_upgrade/shell/unmoving_link/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While Psychic Link is active, you gain maximum movement resistance and gain [get_armor(new_amount)] armor."
+
+/datum/mutation_upgrade/shell/unmoving_link/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	link_ability.armor_amount += get_armor(0)
+	link_ability.movement_resistance = MOVE_FORCE_OVERPOWERING
+	if(!link_ability.psychic_link_status_effect)
+		return
+	if(!link_ability.attached_armor)
+		link_ability.attached_armor = getArmor(link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount)
+		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(link_ability.attached_armor)
+	xenomorph_owner.move_resist = link_ability.movement_resistance
+
+/datum/mutation_upgrade/shell/unmoving_link/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	link_ability.armor_amount -= get_armor(0)
+	link_ability.movement_resistance = initial(link_ability.movement_resistance)
+	if(!link_ability.psychic_link_status_effect)
+		return
+	if(link_ability.attached_armor)
+		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.detachArmor(link_ability.attached_armor)
+		link_ability.attached_armor = null
+	xenomorph_owner.move_resist = initial(xenomorph_owner.move_resist)
+
+/datum/mutation_upgrade/shell/unmoving_link/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	if(link_ability.attached_armor && previous_amount)
+		var/difference = get_armor(new_amount - previous_amount, FALSE)
+		link_ability.attached_armor = link_ability.attached_armor.modifyAllRatings(difference)
+		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyAllRatings(difference)
+
+/// Returns the amount of soft armor that Psychic Link should grant while it is active.
+/datum/mutation_upgrade/shell/unmoving_link/proc/get_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? armor_initial : 0) + (armor_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/necrotic_link
+	name = "Necrotic Link"
+	desc = "Psychic Link no longer forces you to rest. While it is active, Drain is only 20/30/40% effective on corpses."
+	/// For the first structure, the multiplier to add to Drain's corpse healing while Psychic Link is active.
+	var/multiplier_initial = -0.9
+	/// For each structure, the multiplier to add to Drain's corpse healing while Psychic Link is active.
+	var/multiplier_per_structure = 0.1
+
+/datum/mutation_upgrade/spur/necrotic_link/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Psychic Link no longer forces you to rest. While it is active, Drain is only [PERCENT(1 + get_multiplier(new_amount))] effective on corpses."
+
+/datum/mutation_upgrade/spur/necrotic_link/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	link_ability.set_required_rest(FALSE)
+	link_ability.drain_healing_multiplier += get_multiplier(0)
+
+/datum/mutation_upgrade/spur/necrotic_link/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	link_ability.set_required_rest(initial(link_ability.required_rest))
+	link_ability.drain_healing_multiplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/spur/necrotic_link/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
+	if(!link_ability)
+		return
+	link_ability.drain_healing_multiplier += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add to Drain's corpse healing while Psychic Link is active.
+/datum/mutation_upgrade/spur/necrotic_link/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/burst_healing
+	name = "Burst Healing"
+	desc = "Transfusion heals an additional 7.5/15/22.5% maximum health, but requires twice as much plasma."
+	/// For each structure, the percentage to add to Transfusion's maximum health healing.
+	var/percentage_per_structure = 0.075
+
+/datum/mutation_upgrade/veil/burst_healing/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Transfusion heals an additional [PERCENT(get_percentage(new_amount))]% maximum health, but requires twice as much plasma."
+
+/datum/mutation_upgrade/veil/burst_healing/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/transfusion/transfusion_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/transfusion]
+	if(!transfusion_ability)
+		return
+	transfusion_ability.ability_cost += initial(transfusion_ability.ability_cost)
+
+/datum/mutation_upgrade/veil/burst_healing/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/transfusion/transfusion_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/transfusion]
+	if(!transfusion_ability)
+		return
+	transfusion_ability.ability_cost -= initial(transfusion_ability.ability_cost)
+
+/datum/mutation_upgrade/veil/burst_healing/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/transfusion/transfusion_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/transfusion]
+	if(!transfusion_ability)
+		return
+	transfusion_ability.heal_percentage += get_percentage(new_amount - previous_amount)
+
+/// Returns the percentage to add to Transfusion's maximum health healing.
+/datum/mutation_upgrade/veil/burst_healing/proc/get_percentage(structure_count, include_initial = TRUE)
+	return percentage_per_structure * structure_count

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
@@ -69,7 +69,7 @@
 /datum/mutation_upgrade/spur/necrotic_link/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Psychic Link no longer forces you to rest. While it is active, Drain is only [PERCENT(1 + get_multiplier(new_amount))] effective on corpses."
+	return "Psychic Link no longer forces you to rest. While it is active, Drain is only [PERCENT(1 + get_multiplier(new_amount))]% effective on corpses."
 
 /datum/mutation_upgrade/spur/necrotic_link/on_mutation_enabled()
 	. = ..()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1995,6 +1995,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\abilities_gorger.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\castedatum_gorger.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\gorger\gorger.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\gorger\mutations_gorger.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\abilities_hivelord.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\castedatum_hivelord.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\hivelord\hivelord.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Gorger.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Unmoving Link | While Psychic Link is active, you gain maximum movement resistance and gain 5/15/25 armor. |
| Spur | Necrotic Link | Psychic Link no longer forces you to rest. While it is active, Drain is only 20/30/40% effective on corpses. |
| Veil | Burst Healing | Transfusion heals an additional 7.5/15/22.5% maximum health, but requires twice as much plasma. |

Adds a round statistic that tracks how much overhealing Gorgers gave through Transfusion.

Converts the `adjustOverheal` define to a `/xenomorph` level proc.

## Why It's Good For The Game
More mutations & tracking overhealing from Transfusion is nice.

## Changelog
:cl:
add: Defender now has 9 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
add: A new round statistic that tracks how much overheal was given by Gorger's Transfusion.
code: The adjustOverheal define is now a proc on the /xenomorph level.
/:cl:
