### PR TITLE
Remove SH-410 from normal play

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -66,10 +66,6 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
-			/obj/item/weapon/gun/rifle/light_autoshotgun = -1,
-			/obj/item/ammo_magazine/rifle/sh410_sabot = -1,
-			/obj/item/ammo_magazine/rifle/sh410_buckshot = -1,
-			/obj/item/ammo_magazine/rifle/sh410_ricochet = -1,
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,
@@ -295,9 +291,6 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
-			/obj/item/weapon/gun/rifle/light_autoshotgun = -1,
-			/obj/item/ammo_magazine/rifle/sh410_sabot = -1,
-			/obj/item/ammo_magazine/rifle/sh410_buckshot = -1,
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -813,8 +813,6 @@
 			/obj/item/storage/box/visual/magazine/compact/standard_lmg/full = -1,
 			/obj/item/storage/box/visual/magazine/compact/standard_gpmg/full = -1,
 			/obj/item/storage/box/visual/magazine/compact/standard_mmg/full = -1,
-			/obj/item/storage/box/visual/magazine/compact/sh410/buckshot/full = -1,
-			/obj/item/storage/box/visual/magazine/compact/sh410/sabot/full = -1,
 		),
 		"Mecha Ammo" = list(
 			/obj/item/mecha_ammo/vendable/pistol = -1,

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -452,9 +452,6 @@
 			/obj/item/ammo_magazine/shotgun/tracker = 16,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = 30,
 			/obj/item/ammo_magazine/rifle/tx15_slug = 30,
-			/obj/item/ammo_magazine/rifle/sh410_sabot = 30,
-			/obj/item/ammo_magazine/rifle/sh410_buckshot = 30,
-			/obj/item/ammo_magazine/rifle/sh410_ricochet = 30,
 		),
 		"Machinegun" = list(
 			/obj/item/ammo_magazine/standard_lmg = 30,


### PR DESCRIPTION

## About The Pull Request
SH-410 is not available from gun vendors.
## Why It's Good For The Game
I don't know why this gun was added - it's just 'high dps gun', with MASSIVE AP to make it absurdly good against high armour castes, and funny burst mode for huge burst damage with either ammo type.

For reference, the SH-15 it was compared to has something like half the DPS this does.

Someone is free to add it to req or give it to ert or something, but this is not balanced for roundstart gameplay, and since it does nothing but damage, there's really no point in nerfing it instead of removing it.
## Changelog
:cl:
balance: SH-410 removed from normal gameplay
/:cl:
