### PR TITLE
Allows strapping strappable items with unique action

### DIFF
--- a/code/datums/elements/strappable.dm
+++ b/code/datums/elements/strappable.dm
@@ -2,7 +2,7 @@
 	. = ..()
 	if(!isitem(target))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(target, COMSIG_CLICK_ALT, PROC_REF(on_alt_click))
+	RegisterSignals(target, list(COMSIG_CLICK_ALT, COMSIG_ITEM_UNIQUE_ACTION), PROC_REF(toggle_strap))
 	RegisterSignals(target, list(COMSIG_AI_EQUIPPED_GUN, COMSIG_AI_EQUIPPED_MELEE), PROC_REF(ai_try_strap))
 	ADD_TRAIT(target, TRAIT_STRAPPABLE, STRAPPABLE_ITEM_TRAIT)
 
@@ -12,7 +12,7 @@
 	REMOVE_TRAIT(source, TRAIT_STRAPPABLE, STRAPPABLE_ITEM_TRAIT)
 
 ///Toggles strap state
-/datum/element/strappable/proc/on_alt_click(datum/source, mob/user)
+/datum/element/strappable/proc/toggle_strap(datum/source, mob/user)
 	SIGNAL_HANDLER
 	var/obj/item/item_source = source
 	if(!item_source.can_interact(user) \
@@ -43,4 +43,4 @@
 			return
 	else if(unequip)
 		return
-	on_alt_click(source, user)
+	toggle_strap(source, user)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -440,7 +440,7 @@
 
 /obj/item/weapon/twohanded/rocketsledge
 	name = "rocket sledge"
-	desc = "Fitted with a rocket booster at the head, the rocket sledge would deliver a tremendously powerful impact, easily crushing your enemies. Uses fuel to power itself. Press AltClick or Space to tighten your grip. Press AltRightClick to change modes."
+	desc = "Fitted with a rocket booster at the head, the rocket sledge would deliver a tremendously powerful impact, easily crushing your enemies. Uses fuel to power itself. Press AltClick or Unique Action to tighten your grip. Press AltRightClick to change modes."
 	icon_state = "rocketsledge"
 	worn_icon_state = "rocketsledge"
 	force = 30

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -440,7 +440,7 @@
 
 /obj/item/weapon/twohanded/rocketsledge
 	name = "rocket sledge"
-	desc = "Fitted with a rocket booster at the head, the rocket sledge would deliver a tremendously powerful impact, easily crushing your enemies. Uses fuel to power itself. Press AltClick to tighten your grip. Press Spacebar to change modes."
+	desc = "Fitted with a rocket booster at the head, the rocket sledge would deliver a tremendously powerful impact, easily crushing your enemies. Uses fuel to power itself. Press AltClick or Space to tighten your grip. Press AltRightClick to change modes."
 	icon_state = "rocketsledge"
 	worn_icon_state = "rocketsledge"
 	force = 30
@@ -529,7 +529,7 @@
 
 	return ..()
 
-/obj/item/weapon/twohanded/rocketsledge/unique_action(mob/user)
+/obj/item/weapon/twohanded/rocketsledge/AltRightClick(mob/user)
 	. = ..()
 	if(knockback)
 		stun = crush_stun_amount
@@ -789,7 +789,7 @@
 
 /obj/item/weapon/twohanded/chainsaw/sword
 	name = "chainsword"
-	desc = "Cutting heretic and xenos never been easier"
+	desc = "Cutting heretic and xenos never been easier. Wield or AltRightClick to activate."
 	icon_state = "chainsword_off"
 	icon_state_on = "chainsword_on"
 	worn_icon_state = "chainsword"
@@ -802,7 +802,7 @@
 	additional_damage = 60
 
 /// Allow the chainsword variant to be activated without being wielded
-/obj/item/weapon/twohanded/chainsaw/sword/unique_action(mob/user)
+/obj/item/weapon/twohanded/chainsaw/sword/AltRightClick(mob/user)
 	. = ..()
 	if(CHECK_BITFIELD(item_flags, WIELDED))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets you strap items with unique action. Conflicting keybinds (rocket sledge and chainsword) had their existing unique action functionality moved to AltRightClick.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The only items in the games with straps are non-harvester melee weapons and shields, which require the slightly cumbersome alt-click to strap to your hands.
This aims to simplify the inventory management when using such weapons, and speed up how quickly you can draw or holster them.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
add: Strappable items -- mainly non-harvester melees and shields -- can now be strapped using unique action.
code: Conflicting unique action binds on the rocket sledge and chainsword were moved to alt-rightclick.
/:cl:
