### PR TITLE
Adds Lemoline to Corpsman Vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "corps-tools"),
 		/obj/item/clothing/gloves/defibrillator = list(CAT_MEDSUP, "Advanced medical gloves", 5, "corps-tools"),
 		/obj/item/clothing/gloves/healthanalyzer = list(CAT_MEDSUP, "Health scanner gloves", 2, "corps-tools"),
-		/obj/item/tweezers_advanced = list(CAT_MEDSUP, "Shrapnel Drill", 16, "corps-tools"),,
+		/obj/item/tweezers_advanced = list(CAT_MEDSUP, "Shrapnel Drill", 16, "corps-tools"),
 	))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(


### PR DESCRIPTION
## About The Pull Request

10u bottles of lemoline can now be purchased from the corpsman vendor, for 20 points.

## Why It's Good For The Game

Grants access to the more advanced chemicals on game modes like crash, without forcing you to rely on a CMO spawning. 20 points is a hefty price to pay, so it does lock people out of taking a potentially stronger kit.

## Changelog
:cl: Joe13413
balance: Corpsmen can now buy lemoline from their vendor for 20 points.
/:cl:
