### PR TITLE
Crash vendor AG nade increase

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -345,7 +345,7 @@
 			/obj/item/explosive/grenade/sticky = 75,
 			/obj/item/explosive/grenade/incendiary = 25,
 			/obj/item/explosive/grenade/smokebomb/cloak = 15,
-			/obj/item/explosive/grenade/smokebomb/antigas = 10,
+			/obj/item/explosive/grenade/smokebomb/antigas = 25,
 			/obj/item/explosive/grenade/mirage = 50,
 			/obj/item/explosive/grenade/bullet/laser = 15,
 			/obj/item/storage/box/m94 = 200,


### PR DESCRIPTION

## About The Pull Request

Increased the number of AG nades in the crash weapon vendor from 10 to 25.

## Why It's Good For The Game

Defilers, acid wells, boilers, and other xeno gas sources have no real limit to how many times they can be deployed. Increasing the number of AG nades available to marines on crash will balance this out.

## Changelog

:cl: Scav
balance: Increased vendor AG nade count on crash to 25
/:cl:
