### PR TITLE
reworking the vindicator minigun like a boss

### DIFF
--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -29,7 +29,7 @@
 	damage = 25
 	penetration = 15
 	shrapnel_chance = 25
-	sundering = 2.5
+	sundering = 2
 
 /datum/ammo/bullet/minigun_light
 	name = "minigun bullet"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -377,7 +377,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 /obj/item/weapon/gun/minigun
 	name = "\improper MG-100 Vindicator minigun"
-	desc = "A six-barreled rotary machine gun, the ultimate in man-portable firepower. Capable of laying down a steady stream high velocity armor piercing rounds. Try not to kill all of your friends with it."
+	desc = "A six-barreled rotary machine gun, the ultimate in man-portable firepower. While it is extremely unwieldy, it can unleash a devastating amount of high velocity armor piercing rounds. Try not to kill all of your friends with it."
 	icon = 'icons/obj/items/guns/special64.dmi'
 	icon_state = "minigun"
 	worn_icon_state = "minigun"
@@ -386,7 +386,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		slot_r_hand_str = 'icons/mob/inhands/guns/special_right_1.dmi',
 	)
 	fire_animation = "minigun_fire"
-	max_shells = 500 //codex
+	max_shells = 750 //codex
 	caliber = CALIBER_762X51 //codex
 	load_method = MAGAZINE //codex
 	fire_sound = 'sound/weapons/guns/fire/minigun.ogg'
@@ -401,23 +401,24 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		)
 	w_class = WEIGHT_CLASS_HUGE
 	force = 20
-	wield_delay = 1.2 SECONDS
+	wield_delay = 1.8 SECONDS
 	gun_skill_category = SKILL_HEAVY_WEAPONS
-	aim_slowdown = 0.8
-	gun_features_flags = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
+	aim_slowdown = 1.2
+	gun_features_flags = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_SMOKE_PARTICLES
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12)
 	aim_fire_delay = 0.1 SECONDS
 	aim_speed_modifier = 12
 
-	fire_delay = 0.15 SECONDS
-	windup_delay = 0.4 SECONDS
+	fire_delay = 0.1 SECONDS
+	windup_delay = 0.8 SECONDS
 	windup_sound = 'sound/weapons/guns/fire/tank_minigun_start.ogg'
 	scatter = 5
 	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
 	movement_acc_penalty_mult = 4
+	damage_mult = 0.85
 
 	item_flags = TWOHANDED|AUTOBALANCE_CHECK
 
@@ -482,9 +483,10 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	aim_slowdown = 1.2
 	actions_types = list()
 
-	fire_delay = 0.1 SECONDS
 	scatter = -5
 	recoil_unwielded = 4
+	damage_mult = 1
+	windup_delay = 0.4 SECONDS
 
 	item_flags = TWOHANDED
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -412,7 +412,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	aim_speed_modifier = 12
 
 	fire_delay = 0.1 SECONDS
-	windup_delay = 0.8 SECONDS
+	windup_delay = 0.4 SECONDS
 	windup_sound = 'sound/weapons/guns/fire/tank_minigun_start.ogg'
 	scatter = 5
 	recoil_unwielded = 4

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -434,8 +434,8 @@
 	magazine_flags = MAGAZINE_WORN
 	w_class = WEIGHT_CLASS_HUGE
 	default_ammo = /datum/ammo/bullet/minigun
-	current_rounds = 500
-	max_rounds = 500
+	current_rounds = 750
+	max_rounds = 750
 	item_map_variant_flags = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT)
 
 /obj/item/ammo_magazine/minigun_powerpack/fancy


### PR DESCRIPTION
## About The Pull Request

you see i put rework in the title to make this seem more than changing like 3 lines of code

MG-100 changes
fire delay: 0.15 > 0.1 (400 rpm > 600rpm)
damage mult: 1 > 0.85
sunder: 2.5 > 2
wield delay: 1.2 > 1.8
slowdown: 0.8 > 1.2
mag capacity: 500 > 750
The minigun can now only be fired when fully wielded

The DPS of the minigun changed from 167 DPS to 212 DPS
or against a target with 50 armor: 108 DPS to 138 DPS
The sunder/sec of the minigun changed from 16.5 to 20

## Why It's Good For The Game

The minigun seemed like a pointless weapon to me, considering that you had to give up a lot of mobility, handling, a back slot, and 800 req points for something that was essentially an MG-60 with slightly more damage, and some good sunder thrown in there.
It also didn't seem at all like a minigun considering its slow fire rate.

I made these changes to transform the minigun into somewhat of a monster in terms of DPS, but something that could easily be countered by a few stuns.

## Changelog
:cl: Joe13413
balance: The MG-100 minigun now fires 50% faster, but has considerably worse handling, and slightly less damage.
/:cl:
