### PR TITLE
Misc survivor tweaks

### DIFF
--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -173,31 +173,6 @@ Good luck, but do not expect to survive."}
 	skills_type = /datum/skills/civilian/survivor/atmos
 	outfit = /datum/outfit/job/survivor/roboticist
 
-
-/datum/outfit/job/survivor/roboticist
-	name = "Roboticist Survivor"
-	jobtype = /datum/job/survivor/roboticist
-
-	w_uniform = /obj/item/clothing/under/rank/roboticist
-	wear_suit = /obj/item/clothing/suit/storage/labcoat/science
-	belt = /obj/item/storage/belt/utility/full
-	shoes = /obj/item/clothing/shoes/black
-	back = /obj/item/storage/backpack/satchel/tox
-	ears = /obj/item/radio/survivor
-	glasses = /obj/item/clothing/glasses/welding/flipped
-	l_pocket = /obj/item/storage/pouch/electronics/full
-	r_pocket = /obj/item/flashlight/combat
-
-/datum/outfit/job/survivor/roboticist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/medium_stack, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/small_stack, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/deployable_vehicle/tiny, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/cell/high, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/unmanned_vehicle_remote, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/stack/cable_coil, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/cans/waterbottle , SLOT_IN_BACKPACK)
-
 // Rambo Survivor - pretty overpowered, pls spawn with caution
 /datum/job/survivor/rambo
 	title = "Rambo Survivor"

--- a/code/datums/outfits/survivor.dm
+++ b/code/datums/outfits/survivor.dm
@@ -254,11 +254,13 @@
 
 	w_uniform = /obj/item/clothing/under/rank/miner
 	head = /obj/item/clothing/head/helmet/space/rig/mining
+	glasses = /obj/item/clothing/glasses/meson
 	shoes = /obj/item/clothing/shoes/black
+	gloves = /obj/item/clothing/gloves/ruggedgloves
 	back = /obj/item/storage/backpack/satchel/som
 	l_hand = /obj/item/weapon/twohanded/sledgehammer
 	r_pocket = /obj/item/reagent_containers/cup/glass/flask
-	r_hand = /obj/item/clothing/suit/space/rig/mining
+	wear_suit = /obj/item/clothing/suit/space/rig/mining
 	ears = /obj/item/radio/survivor
 
 	backpack_contents = list(
@@ -386,7 +388,6 @@
 		/obj/item/storage/syringe_case/empty = 2,
 	)
 
-
 /datum/outfit/job/survivor/roboticist
 	name = "Roboticist Survivor"
 	jobtype = /datum/job/survivor/roboticist
@@ -404,11 +405,18 @@
 	backpack_contents = list(
 		/obj/item/stack/sheet/metal/medium_stack = 1,
 		/obj/item/stack/sheet/plasteel/small_stack = 1,
-		/obj/item/attachable/buildasentry = 1,
 		/obj/item/cell/high = 1,
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 1,
 	)
+
+/datum/outfit/job/survivor/roboticist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(prob(50))
+		H.equip_to_slot_or_del(new /obj/item/deployable_vehicle/tiny, SLOT_IN_BACKPACK)
+		H.equip_to_slot_or_del(new /obj/item/unmanned_vehicle_remote, SLOT_IN_BACKPACK)
+	else
+		H.equip_to_slot_or_del(new /obj/item/attachable/buildasentry, SLOT_IN_BACKPACK)
 
 /datum/outfit/job/survivor/rambo
 	name = "Overpowered Survivor"
@@ -425,3 +433,8 @@
 	glasses = /obj/item/clothing/glasses/m42_goggles
 	head = /obj/item/clothing/head/headband
 	ears = /obj/item/radio/survivor
+
+/datum/outfit/job/survivor/rambo/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(prob(10))
+		suit_store = /obj/item/weapon/gun/rifle/tx8/scout
+		belt = /obj/item/storage/belt/marine/tx8


### PR DESCRIPTION
## About The Pull Request
Chemists have a 50/50 chance to have BAS or scout drone.
Rambo survivors have a 10% chance to have a scout rifle instead of ALF.
Miner survivors are actually wearing their hardsuit, and have mesons/gloves.

Removed an old duplicate roboticist outfit.
## Why It's Good For The Game
Fixes, also some walance for zombie mode where roboticists are just infinite BAS fodder
## Changelog
:cl:
balance: minor tweaks to some survivor loadouts, notably roboticists only have BAS 50% of the time
/:cl:
