### PR TITLE
Fix campaign jungle_outpost having no comms

### DIFF
--- a/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
+++ b/_maps/map_files/Campaign maps/jungle_outpost/jungle_outpost.dmm
@@ -8910,7 +8910,7 @@
 "Py" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/closed/mineral/smooth/indestructible,
-/area/campaign/jungle_outpost/ground/jungle/south_west)
+/area/storage/testroom)
 "Pz" = (
 /obj/structure/platform{
 	dir = 1


### PR DESCRIPTION

## About The Pull Request

Area was always unpowered - it should be the opposite
## Why It's Good For The Game

Fix = good

## Changelog
:cl: Atropos
fix: fixed comms not working on jungle outpost (campaign map)
/:cl:
