### PR TITLE
Various Mutation Bugfixes

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -382,6 +382,12 @@
 	opacity = FALSE
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
 
+///Xeno neurotox smoke for defiler seethrough smoke; doesn't extinguish or blind
+/obj/effect/particle_effect/smoke/xeno/neuro/lighter
+	alpha = 60
+	opacity = FALSE
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
+
 /obj/effect/particle_effect/smoke/xeno/toxic
 	lifetime = 2
 	alpha = 60
@@ -394,7 +400,7 @@
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_HEMODILE|SMOKE_GASP|SMOKE_HUGGER_PACIFY
 
 /obj/effect/particle_effect/smoke/xeno/hemodile/light
-	alpha = 120
+	alpha = 60
 	opacity = FALSE
 
 /obj/effect/particle_effect/smoke/xeno/transvitox
@@ -402,7 +408,7 @@
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TRANSVITOX|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
 /obj/effect/particle_effect/smoke/xeno/transvitox/light
-	alpha = 120
+	alpha = 60
 	opacity = FALSE
 
 //Toxic smoke when the Defiler successfully uses Defile
@@ -416,7 +422,7 @@
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_OZELOMELYN|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
 /obj/effect/particle_effect/smoke/xeno/ozelomelyn/light
-	alpha = 120
+	alpha = 60
 	opacity = FALSE
 
 /// Smoke that constantly makes pyrogen fire.
@@ -486,6 +492,9 @@
 
 /datum/effect_system/smoke_spread/xeno/neuro/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light
+
+/datum/effect_system/smoke_spread/xeno/neuro/lighter
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/lighter
 
 /datum/effect_system/smoke_spread/xeno/toxic
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/toxic

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -229,7 +229,7 @@
 				if(opaque)
 					emitted_gas = new /datum/effect_system/smoke_spread/xeno/neuro/medium(xeno_owner)
 				else
-					emitted_gas = new /datum/effect_system/smoke_spread/xeno/neuro/light(xeno_owner)
+					emitted_gas = new /datum/effect_system/smoke_spread/xeno/neuro/lighter(xeno_owner)
 			if(/datum/reagent/toxin/xeno_hemodile)
 				if(opaque)
 					emitted_gas = new /datum/effect_system/smoke_spread/xeno/hemodile(xeno_owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -399,7 +399,7 @@
 	if(HAS_TRAIT(owner, TRAIT_PSY_LINKED) || HAS_TRAIT(target, TRAIT_PSY_LINKED))
 		return fail_activate()
 
-	var/psychic_link_status_effect = xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, xeno_owner.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH, TRUE)
+	psychic_link_status_effect = xeno_owner.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, xeno_owner.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH, TRUE)
 	RegisterSignal(psychic_link_status_effect, COMSIG_XENO_PSYCHIC_LINK_REMOVED, PROC_REF(status_removed))
 	if(!attached_armor)
 		attached_armor = getArmor(armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount, armor_amount)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/mutations_gorger.dm
@@ -23,10 +23,10 @@
 	link_ability.movement_resistance = MOVE_FORCE_OVERPOWERING
 	if(!link_ability.psychic_link_status_effect)
 		return
+	xenomorph_owner.move_resist = link_ability.movement_resistance
 	if(!link_ability.attached_armor)
 		link_ability.attached_armor = getArmor(link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount, link_ability.armor_amount)
 		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.attachArmor(link_ability.attached_armor)
-	xenomorph_owner.move_resist = link_ability.movement_resistance
 
 /datum/mutation_upgrade/shell/unmoving_link/on_mutation_disabled()
 	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
@@ -36,20 +36,22 @@
 	link_ability.movement_resistance = initial(link_ability.movement_resistance)
 	if(!link_ability.psychic_link_status_effect)
 		return
+	xenomorph_owner.move_resist = initial(xenomorph_owner.move_resist)
 	if(link_ability.attached_armor)
 		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.detachArmor(link_ability.attached_armor)
 		link_ability.attached_armor = null
-	xenomorph_owner.move_resist = initial(xenomorph_owner.move_resist)
 
 /datum/mutation_upgrade/shell/unmoving_link/on_structure_update(previous_amount, new_amount)
 	. = ..()
 	var/datum/action/ability/activable/xeno/psychic_link/link_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_link]
 	if(!link_ability)
 		return
-	if(link_ability.attached_armor && previous_amount)
-		var/difference = get_armor(new_amount - previous_amount, FALSE)
-		link_ability.attached_armor = link_ability.attached_armor.modifyAllRatings(difference)
-		xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyAllRatings(difference)
+	var/difference = get_armor(new_amount - previous_amount, FALSE)
+	link_ability.armor_amount += difference
+	if(!link_ability.psychic_link_status_effect || !link_ability.attached_armor)
+		return
+	link_ability.attached_armor = link_ability.attached_armor.modifyAllRatings(difference)
+	xenomorph_owner.soft_armor = xenomorph_owner.soft_armor.modifyAllRatings(difference)
 
 /// Returns the amount of soft armor that Psychic Link should grant while it is active.
 /datum/mutation_upgrade/shell/unmoving_link/proc/get_armor(structure_count, include_initial = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -551,7 +551,7 @@
 	/// Has the ability been used to swap to the current set of illusion yet?
 	var/swap_used = FALSE
 	/// The illusion that will take priority when mirage swapping.
-	var/mob/illusion/prioritized_illusion
+	var/mob/illusion/xeno/prioritized_illusion
 
 /datum/action/ability/xeno_action/mirage/remove_action()
 	illusions = list() // No need to manually delete the illusions as the illusions will delete themselves once their life time expires.

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -88,10 +88,10 @@
 		if(xeno_owner.ammo && gaseous_spray_threshold && current_globs >= gaseous_spray_threshold)
 			var/datum/effect_system/smoke_spread/xeno/smoke
 			switch(xeno_owner.ammo.type)
-				if(/datum/ammo/xeno/boiler_gas/corrosive)
+				if(/datum/ammo/xeno/boiler_gas/corrosive, /datum/ammo/xeno/boiler_gas/corrosive/lance)
 					smoke = new /datum/effect_system/smoke_spread/xeno/acid()
-				if(/datum/ammo/xeno/boiler_gas)
-					smoke = new /obj/effect/particle_effect/smoke/xeno/neuro/light()
+				if(/datum/ammo/xeno/boiler_gas, /datum/ammo/xeno/boiler_gas/lance)
+					smoke = new /datum/effect_system/smoke_spread/xeno/neuro/light()
 			if(smoke)
 				smoke.set_up(0, TF)
 				smoke.start()

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -610,7 +610,7 @@
 	return ..()
 
 /datum/action/ability/activable/xeno/psy_blast/action_activate()
-	if(xeno_owner.selected_ability != src || !length(selectable_ammo_types))
+	if(xeno_owner.selected_ability != src || !length(selectable_ammo_types) || particle_holder)
 		return ..()
 
 	var/found_pos = selectable_ammo_types.Find(xeno_owner.ammo.type)


### PR DESCRIPTION

## About The Pull Request
Warlock can no longer switch their ammo type while Psychic Blast is in the process of firing via right-click.

The alpha of the gas from Defiler's Wide Gas was decreased from 120 to 60.

Unmoving Link, the Gorger mutation, was not giving the correct armor. It has been fixed.

Gaseous Spray, the Boiler mutation, did not account for the ammo types associated with Primordial Boiler. It has been fixed.

The illusion from Fleeting Mirage, the Hunter mutation, now uses the correct typepath to initialize itself with which means the AI behavior is now correctly set.

## Why It's Good For The Game
Bugfixes and balancing of mutations.

## Changelog
:cl:
fix: Warlock can no longer switch their ammo type while Psychic Blast is in the process of firing.
balance: Mutations: The gas from Wide Gas is now significantly easier to see through.
fix: Mutations: Unmoving Link now correctly grants armor.
fix: Mutations: Gaseous Spray now accounts for Primordial Boiler's lance globs.
fix: Mutations: The illusion from Fleeting Mirage now correctly flees instead of standing still.
/:cl:
