### PR TITLE
Pyrogen fireball now respects cades

### DIFF
--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -13,15 +13,15 @@
 
 /datum/ammo/xeno/fireball/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
 	. = ..()
-	drop_flame(target_obj, proj)
+	drop_flame((target_obj.density ? get_step_towards(target_obj, proj) : get_turf(target_obj)), proj)
 
 /datum/ammo/xeno/fireball/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	. = ..()
-	drop_flame(target_turf.density ? proj : target_turf, proj)
+	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : get_turf(target_turf)), proj)
 
 /datum/ammo/xeno/fireball/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	. = ..()
-	drop_flame(target_turf.density ? proj : target_turf, proj)
+	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : get_turf(target_turf)), proj)
 
 /datum/ammo/xeno/fireball/drop_flame(atom/target_atom, atom/movable/projectile/proj)
 	new /obj/effect/temp_visual/xeno_fireball_explosion(get_turf(target_atom))

--- a/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/pyrogen_xenoammo.dm
@@ -17,11 +17,11 @@
 
 /datum/ammo/xeno/fireball/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	. = ..()
-	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : get_turf(target_turf)), proj)
+	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : target_turf), proj)
 
 /datum/ammo/xeno/fireball/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	. = ..()
-	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : get_turf(target_turf)), proj)
+	drop_flame((target_turf.density ? get_step_towards(target_turf, proj) : target_turf), proj)
 
 /datum/ammo/xeno/fireball/drop_flame(atom/target_atom, atom/movable/projectile/proj)
 	new /obj/effect/temp_visual/xeno_fireball_explosion(get_turf(target_atom))


### PR DESCRIPTION

## About The Pull Request
Pyrogen fireball currently detonates on the cade's tile when hitting one, instead of the tile it hit the cade. 
This PR makes it detonate outside the cade rather than inside.

Old behavior:
<img width="688" height="437" alt="image" src="https://github.com/user-attachments/assets/7629dcc8-b60c-49ff-a4af-bcee3caeb904" />

New behavior:
<img width="743" height="388" alt="image" src="https://github.com/user-attachments/assets/29be3aca-5b75-4502-b1cb-ac277e0547d5" />
## Why It's Good For The Game
Fixes an inconsistent projectile behavior. Xeno projectiles should stop on the tile it hit, rather than splashing over the cade. Burning the extra tile deep meant marines could not repair the cade safely, which made pyrogen significantly stronger at sieging than dedicated siege castes.
## Changelog
:cl:
balance: Pyrogen fireball now detonates on the tile it hit an object, rather than the object's tile.
/:cl:
