### PR TITLE
GL70 nerf

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -119,4 +119,4 @@
 
 ///Adjusts det time, used for grenade launchers
 /obj/item/explosive/grenade/proc/launched_det_time()
-	det_time = min(1 SECONDS, det_time)
+	det_time = min(2 SECONDS, det_time)

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -140,7 +140,7 @@ The Grenade Launchers
 	)
 	starting_attachment_types = list(/obj/item/attachable/stock/t70stock)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
-	fire_delay = 1.2 SECONDS
+	fire_delay = 2.5 SECONDS
 	max_chamber_items = 5
 
 /obj/item/weapon/gun/grenade_launcher/multinade_launcher/beginner


### PR DESCRIPTION
## About The Pull Request

Increased delay between shots to 2.5 seconds (previously 1.2 seconds)
Increased detonation time for launched grenades to 2 seconds (previously 1 second)

## Why It's Good For The Game

Nade spam is hilariously unbalanced and can completely stop xeno pushes and secure kills with very little effort. 
Grenades do big damage, slowdown, and displace xenos to bad positions. Being able to spam them is a little too effective and is unfun gameplay, not to mention the much faster detonation time on grenades launched from the GL.
Currently the only counterplay to a GL spammer is backing off and doing nothing.

Adding a slight delay to the detonation time for launched grenades makes it possible to consistently react and counterplay, and adding delay between shots cuts down on the spam.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl: Scav
balance: Increased delay between shots to 2.5 seconds (previously 1.2 seconds)
balance: Increased detonation time for launched grenades to 2 seconds (previously 1 second)
/:cl:
