### PR TITLE
Campaign razor nerf

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
@@ -280,13 +280,14 @@
 
 /datum/loadout_item/secondary/kit/tgmc_engineer/razorburn
 	name = "Razorburn"
-	desc = "Three razorburn cannisters, able to make huge fields of razorwire quickly. 'Everyone laughs at razorwire, until they're trying to get through it while being shot to pieces.' Unknown"
+	desc = "Three razorburn cannisters, able to make large fields of razorwire quickly. 'Everyone laughs at razorwire, until they're trying to get through it while being shot to pieces.' Unknown"
 	ui_icon = "default"
+	purchase_cost = 15
 
 /datum/loadout_item/secondary/kit/tgmc_engineer/razorburn/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout, datum/outfit_holder/holder)
 	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/razorburn_large, SLOT_IN_BACKPACK)
-	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/razorburn_large, SLOT_IN_BACKPACK)
-	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/razorburn_large, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/razorburn_small, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/explosive/grenade/chem_grenade/razorburn_small, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_BACKPACK)
 
 /datum/loadout_item/secondary/kit/tgmc_engineer/iguana


### PR DESCRIPTION

## About The Pull Request
The razor secondary kit is now 15 credits to purchase, and has 1 cannister, and 2 small nades - instead of 3 cannisters.
## Why It's Good For The Game
Its a bit too spammable and annoying to deal with currently.
## Changelog
:cl:
balance: Campaign: Razorburn secondary kit costs 15 credits, and has 1 large and 2 small nades
/:cl:
