### PR TITLE
Deleted LZ1 landing on Bluemoon Crash

### DIFF
--- a/_maps/map_files/Blue_Moon/bluemoon.dmm
+++ b/_maps/map_files/Blue_Moon/bluemoon.dmm
@@ -14437,10 +14437,6 @@
 	dir = 1
 	},
 /area/bluemoon/outside/building/cargo/shop)
-"qPS" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/shuttle/drop1/lz1)
 "qQc" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -23364,7 +23360,7 @@ sGJ
 sGJ
 sGJ
 sGJ
-qPS
+sGJ
 sGJ
 sGJ
 sGJ


### PR DESCRIPTION
## About The Pull Request

Deleted the LZ1 crash landing spot on Blue Moon.
<img width="675" height="863" alt="image" src="https://github.com/user-attachments/assets/7cdc4030-053f-4069-8b2e-d62fa31ee87d" />


## Why It's Good For The Game

This particular landing is placed inside the LZ1 building, far away from disks compared to other landings and completely enclosed by walls. 

The exit(s) to the enclosed LZ1 area make it a natural chokepoint, and xenomorphs can easily take advantage of the area east of canter to maze and fish with very low risk due to the large number of objects blocking marine movement and sight lines. 
The long path to disks combined with the LZ1 chokepoint make the initial push very dangerous and almost always results in a mini wipe.
Due to these issues, rounds that have this landing are heavily skewed against marines.

Four landings for a map this size is too many anyways. The three are very well placed and there is no need for the LZ1 landing to exist.

## Changelog

:cl: Scav
del: Deleted LZ1 landing on Bluemoon Crash
/:cl:
