### PR TITLE
Update drinks.dm

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -225,6 +225,7 @@
 	desc = "A Nanotrasen brand protein shake"
 	icon = 'icons/obj/drinks/bottles.dmi'
 	icon_state = "shaker_n"
+	amount_per_transfer_from_this = 120
 	list_reagents = list(
 		/datum/reagent/consumable/nutriment = 60,
 		/datum/reagent/consumable/nutriment/protein = 60


### PR DESCRIPTION
## About The Pull Request

Set the default transfer amount for the protein shake item to 120 units. It was previously 10 units.

## Why It's Good For The Game

The change makes it easier and faster to fill up a reagent pouch with protein shake. 
Previously it would take 12 clicks per shake and 10 shakes in total to fully fill the reagent canister. Doing this at the start of every round to use with nanites is a recipe for carpal tunnel. 

## Changelog

:cl: Scav
qol: Set the transfer amount of protein shakes to 120 units.
/:cl:
