### PR TITLE
NPC grenade fix

### DIFF
--- a/code/modules/ai/ai_behaviors/human_mobs/grenades.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/grenades.dm
@@ -20,7 +20,7 @@
 			return
 	if(!line_of_sight(mob_parent, combat_target, 7))
 		return
-	if(!check_path(mob_parent, combat_target, PASS_THROW))
+	if(check_path(mob_parent, combat_target, PASS_THROW) != get_turf(combat_target))
 		return
 	if(!check_path_ff(mob_parent, combat_target))
 		return


### PR DESCRIPTION

## About The Pull Request
Fixes NPC's trying to throw grenades when their path is blocked.

I forgot to update it when I changed how the proc this relies on works, whoops.
## Why It's Good For The Game
Less FUN nade throwing.
## Changelog
:cl:
fix: fixed NPC's throwing grenades when they don't have a clear path
/:cl:
