### PR TITLE
Slight conqueror rebalance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_conqueror.dm
@@ -15,7 +15,7 @@
 	action_icon = 'icons/Xeno/actions/wraith.dmi'
 	action_icon_state = "rewind"
 	ability_cost = 15
-	cooldown_duration = 3.5 SECONDS
+	cooldown_duration = 4.5 SECONDS
 	use_state_flags = ABILITY_USE_FORTIFIED
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CONQUEROR_DASH,

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -137,7 +137,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 800
+	max_health = 650
 
 	// *** Sunder *** //
 	sunder_multiplier = 1.0


### PR DESCRIPTION
## About The Pull Request

Decreases the conqueror's health from 800 to 650
Increases the dash ability cooldown from 3.5s to 4.5s

## Why It's Good For The Game

So yeah conqueror is pretty very incredibly overtuned especially since the king pop requirement has been lowered down to 8 which makes it almost impossible to kill on lower pops and still very hard to kill with higher pops

## Changelog

:cl:
balance: Conqueror's hp 800 -> 650
balance: Conqueror's dash cd 3.5s -> 4.5s
/:cl:
