### PR TITLE
doubles RoF of mini pepperball gun

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -566,7 +566,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	actions_types = list()
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	gun_features_flags = GUN_IS_ATTACHMENT | GUN_WIELDED_FIRING_ONLY | GUN_ATTACHMENT_FIRE_ONLY | GUN_AMMO_COUNTER
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.1 SECONDS
 	attach_delay = 3 SECONDS
 	detach_delay = 3 SECONDS
 	pixel_shift_x = 18


### PR DESCRIPTION
## About The Pull Request

Changes the firedelay of the mini pepperball gun from 0.2 to 0.1, bringing its firerate to 10 rounds/second, up from 5 rounds/second.

## Why It's Good For The Game

Mini pepperball gun is dogshit. Not only are its pepperballs considerably worse at draining plasma than its bigger brother, it also fires twice as slow. Doubling it's fire-rate would make it a viable choice to counter xenos that rely heavily on plasma, or have lower plasma pools.

## Changelog

:cl: Joe13413
balance: The pepperball underbarrel attachment now fires twice as fast (600RPM, up from 300RPM)
/:cl:
