### PR TITLE
More Hunter Mutations

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -197,6 +197,7 @@
 ///Purges all types of smoke
 #define SMOKE_PURGER (1<<22)
 #define SMOKE_XENO_PYROGEN (1<<23) // Smoke that acts like SMOKE_BLISTERING for non-xenos and applies pyrogen's melting fire status effect when entering.
+#define SMOKE_CAMO_XENO (1<<24)
 
 //Incapacitated
 #define INCAPACITATED_IGNORE_RESTRAINED (1<<0)

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -197,7 +197,6 @@
 ///Purges all types of smoke
 #define SMOKE_PURGER (1<<22)
 #define SMOKE_XENO_PYROGEN (1<<23) // Smoke that acts like SMOKE_BLISTERING for non-xenos and applies pyrogen's melting fire status effect when entering.
-#define SMOKE_CAMO_XENO (1<<24)
 
 //Incapacitated
 #define INCAPACITATED_IGNORE_RESTRAINED (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -634,6 +634,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define HUNTER_SNEAK_SLASH_ARMOR_PEN 10 //bonus AP
 #define HUNTER_SNEAK_ATTACK_RUN_DELAY 2 SECONDS
 #define HUNTER_PSYCHIC_TRACE_COOLDOWN 5 SECONDS //Cooldown of the Hunter's Psychic Trace, and duration of its arrow
+#define HUNTER_MIRAGE_ILLUSION_LIFETIME 10 SECONDS
 #define HUNTER_SILENCE_STAGGER_DURATION 1 SECONDS //Silence imposes this much stagger
 #define HUNTER_SILENCE_SENSORY_STACKS 7 //Silence imposes this many eyeblur and deafen stacks.
 #define HUNTER_SILENCE_MUTE_DURATION 10 SECONDS //Silence imposes this many seconds of the mute status effect.

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -97,7 +97,7 @@
 #define STATUS_EFFECT_DREAD  /datum/status_effect/dread
 /// Deals a variable amount of stamina damage for 6 seconds.
 #define STATUS_EFFECT_DRAINING_DREAD  /datum/status_effect/draining_dread
-/// Cloaked by xenomorph variant of tactical smoke.
+/// Cloaked by xenomorph variant of tactical smoke (aka gas that both has SMOKE_XENO and SMOKE_CAMO).
 #define STATUS_EFFECT_XENOMORPH_CLOAKING  /datum/status_effect/xenomorph_cloaking
 
 /////////////

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -97,6 +97,8 @@
 #define STATUS_EFFECT_DREAD  /datum/status_effect/dread
 /// Deals a variable amount of stamina damage for 6 seconds.
 #define STATUS_EFFECT_DRAINING_DREAD  /datum/status_effect/draining_dread
+/// Cloaked by xenomorph variant of tactical smoke.
+#define STATUS_EFFECT_XENOMORPH_CLOAKING  /datum/status_effect/xenomorph_cloaking
 
 /////////////
 // NEUTRAL //

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -1017,3 +1017,21 @@
 	var/mob/living/carbon/xenomorph/xeno_owner = owner
 	xeno_owner.xeno_melee_damage_modifier -= damage_modifier
 	xeno_owner.remove_filter("[id]_outline")
+
+// ***************************************
+// *********** Cloaking
+// ***************************************
+/datum/status_effect/xenomorph_cloaking
+	id = "xenomorph_cloaking"
+	alert_type = null
+
+/datum/status_effect/cloaking/on_apply()
+	. = ..()
+	if(!isxeno(owner))
+		return FALSE
+	var/mob/living/carbon/xenomorph/xenomorph_owner = owner
+	xenomorph_owner.update_alpha()
+
+/datum/status_effect/cloaking/on_remove()
+	var/mob/living/carbon/xenomorph/xenomorph_owner = owner
+	xenomorph_owner.update_alpha()

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -1025,13 +1025,13 @@
 	id = "xenomorph_cloaking"
 	alert_type = null
 
-/datum/status_effect/cloaking/on_apply()
+/datum/status_effect/xenomorph_cloaking/on_apply()
 	. = ..()
 	if(!isxeno(owner))
 		return FALSE
 	var/mob/living/carbon/xenomorph/xenomorph_owner = owner
-	xenomorph_owner.update_alpha()
+	xenomorph_owner.set_alpha_source(id, HUNTER_STEALTH_STILL_ALPHA)
 
-/datum/status_effect/cloaking/on_remove()
+/datum/status_effect/xenomorph_cloaking/on_remove()
 	var/mob/living/carbon/xenomorph/xenomorph_owner = owner
-	xenomorph_owner.update_alpha()
+	xenomorph_owner.remove_alpha_source(id)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -59,7 +59,7 @@
 	AddElement(/datum/element/connect_loc, connections)
 
 /obj/effect/particle_effect/smoke/Destroy()
-	if(lifetime && CHECK_BITFIELD(smoke_traits, SMOKE_CAMO))
+	if(lifetime && ((smoke_traits && SMOKE_CAMO) || (smoke_traits && SMOKE_CAMO_XENO)))
 		apply_smoke_effect(get_turf(src))
 		LAZYCLEARLIST(cloud?.smoked_mobs)
 	if(CHECK_BITFIELD(smoke_traits, SMOKE_CHEM) && LAZYLEN(cloud?.smoked_mobs)) //so the whole cloud won't stop working somehow
@@ -108,10 +108,11 @@
 
 /obj/effect/particle_effect/smoke/proc/on_exited(datum/source, mob/living/M, direction)
 	SIGNAL_HANDLER
-	if(CHECK_BITFIELD(smoke_traits, SMOKE_CAMO) && istype(M))
-		var/obj/effect/particle_effect/smoke/S = locate() in get_turf(M)
-		if(!CHECK_BITFIELD(S?.smoke_traits, SMOKE_CAMO))
-			M.smokecloak_off()
+	var/obj/effect/particle_effect/smoke/smoke_from_new_turf = locate() in get_turf(M)
+	if(istype(M) && !(smoke_from_new_turf?.smoke_traits && SMOKE_CAMO))
+		M.smokecloak_off()
+	if(isxeno(M) && !(smoke_from_new_turf?.smoke_traits && SMOKE_CAMO_XENO) && M.has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
+		M.remove_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
 
 /obj/effect/particle_effect/smoke/proc/apply_smoke_effect(turf/T)
 	T.effect_smoke(src)
@@ -258,6 +259,12 @@
 	alpha = 40
 	opacity = FALSE
 	smoke_traits = SMOKE_CAMO
+
+/obj/effect/particle_effect/smoke/tactical_xeno
+	alpha = 40
+	opacity = FALSE
+	color = "#282e36"
+	smoke_traits = SMOKE_CAMO_XENO
 
 /////////////////////////////////////////////
 // Sleep smoke
@@ -448,6 +455,9 @@
 
 /datum/effect_system/smoke_spread/tactical
 	smoke_type = /obj/effect/particle_effect/smoke/tactical
+
+/datum/effect_system/smoke_spread/tactical_xeno
+	smoke_type = /obj/effect/particle_effect/smoke/tactical_xeno
 
 /datum/effect_system/smoke_spread/sleepy
 	smoke_type = /obj/effect/particle_effect/smoke/sleepy

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -79,7 +79,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	. = ..()
 	if(!.)
 		return
-	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CAMO))
+	if((S.smoke_traits && SMOKE_CAMO) && !(S.smoke_traits && SMOKE_XENO))
 		smokecloak_on()
 
 /mob/living/carbon/human/inhale_smoke(obj/effect/particle_effect/smoke/S)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -24,8 +24,8 @@
 	var/bonus_stealth_damage_multiplier = 0
 	/// How much bonus armor piercing should sneak attack get if it was done at maximum stealth level?
 	var/bonus_maximum_stealth_ap = 0
-	/// Should a successful sneak attack blind instead of inflicting stagger/slow?
-	var/blinds_instead = FALSE
+	/// How much does a successful sneak attack blind for?
+	var/blinding_stacks = 0
 
 /datum/action/ability/xeno_action/stealth/remove_action(mob/living/L)
 	if(stealth)
@@ -208,11 +208,10 @@
 
 	owner.visible_message(span_danger("\The [owner] strikes [target] with [flavour] precision!"), \
 	span_danger("We strike [target] with [flavour] precision!"))
-	if(!blinds_instead)
-		target.adjust_stagger(staggerslow_stacks SECONDS)
-		target.add_slowdown(staggerslow_stacks)
-	else
-		target.blind_eyes(2)
+	target.adjust_stagger(staggerslow_stacks SECONDS)
+	target.add_slowdown(staggerslow_stacks)
+	if(blinding_stacks)
+		target.blind_eyes(blinding_stacks)
 	if(sneak_attack_stun_duration)
 		target.ParalyzeNoChain(sneak_attack_stun_duration)
 	GLOB.round_statistics.hunter_cloak_victims++

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -68,8 +68,14 @@
 
 	mutations = list(
 		/datum/mutation_upgrade/shell/fleeting_mirage,
+		/datum/mutation_upgrade/shell/splitting_mirage,
+		/datum/mutation_upgrade/shell/cloaking_mirage,
 		/datum/mutation_upgrade/spur/debilitating_strike,
-		/datum/mutation_upgrade/veil/one_target
+		/datum/mutation_upgrade/spur/ambush,
+		/datum/mutation_upgrade/spur/maul,
+		/datum/mutation_upgrade/veil/one_target,
+		/datum/mutation_upgrade/veil/mirage_flood,
+		/datum/mutation_upgrade/veil/faceblind
 	)
 
 /datum/xeno_caste/hunter/normal

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
@@ -378,7 +378,7 @@
 	if(!stealth_ability)
 		return
 	stealth_ability.sneak_attack_stun_duration = initial(stealth_ability.sneak_attack_stun_duration)
-	stealth_ability.blinding_stacks = initial(stealth_ability.blinds_instead)
+	stealth_ability.blinding_stacks = initial(stealth_ability.blinding_stacks)
 
 /datum/mutation_upgrade/veil/faceblind/on_structure_update(previous_amount, new_amount)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
@@ -71,6 +71,101 @@
 /datum/mutation_upgrade/shell/fleeting_mirage/proc/get_threshold(structure_count, include_initial = TRUE)
 	return (include_initial ? health_threshold_initial : 0) + (health_threshold_per_structure * structure_count)
 
+/datum/mutation_upgrade/shell/splitting_mirage
+	name = "Splitting Mirage"
+	desc = "Mirage will instead cause your slashes to create an illusion for the next 12/14/16 seconds. These illusions disappear when the time is up."
+	/// For each structure, the amount of deciseconds to increase Mirage's illusion lifespan by.
+	var/length_per_structure = 2 SECONDS
+
+/datum/mutation_upgrade/shell/splitting_mirage/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Mirage will instead cause your slashes to create an illusion for the next [get_length(new_amount)] seconds. These illusions disappear when the time is up."
+
+/datum/mutation_upgrade/shell/splitting_mirage/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count -= initial(mirage_ability.illusion_count)
+	mirage_ability.illusion_on_slash = TRUE
+	if(length(mirage_ability.illusions)) // Ability is currently active.
+		mirage_ability.register_on_slash()
+
+/datum/mutation_upgrade/shell/splitting_mirage/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count += initial(mirage_ability.illusion_count)
+	mirage_ability.illusion_on_slash = FALSE
+	if(length(mirage_ability.illusions)) // Ability is currently active.
+		mirage_ability.unregister_on_slash()
+
+/datum/mutation_upgrade/shell/splitting_mirage/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_life_time += get_length(new_amount - previous_amount)
+
+/// Returns the amount of deciseconds to increase Mirage's illusion lifespan by.
+/datum/mutation_upgrade/shell/splitting_mirage/proc/get_length(structure_count)
+	return length_per_structure * structure_count
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/datum/mutation_upgrade/shell/cloaking_mirage
+	name = "Cloaking Mirage"
+	desc = "Mirage will instead creates cloaking gas for 12/14/16 seconds in a radius of 2."
+	/// For each structure, the amount of deciseconds to increase Mirage's smoke duration by.
+	var/length_per_structure = 2 SECONDS
+
+/datum/mutation_upgrade/shell/cloaking_mirage/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Mirage will instead creates cloaking gas for [get_length(new_amount)]  in a radius of 2."
+
+/datum/mutation_upgrade/shell/cloaking_mirage/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count -= initial(mirage_ability.illusion_count)
+	mirage_ability.cloaking_gas = TRUE
+
+/datum/mutation_upgrade/shell/cloaking_mirage/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count += initial(mirage_ability.illusion_count)
+	mirage_ability.cloaking_gas = FALSE
+
+/datum/mutation_upgrade/shell/cloaking_mirage/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_life_time += get_length(new_amount - previous_amount)
+
+/// Returns the amount of deciseconds to increase Mirage's illusion lifespan by.
+/datum/mutation_upgrade/shell/cloaking_mirage/proc/get_length(structure_count)
+	return length_per_structure * structure_count
+
 //*********************//
 //         Spur        //
 //*********************//

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/mutations_hunter.dm
@@ -80,7 +80,7 @@
 /datum/mutation_upgrade/shell/splitting_mirage/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Mirage will instead cause your slashes to create an illusion for the next [get_length(new_amount)] seconds. These illusions disappear when the time is up."
+	return "Mirage will instead cause your slashes to create an illusion for the next [(HUNTER_MIRAGE_ILLUSION_LIFETIME + get_length(new_amount)) / 10] seconds. These illusions disappear when the time is up."
 
 /datum/mutation_upgrade/shell/splitting_mirage/on_mutation_enabled()
 	. = ..()
@@ -113,21 +113,6 @@
 /datum/mutation_upgrade/shell/splitting_mirage/proc/get_length(structure_count)
 	return length_per_structure * structure_count
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 /datum/mutation_upgrade/shell/cloaking_mirage
 	name = "Cloaking Mirage"
 	desc = "Mirage will instead creates cloaking gas for 12/14/16 seconds in a radius of 2."
@@ -137,7 +122,7 @@
 /datum/mutation_upgrade/shell/cloaking_mirage/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Mirage will instead creates cloaking gas for [get_length(new_amount)]  in a radius of 2."
+	return "Mirage will instead creates cloaking gas for [(HUNTER_MIRAGE_ILLUSION_LIFETIME + get_length(new_amount)) / 10] seconds in a radius of 2."
 
 /datum/mutation_upgrade/shell/cloaking_mirage/on_mutation_enabled()
 	. = ..()
@@ -183,20 +168,20 @@
 	return "Stealth's sneak attack no longer stuns. [get_multiplier(new_amount)]x of your slash damage is added onto sneak attack instead."
 
 /datum/mutation_upgrade/spur/debilitating_strike/on_mutation_enabled()
+	. = ..()
 	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
 	if(!stealth_ability)
 		return
 	stealth_ability.bonus_stealth_damage_multiplier += get_multiplier(0)
 	stealth_ability.sneak_attack_stun_duration -= initial(stealth_ability.sneak_attack_stun_duration)
-	return ..()
 
 /datum/mutation_upgrade/spur/debilitating_strike/on_mutation_disabled()
+	. = ..()
 	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
 	if(!stealth_ability)
 		return
 	stealth_ability.bonus_stealth_damage_multiplier -= get_multiplier(0)
 	stealth_ability.sneak_attack_stun_duration += initial(stealth_ability.sneak_attack_stun_duration)
-	return ..()
 
 /datum/mutation_upgrade/spur/debilitating_strike/on_structure_update(previous_amount, new_amount)
 	. = ..()
@@ -208,6 +193,85 @@
 /// Returns the multiplier to add as additional damage when Sneak Attack was successfully used on living beings.
 /datum/mutation_upgrade/spur/debilitating_strike/proc/get_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? damage_multiplier_initial : 0) + (damage_multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/spur/ambush
+	name = "Ambush"
+	desc = "Stealth's movement cost is 300% of its original value. While at the maximum stealth power, your next sneak attack has an additional 15/22.5/30 AP."
+	/// For the first structure, the amount of AP that a maximum powered stealth will get.
+	var/ap_initial = 7.5
+	/// For each structure, the additional amount of AP that a maximum powered stealth will get.
+	var/ap_per_structure = 7.5
+
+/datum/mutation_upgrade/spur/ambush/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return  "Stealth's movement cost is 300% of its original value. While at the maximum stealth power, your next sneak attack has an additional [get_ap(new_amount)] AP."
+
+/datum/mutation_upgrade/spur/ambush/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(!stealth_ability)
+		return
+	stealth_ability.movement_cost_multiplier += 2 // 100% -> 300%
+	stealth_ability.bonus_maximum_stealth_ap += get_ap(0)
+
+/datum/mutation_upgrade/spur/ambush/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(!stealth_ability)
+		return
+	stealth_ability.movement_cost_multiplier -= 2 // 300% -> 100%
+	stealth_ability.bonus_maximum_stealth_ap -= get_ap(0)
+
+/datum/mutation_upgrade/spur/ambush/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(!stealth_ability)
+		return
+	stealth_ability.bonus_maximum_stealth_ap += get_ap(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of AP that a maximum powered stealth will get.
+/datum/mutation_upgrade/spur/ambush/proc/get_ap(structure_count, include_initial = TRUE)
+	return (include_initial ? ap_initial : 0) + (ap_per_structure * structure_count)
+
+/datum/mutation_upgrade/spur/maul
+	name = "Maul"
+	desc = "Pounce no longer stuns, but now slashes your target which can trigger sneak attack. Pounce's cooldown is set to 60/50/40% of its original value."
+	/// For the first structure, the multiplier of Pounce's cooldown duration to add to it.
+	var/multiplier_initial = -0.3
+	/// For each structure, the additional multiplier of Pounce's cooldown duration to add to it.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/spur/maul/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/pounce/pounce_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/pounce/runner]
+	if(!pounce_ability)
+		return
+	pounce_ability.cooldown_duration += get_multiplier(0)
+	pounce_ability.stun_duration -= initial(pounce_ability.stun_duration)
+	pounce_ability.self_immobilize_duration -= initial(pounce_ability.self_immobilize_duration)
+	pounce_ability.attack_on_pounce = TRUE
+
+/datum/mutation_upgrade/spur/maul/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/activable/xeno/pounce/pounce_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/pounce/runner]
+	if(!pounce_ability)
+		return
+	pounce_ability.cooldown_duration -= get_multiplier(0)
+	pounce_ability.stun_duration += initial(pounce_ability.stun_duration)
+	pounce_ability.self_immobilize_duration += initial(pounce_ability.self_immobilize_duration)
+	pounce_ability.attack_on_pounce = FALSE
+
+/datum/mutation_upgrade/spur/maul/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/activable/xeno/pounce/pounce_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/pounce/runner]
+	if(!pounce_ability)
+		return
+	pounce_ability.cooldown_duration += get_multiplier(new_amount - previous_amount, FALSE)
+
+/// Returns the amount of AP that a maximum powered stealth will get.
+/datum/mutation_upgrade/spur/maul/proc/get_multiplier(structure_count, include_initial = TRUE)
+	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
 
 //*********************//
 //         Veil        //
@@ -226,18 +290,18 @@
 	return "The effects of Silence against your Hunter's Mark target last [HUNTER_SILENCE_MULTIPLIER + get_multiplier(new_amount)]x as long."
 
 /datum/mutation_upgrade/veil/one_target/on_mutation_enabled()
+	. = ..()
 	var/datum/action/ability/activable/xeno/silence/silence_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/silence]
 	if(!silence_ability)
 		return
 	silence_ability.hunter_mark_multiplier += get_multiplier(0)
-	return ..()
 
 /datum/mutation_upgrade/veil/one_target/on_mutation_disabled()
+	. = ..()
 	var/datum/action/ability/activable/xeno/silence/silence_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/silence]
 	if(!silence_ability)
 		return
 	silence_ability.hunter_mark_multiplier -= get_multiplier(0)
-	return ..()
 
 /datum/mutation_upgrade/veil/one_target/on_structure_update(previous_amount, new_amount)
 	. = ..()
@@ -249,3 +313,79 @@
 /// Returns the multiplier to add to Silence's effectiveness against the Hunter's Mark target.
 /datum/mutation_upgrade/veil/one_target/proc/get_multiplier(structure_count, include_initial = TRUE)
 	return (include_initial ? multiplier_initial : 0) + (multiplier_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/mirage_flood
+	name = "Mirage Flood"
+	desc = "Mirage creates 4 additional illusions, but the duration is reduced by 5/3/1 seconds."
+	/// For the first structure, the amount of deciseconds to add to Mirage's illusion lifespan.
+	var/duration_initial = -7 SECONDS
+	/// For each structure, the additional amount of deciseconds to add to Mirage's illusion lifespan.
+	var/duration_per_structure = 2 SECONDS
+
+/datum/mutation_upgrade/veil/mirage_flood/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Mirage creates 4 additional illusions, but the duration is reduced by [get_duration(new_amount) / 10] seconds."
+
+/datum/mutation_upgrade/veil/mirage_flood/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count += 4
+	mirage_ability.illusion_life_time += get_duration(0)
+
+/datum/mutation_upgrade/veil/mirage_flood/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_count -= 4
+	mirage_ability.illusion_life_time += get_duration(0)
+
+/datum/mutation_upgrade/veil/mirage_flood/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.illusion_life_time += get_duration(new_amount - previous_amount, FALSE)
+
+/datum/mutation_upgrade/veil/mirage_flood/proc/get_duration(structure_count, include_initial = TRUE)
+	return (include_initial ? duration_initial : 0) + (duration_per_structure * structure_count)
+
+/datum/mutation_upgrade/veil/faceblind
+	name = "Faceblind"
+	desc = "Stealth's sneak attack causes temporary blindness, but only mini-stuns. Mirage's cooldown is set to 90/80/70% of its original value."
+	/// For each structure, the additional multiplier of Mirage's cooldown duration to add to it.
+	var/multiplier_per_structure = -0.1
+
+/datum/mutation_upgrade/veil/faceblind/get_desc_for_alert(new_amount)
+	if(!new_amount)
+		return ..()
+	return "Stealth's sneak attack no longer staggers or causes slowdown, but causes temporary blindness. Mirage's cooldown is set to [PERCENT(1 + get_multiplier(new_amount))]% of its original value."
+
+/datum/mutation_upgrade/veil/faceblind/on_mutation_enabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(!stealth_ability)
+		return
+	stealth_ability.sneak_attack_stun_duration = 0.1 SECONDS
+	stealth_ability.blinding_stacks = 2
+
+/datum/mutation_upgrade/veil/faceblind/on_mutation_disabled()
+	. = ..()
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/stealth]
+	if(!stealth_ability)
+		return
+	stealth_ability.sneak_attack_stun_duration = initial(stealth_ability.sneak_attack_stun_duration)
+	stealth_ability.blinding_stacks = initial(stealth_ability.blinds_instead)
+
+/datum/mutation_upgrade/veil/faceblind/on_structure_update(previous_amount, new_amount)
+	. = ..()
+	var/datum/action/ability/xeno_action/mirage/mirage_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/mirage]
+	if(!mirage_ability)
+		return
+	mirage_ability.cooldown_duration += initial(mirage_ability.cooldown_duration) * get_multiplier(new_amount - previous_amount)
+
+/datum/mutation_upgrade/veil/faceblind/proc/get_multiplier(structure_count)
+	return multiplier_per_structure * structure_count

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -292,6 +292,9 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	gib_chance = 5
 	light_system = MOVABLE_LIGHT
 
+	/// All sources that affect our alpha.
+	var/alpha_sources = list()
+
 	///Hive name define
 	var/hivenumber = XENO_HIVE_NORMAL
 	///Hive datum we belong to

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
@@ -8,6 +8,17 @@ Contains most of the procs that are called when a xeno is attacked by something
 /mob/living/carbon/xenomorph/has_smoke_protection()
 	return TRUE
 
+/mob/living/carbon/xenomorph/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(!((S.smoke_traits && SMOKE_CAMO) && (S.smoke_traits && SMOKE_XENO)))
+		return
+	if(!.)
+		if(has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
+			remove_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
+		return
+	if(!has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
+		apply_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
+
 /mob/living/carbon/xenomorph/smoke_contact(obj/effect/particle_effect/smoke/S)
 	var/protection = max(1 - get_permeability_protection() * S.bio_protection) //0.2 by default
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
@@ -21,8 +32,8 @@ Contains most of the procs that are called when a xeno is attacked by something
 			to_chat(src, span_xenowarning("We feel our plasma reserves being drained as we pass through the smoke."))
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CHEM))
 		S.reagents?.reaction(src, TOUCH, S.fraction)
-	if((S.smoke_traits && STATUS_EFFECT_XENOMORPH_CLOAKING) && !has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
-		apply_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
+	//if((S.smoke_traits && SMOKE_CAMO) && (S.smoke_traits && SMOKE_XENO) && !has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
+	//	apply_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
 
 /mob/living/carbon/xenomorph/Stun(amount, updating, ignore_canstun)
 	amount *= 0.5 // half length

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
@@ -21,6 +21,8 @@ Contains most of the procs that are called when a xeno is attacked by something
 			to_chat(src, span_xenowarning("We feel our plasma reserves being drained as we pass through the smoke."))
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CHEM))
 		S.reagents?.reaction(src, TOUCH, S.fraction)
+	if((S.smoke_traits && STATUS_EFFECT_XENOMORPH_CLOAKING) && !has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING))
+		apply_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING)
 
 /mob/living/carbon/xenomorph/Stun(amount, updating, ignore_canstun)
 	amount *= 0.5 // half length

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -616,18 +616,24 @@
 /mob/living/carbon/xenomorph/on_eord(turf/destination)
 	revive(TRUE)
 
-/// Updates the xenomorph's alpha based on various sources.
-/mob/living/carbon/xenomorph/proc/update_alpha()
-	var/lowest_alpha_possible = initial(alpha)
-	// Hunter's Stealth
-	var/datum/action/ability/xeno_action/stealth/stealth_ability = actions_by_path[/datum/action/ability/xeno_action/stealth]
-	//if(stealth_ability && !isnull(stealth_ability.expected_alpha) && stealth_ability.expected_alpha < lowest_alpha_possible)
-	//	lowest_alpha_possible = stealth_ability.expected_alpha
-	// Night Shade
-	//if(HAS_TRAIT(src, TRAIT_STEALTH_PLANT) && HUNTER_STEALTH_RUN_ALPHA < lowest_alpha_possible)
-	//	lowest_alpha_possible = HUNTER_STEALTH_RUN_ALPHA
-	/// Tactical Smoke, Xenomorph Variant
-	if(has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING) && 5 < lowest_alpha_possible)
-		lowest_alpha_possible = 5
-	alpha = clamp(0, lowest_alpha_possible, 255)
 
+/// Sets an alpha source before updating our alpha.
+/mob/living/carbon/xenomorph/proc/set_alpha_source(source, desired_alpha)
+	alpha_sources[source] = desired_alpha
+	update_alpha()
+
+/// Removes an alpha source before updating alpha.
+/mob/living/carbon/xenomorph/proc/remove_alpha_source(source)
+	if(!(source in alpha_sources))
+		return
+	alpha_sources -= source
+	update_alpha()
+
+/// Updates our alpha based on alpha sources.
+/mob/living/carbon/xenomorph/proc/update_alpha()
+	alpha = initial(alpha)
+	for(var/source_name AS in alpha_sources)
+		var/new_alpha = alpha_sources[source_name]
+		if(new_alpha >= alpha)
+			continue
+		alpha = new_alpha

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -615,3 +615,19 @@
 
 /mob/living/carbon/xenomorph/on_eord(turf/destination)
 	revive(TRUE)
+
+/// Updates the xenomorph's alpha based on various sources.
+/mob/living/carbon/xenomorph/proc/update_alpha()
+	var/lowest_alpha_possible = initial(alpha)
+	// Hunter's Stealth
+	var/datum/action/ability/xeno_action/stealth/stealth_ability = actions_by_path[/datum/action/ability/xeno_action/stealth]
+	//if(stealth_ability && !isnull(stealth_ability.expected_alpha) && stealth_ability.expected_alpha < lowest_alpha_possible)
+	//	lowest_alpha_possible = stealth_ability.expected_alpha
+	// Night Shade
+	//if(HAS_TRAIT(src, TRAIT_STEALTH_PLANT) && HUNTER_STEALTH_RUN_ALPHA < lowest_alpha_possible)
+	//	lowest_alpha_possible = HUNTER_STEALTH_RUN_ALPHA
+	/// Tactical Smoke, Xenomorph Variant
+	if(has_status_effect(STATUS_EFFECT_XENOMORPH_CLOAKING) && 5 < lowest_alpha_possible)
+		lowest_alpha_possible = 5
+	alpha = clamp(0, lowest_alpha_possible, 255)
+

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -250,7 +250,7 @@
 /mob/living/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
 	if(!.)
-		if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CAMO))
+		if((S.smoke_traits && SMOKE_CAMO) && !(S.smoke_traits && SMOKE_XENO))
 			smokecloak_off()
 		return
 	if(status_flags & GODMODE)

--- a/code/modules/xenomorph/xenoplant.dm
+++ b/code/modules/xenomorph/xenoplant.dm
@@ -248,7 +248,7 @@
 		for(var/mob/living/carbon/xenomorph/X in tile)
 			if(X.stat == DEAD || isxenohunter(X) || X.alpha != 255) //We don't mess with xenos capable of going stealth by themselves
 				continue
-			X.alpha = HUNTER_STEALTH_RUN_ALPHA
+			X.set_alpha_source("stealth_plant", HUNTER_STEALTH_RUN_ALPHA)
 			new /obj/effect/temp_visual/alien_fruit_eaten(get_turf(X))
 			balloon_alert(X, "We now blend in")
 			to_chat(X, span_xenowarning("The pollen from [src] reacts with our scales, we are blending with our surroundings!"))
@@ -265,6 +265,6 @@
 ///Reveals all xenos hidden by veil()
 /obj/structure/xeno/plant/stealth_plant/proc/unveil()
 	for(var/mob/living/carbon/xenomorph/X AS in camouflaged_xenos)
-		X.alpha = initial(X.alpha)
+		X.remove_alpha_source("stealth_plant")
 		balloon_alert(X, "Effect wears off")
 		to_chat(X, span_xenowarning("The effect of [src] wears off!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drafted until I iron out some bugs (e.g. making cloaking consistent). Otherwise, everything is done and done.

Adds 6 more mutations for Hunter for a total of 9.
| Category  | In-Game Name | In-Game Description |
|--------|--------|--------|
| Shell | Splitting Mirage | Mirage will instead cause your slashes to create an illusion for the next 12/14/16 seconds. These illusions disappear when the time is up. |
| Shell | Cloak | Mirage now instead creates cloaking gas for 8/10/12 seconds in a radius of 2. |
| Spur | Ambush | Stealth's movement cost is 300% of its original value. While at the maximum stealth power, your next sneak attack has an additional 15/22.5/30 AP. |
| Spur | Maul | Pounce no longer stuns, but now slashes your target which can trigger sneak attack. Pounce's cooldown is set to 60/50/40% of its original value. |
| Veil | Mirage Flood | Mirage creates 4 additional illusions, but the duration is reduced by 5/3/1 seconds. |
| Veil | Faceblind | Stealth's sneak attack causes temporary blindness, but only mini-stuns. Mirage's cooldown is set to 90/80/70% of its original value. |

Xenomorph now have their own variant of tactical smoke which is done by adding SMOKE_XENO as a smoke trait along with SMOKE_CAMO.
Xenomorphs now have a list of sources that determines what number their alpha should set to with `update_alpha`.
## Why It's Good For The Game
More variety of mutations.

## Changelog
:cl:
add: Xenomorph variant of tactical smoke.
add: 6 more mutations for Hunter.
code: Xenomorphs now use update_alpha() to determine their alpha rather than directly setting it.
/:cl:
