### PR TITLE
E-pistol nerf with less stupid this time

### DIFF
--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
@@ -80,7 +80,7 @@
 	Uses standard Terra Experimental (abbreviated as TE) power cells. \
 	As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts."
 	ui_icon = "default"
-	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/tactical
+	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
 	loadout_item_flags = NONE
 
 /datum/loadout_item/secondary/gun/marine/standard_machinepistol

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/secondaries.dm
@@ -80,7 +80,7 @@
 	Uses standard Terra Experimental (abbreviated as TE) power cells. \
 	As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts."
 	ui_icon = "default"
-	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
+	item_typepath = /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/tactical
 	loadout_item_flags = NONE
 
 /datum/loadout_item/secondary/gun/marine/standard_machinepistol

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -539,7 +539,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	equip_slot_flags = ITEM_SLOT_BELT
 	gun_skill_category = SKILL_PISTOLS
-	max_shots = 30 //codex stuff
+	max_shots = 20 //codex stuff
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/pistol
 	ammo_level_icon = null
 	rounds_per_shot = 20
@@ -580,7 +580,7 @@
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight)
 
 /datum/lasrifle/energy_pistol_mode/standard
-	rounds_per_shot = 20
+	rounds_per_shot = 30
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/pistol
 	fire_delay = 0.15 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/Laser Pistol Standard.ogg'
@@ -610,6 +610,24 @@
 	icon_state = "tep"
 	radial_icon_state = "laser_heat"
 	description = "Fires an incendiary laser pulse that ignites living targets."
+
+/// energy efficient laspistol for campaign. 30 shots instead of 20.
+
+/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient
+	name = "\improper Terra Experimental Advanced laser pistol"
+	desc = "An experimental TerraGov laser pistol abbreviated as TE-P. It has an integrated charge selector for normal, heat and taser settings. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts. This one efficiently uses its power cell, and can get more shots out of each cell on standard mode."
+
+	mode_list = list(
+		"Standard" = /datum/lasrifle/energy_pistol_mode/standard/efficient,
+		"Heat" = /datum/lasrifle/energy_pistol_mode/heat,
+		"Disabler" = /datum/lasrifle/energy_pistol_mode/disabler,
+	)
+
+/datum/lasrifle/energy_pistol_mode/standard/efficient
+	rounds_per_shot = 20
+
+/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
+	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight)
 
 //TE Standard Laser Carbine
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -611,27 +611,6 @@
 	radial_icon_state = "laser_heat"
 	description = "Fires an incendiary laser pulse that ignites living targets."
 
-/// energy efficient laspistol for campaign. 30 shots instead of 20.
-
-/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient
-	name = "\improper Terra Experimental Advanced laser pistol"
-	desc = "An experimental TerraGov laser pistol abbreviated as TE-P. It has an integrated charge selector for normal, heat and taser settings. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts. This one efficiently uses its power cell, and can get more shots out of each cell on standard mode."
-	max_shots = 30 //codex stuff
-	rounds_per_shot = 20
-
-	mode_list = list(
-		"Standard" = /datum/lasrifle/energy_pistol_mode/standard/efficient,
-		"Heat" = /datum/lasrifle/energy_pistol_mode/heat,
-		"Disabler" = /datum/lasrifle/energy_pistol_mode/disabler,
-	)
-
-// probably should have made this a subtype of energy_pistol_mode/standard but that didnt work
-/datum/lasrifle/energy_pistol_mode/standard/efficient
-	rounds_per_shot = 20
-
-/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient/tactical
-	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/lasersight)
-
 //TE Standard Laser Carbine
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_carbine

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -542,7 +542,7 @@
 	max_shots = 20 //codex stuff
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/pistol
 	ammo_level_icon = null
-	rounds_per_shot = 20
+	rounds_per_shot = 30
 	gun_firemode = GUN_FIREMODE_AUTOMATIC
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	attachable_allowed = list(
@@ -616,6 +616,8 @@
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol/efficient
 	name = "\improper Terra Experimental Advanced laser pistol"
 	desc = "An experimental TerraGov laser pistol abbreviated as TE-P. It has an integrated charge selector for normal, heat and taser settings. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts. This one efficiently uses its power cell, and can get more shots out of each cell on standard mode."
+	max_shots = 30 //codex stuff
+	rounds_per_shot = 20
 
 	mode_list = list(
 		"Standard" = /datum/lasrifle/energy_pistol_mode/standard/efficient,
@@ -623,6 +625,7 @@
 		"Disabler" = /datum/lasrifle/energy_pistol_mode/disabler,
 	)
 
+// probably should have made this a subtype of energy_pistol_mode/standard but that didnt work
 /datum/lasrifle/energy_pistol_mode/standard/efficient
 	rounds_per_shot = 20
 


### PR DESCRIPTION
## About The Pull Request

Increases ammo consumption of the energy pistol on standard mode by 33%. In practice, this means that the standard firemode for the laser pistol goes from 30 shots, to 20 shots.

## Why It's Good For The Game

Pistols in TGMC have great DPS, great mobility, and great one-handed accuracy, which is all offset by their extremely low magazine capacity. The laser pistol has an extremely high magazine capacity for its class, which sets it above most other pistols. Along with its other benefits such as lightspeed velocity, the incendiary fire mode, its ability to take a bayonet, etc etc, makes it way overtuned compared to the other pistol options.
Decreasing its ammo capacity down to 20 puts it in line with the other options.

## Changelog

:cl: Joe13413
balance: Decreased the ammo capacity of the laser pistols standard fire mode to 20, from 30.
/:cl:
