### PR TITLE
shotgun tracking shell rebalance 

### DIFF
--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -311,12 +311,12 @@
 	icon_state = "shotgun_slug"
 	hud_state = "shotgun_tracker"
 	shell_speed = 4
-	max_range = 30
-	damage = 5
-	penetration = 100
+	max_range = 15
+	damage = 40
+	penetration = 30
 
 /datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 60 SECONDS, 3 SECONDS)
 
 /datum/ammo/bullet/shotgun/tracker
 	name = "shotgun tracker shell"
@@ -324,12 +324,12 @@
 	icon_state = "shotgun_slug"
 	hud_state = "shotgun_tracker"
 	shell_speed = 4
-	max_range = 30
-	damage = 5
-	penetration = 100
+	max_range = 15
+	damage = 90
+	penetration = 10
 
 /datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 40 SECONDS, 2 SECONDS)
+	target_mob.AddComponent(/datum/component/dripping, DRIP_ON_TIME, 60 SECONDS, 3 SECONDS)
 
 //I INSERT THE SHELLS IN AN UNKNOWN ORDER
 /datum/ammo/bullet/shotgun/blank


### PR DESCRIPTION
## About The Pull Request

changed both tracker shells to do ten damage less than the normal shells, less pen, 15 range, and extended the status effect while keeping the amount of droplets the same.

## Why It's Good For The Game

Normally the tracker shell types do 5 damage with 100 pen. it makes it useless for defending yourself even with that ap. this should make it slightly weaker than the other shotgun ammo while more viable in keeping yourself alive and helping your team. 

## Changelog
:cl:
balance: MBX and 12 gauge tracker shells damage raised to 40 and 90 respectively.
balance: Ranges are both now 15 
balance: the status effect lasts for 60 seconds and drips every 3 seconds, leaving same number of drops.
balance: both had AP lowered from 100 to something reasonable.
/:cl:
