### PR TITLE
Moved around two vendors (and the shower) in canter medical

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -526,7 +526,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cb" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cc" = (
@@ -557,7 +557,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cg" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/vending/medical,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "cl" = (
@@ -889,7 +889,7 @@ bI
 cs
 cJ
 YI
-cd
+cb
 bo
 cm
 "}
@@ -911,7 +911,7 @@ bz
 bI
 bK
 bU
-cb
+cd
 cg
 bo
 cn


### PR DESCRIPTION

## About The Pull Request

I swapped around the locations of two medical vendors and one shower.  The MarineMed and NanotrasenMed Plus vendors are now next to each other horizontally in the south east corner of canter medical, and the shower has been moved to where the NanotrasenMed Plus vendor previously was located.

Before:
<img width="652" height="542" alt="med-before" src="https://github.com/user-attachments/assets/5030e91b-94c2-4dc7-bf2b-fbf5ed945a56" />

After:
<img width="650" height="542" alt="med-after" src="https://github.com/user-attachments/assets/7ae358d8-c7c8-49e4-bf85-2a13db4f1dd2" />
## Why It's Good For The Game

This change makes it easier to set up cades at canter south during round start. The MarineMed vendor cannot be wrenched and moved around, and therefore was a permanent obstacle for optimal cade setups. This change moves it to be further inside medical relative to the south exit, which allows for a greater range of cade setups.
## Changelog

:cl: Scav
qol: Rearranged the positions of two vendors and the shower in canter medical
/:cl:
