### PR TITLE
Add automated loadout vendors in specialist and leader rooms on sulaco

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -17112,7 +17112,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/machinery/vending/uniform_supply,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "kNy" = (
@@ -44339,7 +44339,7 @@ aPg
 aUt
 aPg
 aLf
-uux
+sQd
 xEi
 uux
 aLf
@@ -45888,7 +45888,7 @@ aLf
 kOs
 gXD
 wAF
-htm
+sQd
 aLf
 knr
 xJd
@@ -48193,7 +48193,7 @@ pjA
 fEv
 uwG
 aJy
-rOy
+sQd
 aMp
 xJd
 rOy


### PR DESCRIPTION

## About The Pull Request

Before
<img width="958" height="522" alt="image" src="https://github.com/user-attachments/assets/7a412e04-649f-457f-8657-c26f2cebd0ed" />

After
<img width="956" height="527" alt="image" src="https://github.com/user-attachments/assets/03c2e6ea-61a6-4860-9de1-96d2f02b8ac8" />

Replaces:
Leader room duplicate weapons rack
Medic room duplicate nanomed plus
Engineer room duplicate clothing vendor
Smartgunner room clothing vendor

## Why It's Good For The Game

Leader and specialists have to go outside of the room into the general area to equip a loadout which leads to their shit spreading all over the place, most of the vendors I replaced have duplicates in the room and are less important than the loadout vendor

## Changelog
:cl:
add: Automated loadout vendors in specialist and leader rooms on sulaco
/:cl:
