### PR TITLE
Campaign Faction leader autoset

### DIFF
--- a/code/datums/gamemodes/campaign.dm
+++ b/code/datums/gamemodes/campaign.dm
@@ -406,8 +406,8 @@
 				qdel(candidate)
 			else if(ishuman(candidate))
 				human_current = candidate
-
-			human_current?.set_undefibbable(TRUE)
+			if(human_current)
+				human_current.set_undefibbable(TRUE)
 
 
 ///Actually respawns the player, if still able

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -210,8 +210,10 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 /datum/faction_stats/proc/set_faction_leader(mob/living/new_leader)
 	var/old_leader = faction_leader
 	faction_leader = new_leader
+	RegisterSignals(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
 
 	if(old_leader && old_leader != faction_leader)
+		UnregisterSignal(old_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
 		for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list_faction[faction])
 			human.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[old_leader] has been demoted from the role of faction commander", LEFT_ALIGN_TEXT), faction_portrait)
 	if(!faction_leader)
@@ -223,6 +225,14 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	to_chat(faction_leader, span_userdanger("You have been promoted to the role of commander for your faction. It is your responsibility to determine your side's course of action, and how to best utilise the resources at your disposal. \
 	Attrition must be set BEFORE a mission starts ensure you team has access to respawns. Check this in the Faction UI screen. \
 	You are the only one that can choose the next mission for your faction. If your faction wins a mission, select the next one in the Faction UI screen, in the Missions tab."))
+
+///Unsets the faction leader and finds a new one after a delay
+/datum/faction_stats/proc/unset_faction_leader(mob/source, mystery_arg, timer_delay = 10 SECONDS) //COMSIG_QDELETING has a mystery arg and I don't want to delete it in case it actually does something
+	SIGNAL_HANDLER
+	if(faction_leader)
+		UnregisterSignal(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
+		faction_leader = null
+	addtimer(CALLBACK(src, PROC_REF(get_selector)), timer_delay)
 
 ///Adds a new asset to the faction for use
 /datum/faction_stats/proc/add_asset(datum/campaign_asset/new_asset)
@@ -275,8 +285,8 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 	generate_new_mission()
 	update_static_data_for_all_viewers()
+	unset_faction_leader(timer_delay = AFTER_MISSION_LEADER_DELAY) //if the leader died, we load a new one after a bit to give respawns some time
 	addtimer(CALLBACK(src, PROC_REF(return_to_base), completed_mission), AFTER_MISSION_TELEPORT_DELAY)
-	addtimer(CALLBACK(src, PROC_REF(get_selector)), AFTER_MISSION_LEADER_DELAY) //if the leader died, we load a new one after a bit to give respawns some time
 
 ///applies cash rewards to the faction and all individuals
 /datum/faction_stats/proc/apply_cash(amount)

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	You are the only one that can choose the next mission for your faction. If your faction wins a mission, select the next one in the Faction UI screen, in the Missions tab."))
 
 ///Unsets the faction leader and finds a new one after a delay
-/datum/faction_stats/proc/unset_faction_leader(mob/source, mystery_arg, timer_delay = 10 SECONDS) //COMSIG_QDELETING has a mystery arg and I don't want to delete it in case it actually does something
+/datum/faction_stats/proc/unset_faction_leader(mob/source, mystery_arg, timer_delay = 15 SECONDS) //COMSIG_QDELETING has a mystery arg and I don't want to delete it in case it actually does something
 	SIGNAL_HANDLER
 	if(faction_leader)
 		UnregisterSignal(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -208,9 +208,11 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 ///Sets the faction leader
 /datum/faction_stats/proc/set_faction_leader(mob/living/new_leader)
+	if(faction_leader == new_leader)
+		return
 	var/old_leader = faction_leader
 	faction_leader = new_leader
-	RegisterSignals(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
+	RegisterSignals(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE), PROC_REF(unset_faction_leader))
 
 	if(old_leader && old_leader != faction_leader)
 		UnregisterSignal(old_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
@@ -292,7 +294,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 /datum/faction_stats/proc/apply_cash(amount)
 	if(!amount)
 		return
-	amount *= 1 + loss_bonus
+	amount *= (1 + loss_bonus)
 	accumulated_mission_reward += amount
 	for(var/i in individual_stat_list)
 		var/datum/individual_stats/player_stats = individual_stat_list[i]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If the leader of a faction is gibbed or goes DNR (including respawning), a new leader will be automatically found after a 15 second delay.

Also fixed a couple of random misc bugs I noticed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Losing your faction leader for the entire mission can be quite detrimental, especially at lower pop.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
qol: Campaign: A new faction leader is found after a short delay, after the old leader is gibbed or goes DNR
/:cl:
