### PR TITLE
Xenomorph's Vote to Forfeit

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -334,6 +334,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define isainode(O) (istype(O, /obj/effect/ai_node))
 
 //Gamemode
+#define isnuclearwargamemode(O) (istype(O, /datum/game_mode/infestation/nuclear_war))
 #define iscrashgamemode(O) (istype(O, /datum/game_mode/infestation/crash))
 #define isinfestationgamemode(O) (istype(O, /datum/game_mode/infestation))
 #define iscombatpatrolgamemode(O) (istype(O, /datum/game_mode/hvh/combat_patrol))

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -42,6 +42,8 @@
 	var/datum/hive_purchases/purchases = new
 	/// The nuke HUD timer datum, shown on each xeno's screen
 	var/atom/movable/screen/text/screen_timer/nuke_hud_timer
+	/// Handles all votes to forfeit the round.
+	var/datum/xeno_forfeit_vote/xeno_forfeit_vote = new
 
 // ***************************************
 // *********** Init

--- a/code/modules/mob/living/carbon/xenomorph/xeno_forfeit_vote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_forfeit_vote.dm
@@ -1,0 +1,82 @@
+/datum/xeno_forfeit_vote
+	/// Is the vote to forfeit ongoing?
+	var/active = FALSE
+	/// Xenomorphs who've been offered the chance to vote.
+	var/list/mob/living/carbon/xenomorph/voters = list()
+	/// The amount of voters who agreed to forfeit.
+	var/agreement_votes = 0
+	/// The timer ID of the proc that'll end the vote.
+	var/timer_id
+	/// Cooldown between votes.
+	COOLDOWN_DECLARE(forfeit_vote_cooldown)
+
+/// Calls the vote to forfeit if possible.
+/datum/xeno_forfeit_vote/proc/try_call_vote(mob/living/carbon/xenomorph/vote_initiator)
+	if(!isnuclearwargamemode(SSticker.mode))
+		to_chat(vote_initiator, span_notice("This is only available during Nuclear War."))
+		return
+	if(vote_initiator.hivenumber != XENO_HIVE_NORMAL)
+		to_chat(vote_initiator, span_notice("Your hive is not allowed to forfeit."))
+		return
+	if(hive.living_xeno_ruler != vote_initiator)
+		to_chat(vote_initiator, span_notice("Only the ruler can start the vote to forfeit."))
+		return
+	if(SSmonitor.gamestate == SHUTTERS_CLOSED)
+		to_chat(vote_initiator, span_notice("It is too early to call for a vote to forfeit."))
+		return
+	if(!COOLDOWN_FINISHED(src, forfeit_vote_cooldown))
+		to_chat(vote_initiator, span_notice("It is too recent to call for an another vote to forfeit."))
+		return
+	if(active)
+		to_chat(vote_initiator, span_notice("A vote to forfeit is already ongoing."))
+		return
+	if(SSticker.mode.round_finished)
+		to_chat(vote_initiator, span_notice("The round has already ended."))
+		return
+
+	active = TRUE
+	COOLDOWN_START(src, forfeit_vote_cooldown, 5 MINUTES)
+
+	for(var/mob/living/carbon/xenomorph/possible_voter AS in GLOB.alive_xeno_list)
+		if(!possible_voter.client)
+			continue
+		if(possible_voter.hivenumber != XENO_HIVE_NORMAL || (possible_voter.xeno_caste.caste_flags & CASTE_IS_A_MINION))
+			continue
+		voters += possible_voter
+
+	for(var/mob/living/carbon/xenomorph/voter AS in voters)
+		INVOKE_NEXT_TICK(src, PROC_REF(handle_vote_alerts), voter) // Giving everyone the ability to vote at the same time without holding the rest of the proc.
+	timer_id = addtimer(CALLBACK(src, PROC_REF(conclude_vote)), 10 SECONDS, TIMER_UNIQUE)
+
+/// Sends a tgui alert to agree or disagree with the forfeit vote.
+/datum/xeno_forfeit_vote/proc/handle_vote_alerts(mob/living/carbon/xenomorph/voter)
+	switch(tgui_alert(voter, "Do you agree to forfeit?", "Forfeit Vote", list("Yes", "No"), 10 SECONDS))
+		if("Yes")
+			agreement_votes += 1
+
+/// Determines whether the vote has failed or succeeded based on the voters vs. agreement votes.
+/datum/xeno_forfeit_vote/proc/conclude_vote()
+	if(!active || SSticker.mode.round_finished)
+		cleanup_variables()
+		return
+	if(length(voters) == agreement_votes)
+		for(var/mob/living/carbon/xenomorph/voter AS in voters)
+			to_chat(voter, span_notice("The vote has passed. [agreement_votes]/[length(voters)] agreed to forfeit."))
+		cleanup_variables()
+
+		var/datum/game_mode/infestation/nuclear_war/nuclearwar_mode = SSticker.mode
+		if(nuclearwar_mode.round_stage == INFESTATION_MARINE_CRASHING)
+			nuclearwar_mode.round_finished = MODE_INFESTATION_M_MINOR
+			return
+		nuclearwar_mode.round_finished = MODE_INFESTATION_M_MAJOR
+		return
+	for(var/mob/living/carbon/xenomorph/voter AS in voters)
+		to_chat(voter, span_notice("The vote has failed. [agreement_votes]/[length(voters)] agreed to forfeit."))
+	cleanup_variables()
+
+/// Resets variables changed by the voting process.
+/datum/xeno_forfeit_vote/proc/cleanup_variables()
+	timer_id = null
+	voters.Cut()
+	agreement_votes = 0
+	active = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -69,7 +69,8 @@
 	if(!actions_by_path[/datum/action/ability/xeno_action/rally_minion])
 		var/datum/action/ability/xeno_action/rally_minion/minion = new /datum/action/ability/xeno_action/rally_minion
 		minion.give_action(src)
-
+	if(!(/mob/living/carbon/xenomorph/proc/vote_to_forfeit in verbs))
+		add_verb(src, /mob/living/carbon/xenomorph/proc/vote_to_forfeit)
 
 ///Helper proc for removing ruler abilities
 /mob/living/carbon/xenomorph/proc/remove_ruler_abilities()
@@ -88,7 +89,8 @@
 	var/datum/action/ability/xeno_action/rally_minion/minion = actions_by_path[/datum/action/ability/xeno_action/rally_minion]
 	if(minion)
 		minion.remove_action(src)
-
+	if(/mob/living/carbon/xenomorph/proc/vote_to_forfeit in verbs)
+		remove_verb(src, /mob/living/carbon/xenomorph/proc/vote_to_forfeit)
 
 /**
  * This handles checking for a xenomorph's potential IFF signals carried by components

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -617,3 +617,10 @@
 
 /mob/living/carbon/xenomorph/on_eord(turf/destination)
 	revive(TRUE)
+
+/// Verb that gives a yes/no popup to xenomorphs in the same hive to end the round. If it passes, it ends the round.
+/mob/living/carbon/xenomorph/proc/vote_to_forfeit()
+	set name = "Vote to Forfeit"
+	set desc = "Calls for a vote to forfeit, ending the round. Requires 100% agreement to pass."
+	set category = "Alien"
+	hive.xeno_forfeit_vote.try_call_vote(src)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1955,6 +1955,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\say.dm"
 #include "code\modules\mob\living\carbon\xenomorph\update_icons.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xeno_defines.dm"
+#include "code\modules\mob\living\carbon\xenomorph\xeno_forfeit_vote.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xeno_helpers.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xenoattacks.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xenomorph.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative to #18280.

In Nuclear War, the hive ruler now has the power to call for a vote to forfeit the round. All surviving xenomorphs at the time will get the option to vote (excluding Minions). This requires an unanimous vote to pass.

## Why It's Good For The Game
If xenomorphs get behind, it is likely that they'll never come back. Rather than holding up the round (or giving them more larva to make up for this), they get the choice to end the round without having to wait for collapse or suiciding it down.

## Changelog
:cl:
add: In Nuclear War, the hive ruler now has the power to call for a vote to forfeit. This requires an unanimous vote to pass.
/:cl:
