### PR TITLE
[TM first] Crash xeno time bonus

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -227,6 +227,10 @@
 
 /datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags = COUNT_IGNORE_HUMAN_SSD)
 	. = 0
+	var/round_duration = round((world.time - SSticker.round_start_time))
+	var/time_bonus = max(floor(round_duration / (10 MINUTES)) - 3, 0)
+	if(time_bonus)
+		. += (time_bonus * LARVA_POINTS_REGULAR)
 
 	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 		if(!H.job)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TM first.

Adds a bonus to larva gen in crash based on how long the round has been going for.
For every 10 minutes after the first 30 minutes, the larva jobworth calc adds the equivilent of another marine.
i.e. if the round has been going for 50 minutes, and there are 10 marines, for larva gen it will count as 12 marines.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Recent changes to crash larva gen have really fucked with the balance of the gamemode (which was already cursed).
Not counting perma'd bodies AND halving marine respawn times means wiping marines often simply benefits the marines long term.
Once marines are wiped, xenos MUST seige the ship to win, but since the wiped marines don't count to larva gen, if they lose any xenos, they can't recover numbers, and can struggle to break into the cantebury. That means marines jsut need to hold out for 10 minutes, get an entirely fresh respawn wave (with brain new sentries/mats/other limited gear) while the xenos then have to start from scratch.

Over all, this means marines have a fundamental advantage if they just keep hang in, as respawns are so quick and beneficial, effectively stalemating the xenos if the marines don't just give up and evac.

This change means marines now have a much stronger incentive to actually be proactive and try win the round by doing disks, instead of just stalling out xenos - 90 minute or 2 hour rounds will now gradually start to favour the xenos more, which is especially useful at very low pop where the difference between 2 xenos and 3, or 3 and 4 is huge, but you can otherwise never reach that point due to lack of players.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Crash: After 30 minutes, the marine player count is effectively increased by 1 every 10 minutes, for larva gen calculations
/:cl:
