### PR TITLE
Humans won't stop pulling other humans when they die

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -46,8 +46,8 @@
 
 
 /mob/living/carbon/human/on_death()
-	if(pulledby)
-		pulledby.stop_pulling()
+	if(!ishuman(pulledby))
+		pulledby?.stop_pulling()
 
 	//Handle species-specific deaths.
 	species.handle_death(src)


### PR DESCRIPTION

## About The Pull Request
Title. When you're pulling a human and they die, you won't stop pulling them unless you're a xeno or some other non-human mob.
## Why It's Good For The Game
You don't have to spend the extra second to re-grab incapacitated humans when you're pulling them for rescue or _other_ purposes and they die. I think this is purely QoL and not balance (mainly because I genuinely can't think of a way this could creep into being balance, someone can make a point otherwise though).
## Changelog
:cl:
qol: Humans won't stop pulling other humans when the pulled human dies.
/:cl:
