### PR TITLE
Acid cade fix

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -396,7 +396,7 @@
 //cade armor defines
 #define CADE_UPGRADE_BOMB 80
 #define CADE_UPGRADE_MELEE list(melee = 30, bullet = 50, laser = 50, energy = 50)
-#define CADE_UPGRADE_ACID 75
+#define CADE_UPGRADE_ACID 35
 
 /obj/structure/barricade/solid
 	name = "metal barricade"


### PR DESCRIPTION

## About The Pull Request
Acid upgrade for cades gives the correct bonus of 35 extra resist instead of 75.
## Why It's Good For The Game
A certain someone is going to get paddled for sneaking through a huge walance change in a fix pr.
## Changelog
:cl:
fix: Acid barricade upgrades no longer give far more resist than intended
/:cl:
