### PR TITLE
NPC escort fix

### DIFF
--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -483,9 +483,6 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		return
 	if(should_hold())
 		return
-	//This allows minions to be buckled to their atom_to_escort without disrupting the movement of atom_to_escort
-	if(current_action == ESCORTING_ATOM && (get_dist(mob_parent, atom_to_walk_to) <= 0)) //todo: Entirely remove this shitcode snowflake check for one specific interaction that doesn't specifically relate to ai_behavior
-		return
 	mob_parent.next_move_slowdown = 0
 	var/list/dir_options = find_next_dirs()
 	if(!length(dir_options))

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -89,6 +89,12 @@
 /datum/ai_behavior/spiderling/set_escort()
 	return FALSE //we don't automatically reset our escort
 
+/datum/ai_behavior/spiderling/should_hold()
+	//We don't move if we're riding mum
+	if(current_action == ESCORTING_ATOM && (mob_parent.buckled = escorted_atom))
+		return TRUE
+	return ..()
+
 /// Decides what to do when widow uses spiderling mark ability
 /datum/ai_behavior/spiderling/proc/decide_mark(source, atom/A)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Finally removes some old spiderling AI shitcode from the main npc behavior datum, and makes it a spiderling specific thing.

NPC mobs will no longer just stop moving because they are on the same turf as their target.
## Why It's Good For The Game
All NPC mobs switching their brains off because of one funny spiderling check is bad.
## Changelog
:cl:
fix: fixed NPC's not moving if they are on top of their target
/:cl:
