### PR TITLE
Mutations: Ravager

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -326,7 +326,7 @@
 /datum/action/ability/xeno_action/endure/proc/damage_taken(mob/living/carbon/xenomorph/xeno_owner, damage_taken)
 	SIGNAL_HANDLER
 	if(xeno_owner.health < 0)
-		to_chat(xeno_owner, "<span class='xenouserdanger' style='color: red;'>We are critically wounded! We can only withstand [-(endure_threshold - xeno_owner.health)] more damage before we perish!</span>")
+		to_chat(xeno_owner, "<span class='xenouserdanger' style='color: red;'>We are critically wounded! We can only withstand [-(endure_threshold + bonus_endure_threshold - xeno_owner.health)] more damage before we perish!</span>")
 		xeno_owner.overlay_fullscreen("endure", /atom/movable/screen/fullscreen/animated/bloodlust)
 	else
 		xeno_owner.clear_fullscreen("endure", 0.7 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -406,7 +406,7 @@
 		var/datum/action/ability/xeno_action/charge = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/charge]
 		var/datum/action/ability/xeno_action/ravage = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/ravage]
 		var/datum/action/ability/xeno_action/endure/endure_ability = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
-		if(endure_ability && !bonus_endure_threshold)
+		if(endure_ability && !endure_ability.bonus_endure_threshold)
 			endure_ability.bonus_endure_threshold = RAVAGER_ENDURE_HP_LIMIT * rage_power
 		if(charge)
 			charge.clear_cooldown() //Reset charge cooldown

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -115,6 +115,8 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RAVAGE,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_RAVAGE_SELECT,
 	)
+	/// The amount of armor penetration that all slash attacks caused by Ravage to have.
+	var/armor_penetration
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
 
@@ -152,6 +154,8 @@
 						atoms_to_ravage += get_step(furthest, turn(owner.dir, 90)).contents
 						atoms_to_ravage += get_step(furthest, turn(owner.dir, -90)).contents
 
+	if(armor_penetration) // Since everything references the caste for armor peneration, this is how to individually give armor peneration without causing everything.
+		RegisterSignal(xeno_owner, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(on_attack_living))
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
 		if(ishitbox(ravaged) || isvehicle(ravaged))
 			ravaged.attack_alien(xeno_owner, xeno_owner.xeno_caste.melee_damage) //Handles APC/Tank stuff. Has to be before the !ishuman check or else ravage does work properly on vehicles.
@@ -159,7 +163,7 @@
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE) || !adjacent_relative.Adjacent(ravaged))
 			continue
 		if(!ishuman(ravaged))
-			ravaged.attack_alien(xeno_owner, xeno_owner.xeno_caste.melee_damage)
+			ravaged.attack_alien(xeno_owner, xeno_owner.xeno_caste.melee_damage, armor_penetration = armor_penetration)
 			ravaged.knockback(xeno_owner, RAV_RAVAGE_THROW_RANGE, RAV_CHARGESPEED)
 			continue
 		var/mob/living/carbon/human/human_victim = ravaged
@@ -169,9 +173,16 @@
 		human_victim.knockback(xeno_owner, RAV_RAVAGE_THROW_RANGE, RAV_CHARGESPEED)
 		shake_camera(human_victim, 2, 1)
 		human_victim.Paralyze(1 SECONDS)
+	if(armor_penetration)
+		UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_ATTACK_LIVING)
 
 	succeed_activate()
 	add_cooldown()
+
+/// Adds armor penetration to attacked living beings.
+/datum/action/ability/activable/xeno/ravage/proc/on_attack_living(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
+	SIGNAL_HANDLER
+	armor_mod += armor_penetration
 
 /// Handles the activation and deactivation of particles, as well as their appearance.
 /datum/action/ability/activable/xeno/ravage/proc/activate_particles(direction) // This could've been an animate()!
@@ -233,12 +244,12 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ENDURE,
 	)
-	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_SOLIDOBJECT //Can use this while staggered
-	///How low the Ravager's health can go while under the effects of Endure before it dies
+	use_state_flags = ABILITY_USE_STAGGERED|ABILITY_USE_SOLIDOBJECT // Can use this while staggered.
+	/// How low the Ravager's health can go while under the effects of Endure before it dies? This is the amount that `get_crit_threshold()` and `get_death_threshold()` will return while the ability is active.
 	var/endure_threshold = RAVAGER_ENDURE_HP_LIMIT
-	///Timer for Endure's duration
+	/// Timer for Endure's duration.
 	var/endure_duration
-	///Timer for Endure's warning
+	/// Timer for Endure's warning.
 	var/endure_warning_duration
 
 /datum/action/ability/xeno_action/endure/on_cooldown_finish()
@@ -291,28 +302,29 @@
 	xeno_owner.endure = FALSE
 	xeno_owner.clear_fullscreen("endure", 0.7 SECONDS)
 	xeno_owner.remove_filter("ravager_endure_outline")
-	if(xeno_owner.health < xeno_owner.get_crit_threshold()) //If we have less health than our death threshold, but more than our Endure death threshold, set our HP to just a hair above insta dying
-		var/total_damage = xeno_owner.getFireLoss() + xeno_owner.getBruteLoss()
-		var/burn_percentile_damage = xeno_owner.getFireLoss() / total_damage
-		var/brute_percentile_damage = xeno_owner.getBruteLoss() / total_damage
-		xeno_owner.setBruteLoss((xeno_owner.xeno_caste.max_health - xeno_owner.get_crit_threshold()-1) * brute_percentile_damage)
-		xeno_owner.setFireLoss((xeno_owner.xeno_caste.max_health - xeno_owner.get_crit_threshold()-1) * burn_percentile_damage)
 
-	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyRating(bomb = -20) //Remove resistances/immunities
+	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyRating(bomb = -20) //Remove resistances  immunities.
 	REMOVE_TRAIT(xeno_owner, TRAIT_STAGGERIMMUNE, ENDURE_TRAIT)
 	REMOVE_TRAIT(xeno_owner, TRAIT_SLOWDOWNIMMUNE, ENDURE_TRAIT)
-	endure_threshold = initial(endure_threshold) //Reset the endure vars to their initial states
+	endure_threshold = initial(endure_threshold) // Reset the endure vars to their initial states.
 	endure_duration = initial(endure_duration)
 	endure_warning_duration = initial(endure_warning_duration)
 
-	to_chat(owner,span_userdanger("The last of the plasma drains from our body... We can no longer endure beyond our normal limits!"))
-	owner.playsound_local(owner, 'sound/voice/hiss4.ogg', 50, 0, 1)
+	xeno_owner.playsound_local(owner, 'sound/voice/hiss4.ogg', 50, 0, 1)
+	if(xeno_owner.health >= xeno_owner.get_crit_threshold())
+		return
+	var/total_damage = xeno_owner.getFireLoss() + xeno_owner.getBruteLoss()
+	var/burn_percentile_damage = xeno_owner.getFireLoss() / total_damage
+	var/brute_percentile_damage = xeno_owner.getBruteLoss() / total_damage
+	xeno_owner.setBruteLoss((xeno_owner.xeno_caste.max_health - xeno_owner.get_crit_threshold() - 1) * brute_percentile_damage)
+	xeno_owner.setFireLoss((xeno_owner.xeno_caste.max_health - xeno_owner.get_crit_threshold() - 1) * burn_percentile_damage)
+	to_chat(xeno_owner, span_userdanger("The last of the plasma drains from our body... We can no longer endure beyond our normal limits!"))
 
 ///Warns us when our health is critically low and tells us exactly how much more punishment we can take
 /datum/action/ability/xeno_action/endure/proc/damage_taken(mob/living/carbon/xenomorph/xeno_owner, damage_taken)
 	SIGNAL_HANDLER
 	if(xeno_owner.health < 0)
-		to_chat(xeno_owner, "<span class='xenouserdanger' style='color: red;'>We are critically wounded! We can only withstand [(RAVAGER_ENDURE_HP_LIMIT-xeno_owner.health) * -1] more damage before we perish!</span>")
+		to_chat(xeno_owner, "<span class='xenouserdanger' style='color: red;'>We are critically wounded! We can only withstand [-(endure_threshold - xeno_owner.health)] more damage before we perish!</span>")
 		xeno_owner.overlay_fullscreen("endure", /atom/movable/screen/fullscreen/animated/bloodlust)
 	else
 		xeno_owner.clear_fullscreen("endure", 0.7 SECONDS)
@@ -392,10 +404,8 @@
 		var/datum/action/ability/xeno_action/charge = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/charge]
 		var/datum/action/ability/xeno_action/ravage = xeno_owner.actions_by_path[/datum/action/ability/activable/xeno/ravage]
 		var/datum/action/ability/xeno_action/endure/endure_ability = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
-
-		if(endure_ability.endure_duration) //Check if Endure is active
-			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -150
-
+		if(endure_ability)
+			endure_ability.endure_threshold += RAVAGER_ENDURE_HP_LIMIT * rage_power
 		if(charge)
 			charge.clear_cooldown() //Reset charge cooldown
 		if(ravage)
@@ -499,11 +509,14 @@
 	xeno_owner.remove_movespeed_modifier(MOVESPEED_ID_RAVAGER_RAGE) //Reset speed
 	xeno_owner.adjust_sunder(rage_sunder) //Remove the temporary Sunder restoration
 	xeno_owner.use_plasma(rage_plasma) //Remove the temporary Plasma
+	if(rage_power >= RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) // If we're super pissed, it's time to get crazy.
+		endure_ability.endure_threshold -= RAVAGER_ENDURE_HP_LIMIT * rage_power
 
 	REMOVE_TRAIT(xeno_owner, TRAIT_STUNIMMUNE, RAGE_TRAIT)
 	REMOVE_TRAIT(xeno_owner, TRAIT_SLOWDOWNIMMUNE, RAGE_TRAIT)
 	REMOVE_TRAIT(xeno_owner, TRAIT_STAGGERIMMUNE, RAGE_TRAIT)
 	UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_ATTACK_LIVING)
+
 
 	rage_sunder = 0
 	rage_power = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -56,6 +56,12 @@
 	///multiplier on plasma amount vs damage that is recieved on being attacked
 	var/plasma_damage_recieved_mult = 0.5
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/little_more,
+		/datum/mutation_upgrade/spur/deep_slash,
+		/datum/mutation_upgrade/veil/recurring_rage
+	)
+
 /datum/xeno_caste/ravager/on_caste_applied(mob/xenomorph)
 	. = ..()
 	xenomorph.AddElement(/datum/element/plasma_on_attack, plasma_damage_dealt_mult)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
@@ -1,0 +1,134 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/little_more
+	name = "Little More"
+	desc = "Endure further decreases your critical and death threshold by 20/35/50, further allowing your health to  "
+	/// For the first structure, the amount to increase the death/critical threshold given by Endure while it is active.
+	var/threshold_initial = -5
+	/// For each structure, the amount to increase the death/critical threshold given by Endure while it is active.
+	var/threshold_per_structure = -15
+
+/datum/mutation_upgrade/shell/little_more/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Endure's critical and death threshold is increased by [get_threshold(new_amount)]."
+
+/datum/mutation_upgrade/shell/little_more/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold += get_threshold(0)
+
+/datum/mutation_upgrade/shell/little_more/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold -= get_threshold(0)
+
+/datum/mutation_upgrade/shell/little_more/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold += get_threshold(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to increase the death/critical threshold given by Endure while it is active.
+/datum/mutation_upgrade/shell/little_more/proc/get_threshold(structure_count, include_initial = TRUE)
+	return (include_initial ? threshold_initial : 0) + (threshold_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/deep_slash
+	name = "Deep Slash"
+	desc = "Ravage's armor penetration is increased by 10/15/20."
+	/// For the first structure, the amount of armor penetration that all slash attacks caused by Ravage to have.
+	var/ap_initial = 5
+	/// For each structure, the amount of armor penetration that all slash attacks caused by Ravage to have.
+	var/ap_per_structure = 5
+
+/datum/mutation_upgrade/spur/deep_slash/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Ravage's armor penetration is increased by [get_ap(new_amount)]."
+
+/datum/mutation_upgrade/spur/deep_slash/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/ravage/ravage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/ravage]
+	if(!ravage_ability)
+		return
+	ravage_ability.armor_penetration += get_ap(0)
+
+/datum/mutation_upgrade/spur/deep_slash/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/ravage/ravage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/ravage]
+	if(!ravage_ability)
+		return
+	ravage_ability.armor_penetration -= get_ap(0)
+
+/datum/mutation_upgrade/spur/deep_slash/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/ravage/ravage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/ravage]
+	if(!ravage_ability)
+		return
+	ravage_ability.armor_penetration += get_ap(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of armor penetration that all slash attacks during Ravage will have.
+/datum/mutation_upgrade/spur/deep_slash/proc/get_ap(structure_count, include_initial = TRUE)
+	return (include_initial ? ap_initial : 0) + (ap_per_structure * structure_count)
+
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/recurring_rage
+	name = "Recurring Rage"
+	desc = "Rage will automatically attempt to activate when your health reaches the minimum required threshold. Rage's cooldown is 90/80/70% of its original cooldown."
+	/// For each structure, the multiplier of Rage's initial cooldown to add to the ability.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/recurring_rage/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Rage will automatically attempt to activate when your health reaches the minimum required threshold. Rage's cooldown is [PERCENT(1 + get_multiplier(new_amount))]% of its original cooldown."
+
+/datum/mutation_upgrade/veil/recurring_rage/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/rage/rage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/rage]
+	if(!rage_ability)
+		return
+	RegisterSignal(xenomorph_owner, list(COMSIG_LIVING_UPDATE_HEALTH), PROC_REF(on_update_health))
+
+/datum/mutation_upgrade/veil/recurring_rage/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/rage/rage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/rage]
+	if(!rage_ability)
+		return
+	UnregisterSignal(xenomorph_owner, COMSIG_LIVING_UPDATE_HEALTH)
+
+/datum/mutation_upgrade/veil/recurring_rage/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/rage/rage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/rage]
+	if(!rage_ability)
+		return
+	rage_ability.cooldown_duration += initial(rage_ability.cooldown_duration) * get_multiplier(new_amount - previous_amount)
+
+/// Returns the multiplier of Rage's initial cooldown to add to the ability.
+/datum/mutation_upgrade/veil/recurring_rage/proc/get_multiplier(structure_count)
+	return multiplier_per_structure * structure_count
+
+/// Checks if Rage can be activated. If so, activate it.
+/datum/mutation_upgrade/veil/recurring_rage/proc/on_update_health()
+	SIGNAL_HANDLER
+	var/health = (xenomorph_owner.status_flags & GODMODE) ? xenomorph_owner.maxHealth : (xenomorph_owner.maxHealth - xenomorph_owner.getFireLoss() - xenomorph_owner.getBruteLoss())
+	if(health <= xenomorph_owner.get_death_threshold())
+		return
+	var/datum/action/ability/xeno_action/rage/rage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/rage]
+	if(!rage_ability)
+		return
+	if(!rage_ability.action_cooldown_finished() || !rage_ability.can_use_action(silent = TRUE))
+		return
+	rage_ability.action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
@@ -3,7 +3,7 @@
 //*********************//
 /datum/mutation_upgrade/shell/little_more
 	name = "Little More"
-	desc = "Endure further decreases your critical and death threshold by 20/35/50, further allowing your health to  "
+	desc = "Endure further decreases your critical and death threshold by 20/35/50."
 	/// For the first structure, the amount to increase the death/critical threshold given by Endure while it is active.
 	var/threshold_initial = -5
 	/// For each structure, the amount to increase the death/critical threshold given by Endure while it is active.

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -18,13 +18,13 @@
 	if(!endure)
 		return
 	var/datum/action/ability/xeno_action/endure/endure_ability = actions_by_path[/datum/action/ability/xeno_action/endure]
-	return endure_ability.endure_threshold
+	return endure_ability.endure_threshold + endure_ability.bonus_endure_threshold
 
 /mob/living/carbon/xenomorph/get_death_threshold()
 	if(!endure)
 		return xeno_caste.crit_health
 	var/datum/action/ability/xeno_action/endure/endure_ability = actions_by_path[/datum/action/ability/xeno_action/endure]
-	return endure_ability.endure_threshold
+	return endure_ability.endure_threshold + endure_ability.bonus_endure_threshold
 
 ///Helper proc for giving the rally abilities
 /mob/living/carbon/xenomorph/proc/give_rally_abilities()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2037,6 +2037,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\queen\queen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\abilities_ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\castedatum_ravager.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\ravager\mutations_ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\abilities_runner.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\castedatum_runner.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a total of 3 mutations all for Ravager.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Little More | Endure further decreases your critical and death threshold by 20/35/50. |
| Spur | Deep Slash | Ravage's armor penetration is increased by 10/15/20. |
| Veil | Recurring Rage | Rage will automatically attempt to activate when your health reaches the minimum required threshold. Rage's cooldown is 90/80/70% of its original cooldown. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Ravager now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
