### PR TITLE
No bwoink sound for zombie revive

### DIFF
--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -393,7 +393,7 @@
 		return
 	var/mob/dead/observer/ghost = get_ghost()
 	if(istype(ghost))
-		notify_ghost(ghost, "<font size=3>Your body slowly regenerated. Return to it if you want to be resurrected!</font>", ghost_sound = 'sound/effects/adminhelp.ogg', enter_text = "Enter", enter_link = "reentercorpse=1", source = src, action = NOTIFY_JUMP)
+		notify_ghost(ghost, "<font size=3>Your body slowly regenerated. Return to it if you want to be resurrected!</font>", ghost_sound = 'sound/effects/gladosmarinerevive.ogg', enter_text = "Enter", enter_link = "reentercorpse=1", source = src, action = NOTIFY_JUMP)
 	do_jitter_animation(1000)
 	ADD_TRAIT(src, TRAIT_IS_RESURRECTING, REVIVE_TO_CRIT_TRAIT)
 	if(should_zombify && (istype(wear_ear, /obj/item/radio/headset/mainship)))


### PR DESCRIPTION
## About The Pull Request
Moron virus.

Replaces the bwoink sound in `revive_to_crit` with the defibrillator alert sound.
## Why it's Good for the Game
We should never be reusing admin sounds for something that's this common and isn't even caused by admin actions.
## Changelog
:cl:
qol: The zombie revive sound now uses the same alert noise as being defibrillated, rather than reusing an admin sound.
/:cl:
