### PR TITLE
NPC medics address toxins

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/heal_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/heal_procs.dm
@@ -12,10 +12,20 @@
 	dam_list = sortTim(dam_list, /proc/cmp_numeric_dsc, TRUE)
 	for(var/dam_type in dam_list)
 		if(dam_list[dam_type] <= 10)
+			if(dam_type == TOX)
+				address_toxins(patient)
 			continue
 		if(heal_by_type(patient, dam_type))
 			. = TRUE
 			continue
+
+///Deals with toxins in the patient if required
+/datum/ai_behavior/human/proc/address_toxins(mob/living/carbon/human/patient)
+	for(var/datum/reagent/toxin/tox in patient.reagents.reagent_list)
+		if(tox.volume < 10) //arbitrary magic number, but there's no simple way to determine an appropriate threshold
+			continue
+		heal_by_type(patient, TOX)
+		return
 
 ///Heal other ailments
 /datum/ai_behavior/human/proc/heal_secondaries(mob/living/carbon/human/patient)

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -422,7 +422,7 @@
 			E.take_damage(1.5*effect_str, TRUE)
 
 /datum/reagent/medicine/dylovene/ai_should_use(mob/living/target, inject_vol)
-	if(target.reagents.get_reagent_amount(type)) //it has downsides so lets not spam it
+	if(target.reagents.get_reagent_amount(type) > 5) //it has downsides so lets not spam it
 		return FALSE
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
NPC medics will now treat toxins in your system.
## Why It's Good For The Game
Currently, medics will only look at actual toxin damage, but ignore the fact that you could have 50u of neurotoxin (also many toxins dont actually do toxin damage).

Now they will actually dylo you to try treat it, above a fairly low threshold.
## Changelog
:cl:
balance: NPC medics will now treat toxins in your system, not just toxin damage
/:cl:
