### PR TITLE
Mutations: Bloodthirster

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -371,7 +371,7 @@
 	)
 	/// The percentage of the owner's maximum health that the owner's current health must be under to activate the ability.
 	var/minimum_health_rage_threshold = RAVAGER_RAGE_MIN_HEALTH_THRESHOLD
-	/// The percentage of the owner's maximum health to use to further increase / calculate rage power. Higher means more rage power which then means it is both easier to reach super rage.
+	/// The percentage of the owner's maximum health to use to further increase / calculate rage power. Higher means more rage power which then means it is easier to reach super rage.
 	var/rage_power_calculation_bonus = 0
 	/// Determines the power of Rage's many effects. Power scales inversely with the Ravager's HP. Ignoring calculation bonus, this can ranges from [0.25 at 50% health] and [0.5 at 0% health]. 0.5 and above triggers special effects.
 	var/rage_power

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -123,6 +123,12 @@
 	plasma_damage_dealt_mult = 2
 	plasma_damage_recieved_mult = 0.75
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/no_end,
+		/datum/mutation_upgrade/spur/early_rage,
+		/datum/mutation_upgrade/veil/safety_trap
+	)
+
 /datum/xeno_caste/ravager/bloodthirster/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_bloodthirster.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_bloodthirster.dm
@@ -1,0 +1,111 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/no_end
+	name = "No End"
+	desc = "Endure can be used in critical. It now costs 150/125/100% of its original plasma cost."
+	/// For the first structure, the multiplier to add as Endure's initial ability cost to add to it.
+	var/multiplier_initial = 0.75
+	/// For each structure, the multiplier to add as Endure's initial ability cost to add to it.
+	var/multiplier_structure = -0.25
+
+/datum/mutation_upgrade/shell/no_end/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Endure can be used in critical. It now costs [PERCENT(1 + get_multiplier(new_amount))]% of its original plasma cost."
+
+/datum/mutation_upgrade/shell/no_end/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.use_state_flags |= (ABILITY_USE_INCAP|ABILITY_USE_LYING)
+	endure_ability.ability_cost += initial(endure_ability.ability_cost) * get_multiplier(0)
+
+/datum/mutation_upgrade/shell/no_end/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.use_state_flags &= ~(ABILITY_USE_INCAP|ABILITY_USE_LYING)
+	endure_ability.ability_cost -= initial(endure_ability.ability_cost) * get_multiplier(0)
+
+/datum/mutation_upgrade/shell/no_end/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.ability_cost += initial(endure_ability.ability_cost) * get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add as Endure's initial ability cost to add to it.
+/datum/mutation_upgrade/shell/no_end/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/early_rage
+	name = "Early Rage"
+	desc = "Rage can be activated at 55/60/65% maximum health. For the purposes of calculating rage power, your current health is assumed to reduced by 5/10/15% of your maximum health. This cannot go beyond the amount required for Super Rage."
+	/// For each structure, the percentage of maximum health to add to Rage's activation threshold and to its rage power calculation.
+	var/percentage_per_structure = 0.05
+
+/datum/mutation_upgrade/spur/early_rage/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Rage can be activated at [PERCENT(RAVAGER_RAGE_MIN_HEALTH_THRESHOLD + get_percentage(new_amount))]% maximum health. For the purposes of calculating rage power, your current health is assumed to reduced by [PERCENT(get_percentage(new_amount))]% of your maximum health. This cannot go beyond the amount required for Super Rage."
+
+/datum/mutation_upgrade/spur/early_rage/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/rage/rage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/rage]
+	if(!rage_ability)
+		return
+	rage_ability.minimum_health_rage_threshold += get_percentage(new_amount - previous_amount)
+	rage_ability.rage_power_calculation_bonus += get_percentage(new_amount - previous_amount)
+
+/// Returns the percentage of maximum health to add to Rage's activation threshold and to its rage power calculation.
+/datum/mutation_upgrade/spur/early_rage/proc/get_percentage(structure_count)
+	return percentage_per_structure * structure_count
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/safety_trap
+	name = "Safety Trap"
+	desc = "Endure further decreases your critical and death threshold by 50/75/100. If Endure ends while your health is under the default death threshold, you die instead."
+	/// For the first structure, the amount to increase the death/critical threshold given by Endure while it is active.
+	var/threshold_initial = -25
+	/// For each structure, the amount to increase the death/critical threshold given by Endure while it is active.
+	var/threshold_per_structure = -25
+
+/datum/mutation_upgrade/veil/safety_trap/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Endure further decreases your critical and death threshold by [-get_threshold(new_amount)]. If Endure ends while your health is under the default death threshold, you die instead."
+
+/datum/mutation_upgrade/veil/safety_trap/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold += get_threshold(0)
+	endure_ability.death_beyond_threshold = TRUE
+
+/datum/mutation_upgrade/veil/safety_trap/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold -= get_threshold(0)
+	endure_ability.death_beyond_threshold = initial(endure_ability.death_beyond_threshold)
+
+/datum/mutation_upgrade/veil/safety_trap/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/endure/endure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/endure]
+	if(!endure_ability)
+		return
+	endure_ability.endure_threshold += get_threshold(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to increase the death/critical threshold given by Endure while it is active.
+/datum/mutation_upgrade/veil/safety_trap/proc/get_threshold(structure_count, include_initial = TRUE)
+	return (include_initial ? threshold_initial : 0) + (threshold_per_structure * structure_count)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/mutations_ravager.dm
@@ -12,7 +12,7 @@
 /datum/mutation_upgrade/shell/little_more/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Endure's critical and death threshold is increased by [get_threshold(new_amount)]."
+	return "Endure further decreases your critical and death threshold by [-get_threshold(new_amount)]."
 
 /datum/mutation_upgrade/shell/little_more/on_mutation_enabled()
 	. = ..()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2045,6 +2045,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\queen\queen.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\abilities_ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\castedatum_ravager.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\ravager\mutations_bloodthirster.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\mutations_ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\ravager\ravager.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\runner\abilities_runner.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Bloodthirster (Ravager Strain).
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | No End | Endure can be used in critical. It now costs 150/125/100% of its original plasma cost. |
| Spur | Early Rage | Rage can be activated at 55/60/65% maximum health. For the purposes of calculating rage power, your current health is assumed to reduced by 5/10/15% of your maximum health. This cannot go beyond the amount required for Super Rage. |
| Veil | Safety Trap | Endure further decreases your critical and death threshold by 50/75/100. If Endure ends while your health is under the default death threshold, you die instead. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Bloodthirster now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
spellcheck: Mutations: The description for Little More has been changed to be more accurate about what it does.
/:cl:
