### PR TITLE
Moves Orion crash landing sites

### DIFF
--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -1066,6 +1066,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/breakroom)
+"fq" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/prep)
 "fr" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -6848,6 +6852,10 @@
 	},
 /turf/open/floor/plating/dmg1,
 /area/orion_outpost/ground/underground/caveS)
+"Ho" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/mainship/gray,
+/area/orion_outpost/surface/building/canteen)
 "Hr" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/orange{
@@ -9713,10 +9721,6 @@
 	dir = 5
 	},
 /area/orion_outpost/surface/landing_pad)
-"Vl" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/orion_outpost/ground/outposts)
 "Vm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10201,10 +10205,6 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostnw)
-"XA" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/orion_outpost/ground/outpostcent)
 "XB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -18241,7 +18241,7 @@ tS
 wJ
 Fk
 OI
-kK
+fq
 kK
 Lq
 kK
@@ -18896,7 +18896,7 @@ DU
 DU
 NP
 DU
-Vl
+DU
 tS
 hX
 Sw
@@ -19918,7 +19918,7 @@ ac
 EW
 EI
 Fm
-XA
+rt
 rt
 rt
 rt
@@ -20308,7 +20308,7 @@ bn
 kp
 AO
 Fm
-Fm
+Ho
 nM
 nM
 nM


### PR DESCRIPTION

## About The Pull Request
Moves two of the crash landing sites to have better entryways into the canterbury, as these spots both had awkward walls and rock preventing crusher lanes on multiple sides.
<img width="500" height="568" alt="orion1" src="https://github.com/user-attachments/assets/a7f2d174-054f-4487-b61d-da25a04ba9ec" />
<img width="623" height="937" alt="image" src="https://github.com/user-attachments/assets/1e931d9d-4fc6-40e4-a82e-6a1a18541248" />
## Why It's Good For The Game
Landing sites need open space for the canterbury doors or else sieges are much more difficult.
## Changelog
:cl:
balance: Moved crash landing sites on Orion Outpost to have better shutter positions to exit and siege.
/:cl:
