### PR TITLE
Zoom pill bottles now contain stimulon

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -524,15 +524,15 @@
 	storage_datum.max_storage_space = 7
 
 /obj/item/storage/pill_bottle/zoom
-	name = "zoom pill bottle"
-	desc = "Containts highly illegal drugs. Trade heart for speed."
+	name = "stimulon pill bottle"
+	desc = "A shady looking pill bottle which contains stimulon, an advanced self-replicating drug that cannot be purged naturally, but it boosts movement speed immensely. This aftermarket stuff can't be very pure though, can it? \n<b>Side effects may include: jittering, shortness of breath, muscle tearing, intense agony, and exponentially increasing genetic damage.\n "
 
 	pill_type_to_fill = /obj/item/reagent_containers/pill/zoom
-	greyscale_colors = "#ef3ad4#ffffff"
+	greyscale_colors = "#776878#ffffff"
 
 /obj/item/storage/pill_bottle/zoom/Initialize(mapload, ...)
 	. = ..()
-	storage_datum.max_storage_space = 7
+	storage_datum.max_storage_space = 1
 
 /obj/item/storage/pill_bottle/attackby(obj/item/attacking_item, mob/user, params)
 	if(!istype(attacking_item, /obj/item/facepaint) || isnull(greyscale_config))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -189,7 +189,7 @@
 
 /obj/item/reagent_containers/pill/zoom
 	pill_desc = "A Zoom pill! Gotta go fast!"
-	list_reagents = list(/datum/reagent/medicine/synaptizine = 3, /datum/reagent/medicine/hyronalin = 5)
+	list_reagents = list(/datum/reagent/medicine/research/stimulon = 0.1, /datum/reagent/toxin/satrapine = 10)
 	pill_id = 14
 
 /obj/item/reagent_containers/pill/russian_red


### PR DESCRIPTION
## About The Pull Request

Zoom pill bottles now contain one pill, with 0.1 units of stimulon, and 10 units of satrapine, cause fuck you.

## Why It's Good For The Game

Zoom pill bottle has been hot dogshit for a long while. It's about time CLF gets their awesome hypervene pills back, but in a more suicidey kind of fashion.

In all seriousness, stimulon does somewhat fit the identity of the CLF as a high speed cannon fodder faction. Stimulon is powerful though, so the satrapine should help prevent it from being too strong, by either forcing you to deal with the toxins by taking dylo (and subsequently locking yourself out of synapt and stam regen), or toughing it out and degrading faster than you would normally.

## Changelog
:cl: Joe13413
balance: The CLFs zoom pill bottle now only contains one pill with stimulon.
/:cl:
