### PR TITLE
Removes Unused Boiler Ability Variable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -248,7 +248,6 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 			unique_glob = FALSE
 			xeno_owner.neurotoxin_ammo++
 			xeno_owner.balloon_alert(xeno_owner, "Neurotoxin globule prepared.")
-	var/total_globs = xeno_owner.corrosive_ammo + xeno_owner.neurotoxin_ammo
 	if(unique_glob)
 		if(xeno_owner.corrosive_ammo > xeno_owner.neurotoxin_ammo)
 			xeno_owner.neurotoxin_ammo++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes an unused variable within boiler abilities file.

## Why It's Good For The Game
Was causing a warning error affecting other branches.

## Changelog
:cl:
code: Removes unused variable from boiler abilities.
/:cl:
