### PR TITLE
Mutations: Conqueror

### DIFF
--- a/code/__DEFINES/action.dm
+++ b/code/__DEFINES/action.dm
@@ -50,6 +50,10 @@
 #define VREF_MUTABLE_GAS_MINE_TIMER "VREF_GASMINE_CHARGETIMER"
 // extra reference for how long untill we recharge a new gas mine
 #define VREF_MUTABLE_ACID_MINE_TIMER "VREF_ACIDMINE_CHARGETIMER"
+// The extra reference for Conqueror's Dash ability if it uses the charge cooldown system. Shows how many charges are available.
+#define VREF_MUTABLE_CONQ_DASH_CHARGES "VREF_CONQDASH_CHARGES"
+// The extra reference for Conqueror's Dash ability if it uses the charge cooldown system. Shows how much time is left before a charge is restored.
+#define VREF_MUTABLE_CONQ_DASH_CHARGETIMER "VREF_CONQDASH_CHARGETIMER"
 
 /// Actions that toggle on click/trigger
 #define ACTION_TOGGLE "toggle"

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
@@ -26,17 +26,43 @@
 	var/last_move_dir
 	/// The timing for activating a dash by double tapping a movement key.
 	var/double_tap_timing = 0.18 SECONDS
+	/// If this ability is in its alternative form, the amount of charges that Dash has. Otherwise, does nothing.
+	var/charges
+	/// The maximum amount of charges that can be restored. Do not set this directly. Use `set_maximum_charges` instead.
+	var/maximum_charges
+	/// The amount of deciseconds until a charge is restored.
+	var/charge_restoration_length
+	/// The timer ID of the charge restoration.
+	var/charge_restoration_timer
 
 /datum/action/ability/xeno_action/conqueror_dash/give_action(mob/living/L)
 	. = ..()
 	toggled = TRUE
 	set_toggle(TRUE)
 	enable_ability()
+	add_button_visuals()
 
 /datum/action/ability/xeno_action/conqueror_dash/remove_action(mob/living/L)
 	toggled = FALSE
 	set_toggle(FALSE)
 	disable_ability()
+	remove_button_visuals()
+	return ..()
+
+/datum/action/ability/xeno_action/conqueror_dash/update_button_icon()
+	if(isnull(charges) || isnull(maximum_charges))
+		return ..()
+	button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES])
+	var/mutable_appearance/number = visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES]
+	number.maptext = MAPTEXT("[charges]/[maximum_charges]")
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES] = number
+	button.add_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES])
+
+	button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
+	var/mutable_appearance/time = visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER]
+	time.maptext = MAPTEXT("[timeleft(charge_restoration_timer) ? "[round(timeleft(charge_restoration_timer) / 10)]s" : ""]")
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER] = time
+	button.add_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
 	return ..()
 
 /datum/action/ability/xeno_action/conqueror_dash/can_use_action(silent, override_flags)
@@ -47,7 +73,20 @@
 		return FALSE
 	if(xeno_owner.endurance_active)
 		return FALSE
+	if(maximum_charges && !charges)
+		return FALSE
 	return TRUE
+
+/datum/action/ability/xeno_action/conqueror_dash/process()
+	if(!charge_restoration_timer)
+		STOP_PROCESSING(SSprocessing, src)
+		button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
+		return
+	button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
+	var/mutable_appearance/time = visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER]
+	time.maptext = MAPTEXT("[timeleft(charge_restoration_timer) ? "[round(timeleft(charge_restoration_timer) / 10)]s" : ""]")
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER] = time
+	button.add_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
 
 /datum/action/ability/xeno_action/conqueror_dash/action_activate()
 	toggled = !toggled
@@ -79,11 +118,23 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(xeno_owner, list(COMSIG_MOB_DEATH, COMSIG_KB_MOVEMENT_EAST_DOWN, COMSIG_KB_MOVEMENT_NORTH_DOWN, COMSIG_KB_MOVEMENT_SOUTH_DOWN, COMSIG_KB_MOVEMENT_WEST_DOWN))
 
-/// If the user dies, a check will be added in the case of revival, to reenable the ability.
+/// On death, disables the ability and stops charges from being restored. Registers a signal to deal with the owner's revival, if it were to happen.
 /datum/action/ability/xeno_action/conqueror_dash/proc/on_death()
 	SIGNAL_HANDLER
 	disable_ability()
-	RegisterSignal(xeno_owner, COMSIG_MOB_REVIVE, PROC_REF(enable_ability))
+	RegisterSignal(xeno_owner, COMSIG_MOB_REVIVE, PROC_REF(on_revive))
+	if(charge_restoration_timer)
+		deltimer(charge_restoration_timer)
+		charge_restoration_timer = null
+
+/// On revival, enables the ability. If it was using the charge system, start the timer to restore charges.
+/datum/action/ability/xeno_action/conqueror_dash/proc/on_revive()
+	SIGNAL_HANDLER
+	enable_ability()
+	UnregisterSignal(xeno_owner, COMSIG_MOB_REVIVE)
+	if(maximum_charges && !charge_restoration_timer)
+		restore_charge(0)
+		START_PROCESSING(SSprocessing, src)
 
 /// Checks if we can dash to the east.
 /datum/action/ability/xeno_action/conqueror_dash/proc/dash_east()
@@ -130,6 +181,9 @@
 	last_move_dir = null
 	add_cooldown()
 	succeed_activate()
+	if(charges)
+		restore_charge(-1)
+		START_PROCESSING(SSprocessing, src)
 	disable_ability() // Ability usage is disabled until the cooldown has concluded. This prevents signals from firing, for the purposes of performance efficiency.
 	addtimer(CALLBACK(src, PROC_REF(enable_ability)), cooldown_duration)
 
@@ -145,6 +199,72 @@
 	if(timing)
 		double_tap_timing = timing SECONDS
 	return COMSIG_KB_ACTIVATED
+
+/// Sets the maximum charges and how long it takes to restore charges. Will switch the ability away or to a charge-based system based on maximum charges.
+/datum/action/ability/xeno_action/conqueror_dash/proc/set_maximum_charges(new_maximum_charges = 0, restoration_length)
+	if(!charge_restoration_length && !restoration_length)
+		restoration_length = cooldown_duration
+	charge_restoration_length = restoration_length
+	if(maximum_charges == new_maximum_charges)
+		return
+	// We only support maximum charges that are two or higher. If it is changed to be under, it means we're no longer using the charge-system anymore.
+	if(new_maximum_charges < 2)
+		if(maximum_charges)
+			if(charges >= 1)
+				clear_cooldown()
+			charges = null
+			maximum_charges = null
+			charge_restoration_length = null
+			if(charge_restoration_timer)
+				deltimer(charge_restoration_timer)
+				charge_restoration_timer = null
+			remove_button_visuals()
+		return
+	// Switching from non-charges to charges.
+	if(!maximum_charges)
+		maximum_charges = new_maximum_charges
+		restore_charge(action_cooldown_finished() ? 1 : 0)
+		add_button_visuals()
+		return
+	maximum_charges = new_maximum_charges
+	restore_charge(0)
+
+/// Restores a certain amount of charges. If under the maximum charges, restart the timer.
+/datum/action/ability/xeno_action/conqueror_dash/proc/restore_charge(amount = 1)
+	charges = clamp(charges + amount, 0, maximum_charges)
+	update_button_icon()
+	if(charges >= maximum_charges)
+		deltimer(charge_restoration_timer)
+		charge_restoration_timer = null
+		return
+	if(!charge_restoration_timer || amount >= 1)
+		charge_restoration_timer = addtimer(CALLBACK(src, PROC_REF(restore_charge)), charge_restoration_length, TIMER_UNIQUE|TIMER_STOPPABLE)
+
+/// If the ability is using the charge system, adds various visuals to indicate current, maximum, and recharge time for charges.
+/datum/action/ability/xeno_action/conqueror_dash/proc/add_button_visuals()
+	if(isnull(charges) || isnull(maximum_charges))
+		return
+	var/mutable_appearance/counter_maptext = mutable_appearance(layer = ACTION_LAYER_MAPTEXT)
+	counter_maptext.pixel_x = 16
+	counter_maptext.pixel_y = -4
+	counter_maptext.maptext = MAPTEXT("[charges]/[maximum_charges]")
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES] = counter_maptext
+
+	var/mutable_appearance/timer_maptext = mutable_appearance(layer = ACTION_LAYER_MAPTEXT)
+	timer_maptext.pixel_x = 16
+	timer_maptext.pixel_y = 24
+	timer_maptext.maptext = MAPTEXT("[timeleft(charge_restoration_timer) ? "[round(timeleft(charge_restoration_timer) / 10)]s" : ""]")
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER] = timer_maptext
+
+/// If the ability is not using the charge system, removes visuals used for charges.
+/datum/action/ability/xeno_action/conqueror_dash/proc/remove_button_visuals()
+	if(!isnull(charges) || !isnull(maximum_charges))
+		return
+	button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES])
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGES] = null
+
+	button.cut_overlay(visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER])
+	visual_references[VREF_MUTABLE_CONQ_DASH_CHARGETIMER] = null
 
 /obj/effect/temp_visual/conqueror/dash_trail
 	icon = 'icons/effects/particles/conqueror.dmi'
@@ -202,6 +322,10 @@
 	var/reset_timer
 	/// Timer ID. Length of time after which the ability will warn the user of an impending reset.
 	var/warning_timer
+	/// On Jab's usage, the percentage of maximum health to heal.
+	var/jab_heal_percentage = 0
+	/// On Jab's usage, the multiplier of damage to deal.
+	var/jab_damage_multiplier = CONQUEROR_WILL_JAB_MULTIPLIER
 
 /datum/action/ability/activable/xeno/conqueror_will/give_action(mob/living/L)
 	. = ..()
@@ -395,7 +519,11 @@
 	addtimer(CALLBACK(src, GLOBAL_PROC_REF(playsound), living_target, 'sound/effects/alien/conqueror/will_extra_3.ogg', 15, TRUE), 0.2 SECONDS, TIMER_CLIENT_TIME)
 	new /obj/effect/temp_visual/conqueror/hook/jab/initial(living_target.loc)
 	living_target.do_attack_animation(get_step(living_target, REVERSE_DIR(get_dir(living_target, xeno_owner))))
-	living_target.apply_damage((xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier) * CONQUEROR_WILL_JAB_MULTIPLIER, BRUTE, xeno_owner.get_limb(xeno_owner.zone_selected), MELEE, TRUE, TRUE, TRUE, CONQUEROR_WILL_JAB_PENETRATION)
+	if(jab_damage_multiplier)
+		living_target.apply_damage((xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier) * jab_damage_multiplier, BRUTE, xeno_owner.get_limb(xeno_owner.zone_selected), MELEE, TRUE, TRUE, TRUE, CONQUEROR_WILL_JAB_PENETRATION)
+	if(jab_heal_percentage)
+		var/health_to_heal = xeno_owner.xeno_caste.max_health * jab_heal_percentage
+		HEAL_XENO_DAMAGE(xeno_owner, health_to_heal, FALSE)
 	INVOKE_ASYNC(living_target, TYPE_PROC_REF(/mob, emote), "pain")
 
 /// A mighty kick that sends the target flying. If they collide with another atom, that atom is also affected.
@@ -687,6 +815,10 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CONQUEROR_DOMINATION,
 	)
+	/// The radius of the area of effect.
+	var/radius = CONQUEROR_DOMINATION_EFFECT_RADIUS
+	/// The amount of deciseconds that the affected will be knocked down for.
+	var/knockdown_duration = CONQUEROR_DOMINATION_KNOCKDOWN
 
 /datum/action/ability/activable/xeno/conqueror_domination/on_cooldown_finish()
 	. = ..()
@@ -718,9 +850,9 @@
 			break
 		valid_turfs += turf_to_check
 	check_distance = min(length(valid_turfs), check_distance)
-	var/list/turf/reappearance_turfs = filled_circle_turfs(valid_turfs[check_distance], CONQUEROR_DOMINATION_EFFECT_RADIUS)
+	var/list/turf/reappearance_turfs = filled_circle_turfs(valid_turfs[check_distance], radius)
 	for(var/turf/turf_to_affect AS in reappearance_turfs)
-		if(isclosedturf(turf_to_affect) || isspaceturf(turf_to_affect) || isspacearea(get_area(turf_to_affect)) || !line_of_sight(turf_target, turf_to_affect, CONQUEROR_DOMINATION_EFFECT_RADIUS, TRUE))
+		if(isclosedturf(turf_to_affect) || isspaceturf(turf_to_affect) || isspacearea(get_area(turf_to_affect)) || !line_of_sight(turf_target, turf_to_affect, radius, TRUE))
 			reappearance_turfs -= turf_to_affect
 			continue
 		new /obj/effect/temp_visual/behemoth/warning/conqueror(turf_to_affect, CONQUEROR_DOMINATION_CASTING_DELAY)
@@ -760,7 +892,7 @@
 				var/knockback_dist = clamp(CONQUEROR_DOMINATION_MAX_PUSH_RANGE - distance, 1, CONQUEROR_DOMINATION_MAX_PUSH_RANGE)
 				mob_target.knockback(xeno_owner, knockback_dist, 1)
 			var/mob/living/living_target = mob_target
-			living_target.Knockdown(CONQUEROR_DOMINATION_KNOCKDOWN)
+			living_target.Knockdown(knockdown_duration)
 			living_target.take_overall_damage(xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier, xeno_owner.xeno_caste.melee_damage_type, MELEE, TRUE, TRUE, TRUE, xeno_owner.xeno_caste.melee_ap, 5)
 
 /obj/effect/temp_visual/conqueror/reappearance

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -169,6 +169,12 @@
 		/datum/action/ability/activable/xeno/conqueror_domination,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/healing_jab,
+		/datum/mutation_upgrade/spur/telefrag,
+		/datum/mutation_upgrade/veil/dasher
+	)
+
 /datum/xeno_caste/king/conqueror/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/mutations_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/mutations_conqueror.dm
@@ -1,0 +1,125 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/healing_jab
+	name = "Healing Jab"
+	desc = "The effects of Jab from Conqueror's Will is replaced. It will instead heal you for 5/10/15% of your maximum health."
+	/// For each structure, the multiplier of the owner's maximium health that Jab from Conqueror's Will will heal.
+	var/percentage_per_structure = 0.05
+
+/datum/mutation_upgrade/shell/healing_jab/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "The effects of Jab from Conqueror's Will is replaced. It will instead heal you for [PERCENT(get_percentage(new_amount))]% of your maximum health."
+
+/datum/mutation_upgrade/shell/healing_jab/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_will/will_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_will]
+	if(!will_ability)
+		return
+	will_ability.jab_damage_multiplier = 0
+
+/datum/mutation_upgrade/shell/healing_jab/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_will/will_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_will]
+	if(!will_ability)
+		return
+	will_ability.jab_damage_multiplier = initial(will_ability.jab_damage_multiplier)
+
+/datum/mutation_upgrade/shell/healing_jab/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_will/will_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_will]
+	if(!will_ability)
+		return
+	will_ability.jab_heal_percentage += get_percentage(new_amount - previous_amount)
+
+/// Returns the percentage of the owner's maximium health that Jab from Conqueror's Will will heal.
+/datum/mutation_upgrade/shell/healing_jab/proc/get_percentage(structure_count)
+	return percentage_per_structure * structure_count
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/telefrag
+	name = "Telefrag"
+	desc = "Domination's radius is reduced by 1, but knocked down for 0.5/0.8/1.1 seconds longer."
+	/// For the first structure, the amount to increase Domination's radius by.
+	var/radius_initial = -1
+	/// For the first structure, the amount of deciseconds to add to Domination's knockdown duration.
+	var/duration_initial = 0.2 SECONDS
+	/// For each structure, the additional amount of deciseconds to add to Domination's knockdown duration.
+	var/duration_per_structure = 0.3 SECONDS
+
+/datum/mutation_upgrade/spur/telefrag/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Domination's radius is reduced by [-radius_initial], but knocked down for [get_duration(new_amount)] seconds longer."
+
+/datum/mutation_upgrade/spur/telefrag/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_domination/domination_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_domination]
+	if(!domination_ability)
+		return
+	domination_ability.radius += radius_initial
+	domination_ability.knockdown_duration += get_duration(0)
+
+/datum/mutation_upgrade/spur/telefrag/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_domination/domination_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_domination]
+	if(!domination_ability)
+		return
+	domination_ability.radius -= radius_initial
+	domination_ability.knockdown_duration -= get_duration(0)
+
+/datum/mutation_upgrade/spur/telefrag/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/conqueror_domination/domination_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/conqueror_domination]
+	if(!domination_ability)
+		return
+	domination_ability.knockdown_duration += get_duration(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of deciseconds to add to Domination's knockdown duration.
+/datum/mutation_upgrade/spur/telefrag/proc/get_duration(structure_count, include_initial = TRUE)
+	return (include_initial ? duration_initial : 0) + (duration_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/dasher
+	name = "Dasher"
+	desc = "Dash can be activated at will as long it has charges. It can store up to 2/3/4 charges which are given at the rate of 200% of the ability's original cooldown."
+	/// For the first structure, the multiplier of Dash's initial cooldown in which a charge will be restored.
+	var/cooldown_multiplier_initial = 2
+	/// For each structure, the amount of charges to add to Dash.
+	var/charges_per_structure = 1
+
+// /datum/action/ability/xeno_action/conqueror_dash
+/datum/mutation_upgrade/veil/dasher/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Dash can be activated at will as long it has charges. It can store up to [get_dashes(new_amount)] charges which are given at the rate of [PERCENT(cooldown_multiplier_initial)]% of the ability's original cooldown."
+
+/datum/mutation_upgrade/veil/dasher/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/conqueror_dash/dash_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/conqueror_dash]
+	if(!dash_ability)
+		return
+	dash_ability.cooldown_duration = 0.1 SECONDS
+
+/datum/mutation_upgrade/veil/dasher/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/conqueror_dash/dash_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/conqueror_dash]
+	if(!dash_ability)
+		return
+	dash_ability.cooldown_duration = initial(dash_ability.cooldown_duration)
+
+/datum/mutation_upgrade/veil/dasher/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/conqueror_dash/dash_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/conqueror_dash]
+	if(!dash_ability)
+		return
+	dash_ability.set_maximum_charges(get_dashes(new_amount), initial(dash_ability.cooldown_duration) * (cooldown_multiplier_initial))
+
+/// Returns the amount of additional uses that Dash should get.
+/datum/mutation_upgrade/veil/dasher/proc/get_dashes(structure_count, include_initial = TRUE)
+	return (include_initial ? 1 : 0) + (charges_per_structure * structure_count)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -2019,6 +2019,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\king\abilities_king.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\king\castedatum_king.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\king\king.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\king\mutations_conqueror.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\larva\castedatum_larva.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\larva\larva.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\mantis\abilities_mantis.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a total of 3 mutations all for Conqueror (King Strain).
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Healing Jab | The effects of Jab from Conqueror's Will is replaced. It will instead heal you for 5/10/15% of your maximum health. |
| Spur | Telefrag | Domination's radius is reduced by 1, but knocked down for 0.5/0.8/1.1 seconds longer. |
| Veil | Dasher | Dash can be activated at will as long it has charges. It can store up to 2/3/4 charges which are given at the rate of 200% of the ability's original cooldown.|

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: Conqueror now has 3 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
