### PR TITLE
Mutations: Praetorian

### DIFF
--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -825,7 +825,7 @@
 					sleep(0.1 SECONDS)
 	else
 		var/error = dist_y/2 - dist_x
-		while(!gc_destroyed && target &&((((y < target.y && dy == NORTH) || (y > target.y && dy == SOUTH)) && get_dist_euclidean(origin, src) < range) || isspaceturf(loc)) && throwing && istype(loc, /turf))
+		while(!gc_destroyed && target &&((((y < target.y && dy == NORTH) || (y > target.y && dy == SOUTH)) && get_dist_euclidean(origin, src) < range) || isspaceturf(loc)) && (!failed_to_move && throwing) && istype(loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dx)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -422,6 +422,10 @@
 	ability_cost = 30
 	desc = "Opens your pheromone options."
 	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_NOTTURF|ABILITY_USE_BUSY|ABILITY_USE_LYING|ABILITY_USE_BUCKLED
+	/// The amount to increase the aura's strength by. This is not used in determining the range.
+	var/bonus_flat_strength = 0
+	/// The amount to increase the aura's range by.
+	var/bonus_flat_range = 0
 
 /datum/action/ability/xeno_action/pheromones/proc/apply_pheros(phero_choice)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -434,7 +438,7 @@
 		X.hud_set_pheromone()
 		return fail_activate()
 	QDEL_NULL(X.current_aura)
-	X.current_aura = SSaura.add_emitter(X, phero_choice, 6 + X.xeno_caste.aura_strength * 2, X.xeno_caste.aura_strength, -1, X.faction, X.hivenumber)
+	X.current_aura = SSaura.add_emitter(X, phero_choice, 6 + (X.xeno_caste.aura_strength * 2) + bonus_flat_range, X.xeno_caste.aura_strength + bonus_flat_strength, -1, X.faction, X.hivenumber)
 	X.balloon_alert(X, "[phero_choice]")
 	playsound(X.loc, SFX_ALIEN_DROOL, 25)
 
@@ -447,7 +451,19 @@
 	var/phero_choice = show_radial_menu(owner, owner, GLOB.pheromone_images_list, radius = 35)
 	if(!phero_choice)
 		return fail_activate()
-	apply_pheros(phero_choice)
+	switch(phero_choice)
+		if(AURA_XENO_RECOVERY)
+			var/datum/action/ability/xeno_action/pheromones/emit_recovery/recovery_pheromones = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_recovery]
+			if(recovery_pheromones)
+				recovery_pheromones.apply_pheros(AURA_XENO_RECOVERY)
+		if(AURA_XENO_WARDING)
+			var/datum/action/ability/xeno_action/pheromones/emit_warding/warding_pheromones = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_warding]
+			if(warding_pheromones)
+				warding_pheromones.apply_pheros(AURA_XENO_WARDING)
+		if(AURA_XENO_FRENZY)
+			var/datum/action/ability/xeno_action/pheromones/emit_frenzy/frenzy_pheromones = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_frenzy]
+			if(frenzy_pheromones)
+				frenzy_pheromones.apply_pheros(AURA_XENO_FRENZY)
 
 /datum/action/ability/xeno_action/pheromones/emit_recovery
 	name = "Toggle Recovery Pheromones"

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -6,6 +6,8 @@
 	desc = "Spray a cone of dangerous acid at your target."
 	ability_cost = 300
 	cooldown_duration = 40 SECONDS
+	/// How will far can the acid go? Tile underneath starts at 1.
+	var/range = 5
 
 /datum/action/ability/activable/xeno/spray_acid/cone/use_ability(atom/A)
 	var/turf/target = get_turf(A)
@@ -29,7 +31,7 @@
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
 
 	xeno_owner.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 1)
-	start_acid_spray_cone(target, xeno_owner.xeno_caste.acid_spray_range)
+	start_acid_spray_cone(target, range)
 	add_cooldown()
 	addtimer(CALLBACK(src, PROC_REF(reset_speed)), rand(2 SECONDS, 3 SECONDS))
 
@@ -118,6 +120,16 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, spray)
 		do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, (distance_left < 5) ? CONE_PART_MIDDLE : CONE_PART_MIDDLE_DIAG, spray)
 
+/datum/action/ability/activable/xeno/spray_acid/cone/circle
+	name = "Spray Acid Circle"
+	desc = "Spray a cone of dangerous acid around you."
+
+/datum/action/ability/activable/xeno/spray_acid/cone/circle/start_acid_spray_cone(turf/T, range)
+	for(var/direction in GLOB.alldirs)
+		if(direction in GLOB.cardinals)
+			do_acid_cone_spray(xeno_owner.loc, range, direction, CONE_PART_MIDDLE, xeno_owner, TRUE)
+		else
+			do_acid_cone_spray(xeno_owner.loc, range, direction, CONE_PART_MIDDLE_DIAG, xeno_owner, TRUE)
 
 // ***************************************
 // *********** Slime Grenade

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -39,7 +39,6 @@
 	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_range = 5
 	acid_spray_damage = 25
 	acid_spray_damage_on_hit = 55
 	acid_spray_structure_damage = 69
@@ -66,6 +65,12 @@
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,
 		/datum/action/ability/xeno_action/pheromones/emit_frenzy,
+	)
+
+	mutations = list(
+		/datum/mutation_upgrade/shell/adaptive_armor,
+		/datum/mutation_upgrade/spur/circular_acid,
+		/datum/mutation_upgrade/veil/wide_pheromones
 	)
 
 /datum/xeno_caste/praetorian/normal
@@ -127,6 +132,8 @@
 		/datum/action/ability/xeno_action/pheromones/emit_frenzy,
 	)
 
+	mutations = list()
+
 /datum/xeno_caste/praetorian/dancer/normal
 	upgrade = XENO_UPGRADE_NORMAL
 
@@ -180,6 +187,8 @@
 		/datum/action/ability/xeno_action/pheromones/emit_warding,
 		/datum/action/ability/xeno_action/pheromones/emit_frenzy,
 	)
+
+	mutations = list()
 
 /datum/xeno_caste/praetorian/oppressor/normal
 	upgrade = XENO_UPGRADE_NORMAL

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/mutations_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/mutations_praetorian.dm
@@ -1,0 +1,199 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/adaptive_armor
+	name = "Adaptive Armor"
+	desc = "When you are hit by a non-friendly projectile, you gain 10/15/20 armor against that particular projectile's armor type and lose 15/22.5/30 in all other types. This lasts only for 10 seconds until it reselects."
+	/// For the first structure, the amount of armor that should be given against the projectile's armor type that the owner was hit with.
+	var/defended_armor_initial = 5
+	/// For each structure, the  amount of armor that should be given against the projectile's armor type that the owner was hit with.
+	var/defended_armor_per_structure = 5
+	/// For the first structure, the amount of armor that should be given against all armor types that isn't the projectile's armor type that the owner was hit with.
+	var/other_armor_initial = -7.5
+	/// For each structure, the amount of armor that should be given against all armor types that isn't the projectile's armor type that the owner was hit with.
+	var/other_armor_per_structure = -7.5
+	/// The attached armor that been given, if any.
+	var/datum/armor/attached_armor
+	/// How long should the armor be given?
+	var/timer_length = 10 SECONDS
+	/// Timer ID for a proc that revokes the armor given when it times out.
+	var/timer_id
+
+/datum/mutation_upgrade/shell/adaptive_armor/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "When you are hit by a non-friendly projectile, you gain [get_defended_armor(new_amount)] armor against that particular projectile's armor type and lose [-get_other_armor(new_amount)] in all other types. This lasts only for [timer_length / 10] seconds until it reselects."
+
+/datum/mutation_upgrade/shell/adaptive_armor/on_mutation_enabled()
+	RegisterSignal(xenomorph_owner, COMSIG_XENO_PROJECTILE_HIT, PROC_REF(pre_projectile_hit))
+	return ..()
+
+/datum/mutation_upgrade/shell/adaptive_armor/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_XENO_PROJECTILE_HIT))
+	return ..()
+
+/// Revokes the attached armor and clears the outline that was given.
+/datum/mutation_upgrade/shell/adaptive_armor/proc/remove_armor()
+	if(timer_id)
+		deltimer(timer_id)
+		timer_id = null
+	if(attached_armor)
+		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.detachArmor(attached_armor)
+		attached_armor = null
+	xenomorph_owner.remove_filter("mutation_adaptive_armor")
+
+/// When hit by a non-friendly projectile but before any of its effects, give the armor if they don't have it.
+/datum/mutation_upgrade/shell/adaptive_armor/proc/pre_projectile_hit(datum/source, atom/movable/projectile/proj, cardinal_move, uncrossing)
+	SIGNAL_HANDLER
+	if(attached_armor || xenomorph_owner.issamexenohive(proj.firer))
+		return
+	var/total_structures = get_total_structures()
+	var/other_amount = get_other_armor(total_structures)
+	attached_armor = getArmor(arglist(list("[proj.ammo.armor_type]" = get_defended_armor(total_structures) - other_amount)))
+	attached_armor = attached_armor.modifyAllRatings(other_amount)
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(attached_armor)
+	var/outline_color = COLOR_BLACK // For if there is an armor type that isn't catched.
+	switch(proj.ammo.armor_type)
+		if(MELEE)
+			outline_color = COLOR_BLUE_GRAY
+		if(BULLET)
+			outline_color = COLOR_BLUE
+		if(LASER)
+			outline_color = COLOR_CYAN
+		if(ENERGY)
+			outline_color = COLOR_DARK_CYAN
+		if(BOMB)
+			outline_color = COLOR_YELLOW
+		if(BIO)
+			outline_color = COLOR_GREEN
+		if(ACID)
+			outline_color = COLOR_VERY_DARK_LIME_GREEN
+		if(FIRE)
+			outline_color = COLOR_BEIGE
+	xenomorph_owner.add_filter("mutation_adaptive_armor", 2, outline_filter(2, outline_color))
+	timer_id = addtimer(CALLBACK(src, PROC_REF(remove_armor)), timer_length, TIMER_STOPPABLE|TIMER_UNIQUE)
+
+/// Returns the amount of armor that should be given against the projectile's armor type that the owner was hit with.
+/datum/mutation_upgrade/shell/adaptive_armor/proc/get_defended_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? defended_armor_initial : 0) + (defended_armor_per_structure * structure_count)
+
+/// Returns the amount of armor that should be given against all armor types that isn't the projectile's armor type that the owner was hit with.
+/datum/mutation_upgrade/shell/adaptive_armor/proc/get_other_armor(structure_count, include_initial = TRUE)
+	return (include_initial ? other_armor_initial : 0) + (other_armor_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/circular_acid
+	name = "Circular Acid"
+	desc = "Acid Spray now creates acid underneath you and in a circle around you in a radius of 2/3/4 tiles. "
+	/// For the first structure, the amount to set Spray Acid Circle's range to.
+	var/range_initial = 1
+	/// For each structure, the amount to set Spray Acid Circle's range to.
+	var/range_per_structure = 1
+
+/datum/mutation_upgrade/spur/circular_acid/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Acid Spray now creates acid underneath you and in a circle around you in a radius of [get_range(new_amount)] tiles."
+
+/datum/mutation_upgrade/spur/circular_acid/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/spray_acid/cone/cone_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone]
+	if(cone_ability)
+		cone_ability.remove_action(xenomorph_owner)
+	var/datum/action/ability/activable/xeno/spray_acid/cone/circle/circle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone/circle]
+	if(!circle_ability)
+		circle_ability = new()
+		circle_ability.give_action(xenomorph_owner) // Range will be set during structure update.
+	return ..()
+
+/datum/mutation_upgrade/spur/circular_acid/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/spray_acid/cone/circle/circle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone/circle]
+	if(circle_ability)
+		circle_ability.remove_action(xenomorph_owner)
+	var/datum/action/ability/activable/xeno/spray_acid/cone/cone_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone]
+	if(!cone_ability)
+		cone_ability = new()
+		cone_ability.give_action(xenomorph_owner)
+	return ..()
+
+/datum/mutation_upgrade/spur/circular_acid/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/spray_acid/cone/circle/circle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone/circle]
+	if(!circle_ability)
+		return
+	// Given that this ability is exclusively from mutations, we can just set the range and not have to worry about anything else messing with it.
+	circle_ability.range = 1 + get_range(new_amount) // 1 (turf underneath) + range (turfs from center).
+
+/datum/mutation_upgrade/spur/circular_acid/on_xenomorph_upgrade()
+	var/datum/action/ability/activable/xeno/spray_acid/cone/cone_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/spray_acid/cone]
+	if(cone_ability)
+		cone_ability.remove_action(xenomorph_owner)
+
+/// Returns the amount to set Spray Acid Circle's range to.
+/datum/mutation_upgrade/spur/circular_acid/proc/get_range(structure_count, include_initial = TRUE)
+	return  range_initial + (range_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/wide_pheromones
+	name = "Wide Pheromones"
+	desc = "Your pheromone strength is decreased by 0.5, but its range is increased by 3/6/9 tiles."
+	/// For the first structure, the amount to add to the strength of all pheromones emitting abilities.
+	var/strength_initial = -0.5
+	/// For each structure, the amount to add to the range of all pheromones emitting abilities.
+	var/range_per_structure = 3
+
+/datum/mutation_upgrade/veil/wide_pheromones/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Your pheromone strength is decreased by [-strength_initial], but its range is increased by [get_range(new_amount)] tiles."
+
+/datum/mutation_upgrade/veil/wide_pheromones/on_mutation_enabled()
+	add_strength_and_range(strength_initial)
+	return ..()
+
+/datum/mutation_upgrade/veil/wide_pheromones/on_mutation_disabled()
+	add_strength_and_range(-strength_initial)
+	return ..()
+
+/datum/mutation_upgrade/veil/wide_pheromones/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	add_strength_and_range(0, get_range(new_amount - previous_amount))
+	if(!xenomorph_owner.current_aura)
+		return
+	var/pheromone_type = xenomorph_owner.current_aura.aura_types[1]
+	QDEL_NULL(xenomorph_owner.current_aura)
+	switch(pheromone_type)
+		if(AURA_XENO_RECOVERY)
+			var/datum/action/ability/xeno_action/pheromones/emit_recovery/recovery_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_recovery]
+			if(recovery_pheromones)
+				recovery_pheromones.apply_pheros(AURA_XENO_RECOVERY)
+		if(AURA_XENO_WARDING)
+			var/datum/action/ability/xeno_action/pheromones/emit_warding/warding_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_warding]
+			if(warding_pheromones)
+				warding_pheromones.apply_pheros(AURA_XENO_WARDING)
+		if(AURA_XENO_FRENZY)
+			var/datum/action/ability/xeno_action/pheromones/emit_frenzy/frenzy_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_frenzy]
+			if(frenzy_pheromones)
+				frenzy_pheromones.apply_pheros(AURA_XENO_FRENZY)
+
+/// Adds strength and/or range to all pheromone abilities by a chosen amount.
+/datum/mutation_upgrade/veil/wide_pheromones/proc/add_strength_and_range(strength = 0, range = 0)
+	var/datum/action/ability/xeno_action/pheromones/emit_recovery/recovery_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_recovery]
+	if(recovery_pheromones)
+		recovery_pheromones.bonus_flat_strength += strength
+		recovery_pheromones.bonus_flat_range += range
+	var/datum/action/ability/xeno_action/pheromones/emit_warding/warding_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_warding]
+	if(warding_pheromones)
+		warding_pheromones.bonus_flat_strength += strength
+		warding_pheromones.bonus_flat_range += range
+	var/datum/action/ability/xeno_action/pheromones/emit_frenzy/frenzy_pheromones = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/pheromones/emit_frenzy]
+	if(frenzy_pheromones)
+		frenzy_pheromones.bonus_flat_strength += strength
+		frenzy_pheromones.bonus_flat_range += range
+
+/// Returns the amount to add to the range of all pheromones emitting abilities.
+/datum/mutation_upgrade/veil/wide_pheromones/proc/get_range(structure_count)
+	return range_per_structure * structure_count

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -229,7 +229,7 @@
 		if(!silent)
 			owner.balloon_alert(owner, "Dead")
 		return FALSE
-	if(get_dist_euclidean_square(living_target, owner) > starting_lunge_distance * 5)
+	if(get_dist_euclidean(living_target, owner) > starting_lunge_distance)
 		if(!silent)
 			owner.balloon_alert(owner, "Too far")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -109,8 +109,6 @@
 	var/list/spit_types
 
 	// *** Acid spray *** //
-	///Number of tiles of the acid spray cone extends outward to. Not recommended to go beyond 4.
-	var/acid_spray_range = 0
 	///How long the acid spray stays on floor before it deletes itself, should be higher than 0 to avoid runtimes with timers.
 	var/acid_spray_duration = 1
 	///The damage acid spray causes on hit.

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2021,6 +2021,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\nymph\nymph.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\praetorian\abilities_praetorian.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\praetorian\castedatum_praetorian.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\praetorian\mutations_praetorian.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\praetorian\praetorian.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppet\abilities_puppet.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppet\castedatum_puppet.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a total of 3 mutations all for Praetorian.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Adaptive Armor | When you are hit by a non-friendly projectile, you gain 10/15/20 armor against that particular projectile's armor type and lose 15/22.5/30 in all other types. A colored outline appears around you for 10 seconds during the duration. |
| Spur | Circular Acid | Acid Spray now creates acid underneath you and in a circle around you in a radius of 2/3/4 tiles. |
| Veil | Wide Pheromones | Your pheromone strength is decreased by 0.5, but its range is increased by 3/6/9 tiles. |

Warrior's distance calculation for the check now uses `get_dist_euclidean` vs. lunge distance instead of `get_dist_euclidean_square` vs. lunge distance * 5; this means that extra lunge distance beyond 5 work properly.

Fixes an bug with #18104 where the loop didn't check if the throw was stopped from a variable inside of the loop; this means that throws from a particular angle now correctly stop when they're suppose to instead of continuing until the end.

## Why It's Good For The Game
More mutations and some bugfixes.

## Changelog
:cl:
add: Praetorian now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
balance: rebalanced something
fix: The distance calculation for Warrior's lunge has been changed to allow lunges beyond 5 tiles to be work.
fix: Throws made at an angle now correctly stop when they're suppose to rather than continuing until the end.
/:cl:
