### PR TITLE
Fix unsetting custom info

### DIFF
--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -165,12 +165,12 @@ ADMIN_VERB(custom_info, R_FUN, "Change Custom Info", "Set a custom info to show 
 	if(isnull(new_info) || GLOB.custom_info == new_info)
 		return
 
+	GLOB.custom_info = new_info
+
 	if(!new_info)
 		log_admin("[key_name(user)] has cleared the custom info.")
 		message_admins("[ADMIN_TPMONTY(user.mob)] has cleared the custom info.")
 		return
-
-	GLOB.custom_info = new_info
 
 	to_chat(world, assemble_alert(
 		title = "Custom Information",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unsetting custom info actually works now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
admin: Unsetting custom info actually works
/:cl:
