### PR TITLE
Double barrel mortar buff

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -27378,6 +27378,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
+"wrl" = (
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "wrs" = (
 /obj/machinery/door_control/mainship{
 	id = "AiCoreShutter";
@@ -27862,6 +27866,7 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "wKW" = (
+/obj/structure/dropship_equipment/electronics/spotlights,
 /obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -36453,8 +36458,8 @@ ahW
 hIO
 ehy
 dxv
+wrl
 ikw
-wKW
 wKW
 qIG
 cSI

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -7961,7 +7961,7 @@
 "kdC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/shuttle/operatingtable,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "kdD" = (
@@ -10253,6 +10253,7 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
 "mJL" = (
+/obj/structure/dropship_equipment/electronics/spotlights,
 /obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -17716,7 +17717,7 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "vYo" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -50973,8 +50974,8 @@ tyN
 iPO
 ovT
 diD
-kdC
 phr
+kdC
 mEd
 bWg
 yjj

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -12754,11 +12754,11 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "fDf" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/door_control/mainship/mech{
 	dir = 8;
 	id = "mech_shutters_2"
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "fDl" = (
@@ -14242,6 +14242,7 @@
 /turf/closed/wall/mainship/outer,
 /area/space)
 "hxN" = (
+/obj/structure/dropship_equipment/electronics/spotlights,
 /obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -25473,6 +25474,10 @@
 "vgl" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hallway/lower_foreship)
+"vgK" = (
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
+/turf/open/floor/prison,
+/area/sulaco/hangar/storage)
 "vgO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -68505,7 +68510,7 @@ rTP
 pWS
 aUL
 pWS
-hxN
+vgK
 oLM
 oLM
 yjO

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -12933,7 +12933,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/tankerbunks)
 "lol" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
 /turf/open/floor/mainship/orange,
 /area/mainship/hallways/hangar)
 "loE" = (
@@ -16824,6 +16824,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "rtt" = (
+/obj/structure/dropship_equipment/electronics/spotlights,
 /obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/orange{
 	dir = 6

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -3281,6 +3281,10 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"rAk" = (
+/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
+/turf/open/floor/mainship,
+/area/mainship/hallways/hangar)
 "rDw" = (
 /turf/open/floor/mainship,
 /area/mainship/command/telecomms)
@@ -4721,7 +4725,7 @@ sgk
 efN
 dwY
 dwY
-dwY
+rAk
 dwY
 acD
 aji

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -450,7 +450,7 @@
 
 /obj/item/mortar_kit/double
 	name = "\improper TA-55DB mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 2 rounds usually fitted in TAV's."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 2 rounds, and is usually fitted in TADs."
 	icon_state = "mortar_db"
 	max_integrity = 400
 	item_flags = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -459,9 +459,7 @@
 
 /obj/machinery/deployable/mortar/double
 	tally_type = TALLY_MORTAR
-	reload_time = 2 SECONDS
+	reload_time = 1 SECONDS
 	fire_amount = 2
 	max_rounds = 2
 	fire_delay = 0.5 SECONDS
-	cool_off_time = 6 SECONDS
-	spread = 2

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -450,7 +450,7 @@
 
 /obj/item/mortar_kit/double
 	name = "\improper TA-55DB mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 4 rounds usually fitted in TAV's."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 2 rounds usually fitted in TAV's."
 	icon_state = "mortar_db"
 	max_integrity = 400
 	item_flags = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -458,8 +458,8 @@
 	deployable_item = /obj/machinery/deployable/mortar/double
 
 /obj/machinery/deployable/mortar/double
-	tally_type = TALLY_MORTAR
-	reload_time = 1 SECONDS
+	reload_time = 2 SECONDS
 	fire_amount = 2
 	max_rounds = 2
 	fire_delay = 0.5 SECONDS
+	cool_off_time = 6 SECONDS

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -450,7 +450,7 @@
 
 /obj/item/mortar_kit/double
 	name = "\improper TA-55DB mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 2 rounds, and is usually fitted in TADs."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. This one is a double barreled mortar that can hold 2 rounds, and is usually fitted in TAVs."
 	icon_state = "mortar_db"
 	max_integrity = 400
 	item_flags = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -458,6 +458,7 @@
 	deployable_item = /obj/machinery/deployable/mortar/double
 
 /obj/machinery/deployable/mortar/double
+	tally_type = TALLY_MORTAR
 	reload_time = 2 SECONDS
 	fire_amount = 2
 	max_rounds = 2

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -656,7 +656,7 @@
 	undeployed_icon_state = "hl_system"
 
 /obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder
-	name = "mortar deployment system"
+	name = "double barrel mortar deployment system"
 	desc = "A box that deploys a TA-55DB mortar. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
 	icon_state = "mortar_system"
 	point_cost = 300


### PR DESCRIPTION
## About The Pull Request
Did you even know this thing existed?
Buffs the spread on the double barrel mortar from 2 to 1.
## Why It's Good For The Game
A long time ago, in a forgotten age, people were evidently spamming this thing on the long tad by mounting three mortars and firing 12 shot fire missions from hell at xenos. 

Long tad doesn't exist anymore. Double mortar deserves better.
## Changelog
:cl:
balance: Double barrel mortar now spawns roundstart, like the HSG nest.
balance: Double barrel mortar spread: 2 -> 1
spellcheck: Makes it more obvious that the double barrel mortar exists.
/:cl:
