### PR TITLE
Nerfs xeno fruit destruction effects

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -439,6 +439,9 @@
 	color = "#cff1ee" // Blueish.
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_PYROGEN|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
+/obj/effect/particle_effect/smoke/xeno/pyrogen_fire/light
+	lifetime = 4 //Lasts for less time
+
 /////////////////////////////////////////////
 // Smoke spreads
 /////////////////////////////////////////////
@@ -536,6 +539,8 @@
 /datum/effect_system/smoke_spread/xeno/pyrogen_fire
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/pyrogen_fire
 
+/datum/effect_system/smoke_spread/xeno/pyrogen_fire/light
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/pyrogen_fire/light
 
 /////////////////////////////////////////////
 // Chem smoke

--- a/code/modules/xenomorph/xenoplant.dm
+++ b/code/modules/xenomorph/xenoplant.dm
@@ -71,8 +71,8 @@
 
 /obj/structure/xeno/plant/heal_fruit/deconstruct(disassembled = TRUE, mob/living/blame_mob)
 	if(!disassembled && mature)
-		var/datum/effect_system/smoke_spread/xeno/acid/opaque/plant_explosion = new(get_turf(src))
-		plant_explosion.set_up(3,src)
+		var/datum/effect_system/smoke_spread/xeno/acid/light/plant_explosion = new(get_turf(src))
+		plant_explosion.set_up(1,src)
 		plant_explosion.start()
 		visible_message(span_danger("[src] bursts, releasing toxic gas!"))
 	return ..()
@@ -112,10 +112,10 @@
 					break
 				far_away_lands = next_turf
 
-			nearby_human.throw_at(far_away_lands, 20, spin = TRUE)
+			nearby_human.throw_at(far_away_lands, 7, spin = TRUE)
 			to_chat(nearby_human, span_warning("[src] bursts, releasing a strong gust of pressurised gas!"))
-			nearby_human.adjust_stagger(3 SECONDS)
-			nearby_human.apply_damage(30, BRUTE, "chest", BOMB)
+			nearby_human.adjust_stagger(1.5 SECONDS)
+			nearby_human.apply_damage(15, BRUTE, "chest", BOMB)
 	return ..()
 
 /obj/structure/xeno/plant/armor_fruit/on_use(mob/user)
@@ -145,8 +145,8 @@
 
 /obj/structure/xeno/plant/plasma_fruit/deconstruct(disassembled = TRUE, mob/living/blame_mob)
 	if(!disassembled && mature)
-		var/datum/effect_system/smoke_spread/xeno/pyrogen_fire/plant_explosion = new(get_turf(src))
-		plant_explosion.set_up(4, src)
+		var/datum/effect_system/smoke_spread/xeno/pyrogen_fire/light/plant_explosion = new(get_turf(src))
+		plant_explosion.set_up(1, src)
 		plant_explosion.start()
 		visible_message(span_warning("[src] bursts, releasing blue hot gas!"))
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Xeno fruits currently have massive effects when destroyed, which majorly stalls pushes and gives xenos another way to make chokes unpushable.

<details> 
  <summary> Old Effects Here </summary>
   Heal Fruit: 3 tile radius opaque acid smoke that lasts for 6 seconds (this is the same smoke as boiler death with a larger radius)
<img width="439" height="379" alt="acid-fruit" src="https://github.com/user-attachments/assets/ad6af182-2209-4507-9879-2c210ccdbe5e" />

Sunder Fruit: **_20_** tile knockback, 3 seconds of stagger, 30 bomb damage.

Power Fruit: 4 tile radius pyrogen burn smoke with 6 second duration
<img width="458" height="414" alt="plasma-fruit" src="https://github.com/user-attachments/assets/4d17ff52-9655-4a45-9f59-af52dbec3ce9" />


</details>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

### Nerfed versions:

Heal Fruit: 1 tile radius transparent acid smoke lasting 4 seconds
Sunder Fruit: 7 tile knockback with 1.5 seconds of stagger and 15 damage
<details>
<summary> Power Fruit: 1 tile radius pyrogen burn smoke with 4 second duration </summary>

<img width="488" height="546" alt="image" src="https://github.com/user-attachments/assets/7d202d6e-ee62-4a08-9b65-9a1c7afb4da9" />

</details>

## Why It's Good For The Game
This primo is already extremely useful. Every single tier has a xeno that can create fruit if they have primo, so it isnt difficult to get these.

These are currently extremely powerful for slowing down a marine push and often require ranged tools to break them if you dont want to risk getting bathed in smoke when you try to melee these. These plant break effects should be a minor feature, rather than being the best trap available to xenos and a hidden nuke that punishes marines for pushing and breaking maze.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Xeno fruit death effects are now weaker.
/:cl:
