### PR TITLE
Hunter stealth balance

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -622,11 +622,11 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define CHARGE_MAX 3
 
 //Hunter Defines
-#define HUNTER_STEALTH_COOLDOWN 50 //5 seconds
-#define HUNTER_STEALTH_WALK_PLASMADRAIN 2
+#define HUNTER_STEALTH_COOLDOWN 80 //8 seconds
+#define HUNTER_STEALTH_WALK_PLASMADRAIN 3
 #define HUNTER_STEALTH_RUN_PLASMADRAIN 5
 #define HUNTER_STEALTH_STILL_ALPHA 25 //90% transparency
-#define HUNTER_STEALTH_WALK_ALPHA 38 //85% transparency
+#define HUNTER_STEALTH_WALK_ALPHA 77 //70% transparency
 #define HUNTER_STEALTH_RUN_ALPHA 128 //50% transparency
 #define HUNTER_STEALTH_STEALTH_DELAY 30 //3 seconds before 95% stealth
 #define HUNTER_STEALTH_INITIAL_DELAY 20 //2 seconds before we can increase stealth


### PR DESCRIPTION
Increased cooldown. Reduced transparency, increased plasma drain while walking in stealth.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The objective is to re-balance hunter's stealth ability to make it better fit the ambusher archetype with these minor nerfs:
- Increased stealth cooldown from 5 to 8 seconds.
- Increased plasma drain while walking in stealth from 2 to 3.
- Reduced transparency while walking in stealth from 85% to 70%.

## Why It's Good For The Game

Hunter is meant to be played as an ambush caste, doing high impact surprise strikes then dipping out to heal and reset. Currently it is possible for hunter to play more as a frontline caste due to how quickly stealth goes off cooldown, and its low plasma drain. Stealth also makes hunter almost fully invisible, to the point where it can openly approach marines without being noticed even off weeds. Hunter is also fairly tanky for a hit-and-run caste which lets it apply overwhelming pressure with very little risk.

My changes will incentivize ambushing around corners and in mazes, actually using stealth as a surprise attack instead of just as a dive. The changes will make standing still in stealth a usable option. Right now, there is no reason not to just dive in using stealth instead of waiting to ambush. The change to transparency will allow marines to have a chance at counterplay while retaining the hunter's ability to remain unnoticed if played smart.

These relatively minor nerfs create more opportunities for skill expression for both the hunter and marines, and balances what is currently a low risk, high reward playstyle.

## Changelog

:cl: Scav
balance: Hunter: Increased stealth cooldown from 5 to 8 seconds.
balance: Hunter: Increased plasma drain while walking in stealth from 2 to 3.
balance: Hunter: Reduced transparency while walking in stealth from 85% to 70%.
/:cl:
