### PR TITLE
Missing detpack secondary for SOM engies

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/SOM/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/secondaries.dm
@@ -138,6 +138,20 @@
 	wearer.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/large_stack, SLOT_IN_BACKPACK)
 	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_BACKPACK)
 
+/datum/loadout_item/secondary/kit/som_engineer/detpack
+	name = "Detpacks"
+	desc = "Detpacks, for blowing things up."
+	ui_icon = "default"
+
+/datum/loadout_item/secondary/kit/som_engineer/detpack/post_equip(mob/living/carbon/human/wearer, datum/outfit/quick/loadout, datum/outfit_holder/holder)
+	wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)
+	if(istype(wearer.back, /obj/item/storage/backpack/marine/engineerpack/som))
+		wearer.equip_to_slot_or_del(new /obj/item/detpack, SLOT_IN_BACKPACK)
+	else
+		wearer.equip_to_slot_or_del(new /obj/item/assembly/signaler, SLOT_IN_BACKPACK)
+	wearer.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_BACKPACK)
+
 /datum/loadout_item/secondary/kit/som_corpsman
 	jobs_supported = list(SOM_SQUAD_CORPSMAN)
 


### PR DESCRIPTION

## About The Pull Request
What it says on the tin, I probably forgot to give it to them when I did up the secondary kits.
## Why It's Good For The Game
Big booma kit
## Changelog
:cl:
balance: Campaign: SOM engineers can get detpacks again
/:cl:
