### PR TITLE
NPC ability fix

### DIFF
--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -67,7 +67,6 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 		return
 	mob_parent = parent_to_assign
 	set_escorted_atom(null, escorted_atom)
-	refresh_abilities()
 	mob_parent.a_intent = INTENT_HARM
 	//We always use the escorted atom as our reference point for looking for target. So if we don't have any escorted atom, we take ourselve as the reference
 	if(is_offered_on_creation)
@@ -94,6 +93,7 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 
 ///Set behaviour to base behavior
 /datum/ai_behavior/proc/late_initialize()
+	refresh_abilities()
 	switch(base_action)
 		if(MOVING_TO_NODE)
 			look_for_next_node()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes NPC's having an incorrect list of abilities in certain situations.

They now refresh their abilities when the AI late inits instead of on new - As their abilities can change while ai_behavior is inactive (i.e. the mob is dead but could be revived).

:cl:
fix: fixed NPC's occasionally having their usable abilities set incorrectly
/:cl:
