### PR TITLE
Focus buff

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1858,7 +1858,8 @@
 			var/mob/living/carbon/human/shooter_human = gun_user
 			gun_accuracy_mod -= round(min(20, (shooter_human.shock_stage * 0.2))) //Accuracy declines with pain, being reduced by 0.2% per point of pain.
 			if(shooter_human.marksman_aura)
-				gun_accuracy_mod += 10 + max(5, shooter_human.marksman_aura * 5) //Accuracy bonus from active focus order
+				gun_accuracy_mod += 10 + max(5, shooter_human.marksman_aura * 5)
+				gun_scatter -= shooter_human.marksman_aura * 2
 
 ///Generates screenshake if the gun has recoil
 /obj/item/weapon/gun/proc/simulate_recoil(recoil_bonus = 0, firing_angle)


### PR DESCRIPTION

## About The Pull Request
Omega buff to focus order.

Slightly reduces weapon scatter.
## Why It's Good For The Game
Focus is kinda garbage - this is a pretty small tweak, but it does mean guns with a bit more scatter are that marginally more accurate (T60/T11, etc) which can actually make a difference, without simply buffing DPS.
## Changelog
:cl:
balance: Focus order slightly reduces scatter
/:cl:
