### PR TITLE
Adds a mech weapons vendor to valhalla

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -8458,6 +8458,10 @@
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla)
+"lWY" = (
+/obj/machinery/vending/mech_vendor,
+/turf/open/floor/plating,
+/area/centcom/valhalla)
 "lXm" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -21605,7 +21609,7 @@ wJM
 jFD
 ivs
 ivs
-boq
+lWY
 boq
 boq
 boq


### PR DESCRIPTION

## About The Pull Request
Adds an old/campaign mech weapons vendor to valhalla vehicle area
## Why It's Good For The Game
Currently you can summon old/campaign mechs via vehicle spawner in valhalla, but can't actually give them any weapons. This allows for people to actually test campaign mechs
## Changelog
:cl:
add: Added a mech weapons vendor to Valhalla
/:cl:
