### PR TITLE
laser pistol mag capacity nerf

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
@@ -80,7 +80,7 @@
 	Uses standard Terra Experimental (abbreviated as TE) power cells. \
 	As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts."
 	ui_icon = "default"
-	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/tactical
+	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
 	loadout_item_flags = NONE
 
 /datum/loadout_item/secondary/gun/marine/standard_machinepistol

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -539,7 +539,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	equip_slot_flags = ITEM_SLOT_BELT
 	gun_skill_category = SKILL_PISTOLS
-	max_shots = 30 //codex stuff
+	max_shots = 20 //codex stuff
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/pistol
 	ammo_level_icon = null
 	rounds_per_shot = 20
@@ -580,7 +580,7 @@
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight)
 
 /datum/lasrifle/energy_pistol_mode/standard
-	rounds_per_shot = 20
+	rounds_per_shot = 30
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/pistol
 	fire_delay = 0.15 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/Laser Pistol Standard.ogg'
@@ -610,6 +610,24 @@
 	icon_state = "tep"
 	radial_icon_state = "laser_heat"
 	description = "Fires an incendiary laser pulse that ignites living targets."
+
+/// energy efficient laspistol for campaign. 30 shots instead of 20.
+
+/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient
+	name = "\improper Terra Experimental Advanced laser pistol"
+	desc = "An experimental TerraGov laser pistol abbreviated as TE-P. It has an integrated charge selector for normal, heat and taser settings. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts. This one efficiently uses its power cell, and can get more shots out of each cell on standard mode."
+
+	mode_list = list(
+		"Standard" = /datum/lasrifle/energy_pistol_mode/standard/efficient,
+		"Heat" = /datum/lasrifle/energy_pistol_mode/heat,
+		"Disabler" = /datum/lasrifle/energy_pistol_mode/disabler,
+	)
+
+/datum/lasrifle/energy_pistol_mode/standard/efficient
+	rounds_per_shot = 20
+
+/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
+	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight)
 
 //TE Standard Laser Carbine
 


### PR DESCRIPTION
## About The Pull Request

Increases ammo consumption of the energy pistols standard fire mode by 33%, decreasing its total shots/cell from 30 down to 20

The laser pistol in campaign is fine considering you have to spend 800 points to even unlock it, so you can still get 30 shots out of your laspistol in campaign.

## Why It's Good For The Game

The biggest drawback of pistols is their limited magazine capacity, but the laser pistol outperforms all other pistols in this respect. The laser pistol is probably the best pistol you can get in the vendors right now, decreasing its magazine capacity to 20 should bring it in line with other pistols.

## Changelog

:cl: Joe13413
balance: Laser Pistol can now only fire 20 standard rounds instead of 30. Laser pistols in campaign are unaffected.
/:cl:
