### PR TITLE
Defiler Envenomed Bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/mutations_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/mutations_defiler.dm
@@ -125,10 +125,11 @@
 /// Injects a percentage of DEFILER_REAGENT_SLASH_INJECT_AMOUNT into the attacked living being.
 /datum/mutation_upgrade/spur/envenomed/proc/on_attack_living(datum/source, mob/living/attacked_mob, damage, damage_mod, armor_mod)
 	SIGNAL_HANDLER
-	if(!isliving(attacked_mob) || !attacked_mob.can_sting())
+	if(!isliving(attacked_mob) || !attacked_mob.can_sting() || xenomorph_owner.plasma_stored < plasma_per_slash)
 		return
 	var/mob/living/attacked_living = attacked_mob
 	attacked_living.reagents.add_reagent(xenomorph_owner.selected_reagent, DEFILER_REAGENT_SLASH_INJECT_AMOUNT * get_percentage(get_total_structures()))
+	xenomorph_owner.use_plasma(plasma_per_slash)
 	playsound(attacked_living, 'sound/effects/spray3.ogg', 8, TRUE, 2)
 	xenomorph_owner.visible_message(attacked_living, span_danger("[attacked_living] is pricked by [xenomorph_owner]'s spines!"), null, 3)
 


### PR DESCRIPTION

## About The Pull Request
Envenomed, one of Defiler's mutation, now correctly checks for and uses the 20 plasma per slash.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Mutations: Envenomed correctly checks for and uses plasma.
/:cl:
