### PR TITLE
Canterbury Medbay Redesign

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -547,10 +547,6 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
-"cf" = (
-/obj/structure/window/framed/mainship/white/canterbury,
-/turf/closed/wall/mainship/outer/canterbury,
-/area/shuttle/canterbury)
 "cg" = (
 /obj/machinery/vending/MarineMed/Blood,
 /obj/machinery/firealarm{
@@ -830,7 +826,7 @@ aa
 an
 an
 an
-cf
+an
 bo
 bo
 bo


### PR DESCRIPTION
Edited medical layout, deleted scanner, added chem machines and grinder.

## About The Pull Request

Rearranged canter medical, added chemistry machines, deleted the body scanner. 

Screenshots:
<img width="368" height="492" alt="updt0" src="https://github.com/user-attachments/assets/ee2f7ae8-ae5e-4a96-8f79-73360803534d" />
<img width="647" height="827" alt="updt1" src="https://github.com/user-attachments/assets/b57c97fd-6192-4847-a963-8d3a30a290df" />

## Why It's Good For The Game

Adding chemistry equipment to canterbury will add chemistry as a gameplay mechanic to crash. Bigbury already had chemistry machines and this change will add them to canter as well. 

The body scanner machine is redundant due to the existence of handheld health scanners. Deleted it to make space for the chem machines.

## Changelog

:cl: Scav
balance: Added chemistry equipment to canterbury, rearranged mebay layout
del: Deleted the body scanner in canterbury medical
/:cl:
