### PR TITLE
Dylo autoinjectors now transfer 3u by default

### DIFF
--- a/code/modules/reagents/reagent_containers/autoinjectors.dm
+++ b/code/modules/reagents/reagent_containers/autoinjectors.dm
@@ -109,6 +109,7 @@
 	icon_state = "autoinjector-1"
 	list_reagents = list(/datum/reagent/medicine/dylovene = 30)
 	description_overlay = "Dy"
+	amount_per_transfer_from_this = 3
 
 /obj/item/reagent_containers/hypospray/autoinjector/tramadol
 	name = "tramadol autoinjector"


### PR DESCRIPTION

## About The Pull Request

what the title says
<img width="585" height="48" alt="image" src="https://github.com/user-attachments/assets/2dca605e-0621-4b47-82ae-2afd14756766" />


## Why It's Good For The Game

Everywhere everyone talking this is better
i agree
others agree
good change

## Changelog
:cl: Atropos
qol: Dylovene autoinjectors now inject 3 u by default
/:cl:
