### PR TITLE
Fixes infinitely stacking barricade armor upgrades

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -513,7 +513,8 @@
 	if(!do_after(user, 2 SECONDS, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
 	if(barricade_upgrade_type)
-		return
+		balloon_alert(user, "Already upgraded")
+		return FALSE
 
 	if(!metal_sheets.use(CADE_UPGRADE_REQUIRED_SHEETS))
 		return FALSE

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -512,6 +512,8 @@
 	balloon_alert_to_viewers("attaching [choice]")
 	if(!do_after(user, 2 SECONDS, NONE, src, BUSY_ICON_BUILD))
 		return FALSE
+	if(barricade_upgrade_type)
+		return
 
 	if(!metal_sheets.use(CADE_UPGRADE_REQUIRED_SHEETS))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Prevents upgrading a barricade multiple times in a row via stacking do_afters by making it so it doesn't go through if it already was upgraded.

## Why It's Good For The Game
Stops this:
<img width="461" height="262" alt="image" src="https://github.com/user-attachments/assets/ec43604b-134f-4f93-9d9e-68a8550d0e0b" />

## Changelog
:cl:
fix: You can no longer infinitely stack armor on barricades by upgrading when you're not suppose to.
/:cl:
