### PR TITLE
NPC door changes

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -366,14 +366,16 @@
 	toggle_open(null, user)
 	return AI_OBSTACLE_RESOLVED
 
-/obj/machinery/door/airlock/ai_handle_obstacle(mob/living/user, move_dir)
-	. = ..()
-	if(!.)
-		return
-	if(operating) //Airlock already doing something
+/obj/machinery/door/ai_handle_obstacle(mob/living/user, move_dir)
+	if(operating) //Airlock already doing something, probably opening
 		return null
-	if(welded || locked) //It's welded or locked, can't force that open
-		return
+	if(welded || locked)
+		return ..()
+	if(isxeno(user))
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, attack_alien), user)
+		return AI_OBSTACLE_RESOLVED
+	if(hasPower() && ishuman(user) && requiresID() && !(allowed(user) || emergency || unrestricted_side(user)))
+		return ..()
 	open(TRUE)
 	return AI_OBSTACLE_RESOLVED
 


### PR DESCRIPTION

## About The Pull Request
Xeno NPC's will once again force doors open.
They will now actually have to channel them open like real xenos (when they're powered).

Human NPC's will no longer force open powered airlocks they don't have access to with their tremendously girthy muscles.

Made these door interactions at the door level, not airlock (i.e. it works on firedoors etc)
## Why It's Good For The Game
More normal behavior.
## Changelog
:cl:
fix: fixed NPC's incorrectly interacting with doors in some cases
/:cl:
