### PR TITLE
mech heavy cannon accuracy nerf

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -833,7 +833,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		hit_chance = round(hit_chance * evasion_bonus)
 
 	if(proj.ammo.ammo_behavior_flags & AMMO_UNWIELDY)
-		hit_chance *= 0.4
+		hit_chance *= 0.5
 
 	hit_chance = max(5, hit_chance) //It's never impossible to hit
 

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -317,6 +317,10 @@
 	hud_icons = list("shell_apcr", "shell_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/heavy_cannon/apply_weapon_modifiers(atom/movable/projectile/projectile_to_fire, mob/firer)
+	. = ..()
+	projectile_to_fire.def_zone = BODY_ZONE_CHEST //no delimb spam
+
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/minigun
 	name = "\improper Rhea vulcan cannon"
 	icon = 'icons/mecha/mecha_equipment_64x32.dmi'


### PR DESCRIPTION

## About The Pull Request
Decreased mech heavy cannon accuracy by 10.
Heavy cannon now always aims at chest.

Note that low accuracy means it still has a chance to hit limbs (and instantly delimb) still, but FAR less likely.
## Why It's Good For The Game
The heavy cannon is pretty inaccurate in campaign, but considering how devastating it is, its still a little TOO accurate. It should now be a little lower, and will be extremely unreliable for delimb shenanigans, while still being able to simply kill people to death if needed.
## Changelog
:cl:
balance: Mech heavy cannon is slightly less accurate, and always aims chest
/:cl:
