### PR TITLE
Makes spotlight duration clearer

### DIFF
--- a/code/game/objects/machinery/overwatch/military.dm
+++ b/code/game/objects/machinery/overwatch/military.dm
@@ -436,7 +436,7 @@
 	new /obj/effect/overwatch_light(target)
 	use_power(10000)	//Huge light needs big power. Still less than autodocs.
 	TIMER_COOLDOWN_START(src, COOLDOWN_ORBITAL_SPOTLIGHT, SPOTLIGHT_COOLDOWN_DURATION)
-	to_chat(source, span_notice("Orbital spotlight activated. Duration : [SPOTLIGHT_DURATION]"))
+	to_chat(source, span_notice("Orbital spotlight activated. Duration : [SPOTLIGHT_DURATION / 10] Seconds"))
 
 //Print order visual to all marines squad hud and give them an arrow to follow the waypoint
 /obj/machinery/computer/camera_advanced/overwatch/military/proc/send_order(datum/source, atom/target)


### PR DESCRIPTION

## About The Pull Request

now says seconds instead of ticks

## Why It's Good For The Game

Magic numbers = bad

## Changelog
:cl: Atropos
fix: CIC spotlights now say how much time they last
/:cl:
