### PR TITLE
Tracker slug buff

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -301,6 +301,7 @@ Important note: colors can end up significantly different from the basic html pi
 #define LIGHT_COLOR_EMISSIVE_RED "#fa6464"
 #define LIGHT_COLOR_EMISSIVE_YELLOW "#f0fa64"
 #define LIGHT_COLOR_EMISSIVE_ORANGE "#faac64"
+#define LIGHT_COLOR_EMISSIVE_BLUE "#7bacc3"
 
 //Colors used by special resin walls.
 #define COLOR_WALL_BULLETPROOF "#ed99f6"

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -130,7 +130,12 @@
 	name = "tracking fluid"
 	desc = "Tracking fluid from a tracking round."
 	basecolor = "#00FFFF"
+	amount = 5
 	layer = ABOVE_WEEDS_LAYER
+
+/obj/effect/decal/cleanable/blood/drip/tracking_fluid/update_icon_state()
+	. = ..()
+	animate(src, time = 90 SECONDS, color = "#003434")
 
 /obj/effect/decal/cleanable/blood/drip/tracking_fluid/dry()
 	name = "dried [name]"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -304,6 +304,7 @@
 	max_range = 15
 	damage = 40
 	penetration = 30
+	bullet_color = LIGHT_COLOR_EMISSIVE_BLUE // The fluid it emits is glowing blue, the bullet should be as well
 
 /datum/ammo/bullet/shotgun/mbx900_tracker/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	if(isxeno(target_mob))
@@ -319,6 +320,7 @@
 	max_range = 15
 	damage = 90
 	penetration = 10
+	bullet_color = LIGHT_COLOR_EMISSIVE_BLUE // The fluid it emits is glowing blue, the bullet should be as well
 
 /datum/ammo/bullet/shotgun/tracker/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	if(isxeno(target_mob))


### PR DESCRIPTION
## About The Pull Request
Bugfix:

- Tracking fluid wasn't properly being layered with BELOW_OBJ_LAYER and was hidden behind everything. I fixed this with ABOVE_WEEDS_LAYER so it can return to how it used to be. This was due to #17285, because of the importance of multiz if this fucks with it I can change it.

Balance:

- Dry tracking fluid is now 80% darker. Tracking fluid will gradually get darker as time goes on.
<img width="56" height="69" alt="wet" src="https://github.com/user-attachments/assets/dd6b6bd1-206c-44ad-9a5a-8264354a5067" />
<img width="49" height="56" alt="dry" src="https://github.com/user-attachments/assets/2fe1b376-a055-42d0-8cd6-547c68803316" />

- Tracking shells now only work on xenos, humans will no longer drop tracking fluid when hit. Still does damage obviously.

- Tracking fluid now produces drops at a rate of 1/sec instead of 3/sec, in turn it lasts 20 seconds now instead of 60. Still only 20 drops.

- TODO: Tracking fluid lasts for 90 seconds. It now emits light, starting at 2.5 tiles, and going down by .5 tiles every 30 seconds until it hits 0
When implemented it would look like this:
At max brightness (2.5 tiles)
<img width="405" height="365" alt="image" src="https://github.com/user-attachments/assets/5219389f-2fb9-4728-9172-3b783420a060" />

After 30 seconds (2 tiles)
<img width="384" height="317" alt="image" src="https://github.com/user-attachments/assets/39dedced-97ea-40ef-aa54-86fe8a9cfe59" />

After 60 seconds (1.5 tiles)
<img width="266" height="277" alt="image" src="https://github.com/user-attachments/assets/4ad99cd2-a159-446e-9b25-f46a14dd3cde" />
ɪ ᴄᴀɴ'ᴛ sᴇᴇ ᴀ ᴅᴀᴍɴ ᴛʜɪɴɢ!!!

## Why It's Good For The Game

- Darker dry fluid makes it much easier to tell the difference between old and new fluid, they were way too identical before. Having the fluid gradually get darker makes it easier to know exactly how long ago the tracks were placed.

- Shells only working on xenos is to ensure that people aren't just shooting each other for a free trail (it would be fucking hilarious though) It's also because I plan on giving the shells one final gimmick in the future and but that requires them to be an HVX exclusive. Not like you can get them in HVH normally though.

- Drops being more clustered actually makes following a trail more viable, the distance a xeno can run is far too great for 3 seconds per drop to make any meaningful difference in actually finding where one went. With drone as a baseline for movement speed this is about every 4-5 tiles off weeds now.
This also makes it so castes with extremely fast getaway tools through dashes, charges, and more can be caught off guard by someone following a trail to a resting point.

- Tracking fluid emitting a tiny amount of light offers up a creative solution to the lack of light while tracking a xeno, this also incentivizes using tracking shells as a support tool for you and your teammates. The light isn't large at all, but it essentially paints a silhouette every time it drops. You can follow whatever you're tracking through the darkness but you can't see much past the xeno you're tracking. Be careful though, the light gets dimmer every 30 seconds so you might be blind following the trail back.


I plan on doing more for tracking shells, I believe an alternative to slugs that doesn't stagger or stun can be made viable and fun for both sides.

## Changelog
:cl:
balance: Tracker fluid only drops from xenos
balance: Tracker fluid now gradually gets darker overtime
balance: Tracker fluid now drops at a rate of 1/sec for 20 seconds now
balance: Tracker fluid now emits light for 90 seconds while gradually getting darker
fix: Tracking fluid now layers properly and above weeds
/:cl:
