### PR TITLE
Hunter now breaks stealth when swapping with mirage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -591,6 +591,9 @@
 	if(!length(illusions) && !prioritized_illusion)
 		to_chat(xeno_owner, span_xenowarning("We have no illusions to swap with!"))
 		return
+	var/datum/action/ability/xeno_action/stealth/stealth_action = xeno_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(stealth_action?.stealth)
+		stealth_action.cancel_stealth()
 
 	xeno_owner.playsound_local(xeno_owner, 'sound/effects/swap.ogg', 10, 0, 1)
 	var/turf/current_turf = get_turf(xeno_owner)


### PR DESCRIPTION

## About The Pull Request
Using the swap ability on mirage will now cancel stealth.
## Why It's Good For The Game
Teleporting next to someone with your fully charged stun is cringe and the marine can do literally nothing about it except shoot at the mirages.
## Changelog
:cl:
balance: Hunter mirage swap now breaks stealth.
/:cl:
