### PR TITLE
Roboticist survivors have Skink drone instead of BAS

### DIFF
--- a/code/datums/outfits/survivor.dm
+++ b/code/datums/outfits/survivor.dm
@@ -404,7 +404,8 @@
 	backpack_contents = list(
 		/obj/item/stack/sheet/metal/medium_stack = 1,
 		/obj/item/stack/sheet/plasteel/small_stack = 1,
-		/obj/item/attachable/buildasentry = 1,
+		/obj/item/deployable_vehicle/tiny = 1,
+		/obj/item/unmanned_vehicle_remote = 1,
 		/obj/item/cell/high = 1,
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 1,


### PR DESCRIPTION

## About The Pull Request
Title, roboticist survivor (and therefore roboticist zombies) have a skink drone and remote in their backpack instead of Build-A-Sentry.
## Why It's Good For The Game
Infinite BAS breaks zombie gamemodes
## Changelog
:cl:
balance: Roboticist survivors (and zombies) now have a Skink drone and remote in their backpack instead of a BAS.
/:cl:
