### PR TITLE
Allow synth to speak zombie language

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -120,7 +120,7 @@
 	languages = list(/datum/language/common, /datum/language/machine)
 
 /datum/language_holder/synthetic
-	languages = list(/datum/language/common, /datum/language/machine, /datum/language/xenocommon)
+	languages = list(/datum/language/common, /datum/language/machine, /datum/language/xenocommon, /datum/language/zombie)
 
 /datum/language_holder/moth
 	languages = list(/datum/language/common, /datum/language/moth)


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

Synth robot
robot smart
smart understand languages
also funny

## Changelog
:cl: Atropos
add: Synths can now speak zombie language
/:cl:
