### PR TITLE
Autodoc automatic mode correctly works on fracs

### DIFF
--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -502,14 +502,12 @@
 			var/datum/limb/head/operated_head = operated_limb
 			if(operated_head.disfigured || operated_head.face_surgery_stage > 0)
 				surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_FACIAL)
-		switch(operated_limb.limb_status)
-			if(LIMB_BROKEN)
-				surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_BROKEN)
-			if(LIMB_DESTROYED)
-				if(operated_limb.body_part != HEAD && !(operated_limb.parent.limb_status & LIMB_DESTROYED)) // We want to pick the missing limb that is most accurate: missing foot = foot, missing foot + leg = leg.
-					surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_MISSING)
-			if(LIMB_NECROTIZED)
-				surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_NECROTIZED)
+		if(operated_limb.limb_status & LIMB_BROKEN)
+			surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_BROKEN)
+		if(operated_limb.limb_status & LIMB_DESTROYED && operated_limb.body_part != HEAD && !(operated_limb.parent?.limb_status & LIMB_DESTROYED)) // We want to pick the missing limb that is most accurate: missing foot = foot, missing foot + leg = leg.
+			surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_MISSING)
+		if(operated_limb.limb_status & LIMB_NECROTIZED)
+			surgery_list += new /datum/autodoc_surgery(operated_limb, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_NECROTIZED)
 		var/already_added_surgery = FALSE
 		if(length(operated_limb.implants))
 			for(var/obj/item/implant_in_question AS in operated_limb.implants)
@@ -1293,7 +1291,7 @@
 			needed = FALSE
 			for(var/i in connected.occupant.limbs)
 				var/datum/limb/L = i
-				if(L.limb_status & LIMB_DESTROYED && !(L.parent.limb_status & LIMB_DESTROYED) && L.body_part != HEAD)
+				if(L.limb_status & LIMB_DESTROYED && L.body_part != HEAD && !(L.parent?.limb_status & LIMB_DESTROYED))
 					N.fields["autodoc_manual"] += new /datum/autodoc_surgery(L, null, SURGERY_CATEGORY_LIMB, SURGERY_PROCEDURE_LIMB_MISSING)
 					needed = TRUE
 			if(!needed)


### PR DESCRIPTION

## About The Pull Request
Autodoc now correctly queues up bone fixing surgery on Automatic mode.
Autodoc no longer runtimes when trying to check the limb status of a limb's parent.

## Why It's Good For The Game
Bugfixes and gets rid of a runtime.

## Changelog
:cl:
fix: Autodoc now correctly queues up bone fixing surgery on Automatic mode.
/:cl:
