### PR TITLE
Walkover additions

### DIFF
--- a/code/game/objects/structures/campaign_props.dm
+++ b/code/game/objects/structures/campaign_props.dm
@@ -85,6 +85,13 @@
 	icon_state = "empty"
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
 
+/obj/structure/prop/train/empty/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+	)
+	AddElement(/datum/element/connect_loc, connections)
+
 /obj/structure/prop/nt_computer
 	name = "server rack"
 	desc = "A server rack. Who knows what's on it?."

--- a/code/game/objects/structures/campaign_structures/destroy_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/destroy_objectives.dm
@@ -4,8 +4,16 @@
 	name = "GENERIC CAMPAIGN DESTRUCTION OBJECTIVE"
 	soft_armor = list(MELEE = 200, BULLET = 200, LASER = 200, ENERGY = 200, BOMB = 200, BIO = 200, FIRE = 200, ACID = 200) //require c4 normally
 	faction = FACTION_TERRAGOV
+	allow_pass_flags = PASSABLE|PASS_WALKOVER
 	///explosion smoke particle holder
 	var/obj/effect/abstract/particle_holder/explosion_smoke
+
+/obj/structure/campaign_objective/destruction_objective/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+	)
+	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/campaign_objective/destruction_objective/Destroy()
 	QDEL_NULL(explosion_smoke)

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -1216,7 +1216,6 @@
 ///BROKEN VEHICLE PROPS
 /obj/structure/prop/vehicle
 	icon = 'icons/obj/vehicles/64x64.dmi'
-	layer = ABOVE_MOB_LAYER
 	density = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 300
@@ -1390,6 +1389,14 @@
 	bound_height = 128
 	bound_width = 128
 	resistance_flags = RESIST_ALL
+	allow_pass_flags = PASSABLE|PASS_WALKOVER
+
+/obj/structure/prop/vehicle/tank/Initialize(mapload)
+	. = ..()
+	var/static/list/connections = list(
+		COMSIG_OBJ_TRY_ALLOW_THROUGH = PROC_REF(can_climb_over),
+	)
+	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/prop/vehicle/tank/north
 	icon = 'icons/obj/structures/prop/tank_vertical.dmi'


### PR DESCRIPTION

## About The Pull Request
Adds the can_climb_over function to various multi tile objects that needed it.

i.e. if you get blown onto a tank prop, you can actually just walk off now.

Also changed vehicle prop layer back to default, since sidemap makes it unneeded.
## Why It's Good For The Game
Getting stuck is lame.
## Changelog
:cl:
qol: Various multitile objects allow you to walk around on top of them normally, instead of being stuck in place
/:cl:
