### PR TITLE
More Carrier Mutations

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1026,7 +1026,7 @@
 	)
 	/// Should the egg contain the owner's selected_hugger_type instead?
 	var/use_selected_hugger = FALSE
-	/// The amount to pass to the egg which will then be used to multiply the created hugger's hand attach time by.
+	/// The amount to multiply the created hugger's hand attach time by.
 	var/hand_attach_time_multiplier = 1
 
 /datum/action/ability/xeno_action/lay_egg/action_activate(mob/living/carbon/xenomorph/user)
@@ -1049,8 +1049,7 @@
 	if(!xeno.loc_weeds_type)
 		return fail_activate()
 
-	var/obj/alien/egg/hugger/egg = new(current_turf, xeno.hivenumber, use_selected_hugger ? xeno_owner.selected_hugger_type : null)
-	egg.hand_attach_time_multiplier = hand_attach_time_multiplier
+	var/obj/alien/egg/hugger/egg = new(current_turf, xeno.hivenumber, use_selected_hugger ? xeno_owner.selected_hugger_type : null, hand_attach_time_multiplier)
 
 	playsound(current_turf, 'sound/effects/splat.ogg', 15, 1)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1026,6 +1026,8 @@
 	)
 	/// Should the egg contain the owner's selected_hugger_type instead?
 	var/use_selected_hugger = FALSE
+	/// The amount to pass to the egg which will then be used to multiply the created hugger's hand attach time by.
+	var/hand_attach_time_multiplier = 1
 
 /datum/action/ability/xeno_action/lay_egg/action_activate(mob/living/carbon/xenomorph/user)
 	var/mob/living/carbon/xenomorph/xeno = owner
@@ -1047,7 +1049,9 @@
 	if(!xeno.loc_weeds_type)
 		return fail_activate()
 
-	new /obj/alien/egg/hugger(current_turf, xeno.hivenumber, use_selected_hugger ? xeno_owner.selected_hugger_type : null)
+	var/obj/alien/egg/hugger/egg = new(current_turf, xeno.hivenumber, use_selected_hugger ? xeno_owner.selected_hugger_type : null)
+	egg.hand_attach_time_multiplier = hand_attach_time_multiplier
+
 	playsound(current_turf, 'sound/effects/splat.ogg', 15, 1)
 
 	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -113,7 +113,6 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 			fake.activate_time = F.activate_time
 			fake.proximity_time = F.proximity_time
 			fake.leap_range = F.leap_range
-			xeno_owner.dropItemToGround(fake)
 			fake.stat = F.stat
 			fake.leaping = F.leaping
 			fake.facehugger_register_source(xeno_owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		F.leaping = FALSE //Hugger is not leaping
 		F.facehugger_register_source(xeno_owner) //Set us as the source
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
-		if(fake_hugger_gradiant_percentage > 0 and !istype(F, /obj/item/clothing/mask/facehugger/combat/harmless))
+		if(fake_hugger_gradiant_percentage > 0 && !istype(F, /obj/item/clothing/mask/facehugger/combat/harmless))
 			var/obj/item/clothing/mask/facehugger/combat/harmless/fake = new(get_turf(xeno_owner), xeno_owner.hivenumber, xeno_owner)
 			fake.set_fire_immunity(F.fire_immune)
 			fake.impact_time = F.impact_time

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -68,9 +68,14 @@
 
 	mutations = list(
 		/datum/mutation_upgrade/shell/shared_jelly,
+		/datum/mutation_upgrade/shell/hugger_overflow,
+		/datum/mutation_upgrade/shell/recurring_panic,
 		/datum/mutation_upgrade/spur/leapfrog,
+		/datum/mutation_upgrade/spur/claw_delivered,
+		/datum/mutation_upgrade/spur/fake_huggers,
 		/datum/mutation_upgrade/veil/oviposition,
-		/datum/mutation_upgrade/veil/life_for_life
+		/datum/mutation_upgrade/veil/life_for_life,
+		/datum/mutation_upgrade/veil/swarm_trap
 	)
 
 /datum/xeno_caste/carrier/normal

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
@@ -356,7 +356,7 @@
 	/// For each structure, the additional amount of huggers that can be stored in the traps.
 	var/huggers_per_structure = 1
 
-/datum/mutation_upgrade/veil/life_for_life/get_desc_for_alert(new_amount)
+/datum/mutation_upgrade/veil/swarm_trap/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
 	return "Your newly created traps can fit [get_huggers(new_amount)] huggers total, but the stun duration divided by the amount of the hugger inside the trap."

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
@@ -39,6 +39,95 @@
 /datum/mutation_upgrade/shell/shared_jelly/proc/get_length(structure_count, include_initial = TRUE)
 	return (include_initial ? length_initial : 0) + (length_per_structure * structure_count)
 
+/datum/mutation_upgrade/shell/hugger_overflow
+	name = "Hugger Overflow"
+	desc = "While you have 8/7/6 or more stored huggers, you will automatically drop one underneath you when you become staggered."
+	/// For the first structure, the threshold of stored huggers that the owner must reach in order to drop one when staggered.
+	var/threshold_initial = 9
+	/// For each structure,  the amount to add to the threshold of stored huggers that the owner must reach in order to drop one when staggered.
+	var/threshold_per_structure = -1
+
+/datum/mutation_upgrade/shell/hugger_overflow/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "While you have [get_threshold(new_amount)] or more stored huggers, you will automatically drop a larval hugger underneath you when you become staggered."
+
+/datum/mutation_upgrade/shell/hugger_overflow/on_mutation_enabled()
+	RegisterSignal(xenomorph_owner, COMSIG_LIVING_STATUS_STAGGER, PROC_REF(on_staggered))
+	return ..()
+
+/datum/mutation_upgrade/shell/hugger_overflow/on_mutation_disabled()
+	UnregisterSignal(xenomorph_owner, COMSIG_LIVING_STATUS_STAGGER)
+	return ..()
+
+/// If the owner is reached and the threshold of stored huggers is reached, drop a larval hugger.
+/datum/mutation_upgrade/shell/hugger_overflow/proc/on_staggered(datum/source, amount, ignore_canstun)
+	if(get_threshold(get_total_structures()) > xenomorph_owner.huggers)
+		return
+	var/obj/item/clothing/mask/facehugger/new_hugger = new /obj/item/clothing/mask/facehugger/larval(get_turf(xenomorph_owner), xenomorph_owner.hivenumber, xenomorph_owner)
+	step_away(new_hugger, xenomorph_owner, 1)
+	addtimer(CALLBACK(new_hugger, TYPE_PROC_REF(/obj/item/clothing/mask/facehugger, go_active), TRUE), new_hugger.jump_cooldown)
+	xenomorph_owner.huggers--
+
+/// Returns the threshold of stored huggers that the owner must reach in order to drop one when staggered.
+/datum/mutation_upgrade/shell/hugger_overflow/proc/get_threshold(structure_count, include_initial = TRUE)
+	return (include_initial ? threshold_initial : 0) + (threshold_per_structure * structure_count)
+
+/datum/mutation_upgrade/shell/recurring_panic
+	name = "Recurring Panic"
+	desc = "If you're not resting, Carrier Panic will automatically attempt to activate when possible. The cooldown duration is set to 20% of its original value. It only consumes 50/40/30% of your maximum plasma."
+	/// For each structure, the multiplier to add to Carrier Panic's plasma consumption. 1 = 100% of the owner's maximum plasma. 0.1 = 10% of the owner's maximum plasma.
+	var/multiplier_initial = -0.4
+	/// For each structure, the multiplier to add to Carrier Panic's plasma consumption.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/shell/recurring_panic/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "If you're not resting, Carrier Panic will automatically attempt to activate when possible. The cooldown duration is to 20% of its original value. It only consumes [PERCENT(1 + get_multiplier(new_amount))]% of your maximum plasma."
+
+/datum/mutation_upgrade/shell/recurring_panic/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/carrier_panic/panic_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/carrier_panic]
+	if(!panic_ability)
+		return
+	RegisterSignal(xenomorph_owner, list(COMSIG_LIVING_UPDATE_HEALTH), PROC_REF(on_update_health))
+	panic_ability.cooldown_duration -= initial(panic_ability.cooldown_duration) * 0.8
+	panic_ability.succeed_cost += get_multiplier(0)
+
+/datum/mutation_upgrade/shell/recurring_panic/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/carrier_panic/panic_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/carrier_panic]
+	if(!panic_ability)
+		return
+	UnregisterSignal(xenomorph_owner, COMSIG_LIVING_UPDATE_HEALTH)
+	panic_ability.cooldown_duration += initial(panic_ability.cooldown_duration) * 0.8
+	panic_ability.succeed_cost -= get_multiplier(0)
+
+/datum/mutation_upgrade/shell/recurring_panic/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/carrier_panic/panic_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/carrier_panic]
+	if(!panic_ability)
+		return
+	panic_ability.succeed_cost += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier of Carrier Panic's initial plasma cost to add to the ability.
+/datum/mutation_upgrade/shell/recurring_panic/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/// Checks if Carrier Panic can be activated and not resting. If so, activate it.
+/datum/mutation_upgrade/shell/recurring_panic/proc/on_update_health()
+	SIGNAL_HANDLER
+	var/health = (xenomorph_owner.status_flags & GODMODE) ? xenomorph_owner.maxHealth : (xenomorph_owner.maxHealth - xenomorph_owner.getFireLoss() - xenomorph_owner.getBruteLoss())
+	if(health <= xenomorph_owner.get_death_threshold())
+		return
+	var/datum/action/ability/xeno_action/carrier_panic/panic_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/carrier_panic]
+	if(!panic_ability)
+		return
+	if(xenomorph_owner.resting || !panic_ability.action_cooldown_finished() || !panic_ability.can_use_action(silent = TRUE))
+		return
+	panic_ability.action_activate()
+
 //*********************//
 //         Spur        //
 //*********************//
@@ -85,6 +174,82 @@
 /// Returns the multiplier to add towards the various activation times that thrown facehuggers via Throw Facehugger will have.
 /datum/mutation_upgrade/spur/leapfrog/proc/get_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/spur/claw_delivered
+	name = "Claw Delivered"
+	desc = "Huggers from your eggs now have a reduced cast time against humans. The cast time is set to 60/50/40% of its original value."
+	/// For the first structure, the multiplier to add to the Hugger's cast time when trying to attach to humans manually.
+	var/multiplier_initial = -0.3
+	/// For each structure, the multiplier to add to the Hugger's cast time when trying to attach to humans manually.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/spur/claw_delivered/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Huggers from your eggs now have a reduced cast time against humans. The cast time is set to [PERCENT(1 + get_multiplier(new_amount))]% of its original value."
+
+/datum/mutation_upgrade/spur/claw_delivered/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	egg_ability.hand_attach_time_multiplier += get_multiplier(0)
+
+/datum/mutation_upgrade/spur/claw_delivered/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	egg_ability.hand_attach_time_multiplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/spur/claw_delivered/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
+	if(!egg_ability)
+		return
+	egg_ability.hand_attach_time_multiplier += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the multiplier to add to the Hugger's cast time when trying to attach to humans manually.
+/datum/mutation_upgrade/spur/claw_delivered/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/spur/fake_huggers
+	name = "Fake Huggers"
+	desc = "Thrown huggers will accompanied by a fake facehugger which will mimic their behavior. Their color will be changed to match 50/70/90% of the original hugger's color."
+	/// For the first structure, the amount to add to Throw Huggers' gradiant to be applied to the fake huggers.
+	var/gradiant_initial = 0.3
+	/// For each structure, the amount to add to Throw Huggers' gradiant to be applied to the fake huggers.
+	var/gradiant_per_structure = 0.2
+
+/datum/mutation_upgrade/spur/fake_huggers/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Thrown huggers will accompanied by a fake facehugger which will mimic their behavior. Their color will be changed to match [PERCENT(get_gradiant(new_amount))]% of the original hugger's color."
+
+/datum/mutation_upgrade/spur/fake_huggers/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fake_hugger_gradiant_percentage += get_gradiant(0)
+
+/datum/mutation_upgrade/spur/fake_huggers/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fake_hugger_gradiant_percentage -= get_gradiant(0)
+
+/datum/mutation_upgrade/spur/fake_huggers/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/throw_hugger/hugger_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/throw_hugger]
+	if(!hugger_ability)
+		return
+	hugger_ability.fake_hugger_gradiant_percentage += get_gradiant(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to add to Throw Huggers' gradiant to be applied to the fake huggers.
+/datum/mutation_upgrade/spur/fake_huggers/proc/get_gradiant(structure_count, include_initial = TRUE)
+	return (include_initial ? gradiant_initial : 0) + (gradiant_per_structure * structure_count)
 
 //*********************//
 //         Veil        //
@@ -184,3 +349,26 @@
 /// Returns the multiplier that will be added to the ability cost of Egg Lay.
 /datum/mutation_upgrade/veil/life_for_life/proc/get_damage(structure_count, include_initial = TRUE)
 	return (include_initial ? damage_initial : 0) + (damage_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/swarm_trap
+	name = "Swarm Trap"
+	desc = "Your newly created traps can fit 2/3/4 huggers total, but the stun duration divided by the amount of the hugger inside the trap."
+	/// For each structure, the additional amount of huggers that can be stored in the traps.
+	var/huggers_per_structure = 1
+
+/datum/mutation_upgrade/veil/life_for_life/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Your newly created traps can fit [get_huggers(new_amount)] huggers total, but the stun duration divided by the amount of the hugger inside the trap."
+
+/datum/mutation_upgrade/veil/swarm_trap/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/place_trap/trap_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/place_trap]
+	if(!trap_ability)
+		return
+	trap_ability.trap_hugger_limit += get_huggers(new_amount - previous_amount)
+
+/// Returns the additional amount of huggers that can be stored in the traps.
+/datum/mutation_upgrade/veil/swarm_trap/proc/get_huggers(structure_count)
+	return huggers_per_structure * structure_count
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
@@ -352,14 +352,14 @@
 
 /datum/mutation_upgrade/veil/swarm_trap
 	name = "Swarm Trap"
-	desc = "Your newly created traps can fit 2/3/4 huggers total, but the stun duration divided by the amount of the hugger inside the trap."
+	desc = "Your newly created traps can fit an additional 1/2/3 huggers, but the stun duration divided by the amount of the hugger inside the trap."
 	/// For each structure, the additional amount of huggers that can be stored in the traps.
 	var/huggers_per_structure = 1
 
 /datum/mutation_upgrade/veil/swarm_trap/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Your newly created traps can fit [get_huggers(new_amount)] huggers total, but the stun duration divided by the amount of the hugger inside the trap."
+	return "Your newly created traps can fit an additional [get_huggers(new_amount)] huggers, but the stun duration divided by the amount of the hugger inside the trap."
 
 /datum/mutation_upgrade/veil/swarm_trap/on_structure_update(previous_amount, new_amount)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -95,7 +95,7 @@
 	if(new_hugger_type)
 		hugger_type = new_hugger_type
 	if(new_hand_attach_time_multiplier)
-		_hand_attach_time_multiplier = new_hand_attach_time_multiplier
+		hand_attach_time_multiplier = new_hand_attach_time_multiplier
 
 /obj/alien/egg/hugger/update_icon_state()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -90,10 +90,12 @@
 	/// The amount to multiply the hugger's hand attach time, if any, by.
 	var/hand_attach_time_multiplier = 1
 
-/obj/alien/egg/hugger/Initialize(mapload, hivenumber, new_hugger_type)
+/obj/alien/egg/hugger/Initialize(mapload, hivenumber, new_hugger_type, new_hand_attach_time_multiplier)
 	. = ..()
 	if(new_hugger_type)
 		hugger_type = new_hugger_type
+	if(new_hand_attach_time_multiplier)
+		_hand_attach_time_multiplier = new_hand_attach_time_multiplier
 
 /obj/alien/egg/hugger/update_icon_state()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -87,6 +87,8 @@
 	trigger_size = 2
 	///What type of hugger are produced here
 	var/hugger_type = /obj/item/clothing/mask/facehugger
+	/// The amount to multiply the hugger's hand attach time, if any, by.
+	var/hand_attach_time_multiplier = 1
 
 /obj/alien/egg/hugger/Initialize(mapload, hivenumber, new_hugger_type)
 	. = ..()
@@ -116,6 +118,7 @@
 	playsound(src.loc, 'sound/effects/alien/egg_move.ogg', 25)
 	flick("egg opening", src)
 	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(src), hivenumber)
+	hugger.hand_attach_time = initial(hugger.hand_attach_time) * hand_attach_time_multiplier
 	hugger_type = null
 	addtimer(CALLBACK(hugger, TYPE_PROC_REF(/atom/movable, forceMove), loc), 1 SECONDS)
 	hugger.go_active()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -66,6 +66,8 @@
 	var/fire_immune = FALSE
 	/// How far can they leap?
 	var/leap_range = 4
+	/// How long in decisecond should it take to manually attach a facehugger to someone?
+	var/hand_attach_time = 1 SECONDS
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload, input_hivenumber, input_source, new_fire_immunity)
 	. = ..()
@@ -174,7 +176,7 @@
 	user.visible_message(span_warning("\ [user] attempts to plant [src] on [M]'s face!"), \
 	span_warning("We attempt to plant [src] on [M]'s face!"))
 	if(M.client && !M.stat) //Delay for conscious cliented mobs, who should be resisting.
-		if(!do_after(user, 1 SECONDS, NONE, M, BUSY_ICON_DANGER))
+		if(!do_after(user, hand_attach_time, NONE, M, BUSY_ICON_DANGER))
 			return
 	if(!try_attach(M))
 		go_idle()
@@ -320,10 +322,10 @@
 		if(E?.insert_new_hugger(src))
 			return FALSE
 		var/obj/structure/xeno/trap/T = locate() in loc
-		if(T && !T.hugger)
+		if(T && (T.hugger_limit > length(T.huggers)))
 			visible_message(span_xenowarning("[src] crawls into [T]!"))
 			forceMove(T)
-			T.hugger = src
+			T.huggers += src
 			T.set_trap_type(TRAP_HUGGER)
 			go_idle(TRUE)
 			return FALSE
@@ -843,6 +845,16 @@
 		if(hivenumber == X.hive.hivenumber) //No friendly fire
 			return FALSE
 
+	return TRUE
+
+
+/obj/item/clothing/mask/facehugger/combat/harmless
+	name = "harmless hugger"
+	color = COLOR_BROWN
+
+/obj/item/clothing/mask/facehugger/combat/harmless/try_attach(mob/M, mob/user)
+	if(!combat_hugger_check_target(M))
+		return FALSE
 	return TRUE
 
 #undef FACEHUGGER_DEATH

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1617,8 +1617,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	return ..()
 
 /obj/structure/xeno/trap/get_xeno_hivenumber()
-	if(hugger)
-		return hugger.hivenumber
+	if(length(huggers))
+		return huggers[1].hivenumber
 	return ..()
 
 /mob/living/carbon/human/get_xeno_hivenumber()

--- a/code/modules/xenomorph/trap.dm
+++ b/code/modules/xenomorph/trap.dm
@@ -12,19 +12,23 @@
 	destroy_sound = SFX_ALIEN_RESIN_BREAK
 	///defines for trap type to trigger on activation
 	var/trap_type
-	///The hugger inside our trap
-	var/obj/item/clothing/mask/facehugger/hugger = null
+	/// All huggers inside of our trap.
+	var/list/obj/item/clothing/mask/facehugger/huggers = list()
 	///smoke effect to create when the trap is triggered
 	var/datum/effect_system/smoke_spread/smoke
 	///connection list for huggers
 	var/static/list/listen_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(trigger_trap),
 	)
+	/// The amount of huggers that can be stored in this trap.
+	var/hugger_limit = 1
 
-/obj/structure/xeno/trap/Initialize(mapload, _hivenumber)
+/obj/structure/xeno/trap/Initialize(mapload, _hivenumber, _hugger_limit)
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(shuttle_crush))
 	AddElement(/datum/element/connect_loc, listen_connections)
+	if(_hugger_limit)
+		hugger_limit = _hugger_limit
 
 /obj/structure/xeno/trap/ex_act(severity)
 	switch(severity)
@@ -56,7 +60,7 @@
 			icon_state = "trap"
 
 /obj/structure/xeno/trap/obj_destruction(damage_amount, damage_type, damage_flag, mob/living/blame_mob)
-	if((damage_amount || damage_flag) && hugger && loc)
+	if((damage_amount || damage_flag) && length(huggers) && loc)
 		trigger_trap()
 	return ..()
 
@@ -78,7 +82,8 @@
 	. += "A hole for a little one to hide in ambush for or for spewing acid."
 	switch(trap_type)
 		if(TRAP_HUGGER)
-			. += "There's a little one inside."
+			var/hugger_amount = length(huggers)
+			. += hugger_amount == 1 ? "There's a little one inside." : "There's [hugger_amount] little ones inside."
 		if(TRAP_SMOKE_NEURO)
 			. += "There's pressurized neurotoxin inside."
 		if(TRAP_SMOKE_ACID)
@@ -93,7 +98,9 @@
 			. += "It's empty."
 
 /obj/structure/xeno/trap/fire_act(burn_level)
-	hugger?.kill_hugger()
+	for(var/obj/item/clothing/mask/facehugger/hugger AS in huggers)
+		hugger.kill_hugger()
+	huggers.Cut()
 	trigger_trap()
 	set_trap_type(null)
 
@@ -108,18 +115,23 @@
 	if(iscarbon(AM))
 		var/mob/living/carbon/crosser = AM
 		crosser.visible_message(span_warning("[crosser] trips on [src]!"), span_danger("You trip on [src]!"))
-		crosser.ParalyzeNoChain(4 SECONDS)
+		crosser.ParalyzeNoChain(4 SECONDS / max(1, length(huggers))) // Don't want to divide by 0.
 	switch(trap_type)
 		if(TRAP_HUGGER)
 			if(!AM)
-				drop_hugger()
+				drop_huggers()
 				return
 			if(!iscarbon(AM))
 				return
 			var/mob/living/carbon/crosser = AM
-			if(!crosser.can_be_facehugged(hugger))
+			var/could_be_hugged = FALSE
+			for(var/obj/item/clothing/mask/facehugger/hugger AS in huggers) // In case of: 4 larval huggers vs. (unfacehuggable) robot.
+				if(crosser.can_be_facehugged(hugger))
+					could_be_hugged = TRUE
+					break
+			if(!could_be_hugged)
 				return
-			drop_hugger()
+			drop_huggers()
 		if(TRAP_SMOKE_NEURO, TRAP_SMOKE_ACID)
 			smoke.start()
 		if(TRAP_ACID_WEAK)
@@ -134,12 +146,13 @@
 	xeno_message("A [trap_type] trap at [AREACOORD_NO_Z(src)] has been triggered!", "xenoannounce", 5, hivenumber,  FALSE, get_turf(src), 'sound/voice/alien/talk2.ogg', FALSE, null, /atom/movable/screen/arrow/attack_order_arrow, COLOR_ORANGE, TRUE)
 	set_trap_type(null)
 
-/// Move the hugger out of the trap
-/obj/structure/xeno/trap/proc/drop_hugger()
-	hugger.forceMove(loc)
-	hugger.go_active(TRUE, TRUE) //Removes stasis
-	visible_message(span_warning("[hugger] gets out of [src]!") )
-	hugger = null
+/// Move all huggers out of the trap.
+/obj/structure/xeno/trap/proc/drop_huggers()
+	for(var/obj/item/clothing/mask/facehugger/hugger AS in huggers)
+		hugger.forceMove(loc)
+		hugger.go_active(TRUE, TRUE) // Removes stasis.
+	visible_message(span_warning((length(huggers) == 1 ? "[huggers[1]] gets out of [src]!" : "Huggers swarm out of [src]!")))
+	huggers.Cut()
 	set_trap_type(null)
 
 /obj/structure/xeno/trap/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
@@ -151,13 +164,15 @@
 	if(trap_type == TRAP_HUGGER)
 		if(!(xeno_attacker.xeno_caste.can_flags & CASTE_CAN_HOLD_FACEHUGGERS))
 			return
-		if(!hugger)
+		if(!length(huggers))
 			balloon_alert(xeno_attacker, "It is empty")
 			return
-		xeno_attacker.put_in_active_hand(hugger)
-		hugger.go_active(TRUE)
-		hugger = null
-		set_trap_type(null)
+		var/obj/item/clothing/mask/facehugger/first_hugger = huggers[1]
+		xeno_attacker.put_in_active_hand(first_hugger)
+		first_hugger.go_active(TRUE)
+		huggers -= first_hugger
+		if(!length(huggers))
+			set_trap_type(null)
 		balloon_alert(xeno_attacker, "Removed facehugger")
 		return
 	var/datum/action/ability/activable/xeno/corrosive_acid/acid_action = locate(/datum/action/ability/activable/xeno/corrosive_acid) in xeno_attacker.actions
@@ -187,17 +202,20 @@
 
 	if(!istype(I, /obj/item/clothing/mask/facehugger) || !isxeno(user))
 		return
-	var/obj/item/clothing/mask/facehugger/FH = I
+	var/obj/item/clothing/mask/facehugger/hugger = I
+	if(hugger.stat == DEAD)
+		balloon_alert(user, "Cannot insert dead facehugger")
+		return
 	if(trap_type)
-		balloon_alert(user, "Already occupied")
-		return
+		if(trap_type != TRAP_HUGGER)
+			balloon_alert(user, "Already occupied")
+			return
+		if(length(huggers) >= hugger_limit)
+			balloon_alert(user, "Already full")
+			return
 
-	if(FH.stat == DEAD)
-		balloon_alert(user, "Cannot insert facehugger")
-		return
-
-	user.transferItemToLoc(FH, src)
-	FH.go_idle(TRUE)
-	hugger = FH
+	user.transferItemToLoc(hugger, src)
+	hugger.go_idle(TRUE)
+	huggers += hugger
 	set_trap_type(TRAP_HUGGER)
 	balloon_alert(user, "Inserted facehugger")


### PR DESCRIPTION
## About The Pull Request
Adds 5 more mutations for Carrier for a total of 9.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Hugger Overflow | While you have 8/7/6 or more stored huggers, you will automatically drop one underneath you when you become staggered. |
| Shell | Recurring Panic | If you're not resting, Carrier Panic will automatically attempt to activate when possible. The cooldown duration is set to 20% of its original value. It only consumes 50/40/30% of your maximum plasma. |
| Spur | Claw Delivered | Huggers from your eggs now have a reduced cast time against humans. The cast time is set to 60/50/40% of its original value. |
| Spur | Fake Huggers | Thrown huggers will accompanied by a fake facehugger which will mimic their behavior. Their color will be changed to match 50/70/90% of the original hugger's color. |
| Veil | Swarm Trap | Your newly created traps can fit an additional 1/2/3 huggers, but the stun duration divided by the amount of the hugger inside the trap. |

## Why It's Good For The Game
More variety of mutations for carriers.

## Changelog
:cl:
add: Carrier now has 5 more new mutations that they can purchase.
/:cl:
