### PR TITLE
Rebalances pyrogen plasma

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/abilities_pyrogen.dm
@@ -5,9 +5,9 @@
 	name = "Fire Charge"
 	action_icon_state = "fireslash"
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
-	desc = "Charge up to 3 tiles, attacking any organic you come across. Extinguishes the target if they were set on fire, but deals extra damage depending on how many fire stacks they have."
+	desc = "Charge up to 3 tiles, attacking any organic you come across. Extinguishes the target if they were set on fire, but deals extra damage and restores plasma depending on how many fire stacks they have."
 	cooldown_duration = 12 SECONDS
-	ability_cost = 30
+	ability_cost = 75
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FIRECHARGE,
 	)
@@ -71,6 +71,7 @@
 		var/stacks_to_give = stacks_to_add ? stacks_to_add : 0
 		if(stack_damage)
 			fire_damage += debuff.stacks * stack_damage
+			xeno_owner.gain_plasma(debuff.stacks * 20) // Restores plasma for each stack consumed
 			stacks_to_give -= debuff.stacks
 		debuff.add_stacks(stacks_to_give, xeno_owner)
 	if(fire_damage)
@@ -91,7 +92,7 @@
 	action_icon_state = "fireball"
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
 	desc = "Release a fireball that explodes on contact."
-	ability_cost = 50
+	ability_cost = 300
 	cooldown_duration = 15 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FIREBALL,
@@ -150,7 +151,7 @@
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
 	desc = "Unleash a fiery tornado that goes in a straight line which will set fire around it as it goes and harm marines that directly touch it."
 	target_flags = ABILITY_TURF_TARGET
-	ability_cost = 50
+	ability_cost = 300
 	cooldown_duration = 12 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FIRENADO,
@@ -200,7 +201,7 @@
 	action_icon_state = "inferno"
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
 	desc = "After a short cast time, release a burst of fire in a 5x5 radius. All tiles are set on fire. Humans are set on fire and burnt."
-	ability_cost = 50
+	ability_cost = 125
 	cooldown_duration = 18 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_INFERNO,
@@ -247,7 +248,7 @@
 	action_icon = 'icons/Xeno/actions/pyrogen.dmi'
 	desc = "Causes a chosen human's flame to burst outwardly. The severity of the damage is based on how badly they were on fire. In addition, the area near them is set on fire."
 	target_flags = ABILITY_MOB_TARGET
-	ability_cost = 40
+	ability_cost = 100
 	cooldown_duration = 6 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_INFERNAL_TRIGGER,

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -20,8 +20,8 @@
 	speed = -0.9
 
 	// *** Plasma *** //
-	plasma_max = 325
-	plasma_gain = 25
+	plasma_max = 1000
+	plasma_gain = 30
 
 	// *** Health *** //
 	max_health = 380
@@ -52,12 +52,22 @@
 		/datum/action/ability/activable/xeno/firestorm,
 		/datum/action/ability/activable/xeno/inferno,
 	)
+	///multiplier on plasma amount vs damage that is recieved on attack
+	var/plasma_damage_dealt_mult = 2.5
 
 	mutations = list(
 		/datum/mutation_upgrade/shell/flame_cloak,
 		/datum/mutation_upgrade/spur/only_fire,
 		/datum/mutation_upgrade/veil/burnt_wounds
 	)
+
+/datum/xeno_caste/pyrogen/on_caste_applied(mob/xenomorph)
+	. = ..()
+	xenomorph.AddElement(/datum/element/plasma_on_attack, plasma_damage_dealt_mult)
+
+/datum/xeno_caste/pyrogen/on_caste_removed(mob/xenomorph)
+	. = ..()
+	xenomorph.RemoveElement(/datum/element/plasma_on_attack, plasma_damage_dealt_mult)
 
 /datum/xeno_caste/pyrogen/normal
 	upgrade = XENO_UPGRADE_NORMAL


### PR DESCRIPTION

## About The Pull Request
Pyrogen changes:
Pyrogen has more plasma but regens it slower, relying on actively fighting to regen plasma quickly.
Max plasma: 325 -> 1000
Plasma Regen 25 -> 30
Pyrogen now gains plasma on hit, equal to 2.5x slash damage (~55 plasma per slash)

Abilities are more expensive, especially ranged ones.
Fire charge: 30 -> 75
Fire charge now restores plasma when consuming firestacks, equal to firestacks * 20 (200 plasma at max burn)
Fireball: 50 -> 300
Firestorm: 50 -> 300
Inferno: 50 -> 125
Infernal Trigger: 40 -> 100
## Why It's Good For The Game
Pyrogen is very good at spamming down a chokepoint forever, and is currently able to use every ability the second they are off cooldown _without ever running out of plasma_ while on weeds.

Giving pyrogen higher plasma costs and alternative ways to restore plasma should encourage them to be more of an active participant in fights and play with much more risk than they currently need to, and hopefully reduce frustrating situations where a pyrogen is spamming max range fireballs endlessly.
## Changelog
:cl:
balance: Pyrogen now has higher plasma costs, but receives plasma when slashing marines or consuming firestacks with Fire Charge.
/:cl:
