### PR TITLE
Comm relay fix

### DIFF
--- a/code/game/objects/machinery/telecomms/machines/relay.dm
+++ b/code/game/objects/machinery/telecomms/machines/relay.dm
@@ -66,6 +66,7 @@
 /obj/machinery/telecomms/relay/preset/telecomms
 	id = "Telecomms Relay"
 	autolinkers = list("relay")
+	use_power = NO_POWER_USE
 
 //proper cicbackup relay
 /obj/machinery/telecomms/relay/preset/telecomms/cicbackup
@@ -78,4 +79,4 @@
 	invisibility = INVISIBILITY_MAXIMUM
 
 /obj/machinery/telecomms/relay/preset/telecomms/onboard/nondense
-	density = FALSE 
+	density = FALSE


### PR DESCRIPTION

## About The Pull Request
Comms works properly on the 1st mission of campaign again.
## Why It's Good For The Game
Note that this bug was due to some changes @TiviPlus made to maploading as part of multi z changes, but I am not certain what specifically broke it.
However relays should always be powered as far as I am aware (breaking power shipside still cuts comms), so this seems fine.
## Changelog
:cl:
fix: fixed comms not working on the 1st mission of campaign
/:cl:
