### PR TITLE
Xenomorph Structures & Mutations for Valhalla/Admeme

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -188,7 +188,7 @@
 	.["user_maturity"] = isxeno(user) ? xeno_user.upgrade_stored : 0
 	.["user_next_mat_level"] = isxeno(user) && xeno_user.upgrade_possible() ? xeno_user.xeno_caste.upgrade_threshold : 0
 	.["user_tracked"] = isxeno(user) && !isnull(xeno_user.tracked) ? REF(xeno_user.tracked) : ""
-	.["user_can_mutate"] = isxeno(user) && (xeno_user.xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED)
+	.["user_can_mutate"] = isxeno(user) && ((xeno_user.xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED) || HAS_TRAIT(xeno_user, TRAIT_VALHALLA_XENO))
 
 	.["user_show_empty"] = !!(user.client.prefs.status_toggle_flags & HIVE_STATUS_SHOW_EMPTY)
 	.["user_show_compact"] = !!(user.client.prefs.status_toggle_flags & HIVE_STATUS_COMPACT_MODE)

--- a/code/modules/mob/living/carbon/xenomorph/mutation_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutation_datum.dm
@@ -101,7 +101,7 @@
 /datum/mutation_datum/proc/try_purchase_mutation(mob/living/carbon/xenomorph/xenomorph_purchaser, datum/mutation_upgrade/mutation_typepath)
 	if(!xenomorph_purchaser.hive || !mutation_typepath)
 		return FALSE
-	if(!(xenomorph_purchaser.xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED))
+	if(!(xenomorph_purchaser.xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED) && !HAS_TRAIT(xenomorph_purchaser, TRAIT_VALHALLA_XENO))
 		return FALSE
 	if(!(mutation_typepath in xenomorph_purchaser.xeno_caste.mutations))
 		to_chat(xenomorph_purchaser, span_warning("That is not a valid mutation."))

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -159,7 +159,7 @@
 
 	. += "Health: [health]/[maxHealth][overheal ? " + [overheal]": ""]" //Changes with balance scalar, can't just use the caste
 
-	if(xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED)
+	if((xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED) || HAS_TRAIT(src, TRAIT_VALHALLA_XENO))
 		. += "Biomass: [!isnull(SSpoints.xeno_biomass_points_by_hive[hivenumber]) ? SSpoints.xeno_biomass_points_by_hive[hivenumber] : 0]/[MUTATION_BIOMASS_MAXIMUM]"
 
 	if(xeno_caste.plasma_max > 0)

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -17,8 +17,13 @@
 	. = ..()
 	if(!(xeno_structure_flags & IGNORE_WEED_REMOVAL))
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, PROC_REF(weed_removed))
-	if(_hivenumber) ///because admins can spawn them
+	if(_hivenumber)
 		hivenumber = _hivenumber
+	else if(is_centcom_level(z) && hivenumber == XENO_HIVE_NORMAL) // For admins that want to play with it.
+		if(istype(get_area(src), /area/centcom/valhalla/xenocave))
+			hivenumber = XENO_HIVE_FALLEN
+		else
+			hivenumber = XENO_HIVE_ADMEME
 	LAZYADDASSOC(GLOB.xeno_structures_by_hive, hivenumber, src)
 	if(xeno_structure_flags & CRITICAL_STRUCTURE)
 		LAZYADDASSOC(GLOB.xeno_critical_structures_by_hive, hivenumber, src)


### PR DESCRIPTION

## About The Pull Request
Xenomorph structures that are created without an specified hive number parameter within the centcom z-level will have their hive number replaced with Valhalla if it is created within xenomorph's Valhalla area or Admeme if elsewhere.

Valhalla xenomorphs can access the mutation menu without needing the caste flag that allows their caste to buy mutations. This does not mean that they are able to buy mutations as the mutation structures are still admin-only / unobtainable through normal gameplay. 

## Why It's Good For The Game
Makes it easier for admins to mess around with xenomorph structures within the Centcom Z-level, let it be Thunderdome or Valhalla. 

In addition, makes it easier for people who are interested in testing out mutations (if the admins do spawn in the mutation chambers to let them to do so).

## Changelog
:cl:
qol: Xenomorph structures spawned by admins within Valhalla or the Centcom Z-level automatically assigns their hive to Fallen or Admeme respectively.
qol: Valhalla xenomorphs can access the Mutations menu to view what mutations are available to their caste and (potentially) buy mutations if they are capable of doing so.
/:cl:
