### PR TITLE
Fixes remote cade upgrades

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -271,7 +271,7 @@
 	to_chat(user, span_rose("You prepare to stab <b>[target != user ? "[target]" : "yourself"]</b>!"))
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 
-	if(do_after(user, 2 SECONDS, TRUE, target, BUSY_ICON_DANGER)) //Channeled heal on help intent
+	if(do_after(user, 2 SECONDS, IGNORE_USER_LOC_CHANGE, target, BUSY_ICON_DANGER)) //Channeled heal on help intent
 		var/skill_heal_amt = user.skills.getRating(SKILL_MEDICAL) * 5
 		target.heal_overall_damage(10 + skill_heal_amt, 0, updating_health = TRUE) //5u of Bica will normally heal 25 damage. Medics get this full amount
 	else

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -499,7 +499,7 @@
 	if(user.skills.getRating(SKILL_CONSTRUCTION) < SKILL_CONSTRUCTION_METAL)
 		balloon_alert_to_viewers("fumbles")
 		var/fumbling_time = 2 SECONDS * ( SKILL_CONSTRUCTION_METAL - user.skills.getRating(SKILL_CONSTRUCTION) )
-		if(!do_after(user, fumbling_time, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_UNSKILLED))
+		if(!do_after(user, fumbling_time, NONE, src, BUSY_ICON_UNSKILLED))
 			return FALSE
 
 	balloon_alert_to_viewers("attaching [choice]")

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -499,7 +499,7 @@
 	if(user.skills.getRating(SKILL_CONSTRUCTION) < SKILL_CONSTRUCTION_METAL)
 		balloon_alert_to_viewers("fumbles")
 		var/fumbling_time = 2 SECONDS * ( SKILL_CONSTRUCTION_METAL - user.skills.getRating(SKILL_CONSTRUCTION) )
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+		if(!do_after(user, fumbling_time, IGNORE_USER_LOC_CHANGE, src, BUSY_ICON_UNSKILLED))
 			return FALSE
 
 	balloon_alert_to_viewers("attaching [choice]")


### PR DESCRIPTION

## About The Pull Request
Fixes #18288 
Also corrects an arg for harvesters to use the actual flag instead of TRUE

:cl:
fix: Ungas can no longer remotely upgrade barricades with their megamind powers
/:cl:
