### PR TITLE
Campaign Loadout UI fix

### DIFF
--- a/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
+++ b/tgui/packages/tgui/interfaces/IndividualStats/index.tsx
@@ -99,7 +99,7 @@ export const IndividualStats = (props) => {
       width={980}
       height={790}
     >
-      <Window.Content>
+      <Window.Content overflowY="auto">
         {unlockedPerk ? (
           <Modal width="500px">
             <Section


### PR DESCRIPTION
## About The Pull Request
This PR fixes an issue where the campaign loadout menu could have content (such as the primary & secondary weapon slots) cut off when at high screen scaling. The loadout window is now scrollable when available screen space is not sufficient to display the whole window. The scrollbar only appears when necessary to view all content. 
## Why It's Good For The Game
It is good to be able to select equipment without having to change display settings. I looked at making only the relevant sections of the window scrollable, but that suffered from the same issue of cutting off content when resizing the window. 
## Testing Evidence
Equipping items and selecting perks were tested and still function as expected.
<details> <summary>Images</summary>
<img width="1250" height="1002" alt="image" src="https://github.com/user-attachments/assets/e40957b2-8863-4d7f-98f7-bbf7cb146d0d" />
<img width="1479" height="1034" alt="image" src="https://github.com/user-attachments/assets/c2082370-6de4-47b0-8e19-10cbd1dd6fb1" />
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
fix: fixed campaign loadout UI at high screen scaling
/:cl:
