### PR TITLE
MP-19 ammo nerf

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -39,9 +39,9 @@
 	icon_state = "t19"
 	worn_icon_state = "t19"
 	fire_sound = 'sound/weapons/guns/fire/tgmc/kinetic/gun_mp19.ogg'
-	caliber = CALIBER_10X20_CASELESS //codex
+	caliber = CALIBER_10X20_CASELESS
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
-	max_shells = 45 //codex
+	max_shells = 30
 	equip_slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	type_of_casings = null
 	default_ammo_type = /obj/item/ammo_magazine/smg/standard_machinepistol

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -40,7 +40,7 @@
 	caliber = CALIBER_10X20_CASELESS
 	icon_state = "t19"
 	icon_state_mini = "mag_smg"
-	max_rounds = 45
+	max_rounds = 30
 	w_class = WEIGHT_CLASS_SMALL
 
 //-------------------------------------------------------


### PR DESCRIPTION

## About The Pull Request
Reverts MP-19 ammo capacity back down to 30.
## Why It's Good For The Game
Its a pistol, 30 round mag is already the highest in the game for pistols, and it has extremely good DPS, zero slowdown when wielded and perfect/scatter accuracy.
With a massive 45 round mag it has absolutely no downsides. A pistol should not be better than most 2 handed weapons.
## Changelog
:cl:
balance: MP-19 has 30 round mags again
/:cl:
