### PR TITLE
HvH deployment fixes

### DIFF
--- a/code/modules/vehicles/armored/som_tank.dm
+++ b/code/modules/vehicles/armored/som_tank.dm
@@ -40,6 +40,7 @@
 	. = ..()
 	add_filter("shadow", 2, drop_shadow_filter(0, SOM_TANK_HOVER_HEIGHT, 1))
 	animate_hover()
+	RegisterSignal(src, COMSIG_MOVABLE_PATROL_DEPLOYED, PROC_REF(animate_hover))
 	var/obj/item/tank_module/module = new /obj/item/tank_module/ability/smoke_launcher()
 	module.on_equip(src)
 

--- a/code/modules/vehicles/hover_bike.dm
+++ b/code/modules/vehicles/hover_bike.dm
@@ -30,6 +30,7 @@
 	add_filter("shadow", 2, drop_shadow_filter(0, -8, 1))
 	update_icon()
 	animate_hover()
+	RegisterSignal(src, COMSIG_MOVABLE_PATROL_DEPLOYED, PROC_REF(animate_hover))
 
 /obj/vehicle/ridden/hover_bike/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Some mainly visual fixes for HvH deploy points.
Mobs riding or standing on top of vehicles now properly animate with their vehicle when deploying.
Said mobs also have spawn protection applied to them.
Hover vehicles update their hover after going through deploy points.
## Why It's Good For The Game
Looks much better
## Changelog
:cl:
fix: fixed some visual issues with HvH deploy points
fix: Mobs riding vehicles as they deploy in HvH get spawn protection as well.
/:cl:
