### PR TITLE
Re added sleeper to canter

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -394,6 +394,9 @@
 /obj/machinery/air_alarm,
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "by" = (
@@ -577,15 +580,11 @@
 /turf/open/floor/plating,
 /area/shuttle/canterbury)
 "cs" = (
-/obj/structure/table/reinforced,
 /obj/machinery/power/apc{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
+/obj/machinery/sleeper,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "cv" = (
@@ -748,6 +747,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"qK" = (
+/obj/structure/cable,
+/obj/machinery/computer/sleep_console,
+/turf/open/floor/mainship/sterile,
+/area/shuttle/canterbury/medical)
 "vY" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
@@ -758,6 +762,10 @@
 /obj/machinery/shower{
 	dir = 1
 	},
+/turf/open/floor/mainship/sterile/dark,
+/area/shuttle/canterbury/medical)
+"yh" = (
+/obj/machinery/reagentgrinder,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "zE" = (
@@ -875,9 +883,9 @@ bC
 bj
 bo
 aC
-bT
+qK
 bH
-cJ
+yh
 ca
 ce
 bo


### PR DESCRIPTION
## About The Pull Request

Re added the sleeper and sleeper console to canter, moved around the chem table and grinder to make space.

<img width="647" height="857" alt="image" src="https://github.com/user-attachments/assets/b911217a-e602-4744-a72f-0f106fd7d464" />


## Why It's Good For The Game

Zombie crash. Sleeper isn't useless anymore.

## Changelog

:cl: Scav
add: Added a sleeper to Canterbury medical
/:cl:
