### PR TITLE
Fixes a runtime with pyrogen fire

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -636,8 +636,10 @@
 	debuff_owner.take_overall_damage(PYROGEN_DAMAGE_PER_STACK * stacks, BURN, FIRE, updating_health = TRUE)
 	if(stacks > 4)
 		visual_fire.icon_state = "melting_high_stacks"
-	else
+	else if (stacks > 0)
 		visual_fire.icon_state = "melting_low_stacks"
+	else
+		return
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 
 	if(QDELETED(debuff_creator) || debuff_creator.stat == DEAD)


### PR DESCRIPTION

## About The Pull Request
Pyrogen fire was runtiming attempting to set the icon_state after the status effect had ran its last tick and been deleted, this fixes that.
## Why It's Good For The Game
Runtime fix good
## Changelog
:cl:
fix: Fixed a runtime when pyrogen fire expires.
/:cl:
