### PR TITLE
Job setup fixes

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -33,12 +33,13 @@ SUBSYSTEM_DEF(job)
 
 ///Clears jobs and resets all occupations
 /datum/controller/subsystem/job/proc/SetupOccupations()
-	QDEL_LIST(occupations)
 	joinable_occupations.Cut()
+	joinable_occupations_by_category.Cut()
 	GLOB.jobs_command.Cut()
 	squads.Cut()
 	type_occupations.Cut()
 	name_occupations.Cut()
+	QDEL_LIST(occupations)
 	var/list/all_jobs = subtypesof(/datum/job)
 	var/list/all_squads = subtypesof(/datum/squad)
 	if(!length(all_jobs))
@@ -136,7 +137,6 @@ SUBSYSTEM_DEF(job)
 		var/mob/new_player/player = p
 		player.assigned_role = null
 		player.assigned_squad = null
-	SetupOccupations()
 	unassigned.Cut()
 
 


### PR DESCRIPTION

## About The Pull Request
Failing to start the round (usually due to lack of players readied up) no longer resets all jobs in the job SS.
I can see no reason WHY this is needed, and it just flood admin logs with 5 million job datum deletion notifications.

Also fixed SetupOccupations() not resetting one more job list, in case anyone needs to ever manually run it
## Why It's Good For The Game
Runtimes and admeme spam
## Changelog
:cl:
code: Removed some unneeded jobSS stuff when a round fails to start
admin: Fixed a runtime with the banpanel in some instances
/:cl:
