### PR TITLE
SOM Campaign Teleporter QOL/Buff

### DIFF
--- a/code/datums/gamemodes/campaign/rewards/teleporter.dm
+++ b/code/datums/gamemodes/campaign/rewards/teleporter.dm
@@ -37,6 +37,7 @@
 
 /datum/campaign_asset/teleporter_enabled/activated_effect()
 	linked_teleporter.enable_teleporter()
+	linked_teleporter.charges += 1
 	to_chat(faction.faction_leader, span_warning("Teleporter Array powered up. Link to Bluespace drive confirmed. Ready for teleportation."))
 
 //adds more charges

--- a/code/game/objects/structures/teleporter_array.dm
+++ b/code/game/objects/structures/teleporter_array.dm
@@ -1,6 +1,6 @@
 /obj/structure/teleporter_array
-	name = "TELEPORTER"
-	desc = "PLACEHOLDER."
+	name = "Teleporter Array"
+	desc = "A large scale teleporter array, capable of transporting an entire squad directly to the battlefield."
 	icon = 'icons/obj/structures/teleporter.dmi'
 	icon_state = "teleporter"
 	obj_flags = NONE
@@ -11,7 +11,7 @@
 	///Current state of teleporter
 	var/teleporter_status = TELEPORTER_ARRAY_READY
 	///How many times this can be used
-	var/charges = 3
+	var/charges = 2
 	///The target turf for teleportation
 	var/turf/target_turf
 	///The Z-level that the teleporter can teleport to
@@ -52,6 +52,13 @@
 	for(var/datum/action/innate/action AS in interaction_actions)
 		action.give_action(controller)
 
+///Provides number of charges remaining to the examine message.
+/obj/structure/teleporter_array/examine()
+	. = ..()
+	if(controller)
+		. += "The teleporter is currently being aimed by [controller]."
+	. += "The teleporter array has [charges] charges remaining."
+
 ///Enables the teleporter for us
 /obj/structure/teleporter_array/proc/enable_teleporter(forced = FALSE)
 	if(!forced && (teleporter_status == TELEPORTER_ARRAY_INOPERABLE))
@@ -86,8 +93,11 @@
 	if(teleporter_status == TELEPORTER_ARRAY_IN_USE)
 		to_chat(controller, span_warning("The Teleporter Array is already running!"))
 		return
-	if(!charges || teleporter_status == TELEPORTER_ARRAY_INACTIVE)
+	if(teleporter_status == TELEPORTER_ARRAY_INACTIVE)
 		to_chat(controller, span_warning("The Teleporter Array is not currently available for our use."))
+		return
+	if(!charges)
+		to_chat(controller, span_warning("The Teleporter Array has no charges remaining. Buy and activate more using attrition."))
 		return
 	if(!target_turf)
 		to_chat(controller, span_warning("The Teleporter Array Has no destination set."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
SOM Teleporter now:
- Starts with one less charge but gets one charge every time you use the activate asset.
- Tells you who is aiming it when examined
- Tells you how many charges are left when examined
- Has different messages for being not activated or not having charges left.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moving a charge to the activation ability is a slight buff but mainly removes the potential feels bad moment of spending the asset to activate it but not having charges. Is this a skill issue? Definitely. Is it still annoying as hell? Yes.

The better examine message fixes two of the other difficulties of the teleporter, not knowing how many charges are left and not knowing who is afk with the aim menu open.
Splitting up the not activated and no charges message also helps reduce confusion when trying to use the teleporter.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Campaign teleporter now starts with one less charge but gains one each time the activation asset is used.
qol: Campaign teleporter now provides better information when examined.
/:cl:
