### PR TITLE
Autodoc Fixes

### DIFF
--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -1366,6 +1366,8 @@
 
 	if(href_list["automatictoggle"])
 		connected.automatic_mode = !connected.automatic_mode
+		if(connected.occupant && connected.automatic_mode)
+			connected.begin_surgery_operation()
 
 	if(href_list["surgery"])
 		if(connected.occupant)

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -1372,9 +1372,13 @@
 			to_chat(usr, span_warning("Access denied."))
 			playsound(loc,'sound/machines/buzz-two.ogg', 25, 1)
 
-	if(href_list["automatictoggle"])
+	if(href_list["automatictoggle"] && !connected.is_active())
 		connected.automatic_mode = !connected.automatic_mode
-		if(connected.occupant && connected.automatic_mode)
+		if(!connected.automatic_mode && connected.autostart_timer_id)
+			deltimer(connected.autostart_timer_id)
+			connected.autostart_timer_id = null
+			say("Automatic mode disengaged, awaiting manual inputs.")
+		if(connected.automatic_mode && !connected.autostart_timer_id)
 			connected.say("Automatic mode engaged, initialising procedures.")
 			connected.autostart_timer_id = addtimer(CALLBACK(connected, TYPE_PROC_REF(/obj/machinery/autodoc, auto_start)), 5 SECONDS)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While someone is inside the Autodoc, changing the mode to Automatic now begins the automatic surgery process just like entering it would.

While Autodoc is active, it cannot be switched between Automatic and Manual mode. This prevents people from changing it to Manual (despite the surgery list was chosen via Automatic mode) to avoid the bonus 50% surgery delay penalty from using Automatic mode.

## Why It's Good For The Game
Makes Autodoc more intuitive & stops people from cheesing Autodoc by starting it in Automatic mode and then switching it to manual to get rid of the 50% additional delay.

## Changelog
:cl:
add: Setting Autodoc to automatic mode while someone is already inside now begins the automatic surgery process.
fix: Autodoc no longer can switch between manual/automatic modes while it is active; prevents automatic mode from benefiting from manual mode speed.
/:cl:
