### PR TITLE
NPC diag shuffle movement

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1101,10 +1101,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return pois
 
 ///Returns the left and right dir of the input dir, used for AI stutter step while attacking
-/proc/LeftAndRightOfDir(direction, diagonal_check = FALSE)
-	if(diagonal_check)
-		if(ISDIAGONALDIR(direction))
-			return list(turn(direction, 45), turn(direction, -45))
+/proc/LeftAndRightOfDir(direction, diagonal_check = FALSE, always_diag = FALSE)
+	if(always_diag || (diagonal_check && ISDIAGONALDIR(direction)))
+		return list(turn(direction, 45), turn(direction, -45))
 	return list(turn(direction, 90), turn(direction, -90))
 
 /proc/CallAsync(datum/source, proctype, list/arguments)

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -505,7 +505,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		if(prob(atom_to_walk_to == escorted_atom ? 80 : 50)) //If we're holding around an escort target, we don't move too much
 			return
 		if(prob(sidestep_prob)) //shuffle about
-			dir_options += LeftAndRightOfDir(dir_to_target)
+			dir_options += LeftAndRightOfDir(dir_to_target, TRUE)
 	if(dist_to_target > min_range) //above min range, its valid to come closer
 		dir_options += dir_to_target
 	if(dist_to_target < max_range) //less than max range, its valid to walk away
@@ -517,13 +517,13 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 /datum/ai_behavior/proc/ai_complete_move(move_dir, try_sidestep = TRUE)
 	var/turf/new_loc = get_step(mob_parent, move_dir)
 	if(new_loc?.atom_flags & AI_BLOCKED)
-		move_dir = pick(LeftAndRightOfDir(move_dir))
+		move_dir = pick(LeftAndRightOfDir(move_dir, always_diag = TRUE))
 		new_loc = get_step(mob_parent, move_dir)
 		if(new_loc?.atom_flags & AI_BLOCKED || !can_cross_lava_turf(new_loc))
 			return
 	if(!mob_parent.Move(new_loc, move_dir))
 		if(!(SEND_SIGNAL(mob_parent, COMSIG_OBSTRUCTED_MOVE, move_dir) & COMSIG_OBSTACLE_DEALT_WITH) && try_sidestep)
-			ai_complete_move(pick(LeftAndRightOfDir(move_dir)), FALSE)
+			ai_complete_move(pick(LeftAndRightOfDir(move_dir, always_diag = TRUE)), FALSE)
 		return
 	if(ISDIAGONALDIR(move_dir))
 		mob_parent.next_move_slowdown += (DIAG_MOVEMENT_ADDED_DELAY_MULTIPLIER - 1) * mob_parent.cached_multiplicative_slowdown

--- a/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/hazard_avoidance.dm
@@ -45,6 +45,7 @@
 			//todo: Need to have NPC path around lava entirely (or jump over it), if their direct path is into lava
 
 	//hazards
+	exclude_dirs.Cut()
 	for(var/atom/movable/thing AS in hazard_list)
 		var/dist = get_dist(mob_parent, thing)
 		if(dist > hazard_list[thing] + 1)


### PR DESCRIPTION

## About The Pull Request
Tweaked NPC movement so they will do diagonal moves in more situations - namely when their preferred move is blocked, or when just side stepping in optimal range.
## Why It's Good For The Game
Not doing diag movement when blocked means if they try to path to things in a certain direction, where blockers are blocking specific directions, they will endless loop between 2 tiles and never be able actually move around the obstacle.
## Changelog
:cl:
qol: NPC's are less likely to get stuck on obstacles in certain circumstances
/:cl:
