### PR TITLE
Canter medvendors rearrange (UPDATE - re added light fixture)

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -550,6 +550,7 @@
 /obj/structure/sink{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cf" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -526,7 +526,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cb" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cc" = (
@@ -557,7 +557,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "cg" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/vending/medical,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "cl" = (
@@ -889,7 +889,7 @@ bI
 cs
 cJ
 YI
-cd
+cb
 bo
 cm
 "}
@@ -911,7 +911,7 @@ bz
 bI
 bK
 bU
-cb
+cd
 cg
 bo
 cn


### PR DESCRIPTION

## About The Pull Request

Re-added a light fixture in canter medical that I accidentally deleted when re arranging vendors in my last PR
## Why It's Good For The Game

Being able to see while performing surgery is good actually
## Changelog

:cl: Scav
fix: Re-added a light fixture in canter medical
/:cl:
