### PR TITLE
NPC's stay on op tables

### DIFF
--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -143,6 +143,9 @@
 	else if(ismob(A))
 		..(A, user)
 
+/obj/machinery/optable/ai_should_stay_buckled(mob/living/carbon/npc)
+	return TRUE //nurse, hold him down
+
 /obj/machinery/optable/proc/check_victim()
 	if(locate(/mob/living/carbon/human, loc))
 		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)


### PR DESCRIPTION

## About The Pull Request
NPC's will no longer desperately try get out from under the knife.
## Why It's Good For The Game
Having to sedate NPC's is somewhat funny but annoying.
## Changelog
:cl:
qol: NPC's won't try resist off operating tables
/:cl:
