### PR TITLE
King has normal pop requirements again

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -29,9 +29,8 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 8
+	evolve_min_xenos = 12
 	death_evolution_delay = 7 MINUTES
-	evolve_population_lock = 40 // Mech
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_STAGGER_RESISTANT|CASTE_LEADER_TYPE|CASTE_INSTANT_EVOLUTION|CASTE_HAS_WOUND_MASK|CASTE_MUTATIONS_ALLOWED


### PR DESCRIPTION
## About The Pull Request
King no longer requires a minimum pop at ROUND START to be evolvable, and is just back to the simple 12 pop hive requirement.
## Why It's Good For The Game
Mechs aren't a thing anymore, and king existed (unchanged) before tank and mechs, and either way this was an entirely unneeded restriction.
## Changelog
:cl:
balance: King requires 12 pop hive to evo, no longer has minimum roundstart pop requirements
/:cl:
