### PR TITLE
crash disk computer fix

### DIFF
--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -178,12 +178,13 @@
 	current_timer = null
 	completed_segments = min(completed_segments + 1, total_segments)
 
-	// If the gamemode is crash, Add 5 Vendor points to all marines.
 	if(iscrashgamemode(SSticker.mode))
-		for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
-			if(!H.job)
+		for(var/mob/living/carbon/human/human AS in GLOB.human_mob_list)
+			if(!human.job)
 				continue
-			var/obj/item/card/id/user_id =  H.get_idcard()
+			var/obj/item/card/id/user_id =  human.get_idcard()
+			if(!user_id)
+				continue
 			for(var/i in user_id.marine_points)
 				user_id.marine_points[i] += 2
 


### PR DESCRIPTION

## About The Pull Request
Fixed a runtime that would completely bug out disk computers on crash, due to no proper check before trying to give vendor points.
## Why It's Good For The Game
The game getting cursed because someone doesn't have their ID on is bad.
## Changelog
:cl:
fix: fixed disk computers in crash sometimes bugging out
/:cl:
