### PR TITLE
ULTIMATE MARINE COPE 9000: MAW NERF OF THE CENTURY

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/building/acid_maw
 	name = "Acid Maw"
 	desc = "Constructs an acid maw that allows the hive to unleash its most devastating bombardments from any location. This structure's acid is strong enough to eat through any ceiling above it, but it requires ten minutes to prepare each shot."
-	psypoint_cost = 1200
+	psypoint_cost = 1000
 	icon = "maw"
 	gamemode_flags = ABILITY_NUCLEARWAR
 	building_type = /obj/structure/xeno/acid_maw
@@ -321,6 +321,11 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	if(buildloc.density)
 		if(!silent)
 			to_chat(buyer, span_xenowarning("You cannot build in a dense location!"))
+		return FALSE
+	var/area/buildzone = get_area(buyer)
+	if(buildzone.ceiling >= CEILING_DEEP_UNDERGROUND)
+		if(!silent)
+			to_chat(buyer, span_xenowarning("We cannot fire this structure through deep cave ceilings! Find a shallow part of the cave to build in."))
 		return FALSE
 
 /datum/hive_upgrade/building/mutation_chamber


### PR DESCRIPTION
## About The Pull Request

Acid maw (the one that shoots the minions and huggers) can no longer be placed in deep caves. shallow caves are still fair game. Reduces the price of the maw from 1200 psypoints to 1000 psypoints.

## Why It's Good For The Game

I'm very opinionated against acid maw, but I'll keep this a bit short. Maw is extremely good at breaking marine formations, and it makes me sad that there's little counter play you can do against it. Due to the fact it can be placed in deep caves, it is almost always placed beside silo, and marines can really only destroy it when they're in a position to silo rush. 
Restricting it to shallow caves allows marines to target it as an objective other than disks, without making it vulnerable outside.
Now for the more subjective shit I hate about maw
Primos are fun. Mutations are fun (probably. I haven't actually tried them yet). I don't want these things to be swept to the sidelines because of the raw destructive power of the maw.

Anywho the price reduction should help slightly ease the risk of having a maw. It could be changed back to it's original 1200 psy if thats a problem.

## Changelog

:cl: Joe13413
balance: The acid maw now can no longer be placed in deep caverns. The acid maws price has been reduced from 1200 to 1000.
/:cl:
