### PR TITLE
Fixes Autodoc stoppable timer

### DIFF
--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -403,7 +403,7 @@
 	autodoc_scan(occupant)
 	if(automatic_mode)
 		say("Automatic mode engaged, initialising procedures.")
-		autostart_timer_id = addtimer(CALLBACK(src, PROC_REF(auto_start)), 5 SECONDS)
+		autostart_timer_id = addtimer(CALLBACK(src, PROC_REF(auto_start)), 5 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
 
 /// Callback to start the surgery operation for automatic mode.
 /obj/machinery/autodoc/proc/auto_start()
@@ -1380,7 +1380,7 @@
 			connected.say("Automatic mode disengaged, awaiting manual inputs.")
 		if(connected.automatic_mode && !connected.autostart_timer_id)
 			connected.say("Automatic mode engaged, initialising procedures.")
-			connected.autostart_timer_id = addtimer(CALLBACK(connected, TYPE_PROC_REF(/obj/machinery/autodoc, auto_start)), 5 SECONDS)
+			connected.autostart_timer_id = addtimer(CALLBACK(connected, TYPE_PROC_REF(/obj/machinery/autodoc, auto_start)), 5 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
 
 	if(href_list["surgery"])
 		if(connected.occupant)


### PR DESCRIPTION

## About The Pull Request
Fixes a runtime regarding deltimer for a timer in Autodoc.
<img width="883" height="255" alt="image" src="https://github.com/user-attachments/assets/25f813dc-1c30-4cb8-acc8-3d3a6caf7d0c" />

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Ejecting out of an autodoc's automatic mode before it starts no longer runtimes / breaks.
/:cl:
