### PR TITLE
Mutations: Dragon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -371,11 +371,41 @@
 	var/ability_timer
 	/// The timer id for the timer that occurs every tick while the ability is active.
 	var/tick_timer
+	/// The typepath of the melting fire that will be created.
+	var/obj/fire/melting_fire/selected_typepath = /obj/fire/melting_fire
+	/// An image list for the fire selection's radical menu.
+	var/selectable_fire_images_list = list()
+
+/datum/action/ability/activable/xeno/backhand/dragon_breath/New()
+	. = ..()
+	selectable_fire_images_list["Melting"] = image('icons/effects/fire.dmi', icon_state = "purple_3")
 
 /datum/action/ability/activable/xeno/backhand/dragon_breath/use_ability(atom/target)
 	if(!ability_timer)
 		return ..()
 	end_ability()
+
+/datum/action/ability/activable/xeno/backhand/dragon_breath/alternate_action_activate()
+	if(length(selectable_fire_images_list) <= 1 || ability_timer)
+		return
+	INVOKE_ASYNC(src, PROC_REF(switch_fire))
+	return COMSIG_KB_ACTIVATED
+
+/// Shows a radical menu that lets the owner choose which type of fire they want to use.
+/datum/action/ability/activable/xeno/backhand/dragon_breath/proc/switch_fire()
+	var/fire_choice = show_radial_menu(owner, owner, selectable_fire_images_list, radius = 35)
+	if(!fire_choice)
+		return
+	switch(fire_choice)
+		if("Melting")
+			selected_typepath = /obj/fire/melting_fire
+			to_chat(owner, span_xenonotice("Our breath will spew melting fire."))
+		if("Shattering")
+			selected_typepath = /obj/fire/melting_fire/shattering
+			to_chat(owner, span_xenonotice("Our breath will spew shattering fire."))
+		if("Melting Acid")
+			selected_typepath = /obj/fire/melting_fire/melting_acid
+			to_chat(owner, span_xenonotice("Our breath will spew acidic fire."))
 
 /datum/action/ability/activable/xeno/backhand/dragon_breath/get_damage()
 	return 20 * xeno_owner.xeno_melee_damage_modifier
@@ -387,18 +417,38 @@
 	xeno_owner.visible_message(span_danger("[xeno_owner] inhales and turns their sights to [grabbed_human]..."))
 	if(do_after(xeno_owner, DRAGON_GRABBED_ABILITY_TIME, IGNORE_HELD_ITEM, xeno_owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, PROC_REF(grab_extra_check))))
 		xeno_owner.stop_pulling()
-		xeno_owner.visible_message(span_danger("[xeno_owner] exhales a massive fireball right ontop of [grabbed_human]!"))
-		new /obj/effect/temp_visual/dragon/grab_fire(get_turf(grabbed_human))
 		grabbed_human.emote("scream")
 		grabbed_human.Shake(duration = 0.5 SECONDS) // Must stop pulling first for Shake to work.
+		xeno_owner.visible_message(span_danger("[xeno_owner] exhales a massive fireball right ontop of [grabbed_human]!"))
 		playsound(get_turf(xeno_owner), 'sound/effects/alien/fireball.ogg', 50, 1)
-		new /obj/effect/temp_visual/xeno_fireball_explosion(get_turf(grabbed_human))
-		var/datum/status_effect/stacking/melting_fire/debuff = grabbed_human.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
-		if(debuff)
-			debuff.add_stacks(10)
-		else
-			grabbed_human.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, 10)
-		grabbed_human.take_overall_damage(get_damage() * 5.5, BURN, FIRE, max_limbs = length(grabbed_human.get_damageable_limbs()), updating_health = TRUE) // 110
+		var/obj/effect/temp_visual/dragon/grab_fire/visual_grab_fire = new(get_turf(grabbed_human))
+		var/obj/effect/temp_visual/xeno_fireball_explosion/visual_fireball_explosion = new(get_turf(grabbed_human))
+		var/armor_type = BURN
+		switch(selected_typepath)
+			if(/obj/fire/melting_fire)
+				var/datum/status_effect/stacking/melting_fire/debuff = grabbed_human.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
+				if(debuff)
+					debuff.add_stacks(10, xeno_owner) // 110 (avoidable / extinguishable)
+				else
+					grabbed_human.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, 10)
+			if(/obj/fire/melting_fire/shattering)
+				visual_grab_fire.add_atom_colour("#ff000d", FIXED_COLOR_PRIORITY)
+				visual_fireball_explosion.add_atom_colour("#ff000d", FIXED_COLOR_PRIORITY)
+				var/datum/status_effect/stacking/melting_fire/debuff = grabbed_human.has_status_effect(STATUS_EFFECT_MELTING_FIRE)
+				if(debuff)
+					debuff.add_stacks(10, xeno_owner) // 110 (avoidable / extinguishable)
+				else
+					grabbed_human.apply_status_effect(STATUS_EFFECT_MELTING_FIRE, 10)
+			if(/obj/fire/melting_fire/melting_acid)
+				visual_grab_fire.add_atom_colour("#00ff15", FIXED_COLOR_PRIORITY)
+				visual_fireball_explosion.add_atom_colour("#00ff15", FIXED_COLOR_PRIORITY)
+				var/datum/status_effect/stacking/melting_acid/debuff = grabbed_human.has_status_effect(STATUS_EFFECT_MELTING_ACID)
+				if(debuff)
+					debuff.add_stacks(15) // 75 (unavoidable)
+				else
+					grabbed_human.apply_status_effect(STATUS_EFFECT_MELTING_ACID, 15)
+				armor_type = ACID
+		grabbed_human.take_overall_damage(get_damage() * 5.5, BURN, armor_type, max_limbs = length(grabbed_human.get_damageable_limbs()), updating_health = TRUE) // 110
 		grabbed_human.knockback(xeno_owner, 5, 1)
 		xeno_owner.gain_plasma(250)
 	xeno_owner.move_resist = initial(xeno_owner.move_resist)
@@ -416,6 +466,11 @@
 	RegisterSignal(xeno_owner, COMSIG_MOB_STAT_CHANGED, PROC_REF(on_stat_changed))
 	starting_direction = get_cardinal_dir(xeno_owner, target)
 	visual_effect = new /obj/effect/temp_visual/dragon/fire_breath(get_step(xeno_owner, target), starting_direction)
+	switch(selected_typepath)
+		if(/obj/fire/melting_fire/shattering)
+			visual_effect.add_atom_colour("#ff000d", FIXED_COLOR_PRIORITY)
+		if(/obj/fire/melting_fire/melting_acid)
+			visual_effect.add_atom_colour("#00ff15", FIXED_COLOR_PRIORITY)
 	ability_timer = addtimer(CALLBACK(src, PROC_REF(end_ability)), 10 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE)
 	tick_effects(get_turf(target), affected_turfs, list())
 	return TRUE
@@ -439,7 +494,7 @@
 		affected_turfs_in_order += get_step(maximum_distance_turf, turn(xeno_owner.dir, 90))
 		affected_turfs_in_order += get_step(maximum_distance_turf, turn(xeno_owner.dir, -90))
 
-/// Performs the ability at a pace similar of CAS which is one width length at a length.
+/// Performs the ability at a pace similar of CAS which is one width length at a time.
 /datum/action/ability/activable/xeno/backhand/dragon_breath/proc/tick_effects()
 	xeno_owner.setDir(starting_direction) // To prevent them from spinning and looking funky while using this ability.
 	playsound(xeno_owner, SFX_GUN_FLAMETHROWER, 50, 1)
@@ -468,15 +523,19 @@
 			var/mob/living/affected_living = affected_atom
 			if(affected_living.stat == DEAD)
 				continue
-			affected_living.take_overall_damage(get_damage(), BURN, FIRE, updating_health = TRUE, penetration = 30, max_limbs = 5)
+
+			var/armor_type = BURN
+			if(selected_typepath == /obj/fire/melting_fire/melting_acid)
+				armor_type = ACID
+			affected_living.take_overall_damage(get_damage(), BURN, armor_type, updating_health = TRUE, penetration = 30, max_limbs = 5)
 			continue
 	tick_timer = addtimer(CALLBACK(src, PROC_REF(tick_effects)), 0.1 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE)
 
 /// Creates a melting fire if it does not exist. If it does, refresh it and affect all atoms in the same turf.
 /datum/action/ability/activable/xeno/backhand/dragon_breath/proc/refresh_or_create_fire(turf/target_turf)
-	var/obj/fire/melting_fire/fire_in_turf = locate(/obj/fire/melting_fire) in target_turf.contents
+	var/obj/fire/melting_fire/fire_in_turf = locate(selected_typepath) in target_turf.contents
 	if(!fire_in_turf)
-		new /obj/fire/melting_fire(target_turf)
+		new selected_typepath(target_turf)
 		return
 	fire_in_turf.burn_ticks = initial(fire_in_turf.burn_ticks)
 	for(var/something_in_turf in get_turf(fire_in_turf))

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/castedatum_dragon.dm
@@ -62,6 +62,12 @@
 		/datum/action/ability/xeno_action/blessing_menu,
 	)
 
+	mutations = list(
+		/datum/mutation_upgrade/shell/regenerative_armor,
+		/datum/mutation_upgrade/spur/breath_of_variety,
+		/datum/mutation_upgrade/veil/benevolence
+	)
+
 /datum/xeno_caste/dragon/normal
 	upgrade = XENO_UPGRADE_NORMAL
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/mutations_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/mutations_dragon.dm
@@ -1,0 +1,121 @@
+//*********************//
+//        Shell        //
+//*********************//
+/datum/mutation_upgrade/shell/regenerative_armor
+	name = "Regenerative Armor"
+	desc = "Whenever you passively regenerate health, you will also gain 2.5/5/7.5% of your maximum plasma. This scales with regenerative power."
+	/// For each structure, the percentage (0-1) of the owner's maximum plasma to regenerate.
+	var/percentage_per_structure = 0.025
+
+/datum/mutation_upgrade/shell/regenerative_armor/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Whenever you regenerate health, you will also gain [PERCENT(get_percentage(new_amount))]% of your maximum plasma. This scales with regenerative power."
+
+/datum/mutation_upgrade/shell/regenerative_armor/on_mutation_enabled()
+	RegisterSignal(xenomorph_owner, COMSIG_XENOMORPH_HEALTH_REGEN, PROC_REF(on_health_regeneration))
+	return ..()
+
+/datum/mutation_upgrade/shell/regenerative_armor/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, list(COMSIG_XENOMORPH_HEALTH_REGEN))
+	return ..()
+
+/// Restores a percentage of the owner's plasma based on their maximum plasma then scaling with the amount of structure and regeneration power.
+/datum/mutation_upgrade/shell/regenerative_armor/proc/on_health_regeneration(datum/source, heal_data, seconds_per_tick)
+	SIGNAL_HANDLER
+	if(xenomorph_owner.regen_power <= 0)
+		return
+	xenomorph_owner.gain_plasma(xenomorph_owner.xeno_caste.plasma_max * get_percentage(get_total_structures()) * (seconds_per_tick * XENO_PER_SECOND_LIFE_MOD) * xenomorph_owner.regen_power)
+
+/// Returns the percentage (0-1) of the owner's maximum plasma to regenerate.
+/datum/mutation_upgrade/shell/regenerative_armor/proc/get_percentage(structure_count)
+	return percentage_per_structure * structure_count
+
+//*********************//
+//         Spur        //
+//*********************//
+/datum/mutation_upgrade/spur/breath_of_variety
+	name = "Breath of Variety"
+	desc = "Dragon Breath can switch between additional fire types to replace it with different effects: shatter or melting acid. Dragon Breath's cooldown is set to 150/125/100% of its original cooldown."
+	/// For the first structure, the multiplier of Dragon Breath's initial cooldown duration to add to the ability.
+	var/multiplier_initial = 0.75
+	/// For each structure, the multiplier of Dragon Breath's initial cooldown duration to add to the ability.
+	var/multiplier_per_structure = -0.25
+
+/datum/mutation_upgrade/spur/breath_of_variety/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Dragon Breath can switch between additional fire types to replace it with different effects: shatter or melting acid. Dragon Breath's cooldown is set to 150/125/100% [PERCENT((1 + get_multiplier(new_amount)))] of its original cooldown."
+
+/datum/mutation_upgrade/spur/breath_of_variety/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/backhand/dragon_breath/breath_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/backhand/dragon_breath]
+	if(!breath_ability)
+		return
+	breath_ability.cooldown_duration += initial(breath_ability.cooldown_duration) * get_multiplier(0)
+	breath_ability.selectable_fire_images_list["Shattering"] = image('icons/effects/fire.dmi', icon_state = "violet_3")
+	breath_ability.selectable_fire_images_list["Melting Acid"] = image('icons/effects/fire.dmi', icon_state = "green_3")
+
+/datum/mutation_upgrade/spur/breath_of_variety/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/backhand/dragon_breath/breath_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/backhand/dragon_breath]
+	if(!breath_ability)
+		return
+	breath_ability.cooldown_duration -= initial(breath_ability.cooldown_duration) * get_multiplier(0)
+	breath_ability.selectable_fire_images_list["Shattering"] = null
+	breath_ability.selectable_fire_images_list["Melting Acid"] = null
+
+/datum/mutation_upgrade/spur/breath_of_variety/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/backhand/dragon_breath/breath_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/backhand/dragon_breath]
+	if(!breath_ability)
+		return
+	breath_ability.cooldown_duration += initial(breath_ability.cooldown_duration) * get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier of Dragon Breath's initial cooldown duration to add to the ability.
+/datum/mutation_upgrade/spur/breath_of_variety/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+//*********************//
+//         Veil        //
+//*********************//
+/datum/mutation_upgrade/veil/benevolence
+	name = "Benevolence"
+	desc = "You emit all types of pheromones at 2/2.5/3 power in a radius of 14/15/16."
+	/// For the first structure, the amount of power to increase the pheromones by.
+	var/power_increase_initial = 1.5
+	/// For each structure, the amount of power to increase the pheromones by.
+	var/power_increase_per_structure = 0.5
+	/// The frenzy aura if it exists.
+	var/datum/aura_bearer/frenzy_aura
+	/// The warding aura if it exists.
+	var/datum/aura_bearer/warding_aura
+	/// The recovery aura if it exists.
+	var/datum/aura_bearer/recovery_aura
+
+/datum/mutation_upgrade/veil/benevolence/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You emit all types of pheromones at [get_power(new_amount)] power in a radius of [get_radius(new_amount)]."
+
+/datum/mutation_upgrade/veil/benevolence/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	if(frenzy_aura)
+		QDEL_NULL(frenzy_aura)
+	if(warding_aura)
+		QDEL_NULL(warding_aura)
+	if(recovery_aura)
+		QDEL_NULL(recovery_aura)
+	if(!new_amount)
+		return
+	frenzy_aura = SSaura.add_emitter(xenomorph_owner, AURA_XENO_FRENZY, get_radius(new_amount), get_power(new_amount), -1, FACTION_XENO, xenomorph_owner.hivenumber)
+	warding_aura = SSaura.add_emitter(xenomorph_owner, AURA_XENO_WARDING, get_radius(new_amount), get_power(new_amount), -1, FACTION_XENO, xenomorph_owner.hivenumber)
+	recovery_aura = SSaura.add_emitter(xenomorph_owner, AURA_XENO_RECOVERY, get_radius(new_amount), get_power(new_amount), -1, FACTION_XENO, xenomorph_owner.hivenumber)
+
+/// Returns the power of the aura(s).
+/datum/mutation_upgrade/veil/benevolence/proc/get_power(structure_count)
+	return power_increase_initial + (power_increase_per_structure * structure_count)
+
+/// Returns the radius of the aura(s).
+/datum/mutation_upgrade/veil/benevolence/proc/get_radius(power)
+	return (6 + power) * 2

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1996,6 +1996,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\castes\dragon\abilities_dragon.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\dragon\castedatum_dragon.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\dragon\dragon.dm"
+#include "code\modules\mob\living\carbon\xenomorph\castes\dragon\mutations_dragon.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\abilities_drone.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\castedatum_drone.dm"
 #include "code\modules\mob\living\carbon\xenomorph\castes\drone\drone.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a total of 3 mutations all for Dragon.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Regenerative Armor | Whenever you passively regenerate health, you will also gain 2.5/5/7.5% of your maximum plasma. This scales with regenerative power. |
| Spur | Breath of Variety | Dragon Breath can switch between additional fire types to replace it with different effects: shatter or melting acid. Dragon Breath's cooldown is set to 150/125/100% of its original cooldown. |
| Veil | Benevolence | You emit all types of pheromones at 2/2.5/3 power in a radius of 14/15/16. |

## Why It's Good For The Game
More mutations.

## Changelog
:cl:
add: King now has 4 new mutations that they can purchase if their hive has enough biomass and mutation structures. Not accessible without admin intervention for now.
/:cl:
