### PR TITLE
Mutations: Puppeteer

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -93,6 +93,10 @@
 #define STATUS_EFFECT_SHATTER /datum/status_effect/shatter
 ///recenly hit by a sniper round
 #define STATUS_EFFECT_SNIPED /datum/status_effect/incapacitating/recently_sniped
+// Applies a movement speed multiplier of 0.4 for 6 seconds.
+#define STATUS_EFFECT_DREAD  /datum/status_effect/dread
+/// Deals a variable amount of stamina damage for 6 seconds.
+#define STATUS_EFFECT_DRAINING_DREAD  /datum/status_effect/draining_dread
 
 /////////////
 // NEUTRAL //

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -707,11 +707,11 @@
 	id = "dread"
 	status_type = STATUS_EFFECT_REPLACE
 	tick_interval = 2 SECONDS
+	duration = 6 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/dread
 
-/datum/status_effect/dread/on_creation(mob/living/new_owner, set_duration)
+/datum/status_effect/dread/on_creation(mob/living/new_owner)
 	owner = new_owner
-	duration = set_duration
 	return ..()
 
 /datum/status_effect/dread/tick(delta_time)
@@ -728,6 +728,29 @@
 /datum/status_effect/dread/on_remove()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_XENO_DREAD)
 	return ..()
+
+/atom/movable/screen/alert/status_effect/draining_dread
+	name = "Draining Dread"
+	desc = "A dreadful presence. You take constant stamina damage until this expires."
+	icon_state = "dread"
+
+/datum/status_effect/draining_dread
+	id = "draining_dread"
+	status_type = STATUS_EFFECT_REPLACE
+	duration = 6 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/draining_dread
+	var/stamina_damage = 4
+
+/datum/status_effect/draining_dread/on_creation(mob/living/new_owner, set_stamina_damage)
+	owner = new_owner
+	if(set_stamina_damage)
+		stamina_damage = set_stamina_damage
+	return ..()
+
+/datum/status_effect/draining_dread/tick(delta_time)
+	. = ..()
+	owner.do_jitter_animation(250)
+	owner.adjustStaminaLoss(stamina_damage)
 
 // ***************************************
 // *********** Melting

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -97,13 +97,18 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DREADFULPRESENCE,
 	)
+	/// Should it give a status effect that deals stamina damage instead? If so, how much stamina damage per second?
+	var/stamina_draining
 
 /datum/action/ability/xeno_action/dreadful_presence/action_activate()
 	var/obj/effect/overlay/dread/effect = new
 	owner.vis_contents += effect
 	for(var/mob/living/carbon/human/human in view(DREAD_RANGE, owner.loc))
 		to_chat(human, span_userdanger("An overwhelming sense of dread washes over you... You are temporarily slowed down!"))
-		human.set_timed_status_effect(6 SECONDS, /datum/status_effect/dread)
+		if(stamina_draining)
+			human.apply_status_effect(STATUS_EFFECT_DRAINING_DREAD, stamina_draining)
+		else
+			human.apply_status_effect(STATUS_EFFECT_DREAD)
 		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob/living/carbon/human, emote), "scream"), rand(1,2))
 	addtimer(CALLBACK(src, PROC_REF(clear_effect), effect), 3 SECONDS)
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -45,6 +45,12 @@
 		/datum/action/ability/activable/xeno/puppet_blessings,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/flesh_for_life,
+		/datum/mutation_upgrade/spur/suffocating_presence,
+		/datum/mutation_upgrade/veil/shifting_costs
+	)
+
 /datum/xeno_caste/puppeteer/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
@@ -27,7 +27,7 @@
 	SIGNAL_HANDLER
 	if(xenomorph_owner.stat == DEAD)
 		return
-	var/damage_until_threshold = xenomorph_owner.health - xenomorph_owner.health_threshold_crit
+	var/damage_until_threshold = xenomorph_owner.health - xenomorph_owner.get_crit_threshold()
 	if(damage_until_threshold > amount)
 		return
 	var/plasma_per_damage = get_plasma_per_damage(get_total_structures())
@@ -53,7 +53,7 @@
 /datum/mutation_upgrade/spur/suffocating_presence/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Dreadful Presence will inflict a temporary effect that deals [get_damage(new_amount)] stamina damage every second instead.
+	return "Dreadful Presence will inflict a temporary effect that deals [get_damage(new_amount)] stamina damage every second instead."
 
 /datum/mutation_upgrade/spur/suffocating_presence/on_mutation_enabled()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
@@ -22,10 +22,10 @@
 	UnregisterSignal(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
 	return ..()
 
-/// If they are awake and receive damage that would put them into critical, subtract damage as long they have plasma.
+/// If they receive damage that would put them into critical, subtract damage as long they have plasma.
 /datum/mutation_upgrade/shell/flesh_for_life/proc/on_damage(datum/source, amount, list/amount_mod)
 	SIGNAL_HANDLER
-	if(!xenomorph_owner.stat == DEAD)
+	if(xenomorph_owner.stat == DEAD)
 		return
 	var/damage_until_threshold = xenomorph_owner.health - xenomorph_owner.health_threshold_crit
 	if(damage_until_threshold > amount)

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/mutations_puppeteer.dm
@@ -1,0 +1,132 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/flesh_for_life
+	name = "Flesh For Life"
+	desc = "If damage taken would put you into critical, lose 1.5/1.25/1x amount of plasma instead."
+	/// For the first structure, the amount of plasma to consume for each point of damage.
+	var/plasma_per_damage_initial = 1.75
+	/// For each structure, the amount of plasma to consume for each point of damage.
+	var/plasma_per_damage_per_structure = -0.25
+
+/datum/mutation_upgrade/shell/flesh_for_life/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "If damage taken would put you into critical, lose [get_plasma_per_damage(new_amount)]x amount of plasma instead."
+
+/datum/mutation_upgrade/shell/flesh_for_life/on_mutation_enabled()
+	RegisterSignals(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE), PROC_REF(on_damage))
+	return ..()
+
+/datum/mutation_upgrade/shell/flesh_for_life/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
+	return ..()
+
+/// If they are awake and receive damage that would put them into critical, subtract damage as long they have plasma.
+/datum/mutation_upgrade/shell/flesh_for_life/proc/on_damage(datum/source, amount, list/amount_mod)
+	SIGNAL_HANDLER
+	if(!xenomorph_owner.stat == DEAD)
+		return
+	var/damage_until_threshold = xenomorph_owner.health - xenomorph_owner.health_threshold_crit
+	if(damage_until_threshold > amount)
+		return
+	var/plasma_per_damage = get_plasma_per_damage(get_total_structures())
+	var/damage_reduction = min(amount, xenomorph_owner.plasma_stored / plasma_per_damage)
+	xenomorph_owner.use_plasma(ROUND_UP(damage_reduction * plasma_per_damage))
+	amount_mod += damage_reduction
+
+/// Returns the amount of plasma to consume for each point of damage.
+/datum/mutation_upgrade/shell/flesh_for_life/proc/get_plasma_per_damage(structure_count)
+	return plasma_per_damage_initial + (plasma_per_damage_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/suffocating_presence
+	name = "Suffocating Presence"
+	desc = "Dreadful Presence will inflict a temporary effect that deals 4/6/8 stamina damage every second instead."
+	/// For the first structure, the amount of stamina damage that Dreadful Presence should be doing per second.
+	var/damage_initial = 2
+	/// For each structure, the amount of stamina damage that Dreadful Presence should be doing per second.
+	var/damage_per_structure = 2
+
+/datum/mutation_upgrade/spur/suffocating_presence/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Dreadful Presence will inflict a temporary effect that deals [get_damage(new_amount)] stamina damage every second instead.
+
+/datum/mutation_upgrade/spur/suffocating_presence/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/dreadful_presence/dreadful_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/dreadful_presence]
+	if(!dreadful_ability)
+		return
+	dreadful_ability.stamina_draining += get_damage(0)
+
+/datum/mutation_upgrade/spur/suffocating_presence/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/dreadful_presence/dreadful_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/dreadful_presence]
+	if(!dreadful_ability)
+		return
+	dreadful_ability.stamina_draining -= get_damage(0)
+
+/datum/mutation_upgrade/spur/suffocating_presence/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/dreadful_presence/dreadful_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/dreadful_presence]
+	if(!dreadful_ability)
+		return
+	dreadful_ability.stamina_draining += get_damage(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of stamina damage that Dreadful Presence should be doing per second.
+/datum/mutation_upgrade/spur/suffocating_presence/proc/get_damage(structure_count, include_initial = TRUE)
+	return (include_initial ? damage_initial : 0) + (damage_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/shifting_costs
+	name = "Shifting Costs"
+	desc = "Stitch Puppet's cost is 20% of its original cost. Bestow Blessing costs 40/30/20% more."
+	/// For the first structure, the multiplier to add as Stitch Puppet's initial ability cost to its current cost.
+	var/puppet_multiplier_initial = -0.8
+	/// For the first structure, the multiplier to add as Bestow Blessings' initial ability cost to its current cost.
+	var/blessings_multiplier_initial = 0.5
+	/// For each structure, the multiplier to add as Bestow Blessings' initial ability cost to its current cost.
+	var/blessings_multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/shifting_costs/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Stitch Puppet's cost is [PERCENT(1 + puppet_multiplier_initial)]% of its original cost. Bestow Blessings' cost is [PERCENT(1 + get_blessings_multiplier(new_amount))]% of its original cost."
+
+/datum/mutation_upgrade/veil/shifting_costs/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/puppet/puppet_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/puppet]
+	if(!puppet_ability)
+		return
+	var/datum/action/ability/activable/xeno/puppet_blessings/blessings_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/puppet_blessings]
+	if(!blessings_ability)
+		return
+	puppet_ability.ability_cost += initial(puppet_ability.ability_cost) * puppet_multiplier_initial
+	blessings_ability.ability_cost += initial(blessings_ability.ability_cost) * get_blessings_multiplier(0)
+
+/datum/mutation_upgrade/veil/shifting_costs/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/puppet/puppet_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/puppet]
+	if(!puppet_ability)
+		return
+	var/datum/action/ability/activable/xeno/puppet_blessings/blessings_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/puppet_blessings]
+	if(!blessings_ability)
+		return
+	puppet_ability.ability_cost -= initial(puppet_ability.ability_cost) * puppet_multiplier_initial
+	blessings_ability.ability_cost -= initial(blessings_ability.ability_cost) * get_blessings_multiplier(0)
+
+/datum/mutation_upgrade/veil/shifting_costs/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/puppet_blessings/blessings_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/puppet_blessings]
+	if(!blessings_ability)
+		return
+	blessings_ability.ability_cost += initial(blessings_ability.ability_cost) * get_blessings_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add as Bestow Blessings' initial ability cost to its current cost.
+/datum/mutation_upgrade/veil/shifting_costs/proc/get_blessings_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? blessings_multiplier_initial : 0) + (blessings_multiplier_initial * structure_count)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2030,6 +2030,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppet\puppet.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppeteer\abilities_puppeteer.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppeteer\castedatum_puppeteer.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\puppeteer\mutations_puppeteer.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\puppeteer\puppeteer.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\abilities_pyrogen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\pyrogen\castedatum_pyrogen.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a total of 3 mutations all for Puppeteer.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Flesh For Life | If damage taken would put you into critical, lose 1.5/1.25/1x amount of plasma instead. |
| Spur | Suffocating Presence | Dreadful Presence will inflict a temporary effect that deals 4/6/8 stamina damage every second instead. |
| Veil | Shifting Costs | Stitch Puppet's cost is 20% of its original cost. Bestow Blessing costs 40/30/20% more. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Puppeteer now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
