### PR TITLE
Fixes Mutation Typos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/mutations_sizzler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/mutations_sizzler.dm
@@ -46,7 +46,7 @@
 /datum/mutation_upgrade/spur/neurotoxin_swap/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Smokescreen Spit does stamina damage emits Neurotoxin instead. Smokescreen Spit's plasma cost is [PERCENT(1 + get_cost_multiplier(new_amount))]% of its original cost."
+	return "Smokescreen Spit does stamina damage and emits Neurotoxin instead. Smokescreen Spit's plasma cost is [PERCENT(1 + get_cost_multiplier(new_amount))]% of its original cost."
 
 /datum/mutation_upgrade/spur/neurotoxin_swap/on_mutation_enabled()
 	var/datum/action/ability/xeno_action/smokescreen_spit/smokescreen_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/smokescreen_spit]

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/mutations_conqueror.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/mutations_conqueror.dm
@@ -53,7 +53,7 @@
 /datum/mutation_upgrade/spur/telefrag/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Domination's radius is reduced by [-radius_initial], but knocked down for [get_duration(new_amount)] seconds longer."
+	return "Domination's radius is reduced by [-radius_initial], but knocked down for [get_duration(new_amount) / 10] seconds longer."
 
 /datum/mutation_upgrade/spur/telefrag/on_mutation_enabled()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes two typos in mutation descriptions in Neurotoxin Swap (Sizzler) and Telefrag (Conqueror).


## Why It's Good For The Game
Typos are bad.

## Changelog
:cl:
spellcheck: Mutations: Neurotoxin Swap's description now has the conjunction "and" that it was missing.
spellcheck: Mutations: Telefrag's description now uses the correct duration to display as seconds.
/:cl:
