### PR TITLE
Mutations: Shrike

### DIFF
--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -349,7 +349,7 @@ directive is properly returned.
 
 /atom/proc/hitby(atom/movable/AM, speed = 5)
 	if(density)
-		AM.stop_throw()
+		AM.set_throwing(FALSE)
 		return TRUE
 
 ///Psionic interaction with this atom

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -87,7 +87,7 @@
 		throw_damage *= thrown_mob.mob_size * 8
 	take_damage(throw_damage)
 	if(obj_integrity > 0) //we only stop if we don't break the window
-		AM.stop_throw()
+		AM.set_throwing(FALSE)
 		. = TRUE
 	if(thrown_mob)
 		thrown_mob.take_overall_damage(speed * 5, BRUTE, MELEE, !., FALSE, TRUE, 0, 4) //done here for dramatic effect, and to make the damage sharp if we broke the window

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -19,7 +19,7 @@
 	add_debris_element()
 
 /turf/closed/hitby(atom/movable/AM, speed = 5)
-	AM.stop_throw()
+	AM.set_throwing(FALSE)
 	AM.turf_collision(src, speed)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -234,7 +234,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			apply_damage(throw_damage, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
 		if(thrown_mob.mob_size <= mob_size)
 			thrown_mob.apply_damage(speed, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
-		thrown_mob.stop_throw()
+		thrown_mob.set_throwing(FALSE)
 
 	else if(isitem(AM))
 		var/obj/item/thrown_item = AM
@@ -267,7 +267,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		if(thrown_item.thrower != src)
 			throw_damage = check_shields(COMBAT_MELEE_ATTACK, throw_damage, MELEE)
 			if(!throw_damage)
-				thrown_item.stop_throw()
+				thrown_item.set_throwing(FALSE)
 				visible_message(span_danger("[src] deflects \the [thrown_item]!"))
 				if(living_thrower)
 					log_combat(living_thrower, src, "thrown at", thrown_item, "(FAILED: shield blocked)")
@@ -279,7 +279,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			log_combat(living_thrower, src, "thrown at", thrown_item, "(FAILED: target limb missing)")
 			return FALSE
 
-		thrown_item.stop_throw() // Hit the limb.
+		thrown_item.set_throwing(FALSE) // Hit the limb.
 		var/applied_damage = modify_by_armor(throw_damage, MELEE, thrown_item.penetration, zone)
 
 		if(applied_damage <= 0)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
@@ -429,11 +429,7 @@
 /// Ends the target's throw. Taken from Warrior code.
 /datum/action/ability/activable/xeno/conqueror_will/proc/kicked_end(datum/source)
 	SIGNAL_HANDLER
-	UnregisterSignal(source, COMSIG_MOVABLE_POST_THROW)
-	/* So the reason why we do not flat out unregister this is because, when an atom makes impact with something, it calls throw_impact(). Calling it this way causes
-	stop_throw() to be called in most cases, because impacts can cause a bounce effect and ending the throw makes it happen. Given the way we have signals setup, unregistering
-	it at that point would cause thrown_into() to never get called, and that is exactly the reason why the line of code below exists. */
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, UnregisterSignal), source, COMSIG_MOVABLE_IMPACT, COMSIG_MOVABLE_POST_THROW), 0.5)
+	UnregisterSignal(source, list(COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_IMPACT))
 	var/mob/living/living_target = source
 	living_target.Knockdown(CONQUEROR_WILL_COMBO_DEBUFF)
 	if(living_target.pass_flags & PASS_XENO)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -67,7 +67,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_FLING,
 	)
 	target_flags = ABILITY_MOB_TARGET
-	/// How long in deciseconds should humans be stunned i? If they are to be stunned, they will also drop held items.
+	/// How long in deciseconds should humans be stunned? If they are to be stunned, they will also drop held items.
 	var/stun_duration = 2 SECONDS
 	/// Should humans take damage immediately? If so, what is the multiplier of the owner's melee damage for determining how much damage to deal?
 	var/damage_multiplier = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -169,7 +169,6 @@
 	if(collusion_paralyze_duration)
 		living_source.Paralyze(collusion_paralyze_duration)
 	if(isliving(hit_atom) && !living_source.issamexenohive(hit_atom))
-		new /obj/effect/temp_visual/warrior/impact(living_source.loc, get_dir(living_source, xeno_owner))
 		INVOKE_ASYNC(living_source, TYPE_PROC_REF(/mob, emote), "scream")
 		if(damage)
 			living_source.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -152,10 +152,7 @@
 	var/mob/living/living_source = source
 	UnregisterSignal(living_source, COMSIG_MOVABLE_POST_THROW)
 	if(collusion_paralyze_duration || collusion_damage_multiplier)
-		// In most cases: COMSIG_MOVABLE_POST_THROW (on_post_throw) happens first and then COMSIG_MOVABLE_IMPACT (on_throw_impact) happens afterward.
-		// The reason behind this is because some things call `stop_throw` before the impact even happens.
-		// Because of this, we have to unregister it in the next tick. Even if the impact didn't happen (or was on time), we want to unregister it anyways.
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, UnregisterSignal), source, COMSIG_MOVABLE_IMPACT), 1)
+		UnregisterSignal(living_source, COMSIG_MOVABLE_IMPACT)
 		return
 	living_source.remove_pass_flags(PASS_MOB, THROW_TRAIT)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -125,6 +125,8 @@
 		if(stun_duration)
 			victim.Stun(2 SECONDS)
 			victim.drop_all_held_items()
+		if(damage_multiplier)
+			victim.apply_damage(xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * damage_multiplier, BRUTE, blocked = MELEE, updating_health = TRUE)
 		RegisterSignal(victim, COMSIG_MOVABLE_POST_THROW, PROC_REF(on_post_throw))
 		if(collusion_paralyze_duration || collusion_damage_multiplier)
 			RegisterSignal(victim, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
@@ -150,7 +152,8 @@
 	var/mob/living/living_source = source
 	UnregisterSignal(living_source, COMSIG_MOVABLE_POST_THROW)
 	if(collusion_paralyze_duration || collusion_damage_multiplier)
-		UnregisterSignal(living_source, COMSIG_MOVABLE_IMPACT) // Because it is possible we had no impacts.
+		// If we had an impact, we have to unregister it in the next tick as `on_throw_impact` doesn't happen if it was unregistered now.
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, UnregisterSignal), source, COMSIG_MOVABLE_IMPACT), 1)
 		return
 	living_source.remove_pass_flags(PASS_MOB, THROW_TRAIT)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -184,6 +184,7 @@
 			hit_wall.take_damage(damage, BRUTE, MELEE)
 	if(!valid_impact)
 		return
+	INVOKE_ASYNC(living_source, TYPE_PROC_REF(/mob, emote), "scream")
 	if(damage)
 		living_source.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
 	if(collusion_paralyze_duration)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -67,12 +67,18 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_FLING,
 	)
 	target_flags = ABILITY_MOB_TARGET
-
+	/// How long should humans be stunned? If they are to be stunned, they will also drop held items.
+	var/stun_duration = 2 SECONDS
+	/// Should humans take damage immediately? If so, what is the multiplier of the owner's melee damage for determining how much damage to deal?
+	var/damage_multiplier = 0
+	/// If humans were to collide with something, how long should they be paralyzed for collusion?
+	var/collusion_paralyze_duration = 0
+	/// If humans were to collide with something, what is the multiplier of the owner's melee damage for determining how much damage to deal?
+	var/collusion_damage_multiplier = 0
 
 /datum/action/ability/activable/xeno/psychic_fling/on_cooldown_finish()
 	to_chat(owner, span_notice("We gather enough mental strength to fling something again."))
 	return ..()
-
 
 /datum/action/ability/activable/xeno/psychic_fling/can_use_ability(atom/movable/target, silent = FALSE, override_flags)
 	. = ..()
@@ -96,7 +102,6 @@
 		if(!CHECK_BITFIELD(use_state_flags|override_flags, ABILITY_IGNORE_DEAD_TARGET) && victim.stat == DEAD)
 			return FALSE
 
-
 /datum/action/ability/activable/xeno/psychic_fling/use_ability(atom/target)
 	var/mob/living/victim = target
 	GLOB.round_statistics.psychic_flings++
@@ -117,7 +122,14 @@
 	succeed_activate()
 	add_cooldown()
 	if(ishuman(victim))
-		victim.apply_effects(2 SECONDS, 0.2 SECONDS) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned for long.
+		if(stun_duration)
+			victim.Stun(2 SECONDS)
+			victim.drop_all_held_items()
+		RegisterSignal(victim, COMSIG_MOVABLE_POST_THROW, PROC_REF(on_post_throw))
+		if(collusion_paralyze_duration || collusion_damage_multiplier)
+			RegisterSignal(victim, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
+		else
+			victim.add_pass_flags(PASS_MOB, THROW_TRAIT)
 		shake_camera(victim, 2, 1)
 
 	var/facing = get_dir(owner, victim)
@@ -132,6 +144,37 @@
 		T = temp
 	victim.throw_at(T, fling_distance, 1, owner, TRUE)
 
+/// Called when the throw has ended.
+/datum/action/ability/activable/xeno/psychic_fling/proc/on_post_throw(datum/source)
+	SIGNAL_HANDLER
+	var/mob/living/living_source = source
+	UnregisterSignal(living_source, COMSIG_MOVABLE_POST_THROW)
+	if(collusion_paralyze_duration || collusion_damage_multiplier)
+		UnregisterSignal(living_source, COMSIG_MOVABLE_IMPACT) // Because it is possible we had no impacts.
+		return
+	living_source.remove_pass_flags(PASS_MOB, THROW_TRAIT)
+
+/// Called when the source has hit something.
+/datum/action/ability/activable/xeno/psychic_fling/proc/on_throw_impact(datum/source, atom/hit_atom, impact_speed)
+	SIGNAL_HANDLER
+	var/mob/living/living_source = source
+	UnregisterSignal(source, COMSIG_MOVABLE_IMPACT)
+	if(!isliving(hit_atom) && !isobj(hit_atom) && !isclosedturf(hit_atom))
+		return
+	new /obj/effect/temp_visual/warrior/impact(living_source.loc, get_dir(living_source, xeno_owner))
+	INVOKE_ASYNC(living_source, TYPE_PROC_REF(/mob, emote), "scream")
+	var/damage = xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * collusion_damage_multiplier
+	if(damage)
+		living_source.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
+	if(collusion_paralyze_duration)
+		living_source.Paralyze(collusion_paralyze_duration)
+	if(isliving(hit_atom) && !living_source.issamexenohive(hit_atom))
+		new /obj/effect/temp_visual/warrior/impact(living_source.loc, get_dir(living_source, xeno_owner))
+		INVOKE_ASYNC(living_source, TYPE_PROC_REF(/mob, emote), "scream")
+		if(damage)
+			living_source.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
+		if(collusion_paralyze_duration)
+			living_source.Paralyze(collusion_paralyze_duration)
 
 // ***************************************
 // *********** Unrelenting Force
@@ -231,9 +274,13 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_CURE,
 	)
-	var/heal_range = SHRIKE_HEAL_RANGE
 	target_flags = ABILITY_MOB_TARGET
-
+	/// How far can the ability be used?
+	var/heal_range = SHRIKE_HEAL_RANGE
+	/// If the ability was used on themselves, what is the amount to multiply healing power by?
+	var/self_heal_multiplier = 1
+	/// If the ability was used on themselves, what is the amount to multiply cooldown duration by?
+	var/self_cooldown_multiplier = 1
 
 /datum/action/ability/activable/xeno/psychic_cure/on_cooldown_finish()
 	to_chat(owner, span_notice("We gather enough mental strength to cure sisters again."))
@@ -291,8 +338,8 @@
 	playsound(target,'sound/effects/magic.ogg', 75, 1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/mob/living/carbon/xenomorph/patient = target
-	patient.heal_wounds(SHRIKE_CURE_HEAL_MULTIPLIER)
-	patient.adjust_sunder(-SHRIKE_CURE_HEAL_MULTIPLIER)
+	patient.heal_wounds(xeno_owner == patient ? SHRIKE_CURE_HEAL_MULTIPLIER * self_heal_multiplier : SHRIKE_CURE_HEAL_MULTIPLIER)
+	patient.adjust_sunder(xeno_owner == patient ?  -SHRIKE_CURE_HEAL_MULTIPLIER * self_heal_multiplier : -SHRIKE_CURE_HEAL_MULTIPLIER)
 	if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
 		patient.SetUnconscious(0)
 		patient.SetStun(0)
@@ -306,7 +353,7 @@
 	log_combat(owner, patient, "psychically cured")
 
 	succeed_activate()
-	add_cooldown()
+	add_cooldown(xeno_owner == patient ? cooldown_duration * self_cooldown_multiplier : null)
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -169,11 +169,12 @@
 	if(collusion_paralyze_duration)
 		living_source.Paralyze(collusion_paralyze_duration)
 	if(isliving(hit_atom) && !living_source.issamexenohive(hit_atom))
-		INVOKE_ASYNC(living_source, TYPE_PROC_REF(/mob, emote), "scream")
+		var/mob/living/living_hit = hit_atom
+		INVOKE_ASYNC(living_hit, TYPE_PROC_REF(/mob, emote), "scream")
 		if(damage)
-			living_source.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
+			living_hit.apply_damage(damage, BRUTE, blocked = MELEE, updating_health = TRUE)
 		if(collusion_paralyze_duration)
-			living_source.Paralyze(collusion_paralyze_duration)
+			living_hit.Paralyze(collusion_paralyze_duration)
 
 // ***************************************
 // *********** Unrelenting Force

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -152,7 +152,9 @@
 	var/mob/living/living_source = source
 	UnregisterSignal(living_source, COMSIG_MOVABLE_POST_THROW)
 	if(collusion_paralyze_duration || collusion_damage_multiplier)
-		// If we had an impact, we have to unregister it in the next tick as `on_throw_impact` doesn't happen if it was unregistered now.
+		// In most cases: COMSIG_MOVABLE_POST_THROW (on_post_throw) happens first and then COMSIG_MOVABLE_IMPACT (on_throw_impact) happens afterward.
+		// The reason behind this is because some things call `stop_throw` before the impact even happens.
+		// Because of this, we have to unregister it in the next tick. Even if the impact didn't happen (or was on time), we want to unregister it anyways.
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, UnregisterSignal), source, COMSIG_MOVABLE_IMPACT), 1)
 		return
 	living_source.remove_pass_flags(PASS_MOB, THROW_TRAIT)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -79,6 +79,12 @@
 		/datum/action/ability/activable/xeno/place_pattern,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/lone_healer,
+		/datum/mutation_upgrade/spur/smashing_fling,
+		/datum/mutation_upgrade/veil/stand_in_recycler
+	)
+
 /datum/xeno_caste/shrike/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
@@ -57,7 +57,7 @@
 //*********************//
 /datum/mutation_upgrade/spur/smashing_fling
 	name = "Smashing Fling"
-	desc = "Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: they are briefly paralyzed and dealt damage again."
+	desc = "Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: both are briefly paralyzed and dealt damage again."
 	/// For the first structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
 	var/multiplier_initial = 0.75
 	/// For each structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
@@ -66,7 +66,7 @@
 /datum/mutation_upgrade/spur/smashing_fling/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Psychic Fling deals [PERCENT(get_multiplier(new_amount))]% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: they are paralyzed and dealt damage again."
+	return "Psychic Fling deals [PERCENT(get_multiplier(new_amount))]% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: both are paralyzed and dealt damage again."
 
 /datum/mutation_upgrade/spur/smashing_fling/on_mutation_enabled()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
@@ -1,0 +1,144 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/lone_healer
+	name = "Lone Healer"
+	desc = "Psychic Cure can now target yourself. Healing yourself is only 50/60/70% as effective and will set the cooldown to 200/175/150% of its original value."
+	/// For the first structure, the multiplier of Psychic Cure's initial healing power to add to the ability.
+	var/self_heal_multiplier_initial = -0.6
+	/// For each structure, the multiplier of Psychic Cure's initial healing power to add to the ability.
+	var/self_heal_multiplier_per_structure = 0.1
+	/// For the first structure, the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
+	var/self_cooldown_multiplier_initial = 1.25
+	/// For each structure, the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
+	var/self_cooldown_multiplier_per_structure = -0.25
+
+/datum/mutation_upgrade/shell/lone_healer/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Psychic Cure can now target yourself. Healing yourself is only [PERCENT(1 + get_self_heal_multiplier(new_amount))]% as effective and will set the cooldown to [PERCENT(1 + get_self_cooldown_multiplier(new_amount))]% of its original value."
+
+/datum/mutation_upgrade/shell/lone_healer/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.use_state_flags |= ABILITY_TARGET_SELF
+	cure_ability.self_heal_multiplier += get_self_heal_multiplier(0)
+	cure_ability.self_cooldown_multiplier += get_self_cooldown_multiplier(0)
+
+/datum/mutation_upgrade/shell/lone_healer/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.use_state_flags &= ~(ABILITY_TARGET_SELF)
+	cure_ability.self_heal_multiplier -= get_self_heal_multiplier(0)
+	cure_ability.self_cooldown_multiplier -= get_self_cooldown_multiplier(0)
+
+/datum/mutation_upgrade/shell/lone_healer/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.self_heal_multiplier += get_self_heal_multiplier(new_amount - previous_amount, FALSE)
+	cure_ability.self_cooldown_multiplier += get_self_cooldown_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier of Psychic Cure's initial healing power to add to the ability.
+/datum/mutation_upgrade/shell/lone_healer/proc/get_self_heal_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? self_heal_multiplier_initial : 0) + (self_heal_multiplier_per_structure * structure_count)
+
+/// Returns the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
+/datum/mutation_upgrade/shell/lone_healer/proc/get_self_cooldown_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? self_cooldown_multiplier_initial : 0) + (self_cooldown_multiplier_per_structure * structure_count)
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/smashing_fling
+	name = "Smashing Fling"
+	desc = "Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with anything, they are paralyzed for 0.5 seconds and dealt damage again."
+	/// For the first structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
+	var/multiplier_initial = 0.75
+	/// For each structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
+	var/multiplier_per_structure = 0.25
+
+/datum/mutation_upgrade/spur/smashing_fling/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Psychic Fling deals [PERCENT(get_multiplier(new_amount))]% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with anything, they are paralyzed for 0.5 seconds and dealt damage again."
+
+/datum/mutation_upgrade/spur/smashing_fling/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	fling_ability.stun_duration = 0 SECONDS
+	fling_ability.damage_multiplier += get_multiplier(0)
+	fling_ability.collusion_paralyze_duration = 0.5 SECONDS
+	fling_ability.collusion_damage_multiplier += get_multiplier(0)
+
+/datum/mutation_upgrade/spur/smashing_fling/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	fling_ability.stun_duration = initial(fling_ability.stun_duration)
+	fling_ability.damage_multiplier -= get_multiplier(0)
+	fling_ability.collusion_paralyze_duration = initial(fling_ability.collusion_paralyze_duration)
+	fling_ability.collusion_damage_multiplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/spur/smashing_fling/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	var/amount = get_multiplier(new_amount - previous_amount)
+	fling_ability.damage_multiplier += amount
+	fling_ability.collusion_damage_multiplier += amount
+
+/// Returns the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
+/datum/mutation_upgrade/spur/smashing_fling/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/stand_in_recycler
+	name = "Stand-In Recycler"
+	desc = "You gain the Recycle ability. It costs 80/65/50% of its original cost."
+	/// For the first structure, the multiplier of Recycle's initial ability cost to add to the ability.
+	var/multiplier_initial = -0.05
+	/// For each structure, the multiplier of Recycle's initial ability cost to add to the ability.
+	var/multiplier_per_structure = -0.15
+
+/datum/mutation_upgrade/veil/stand_in_recycler/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You gain the Recycle ability. Recycle's ability cost is [PERCENT(1 + get_multiplier(new_amount))]% of its original value."
+
+/datum/mutation_upgrade/veil/stand_in_recycler/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
+	if(!recycle_ability)
+		recycle_ability = new()
+		recycle_ability.give_action(xenomorph_owner)
+		recycle_ability.ability_cost += initial(recycle_ability.ability_cost) * get_multiplier(0)
+	return ..()
+
+/datum/mutation_upgrade/veil/stand_in_recycler/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
+	if(recycle_ability)
+		recycle_ability.remove_action(xenomorph_owner)
+		qdel(recycle_ability)
+	return ..()
+
+/datum/mutation_upgrade/veil/stand_in_recycler/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
+	if(!recycle_ability)
+		return
+	recycle_ability.ability_cost += initial(recycle_ability.ability_cost) * get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier of Recycle's initial ability cost to add to the ability.
+/datum/mutation_upgrade/veil/stand_in_recycler/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
@@ -57,7 +57,7 @@
 //*********************//
 /datum/mutation_upgrade/spur/smashing_fling
 	name = "Smashing Fling"
-	desc = "Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with anything, they are paralyzed for 0.5 seconds and dealt damage again."
+	desc = "Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: they are briefly paralyzed and dealt damage again."
 	/// For the first structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
 	var/multiplier_initial = 0.75
 	/// For each structure, the multiplier of the owner's melee damage to deal as both immediate and collusion damage.
@@ -66,7 +66,7 @@
 /datum/mutation_upgrade/spur/smashing_fling/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Psychic Fling deals [PERCENT(get_multiplier(new_amount))]% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with anything, they are paralyzed for 0.5 seconds and dealt damage again."
+	return "Psychic Fling deals [PERCENT(get_multiplier(new_amount))]% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: they are paralyzed and dealt damage again."
 
 /datum/mutation_upgrade/spur/smashing_fling/on_mutation_enabled()
 	. = ..()
@@ -75,7 +75,7 @@
 		return
 	fling_ability.stun_duration = 0 SECONDS
 	fling_ability.damage_multiplier += get_multiplier(0)
-	fling_ability.collusion_paralyze_duration = 0.5 SECONDS
+	fling_ability.collusion_paralyze_duration = 0.1 SECONDS // This is honestly flavor.
 	fling_ability.collusion_damage_multiplier += get_multiplier(0)
 
 /datum/mutation_upgrade/spur/smashing_fling/on_mutation_disabled()
@@ -93,7 +93,7 @@
 	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
 	if(!fling_ability)
 		return
-	var/amount = get_multiplier(new_amount - previous_amount)
+	var/amount = get_multiplier(new_amount - previous_amount, FALSE)
 	fling_ability.damage_multiplier += amount
 	fling_ability.collusion_damage_multiplier += amount
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -151,11 +151,7 @@
 /// Ends the target's throw.
 /datum/action/ability/activable/xeno/warrior/proc/throw_ended(datum/source)
 	SIGNAL_HANDLER
-	UnregisterSignal(source, COMSIG_MOVABLE_POST_THROW)
-	/* So the reason why we do not flat out unregister this is because, when an atom makes impact with something, it calls throw_impact(). Calling it this way causes
-	stop_throw() to be called in most cases, because impacts can cause a bounce effect and ending the throw makes it happen. Given the way we have signals setup, unregistering
-	it at that point would cause thrown_into() to never get called, and that is exactly the reason why the line of code below exists. */
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, UnregisterSignal), source, COMSIG_MOVABLE_IMPACT, COMSIG_MOVABLE_POST_THROW), 1)
+	UnregisterSignal(source, list(COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_IMPACT))
 	var/mob/living/living_target = source
 	living_target.Knockdown(0.5 SECONDS)
 	living_target.remove_pass_flags(PASS_XENO, THROW_TRAIT)
@@ -262,7 +258,7 @@
 	UnregisterSignal(lunge_target, COMSIG_QDELETING)
 	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_POST_THROW))
 	lunge_target = null
-	owner.stop_throw()
+	owner.set_throwing(FALSE)
 	owner.remove_filter("warrior_lunge")
 
 /// Do the grab on the target, and clean all previous vars

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -328,7 +328,7 @@
 	if(isliving(hit_atom)) //Hit a mob! This overwrites normal throw code.
 		if(SEND_SIGNAL(src, COMSIG_XENO_LIVING_THROW_HIT, hit_atom) & COMPONENT_KEEP_THROWING)
 			return FALSE
-		stop_throw() //Resert throwing since something was hit.
+		set_throwing(FALSE) //Resert throwing since something was hit.
 		return TRUE
 
 	return ..() //Do the parent otherwise, for turfs.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,11 +65,11 @@
 		if(thrown_mob.mob_size >= mob_size)
 			apply_damage((thrown_mob.mob_size + 1 - mob_size) * speed, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
 		if(thrown_mob.mob_size <= mob_size)
-			thrown_mob.stop_throw()
+			thrown_mob.set_throwing(FALSE)
 			thrown_mob.apply_damage(speed, BRUTE, BODY_ZONE_CHEST, MELEE, updating_health = TRUE)
 	else if(isobj(AM))
 		var/obj/O = AM
-		O.stop_throw()
+		O.set_throwing(FALSE)
 		apply_damage(O.throwforce*(speed * 0.2), O.damtype, BODY_ZONE_CHEST, MELEE, is_sharp(O), has_edge(O), TRUE, O.penetration)
 
 	visible_message(span_warning("[src] has been hit by [AM]."), null, null, 5)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2061,6 +2061,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\sentinel\sentinel.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\shrike\abilities_shrike.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\shrike\castedatum_shrike.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\shrike\mutations_shrike.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\shrike\shrike.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\spiderling\castedatum_spiderling.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\spiderling\spiderling.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Oppressor (Praetorian Strain).
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Lone Healer | Psychic Cure can now target yourself. Healing yourself is only 50/60/70% as effective and will set the cooldown to 200/175/150% of its original value. |
| Spur | Smashing Fling | Psychic Fling deals 100/125/150% damage equal to your melee damage, enables collusions, but no longer immediately stuns. If the target collides with a human, object, or wall: both are briefly paralyzed and dealt damage again. |
| Veil | Stand-In Recycler | You gain the Recycle ability. It costs 80/65/50% of its original cost. |

Psychic Fling's 0.2 second paralyze is replaced with a passthrough flag to go through mobs and forces them drop their held items. This shouldn't have an impact on balance. As per code comments, the paralyze was intended to have them drop their held items - but since it also made them go through mobs, I've given them the passthrough flag as well.
 
## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Shrike now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
code: The signal for throw impacts is now sent first. This is a change from the signal from throw ending happening first and then throw impacts second.
/:cl:
