### PR TITLE
Crash autodoc is now 2 times faster

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -90,7 +90,7 @@
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "ay" = (
-/obj/machinery/autodoc,
+/obj/machinery/autodoc/crash,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "az" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -458,7 +458,7 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "bG" = (
-/obj/machinery/autodoc,
+/obj/machinery/autodoc/crash,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bH" = (

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -1433,3 +1433,7 @@
 	var/datum/data/record/medical_record = find_medical_record(occupant)
 	var/datum/historic_scan/scan = medical_record.fields["historic_scan"]
 	scan.ui_interact(usr)
+
+//Autodoc but faster
+/obj/machinery/autodoc/crash
+	surgery_time_multiplier = 2

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -1436,4 +1436,4 @@
 
 //Autodoc but faster
 /obj/machinery/autodoc/crash
-	surgery_time_multiplier = 2
+	surgery_time_multiplier = 0.5


### PR DESCRIPTION

## About The Pull Request
Look mom im making marine buff PR while playing xeno

## Why It's Good For The Game
No cmo (99%) on crash sucks 
theres a carrier or you get anything except frac and you gotta wait forever in the autodoc
lets lower the waiting part so you can play the game more

## Changelog
:cl: Atropos
balance: Crash autodoc is now 2 times faster
/:cl:
