### PR TITLE
Campaign repair stat fix

### DIFF
--- a/code/datums/personal_statistics.dm
+++ b/code/datums/personal_statistics.dm
@@ -364,7 +364,7 @@ GLOBAL_LIST_EMPTY(personal_statistics_list)
 	credit_bonus += mission_traps_created * 4
 	credit_bonus += mission_grenades_primed * 2
 	credit_bonus += mission_heals * 1
-	credit_bonus += integrity_repaired * 0.1
+	credit_bonus += mission_integrity_repaired * 0.1
 
 	return max(floor(credit_bonus), 0)
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -35,7 +35,8 @@
 	if(user?.client)
 		var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[user.ckey]
 		personal_statistics.integrity_repaired += repair_amount
-		personal_statistics.mission_integrity_repaired += repair_amount
+		if(!is_ground_level(user.z)) //Can't trust players
+			personal_statistics.mission_integrity_repaired += repair_amount
 		personal_statistics.times_repaired++
 	obj_integrity += repair_amount
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed the wrong stat being checked for campaign repairs.

Prevents stinky nerd players from farming cash by repairing stuff in spawn instead of actually playing and helping their team.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Encouraging people to be deadweight is bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Campaign: You no longer get rewarded for repairing stuff in spawn
fix: Campaign: Fixed the credit calculation using the wrong repair stat
/:cl:
