### PR TITLE
Weather cleanup in campaign

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -88,6 +88,12 @@ SUBSYSTEM_DEF(weather)
 	eligible_zlevels[z] = possible_weather
 	next_hit_by_zlevel["[z]"] = null
 
+///Removes a z level from the weather SS
+/datum/controller/subsystem/weather/proc/remove_eligible(z)
+	eligible_zlevels -= "[z]"
+	deltimer(next_hit_by_zlevel["[z]"])
+	next_hit_by_zlevel -= "[z]"
+
 /datum/controller/subsystem/weather/proc/get_weather(z, area/active_area)
 	var/datum/weather/A
 	for(var/V in processing)

--- a/code/datums/gamemodes/campaign/campaign_mission.dm
+++ b/code/datums/gamemodes/campaign/campaign_mission.dm
@@ -336,9 +336,8 @@
 	QDEL_LIST(GLOB.campaign_structures)
 	QDEL_LIST(GLOB.patrol_point_list) //purge all existing links, cutting off the current ground map. Start point links are auto severed, and will reconnect to new points when a new map is loaded and upon use.
 	STOP_PROCESSING(SSslowprocess, src)
-	//No point running weather in the background
-	SSweather.eligible_zlevels -= mission_z_level.z_value
-	SSweather.next_hit_by_zlevel -= mission_z_level.z_value
+
+	SSweather.remove_eligible(mission_z_level.z_value)
 
 	mission_state = MISSION_STATE_FINISHED
 	apply_outcome()


### PR DESCRIPTION

## About The Pull Request
Weather is stopped on a mission z level once that mission is over.
## Why It's Good For The Game
Performance or something
## Changelog
:cl:
fix: weather doesnt run on old campaign mission z levels
/:cl:
