### PR TITLE
Mech sword walance

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -551,6 +551,12 @@
 	chassis.throw_at(target, laser_dash_range, 1)
 	return ..()
 
+/obj/item/mecha_parts/mecha_equipment/laser_sword/attack(mob/living/M, mob/living/user)
+	var/user_target_zone = user.zone_selected //stops 1 hit delimbs
+	user.zone_selected = BODY_ZONE_CHEST
+	. = ..()
+	user.zone_selected = user_target_zone
+
 ///signal handler, drops afterimage every move executed while dashing
 /obj/item/mecha_parts/mecha_equipment/laser_sword/proc/drop_afterimage(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Mech sword now always aims chest.
## Why It's Good For The Game
(Almost) guaranteed one hit delimbs is uh, not ideal.
## Changelog
:cl:
balance: Mech laser sword always hits chest
/:cl:
