### PR TITLE
Shrike Mutation Changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -84,11 +84,11 @@
 		/datum/mutation_upgrade/shell/shared_cure,
 		/datum/mutation_upgrade/shell/resistant_cure,
 		/datum/mutation_upgrade/spur/smashing_fling,
-		/datum/mutation_upgrade/spur/psychic_choke,
+		/datum/mutation_upgrade/spur/body_fling,
 		/datum/mutation_upgrade/spur/gravity_tide,
 		/datum/mutation_upgrade/veil/delayed_condition,
 		/datum/mutation_upgrade/veil/deflective_force,
-		/datum/mutation_upgrade/veil/utility_fling
+		/datum/mutation_upgrade/veil/psychic_choke
 	)
 
 /datum/xeno_caste/shrike/normal


### PR DESCRIPTION

## About The Pull Request
Smashing Fling now scales at 150/175/200% damage from 100/125/150% damage.

Psychic Choke has been moved to the Veil (utility) category as it wasn't offensive enough to be sorted into Spur (attack) mutations.

Utility Fling has renamed to Body Fling and moved to the Spur category from the Veil category. It no longer reduces the cooldown of Psychic Fling. Instead, it causes flung xenomorphs to deal 150/175/200% damage and 2 seconds of paralyze to humans that they collide with.

## Why It's Good For The Game
Per feedback, Smashing Fling apparently sucks when compared to unchanged Psychic Fling. In addition, Utility Fling was boring and there was little reason to choose it.

## Changelog
:cl:
balance: Mutations: Smashing Fling now scales at 150/175/200% damage from 100/125/150% damage.
balance: Mutations: Psychic Choke is now a veil mutation.
balance: Mutations: Utility Fling has renamed to Body Fling, is now a spur mutation, and no longer gives cooldown reduction. It now deals 150/175/200% damage and paralyzes humans for 2 seconds if they are hit by flung xenomorphs.
/:cl:
