### PR TITLE
Minor miner nerf

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -11,7 +11,7 @@
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
 #define PHORON_CRATE_SELL_AMOUNT 150
-#define PLATINUM_CRATE_SELL_AMOUNT 300
+#define PLATINUM_CRATE_SELL_AMOUNT 250
 #define PHORON_DROPSHIP_BONUS_AMOUNT 15
 #define PLATINUM_DROPSHIP_BONUS_AMOUNT 30
 ///Resource generator that produces a certain material that can be repaired by marines and attacked by xenos, Intended as an objective for marines to play towards to get more req gear
@@ -108,8 +108,9 @@
 			max_miner_integrity = 300
 			miner_integrity = 300
 		if(MINER_OVERCLOCKED)
-			required_ticks = 60
+			required_ticks -= 10
 		if(MINER_AUTOMATED)
+			required_ticks += 10
 			if(stored_mineral)
 				SSpoints.supply_points[faction] += mineral_value * stored_mineral
 				SSpoints.dropship_points += dropship_bonus * stored_mineral
@@ -162,6 +163,7 @@
 				upgrade = new /obj/item/minerupgrade/overclock
 				required_ticks = initial(required_ticks)
 			if(MINER_AUTOMATED)
+				required_ticks = initial(required_ticks)
 				upgrade = new /obj/item/minerupgrade/automatic
 		upgrade.forceMove(user.loc)
 		miner_upgrade_type = null


### PR DESCRIPTION

## About The Pull Request
Plat miners give 250 req instead of 300.
Autominer upgrades now INCREASE mining time by 10 ticks (overclocker speeds it up by 10 for reference).
## Why It's Good For The Game
Plat miners are very strong, and holding one for an extended period of time can be a potentially gamebreaking advantage for marines. This tones them down just a bit, while still keeping them significantly better than more accessible phoron miners.

The nerf to autominers reduces the power of holding 5+ different miners at the same time, which is usually seen only when xenos are already seriously at a disadvantage.
Now marines can either take a (pretty small) loss of income for their macro advantage, or actually have to run around to keep them all running at full capacity.
## Changelog
:cl:
balance: Platinum miners gives 250 req points instead of 300
balance: Autominer upgrades now increase the mining time of the miner they are attached to
/:cl:
