### PR TITLE
More Shrike Mutations

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_keybindings.dm
+++ b/code/__DEFINES/dcs/signals/signals_keybindings.dm
@@ -282,6 +282,7 @@
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE "xenoability_unrelenting_force"
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT "xenoability_unrelenting_force_select"
 #define COMSIG_XENOABILITY_PSYCHIC_VORTEX "xenoability_psychic_vortex"
+#define COMSIG_XENOABILITY_PSYCHIC_CHOKE "xenoability_psychic_choke"
 
 #define COMSIG_XENOABILITY_RAVAGER_CHARGE "xenoability_ravager_charge"
 #define COMSIG_XENOABILITY_RAVAGE "xenoability_ravage"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -150,6 +150,7 @@
 //=================================================
 
 #define EFFECT_STUN "stun"
+#define EFFECT_KNOCKDOWN "knockdown"
 #define EFFECT_PARALYZE "paralyze"
 #define EFFECT_UNCONSCIOUS "unconscious"
 #define EFFECT_STAGGER "stagger"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -119,6 +119,7 @@
 #define HEATRAY_BEAM_ABILITY_TRAIT "heatray_ability_trait"
 #define DRAGON_ABILITY_TRAIT "dragon_ability_trait"
 #define HIVELORD_ABILITY_TRAIT "hivelord_ability_trait"
+#define SHRIKE_ABILITY_TRAIT "shrike_ability_trait"
 #define VALHALLA_TRAIT "valhalla"
 #define WEIGHTBENCH_TRAIT "weightbench"
 #define BOILER_ROOTED_TRAIT "boiler_rooted"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -1059,6 +1059,13 @@
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_VORTEX
 	hotkey_keys = list("X")
 
+/datum/keybinding/xeno/psychic_choke
+	name = "psychic_choke"
+	full_name = "Shrike: Psychic Choke"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CHOKE
+	hotkey_keys = list("E") // Same key as Psychic Fling as this ability effectively replaces it.
+
 /datum/keybinding/xeno/scatter_spit
 	name = "scatter_spit"
 	full_name = "Spitter: Scatter Spit"

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -248,7 +248,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 			unique_glob = FALSE
 			xeno_owner.neurotoxin_ammo++
 			xeno_owner.balloon_alert(xeno_owner, "Neurotoxin globule prepared.")
-	var/total_globs = xeno_owner.corrosive_ammo + xeno_owner.neurotoxin_ammo
 	if(unique_glob)
 		if(xeno_owner.corrosive_ammo > xeno_owner.neurotoxin_ammo)
 			xeno_owner.neurotoxin_ammo++

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -129,7 +129,8 @@
 	if(target_human.stat == DEAD)
 		var/overheal_gain = 0
 		while((xeno_owner.health < xeno_owner.maxHealth || xeno_owner.overheal < xeno_owner.xeno_caste.overheal_max) && do_after(xeno_owner, 2 SECONDS, NONE, target_human, BUSY_ICON_HOSTILE))
-			overheal_gain = xeno_owner.heal_wounds(dead_multiplier)
+			var/list/healing_results = xeno_owner.heal_wounds(dead_multiplier)
+			overheal_gain = healing_results[1]
 			xeno_owner.adjustOverheal(overheal_gain)
 			xeno_owner.adjust_sunder(-2.5)
 		to_chat(xeno_owner, span_notice("We feel fully restored."))

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -304,7 +304,7 @@
 		hugger.kill_hugger()
 		owner.dropItemToGround(hugger)
 
-	add_cooldown(cooldown_duration * (damage_deflected >= 100 ? projectile_cooldown_mulitplier : 1))
+	add_cooldown(cooldown_duration * (damage_deflected >= 50 ? projectile_cooldown_mulitplier : 1))
 	succeed_activate()
 
 /// Throws things back the other way.

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -75,6 +75,8 @@
 	var/collusion_paralyze_duration = 0
 	/// If humans were to collide with something, what is the multiplier of the owner's melee damage for determining how much damage to deal?
 	var/collusion_damage_multiplier = 0
+	/// Can this ability be used on xenomorphs? If so, what amount should the cooldown duration be mulitplied by?
+	var/friendly_cooldown_multiplier = 0
 
 /datum/action/ability/activable/xeno/psychic_fling/on_cooldown_finish()
 	to_chat(owner, span_notice("We gather enough mental strength to fling something again."))
@@ -86,7 +88,9 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
-	if(!isitem(target) && !ishuman(target) && !isdroid(target))	//only items, droids, and mobs can be flung.
+	if(!isitem(target) && !ishuman(target) && !isdroid(target) && !isxeno(target)) // Only items, humans, droids, and xenomorphs.
+		return FALSE
+	if(isxeno(target) && !friendly_cooldown_multiplier)
 		return FALSE
 	if(target.move_resist >= MOVE_FORCE_OVERPOWERING)
 		return FALSE
@@ -103,48 +107,48 @@
 			return FALSE
 
 /datum/action/ability/activable/xeno/psychic_fling/use_ability(atom/target)
-	var/mob/living/victim = target
+	var/atom/movable/movable_target = target
 	GLOB.round_statistics.psychic_flings++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "psychic_flings")
 
-	owner.visible_message(span_xenowarning("A strange and violent psychic aura is suddenly emitted from \the [owner]!"), \
-	span_xenowarning("We violently fling [victim] with the power of our mind!"))
-	victim.visible_message(span_xenowarning("[victim] is violently flung away by an unseen force!"), \
-	span_xenowarning("You are violently flung to the side by an unseen force!"))
-	playsound(owner,'sound/effects/magic.ogg', 75, 1)
-	playsound(victim,'sound/weapons/alien_claw_block.ogg', 75, 1)
+	xeno_owner.visible_message(span_xenowarning("A strange and violent psychic aura is suddenly emitted from \the [xeno_owner]!"), \
+		span_xenowarning("We violently fling [movable_target] with the power of our mind!"))
+	movable_target.visible_message(span_xenowarning("[movable_target] is violently flung away by an unseen force!"), \
+		span_xenowarning("You are violently flung to the side by an unseen force!"))
+	playsound(xeno_owner, 'sound/effects/magic.ogg', 75, 1)
+	playsound(movable_target, 'sound/weapons/alien_claw_block.ogg', 75, 1)
 
-	//Held facehuggers get killed for balance reasons
-	for(var/obj/item/clothing/mask/facehugger/hugger in owner.get_held_items())
-		hugger.kill_hugger()
-		owner.dropItemToGround(hugger)
-
-	succeed_activate()
-	add_cooldown()
-	if(ishuman(victim))
+	if(ishuman(movable_target))
+		// Held facehuggers get killed for balance reasons; preventing a near-immediate facehug after a stun.
+		for(var/obj/item/clothing/mask/facehugger/hugger in xeno_owner.get_held_items())
+			hugger.kill_hugger()
+			xeno_owner.dropItemToGround(hugger)
+		var/mob/living/carbon/human/human_target = movable_target
 		if(stun_duration)
-			victim.Stun(2 SECONDS)
-			victim.drop_all_held_items()
+			human_target.Stun(stun_duration)
+			human_target.drop_all_held_items()
 		if(damage_multiplier)
-			victim.apply_damage(xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * damage_multiplier, BRUTE, blocked = MELEE, updating_health = TRUE)
-		RegisterSignal(victim, COMSIG_MOVABLE_POST_THROW, PROC_REF(on_post_throw))
+			human_target.apply_damage(xeno_owner.xeno_caste.melee_damage * xeno_owner.xeno_melee_damage_modifier * damage_multiplier, BRUTE, blocked = MELEE, updating_health = TRUE)
+		RegisterSignal(human_target, COMSIG_MOVABLE_POST_THROW, PROC_REF(on_post_throw))
 		if(collusion_paralyze_duration || collusion_damage_multiplier)
-			RegisterSignal(victim, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
+			RegisterSignal(human_target, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
 		else
-			victim.add_pass_flags(PASS_MOB, THROW_TRAIT)
-		shake_camera(victim, 2, 1)
+			human_target.add_pass_flags(PASS_MOB, THROW_TRAIT)
+		shake_camera(human_target, 2, 1)
 
-	var/facing = get_dir(owner, victim)
-	var/fling_distance = (isitem(victim)) ? 4 : 3 //Objects get flung further away.
-	var/turf/T = victim.loc
+	var/facing = xeno_owner == movable_target ? xeno_owner.dir : get_dir(xeno_owner, movable_target)
+	var/fling_distance = (isitem(movable_target)) ? 4 : 3 // Objects get flung further away.
+	var/turf/T = movable_target.loc
 	var/turf/temp
-
 	for(var/x in 1 to fling_distance)
 		temp = get_step(T, facing)
 		if(!temp)
 			break
 		T = temp
-	victim.throw_at(T, fling_distance, 1, owner, TRUE)
+	movable_target.throw_at(T, fling_distance, 1, xeno_owner, TRUE)
+
+	add_cooldown(cooldown_duration * ((isxeno(movable_target) || isitem(movable_target)) ? friendly_cooldown_multiplier : 1))
+	succeed_activate()
 
 /// Called when the throw has ended.
 /datum/action/ability/activable/xeno/psychic_fling/proc/on_post_throw(datum/source)
@@ -205,44 +209,53 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_UNRELENTING_FORCE,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT,
 	)
-
+	/// The amount of distance that to throw things.
+	var/throwing_distance = 6
+	/// Should this ability reflect projectiles as well? If so, what amount should the cooldown duration be mulitplied by if 100+ projectle damage was reflected?
+	var/projectile_cooldown_mulitplier = 0
+	/// Should things be thrown toward the owner first before getting thrown away?
+	var/rebound_throwing = FALSE
+	/// What direction was the owner facing at the start of the ability? Kept around to reuse for rebound signals.
+	var/starting_direction
 
 /datum/action/ability/activable/xeno/unrelenting_force/on_cooldown_finish()
 	to_chat(owner, span_notice("Our mind is ready to unleash another blast of force."))
 	return ..()
 
-
 /datum/action/ability/activable/xeno/unrelenting_force/use_ability(atom/target)
-	succeed_activate()
-	add_cooldown()
-	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, update_icons)), 1 SECONDS)
-	owner.icon_state = "[xeno_owner.xeno_caste.caste_name][(xeno_owner.xeno_flags & XENO_ROUNY) ? " rouny" : ""] Screeching"
+	addtimer(CALLBACK(xeno_owner, TYPE_PROC_REF(/mob, update_icons)), 1 SECONDS)
+	xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name][(xeno_owner.xeno_flags & XENO_ROUNY) ? " rouny" : ""] Screeching"
 	if(target) // Keybind use doesn't have a target
-		owner.face_atom(target)
+		xeno_owner.face_atom(target)
+	starting_direction = xeno_owner.dir
 
 	var/turf/lower_left
 	var/turf/upper_right
-	switch(owner.dir)
+	switch(starting_direction)
 		if(NORTH)
-			lower_left = locate(owner.x - 1, owner.y + 1, owner.z)
-			upper_right = locate(owner.x + 1, owner.y + 3, owner.z)
+			lower_left = locate(xeno_owner.x - 1, xeno_owner.y + 1, xeno_owner.z)
+			upper_right = locate(xeno_owner.x + 1, xeno_owner.y + 3, xeno_owner.z)
 		if(SOUTH)
-			lower_left = locate(owner.x - 1, owner.y - 3, owner.z)
-			upper_right = locate(owner.x + 1, owner.y - 1, owner.z)
+			lower_left = locate(xeno_owner.x - 1, xeno_owner.y - 3, xeno_owner.z)
+			upper_right = locate(xeno_owner.x + 1, xeno_owner.y - 1, xeno_owner.z)
 		if(WEST)
-			lower_left = locate(owner.x - 3, owner.y - 1, owner.z)
-			upper_right = locate(owner.x - 1, owner.y + 1, owner.z)
+			lower_left = locate(xeno_owner.x - 3, xeno_owner.y - 1, xeno_owner.z)
+			upper_right = locate(xeno_owner.x - 1, xeno_owner.y + 1, xeno_owner.z)
 		if(EAST)
-			lower_left = locate(owner.x + 1, owner.y - 1, owner.z)
-			upper_right = locate(owner.x + 3, owner.y + 1, owner.z)
+			lower_left = locate(xeno_owner.x + 1, xeno_owner.y - 1, xeno_owner.z)
+			upper_right = locate(xeno_owner.x + 3, xeno_owner.y + 1, xeno_owner.z)
 
 	var/list/things_to_throw = list()
+	var/list/atom/movable/projectile/things_to_deflect = list()
 	for(var/turf/affected_tile in block(lower_left, upper_right)) //everything in the 3x3 block is found.
 		affected_tile.Shake(duration = 0.5 SECONDS)
 		for(var/atom/movable/affected AS in affected_tile)
 			if(isfire(affected))
 				var/obj/fire/fire = affected
 				fire.reduce_fire(10)
+				continue
+			if(projectile_cooldown_mulitplier && istype(affected, /atom/movable/projectile))
+				things_to_deflect += affected
 				continue
 			if(!ishuman(affected) && !istype(affected, /obj/item) && !isdroid(affected))
 				affected.Shake(duration = 0.5 SECONDS)
@@ -259,9 +272,26 @@
 
 	for(var/atom/movable/affected AS in things_to_throw)
 		var/throwlocation = affected.loc
-		for(var/x in 1 to 6)
-			throwlocation = get_step(throwlocation, owner.dir)
-		affected.throw_at(throwlocation, 6, 1, owner, TRUE)
+		for(var/x in 1 to throwing_distance)
+			throwlocation = get_step(throwlocation, rebound_throwing ? REVERSE_DIR(starting_direction) : starting_direction)
+		if(rebound_throwing)
+			RegisterSignal(affected, COMSIG_MOVABLE_POST_THROW, PROC_REF(on_throw_end))
+		affected.throw_at(throwlocation, throwing_distance, 1, xeno_owner, TRUE)
+
+	var/damage_deflected = 0
+	for(var/atom/movable/projectile/affected_projectile AS in things_to_deflect)
+		if(starting_direction == affected_projectile.dir)
+			continue
+		var/perpendicular_angle = Get_Angle(get_turf(xeno_owner), get_step(xeno_owner, starting_direction))
+		var/bounced_angle = perpendicular_angle + (perpendicular_angle - affected_projectile.dir_angle - (starting_direction == REVERSE_DIR(affected_projectile.dir) ? 180 : 90))
+		if(bounced_angle < 0)
+			bounced_angle += 360
+		else if(bounced_angle > 360)
+			bounced_angle -= 360
+		affected_projectile.distance_travelled = 0
+		affected_projectile.iff_signal = null
+		affected_projectile.fire_at(shooter = xeno_owner, source = get_step(xeno_owner, starting_direction), angle = bounced_angle, recursivity = TRUE)
+		damage_deflected += affected_projectile.damage
 
 	owner.visible_message(span_xenowarning("[owner] sends out a huge blast of psychic energy!"), \
 	span_xenowarning("We send out a huge blast of psychic energy!"))
@@ -269,11 +299,23 @@
 	playsound(owner,'sound/effects/bamf.ogg', 75, TRUE)
 	playsound(owner, SFX_ALIEN_ROAR, 50)
 
-	//Held facehuggers get killed for balance reasons
+	// Held facehuggers get killed for balance reasons.
 	for(var/obj/item/clothing/mask/facehugger/hugger in owner.get_held_items())
 		hugger.kill_hugger()
 		owner.dropItemToGround(hugger)
 
+	add_cooldown(cooldown_duration * (damage_deflected >= 100 ? projectile_cooldown_mulitplier : 1))
+	succeed_activate()
+
+/// Throws things back the other way.
+/datum/action/ability/activable/xeno/unrelenting_force/proc/on_throw_end(datum/source)
+	SIGNAL_HANDLER
+	var/atom/movable/movable_source = source
+	UnregisterSignal(movable_source, list(COMSIG_MOVABLE_POST_THROW))
+	var/throw_location = movable_source.loc
+	for(var/x in 1 to throwing_distance)
+		throw_location = get_step(throw_location, starting_direction)
+	movable_source.throw_at(throw_location, throwing_distance, 1, xeno_owner, TRUE)
 
 // ***************************************
 // *********** Psychic Cure
@@ -293,13 +335,22 @@
 	var/heal_range = SHRIKE_HEAL_RANGE
 	/// If the ability was used on themselves, what is the amount to multiply healing power by?
 	var/self_heal_multiplier = 1
-	/// If the ability was used on themselves, what is the amount to multiply cooldown duration by?
-	var/self_cooldown_multiplier = 1
+	/// The percentage of restored health that will be re-applied to the owner. 1 = 100%, 0.01 = 1%.
+	var/rebound_percentage = 0
+	/// The amount of deciseconds that the Resin Jelly Coating status effect will be applied.
+	var/resin_jelly_duration = 0
+	/// The amount of deciseconds that various status effects are delayed: Stun, Knockdown, and Stagger. Slowdown immunity is given, but not delayed.
+	var/delayed_status_duration = 0
+	/// List of all delayed status effects to be reapplied at the end.
+	var/list/delayed_status_list = list()
+	/// The xenomorph who is having their status effects being delayed.
+	var/mob/living/carbon/xenomorph/delayed_status_patient
+	/// Timer that will give back any delayed status effect.
+	var/delayed_status_timer
 
 /datum/action/ability/activable/xeno/psychic_cure/on_cooldown_finish()
 	to_chat(owner, span_notice("We gather enough mental strength to cure sisters again."))
 	return ..()
-
 
 /datum/action/ability/activable/xeno/psychic_cure/can_use_ability(atom/target, silent = FALSE, override_flags)
 	. = ..()
@@ -317,7 +368,6 @@
 			to_chat(owner, span_warning("It's too late. This sister won't be coming back."))
 		return FALSE
 
-
 /datum/action/ability/activable/xeno/psychic_cure/proc/check_distance(atom/target, silent)
 	var/dist = get_dist(owner, target)
 	if(dist > heal_range)
@@ -329,7 +379,6 @@
 			to_chat(owner, span_warning("We can't focus properly without a clear line of sight!"))
 		return FALSE
 	return TRUE
-
 
 /datum/action/ability/activable/xeno/psychic_cure/use_ability(atom/target)
 	if(owner.do_actions)
@@ -352,7 +401,7 @@
 	playsound(target,'sound/effects/magic.ogg', 75, 1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/mob/living/carbon/xenomorph/patient = target
-	patient.heal_wounds(xeno_owner == patient ? SHRIKE_CURE_HEAL_MULTIPLIER * self_heal_multiplier : SHRIKE_CURE_HEAL_MULTIPLIER)
+	var/healing_results = patient.heal_wounds(xeno_owner == patient ? SHRIKE_CURE_HEAL_MULTIPLIER * self_heal_multiplier : SHRIKE_CURE_HEAL_MULTIPLIER)
 	patient.adjust_sunder(xeno_owner == patient ?  -SHRIKE_CURE_HEAL_MULTIPLIER * self_heal_multiplier : -SHRIKE_CURE_HEAL_MULTIPLIER)
 	if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
 		patient.SetUnconscious(0)
@@ -362,12 +411,66 @@
 		patient.set_slowdown(0)
 	patient.updatehealth()
 
-	owner.changeNext_move(CLICK_CD_RANGE)
+	var/amount_healed = healing_results[2] - healing_results[1]
+	if(rebound_percentage && amount_healed)
+		var/amount_to_heal = amount_healed * rebound_percentage
+		HEAL_XENO_DAMAGE(xeno_owner, amount_to_heal, FALSE)
+	if(resin_jelly_duration)
+		xeno_owner.apply_status_effect(STATUS_EFFECT_RESIN_JELLY_COATING, resin_jelly_duration)
+		xeno_owner.emote("roar")
+		if(xeno_owner != patient)
+			patient.apply_status_effect(STATUS_EFFECT_RESIN_JELLY_COATING, resin_jelly_duration)
+			patient.emote("roar")
 
+	if(delayed_status_patient)
+		end_delayed_status_effects()
+	if(delayed_status_duration)
+		start_delayed_status_effects(patient)
 	log_combat(owner, patient, "psychically cured")
 
 	succeed_activate()
-	add_cooldown(xeno_owner == patient ? cooldown_duration * self_cooldown_multiplier : null)
+	add_cooldown()
+
+/datum/action/ability/activable/xeno/psychic_cure/proc/start_delayed_status_effects(mob/living/carbon/xenomorph/patient)
+	delayed_status_timer = addtimer(CALLBACK(src, PROC_REF(end_delayed_status_effects)), delayed_status_duration, TIMER_UNIQUE|TIMER_STOPPABLE)
+	delayed_status_patient = patient
+	ADD_TRAIT(delayed_status_patient, TRAIT_SLOWDOWNIMMUNE, SHRIKE_ABILITY_TRAIT)
+	RegisterSignal(patient, COMSIG_LIVING_STATUS_STUN, PROC_REF(on_stun))
+	RegisterSignal(patient, COMSIG_LIVING_STATUS_KNOCKDOWN, PROC_REF(on_knockdown))
+	RegisterSignal(patient, COMSIG_LIVING_STATUS_STAGGER, PROC_REF(on_stagger))
+	delayed_status_patient.add_filter("psychic_cure_delayed", 2, outline_filter(2, COLOR_BLUE))
+
+/datum/action/ability/activable/xeno/psychic_cure/proc/end_delayed_status_effects()
+	if(delayed_status_timer)
+		deltimer(delayed_status_timer)
+		delayed_status_timer = null
+	REMOVE_TRAIT(delayed_status_patient, TRAIT_SLOWDOWNIMMUNE, SHRIKE_ABILITY_TRAIT)
+	UnregisterSignal(delayed_status_patient, COMSIG_LIVING_STATUS_STUN)
+	UnregisterSignal(delayed_status_patient, COMSIG_LIVING_STATUS_KNOCKDOWN)
+	UnregisterSignal(delayed_status_patient, COMSIG_LIVING_STATUS_STAGGER)
+	for(var/status_effect_name AS in delayed_status_list)
+		var/duration = delayed_status_list[status_effect_name]
+		delayed_status_patient.apply_effect(duration, status_effect_name)
+	delayed_status_patient.remove_filter("psychic_cure_delayed")
+	delayed_status_list.Cut()
+	delayed_status_patient = null
+
+/datum/action/ability/activable/xeno/psychic_cure/proc/on_stun(datum/source, amount, ignore_canstun)
+	SIGNAL_HANDLER
+	delayed_status_list[EFFECT_STUN] += amount
+	return COMPONENT_NO_STUN
+
+/datum/action/ability/activable/xeno/psychic_cure/proc/on_knockdown(datum/source, amount, ignore_canstun)
+	SIGNAL_HANDLER
+	delayed_status_list[EFFECT_KNOCKDOWN] += amount
+	return COMPONENT_NO_STUN
+
+/datum/action/ability/activable/xeno/psychic_cure/proc/on_stagger(datum/source, amount, ignore_canstun)
+	SIGNAL_HANDLER
+	delayed_status_list[EFFECT_STAGGER] += amount
+	return COMPONENT_NO_STUN
+
+// COMSIG_LIVING_STATUS_STAGGER
 
 
 // ***************************************
@@ -499,3 +602,139 @@
 		var/turf/targetturf = get_turf(owner)
 		targetturf = locate(targetturf.x + rand(1, 4), targetturf.y + rand(1, 4), targetturf.z)
 		movable_victim.throw_at(targetturf, 4, 1, owner, FALSE, FALSE)
+
+
+#define PSYCHIC_CHOKE_DAMAGE_THRESHOLD 5
+
+// ***************************************
+// *********** Psychic Choke
+// ***************************************
+/datum/action/ability/activable/xeno/psychic_choke
+	name = "Psychic Choke"
+	action_icon_state = "fling"
+	action_icon = 'icons/Xeno/actions/shrike.dmi'
+	desc = "Channel at a distance to hold a human in your psychic grasp."
+	cooldown_duration = 12 SECONDS
+	ability_cost = 100
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_CHOKE,
+	)
+	target_flags = ABILITY_MOB_TARGET
+	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
+	var/obj/effect/abstract/particle_holder/particle_holder
+	/// How much damage by the owner or the target has been taken so far while channeling?
+	var/damage_taken_so_far = 0
+	/// If damage taken reaches this amount, channeling will end.
+	var/damage_threshold = PSYCHIC_CHOKE_DAMAGE_THRESHOLD
+	/// What is the human being choked right now?
+	var/mob/living/carbon/human/choked_human
+
+/datum/action/ability/activable/xeno/psychic_choke/can_use_ability(atom/movable/target, silent = FALSE, override_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(QDELETED(target) || !ishuman(target))
+		return FALSE
+	var/dist = get_dist(xeno_owner, target)
+	switch(dist)
+		if(-1 to 1)
+			if(!silent)
+				xeno_owner.balloon_alert(target, "Too close!")
+			return FALSE
+		if(2 to 3)
+			if(!line_of_sight(xeno_owner, target, 3))
+				if(!silent)
+					xeno_owner.balloon_alert(target, "Not in line of sight!")
+				return FALSE
+		if(4 to INFINITY)
+			if(!silent)
+				xeno_owner.balloon_alert(target, "Too far!")
+			return FALSE
+	var/mob/living/carbon/human/human_target = target
+	if(human_target.stat == DEAD)
+		if(!silent)
+			xeno_owner.balloon_alert(target, "Already dead!")
+		return FALSE
+
+/datum/action/ability/activable/xeno/psychic_choke/use_ability(atom/target)
+	if(choked_human)
+		return
+	choked_human = target
+	xeno_owner.face_atom(choked_human)
+
+	xeno_owner.visible_message(span_xenowarning("A strange and violent psychic aura is suddenly emitted from \the [xeno_owner]!"), \
+		span_xenowarning("We choke [choked_human] with the power of our mind!"))
+	choked_human.visible_message(span_xenowarning("[choked_human] is suddenly grabbed by the neck by an unseen force!"), \
+		span_xenowarning("You are suddenly grabbed by an unseen force!"))
+	playsound(xeno_owner, 'sound/effects/magic.ogg', 75, 1)
+
+	choked_human.drop_all_held_items()
+	choked_human.Stun(4 SECONDS)
+
+	ADD_TRAIT(xeno_owner, TRAIT_HANDS_BLOCKED, SHRIKE_ABILITY_TRAIT)
+	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_TAKING_DAMAGE, PROC_REF(on_damage_taken))
+	RegisterSignal(choked_human, COMSIG_HUMAN_DAMAGE_TAKEN, PROC_REF(on_damage_taken))
+	RegisterSignals(choked_human, list(COMSIG_LIVING_STATUS_STUN,
+		COMSIG_LIVING_STATUS_KNOCKDOWN,
+		COMSIG_LIVING_STATUS_PARALYZE,
+		COMSIG_LIVING_STATUS_UNCONSCIOUS,
+		COMSIG_LIVING_STATUS_SLEEP,
+		COMSIG_LIVING_IGNITED), PROC_REF(end_choke))
+
+	var/angle = Get_Angle(get_turf(xeno_owner), get_turf(choked_human))
+	particle_holder = new(xeno_owner, /particles/psychic_choke)
+	particle_holder.pixel_x = 16
+	particle_holder.pixel_y = 0
+	particle_holder.particles.velocity = list(sin(angle) * 3.5, cos(angle) * 3.5)
+	particle_holder.particles.gravity = list(sin(angle) * 7, cos(angle) * 7)
+	particle_holder.particles.rotation = angle
+	xeno_owner.update_glow(3, 3, "#9e1f1f")
+
+	if(!do_after(xeno_owner, 4 SECONDS, NONE, xeno_owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, PROC_REF(can_continue_choke))))
+		end_choke()
+		return
+	end_choke()
+
+/datum/action/ability/activable/xeno/psychic_choke/proc/can_continue_choke()
+	return can_use_action(TRUE, ABILITY_USE_BUSY) && choked_human
+
+/datum/action/ability/activable/xeno/psychic_choke/proc/end_choke()
+	choked_human.SetStun(0)
+
+	REMOVE_TRAIT(xeno_owner, TRAIT_HANDS_BLOCKED, SHRIKE_ABILITY_TRAIT)
+	UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_TAKING_DAMAGE)
+	UnregisterSignal(choked_human, COMSIG_HUMAN_DAMAGE_TAKEN)
+	UnregisterSignal(choked_human, list(COMSIG_LIVING_STATUS_STUN,
+		COMSIG_LIVING_STATUS_KNOCKDOWN,
+		COMSIG_LIVING_STATUS_PARALYZE,
+		COMSIG_LIVING_STATUS_UNCONSCIOUS,
+		COMSIG_LIVING_STATUS_SLEEP,
+		COMSIG_LIVING_IGNITED))
+
+	QDEL_NULL(particle_holder)
+	xeno_owner.update_glow()
+
+	choked_human = null
+	add_cooldown()
+	succeed_activate()
+
+/// Keeps track of how much damage has been taken so far by the owner and the choked human.
+/datum/action/ability/activable/xeno/psychic_choke/proc/on_damage_taken(datum/source, damage_amount)
+	damage_taken_so_far += damage_amount
+	if(damage_taken_so_far >= damage_threshold)
+		end_choke()
+
+/particles/psychic_choke
+	icon = 'icons/effects/particles/generic_particles.dmi'
+	icon_state = "lemon"
+	width = 250
+	height = 250
+	count = 300
+	spawning = 20
+	lifespan = 12
+	fade = 12
+	grow = -0.02
+	velocity = list(0, 3)
+	position = generator(GEN_CIRCLE, 15, 17, NORMAL_RAND)
+	scale = generator(GEN_VECTOR, list(0.1, 0.1), list(0.5, 0.5), NORMAL_RAND)
+	color = "#970f0f"

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -81,8 +81,14 @@
 
 	mutations = list(
 		/datum/mutation_upgrade/shell/lone_healer,
+		/datum/mutation_upgrade/shell/shared_cure,
+		/datum/mutation_upgrade/shell/resistant_cure,
 		/datum/mutation_upgrade/spur/smashing_fling,
-		/datum/mutation_upgrade/veil/stand_in_recycler
+		/datum/mutation_upgrade/spur/psychic_choke,
+		/datum/mutation_upgrade/spur/gravity_tide,
+		/datum/mutation_upgrade/veil/delayed_condition,
+		/datum/mutation_upgrade/veil/deflective_force,
+		/datum/mutation_upgrade/veil/utility_fling
 	)
 
 /datum/xeno_caste/shrike/normal

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
@@ -3,20 +3,16 @@
 //*********************//
 /datum/mutation_upgrade/shell/lone_healer
 	name = "Lone Healer"
-	desc = "Psychic Cure can now target yourself. Healing yourself is only 50/60/70% as effective and will set the cooldown to 200/175/150% of its original value."
+	desc = "Psychic Cure can now target yourself. Healing yourself is only 50/60/70% as effective."
 	/// For the first structure, the multiplier of Psychic Cure's initial healing power to add to the ability.
 	var/self_heal_multiplier_initial = -0.6
 	/// For each structure, the multiplier of Psychic Cure's initial healing power to add to the ability.
 	var/self_heal_multiplier_per_structure = 0.1
-	/// For the first structure, the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
-	var/self_cooldown_multiplier_initial = 1.25
-	/// For each structure, the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
-	var/self_cooldown_multiplier_per_structure = -0.25
 
 /datum/mutation_upgrade/shell/lone_healer/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Psychic Cure can now target yourself. Healing yourself is only [PERCENT(1 + get_self_heal_multiplier(new_amount))]% as effective and will set the cooldown to [PERCENT(1 + get_self_cooldown_multiplier(new_amount))]% of its original value."
+	return "Psychic Cure can now target yourself. Healing yourself is only [PERCENT(1 + get_self_heal_multiplier(new_amount))]% as effective."
 
 /datum/mutation_upgrade/shell/lone_healer/on_mutation_enabled()
 	. = ..()
@@ -25,7 +21,6 @@
 		return
 	cure_ability.use_state_flags |= ABILITY_TARGET_SELF
 	cure_ability.self_heal_multiplier += get_self_heal_multiplier(0)
-	cure_ability.self_cooldown_multiplier += get_self_cooldown_multiplier(0)
 
 /datum/mutation_upgrade/shell/lone_healer/on_mutation_disabled()
 	. = ..()
@@ -34,7 +29,6 @@
 		return
 	cure_ability.use_state_flags &= ~(ABILITY_TARGET_SELF)
 	cure_ability.self_heal_multiplier -= get_self_heal_multiplier(0)
-	cure_ability.self_cooldown_multiplier -= get_self_cooldown_multiplier(0)
 
 /datum/mutation_upgrade/shell/lone_healer/on_structure_update(previous_amount, new_amount)
 	. = ..()
@@ -42,15 +36,86 @@
 	if(!cure_ability)
 		return
 	cure_ability.self_heal_multiplier += get_self_heal_multiplier(new_amount - previous_amount, FALSE)
-	cure_ability.self_cooldown_multiplier += get_self_cooldown_multiplier(new_amount - previous_amount, FALSE)
 
 /// Returns the multiplier of Psychic Cure's initial healing power to add to the ability.
 /datum/mutation_upgrade/shell/lone_healer/proc/get_self_heal_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? self_heal_multiplier_initial : 0) + (self_heal_multiplier_per_structure * structure_count)
 
-/// Returns the multiplier of Psychic Cure's initial cooldown duration to add to the ability.
-/datum/mutation_upgrade/shell/lone_healer/proc/get_self_cooldown_multiplier(structure_count, include_initial = TRUE)
-	return (include_initial ? self_cooldown_multiplier_initial : 0) + (self_cooldown_multiplier_per_structure * structure_count)
+/datum/mutation_upgrade/shell/shared_cure
+	name = "Shared Cure"
+	desc = "20/35/50% of the health restored from Psychic Cure is reapplied to you."
+	/// For the first structure, the percentage of restored health from Psychic Cure to heal the owner. 1 = 100%, 0.01 = 1%.
+	var/rebound_initial = 0.05
+	/// For each structure, the additional percentage of restored health from Psychic Cure to heal the owner.
+	var/rebound_per_structure = 0.15
+
+/datum/mutation_upgrade/shell/shared_cure/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "[PERCENT(get_rebound(new_amount))]% of the health restored from Psychic Cure is reapplied to you."
+
+/datum/mutation_upgrade/shell/shared_cure/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.rebound_percentage += get_rebound(0)
+
+/datum/mutation_upgrade/shell/shared_cure/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.rebound_percentage -= get_rebound(0)
+
+/datum/mutation_upgrade/shell/shared_cure/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.rebound_percentage += get_rebound(new_amount - previous_amount, FALSE)
+
+/// Returns the percentage of restored health from Psychic Cure to heal the owner.
+/datum/mutation_upgrade/shell/shared_cure/proc/get_rebound(structure_count, include_initial = TRUE)
+	return (include_initial ? rebound_initial : 0) + (rebound_per_structure * structure_count)
+
+/datum/mutation_upgrade/shell/resistant_cure
+	name = "Resistant Cure"
+	desc = "Psychic Cure now also applies the effects of resin jelly to you and your target for 40/50/60 seconds."
+	/// For the first structure, the amount of deciseconds that Psychic Cure will give fire immunity.
+	var/duration_initial = 30 SECONDS
+	/// For each structure, the amount of deciseconds that Psychic Cure will give fire immunity.
+	var/duration_per_structure = 10 SECONDS
+
+/datum/mutation_upgrade/shell/resistant_cure/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Psychic Cure now also applies the effects of resin jelly to you and your target for [get_duration(new_amount) / 10] seconds."
+
+/datum/mutation_upgrade/shell/resistant_cure/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.resin_jelly_duration += get_duration(0)
+
+/datum/mutation_upgrade/shell/resistant_cure/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.resin_jelly_duration -= get_duration(0)
+
+/datum/mutation_upgrade/shell/resistant_cure/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.resin_jelly_duration += get_duration(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of deciseconds that Psychic Cure will give fire immunity.
+/datum/mutation_upgrade/shell/resistant_cure/proc/get_duration(structure_count, include_initial = TRUE)
+	return (include_initial ? duration_initial : 0) + (duration_per_structure * structure_count)
 
 //*********************//
 //         Spur        //
@@ -101,44 +166,204 @@
 /datum/mutation_upgrade/spur/smashing_fling/proc/get_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
 
+/datum/mutation_upgrade/spur/gravity_tide
+	name = "Gravity Tide"
+	desc = "Unrelenting Force pulls things towards you then pushes them away. The distance they are thrown is increased by 2/3/4."
+	/// For the first structure, the amount of distance that Unrelenting Force will throw things.
+	var/distance_initial = 1
+	/// For each structure, the additional amount of distance that Unrelenting Force will throw things.
+	var/distance_per_structure = -1
+
+/datum/mutation_upgrade/spur/gravity_tide/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Unrelenting Force pulls things towards you then pushes them away. The distance they are thrown is increased by [get_distance(new_amount)]."
+
+/datum/mutation_upgrade/spur/gravity_tide/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.rebound_throwing = TRUE
+	force_ability.throwing_distance += get_distance(0)
+
+/datum/mutation_upgrade/spur/gravity_tide/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.rebound_throwing = initial(force_ability.rebound_throwing)
+	force_ability.throwing_distance -= get_distance(0)
+
+/datum/mutation_upgrade/spur/gravity_tide/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.throwing_distance += get_distance(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of distance that Unrelenting Force will throw things.
+/datum/mutation_upgrade/spur/gravity_tide/proc/get_distance(structure_count, include_initial = TRUE)
+	return (include_initial ? distance_initial : 0) + (distance_per_structure * structure_count)
+
+
+
+
+
+/datum/mutation_upgrade/spur/psychic_choke
+	name = "Psychic Choke"
+	desc = "You lose the ability Psychic Fling in exchange for the ability Psychic Choke. Psychic Choke lets you paralyze a marine as long you channel it. The damage threshold to disrupt Psychic Choke is 20/35/50."
+	/// For each structure, the amount to increase Psychic Choke's damage threshold.
+	var/threshold_per_structure = 15
+
+/datum/mutation_upgrade/spur/psychic_choke/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "You lose the ability Psychic Fling in exchange for the ability Psychic Choke. Psychic Choke lets you paralyze a marine as long you channel it. The damage threshold to disrupt Psychic Choke is [get_threshold(new_amount)]."
+
+/datum/mutation_upgrade/spur/psychic_choke/on_mutation_enabled()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(fling_ability)
+		fling_ability.remove_action(xenomorph_owner)
+	var/datum/action/ability/activable/xeno/psychic_choke/choke_ability = new()
+	choke_ability.give_action(xenomorph_owner)
+	return ..()
+
+/datum/mutation_upgrade/spur/psychic_choke/on_mutation_disabled()
+	var/datum/action/ability/activable/xeno/psychic_choke/choke_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_choke]
+	if(choke_ability)
+		choke_ability.remove_action(xenomorph_owner)
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = new()
+	fling_ability.give_action(xenomorph_owner)
+	return ..()
+
+/datum/mutation_upgrade/spur/psychic_choke/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_choke/choke_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_choke]
+	if(!choke_ability)
+		return
+	choke_ability.damage_threshold += get_threshold(new_amount - previous_amount, FALSE)
+
+/datum/mutation_upgrade/spur/psychic_choke/on_xenomorph_upgrade()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(fling_ability)
+		fling_ability.remove_action(xenomorph_owner) // Since upgrading give abilities that are missing, we have to remove it again.
+
+/// Returns the amount to increase Psychic Choke's damage threshold.
+/datum/mutation_upgrade/spur/psychic_choke/proc/get_threshold(structure_count, include_initial = TRUE)
+	return (include_initial ? PSYCHIC_CHOKE_DAMAGE_THRESHOLD : 0) + (threshold_per_structure * structure_count)
+
 //*********************//
 //         Veil        //
 //*********************//
-/datum/mutation_upgrade/veil/stand_in_recycler
-	name = "Stand-In Recycler"
-	desc = "You gain the Recycle ability. It costs 80/65/50% of its original cost."
-	/// For the first structure, the multiplier of Recycle's initial ability cost to add to the ability.
-	var/multiplier_initial = -0.05
-	/// For each structure, the multiplier of Recycle's initial ability cost to add to the ability.
-	var/multiplier_per_structure = -0.15
+/datum/mutation_upgrade/veil/delayed_condition
+	name = "Delayed Condition"
+	desc = "Psychic Heal grants slowdown immunity and delays all inbound stun, knockdown, and stagger effects caused to your target by 8/10/12 seconds. At the end of this duration, delayed status effects are reapplied."
+	/// For the first structure, the amount of deciseconds that Psychic Cure will delay various status effects by.
+	var/duration_initial = 6 SECONDS
+	/// For each structure, the amount of deciseconds that Psychic Cure will delay various status effects by.
+	var/duration_per_structure = 2 SECONDS
 
-/datum/mutation_upgrade/veil/stand_in_recycler/get_desc_for_alert(new_amount)
+/datum/mutation_upgrade/veil/delayed_condition/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "You gain the Recycle ability. Recycle's ability cost is [PERCENT(1 + get_multiplier(new_amount))]% of its original value."
+	return "Psychic Heal grants slowdown immunity and delays all inbound stun, knockdown, and stagger effects caused to your target by [get_duration(new_amount) / 10] seconds. At the end of this duration, delayed status effects are reapplied."
 
-/datum/mutation_upgrade/veil/stand_in_recycler/on_mutation_enabled()
-	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
-	if(!recycle_ability)
-		recycle_ability = new()
-		recycle_ability.give_action(xenomorph_owner)
-		recycle_ability.ability_cost += initial(recycle_ability.ability_cost) * get_multiplier(0)
-	return ..()
-
-/datum/mutation_upgrade/veil/stand_in_recycler/on_mutation_disabled()
-	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
-	if(recycle_ability)
-		recycle_ability.remove_action(xenomorph_owner)
-		qdel(recycle_ability)
-	return ..()
-
-/datum/mutation_upgrade/veil/stand_in_recycler/on_structure_update(previous_amount, new_amount)
+/datum/mutation_upgrade/veil/delayed_condition/on_mutation_enabled()
 	. = ..()
-	var/datum/action/ability/activable/xeno/recycle/recycle_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/recycle]
-	if(!recycle_ability)
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
 		return
-	recycle_ability.ability_cost += initial(recycle_ability.ability_cost) * get_multiplier(new_amount - previous_amount, FALSE)
+	cure_ability.delayed_status_duration += get_duration(0)
 
-/// Returns the multiplier of Recycle's initial ability cost to add to the ability.
-/datum/mutation_upgrade/veil/stand_in_recycler/proc/get_multiplier(structure_count, include_initial = TRUE)
+/datum/mutation_upgrade/veil/delayed_condition/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.delayed_status_duration -= get_duration(0)
+
+/datum/mutation_upgrade/veil/delayed_condition/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_cure/cure_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_cure]
+	if(!cure_ability)
+		return
+	cure_ability.delayed_status_duration += get_duration(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of deciseconds that Psychic Cure will delay various status effects by.
+/datum/mutation_upgrade/veil/delayed_condition/proc/get_duration(structure_count, include_initial = TRUE)
+	return (include_initial ? duration_initial : 0) + (duration_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/deflective_force
+	name = "Deflective Force"
+	desc = "Unrelenting Force now reflects all projectiles in its affected area. Reflecting more than 100 projectile damage resets Psychic Scream's cooldown to 50/40/30% of its original value."
+	/// For the first structure, the amount to multiply Psychic Scream's cooldown by if enough projectile damage was reflected.
+	var/multiplier_initial = 0.6
+	/// For each structure, the additional amount to multiply Psychic Scream's cooldown by if enough projectile damage was reflected.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/deflective_force/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Unrelenting Force now reflects all projectiles in its affected area. Reflecting more than 100 projectile damage resets Psychic Scream's cooldown to [PERCENT(get_multiplier(new_amount))]% of its original value."
+
+/datum/mutation_upgrade/veil/deflective_force/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.projectile_cooldown_mulitplier += get_multiplier(0)
+
+/datum/mutation_upgrade/veil/deflective_force/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.projectile_cooldown_mulitplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/veil/deflective_force/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/unrelenting_force/force_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/unrelenting_force]
+	if(!force_ability)
+		return
+	force_ability.projectile_cooldown_mulitplier += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to multiply Psychic Scream's cooldown by if enough projectile damage was reflected.
+/datum/mutation_upgrade/veil/deflective_force/proc/get_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/utility_fling
+	name = "Utility Fling"
+	desc = "Psychic Fling can be used on yourself and allied xenomorphs. Psychic Fling's cooldown is set to 40/30/20% of its original value if it was used on an item or xenomorph."
+	/// For the first structure, the amount to multiply Psychic Fling's cooldown by if it was used on an xenomorph or item.
+	var/multiplier_initial = 0.5
+	/// For each structure, the additional amount to multiply Psychic Fling's cooldown by if it was used on an xenomorph or item.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/utility_fling/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Psychic Fling can be used on yourself and allied xenomorphs. Psychic Fling's cooldown is set to [PERCENT(get_multiplier(new_amount))]% of its original value if it was used on an item or xenomorph."
+
+/datum/mutation_upgrade/veil/utility_fling/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	fling_ability.use_state_flags |= ABILITY_TARGET_SELF
+	fling_ability.friendly_cooldown_multiplier += get_multiplier(0)
+
+/datum/mutation_upgrade/veil/utility_fling/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	fling_ability.use_state_flags &= ~ABILITY_TARGET_SELF
+	fling_ability.friendly_cooldown_multiplier -= get_multiplier(0)
+
+/datum/mutation_upgrade/veil/utility_fling/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/psychic_fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/psychic_fling]
+	if(!fling_ability)
+		return
+	fling_ability.friendly_cooldown_multiplier += get_multiplier(new_amount - previous_amount, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/mutations_shrike.dm
@@ -206,13 +206,12 @@
 /datum/mutation_upgrade/spur/gravity_tide/proc/get_distance(structure_count, include_initial = TRUE)
 	return (include_initial ? distance_initial : 0) + (distance_per_structure * structure_count)
 
-
-
-
-
 /datum/mutation_upgrade/spur/psychic_choke
 	name = "Psychic Choke"
 	desc = "You lose the ability Psychic Fling in exchange for the ability Psychic Choke. Psychic Choke lets you paralyze a marine as long you channel it. The damage threshold to disrupt Psychic Choke is 20/35/50."
+	conflicting_mutation_types = list(
+		/datum/mutation_upgrade/veil/utility_fling
+	)
 	/// For each structure, the amount to increase Psychic Choke's damage threshold.
 	var/threshold_per_structure = 15
 
@@ -335,6 +334,9 @@
 /datum/mutation_upgrade/veil/utility_fling
 	name = "Utility Fling"
 	desc = "Psychic Fling can be used on yourself and allied xenomorphs. Psychic Fling's cooldown is set to 40/30/20% of its original value if it was used on an item or xenomorph."
+	conflicting_mutation_types = list(
+		/datum/mutation_upgrade/spur/psychic_choke
+	)
 	/// For the first structure, the amount to multiply Psychic Fling's cooldown by if it was used on an xenomorph or item.
 	var/multiplier_initial = 0.5
 	/// For each structure, the additional amount to multiply Psychic Fling's cooldown by if it was used on an xenomorph or item.
@@ -367,3 +369,7 @@
 	if(!fling_ability)
 		return
 	fling_ability.friendly_cooldown_multiplier += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the amount to multiply Psychic Fling's cooldown by if it was used on an xenomorph or item.
+/datum/mutation_upgrade/veil/utility_fling/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -103,10 +103,10 @@
 		amount *= regen_power
 	amount *= multiplier * GLOB.xeno_stat_multiplicator_buff * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD
 
-	var/list/heal_data = list(amount)
+	var/list/heal_data = list(amount, amount)
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, heal_data, seconds_per_tick)
 	HEAL_XENO_DAMAGE(src, heal_data[1], TRUE)
-	return heal_data[1]
+	return heal_data // [1] = amount of unused healing, [2] = raw healing
 
 /mob/living/carbon/xenomorph/proc/handle_living_plasma_updates(seconds_per_tick)
 	var/turf/T = loc

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -76,6 +76,8 @@
 	switch(effect_type)
 		if(EFFECT_STUN)
 			Stun(effect)
+		if(EFFECT_KNOCKDOWN)
+			Knockdown(effect)
 		if(EFFECT_PARALYZE)
 			Paralyze(effect)
 		if(EFFECT_UNCONSCIOUS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 8 more mutations for Shrike for a total of 9.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Shared Cure | 20/35/50% of the health restored from Psychic Cure is reapplied to you. |
| Shell | Resistant Cure | Psychic Cure grants you and your target 40/50/60 seconds of fire immunity. |
| Spur | Psychic Choke | You lose the ability Psychic Fling in exchange for the ability Psychic Choke. Psychic Choke lets you paralyze a marine as long you channel it. The damage threshold to disrupt Psychic Choke is 20/35/50. |
| Spur | Gravity Tide | Psychic Scream pulls humans towards you then pushes them away. The distance they are thrown is increased by 2/3/4. |
| Veil | Delayed Condition | Psychic Heal delays all inbound stagger, stun, and slowdown effects caused to your target by 8/10/12 seconds. At the end of this duration, all effects are applied in full force. |
| Veil | Deflective Scream | Psychic Scream now reflects all projectiles in its affected area. Reflecting more than 50 projectile damage resets Psychic Scream's cooldown to 50/40/30% of its original value. |
| Veil | Utility Fling | Psychic Fling can be used on yourself and allied xenomorphs. Psychic Fling's cooldown is set to 40/30/20% of its original value if it was used on an item or xenomorph. |

Stand-In Recycler, one of Shrike's mutations, has been removed.
Lone Healer, one of Shrike's mutations, no longer has the downside of increasing cooldown duration for self-healing.

Removes an unused variable from boilers abilities file.

## Why It's Good For The Game
More variety of mutations and some balancing for them.

## Changelog
:cl:
add: 8 more mutations for Shrike.
del: Mutations: Stand-In Recycler has been removed.
balance: Psychic Fling only kills facehuggers in hand if the target was a human.
balance: Mutations: Lone Healer no longer increases cooldown duration for Psychic Cure.
/:cl:
