### PR TITLE
Fix gamemode vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -146,30 +146,34 @@ SUBSYSTEM_DEF(vote)
 			SSticker.save_mode(.) //changes the next game mode
 			if(GLOB.master_mode == .)
 				return
-			if(SSticker.HasRoundStarted())
-				restart = TRUE
-			else
-				var/ship_change_required
-				var/ground_change_required
-				var/datum/game_mode/new_gamemode = config.pick_mode(.)
-				GLOB.master_mode = . //changes the current gamemode
-				//we check the gamemode's whitelists and blacklists to see if a map change and restart is required
-				if(!(new_gamemode.whitelist_ship_maps && (SSmapping.configs[SHIP_MAP].map_name in new_gamemode.whitelist_ship_maps)) && !(new_gamemode.blacklist_ship_maps && !(SSmapping.configs[SHIP_MAP].map_name in new_gamemode.blacklist_ship_maps)))
-					ship_change_required = TRUE
-				if(!(new_gamemode.whitelist_ground_maps && (SSmapping.configs[GROUND_MAP].map_name in new_gamemode.whitelist_ground_maps)) && !(new_gamemode.blacklist_ground_maps && !(SSmapping.configs[GROUND_MAP].map_name in new_gamemode.blacklist_ground_maps)))
-					ground_change_required = TRUE
-				//we queue up the required votes and restarts
-				if(ship_change_required && ground_change_required)
-					addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
-					addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), CONFIG_GET(number/vote_period) + 5 SECONDS)
-					SSticker.Reboot("Restarting server when valid ship and ground map selected", (CONFIG_GET(number/vote_period) * 2) + 15 SECONDS)
-					return
-				else if(ship_change_required)
-					addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
-					SSticker.Reboot("Restarting server when valid ship map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
-				else if(ground_change_required)
-					addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), 5 SECONDS)
-					SSticker.Reboot("Restarting server when valid ground map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
+			if(SSticker.current_state < GAME_STATE_PLAYING)
+				//if the game is in preround, we can play the newly voted mode immediately
+				GLOB.master_mode = .
+				return
+			if(SSticker.current_state == GAME_STATE_PLAYING)
+				//If round is ongoing, we keep playing the round - vote for restart manually
+				return
+			var/ship_change_required
+			var/ground_change_required
+			var/datum/game_mode/new_gamemode = config.pick_mode(.)
+			GLOB.master_mode = . //changes the current gamemode
+			//we check the gamemode's whitelists and blacklists to see if a map change and restart is required
+			if(!(new_gamemode.whitelist_ship_maps && (SSmapping.configs[SHIP_MAP].map_name in new_gamemode.whitelist_ship_maps)) && !(new_gamemode.blacklist_ship_maps && !(SSmapping.configs[SHIP_MAP].map_name in new_gamemode.blacklist_ship_maps)))
+				ship_change_required = TRUE
+			if(!(new_gamemode.whitelist_ground_maps && (SSmapping.configs[GROUND_MAP].map_name in new_gamemode.whitelist_ground_maps)) && !(new_gamemode.blacklist_ground_maps && !(SSmapping.configs[GROUND_MAP].map_name in new_gamemode.blacklist_ground_maps)))
+				ground_change_required = TRUE
+			//we queue up the required votes and restarts
+			if(ship_change_required && ground_change_required)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), CONFIG_GET(number/vote_period) + 5 SECONDS)
+				SSticker.Reboot("Restarting server when valid ship and ground map selected", (CONFIG_GET(number/vote_period) * 2) + 15 SECONDS)
+				return
+			else if(ship_change_required)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
+				SSticker.Reboot("Restarting server when valid ship map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
+			else if(ground_change_required)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), 5 SECONDS)
+				SSticker.Reboot("Restarting server when valid ground map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
 			return
 		if("groundmap")
 			var/datum/map_config/VM = config.maplist[GROUND_MAP][.]


### PR DESCRIPTION

## About The Pull Request
Gamemode vote will no longer trigger a restart if the game is ongoing.

Now it will immediately change the mode if the game has not yet started, simply set the next mode if the game is ongoing, or do the full end of round vote routine if the game has actually ended.

Our vote code is still pretty cursed though.
## Why It's Good For The Game
CUrsed restarts are bad.
## Changelog
:cl:
admin: Gamemode votes won't trigger a restart mid game anymore
/:cl:
