### PR TITLE
Job SS fix

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -54,12 +54,8 @@ SUBSYSTEM_DEF(job)
 		if(!job.map_check())
 			continue
 		occupations += job
-		if(job.title == "Xenomorph")
-			to_chat(world, span_boldnotice("checking xeno [job.type]"))
 		if(!name_occupations[job.title]) //we have multiple jobs with the same title, such as vatborn
 			name_occupations[job.title] = job
-		else
-			to_chat(world, span_boldnotice("job title already exists"))
 		type_occupations[J] = job
 	sortTim(occupations, GLOBAL_PROC_REF(cmp_job_display_asc))
 


### PR DESCRIPTION

## About The Pull Request
Fixes a 7 year old bug that means the job lists in the job SS get cursed if the server fails to start the round (i.e. due to lack of xeno players ready'd up, etc).

This meant there was a mismatch between type_occupations and name_occupations (and there would be 210 extra job datums just floating around every time the server fails to start the round).
## Why It's Good For The Game
Working stuff good.
## Changelog
:cl:
admin: Fixed the job panel breaking if the gamemode fails to start 1 or more times
/:cl:
