### PR TITLE
Petrify goes on cooldown when giving armor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -112,7 +112,7 @@
 		human.overlays += stone_overlay
 		petrified_humans[human] = stone_overlay
 
-	if(!length(petrified_humans))
+	if(!length(petrified_humans) && !length(viewing_xenomorphs))
 		flick("eye_closing", eye)
 		addtimer(CALLBACK(src, PROC_REF(remove_eye), eye), 7, TIMER_CLIENT_TIME)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
King's Petrify now fully activates and thus goes on cooldown if any xenomorphs were granted armor by it.

## Why It's Good For The Game
Infinite armor bad.

## Changelog
:cl:
fix: King's Petrify now goes on cooldown if any xenomorphs affected by it were given armor.
/:cl:
