### PR TITLE
NPC goal unsticking

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -55,6 +55,8 @@
 
 #define MAX_NODE_RANGE 15
 #define PATHFINDER_MAX_TRIES 200
+///NPC's will try this many times to path to a goal before ignoring it
+#define AI_MAX_GOAL_PATH_FAILS 10
 
 ///The AI will maintain a combat target within this range, even without LOS
 #define AI_COMBAT_TARGET_BLIND_DISTANCE 4 //required since byond LOS is not the same as true LOS, but also since either can be easily broken by stepping behind a corner etc

--- a/code/controllers/subsystem/advanced_pathfinding.dm
+++ b/code/controllers/subsystem/advanced_pathfinding.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(goal_nodes)
 	goal_image.pixel_y += 10
 	animate(goal_image, pixel_y = pixel_y - 3, time = 7, loop = -1, easing = EASE_OUT)
 	animate(pixel_y = pixel_y + 3, time = 7, loop = -1, easing = EASE_OUT)
-	creator.client.images += goal_image
+	creator?.client?.images += goal_image
 
 /obj/effect/ai_node/goal/LateInitialize()
 	make_adjacents(TRUE)
@@ -174,13 +174,13 @@ GLOBAL_LIST_EMPTY(goal_nodes)
 /obj/effect/ai_node/goal/Destroy()
 	GLOB.goal_nodes -= faction
 	if(creator)
-		creator.client.images -= goal_image
+		creator?.client?.images -= goal_image
 	return ..()
 
 ///Null creator to prevent harddel
 /obj/effect/ai_node/goal/proc/clean_creator()
 	SIGNAL_HANDLER
-	creator.client.images -= goal_image
+	creator?.client?.images -= goal_image
 	creator = null
 
 ///Delete this ai_node goal

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -58,6 +58,8 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 	var/weak_escort = FALSE
 	///List of abilities to consider doing every Process()
 	var/list/ability_list = list()
+	///Count of how many times we've failed to form a path to our goal node
+	var/fail_goal_path_count = 0
 
 /datum/ai_behavior/New(loc, mob/parent_to_assign, atom/escorted_atom)
 	..()
@@ -176,11 +178,12 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 		mob_parent.a_intent = INTENT_HARM
 	return TRUE
 
-///Try to find a node to go to. If ignore_current_node is true, we will just find the closest current_node, and not the current_node best adjacent node
+///Try to find a node to go to
 /datum/ai_behavior/proc/look_for_next_node(blacklist_node = current_node, should_reset_goal_nodes = FALSE)
 	if(should_reset_goal_nodes)
 		set_current_node(null)
-	if(blacklist_node || QDELETED(current_node) || !length(current_node.adjacent_nodes)) //We don't have a current node, let's find the closest in our LOS
+	//We don't have a current node, or we specifically want to avoid one, let's find the closest in our LOS
+	if(blacklist_node || QDELETED(current_node) || !length(current_node.adjacent_nodes))
 		var/new_node = find_closest_node(mob_parent, blacklist_node)
 		if(!new_node)
 			return
@@ -355,6 +358,10 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 	else
 		goal_nodes = list()
 		set_current_node(null)
+		fail_goal_path_count ++
+		if(fail_goal_path_count >= AI_MAX_GOAL_PATH_FAILS) //Failure usually means a mapping issue, or the mob/goal is outside of the normal game area
+			message_admins("[mob_parent] at [ADMIN_VERBOSEJMP(mob_parent)] failed to path to [goal_node] at [ADMIN_VERBOSEJMP(goal_node)].")
+			do_unset_target(goal_node)
 	look_for_next_node(previous_current_node)
 
 ///Signal handler when we reached our current tile goal
@@ -416,6 +423,7 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 		return
 	if(new_goal_node.faction && new_goal_node.faction != mob_parent.faction)
 		return
+	fail_goal_path_count = 0
 	if(goal_node)
 		do_unset_target(goal_node)
 	goal_node = new_goal_node
@@ -540,7 +548,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 ///Finds the most suitable thing to escort
 /datum/ai_behavior/proc/get_atom_to_escort()
 	var/list/goal_list = list()
-	if(GLOB.goal_nodes[mob_parent.faction])
+	if(GLOB.goal_nodes[mob_parent.faction] && (fail_goal_path_count < AI_MAX_GOAL_PATH_FAILS))
 		goal_list[GLOB.goal_nodes[mob_parent.faction]] = AI_ESCORT_RATING_FACTION_GOAL
 	var/mob/living/escorted_mob = escorted_atom
 	if(ismob(escorted_mob) && !QDELETED(escorted_mob) && (escorted_mob.stat != DEAD) && (escorted_mob.z == mob_parent.z) && (get_dist(mob_parent, escorted_mob) <= (AI_ESCORTING_BREAK_DISTANCE)))


### PR DESCRIPTION
## About The Pull Request
If an NPC cannot find a path to a goal node, it will now ignore the goal node permanently after a certain number of attempts.

Previous PR's have made it less likely that NPC's should get stuck, but as it can never be foolproof, this is a final measure to ensure NPC's dont simply get stuck permanently if something fucky is happening with the node map/badminnery/my shitcode explodes etc.

Adds some admin logging so it can be investigated - handy if it turns out to be a mapping issue.

Also fixed a semi related runtime I noticed, and cleaned up a couple of now inaccurate comments.
## Why It's Good For The Game
Ensures NPC's will never get perma stuck in place.
## Changelog
:cl:
fix: If NPC's cannot path to a goal node after repeated attempts, they will now simply ignore it instead of getting stuck in place
/:cl:
